### PR TITLE
fix: add Accept: application/json to OAuth token exchange

### DIFF
--- a/packages/connect/src/token-utils.ts
+++ b/packages/connect/src/token-utils.ts
@@ -17,6 +17,7 @@ export function buildTokenHeaders(
 ): Record<string, string> {
   const headers: Record<string, string> = {
     "Content-Type": "application/x-www-form-urlencoded",
+    Accept: "application/json",
   };
   if (tokenAuthMethod === "client_secret_basic") {
     // RFC 6749 §2.3.1: credentials MUST be URL-encoded before base64


### PR DESCRIPTION
## Summary
- GitHub's token endpoint returns `application/x-www-form-urlencoded` by default, causing `Token exchange returned non-JSON response` errors
- Adds `Accept: application/json` header to `buildTokenHeaders()` — fixes GitHub and any other non-compliant provider
- Covers both initial token exchange and refresh flow (shared utility)

## Test plan
- [ ] Connect a GitHub provider via OAuth and verify token exchange succeeds
- [ ] Verify existing providers (Google, Slack, Notion) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)