### PR TITLE
fix: allow editing schedules with foreign profiles

### DIFF
--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -128,8 +128,8 @@ export function createSchedulesRouter() {
     const body = await c.req.json();
     const data = parseBody(updateScheduleSchema, body);
 
-    // Validate ownership — user can only update schedule to use their own profiles
-    if (data.connectionProfileId) {
+    // Validate ownership — only check when the profile is actually changing
+    if (data.connectionProfileId && data.connectionProfileId !== existing.connectionProfileId) {
       const actor = getActor(c);
       const profile = await getAccessibleProfile(data.connectionProfileId, actor, orgId);
       if (!profile) {

--- a/apps/web/src/components/combined-profile-select.tsx
+++ b/apps/web/src/components/combined-profile-select.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Building2 } from "lucide-react";
+import { Building2, User } from "lucide-react";
 import {
   Select,
   SelectContent,
@@ -12,6 +13,12 @@ import {
 } from "@/components/ui/select";
 import { useConnectionProfiles, useOrgProfiles } from "../hooks/use-connection-profiles";
 import { PROFILE_ALL_VALUE, encodeProfileValue, decodeProfileValue } from "@/lib/profile-selection";
+
+export interface ForeignProfile {
+  id: string;
+  name: string;
+  ownerName: string;
+}
 
 interface CombinedProfileSelectProps {
   /** Current value */
@@ -24,6 +31,8 @@ interface CombinedProfileSelectProps {
   triggerClassName?: string;
   /** ID for form association */
   id?: string;
+  /** A profile owned by another user — shown as disabled, selectable only if currently active */
+  foreignProfile?: ForeignProfile;
 }
 
 export function CombinedProfileSelect({
@@ -32,6 +41,7 @@ export function CombinedProfileSelect({
   showAllOption,
   triggerClassName = "w-[200px]",
   id,
+  foreignProfile,
 }: CombinedProfileSelectProps) {
   const { t } = useTranslation(["settings", "agents"]);
   const { data: userProfiles } = useConnectionProfiles();
@@ -40,9 +50,20 @@ export function CombinedProfileSelect({
   const hasUserProfiles = (userProfiles?.length ?? 0) > 0;
   const hasOrgProfiles = (orgProfiles?.length ?? 0) > 0;
 
+  // Determine if the foreign profile should be shown (value matches and not in own/org lists)
+  const showForeign = useMemo(() => {
+    if (!foreignProfile) return false;
+    const inUser = userProfiles?.some((p) => p.id === foreignProfile.id) ?? false;
+    const inOrg = orgProfiles?.some((p) => p.id === foreignProfile.id) ?? false;
+    return !inUser && !inOrg;
+  }, [foreignProfile, userProfiles, orgProfiles]);
+
+  const hasMeaningfulChoice = hasUserProfiles || hasOrgProfiles || showForeign;
+
   // Hide when no meaningful choice
-  if (!hasUserProfiles && !hasOrgProfiles) return null;
-  if (!showAllOption && !hasOrgProfiles && (userProfiles?.length ?? 0) <= 1) return null;
+  if (!hasMeaningfulChoice) return null;
+  if (!showAllOption && !hasOrgProfiles && !showForeign && (userProfiles?.length ?? 0) <= 1)
+    return null;
 
   const selectValue = encodeProfileValue(value);
 
@@ -57,6 +78,24 @@ export function CombinedProfileSelect({
       </SelectTrigger>
       <SelectContent>
         {showAllOption && <SelectItem value={PROFILE_ALL_VALUE}>{t("profiles.all")}</SelectItem>}
+        {showForeign && foreignProfile && (
+          <SelectGroup>
+            <div
+              className="text-muted-foreground flex items-center gap-1 px-2 py-1.5 text-xs font-medium"
+              role="presentation"
+            >
+              <User className="size-3" />
+              {foreignProfile.ownerName}
+            </div>
+            <SelectItem
+              key={foreignProfile.id}
+              value={foreignProfile.id}
+              disabled={value !== foreignProfile.id}
+            >
+              {foreignProfile.name}
+            </SelectItem>
+          </SelectGroup>
+        )}
         {userProfiles?.map((p) => (
           <SelectItem key={p.id} value={p.id}>
             {p.name}

--- a/apps/web/src/components/schedule-form.tsx
+++ b/apps/web/src/components/schedule-form.tsx
@@ -24,7 +24,7 @@ import {
   type SchemaWrapper,
 } from "@appstrate/core/form";
 import { useConnectionProfiles, useOrgProfiles } from "../hooks/use-connection-profiles";
-import { CombinedProfileSelect } from "./combined-profile-select";
+import { CombinedProfileSelect, type ForeignProfile } from "./combined-profile-select";
 
 function getCronPresets(t: (key: string) => string) {
   return [
@@ -74,6 +74,8 @@ interface ScheduleFormProps {
   onDelete?: () => void;
   isPending?: boolean;
   blockedMessage?: string;
+  /** Profile owned by another user — shown read-only in the selector */
+  foreignProfile?: ForeignProfile;
 }
 
 interface FormFields {
@@ -96,6 +98,7 @@ export function ScheduleForm({
   onDelete,
   isPending,
   blockedMessage,
+  foreignProfile,
 }: ScheduleFormProps) {
   const { t } = useTranslation(["agents", "common"]);
   const cronPresets = getCronPresets(t);
@@ -196,7 +199,7 @@ export function ScheduleForm({
       )}
 
       {/* Connection profile */}
-      {allProfiles.length > 1 && (
+      {(allProfiles.length > 1 || foreignProfile) && (
         <div className="space-y-3">
           <Label htmlFor="sched-profile">{t("schedule.connectionProfile")}</Label>
           <CombinedProfileSelect
@@ -207,6 +210,7 @@ export function ScheduleForm({
             }}
             triggerClassName="w-full"
             id="sched-profile"
+            foreignProfile={foreignProfile}
           />
         </div>
       )}

--- a/apps/web/src/pages/schedule-edit.tsx
+++ b/apps/web/src/pages/schedule-edit.tsx
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { useMemo } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { usePermissions } from "../hooks/use-permissions";
 import { usePackageDetail } from "../hooks/use-packages";
 import { useScheduleById, useUpdateSchedule, useDeleteSchedule } from "../hooks/use-schedules";
+import { useConnectionProfiles, useOrgProfiles } from "../hooks/use-connection-profiles";
 import { ScheduleForm } from "../components/schedule-form";
+import type { ForeignProfile } from "../components/combined-profile-select";
 import { PageHeader } from "../components/page-header";
 import { LoadingState, ErrorState } from "../components/page-states";
 import { isFileField } from "@appstrate/core/form";
@@ -20,6 +23,24 @@ export function ScheduleEditPage() {
   const { data: agentDetail } = usePackageDetail("agent", schedule?.packageId || undefined);
   const updateSchedule = useUpdateSchedule();
   const deleteSchedule = useDeleteSchedule();
+
+  const { data: userProfiles } = useConnectionProfiles();
+  const { data: orgProfiles } = useOrgProfiles();
+
+  // Build foreign profile when the schedule's profile belongs to another user
+  const foreignProfile = useMemo<ForeignProfile | undefined>(() => {
+    if (!schedule) return undefined;
+    const profileId = schedule.connectionProfileId;
+    const inUser = userProfiles?.some((p) => p.id === profileId) ?? false;
+    const inOrg = orgProfiles?.some((p) => p.id === profileId) ?? false;
+    if (inUser || inOrg) return undefined;
+    if (schedule.profileType !== "user" || !schedule.profileName) return undefined;
+    return {
+      id: profileId,
+      name: schedule.profileName,
+      ownerName: schedule.profileOwnerName ?? "",
+    };
+  }, [schedule, userProfiles, orgProfiles]);
 
   if (!isMember) return null;
   if (isLoading) return <LoadingState />;
@@ -69,6 +90,7 @@ export function ScheduleEditPage() {
           });
         }}
         onCancel={() => navigate(-1)}
+        foreignProfile={foreignProfile}
       />
     </>
   );


### PR DESCRIPTION
## Summary

- **Backend**: skip profile ownership validation in `PUT /api/schedules/:id` when `connectionProfileId` hasn't changed — fixes the "Cannot use a profile you do not own" error when editing cron/name/enabled on a schedule owned by another org member's profile
- **Frontend**: show the current foreign profile as a read-only disabled item in `CombinedProfileSelect`, so users can see who owns the assigned profile and switch to their own or an org profile

## Test plan

- [ ] User A creates a schedule with their profile
- [ ] User B edits that schedule (cron, name, enabled) without changing the profile → should succeed (no 403)
- [ ] User B sees User A's profile displayed (with owner name) in the profile selector
- [ ] User B switches the profile to their own → should succeed
- [ ] User B cannot re-select User A's profile once switched away (item disabled)
- [ ] Creating a new schedule still validates profile ownership normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)