### PR TITLE
chore(core): bump to 2.10.2

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `@appstrate/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.10.1] — 2026-04-02
+## [2.10.2] — 2026-04-02
 
 ### Changed
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump core version to 2.10.2 (2.10.0 and 2.10.1 tags pointed to wrong commits due to squash-merge divergence, and are protected/undeletable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)