### PR TITLE
fix(core): regenerate schemas + prettierignore + bump 2.10.2

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Generated files — managed by scripts, not prettier
+packages/core/schema/

--- a/packages/core/schema/agent.schema.json
+++ b/packages/core/schema/agent.schema.json
@@ -117,7 +117,13 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["string", "number", "boolean", "array", "object"]
+                    "enum": [
+                      "string",
+                      "number",
+                      "boolean",
+                      "array",
+                      "object"
+                    ]
                   },
                   "description": {
                     "type": "string"
@@ -138,7 +144,13 @@
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": ["string", "number", "boolean", "array", "object"]
+                        "enum": [
+                          "string",
+                          "number",
+                          "boolean",
+                          "array",
+                          "object"
+                        ]
                       },
                       "description": {
                         "type": "string"
@@ -150,7 +162,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": {}
                   },
                   "maxItems": {
@@ -159,7 +173,9 @@
                     "maximum": 9007199254740991
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": {}
               }
             },
@@ -170,7 +186,10 @@
               }
             }
           },
-          "required": ["type", "properties"],
+          "required": [
+            "type",
+            "properties"
+          ],
           "additionalProperties": {}
         },
         "fileConstraints": {
@@ -214,7 +233,9 @@
           }
         }
       },
-      "required": ["schema"],
+      "required": [
+        "schema"
+      ],
       "additionalProperties": false
     },
     "output": {
@@ -237,7 +258,13 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["string", "number", "boolean", "array", "object"]
+                    "enum": [
+                      "string",
+                      "number",
+                      "boolean",
+                      "array",
+                      "object"
+                    ]
                   },
                   "description": {
                     "type": "string"
@@ -258,7 +285,13 @@
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": ["string", "number", "boolean", "array", "object"]
+                        "enum": [
+                          "string",
+                          "number",
+                          "boolean",
+                          "array",
+                          "object"
+                        ]
                       },
                       "description": {
                         "type": "string"
@@ -270,7 +303,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": {}
                   },
                   "maxItems": {
@@ -279,7 +314,9 @@
                     "maximum": 9007199254740991
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": {}
               }
             },
@@ -290,7 +327,10 @@
               }
             }
           },
-          "required": ["type", "properties"],
+          "required": [
+            "type",
+            "properties"
+          ],
           "additionalProperties": {}
         },
         "fileConstraints": {
@@ -334,7 +374,9 @@
           }
         }
       },
-      "required": ["schema"],
+      "required": [
+        "schema"
+      ],
       "additionalProperties": false
     },
     "config": {
@@ -357,7 +399,13 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["string", "number", "boolean", "array", "object"]
+                    "enum": [
+                      "string",
+                      "number",
+                      "boolean",
+                      "array",
+                      "object"
+                    ]
                   },
                   "description": {
                     "type": "string"
@@ -378,7 +426,13 @@
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": ["string", "number", "boolean", "array", "object"]
+                        "enum": [
+                          "string",
+                          "number",
+                          "boolean",
+                          "array",
+                          "object"
+                        ]
                       },
                       "description": {
                         "type": "string"
@@ -390,7 +444,9 @@
                         "type": "string"
                       }
                     },
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "additionalProperties": {}
                   },
                   "maxItems": {
@@ -399,7 +455,9 @@
                     "maximum": 9007199254740991
                   }
                 },
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "additionalProperties": {}
               }
             },
@@ -410,7 +468,10 @@
               }
             }
           },
-          "required": ["type", "properties"],
+          "required": [
+            "type",
+            "properties"
+          ],
           "additionalProperties": {}
         },
         "fileConstraints": {
@@ -454,7 +515,9 @@
           }
         }
       },
-      "required": ["schema"],
+      "required": [
+        "schema"
+      ],
       "additionalProperties": false
     },
     "timeout": {
@@ -462,6 +525,13 @@
       "exclusiveMinimum": 0
     }
   },
-  "required": ["name", "version", "type", "displayName", "schemaVersion", "author"],
+  "required": [
+    "name",
+    "version",
+    "type",
+    "displayName",
+    "schemaVersion",
+    "author"
+  ],
   "additionalProperties": {}
 }

--- a/packages/core/schema/provider.schema.json
+++ b/packages/core/schema/provider.schema.json
@@ -90,7 +90,13 @@
       "properties": {
         "authMode": {
           "type": "string",
-          "enum": ["oauth2", "oauth1", "api_key", "basic", "custom"]
+          "enum": [
+            "oauth2",
+            "oauth1",
+            "api_key",
+            "basic",
+            "custom"
+          ]
         },
         "oauth2": {
           "type": "object",
@@ -102,7 +108,10 @@
               "type": "string"
             }
           },
-          "required": ["authorizationUrl", "tokenUrl"],
+          "required": [
+            "authorizationUrl",
+            "tokenUrl"
+          ],
           "additionalProperties": {}
         },
         "oauth1": {
@@ -115,7 +124,10 @@
               "type": "string"
             }
           },
-          "required": ["requestTokenUrl", "accessTokenUrl"],
+          "required": [
+            "requestTokenUrl",
+            "accessTokenUrl"
+          ],
           "additionalProperties": {}
         },
         "credentials": {
@@ -129,7 +141,9 @@
               "additionalProperties": {}
             }
           },
-          "required": ["schema"],
+          "required": [
+            "schema"
+          ],
           "additionalProperties": {}
         },
         "authorizedUris": {
@@ -146,7 +160,9 @@
           "items": {}
         }
       },
-      "required": ["authMode"],
+      "required": [
+        "authMode"
+      ],
       "additionalProperties": {}
     },
     "setupGuide": {
@@ -167,7 +183,9 @@
                 "type": "string"
               }
             },
-            "required": ["label"],
+            "required": [
+              "label"
+            ],
             "additionalProperties": {}
           }
         }
@@ -175,6 +193,11 @@
       "additionalProperties": false
     }
   },
-  "required": ["name", "version", "type", "definition"],
+  "required": [
+    "name",
+    "version",
+    "type",
+    "definition"
+  ],
   "additionalProperties": {}
 }

--- a/packages/core/schema/skill.schema.json
+++ b/packages/core/schema/skill.schema.json
@@ -74,6 +74,10 @@
       "additionalProperties": {}
     }
   },
-  "required": ["name", "version", "type"],
+  "required": [
+    "name",
+    "version",
+    "type"
+  ],
   "additionalProperties": {}
 }

--- a/packages/core/schema/tool.schema.json
+++ b/packages/core/schema/tool.schema.json
@@ -94,10 +94,20 @@
           "additionalProperties": {}
         }
       },
-      "required": ["name", "description", "inputSchema"],
+      "required": [
+        "name",
+        "description",
+        "inputSchema"
+      ],
       "additionalProperties": false
     }
   },
-  "required": ["name", "version", "type", "entrypoint", "tool"],
+  "required": [
+    "name",
+    "version",
+    "type",
+    "entrypoint",
+    "tool"
+  ],
   "additionalProperties": {}
 }


### PR DESCRIPTION
## Summary

- Regenerate all 4 JSON schemas after flow → agent rename
- Add `.prettierignore` for `packages/core/schema/` (generated files, managed by `generate:schemas`)
- Bump core to 2.10.2 (2.10.0 + 2.10.1 tags unusable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)