### PR TITLE
fix: remove turbo.json from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -39,7 +39,6 @@ CHANGELOG.md
 CODE_OF_CONDUCT.md
 SECURITY.md
 TRADEMARK.md
-turbo.json
 bunfig.toml
 commitlint.config.ts
 eslint.config.mjs


### PR DESCRIPTION
Dockerfile COPY turbo.json but .dockerignore excludes it, breaking image builds.