### PR TITLE
fix(web): add zod as direct dep for Docker build

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -52,6 +52,7 @@
     "remark-gfm": "^4.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
+    "zod": "^4.3.6",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/bun.lock
+++ b/bun.lock
@@ -106,6 +106,7 @@
         "remark-gfm": "^4.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
+        "zod": "^4.3.6",
         "zustand": "^5.0.11",
       },
       "devDependencies": {
@@ -133,7 +134,7 @@
     },
     "packages/core": {
       "name": "@appstrate/core",
-      "version": "2.9.8",
+      "version": "2.10.3",
       "dependencies": {
         "@afps-spec/schema": "^1.0.4",
         "fflate": "^0.8.0",


### PR DESCRIPTION
Vite cannot resolve transitive zod dep from @appstrate/core in CI Docker builds. Verified locally with `docker build --no-cache`.