### PR TITLE
fix: drop legacy notify triggers and fix Docker socket permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,12 @@ RUN mkdir -p data storage && chown -R bun:bun data storage
 COPY --from=build /app/package.json ./
 COPY --from=build /app/system-packages ./system-packages
 
-USER bun
+# su-exec for lightweight privilege drop in entrypoint
+RUN apk add --no-cache su-exec
+
+# Entrypoint: detects Docker socket GID and adds bun to that group before exec
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 EXPOSE 3000
 
@@ -104,4 +109,5 @@ ENV NODE_ENV=production
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
   CMD wget -q -O /dev/null http://localhost:3000/ || exit 1
 
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["bun", "apps/api/src/index.ts"]

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -29,6 +29,9 @@ services:
   appstrate-minio:
     image: minio/minio:RELEASE.2025-03-12T18-04-18Z
     command: server /data --console-address ":9001"
+    networks:
+      - appstrate-data
+      - default
     ports:
       - "9000:9000"
       - "9001:9001"
@@ -56,6 +59,22 @@ services:
       mc mb --ignore-existing local/appstrate &&
       echo 'Bucket appstrate ready'
       "
+
+  # ── Expose database ports to host for local development ────────
+  # appstrate-data is internal: true, so ports require a non-internal network.
+  appstrate-postgres:
+    networks:
+      - appstrate-data
+      - default
+    ports:
+      - "5432:5432"
+
+  appstrate-redis:
+    networks:
+      - appstrate-data
+      - default
+    ports:
+      - "6379:6379"
 
   # ── Disable services handled manually in dev ────────────────────
   # Migrations: bun run db:migrate

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
+#
+# Entrypoint wrapper: ensures the bun user can access the Docker socket.
+# The Docker socket's group varies per host (often 988, 999, or 998).
+# This script detects the GID at runtime and adds bun to that group.
+
+SOCKET="${DOCKER_SOCKET:-/var/run/docker.sock}"
+
+if [ -S "$SOCKET" ] && [ "$(id -u)" = "0" ]; then
+  SOCK_GID=$(stat -c '%g' "$SOCKET" 2>/dev/null)
+  if [ -n "$SOCK_GID" ] && [ "$SOCK_GID" != "0" ]; then
+    # Create a group with the socket's GID if it doesn't exist
+    if ! getent group "$SOCK_GID" >/dev/null 2>&1; then
+      addgroup -g "$SOCK_GID" -S dockersock 2>/dev/null || true
+    fi
+    SOCK_GROUP=$(getent group "$SOCK_GID" | cut -d: -f1)
+    addgroup bun "$SOCK_GROUP" 2>/dev/null || true
+  fi
+  exec su-exec bun "$@"
+else
+  exec "$@"
+fi

--- a/packages/db/drizzle/0016_rename_flow_to_agent_execution_to_run.sql
+++ b/packages/db/drizzle/0016_rename_flow_to_agent_execution_to_run.sql
@@ -33,5 +33,10 @@ ALTER TABLE runs RENAME CONSTRAINT executions_at_most_one_actor TO runs_at_most_
 -- 6. Sequence rename (serial column)
 ALTER SEQUENCE execution_logs_id_seq RENAME TO run_logs_id_seq;
 
--- 7. Update pg_notify triggers/functions if they reference old names
--- (Drizzle pg_notify is application-level, not DB triggers — no action needed)
+-- 7. Drop legacy pg_notify triggers and functions that reference old column names.
+-- The old execution_logs_notify_trigger references NEW.execution_id (now run_id),
+-- causing INSERT failures on run_logs.
+DROP TRIGGER IF EXISTS executions_notify_trigger ON runs;
+DROP TRIGGER IF EXISTS execution_logs_notify_trigger ON run_logs;
+DROP FUNCTION IF EXISTS notify_execution_change();
+DROP FUNCTION IF EXISTS notify_execution_log_insert();

--- a/packages/db/src/notify.ts
+++ b/packages/db/src/notify.ts
@@ -57,6 +57,22 @@ export async function createNotifyTriggers(db: Db): Promise<void> {
     $$ LANGUAGE plpgsql
   `);
 
+  // Drop legacy triggers from pre-rename era (flow→agent, execution→run).
+  // The old execution_logs_notify_trigger references NEW.execution_id which no longer exists,
+  // causing every INSERT into run_logs to fail.
+  await db.execute(drizzleSql`
+    DROP TRIGGER IF EXISTS executions_notify_trigger ON runs
+  `);
+  await db.execute(drizzleSql`
+    DROP TRIGGER IF EXISTS execution_logs_notify_trigger ON run_logs
+  `);
+  await db.execute(drizzleSql`
+    DROP FUNCTION IF EXISTS notify_execution_change()
+  `);
+  await db.execute(drizzleSql`
+    DROP FUNCTION IF EXISTS notify_execution_log_insert()
+  `);
+
   // Create triggers (drop first to avoid duplicates)
   await db.execute(drizzleSql`
     DROP TRIGGER IF EXISTS runs_notify_trigger ON runs


### PR DESCRIPTION
## Summary

- Drop stale `executions_notify_trigger` and `execution_logs_notify_trigger` that reference `NEW.execution_id` (renamed to `run_id` in #16), causing every `INSERT INTO run_logs` to crash
- Add `docker-entrypoint.sh` that detects Docker socket GID at runtime and adds `bun` to that group — fixes "Was there a typo in the url or port?" on production
- Expose Postgres/Redis/MinIO ports in dev override (internal network blocked port publishing)
- Fix migration 0016 to drop legacy triggers/functions

## Test plan

- [x] Fresh DB: `bun run db:migrate` — all migrations apply cleanly
- [x] Boot: `bun run dev` — server starts, triggers installed, no errors
- [x] Triggers: only `runs_notify_trigger` + `run_logs_notify_trigger` present
- [x] Quality gate: `bun run check` — all pass
- [x] Tests: `bun test` — 1658/1658 pass
- [x] Production DB: legacy triggers dropped manually, boot clean after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)