### PR TITLE
feat: OAuth scope upgrade flow + connection invalidation

### DIFF
--- a/apps/api/src/openapi/paths/internal.ts
+++ b/apps/api/src/openapi/paths/internal.ts
@@ -77,4 +77,47 @@ export const internalPaths = {
       },
     },
   },
+  "/internal/connections/report-auth-failure": {
+    post: {
+      operationId: "reportAuthFailure",
+      tags: ["Internal"],
+      summary: "Report upstream auth failure",
+      description:
+        "Called by sidecar when an upstream provider returns 401. Flags the connection as needs_reconnection. Container-to-host only. Auth via Bearer run token.",
+      security: [{ bearerExecToken: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                providerId: {
+                  type: "string",
+                  description: "Provider ID that returned 401",
+                },
+              },
+              required: ["providerId"],
+            },
+          },
+        },
+      },
+      responses: {
+        "200": {
+          description: "Acknowledgement",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  flagged: { type: "boolean" },
+                },
+              },
+            },
+          },
+        },
+        "401": { $ref: "#/components/responses/Unauthorized" },
+      },
+    },
+  },
 } as const;

--- a/apps/api/src/openapi/paths/providers.ts
+++ b/apps/api/src/openapi/paths/providers.ts
@@ -204,6 +204,11 @@ export const providersPaths = {
                   type: "boolean",
                   description: "Whether to enable this provider for use",
                 },
+                invalidateConnections: {
+                  type: "boolean",
+                  description:
+                    "When true and credentials are provided, all existing user connections for this provider in the org are deleted. Users will need to reconnect.",
+                },
               },
             },
           },

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -429,6 +429,7 @@ export const schemas = {
       authMode: { type: "string" },
       connectionId: { type: "string" },
       connectedAt: { type: "string" },
+      scopesGranted: { type: "array", items: { type: "string" } },
     },
   },
   ConnectionStatus: {

--- a/apps/api/src/routes/internal.ts
+++ b/apps/api/src/routes/internal.ts
@@ -3,9 +3,9 @@
 import { z } from "zod";
 import { Hono } from "hono";
 import type { Context } from "hono";
-import { eq } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
-import { runs } from "@appstrate/db/schema";
+import { runs, userProviderConnections } from "@appstrate/db/schema";
 import { logger } from "../lib/logger.ts";
 import { parseSignedToken } from "../lib/run-token.ts";
 import { rateLimitByBearer } from "../middleware/rate-limit.ts";
@@ -13,7 +13,7 @@ import { getRecentRuns } from "../services/state/index.ts";
 import { getPackage } from "../services/agent-service.ts";
 import { resolveCredentialsForProxy } from "@appstrate/connect";
 import { resolveManifestProviders } from "../lib/manifest-utils.ts";
-import { unauthorized, forbidden, notFound, internalError } from "../lib/errors.ts";
+import { unauthorized, forbidden, notFound, invalidRequest, internalError } from "../lib/errors.ts";
 import { actorFromIds, type Actor } from "../lib/actor.ts";
 
 /**
@@ -178,6 +178,42 @@ export function createInternalRouter() {
     });
 
     return c.json(result);
+  });
+
+  // POST /internal/connections/report-auth-failure — sidecar reports upstream 401
+  router.post("/connections/report-auth-failure", async (c) => {
+    const { runId, run } = await verifyRunToken(c);
+    const body = await c.req.json();
+    const parsed = z.object({ providerId: z.string().min(1) }).safeParse(body);
+    if (!parsed.success) {
+      throw invalidRequest("Missing or invalid providerId");
+    }
+    const { providerId } = parsed.data;
+
+    const profileId = run.providerProfileIds?.[providerId];
+    if (!profileId) {
+      logger.warn("Auth failure report for unknown provider profile", { runId, providerId });
+      return c.json({ flagged: false });
+    }
+
+    await db
+      .update(userProviderConnections)
+      .set({ needsReconnection: true, updatedAt: new Date() })
+      .where(
+        and(
+          eq(userProviderConnections.profileId, profileId),
+          eq(userProviderConnections.providerId, providerId),
+          eq(userProviderConnections.orgId, run.orgId),
+        ),
+      );
+
+    logger.info("Connection flagged for reconnection after upstream 401", {
+      runId,
+      providerId,
+      profileId,
+    });
+
+    return c.json({ flagged: true });
   });
 
   return router;

--- a/apps/api/src/routes/providers.ts
+++ b/apps/api/src/routes/providers.ts
@@ -4,7 +4,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { eq, and, sql } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
-import { providerCredentials, packages } from "@appstrate/db/schema";
+import { providerCredentials, packages, userProviderConnections } from "@appstrate/db/schema";
 import type { AppEnv } from "../types/index.ts";
 import type { ProviderConfig } from "@appstrate/shared-types";
 import type { JSONSchemaObject } from "@appstrate/core/form";
@@ -422,6 +422,7 @@ export function createProvidersRouter() {
       const credSchema = z.object({
         credentials: z.record(z.string(), z.string().min(1)).optional(),
         enabled: z.boolean().optional(),
+        invalidateConnections: z.boolean().optional(),
       });
       const data = parseBody(credSchema, body);
 
@@ -474,6 +475,22 @@ export function createProvidersRouter() {
           target: [providerCredentials.providerId, providerCredentials.orgId],
           set: setClause,
         });
+
+      // Invalidate all user connections when admin explicitly requests it (credential rotation)
+      if (hasCredentials && data.invalidateConnections) {
+        await db
+          .delete(userProviderConnections)
+          .where(
+            and(
+              eq(userProviderConnections.providerId, providerId),
+              eq(userProviderConnections.orgId, orgId),
+            ),
+          );
+        logger.info("Invalidated user connections after credential update", {
+          providerId,
+          orgId,
+        });
+      }
 
       return c.json({ configured: true });
     },

--- a/apps/api/src/services/connection-manager/providers.ts
+++ b/apps/api/src/services/connection-manager/providers.ts
@@ -49,6 +49,7 @@ export async function getAvailableProvidersWithStatus(
         authMode: authModeLabel(provider.authMode),
         connectionId: conn.id,
         connectedAt: conn.createdAt,
+        scopesGranted: conn.scopesGranted,
       };
     }
     return {

--- a/apps/api/src/services/connection-manager/status.ts
+++ b/apps/api/src/services/connection-manager/status.ts
@@ -27,7 +27,7 @@ export async function getConnectionStatus(
   if (conn) {
     return {
       provider,
-      status: "connected",
+      status: conn.needsReconnection ? "needs_reconnection" : "connected",
       connectionId: conn.id,
       connectedAt: conn.createdAt,
       scopesGranted: conn.scopesGranted,
@@ -101,7 +101,12 @@ async function buildProfileInfoMap(
 async function batchGetConnectionStatuses(
   profileIds: string[],
   orgId: string,
-): Promise<Map<string, { id: string; createdAt: string; scopesGranted: string[] | null }>> {
+): Promise<
+  Map<
+    string,
+    { id: string; createdAt: string; scopesGranted: string[] | null; needsReconnection: boolean }
+  >
+> {
   if (profileIds.length === 0) return new Map();
 
   const rows = await db
@@ -111,6 +116,7 @@ async function batchGetConnectionStatuses(
       providerId: userProviderConnections.providerId,
       createdAt: userProviderConnections.createdAt,
       scopesGranted: userProviderConnections.scopesGranted,
+      needsReconnection: userProviderConnections.needsReconnection,
     })
     .from(userProviderConnections)
     .where(
@@ -120,13 +126,17 @@ async function batchGetConnectionStatuses(
       ),
     );
 
-  const map = new Map<string, { id: string; createdAt: string; scopesGranted: string[] | null }>();
+  const map = new Map<
+    string,
+    { id: string; createdAt: string; scopesGranted: string[] | null; needsReconnection: boolean }
+  >();
   for (const row of rows) {
     const key = `${row.profileId}:${row.providerId}`;
     map.set(key, {
       id: row.id,
       createdAt: toISORequired(row.createdAt) || toISORequired(new Date()),
       scopesGranted: row.scopesGranted,
+      needsReconnection: row.needsReconnection,
     });
   }
   return map;
@@ -190,7 +200,11 @@ export async function resolveProviderStatuses(
     // Look up connection from batch-fetched map
     const connKey = `${entry.profileId}:${svc.id}`;
     const conn = connectionMap.get(connKey);
-    const connStatus: ConnectionStatusValue = conn ? "connected" : "not_connected";
+    const connStatus: ConnectionStatusValue = conn
+      ? conn.needsReconnection
+        ? "needs_reconnection"
+        : "connected"
+      : "not_connected";
 
     const profileInfo = profileInfoMap.get(entry.profileId) ?? {
       profileName: null,

--- a/apps/api/src/services/dependency-validation.ts
+++ b/apps/api/src/services/dependency-validation.ts
@@ -19,7 +19,10 @@ export interface DependencyValidationDeps {
     connectionProfileId: string,
     orgId: string,
   ) => Promise<ConnectionStatus>;
-  validateScopes: (granted: string[], required: string[]) => { sufficient: boolean };
+  validateScopes: (
+    granted: string[],
+    required: string[],
+  ) => { sufficient: boolean; missing: string[] };
 }
 
 const defaultDeps: DependencyValidationDeps = {
@@ -100,7 +103,7 @@ export async function validateAgentDependencies(
           status: 400,
           code: "scope_insufficient",
           title: "Scope Insufficient",
-          detail: `Provider '${provider.id}' requires additional permissions`,
+          detail: `Provider '${provider.id}' requires additional permissions: ${scopeResult.missing.join(", ")}`,
         });
       }
     }

--- a/apps/api/test/helpers/seed.ts
+++ b/apps/api/test/helpers/seed.ts
@@ -20,8 +20,10 @@ import {
   orgProviderKeys,
   orgModels,
   connectionProfiles,
+  userProviderConnections,
   orgInvitations,
   packageVersions,
+  providerCredentials,
 } from "@appstrate/db/schema";
 import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
 
@@ -312,6 +314,52 @@ export async function seedConnectionProfile(
     })
     .returning();
   return profile!;
+}
+
+// ─── User Provider Connections ────────────────────────────
+
+type UserConnectionInsert = Partial<InferInsertModel<typeof userProviderConnections>> & {
+  profileId: string;
+  providerId: string;
+  orgId: string;
+};
+
+export async function seedUserConnection(
+  overrides: UserConnectionInsert,
+): Promise<InferSelectModel<typeof userProviderConnections>> {
+  const [conn] = await db
+    .insert(userProviderConnections)
+    .values({
+      credentialsEncrypted: "test-encrypted",
+      ...overrides,
+    })
+    .returning();
+  return conn!;
+}
+
+// ─── Provider Credentials ────────────────────────────────
+
+type ProviderCredentialsInsert = Partial<InferInsertModel<typeof providerCredentials>> & {
+  providerId: string;
+  orgId: string;
+};
+
+export async function seedProviderCredentials(
+  overrides: ProviderCredentialsInsert,
+): Promise<InferInsertModel<typeof providerCredentials>> {
+  const values = {
+    enabled: true,
+    credentialsEncrypted: "test-admin-encrypted",
+    ...overrides,
+  };
+  await db
+    .insert(providerCredentials)
+    .values(values)
+    .onConflictDoUpdate({
+      target: [providerCredentials.providerId, providerCredentials.orgId],
+      set: values,
+    });
+  return values;
 }
 
 // ─── Invitations ──────────────────────────────────────────

--- a/apps/api/test/integration/routes/providers.test.ts
+++ b/apps/api/test/integration/routes/providers.test.ts
@@ -4,7 +4,15 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import { getTestApp } from "../../helpers/app.ts";
 import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
-import { seedPackage } from "../../helpers/seed.ts";
+import {
+  seedPackage,
+  seedConnectionProfile,
+  seedUserConnection,
+  seedProviderCredentials,
+} from "../../helpers/seed.ts";
+import { assertDbCount } from "../../helpers/assertions.ts";
+import { userProviderConnections } from "@appstrate/db/schema";
+import { eq } from "drizzle-orm";
 
 const app = getTestApp();
 
@@ -268,6 +276,145 @@ describe("Providers API", () => {
       });
 
       expect(res.status).toBe(404);
+    });
+  });
+
+  // ─── PUT /api/providers/credentials — invalidateConnections ──
+
+  describe("PUT /api/providers/credentials/:scope/:name — invalidateConnections", () => {
+    const providerId = "@provorg/oauth-provider";
+
+    async function setupProviderWithConnections() {
+      await seedPackage({
+        id: providerId,
+        orgId: ctx.orgId,
+        type: "provider",
+        draftManifest: {
+          name: providerId,
+          type: "provider",
+          version: "1.0.0",
+          displayName: "OAuth Provider",
+          definition: { authMode: "oauth2" },
+        },
+      });
+
+      await seedProviderCredentials({
+        providerId,
+        orgId: ctx.orgId,
+      });
+
+      const profile = await seedConnectionProfile({
+        userId: ctx.user.id,
+        isDefault: true,
+      });
+
+      await seedUserConnection({
+        profileId: profile.id,
+        providerId,
+        orgId: ctx.orgId,
+      });
+
+      return profile;
+    }
+
+    it("deletes user connections when invalidateConnections is true", async () => {
+      await setupProviderWithConnections();
+      await assertDbCount(
+        userProviderConnections,
+        eq(userProviderConnections.providerId, providerId),
+        1,
+      );
+
+      const res = await app.request(`/api/providers/credentials/@provorg/oauth-provider`, {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          credentials: { clientId: "new-id", clientSecret: "new-secret" },
+          invalidateConnections: true,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      await assertDbCount(
+        userProviderConnections,
+        eq(userProviderConnections.providerId, providerId),
+        0,
+      );
+    });
+
+    it("preserves user connections when invalidateConnections is false", async () => {
+      await setupProviderWithConnections();
+      await assertDbCount(
+        userProviderConnections,
+        eq(userProviderConnections.providerId, providerId),
+        1,
+      );
+
+      const res = await app.request(`/api/providers/credentials/@provorg/oauth-provider`, {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          credentials: { clientId: "new-id", clientSecret: "new-secret" },
+          invalidateConnections: false,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      await assertDbCount(
+        userProviderConnections,
+        eq(userProviderConnections.providerId, providerId),
+        1,
+      );
+    });
+
+    it("preserves user connections when invalidateConnections is omitted", async () => {
+      await setupProviderWithConnections();
+      await assertDbCount(
+        userProviderConnections,
+        eq(userProviderConnections.providerId, providerId),
+        1,
+      );
+
+      const res = await app.request(`/api/providers/credentials/@provorg/oauth-provider`, {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          credentials: { clientId: "new-id", clientSecret: "new-secret" },
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      await assertDbCount(
+        userProviderConnections,
+        eq(userProviderConnections.providerId, providerId),
+        1,
+      );
+    });
+
+    it("does not delete connections when only enabled changes", async () => {
+      await setupProviderWithConnections();
+      await assertDbCount(
+        userProviderConnections,
+        eq(userProviderConnections.providerId, providerId),
+        1,
+      );
+
+      const res = await app.request(`/api/providers/credentials/@provorg/oauth-provider`, {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          enabled: false,
+          invalidateConnections: true,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      // invalidateConnections only takes effect when credentials are provided
+      await assertDbCount(
+        userProviderConnections,
+        eq(userProviderConnections.providerId, providerId),
+        1,
+      );
     });
   });
 });

--- a/apps/api/test/unit/dependency-validation.test.ts
+++ b/apps/api/test/unit/dependency-validation.test.ts
@@ -25,7 +25,7 @@ function createMockDeps(overrides?: Partial<DependencyValidationDeps>): Dependen
       status: "connected" as const,
       scopesGranted: ["read", "write"],
     }),
-    validateScopes: () => ({ sufficient: true }),
+    validateScopes: () => ({ sufficient: true, missing: [] }),
     ...overrides,
   };
 }
@@ -112,7 +112,7 @@ describe("validateAgentDependencies", () => {
 
   it("throws when scopes are insufficient", async () => {
     const deps = createMockDeps({
-      validateScopes: () => ({ sufficient: false }),
+      validateScopes: () => ({ sufficient: false, missing: ["write"] }),
     });
     const providers = [{ id: "@test/gmail", scopes: ["read", "write"] }];
     const profiles = profileMap({ "@test/gmail": "profile-1" });
@@ -123,6 +123,7 @@ describe("validateAgentDependencies", () => {
     } catch (err) {
       expect(err).toBeInstanceOf(ApiError);
       expect((err as ApiError).code).toBe("scope_insufficient");
+      expect((err as ApiError).message).toContain("write");
     }
   });
 
@@ -131,7 +132,7 @@ describe("validateAgentDependencies", () => {
     const deps = createMockDeps({
       validateScopes: () => {
         scopesCalled = true;
-        return { sufficient: true };
+        return { sufficient: true, missing: [] };
       },
     });
     const providers = [{ id: "@test/gmail" }];
@@ -146,7 +147,7 @@ describe("validateAgentDependencies", () => {
     const deps = createMockDeps({
       validateScopes: () => {
         scopesCalled = true;
-        return { sufficient: true };
+        return { sufficient: true, missing: [] };
       },
     });
     const providers = [{ id: "@test/gmail", scopes: [] }];

--- a/apps/web/src/components/connection-summary-modal.tsx
+++ b/apps/web/src/components/connection-summary-modal.tsx
@@ -1,7 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useTranslation } from "react-i18next";
-import { Building2, User, AlertTriangle, AlertCircle, CheckCircle2, Plug } from "lucide-react";
+import {
+  Building2,
+  User,
+  AlertTriangle,
+  AlertCircle,
+  CheckCircle2,
+  Plug,
+  Shield,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "./spinner";
 import { Modal } from "./modal";
@@ -32,7 +40,9 @@ export function ConnectionSummaryModal({
   const { t } = useTranslation(["agents", "settings", "common"]);
   const { data: providersData } = useProviders();
 
-  const allReady = providers.every((p) => isProviderStatusConnected(p.status));
+  const allReady = providers.every(
+    (p) => isProviderStatusConnected(p.status) && p.scopesSufficient !== false,
+  );
 
   return (
     <Modal
@@ -103,7 +113,12 @@ export function ConnectionSummaryModal({
                 </span>
               )}
 
-              {isConnected && svc.status === "needs_reconnection" ? (
+              {isConnected && svc.scopesSufficient === false ? (
+                <span className="inline-flex items-center gap-1 text-xs text-amber-500">
+                  <Shield className="size-3.5 shrink-0" />
+                  {t("providerCard.scopesMissing")}
+                </span>
+              ) : isConnected && svc.status === "needs_reconnection" ? (
                 <AlertCircle className="size-3.5 shrink-0 text-amber-500" />
               ) : isConnected ? (
                 <CheckCircle2 className="text-success size-3.5 shrink-0" />

--- a/apps/web/src/components/package-detail/agent-providers-section.tsx
+++ b/apps/web/src/components/package-detail/agent-providers-section.tsx
@@ -47,6 +47,8 @@ export function AgentProvidersSection({
           packageId={packageId}
           orgProfileId={agentOrgProfileId ?? undefined}
           orgProfileName={agentOrgProfileName ?? undefined}
+          scopesRequired={svc.scopesRequired}
+          scopesMissing={svc.scopesMissing}
         />
       ))}
     </div>

--- a/apps/web/src/components/provider-connection-card.tsx
+++ b/apps/web/src/components/provider-connection-card.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { CheckCircle2, AlertTriangle, Unlink, Plug, Building2 } from "lucide-react";
+import { CheckCircle2, AlertTriangle, Unlink, Plug, Building2, Shield } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -30,6 +30,10 @@ interface ProviderConnectionCardProps {
   readOnly?: boolean;
   /** Profile ID to check connection status for (e.g. schedule owner's profile). */
   viewProfileId?: string;
+  /** Scopes required by the agent for this provider. */
+  scopesRequired?: string[];
+  /** Scopes missing from the current connection (subset of scopesRequired). */
+  scopesMissing?: string[];
 }
 
 export function ProviderConnectionCard({
@@ -39,6 +43,8 @@ export function ProviderConnectionCard({
   orgProfileName,
   readOnly: readOnlyProp,
   viewProfileId,
+  scopesRequired,
+  scopesMissing,
 }: ProviderConnectionCardProps) {
   const { t } = useTranslation(["settings", "agents"]);
 
@@ -47,6 +53,7 @@ export function ProviderConnectionCard({
     hasMultipleProfiles,
     effectiveProfileId,
     isConnected,
+    profileConnections,
     binding,
     isBoundButDisconnected,
     isEffectivelyBound,
@@ -81,13 +88,19 @@ export function ProviderConnectionCard({
   const authMode = provider?.authMode;
   const credentialSchema = provider?.credentialSchema as JSONSchemaObject | undefined;
 
+  const hasMissingScopes = scopesMissing && scopesMissing.length > 0;
+
   const handleConnect = () => {
     if (authMode === "api_key") {
       setApiKeyOpen(true);
     } else if (authMode === "custom" && credentialSchema) {
       setCustomCredOpen(true);
     } else {
-      connectMutation.mutate({ provider: providerId, ...profileParam });
+      connectMutation.mutate({
+        provider: providerId,
+        ...(scopesRequired ? { scopes: scopesRequired } : {}),
+        ...profileParam,
+      });
     }
   };
 
@@ -98,6 +111,7 @@ export function ProviderConnectionCard({
   // ─── Determine active mode: org-bound or user-managed ────
 
   const isOrgMode = isEffectivelyBound || isBoundButDisconnected;
+  const scopesGranted = profileConnections?.find((c) => c.providerId === providerId)?.scopesGranted;
 
   return (
     <>
@@ -147,10 +161,46 @@ export function ProviderConnectionCard({
           /* ─── User-managed mode: profile selector + connect/disconnect ── */
           <>
             {isConnected ? (
-              <span className="text-success inline-flex shrink-0 items-center gap-1 text-xs">
-                <CheckCircle2 className="size-3" />
-                {t("providers.connected")}
-              </span>
+              <div className="flex shrink-0 items-center gap-2">
+                {hasMissingScopes ? (
+                  <span className="inline-flex items-center gap-1 text-xs text-amber-500">
+                    <AlertTriangle className="size-3" />
+                    {t("providerCard.scopesMissing", { ns: "agents" })}
+                  </span>
+                ) : (
+                  <span className="text-success inline-flex items-center gap-1 text-xs">
+                    <CheckCircle2 className="size-3" />
+                    {t("providers.connected")}
+                  </span>
+                )}
+                {scopesGranted && scopesGranted.length > 0 && (
+                  <div className="flex items-center gap-1">
+                    <Shield className="text-muted-foreground size-3" />
+                    {scopesGranted.map((scope) => (
+                      <span
+                        key={scope}
+                        className={`rounded px-1.5 py-0.5 font-mono text-[10px] ${
+                          scopesMissing?.includes(scope)
+                            ? "bg-amber-500/10 text-amber-500"
+                            : "bg-muted text-muted-foreground"
+                        }`}
+                      >
+                        {scope}
+                      </span>
+                    ))}
+                    {scopesMissing?.map((scope) =>
+                      !scopesGranted.includes(scope) ? (
+                        <span
+                          key={scope}
+                          className="rounded bg-amber-500/10 px-1.5 py-0.5 font-mono text-[10px] text-amber-500"
+                        >
+                          {scope}
+                        </span>
+                      ) : null,
+                    )}
+                  </div>
+                )}
+              </div>
             ) : readOnly ? (
               <span className="text-muted-foreground inline-flex shrink-0 items-center gap-1 text-xs">
                 <AlertTriangle className="size-3" />
@@ -187,7 +237,19 @@ export function ProviderConnectionCard({
                     {t("providerCard.connect")}
                   </Button>
                 )}
-                {isConnected && (
+                {isConnected && hasMissingScopes && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-7 border-amber-500/50 px-2 text-xs text-amber-500 hover:bg-amber-500/10"
+                    onClick={handleConnect}
+                    disabled={isPending}
+                  >
+                    <Shield className="mr-1 size-3" />
+                    {t("providerCard.updatePermissions", { ns: "agents" })}
+                  </Button>
+                )}
+                {isConnected && !hasMissingScopes && (
                   <Button
                     variant="outline"
                     size="sm"

--- a/apps/web/src/components/provider-credentials-form.tsx
+++ b/apps/web/src/components/provider-credentials-form.tsx
@@ -8,7 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Spinner } from "./spinner";
 import { useConfigureProviderCredentials } from "../hooks/use-mutations";
-import { ExternalLink, Copy, Check } from "lucide-react";
+import { ExternalLink, Copy, Check, AlertTriangle } from "lucide-react";
 import type { ProviderConfig } from "@appstrate/shared-types";
 
 interface ProviderCredentialsFormProps {
@@ -33,6 +33,7 @@ export function ProviderCredentialsForm({
   const mutation = useConfigureProviderCredentials();
   const [visibleFields, setVisibleFields] = useState<Record<string, boolean>>({});
   const [copied, setCopied] = useState(false);
+  const [invalidateConnections, setInvalidateConnections] = useState(true);
 
   const schema = provider.adminCredentialSchema;
   const properties = schema?.properties ?? {};
@@ -80,6 +81,7 @@ export function ProviderCredentialsForm({
       providerId: string;
       credentials?: Record<string, string>;
       enabled: boolean;
+      invalidateConnections?: boolean;
     } = { providerId: provider.id, enabled: true };
 
     if (hasSchemaFields) {
@@ -94,6 +96,9 @@ export function ProviderCredentialsForm({
       }
     }
 
+    if (provider.hasCredentials && payload.credentials) {
+      payload.invalidateConnections = invalidateConnections;
+    }
     mutation.mutate(payload, { onSuccess });
   };
 
@@ -190,6 +195,22 @@ export function ProviderCredentialsForm({
           </div>
         )}
       </div>
+
+      {/* Warning: credential update invalidates user connections */}
+      {provider.hasCredentials && hasSchemaFields && (
+        <label className="mt-4 flex items-start gap-2 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2.5">
+          <input
+            type="checkbox"
+            checked={invalidateConnections}
+            onChange={(e) => setInvalidateConnections(e.target.checked)}
+            className="mt-0.5"
+          />
+          <span className="text-xs text-amber-600 dark:text-amber-400">
+            <AlertTriangle className="mr-1 inline size-3" />
+            {t("providers.form.invalidateWarning")}
+          </span>
+        </label>
+      )}
 
       <div className="border-border mt-4 flex items-center border-t pt-4">
         <div className="flex-1">{footer}</div>

--- a/apps/web/src/components/register-form.tsx
+++ b/apps/web/src/components/register-form.tsx
@@ -74,7 +74,7 @@ export function RegisterForm({
           data.password,
           data.displayName.trim() || undefined,
         );
-        if (result.emailVerificationRequired) {
+        if (features.smtp && result.emailVerificationRequired) {
           navigate("/verify-email", { state: { email: data.email } });
         }
       }

--- a/apps/web/src/hooks/use-mutations.ts
+++ b/apps/web/src/hooks/use-mutations.ts
@@ -381,14 +381,16 @@ export function useConfigureProviderCredentials() {
       providerId,
       credentials,
       enabled,
+      invalidateConnections,
     }: {
       providerId: string;
       credentials?: Record<string, string>;
       enabled?: boolean;
+      invalidateConnections?: boolean;
     }) => {
       return api(`/providers/credentials/${providerId}`, {
         method: "PUT",
-        body: JSON.stringify({ credentials, enabled }),
+        body: JSON.stringify({ credentials, enabled, invalidateConnections }),
       });
     },
     onSuccess: () => invalidateProviderQueries(qc),

--- a/apps/web/src/lib/provider-status.ts
+++ b/apps/web/src/lib/provider-status.ts
@@ -20,10 +20,14 @@ export function isProviderConnectedInProfile(
 }
 
 /**
- * Check whether any provider in the list is not connected.
+ * Check whether any provider in the list is not connected or has insufficient scopes.
  */
-export function hasDisconnectedProviders(providers: Array<{ status: string }>): boolean {
-  return providers.some((p) => !isProviderStatusConnected(p.status));
+export function hasDisconnectedProviders(
+  providers: Array<{ status: string; scopesSufficient?: boolean | null }>,
+): boolean {
+  return providers.some(
+    (p) => !isProviderStatusConnected(p.status) || p.scopesSufficient === false,
+  );
 }
 
 /**

--- a/apps/web/src/lib/test/provider-status.test.ts
+++ b/apps/web/src/lib/test/provider-status.test.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "bun:test";
+import { hasDisconnectedProviders, isProviderStatusConnected } from "../provider-status";
+
+describe("isProviderStatusConnected", () => {
+  it("returns true for connected", () => {
+    expect(isProviderStatusConnected("connected")).toBe(true);
+  });
+
+  it("returns true for needs_reconnection", () => {
+    expect(isProviderStatusConnected("needs_reconnection")).toBe(true);
+  });
+
+  it("returns false for not_connected", () => {
+    expect(isProviderStatusConnected("not_connected")).toBe(false);
+  });
+});
+
+describe("hasDisconnectedProviders", () => {
+  it("returns false when all providers are connected with sufficient scopes", () => {
+    const providers = [
+      { status: "connected", scopesSufficient: true },
+      { status: "connected", scopesSufficient: true },
+    ];
+    expect(hasDisconnectedProviders(providers)).toBe(false);
+  });
+
+  it("returns true when a provider is not connected", () => {
+    const providers = [
+      { status: "connected", scopesSufficient: true },
+      { status: "not_connected" },
+    ];
+    expect(hasDisconnectedProviders(providers)).toBe(true);
+  });
+
+  it("returns true when a provider has insufficient scopes", () => {
+    const providers = [
+      { status: "connected", scopesSufficient: true },
+      { status: "connected", scopesSufficient: false },
+    ];
+    expect(hasDisconnectedProviders(providers)).toBe(true);
+  });
+
+  it("returns false when scopesSufficient is undefined (no scope requirements)", () => {
+    const providers = [{ status: "connected" }, { status: "connected" }];
+    expect(hasDisconnectedProviders(providers)).toBe(false);
+  });
+
+  it("returns false when scopesSufficient is null", () => {
+    const providers = [{ status: "connected", scopesSufficient: null }];
+    expect(hasDisconnectedProviders(providers)).toBe(false);
+  });
+});

--- a/apps/web/src/locales/en/agents.json
+++ b/apps/web/src/locales/en/agents.json
@@ -337,5 +337,7 @@
   "schedule.providersNotBoundWarning": "Some providers are not bound to this profile. The schedule cannot run until all required providers are bound.",
   "run.notConnected": "Not connected",
   "run.notAllConnected": "All providers must be connected before running this agent.",
-  "run.configureConnections": "Configure connections"
+  "run.configureConnections": "Configure connections",
+  "providerCard.scopesMissing": "Insufficient permissions",
+  "providerCard.updatePermissions": "Update permissions"
 }

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -255,6 +255,7 @@
   "providers.form.activated": "Activated",
   "providers.form.submit": "Add provider",
   "providers.form.noCredsNeeded": "No credentials needed at this step. After creation, go to the Connectors page to add your API key.",
+  "providers.form.invalidateWarning": "Invalidate existing connections. Users will need to reconnect this provider.",
   "orgSettings.pendingInvitations": "Pending invitations",
   "orgSettings.invited": "Invited",
   "orgSettings.invitationSent": "Invitation sent by email.",

--- a/apps/web/src/locales/fr/agents.json
+++ b/apps/web/src/locales/fr/agents.json
@@ -337,5 +337,7 @@
   "schedule.providersNotBoundWarning": "Certains services ne sont pas liés à ce profil. La planification ne pourra pas s'exécuter tant que tous les services requis ne sont pas liés.",
   "run.notConnected": "Non connecté",
   "run.notAllConnected": "Tous les providers doivent être connectés avant de lancer cet agent.",
-  "run.configureConnections": "Configurer les connexions"
+  "run.configureConnections": "Configurer les connexions",
+  "providerCard.scopesMissing": "Permissions insuffisantes",
+  "providerCard.updatePermissions": "Mettre à jour"
 }

--- a/apps/web/src/locales/fr/settings.json
+++ b/apps/web/src/locales/fr/settings.json
@@ -255,6 +255,7 @@
   "providers.form.activated": "Activé",
   "providers.form.submit": "Ajouter le provider",
   "providers.form.noCredsNeeded": "Aucun identifiant requis à cette étape. Après la création, allez sur la page Providers pour ajouter votre clé API.",
+  "providers.form.invalidateWarning": "Invalider les connexions existantes. Les utilisateurs devront reconnecter ce provider.",
   "orgSettings.pendingInvitations": "Invitations en attente",
   "orgSettings.invited": "Invité",
   "orgSettings.invitationSent": "Invitation envoyée par email.",

--- a/packages/connect/src/credentials.ts
+++ b/packages/connect/src/credentials.ts
@@ -205,6 +205,7 @@ export async function saveConnection(
     credentialsEncrypted: encrypted,
     scopesGranted: options?.scopesGranted ?? [],
     expiresAt: options?.expiresAt ? new Date(options.expiresAt) : null,
+    needsReconnection: false,
   };
 
   await db
@@ -266,6 +267,7 @@ function rowToConnection(row: typeof userProviderConnections.$inferSelect): Conn
     orgId: row.orgId,
     credentialsEncrypted: row.credentialsEncrypted,
     scopesGranted: (row.scopesGranted as string[]) ?? [],
+    needsReconnection: row.needsReconnection,
     expiresAt: row.expiresAt?.toISOString() ?? null,
     createdAt: row.createdAt!.toISOString(),
     updatedAt: row.updatedAt!.toISOString(),

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -20,6 +20,7 @@ export interface ConnectionRecord {
   orgId: string;
   credentialsEncrypted: string;
   scopesGranted: string[];
+  needsReconnection: boolean;
   expiresAt: string | null;
   createdAt: string;
   updatedAt: string;

--- a/packages/db/drizzle/0017_add_needs_reconnection.sql
+++ b/packages/db/drizzle/0017_add_needs_reconnection.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user_provider_connections" ADD COLUMN IF NOT EXISTS "needs_reconnection" boolean DEFAULT false NOT NULL;

--- a/packages/db/drizzle/meta/0017_snapshot.json
+++ b/packages/db/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,4146 @@
+{
+  "id": "e2883e0a-b6a5-4c5c-b05f-7bb882e04c82",
+  "prevId": "e2ed713e-5b3c-4d3b-b8c8-1c0cca0c616a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_keys_org_id": {
+          "name": "idx_api_keys_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_keys_application_id": {
+          "name": "idx_api_keys_application_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_keys_key_hash": {
+          "name": "idx_api_keys_key_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_keys_key_prefix": {
+          "name": "idx_api_keys_key_prefix",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_org_id_organizations_id_fk": {
+          "name": "api_keys_org_id_organizations_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_application_id_applications_id_fk": {
+          "name": "api_keys_application_id_applications_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_created_by_user_id_fk": {
+          "name": "api_keys_created_by_user_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_invitations": {
+      "name": "org_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_invitations_token": {
+          "name": "idx_org_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_invitations_org_id": {
+          "name": "idx_org_invitations_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_invitations_email": {
+          "name": "idx_org_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_invitations_org_id_organizations_id_fk": {
+          "name": "org_invitations_org_id_organizations_id_fk",
+          "tableFrom": "org_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_invitations_invited_by_user_id_fk": {
+          "name": "org_invitations_invited_by_user_id_fk",
+          "tableFrom": "org_invitations",
+          "tableTo": "user",
+          "columnsFrom": ["invited_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "org_invitations_accepted_by_user_id_fk": {
+          "name": "org_invitations_accepted_by_user_id_fk",
+          "tableFrom": "org_invitations",
+          "tableTo": "user",
+          "columnsFrom": ["accepted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_invitations_token_unique": {
+          "name": "org_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_models": {
+      "name": "org_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api": {
+          "name": "api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_key_id": {
+          "name": "provider_key_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_models_org_id": {
+          "name": "idx_org_models_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_models_one_default": {
+          "name": "idx_org_models_one_default",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"org_models\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_models_org_id_organizations_id_fk": {
+          "name": "org_models_org_id_organizations_id_fk",
+          "tableFrom": "org_models",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_models_provider_key_id_org_provider_keys_id_fk": {
+          "name": "org_models_provider_key_id_org_provider_keys_id_fk",
+          "tableFrom": "org_models",
+          "tableTo": "org_provider_keys",
+          "columnsFrom": ["provider_key_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_models_created_by_user_id_fk": {
+          "name": "org_models_created_by_user_id_fk",
+          "tableFrom": "org_models",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_provider_keys": {
+      "name": "org_provider_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api": {
+          "name": "api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_encrypted": {
+          "name": "api_key_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_provider_keys_org_id": {
+          "name": "idx_org_provider_keys_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_provider_keys_org_id_organizations_id_fk": {
+          "name": "org_provider_keys_org_id_organizations_id_fk",
+          "tableFrom": "org_provider_keys",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_provider_keys_created_by_user_id_fk": {
+          "name": "org_provider_keys_created_by_user_id_fk",
+          "tableFrom": "org_provider_keys",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_proxies": {
+      "name": "org_proxies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_encrypted": {
+          "name": "url_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_proxies_org_id": {
+          "name": "idx_org_proxies_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_proxies_one_default": {
+          "name": "idx_org_proxies_one_default",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"org_proxies\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_proxies_org_id_organizations_id_fk": {
+          "name": "org_proxies_org_id_organizations_id_fk",
+          "tableFrom": "org_proxies",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_proxies_created_by_user_id_fk": {
+          "name": "org_proxies_created_by_user_id_fk",
+          "tableFrom": "org_proxies",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_members_user_id": {
+          "name": "idx_org_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_members_org_id_organizations_id_fk": {
+          "name": "org_members_org_id_organizations_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_members_user_id_user_id_fk": {
+          "name": "org_members_user_id_user_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_members_org_id_user_id_pk": {
+          "name": "org_members_org_id_user_id_pk",
+          "columns": ["org_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_created_by_user_id_fk": {
+          "name": "organizations_created_by_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_applications_org_id": {
+          "name": "idx_applications_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_applications_one_default": {
+          "name": "idx_applications_one_default",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"applications\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_org_id_organizations_id_fk": {
+          "name": "applications_org_id_organizations_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applications_created_by_user_id_fk": {
+          "name": "applications_created_by_user_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.end_users": {
+      "name": "end_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_end_users_external_id": {
+          "name": "idx_end_users_external_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"end_users\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_end_users_app_email": {
+          "name": "idx_end_users_app_email",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "email IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_end_users_application_id": {
+          "name": "idx_end_users_application_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_end_users_org_id": {
+          "name": "idx_end_users_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "end_users_application_id_applications_id_fk": {
+          "name": "end_users_application_id_applications_id_fk",
+          "tableFrom": "end_users",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "end_users_org_id_organizations_id_fk": {
+          "name": "end_users_org_id_organizations_id_fk",
+          "tableFrom": "end_users",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_user_id_fk": {
+          "name": "profiles_id_user_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "user",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "language_check": {
+          "name": "language_check",
+          "value": "\"profiles\".\"language\" IN ('fr', 'en')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.package_configs": {
+      "name": "package_configs",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_id": {
+          "name": "proxy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_profile_id": {
+          "name": "org_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_package_configs_org_id": {
+          "name": "idx_package_configs_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_package_configs_org_profile_id": {
+          "name": "idx_package_configs_org_profile_id",
+          "columns": [
+            {
+              "expression": "org_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_configs_org_id_organizations_id_fk": {
+          "name": "package_configs_org_id_organizations_id_fk",
+          "tableFrom": "package_configs",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_configs_package_id_packages_id_fk": {
+          "name": "package_configs_package_id_packages_id_fk",
+          "tableFrom": "package_configs",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_configs_org_profile_id_connection_profiles_id_fk": {
+          "name": "package_configs_org_profile_id_connection_profiles_id_fk",
+          "tableFrom": "package_configs",
+          "tableTo": "connection_profiles",
+          "columnsFrom": ["org_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "package_configs_org_id_package_id_pk": {
+          "name": "package_configs_org_id_package_id_pk",
+          "columns": ["org_id", "package_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.package_dist_tags": {
+      "name": "package_dist_tags",
+      "schema": "",
+      "columns": {
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "package_dist_tags_package_id_packages_id_fk": {
+          "name": "package_dist_tags_package_id_packages_id_fk",
+          "tableFrom": "package_dist_tags",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_dist_tags_version_id_package_versions_id_fk": {
+          "name": "package_dist_tags_version_id_package_versions_id_fk",
+          "tableFrom": "package_dist_tags",
+          "tableTo": "package_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "package_dist_tags_package_id_tag_pk": {
+          "name": "package_dist_tags_package_id_tag_pk",
+          "columns": ["package_id", "tag"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.package_version_dependencies": {
+      "name": "package_version_dependencies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dep_scope": {
+          "name": "dep_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dep_name": {
+          "name": "dep_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dep_type": {
+          "name": "dep_type",
+          "type": "package_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_range": {
+          "name": "version_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pkg_ver_deps_unique": {
+          "name": "pkg_ver_deps_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dep_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dep_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dep_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pkg_ver_deps_version_id": {
+          "name": "idx_pkg_ver_deps_version_id",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_version_dependencies_version_id_package_versions_id_fk": {
+          "name": "package_version_dependencies_version_id_package_versions_id_fk",
+          "tableFrom": "package_version_dependencies",
+          "tableTo": "package_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.package_versions": {
+      "name": "package_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_size": {
+          "name": "artifact_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "yanked": {
+          "name": "yanked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "yanked_reason": {
+          "name": "yanked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "package_versions_pkg_version_unique": {
+          "name": "package_versions_pkg_version_unique",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_package_versions_package_id": {
+          "name": "idx_package_versions_package_id",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_versions_package_id_packages_id_fk": {
+          "name": "package_versions_package_id_packages_id_fk",
+          "tableFrom": "package_versions",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_versions_org_id_organizations_id_fk": {
+          "name": "package_versions_org_id_organizations_id_fk",
+          "tableFrom": "package_versions",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_versions_created_by_user_id_fk": {
+          "name": "package_versions_created_by_user_id_fk",
+          "tableFrom": "package_versions",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.packages": {
+      "name": "packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "package_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "package_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "draft_manifest": {
+          "name": "draft_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_content": {
+          "name": "draft_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_installed": {
+          "name": "auto_installed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lock_version": {
+          "name": "lock_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_packages_org_id": {
+          "name": "idx_packages_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_packages_type": {
+          "name": "idx_packages_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "packages_org_id_organizations_id_fk": {
+          "name": "packages_org_id_organizations_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "packages_created_by_user_id_fk": {
+          "name": "packages_created_by_user_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "packages_id_format": {
+          "name": "packages_id_format",
+          "value": "\"packages\".\"id\" ~ '^@[a-z0-9][a-z0-9-]*/[a-z0-9][a-z0-9-]*$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.package_memories": {
+      "name": "package_memories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_package_memories_package_org": {
+          "name": "idx_package_memories_package_org",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_package_memories_org_id": {
+          "name": "idx_package_memories_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_memories_package_id_packages_id_fk": {
+          "name": "package_memories_package_id_packages_id_fk",
+          "tableFrom": "package_memories",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_memories_org_id_organizations_id_fk": {
+          "name": "package_memories_org_id_organizations_id_fk",
+          "tableFrom": "package_memories",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_memories_run_id_runs_id_fk": {
+          "name": "package_memories_run_id_runs_id_fk",
+          "tableFrom": "package_memories",
+          "tableTo": "runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.package_schedules": {
+      "name": "package_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_profile_id": {
+          "name": "connection_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_schedules_package_id": {
+          "name": "idx_schedules_package_id",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_connection_profile_id": {
+          "name": "idx_schedules_connection_profile_id",
+          "columns": [
+            {
+              "expression": "connection_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_package_schedules_org_id": {
+          "name": "idx_package_schedules_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_schedules_package_id_packages_id_fk": {
+          "name": "package_schedules_package_id_packages_id_fk",
+          "tableFrom": "package_schedules",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_schedules_connection_profile_id_connection_profiles_id_fk": {
+          "name": "package_schedules_connection_profile_id_connection_profiles_id_fk",
+          "tableFrom": "package_schedules",
+          "tableTo": "connection_profiles",
+          "columnsFrom": ["connection_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_schedules_org_id_organizations_id_fk": {
+          "name": "package_schedules_org_id_organizations_id_fk",
+          "tableFrom": "package_schedules",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.run_logs": {
+      "name": "run_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'progress'"
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'debug'"
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_logs_run_id": {
+          "name": "idx_run_logs_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_logs_lookup": {
+          "name": "idx_run_logs_lookup",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_logs_org_id": {
+          "name": "idx_run_logs_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_logs_run_id_runs_id_fk": {
+          "name": "run_logs_run_id_runs_id_fk",
+          "tableFrom": "run_logs",
+          "tableTo": "runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_logs_org_id_organizations_id_fk": {
+          "name": "run_logs_org_id_organizations_id_fk",
+          "tableFrom": "run_logs",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_usage": {
+          "name": "token_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_profile_id": {
+          "name": "connection_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_version_id": {
+          "name": "package_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_label": {
+          "name": "proxy_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_label": {
+          "name": "model_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_number": {
+          "name": "run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_profile_ids": {
+          "name": "provider_profile_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_runs_package_id": {
+          "name": "idx_runs_package_id",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_status": {
+          "name": "idx_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_user_id": {
+          "name": "idx_runs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_end_user_id": {
+          "name": "idx_runs_end_user_id",
+          "columns": [
+            {
+              "expression": "end_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_application_id": {
+          "name": "idx_runs_application_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_org_id": {
+          "name": "idx_runs_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_notification": {
+          "name": "idx_runs_notification",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notified_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_user_id_user_id_fk": {
+          "name": "runs_user_id_user_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runs_end_user_id_end_users_id_fk": {
+          "name": "runs_end_user_id_end_users_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "end_users",
+          "columnsFrom": ["end_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runs_application_id_applications_id_fk": {
+          "name": "runs_application_id_applications_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runs_org_id_organizations_id_fk": {
+          "name": "runs_org_id_organizations_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_package_version_id_package_versions_id_fk": {
+          "name": "runs_package_version_id_package_versions_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "package_versions",
+          "columnsFrom": ["package_version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runs_at_most_one_actor": {
+          "name": "runs_at_most_one_actor",
+          "value": "NOT (user_id IS NOT NULL AND end_user_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.connection_profiles": {
+      "name": "connection_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_connection_profiles_default": {
+          "name": "idx_connection_profiles_default",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connection_profiles\".\"is_default\" = true AND \"connection_profiles\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connection_profiles_default_end_user": {
+          "name": "idx_connection_profiles_default_end_user",
+          "columns": [
+            {
+              "expression": "end_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"connection_profiles\".\"is_default\" = true AND \"connection_profiles\".\"end_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connection_profiles_user_id": {
+          "name": "idx_connection_profiles_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connection_profiles_end_user_id": {
+          "name": "idx_connection_profiles_end_user_id",
+          "columns": [
+            {
+              "expression": "end_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_connection_profiles_org_id": {
+          "name": "idx_connection_profiles_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "connection_profiles_user_id_user_id_fk": {
+          "name": "connection_profiles_user_id_user_id_fk",
+          "tableFrom": "connection_profiles",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_profiles_end_user_id_end_users_id_fk": {
+          "name": "connection_profiles_end_user_id_end_users_id_fk",
+          "tableFrom": "connection_profiles",
+          "tableTo": "end_users",
+          "columnsFrom": ["end_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "connection_profiles_org_id_organizations_id_fk": {
+          "name": "connection_profiles_org_id_organizations_id_fk",
+          "tableFrom": "connection_profiles",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "connection_profiles_exactly_one_owner": {
+          "name": "connection_profiles_exactly_one_owner",
+          "value": "(\n        (user_id IS NOT NULL AND end_user_id IS NULL AND org_id IS NULL) OR\n        (user_id IS NULL AND end_user_id IS NOT NULL AND org_id IS NULL) OR\n        (user_id IS NULL AND end_user_id IS NULL AND org_id IS NOT NULL)\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_states": {
+      "name": "oauth_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_verifier": {
+          "name": "code_verifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_token_secret": {
+          "name": "oauth_token_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_mode": {
+          "name": "auth_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'oauth2'"
+        },
+        "scopes_requested": {
+          "name": "scopes_requested",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "NOW() + INTERVAL '10 minutes'"
+        }
+      },
+      "indexes": {
+        "idx_oauth_states_expires": {
+          "name": "idx_oauth_states_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_states_org_id_organizations_id_fk": {
+          "name": "oauth_states_org_id_organizations_id_fk",
+          "tableFrom": "oauth_states",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_states_user_id_user_id_fk": {
+          "name": "oauth_states_user_id_user_id_fk",
+          "tableFrom": "oauth_states",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_states_end_user_id_end_users_id_fk": {
+          "name": "oauth_states_end_user_id_end_users_id_fk",
+          "tableFrom": "oauth_states",
+          "tableTo": "end_users",
+          "columnsFrom": ["end_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_states_profile_id_connection_profiles_id_fk": {
+          "name": "oauth_states_profile_id_connection_profiles_id_fk",
+          "tableFrom": "oauth_states",
+          "tableTo": "connection_profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "oauth_states_exactly_one_actor": {
+          "name": "oauth_states_exactly_one_actor",
+          "value": "(user_id IS NOT NULL AND end_user_id IS NULL) OR (user_id IS NULL AND end_user_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_profile_provider_bindings": {
+      "name": "org_profile_provider_bindings",
+      "schema": "",
+      "columns": {
+        "org_profile_id": {
+          "name": "org_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_profile_id": {
+          "name": "source_profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bound_by_user_id": {
+          "name": "bound_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_profile_bindings_source": {
+          "name": "idx_org_profile_bindings_source",
+          "columns": [
+            {
+              "expression": "source_profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_profile_bindings_user": {
+          "name": "idx_org_profile_bindings_user",
+          "columns": [
+            {
+              "expression": "bound_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_profile_provider_bindings_org_profile_id_connection_profiles_id_fk": {
+          "name": "org_profile_provider_bindings_org_profile_id_connection_profiles_id_fk",
+          "tableFrom": "org_profile_provider_bindings",
+          "tableTo": "connection_profiles",
+          "columnsFrom": ["org_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_profile_provider_bindings_source_profile_id_connection_profiles_id_fk": {
+          "name": "org_profile_provider_bindings_source_profile_id_connection_profiles_id_fk",
+          "tableFrom": "org_profile_provider_bindings",
+          "tableTo": "connection_profiles",
+          "columnsFrom": ["source_profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_profile_provider_bindings_bound_by_user_id_user_id_fk": {
+          "name": "org_profile_provider_bindings_bound_by_user_id_user_id_fk",
+          "tableFrom": "org_profile_provider_bindings",
+          "tableTo": "user",
+          "columnsFrom": ["bound_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_profile_provider_bindings_org_profile_id_provider_id_pk": {
+          "name": "org_profile_provider_bindings_org_profile_id_provider_id_pk",
+          "columns": ["org_profile_id", "provider_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_credentials": {
+      "name": "provider_credentials",
+      "schema": "",
+      "columns": {
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_encrypted": {
+          "name": "credentials_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "provider_credentials_provider_id_packages_id_fk": {
+          "name": "provider_credentials_provider_id_packages_id_fk",
+          "tableFrom": "provider_credentials",
+          "tableTo": "packages",
+          "columnsFrom": ["provider_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "provider_credentials_org_id_organizations_id_fk": {
+          "name": "provider_credentials_org_id_organizations_id_fk",
+          "tableFrom": "provider_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "provider_credentials_provider_id_org_id_pk": {
+          "name": "provider_credentials_provider_id_org_id_pk",
+          "columns": ["provider_id", "org_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_agent_provider_profiles": {
+      "name": "user_agent_provider_profiles",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ufpp_member": {
+          "name": "idx_ufpp_member",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_agent_provider_profiles\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ufpp_end_user": {
+          "name": "idx_ufpp_end_user",
+          "columns": [
+            {
+              "expression": "end_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_agent_provider_profiles\".\"end_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ufpp_package_id": {
+          "name": "idx_ufpp_package_id",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ufpp_profile_id": {
+          "name": "idx_ufpp_profile_id",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_agent_provider_profiles_user_id_user_id_fk": {
+          "name": "user_agent_provider_profiles_user_id_user_id_fk",
+          "tableFrom": "user_agent_provider_profiles",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_agent_provider_profiles_end_user_id_end_users_id_fk": {
+          "name": "user_agent_provider_profiles_end_user_id_end_users_id_fk",
+          "tableFrom": "user_agent_provider_profiles",
+          "tableTo": "end_users",
+          "columnsFrom": ["end_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_agent_provider_profiles_package_id_packages_id_fk": {
+          "name": "user_agent_provider_profiles_package_id_packages_id_fk",
+          "tableFrom": "user_agent_provider_profiles",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_agent_provider_profiles_profile_id_connection_profiles_id_fk": {
+          "name": "user_agent_provider_profiles_profile_id_connection_profiles_id_fk",
+          "tableFrom": "user_agent_provider_profiles",
+          "tableTo": "connection_profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "ufpp_exactly_one_actor": {
+          "name": "ufpp_exactly_one_actor",
+          "value": "(user_id IS NOT NULL AND end_user_id IS NULL) OR (user_id IS NULL AND end_user_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.user_provider_connections": {
+      "name": "user_provider_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_encrypted": {
+          "name": "credentials_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes_granted": {
+          "name": "scopes_granted",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::text[]"
+        },
+        "needs_reconnection": {
+          "name": "needs_reconnection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_user_provider_connections_unique": {
+          "name": "idx_user_provider_connections_unique",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_provider_connections_profile": {
+          "name": "idx_user_provider_connections_profile",
+          "columns": [
+            {
+              "expression": "profile_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_user_provider_connections_org_id": {
+          "name": "idx_user_provider_connections_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_provider_connections_profile_id_connection_profiles_id_fk": {
+          "name": "user_provider_connections_profile_id_connection_profiles_id_fk",
+          "tableFrom": "user_provider_connections",
+          "tableTo": "connection_profiles",
+          "columnsFrom": ["profile_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_provider_connections_org_id_organizations_id_fk": {
+          "name": "user_provider_connections_org_id_organizations_id_fk",
+          "tableFrom": "user_provider_connections",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency": {
+          "name": "latency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_webhook_deliveries_webhook_id": {
+          "name": "idx_webhook_deliveries_webhook_id",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_webhook_deliveries_event_id": {
+          "name": "idx_webhook_deliveries_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_webhook_deliveries_status": {
+          "name": "idx_webhook_deliveries_status",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": ["webhook_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'application'"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_mode": {
+          "name": "payload_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_secret": {
+          "name": "previous_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_secret_expires_at": {
+          "name": "previous_secret_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_webhooks_org_id": {
+          "name": "idx_webhooks_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_webhooks_scope_org": {
+          "name": "idx_webhooks_scope_org",
+          "columns": [
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_webhooks_application_id": {
+          "name": "idx_webhooks_application_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_webhooks_app_active": {
+          "name": "idx_webhooks_app_active",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_org_id_organizations_id_fk": {
+          "name": "webhooks_org_id_organizations_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhooks_application_id_applications_id_fk": {
+          "name": "webhooks_application_id_applications_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": ["pending", "accepted", "expired", "cancelled"]
+    },
+    "public.org_role": {
+      "name": "org_role",
+      "schema": "public",
+      "values": ["owner", "admin", "member", "viewer"]
+    },
+    "public.package_source": {
+      "name": "package_source",
+      "schema": "public",
+      "values": ["local", "system"]
+    },
+    "public.package_type": {
+      "name": "package_type",
+      "schema": "public",
+      "values": ["agent", "skill", "tool", "provider"]
+    },
+    "public.run_status": {
+      "name": "run_status",
+      "schema": "public",
+      "values": ["pending", "running", "success", "failed", "timeout", "cancelled"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1774950000000,
       "tag": "0016_rename_flow_to_agent_execution_to_run",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1775187087525,
+      "tag": "0017_add_needs_reconnection",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/connections.ts
+++ b/packages/db/src/schema/connections.ts
@@ -144,6 +144,7 @@ export const userProviderConnections = pgTable(
     scopesGranted: text("scopes_granted")
       .array()
       .default(sql`'{}'::text[]`),
+    needsReconnection: boolean("needs_reconnection").default(false).notNull(),
     expiresAt: timestamp("expires_at"),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -405,6 +405,7 @@ export interface AvailableProvider {
   authMode?: string;
   connectionId?: string;
   connectedAt?: string;
+  scopesGranted?: string[];
 }
 
 // --- Provider Config Types ---

--- a/runtime-pi/sidecar/app.ts
+++ b/runtime-pi/sidecar/app.ts
@@ -67,6 +67,7 @@ export function createApp(deps: AppDeps): Hono {
   const { config, fetchCredentials, cookieJar } = deps;
   const fetchFn = deps.fetchFn ?? fetch;
   const isReady = deps.isReady ?? (() => true);
+  const reportedAuthFailures = new Set<string>();
 
   const app = new Hono();
 
@@ -370,6 +371,24 @@ export function createApp(deps: AppDeps): Hono {
     const responseHeaders: Record<string, string> = { "Content-Type": contentType };
     if (truncated) {
       responseHeaders["X-Truncated"] = "true";
+    }
+
+    // Report auth failures to platform so connections can be flagged (once per provider per run)
+    if (
+      targetRes.status === 401 &&
+      config.platformApiUrl &&
+      config.runToken &&
+      !reportedAuthFailures.has(providerId)
+    ) {
+      reportedAuthFailures.add(providerId);
+      fetch(`${config.platformApiUrl}/internal/connections/report-auth-failure`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${config.runToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ providerId }),
+      }).catch(() => {});
     }
 
     return c.body(text, targetRes.status, responseHeaders);

--- a/scripts/verify-openapi.ts
+++ b/scripts/verify-openapi.ts
@@ -221,6 +221,7 @@ const expectedEndpoints = [
   // Internal
   "GET /internal/run-history",
   "GET /internal/credentials/{scope}/{name}",
+  "POST /internal/connections/report-auth-failure",
 
   // Meta
   "GET /api/openapi.json",


### PR DESCRIPTION
## Summary

- **Scope upgrade flow**: Display granted/missing scopes on provider connection cards, show "Insufficient permissions" warning when agent requires scopes not granted, add "Update permissions" button that re-triggers OAuth with required scopes. Block run when scopes are insufficient (badge on run button + confirmation modal).
- **Connection invalidation on credential change**: Admin checkbox to invalidate all user connections when updating provider credentials (approach A).
- **Runtime 401 detection**: Sidecar reports upstream 401 to platform, which flags the connection as `needs_reconnection`. Deduplicated per provider per run (approach B).
- **Minor fix**: Skip email verification redirect when SMTP is not configured.

## Test plan

- [ ] `bun run check` passes (typecheck + lint + OpenAPI validation — 182 endpoints)
- [ ] `bun test` — 37 related tests pass (4 new integration tests for credential invalidation)
- [ ] Verify scope badges appear on provider connection cards
- [ ] Verify "Update permissions" button re-triggers OAuth flow
- [ ] Verify run button shows orange badge when scopes insufficient
- [ ] Verify confirmation modal blocks run when scopes insufficient
- [ ] Verify admin credential update with checkbox deletes user connections
- [ ] Run migration `0017_add_needs_reconnection` before testing approach B

🤖 Generated with [Claude Code](https://claude.com/claude-code)