### PR TITLE
feat: full JSON Schema 2020-12 support in AFPS schemas

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,15 +7,16 @@ on:
   schedule:
     - cron: "0 6 * * 1" # Monday 6am UTC
 
-permissions:
-  security-events: write
-  id-token: write
-  contents: read
+permissions: read-all
 
 jobs:
   analysis:
     name: Scorecard Analysis
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
     timeout-minutes: 10
 
     steps:

--- a/apps/api/test/unit/schema-validation.test.ts
+++ b/apps/api/test/unit/schema-validation.test.ts
@@ -185,7 +185,9 @@ describe("validateManifest", () => {
     };
     const result = validateManifest(bad);
     expect(result.valid).toBe(false);
-    expect(result.errors.some((e: string) => e.includes("type"))).toBe(true);
+    expect(result.errors.some((e: string) => e.includes("JSON Schema") || e.includes("type"))).toBe(
+      true,
+    );
   });
 
   it("accepts custom placeholder property in schema", () => {

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "appstrate",
       "dependencies": {
-        "@afps-spec/schema": "^1.1.0",
+        "@afps-spec/schema": "^1.2.1",
         "@appstrate/core": "workspace:*",
       },
       "devDependencies": {
@@ -136,7 +136,7 @@
       "name": "@appstrate/core",
       "version": "2.10.3",
       "dependencies": {
-        "@afps-spec/schema": "^1.0.4",
+        "@afps-spec/schema": "^1.2.1",
         "fflate": "^0.8.0",
         "pino": "^10.3.1",
         "semver": "^7.7.1",
@@ -204,7 +204,7 @@
     },
   },
   "packages": {
-    "@afps-spec/schema": ["@afps-spec/schema@1.1.0", "", { "dependencies": { "semver": "^7.7.4", "zod": "^4.3.6" } }, "sha512-Ljqo4TEtRPtoDRbJxECWvpHzoxLvk1Fcjb3A+up7NsPtZAOD8WIT0a6r0gjdz3IY/yIIOMVoBzVz3TwPoJjpqw=="],
+    "@afps-spec/schema": ["@afps-spec/schema@1.2.1", "", { "dependencies": { "ajv": "^8.17.1", "semver": "^7.7.4", "zod": "^4.3.6" } }, "sha512-x1t5HSsoqTTuk6m8H+bwg6gkA3JXeTh5USi4/+O7yAUtOVm4QXhHiNBTNupMxpSYcwM7J0mDwoMIzRoTmTPcJA=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.73.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -203,6 +203,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@redocly/openapi-core@2.25.2": "patches/@redocly%2Fopenapi-core@2.25.2.patch",
+  },
   "packages": {
     "@afps-spec/schema": ["@afps-spec/schema@1.2.1", "", { "dependencies": { "ajv": "^8.17.1", "semver": "^7.7.4", "zod": "^4.3.6" } }, "sha512-x1t5HSsoqTTuk6m8H+bwg6gkA3JXeTh5USi4/+O7yAUtOVm4QXhHiNBTNupMxpSYcwM7J0mDwoMIzRoTmTPcJA=="],
 
@@ -1034,7 +1037,7 @@
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+    "ajv": ["@redocly/ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA=="],
 
     "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
 
@@ -1998,6 +2001,8 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@afps-spec/schema/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
     "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
@@ -2010,13 +2015,13 @@
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@commitlint/config-validator/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
     "@emotion/babel-plugin/convert-source-map": ["convert-source-map@1.9.0", "", {}, "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
-
-    "@mariozechner/pi-ai/ajv": ["@redocly/ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA=="],
 
     "@mariozechner/pi-coding-agent/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
@@ -2048,11 +2053,7 @@
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
-    "@readme/openapi-parser/ajv": ["@redocly/ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA=="],
-
     "@redocly/config/json-schema-to-ts": ["json-schema-to-ts@2.7.2", "", { "dependencies": { "@babel/runtime": "^7.18.3", "@types/json-schema": "^7.0.9", "ts-algebra": "^1.2.0" } }, "sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ=="],
-
-    "@redocly/openapi-core/ajv": ["@redocly/ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
@@ -2067,8 +2068,6 @@
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "ajv-formats/ajv": ["@redocly/ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA=="],
 
     "babel-plugin-macros/cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 

--- a/package.json
+++ b/package.json
@@ -90,5 +90,8 @@
   "dependencies": {
     "@afps-spec/schema": "^1.2.1",
     "@appstrate/core": "workspace:*"
+  },
+  "patchedDependencies": {
+    "@redocly/openapi-core@2.25.2": "patches/@redocly%2Fopenapi-core@2.25.2.patch"
   }
 }

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "*.{ts,tsx,json,md,yml,yaml}": "prettier --write"
   },
   "dependencies": {
-    "@afps-spec/schema": "^1.1.0",
+    "@afps-spec/schema": "^1.2.1",
     "@appstrate/core": "workspace:*"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -58,7 +58,7 @@
     "./form": "./src/form.ts"
   },
   "dependencies": {
-    "@afps-spec/schema": "^1.0.4",
+    "@afps-spec/schema": "^1.2.1",
     "fflate": "^0.8.0",
     "pino": "^10.3.1",
     "semver": "^7.7.1",

--- a/packages/core/schema/agent.schema.json
+++ b/packages/core/schema/agent.schema.json
@@ -101,96 +101,23 @@
       "type": "object",
       "properties": {
         "schema": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "object"
+          "allOf": [
+            {
+              "$ref": "https://json-schema.org/draft/2020-12/schema"
             },
-            "properties": {
+            {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
-              "additionalProperties": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "string",
-                      "number",
-                      "boolean",
-                      "array",
-                      "object"
-                    ]
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "default": {},
-                  "enum": {
-                    "type": "array",
-                    "items": {}
-                  },
-                  "format": {
-                    "type": "string"
-                  },
-                  "contentMediaType": {
-                    "type": "string"
-                  },
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "string",
-                          "number",
-                          "boolean",
-                          "array",
-                          "object"
-                        ]
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "format": {
-                        "type": "string"
-                      },
-                      "contentMediaType": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "type"
-                    ],
-                    "additionalProperties": {}
-                  },
-                  "maxItems": {
-                    "type": "integer",
-                    "exclusiveMinimum": 0,
-                    "maximum": 9007199254740991
-                  }
-                },
-                "required": [
-                  "type"
-                ],
-                "additionalProperties": {}
-              }
-            },
-            "required": {
-              "type": "array",
-              "items": {
-                "type": "string"
+              "required": [
+                "type",
+                "properties"
+              ],
+              "properties": {
+                "type": {
+                  "const": "object"
+                }
               }
             }
-          },
-          "required": [
-            "type",
-            "properties"
-          ],
-          "additionalProperties": {}
+          ]
         },
         "fileConstraints": {
           "type": "object",
@@ -242,96 +169,23 @@
       "type": "object",
       "properties": {
         "schema": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "object"
+          "allOf": [
+            {
+              "$ref": "https://json-schema.org/draft/2020-12/schema"
             },
-            "properties": {
+            {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
-              "additionalProperties": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "string",
-                      "number",
-                      "boolean",
-                      "array",
-                      "object"
-                    ]
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "default": {},
-                  "enum": {
-                    "type": "array",
-                    "items": {}
-                  },
-                  "format": {
-                    "type": "string"
-                  },
-                  "contentMediaType": {
-                    "type": "string"
-                  },
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "string",
-                          "number",
-                          "boolean",
-                          "array",
-                          "object"
-                        ]
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "format": {
-                        "type": "string"
-                      },
-                      "contentMediaType": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "type"
-                    ],
-                    "additionalProperties": {}
-                  },
-                  "maxItems": {
-                    "type": "integer",
-                    "exclusiveMinimum": 0,
-                    "maximum": 9007199254740991
-                  }
-                },
-                "required": [
-                  "type"
-                ],
-                "additionalProperties": {}
-              }
-            },
-            "required": {
-              "type": "array",
-              "items": {
-                "type": "string"
+              "required": [
+                "type",
+                "properties"
+              ],
+              "properties": {
+                "type": {
+                  "const": "object"
+                }
               }
             }
-          },
-          "required": [
-            "type",
-            "properties"
-          ],
-          "additionalProperties": {}
+          ]
         },
         "fileConstraints": {
           "type": "object",
@@ -383,96 +237,23 @@
       "type": "object",
       "properties": {
         "schema": {
-          "type": "object",
-          "properties": {
-            "type": {
-              "type": "string",
-              "const": "object"
+          "allOf": [
+            {
+              "$ref": "https://json-schema.org/draft/2020-12/schema"
             },
-            "properties": {
+            {
               "type": "object",
-              "propertyNames": {
-                "type": "string"
-              },
-              "additionalProperties": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "enum": [
-                      "string",
-                      "number",
-                      "boolean",
-                      "array",
-                      "object"
-                    ]
-                  },
-                  "description": {
-                    "type": "string"
-                  },
-                  "default": {},
-                  "enum": {
-                    "type": "array",
-                    "items": {}
-                  },
-                  "format": {
-                    "type": "string"
-                  },
-                  "contentMediaType": {
-                    "type": "string"
-                  },
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "type": {
-                        "type": "string",
-                        "enum": [
-                          "string",
-                          "number",
-                          "boolean",
-                          "array",
-                          "object"
-                        ]
-                      },
-                      "description": {
-                        "type": "string"
-                      },
-                      "format": {
-                        "type": "string"
-                      },
-                      "contentMediaType": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "type"
-                    ],
-                    "additionalProperties": {}
-                  },
-                  "maxItems": {
-                    "type": "integer",
-                    "exclusiveMinimum": 0,
-                    "maximum": 9007199254740991
-                  }
-                },
-                "required": [
-                  "type"
-                ],
-                "additionalProperties": {}
-              }
-            },
-            "required": {
-              "type": "array",
-              "items": {
-                "type": "string"
+              "required": [
+                "type",
+                "properties"
+              ],
+              "properties": {
+                "type": {
+                  "const": "object"
+                }
               }
             }
-          },
-          "required": [
-            "type",
-            "properties"
-          ],
-          "additionalProperties": {}
+          ]
         },
         "fileConstraints": {
           "type": "object",

--- a/packages/core/scripts/generate-schemas.ts
+++ b/packages/core/scripts/generate-schemas.ts
@@ -17,6 +17,7 @@ import {
   skillManifestSchema,
   toolManifestSchema,
   providerManifestSchema,
+  afpsJsonSchemaOverride,
 } from "@afps-spec/schema";
 
 const OUTPUT_DIR = resolve(dirname(import.meta.filename!), "../schema");
@@ -64,6 +65,7 @@ for (const entry of appstrateSchemas) {
   const jsonSchema = toJSONSchema(entry.schema, {
     unrepresentable: "any",
     target: "draft-2020-12",
+    override: afpsJsonSchemaOverride,
   }) as Record<string, unknown>;
 
   delete jsonSchema.$schema;

--- a/patches/@redocly%2Fopenapi-core@2.25.2.patch
+++ b/patches/@redocly%2Fopenapi-core@2.25.2.patch
@@ -1,0 +1,13 @@
+diff --git a/lib/types/oas3_1.js b/lib/types/oas3_1.js
+index 48dd609b88aafe7f84ed0435b7c29778ad6836d6..3ad9e341b10117bd1c68eac34396204212b1bd2e 100644
+--- a/lib/types/oas3_1.js
++++ b/lib/types/oas3_1.js
+@@ -95,7 +95,7 @@ const Schema = {
+         $schema: { type: 'string' },
+         definitions: 'NamedSchemas',
+         $defs: 'NamedSchemas',
+-        $vocabulary: { type: 'string' },
++        $vocabulary: null,
+         externalDocs: 'ExternalDocs',
+         discriminator: 'Discriminator',
+         title: { type: 'string' },


### PR DESCRIPTION
## Summary

- Upgrade `@afps-spec/schema` to ^1.2.1 — schema fields (`input.schema`, `output.schema`, `config.schema`) are now validated against the official JSON Schema 2020-12 meta-schema via AJV instead of a hand-rolled Zod subset
- Use `afpsJsonSchemaOverride` in `generate-schemas.ts` so generated `.schema.json` files reference the meta-schema via `$ref`
- Regenerate core JSON schemas
- Patch `@redocly/openapi-core` for upstream bug where `$vocabulary` is typed as `string` instead of `object` (causes false positive when linting specs referencing JSON Schema 2020-12 documents)

## Test plan

- [x] 1670 tests pass (0 failures)
- [x] `bun run check` passes (typecheck + eslint + prettier + OpenAPI validation)
- [x] Generated JSON schemas have correct `allOf[$ref meta-schema]` structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)