### PR TITLE
fix: copy patches/ in Dockerfile deps stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY packages/emails/package.json packages/emails/
 COPY packages/env/package.json packages/env/
 COPY runtime-pi/package.json runtime-pi/
 COPY runtime-pi/sidecar/package.json runtime-pi/sidecar/
+COPY patches/ patches/
 
 RUN bun install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

- Add `COPY patches/ patches/` before `bun install --frozen-lockfile` in the Dockerfile deps stage
- Required because `@redocly/openapi-core` patch (from #30) is referenced in `patchedDependencies`

## Test plan

- [x] CI build should pass with `--frozen-lockfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)