### PR TITLE
ci: skip integration tests on main push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,9 +39,7 @@ jobs:
 
   integration:
     name: Integration tests
-    if: >-
-      github.event_name == 'push' ||
-      contains(github.event.pull_request.labels.*.name, 'integration')
+    if: contains(github.event.pull_request.labels.*.name, 'integration')
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
## Summary
- Integration tests were running on every push to `main`, wasting CI minutes
- Now they only run on PRs with the `integration` label

## Test plan
- [ ] Verify push to `main` no longer triggers the `integration` job
- [ ] Verify PR with `integration` label still triggers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)