### PR TITLE
feat: provider UX improvements — toast confirmations + auto-enable

### DIFF
--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -7,7 +7,7 @@ import type { AppEnv } from "../types/index.ts";
 import { parsePackageZip, PackageZipError, zipArtifact } from "@appstrate/core/zip";
 import { buildDownloadHeaders } from "@appstrate/core/integrity";
 import { eq, and, inArray } from "drizzle-orm";
-import { packages, profiles } from "@appstrate/db/schema";
+import { packages, profiles, providerCredentials } from "@appstrate/db/schema";
 import { db } from "@appstrate/db/client";
 import { postInstallPackage } from "../services/post-install-package.ts";
 import { parseManifestBytesSafe } from "../lib/manifest-parser.ts";
@@ -33,7 +33,7 @@ import {
   PackageAlreadyExistsError,
   type PackageTypeConfig,
 } from "../services/package-items/index.ts";
-import { validateToolSource, validateManifest } from "@appstrate/core/validation";
+import { validateToolSource, validateManifest, type PackageType } from "@appstrate/core/validation";
 import { parseScopedName, SLUG_REGEX } from "@appstrate/core/naming";
 import { unzipAndNormalize } from "../services/package-storage.ts";
 import { isValidVersion } from "@appstrate/core/semver";
@@ -272,6 +272,8 @@ async function createVersionSafe(params: {
 
 interface PackageRouteConfig {
   cfg: PackageTypeConfig;
+  /** URL path segment used for routing (e.g. "skills", "providers"). */
+  path: string;
   parseOpts: {
     requiredFile: string | null;
     contentFileExt: string | null;
@@ -305,17 +307,19 @@ interface PackageRouteConfig {
   getHandler?: (c: Context<AppEnv>) => Promise<Response>;
 }
 
-const ROUTE_CONFIGS: Record<string, PackageRouteConfig> = {
-  skills: {
+const ROUTE_CONFIGS: Record<PackageType, PackageRouteConfig> = {
+  skill: {
     cfg: SKILL_CONFIG,
+    path: "skills",
     parseOpts: { requiredFile: "SKILL.md", contentFileExt: null },
     responseKey: "skill",
     storageFileName: () => "SKILL.md",
     jsonBodyCreate: true,
     requireContent: true,
   },
-  tools: {
+  tool: {
     cfg: TOOL_CONFIG,
+    path: "tools",
     parseOpts: { requiredFile: null, contentFileExt: ".ts" },
     responseKey: "tool",
     validateSource: validateToolSource,
@@ -323,8 +327,9 @@ const ROUTE_CONFIGS: Record<string, PackageRouteConfig> = {
     sourceFileName: (id) => `${parseScopedName(id)?.name ?? id}.ts`,
     jsonBodyCreate: true,
   },
-  agents: {
+  agent: {
     cfg: AGENT_CONFIG,
+    path: "agents",
     parseOpts: { requiredFile: null, contentFileExt: null },
     responseKey: "agent",
     storageFileName: () => "prompt.md",
@@ -333,12 +338,19 @@ const ROUTE_CONFIGS: Record<string, PackageRouteConfig> = {
     requireMutableForVersionOps: true,
     getHandler: agentDetailHandler,
   },
-  providers: {
+  provider: {
     cfg: PROVIDER_CONFIG,
+    path: "providers",
     parseOpts: { requiredFile: null, contentFileExt: null },
     responseKey: "provider",
     storageFileName: () => "PROVIDER.md",
     jsonBodyCreate: true,
+    afterCreate: async ({ packageId, orgId }) => {
+      await db
+        .insert(providerCredentials)
+        .values({ providerId: packageId, orgId, credentialsEncrypted: null, enabled: true })
+        .onConflictDoNothing();
+    },
   },
 };
 
@@ -1017,7 +1029,8 @@ export function createPackagesRouter() {
   const router = new Hono<AppEnv>();
 
   // --- Package CRUD routes (skills, tools, agents, providers) ---
-  for (const [path, rcfg] of Object.entries(ROUTE_CONFIGS)) {
+  for (const rcfg of Object.values(ROUTE_CONFIGS)) {
+    const { path } = rcfg;
     // Permission resource matches the route path (e.g. "skills", "tools", "agents", "providers")
     const resource = path as import("../lib/permissions.ts").Resource;
     const writeGuard = requirePermission(resource, "write");
@@ -1233,7 +1246,7 @@ export function createPackagesRouter() {
         .where(and(eq(packages.id, packageId), eq(packages.orgId, orgId)));
     } else {
       // New package — insert
-      const cfg = ROUTE_CONFIGS[packageType + "s"]?.cfg;
+      const cfg = ROUTE_CONFIGS[packageType as PackageType]?.cfg;
       if (!cfg) {
         throw invalidRequest(`Unknown package type '${packageType}'`);
       }
@@ -1272,6 +1285,12 @@ export function createPackagesRouter() {
         title: "Post-Install Failed",
         detail: message,
       });
+    }
+
+    // After-create hook (e.g. auto-enable provider)
+    const rcfg = ROUTE_CONFIGS[packageType as PackageType];
+    if (rcfg?.afterCreate) {
+      await rcfg.afterCreate({ packageId, orgId, manifest: manifest as Record<string, unknown> });
     }
 
     // Force import: replace existing version content if integrity differs

--- a/apps/web/src/hooks/use-mutations.ts
+++ b/apps/web/src/hooks/use-mutations.ts
@@ -116,7 +116,10 @@ export function useConnect() {
         }, 500);
       });
     },
-    onSuccess: () => invalidateConnectionRelated(qc),
+    onSuccess: () => {
+      invalidateConnectionRelated(qc);
+      toast.success(i18n.t("settings:providers.connectSuccess"));
+    },
     onError: onMutationError,
   });
 }
@@ -138,7 +141,10 @@ export function useConnectApiKey() {
         body: JSON.stringify({ apiKey, ...(profileId ? { profileId } : {}) }),
       });
     },
-    onSuccess: () => invalidateConnectionRelated(qc),
+    onSuccess: () => {
+      invalidateConnectionRelated(qc);
+      toast.success(i18n.t("settings:providers.connectSuccess"));
+    },
     onError: onMutationError,
   });
 }
@@ -246,7 +252,10 @@ export function useConnectCredentials() {
         body: JSON.stringify({ credentials, ...(profileId ? { profileId } : {}) }),
       });
     },
-    onSuccess: () => invalidateConnectionRelated(qc),
+    onSuccess: () => {
+      invalidateConnectionRelated(qc);
+      toast.success(i18n.t("settings:providers.connectSuccess"));
+    },
     onError: onMutationError,
   });
 }
@@ -397,7 +406,10 @@ export function useConfigureProviderCredentials() {
         body: JSON.stringify({ credentials, enabled, invalidateConnections }),
       });
     },
-    onSuccess: () => invalidateProviderQueries(qc),
+    onSuccess: () => {
+      invalidateProviderQueries(qc);
+      toast.success(i18n.t("settings:providers.credentialsSaved"));
+    },
     onError: onMutationError,
   });
 }

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -91,6 +91,8 @@
   "services.empty": "No connectors configured.",
   "services.emptyHint": "Configure connectors to see them here.",
   "providers.connected": "Connected",
+  "providers.connectSuccess": "Provider connected successfully.",
+  "providers.credentialsSaved": "Provider configuration saved.",
   "services.notConnected": "Not connected",
   "services.disconnectConfirm": "Disconnect connector \"{{name}}\"?",
   "packages.title": "Packages",

--- a/apps/web/src/locales/fr/settings.json
+++ b/apps/web/src/locales/fr/settings.json
@@ -91,6 +91,8 @@
   "services.empty": "Aucun provider configuré.",
   "services.emptyHint": "Configurez des providers pour les voir ici.",
   "providers.connected": "Connecté",
+  "providers.connectSuccess": "Provider connecté avec succès.",
+  "providers.credentialsSaved": "Configuration du provider enregistrée.",
   "services.notConnected": "Non connecté",
   "services.disconnectConfirm": "Déconnecter le provider \"{{name}}\" ?",
   "packages.title": "Packages",


### PR DESCRIPTION
## Summary
- Toast confirmation on provider connection and credential save
- Auto-enable provider on creation and import

## Test plan
- [ ] Connect a provider → verify toast appears
- [ ] Create a provider → verify it is auto-enabled
- [ ] Import a provider → verify it is auto-enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)