### PR TITLE
refactor: deduplicate run pipeline, clean up dead code and indirection

### DIFF
--- a/apps/api/src/lib/manifest-utils.ts
+++ b/apps/api/src/lib/manifest-utils.ts
@@ -3,6 +3,8 @@
 import type { Manifest } from "@appstrate/core/validation";
 import type { AgentProviderRequirement } from "../types/index.ts";
 import { asRecord } from "./safe-json.ts";
+import { asJSONSchemaObject } from "@appstrate/core/form";
+import type { JSONSchemaObject } from "@appstrate/core/form";
 
 /** Extract skill, tool, and provider IDs from a manifest's dependencies section. */
 export function extractDepsFromManifest(manifest: Partial<Manifest>) {
@@ -30,4 +32,18 @@ export function resolveManifestProviders(manifest: Partial<Manifest>): AgentProv
     id: providerId,
     scopes: config[providerId]?.scopes,
   }));
+}
+
+/** Extract input/config/output JSON schemas from a manifest, with safe narrowing. */
+export function extractManifestSchemas(manifest: Partial<Manifest>): {
+  input?: JSONSchemaObject;
+  config?: JSONSchemaObject;
+  output?: JSONSchemaObject;
+} {
+  const m = manifest as Record<string, { schema?: unknown } | undefined>;
+  return {
+    input: m.input?.schema ? asJSONSchemaObject(m.input.schema) : undefined,
+    config: m.config?.schema ? asJSONSchemaObject(m.config.schema) : undefined,
+    output: m.output?.schema ? asJSONSchemaObject(m.output.schema) : undefined,
+  };
 }

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -5,13 +5,11 @@ import { Hono } from "hono";
 import { logger } from "../lib/logger.ts";
 import type { LoadedPackage, AppEnv } from "../types/index.ts";
 import {
-  createRun,
   updateRun,
   appendRunLog,
   getRun,
   getRunFull,
   getRunningRunsForPackage,
-  getRunningRunCountForOrg,
   deletePackageRuns,
   listPackageRuns,
   listScheduleRuns,
@@ -29,7 +27,6 @@ import { validateAgentReadiness } from "../services/agent-readiness.ts";
 import { PiAdapter, TimeoutError } from "../services/adapters/index.ts";
 import type { TokenUsage } from "../services/adapters/index.ts";
 import type { PromptContext, UploadedFile } from "../services/adapters/types.ts";
-import { buildRunContext, ModelNotConfiguredError } from "../services/env-builder.ts";
 import { getVersionDetail } from "../services/package-versions.ts";
 import { validateOutput } from "../services/schema.ts";
 import { parseRequestInput } from "../services/input-parser.ts";
@@ -42,7 +39,8 @@ import { requireAgent } from "../middleware/guards.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
 import { getOrchestrator } from "../services/orchestrator/index.ts";
 import { getCloudModule } from "../lib/cloud-loader.ts";
-import { dispatchWebhookEvents } from "../services/webhooks.ts";
+import { dispatchRunWebhook } from "../services/webhooks.ts";
+import { prepareAndExecuteRun } from "../services/run-pipeline.ts";
 import { getActor } from "../lib/actor.ts";
 
 function accumulateUsage(total: TokenUsage, addition: TokenUsage): void {
@@ -52,29 +50,6 @@ function accumulateUsage(total: TokenUsage, addition: TokenUsage): void {
     (total.cache_creation_input_tokens ?? 0) + (addition.cache_creation_input_tokens ?? 0);
   total.cache_read_input_tokens =
     (total.cache_read_input_tokens ?? 0) + (addition.cache_read_input_tokens ?? 0);
-}
-
-/** Fire-and-forget webhook dispatch after run status change. */
-function dispatchWebhooks(
-  orgId: string,
-  status: string,
-  runId: string,
-  packageId: string,
-  extra?: Record<string, unknown>,
-  applicationId?: string | null,
-): void {
-  const eventType = `run.${status}` as Parameters<typeof dispatchWebhookEvents>[1];
-  dispatchWebhookEvents(
-    orgId,
-    eventType,
-    { id: runId, packageId, status, ...extra },
-    applicationId,
-  ).catch((err) => {
-    logger.warn("Webhook dispatch failed", {
-      runId,
-      error: err instanceof Error ? err.message : String(err),
-    });
-  });
 }
 
 // --- Background run (decoupled from client) ---
@@ -99,7 +74,7 @@ export async function executeAgentInBackground(
   try {
     // Update status to running
     await updateRun(runId, orgId, { status: "running" });
-    dispatchWebhooks(orgId, "started", runId, agent.id, undefined, applicationId);
+    dispatchRunWebhook(orgId, "started", runId, agent.id, undefined, applicationId);
 
     // Execute via adapter
     const adapter = new PiAdapter();
@@ -212,7 +187,7 @@ export async function executeAgentInBackground(
           },
           "error",
         );
-        dispatchWebhooks(orgId, "timeout", runId, agent.id, { duration }, applicationId);
+        dispatchRunWebhook(orgId, "timeout", runId, agent.id, { duration }, applicationId);
         return;
       }
       throw err;
@@ -250,7 +225,7 @@ export async function executeAgentInBackground(
         { runId, status: "failed", error },
         "error",
       );
-      dispatchWebhooks(orgId, "failed", runId, agent.id, { error, duration }, applicationId);
+      dispatchRunWebhook(orgId, "failed", runId, agent.id, { error, duration }, applicationId);
     } else {
       // --- Success path (with or without structured output) ---
 
@@ -332,7 +307,7 @@ export async function executeAgentInBackground(
         { runId, status: "success" },
         "info",
       );
-      dispatchWebhooks(orgId, "completed", runId, agent.id, { result, duration }, applicationId);
+      dispatchRunWebhook(orgId, "completed", runId, agent.id, { result, duration }, applicationId);
     }
   } catch (err) {
     // If aborted (cancelled), the cancel route already wrote DB status
@@ -360,7 +335,7 @@ export async function executeAgentInBackground(
       },
       "error",
     );
-    dispatchWebhooks(
+    dispatchRunWebhook(
       orgId,
       "failed",
       runId,
@@ -466,103 +441,43 @@ export function createRunsRouter() {
         size: f.size,
       }));
 
-      // Build run context (tokens, config, state, providers, package, version)
-      let promptContext: PromptContext;
-      let agentPackage: Buffer | null;
-      let packageVersionId: number | null;
-      let proxyLabel: string | null;
-      let modelLabel: string | null;
-      let modelSource: string | null;
-      try {
-        ({
-          promptContext,
-          agentPackage: agentPackage,
-          packageVersionId,
-          proxyLabel,
-          modelLabel,
-          modelSource,
-        } = await buildRunContext({
-          runId,
-          agent: effectiveAgent,
-          providerProfiles,
-          orgId,
-          actor,
-          input: parsedInput,
-          files: fileRefs,
-          config,
-          modelId: modelIdOverride ?? preflightModelId,
-          proxyId: proxyIdOverride ?? preflightProxyId,
-          overrideVersionId,
-        }));
-      } catch (err) {
-        if (err instanceof ModelNotConfiguredError) {
+      const result = await prepareAndExecuteRun({
+        runId,
+        agent: effectiveAgent,
+        providerProfiles,
+        orgId,
+        actor,
+        input: parsedInput,
+        files: fileRefs,
+        config,
+        modelId: modelIdOverride ?? preflightModelId,
+        proxyId: proxyIdOverride ?? preflightProxyId,
+        overrideVersionId,
+        connectionProfileId: defaultUserProfileId ?? undefined,
+        applicationId: c.get("applicationId") ?? null,
+        uploadedFiles,
+      });
+
+      if (!result.ok) {
+        const { error } = result;
+        if (error.code === "model_not_configured") {
           throw new ApiError({
             status: 400,
             code: "model_not_configured",
             title: "Bad Request",
-            detail: err.message,
+            detail: error.message,
           });
         }
-        throw err;
-      }
-
-      // Pre-run quota check (Cloud only — reject before creating the run record)
-      const cloud = getCloudModule();
-      if (cloud) {
-        try {
-          const runningCount = await getRunningRunCountForOrg(orgId);
-          await cloud.cloudHooks.checkQuota(orgId, runningCount);
-        } catch (err) {
-          if (err instanceof cloud.QuotaExceededError) {
-            throw new ApiError({
-              status: 402,
-              code: "quota_exceeded",
-              title: "Payment Required",
-              detail: err.message,
-            });
-          }
-          throw err;
+        if (error.code === "quota_exceeded") {
+          throw new ApiError({
+            status: 402,
+            code: "quota_exceeded",
+            title: "Payment Required",
+            detail: error.message,
+          });
         }
+        throw new Error(error.message);
       }
-
-      // Extract just the profileId map (strip source field)
-      const profileIdMap = Object.fromEntries(
-        Object.entries(providerProfiles).map(([k, v]) => [k, v.profileId]),
-      );
-
-      // Create run record
-      await createRun(
-        runId,
-        packageId,
-        actor,
-        orgId,
-        parsedInput ?? null,
-        undefined,
-        packageVersionId ?? undefined,
-        defaultUserProfileId ?? undefined,
-        proxyLabel ?? undefined,
-        modelLabel ?? undefined,
-        modelSource ?? undefined,
-        c.get("applicationId") ?? null,
-        profileIdMap,
-      );
-
-      // Fire-and-forget background run
-      executeAgentInBackground(
-        runId,
-        orgId,
-        effectiveAgent,
-        promptContext,
-        agentPackage,
-        uploadedFiles,
-        c.get("applicationId") ?? null,
-        modelSource,
-      ).catch((err) => {
-        logger.error("Unhandled error in background run", {
-          runId,
-          error: err instanceof Error ? err.message : String(err),
-        });
-      });
 
       return c.json({ runId });
     },
@@ -693,7 +608,7 @@ export function createRunsRouter() {
       .stopByRunId(runId)
       .catch(() => {});
 
-    dispatchWebhooks(
+    dispatchRunWebhook(
       orgId,
       "cancelled",
       runId,

--- a/apps/api/src/services/agent-readiness.ts
+++ b/apps/api/src/services/agent-readiness.ts
@@ -8,10 +8,9 @@
 import type { LoadedPackage, ProviderProfileMap } from "../types/index.ts";
 import { validateAgentDependencies } from "./dependency-validation.ts";
 import { validateConfig } from "./schema.ts";
-import { resolveManifestProviders } from "../lib/manifest-utils.ts";
-import { isPromptEmpty, findMissingDependencies } from "@appstrate/shared-types";
+import { resolveManifestProviders, extractManifestSchemas } from "../lib/manifest-utils.ts";
+import { isPromptEmpty, findMissingDependencies } from "@appstrate/core/validation";
 import { ApiError } from "../lib/errors.ts";
-import { asJSONSchemaObject } from "@appstrate/core/form";
 
 /**
  * Validate that an agent is ready for a run.
@@ -78,11 +77,9 @@ export async function validateAgentReadiness(params: {
 
   // 5. Config validation
   if (config) {
-    const configSchema = manifest.config?.schema ?? {
-      type: "object" as const,
-      properties: {},
-    };
-    const configValidation = validateConfig(config, asJSONSchemaObject(configSchema));
+    const { config: configSchema } = extractManifestSchemas(manifest);
+    const effectiveSchema = configSchema ?? { type: "object" as const, properties: {} };
+    const configValidation = validateConfig(config, effectiveSchema);
     if (!configValidation.valid) {
       const first = configValidation.errors[0]!;
       throw new ApiError({

--- a/apps/api/src/services/env-builder.ts
+++ b/apps/api/src/services/env-builder.ts
@@ -14,8 +14,7 @@ import { buildAgentPackage } from "./package-storage.ts";
 import { getLatestVersionWithManifest } from "./package-versions.ts";
 import { resolveProxy } from "./org-proxies.ts";
 import { resolveModel } from "./org-models.ts";
-import { asJSONSchemaObject } from "@appstrate/core/form";
-import { resolveManifestProviders } from "../lib/manifest-utils.ts";
+import { resolveManifestProviders, extractManifestSchemas } from "../lib/manifest-utils.ts";
 import type { ProviderProfileMap } from "../types/index.ts";
 import { toISO } from "../lib/date-helpers.ts";
 
@@ -135,17 +134,7 @@ export async function buildRunContext(params: {
     runApi: { url: runApiUrl, token: signRunToken(runId) },
     input: input ?? {},
     files,
-    schemas: {
-      input: agent.manifest.input?.schema
-        ? asJSONSchemaObject(agent.manifest.input.schema)
-        : undefined,
-      config: agent.manifest.config?.schema
-        ? asJSONSchemaObject(agent.manifest.config.schema)
-        : undefined,
-      output: agent.manifest.output?.schema
-        ? asJSONSchemaObject(agent.manifest.output.schema)
-        : undefined,
-    },
+    schemas: extractManifestSchemas(agent.manifest),
     providers: providerDefs,
     memories: memories.map((m) => ({
       id: m.id,

--- a/apps/api/src/services/package-versions.ts
+++ b/apps/api/src/services/package-versions.ts
@@ -241,29 +241,11 @@ export async function getVersionForDownload(
   return row ?? null;
 }
 
-/** Resolve a version query and return only the manifest (no ZIP download). */
-export async function resolveVersionManifest(
-  packageId: string,
-  versionQuery: string,
-): Promise<Record<string, unknown> | null> {
-  const versionId = await resolveVersion(packageId, versionQuery);
-  if (!versionId) return null;
-
-  const [row] = await db
-    .select({ manifest: packageVersions.manifest })
-    .from(packageVersions)
-    .where(eq(packageVersions.id, versionId))
-    .limit(1);
-
-  if (!row?.manifest) return null;
-  return asRecordOrNull(row.manifest);
-}
-
 // ─────────────────────────────────────────────
 // Version detail
 // ─────────────────────────────────────────────
 
-export interface VersionDetail {
+interface VersionDetail {
   id: number;
   version: string;
   manifest: Record<string, unknown>;
@@ -516,8 +498,8 @@ export async function getLatestVersionIntegrity(packageId: string): Promise<stri
   return row?.integrity ?? null;
 }
 
-export type CreateVersionError = "invalid_version" | "no_changes";
-export type CreateVersionResult = { id: number; version: string } | { error: CreateVersionError };
+type CreateVersionError = "invalid_version" | "no_changes";
+type CreateVersionResult = { id: number; version: string } | { error: CreateVersionError };
 
 /** Create an immutable version snapshot from the current draft (packages table).
  *  Uses manifest.version as-is — no auto-bump. Returns an error object if version is missing,

--- a/apps/api/src/services/package-versions.ts
+++ b/apps/api/src/services/package-versions.ts
@@ -21,7 +21,7 @@ import {
   type DistTagEntry,
 } from "@appstrate/core/semver";
 import { planCreateVersionOutcome, planTagReassignment } from "@appstrate/core/version-policy";
-import { isValidDistTag, isProtectedTag } from "@appstrate/core/dist-tags";
+
 import { buildDependencies } from "./package-items/dependencies.ts";
 import { parseScopedName } from "@appstrate/core/naming";
 import { zipArtifact } from "@appstrate/core/zip";
@@ -354,60 +354,6 @@ export async function getVersionCount(packageId: string): Promise<number> {
 // Yank
 // ─────────────────────────────────────────────
 
-/** Yank a version. Reassigns dist-tags pointing to the yanked version. */
-export async function yankVersion(
-  packageId: string,
-  version: string,
-  reason?: string,
-): Promise<boolean> {
-  return db.transaction(async (tx) => {
-    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${packageId}))`);
-
-    const [yanked] = await tx
-      .update(packageVersions)
-      .set({ yanked: true, yankedReason: reason ?? null })
-      .where(and(eq(packageVersions.packageId, packageId), eq(packageVersions.version, version)))
-      .returning({ id: packageVersions.id });
-
-    if (!yanked) return false;
-
-    const affectedTags = await tx
-      .select({ tag: packageDistTags.tag })
-      .from(packageDistTags)
-      .where(
-        and(eq(packageDistTags.packageId, packageId), eq(packageDistTags.versionId, yanked.id)),
-      );
-
-    if (affectedTags.length > 0) {
-      const candidates = await tx
-        .select({ id: packageVersions.id, version: packageVersions.version })
-        .from(packageVersions)
-        .where(and(eq(packageVersions.packageId, packageId), eq(packageVersions.yanked, false)));
-
-      const instructions = planTagReassignment(affectedTags, candidates);
-
-      for (const instr of instructions) {
-        if (instr.action === "reassign") {
-          await tx
-            .update(packageDistTags)
-            .set({ versionId: instr.newVersionId, updatedAt: new Date() })
-            .where(
-              and(eq(packageDistTags.packageId, packageId), eq(packageDistTags.tag, instr.tag)),
-            );
-        } else {
-          await tx
-            .delete(packageDistTags)
-            .where(
-              and(eq(packageDistTags.packageId, packageId), eq(packageDistTags.tag, instr.tag)),
-            );
-        }
-      }
-    }
-
-    return true;
-  });
-}
-
 // ─────────────────────────────────────────────
 // Delete version
 // ─────────────────────────────────────────────
@@ -478,26 +424,6 @@ export async function deletePackageVersion(packageId: string, version: string): 
 // ─────────────────────────────────────────────
 // Dist-tags
 // ─────────────────────────────────────────────
-
-export async function addDistTag(packageId: string, tag: string, versionId: number): Promise<void> {
-  if (!isValidDistTag(tag)) throw new Error(`Invalid tag name '${tag}'`);
-  if (isProtectedTag(tag)) throw new Error("The 'latest' tag cannot be set manually");
-
-  await db
-    .insert(packageDistTags)
-    .values({ packageId, tag, versionId })
-    .onConflictDoUpdate({
-      target: [packageDistTags.packageId, packageDistTags.tag],
-      set: { versionId, updatedAt: new Date() },
-    });
-}
-
-export async function removeDistTag(packageId: string, tag: string): Promise<void> {
-  if (isProtectedTag(tag)) throw new Error("The 'latest' tag cannot be removed");
-  await db
-    .delete(packageDistTags)
-    .where(and(eq(packageDistTags.packageId, packageId), eq(packageDistTags.tag, tag)));
-}
 
 async function listDistTags(packageId: string): Promise<{ tag: string; version: string }[]> {
   return db

--- a/apps/api/src/services/run-pipeline.ts
+++ b/apps/api/src/services/run-pipeline.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared run pipeline — the common tail of "build context ��� quota check → create run → execute".
+ * Used by both the POST /run route and the scheduler's triggerScheduledRun.
+ */
+
+import { logger } from "../lib/logger.ts";
+import { buildRunContext, ModelNotConfiguredError } from "./env-builder.ts";
+import { getCloudModule } from "../lib/cloud-loader.ts";
+import { createRun, getRunningRunCountForOrg } from "./state/index.ts";
+import { executeAgentInBackground } from "../routes/runs.ts";
+import type { LoadedPackage, ProviderProfileMap } from "../types/index.ts";
+import type { Actor } from "../lib/actor.ts";
+import type { UploadedFile, FileReference } from "./adapters/types.ts";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RunPipelineParams {
+  runId: string;
+  agent: LoadedPackage;
+  providerProfiles: ProviderProfileMap;
+  orgId: string;
+  actor: Actor | null;
+  input?: Record<string, unknown> | null;
+  files?: FileReference[];
+  config: Record<string, unknown>;
+  modelId?: string | null;
+  proxyId?: string | null;
+  overrideVersionId?: number;
+  /** Schedule ID — set only for scheduled runs. */
+  scheduleId?: string;
+  /** Connection profile ID used to create the run. */
+  connectionProfileId?: string;
+  /** Application ID for webhook scoping. */
+  applicationId?: string | null;
+  /** Uploaded files to inject into the container. */
+  uploadedFiles?: UploadedFile[];
+}
+
+export type RunPipelineError =
+  | { code: "model_not_configured"; message: string }
+  | { code: "quota_exceeded"; message: string }
+  | { code: "unexpected"; message: string };
+
+export type RunPipelineResult =
+  | { ok: true; runId: string; modelSource: string | null }
+  | { ok: false; error: RunPipelineError };
+
+// ---------------------------------------------------------------------------
+// Pipeline
+// ---------------------------------------------------------------------------
+
+/**
+ * Build run context, check quota, create run record, and fire-and-forget execution.
+ *
+ * Returns a result type instead of throwing — callers decide how to surface errors
+ * (e.g. throw ApiError for HTTP routes, or failSchedule for scheduled runs).
+ */
+export async function prepareAndExecuteRun(params: RunPipelineParams): Promise<RunPipelineResult> {
+  const {
+    runId,
+    agent,
+    providerProfiles,
+    orgId,
+    actor,
+    input,
+    files,
+    config,
+    modelId,
+    proxyId,
+    overrideVersionId,
+    scheduleId,
+    connectionProfileId,
+    applicationId,
+    uploadedFiles,
+  } = params;
+
+  // --- Step 1: Build run context ---
+  let promptContext;
+  let agentPackage: Buffer | null;
+  let packageVersionId: number | null;
+  let proxyLabel: string | null;
+  let modelLabel: string | null;
+  let modelSource: string | null;
+  try {
+    ({ promptContext, agentPackage, packageVersionId, proxyLabel, modelLabel, modelSource } =
+      await buildRunContext({
+        runId,
+        agent,
+        providerProfiles,
+        orgId,
+        actor,
+        input: input ?? undefined,
+        files,
+        config,
+        modelId,
+        proxyId,
+        overrideVersionId,
+      }));
+  } catch (err) {
+    if (err instanceof ModelNotConfiguredError) {
+      return { ok: false, error: { code: "model_not_configured", message: err.message } };
+    }
+    return {
+      ok: false,
+      error: { code: "unexpected", message: err instanceof Error ? err.message : String(err) },
+    };
+  }
+
+  // --- Step 2: Quota check (Cloud only) ---
+  const cloud = getCloudModule();
+  if (cloud) {
+    try {
+      const runningCount = await getRunningRunCountForOrg(orgId);
+      await cloud.cloudHooks.checkQuota(orgId, runningCount);
+    } catch (err) {
+      if (err instanceof cloud.QuotaExceededError) {
+        return { ok: false, error: { code: "quota_exceeded", message: err.message } };
+      }
+      return {
+        ok: false,
+        error: { code: "unexpected", message: err instanceof Error ? err.message : String(err) },
+      };
+    }
+  }
+
+  // --- Step 3: Extract profile ID map ---
+  const profileIdMap = Object.fromEntries(
+    Object.entries(providerProfiles).map(([k, v]) => [k, v.profileId]),
+  );
+
+  // --- Step 4: Create run record ---
+  await createRun(
+    runId,
+    agent.id,
+    actor,
+    orgId,
+    input ?? null,
+    scheduleId,
+    packageVersionId ?? undefined,
+    connectionProfileId,
+    proxyLabel ?? undefined,
+    modelLabel ?? undefined,
+    modelSource ?? undefined,
+    applicationId ?? undefined,
+    profileIdMap,
+  );
+
+  // --- Step 5: Fire-and-forget execution ---
+  executeAgentInBackground(
+    runId,
+    orgId,
+    agent,
+    promptContext,
+    agentPackage,
+    uploadedFiles,
+    applicationId,
+    modelSource,
+  ).catch((err) => {
+    logger.error("Unhandled error in background run", {
+      runId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+
+  return { ok: true, runId, modelSource };
+}

--- a/apps/api/src/services/scheduler.ts
+++ b/apps/api/src/services/scheduler.ts
@@ -12,12 +12,10 @@ import {
 import { batchLoadUserNames } from "../lib/user-helpers.ts";
 import { logger } from "../lib/logger.ts";
 import type { Schedule, EnrichedSchedule, ScheduleReadiness } from "@appstrate/shared-types";
-import { createRun, createFailedRun } from "./state/index.ts";
-import { executeAgentInBackground } from "../routes/runs.ts";
-import { dispatchWebhookEvents } from "./webhooks.ts";
-import { buildRunContext, ModelNotConfiguredError } from "./env-builder.ts";
+import { createFailedRun } from "./state/index.ts";
+import { dispatchRunWebhook } from "./webhooks.ts";
+import { prepareAndExecuteRun } from "./run-pipeline.ts";
 import { asRecordOrNull } from "../lib/safe-json.ts";
-import type { PromptContext } from "./adapters/types.ts";
 import { getPackage, packageExists } from "./agent-service.ts";
 import { getPackageConfig } from "./state/index.ts";
 import { validateAgentReadiness } from "./agent-readiness.ts";
@@ -34,8 +32,6 @@ import { ApiError, internalError } from "../lib/errors.ts";
 import { validateInput } from "./schema.ts";
 import { asJSONSchemaObject } from "@appstrate/core/form";
 import { computeNextRun } from "../lib/cron.ts";
-import { getRunningRunCountForOrg } from "./state/index.ts";
-import { getCloudModule } from "../lib/cloud-loader.ts";
 import { actorFromIds, type Actor } from "../lib/actor.ts";
 
 // ---------------------------------------------------------------------------
@@ -183,12 +179,7 @@ async function triggerScheduledRun(
     const runId = `run_${crypto.randomUUID()}`;
     try {
       await createFailedRun(runId, packageId, actor, orgId, error, scheduleId, connectionProfileId);
-      dispatchWebhookEvents(orgId, "run.failed", {
-        id: runId,
-        packageId,
-        status: "failed",
-        error,
-      }).catch(() => {});
+      dispatchRunWebhook(orgId, "failed", runId, packageId, { error });
     } catch (err) {
       logger.error("Failed to create failed schedule run record", {
         scheduleId,
@@ -301,99 +292,31 @@ async function triggerScheduledRun(
 
     const runId = `run_${crypto.randomUUID()}`;
 
-    // Build run context (tokens, config, state, providers, package, version)
-    let promptContext: PromptContext;
-    let agentPackage: Buffer | null;
-    let packageVersionId: number | null;
-    let proxyLabel: string | null;
-    let modelLabel: string | null;
-    let modelSource: string | null;
-    try {
-      ({ promptContext, agentPackage, packageVersionId, proxyLabel, modelLabel, modelSource } =
-        await buildRunContext({
-          runId,
-          agent,
-          providerProfiles,
-          orgId,
-          actor,
-          input,
-          config,
-          modelId: preflightModelId,
-          proxyId: preflightProxyId,
-        }));
-    } catch (err) {
-      if (err instanceof ModelNotConfiguredError) {
-        logger.warn("No model configured, skipping scheduled run", {
-          scheduleId,
-          packageId,
-          orgId,
-        });
-        await failSchedule("No model configured", actor);
-        return;
-      }
-      logger.error("Unexpected error building run context for schedule", {
+    const result = await prepareAndExecuteRun({
+      runId,
+      agent,
+      providerProfiles,
+      orgId,
+      actor,
+      input,
+      config,
+      modelId: preflightModelId,
+      proxyId: preflightProxyId,
+      scheduleId,
+      connectionProfileId,
+    });
+
+    if (!result.ok) {
+      logger.warn("Scheduled run pipeline failed", {
         scheduleId,
         packageId,
-        error: err instanceof Error ? err.message : String(err),
+        orgId,
+        code: result.error.code,
+        detail: result.error.message,
       });
-      await failSchedule(
-        `Run context error: ${err instanceof Error ? err.message : String(err)}`,
-        actor,
-      );
+      await failSchedule(result.error.message, actor);
       return;
     }
-
-    // Pre-run quota check (Cloud only — skip silently if quota exceeded)
-    const cloud = getCloudModule();
-    if (cloud) {
-      try {
-        const runningCount = await getRunningRunCountForOrg(orgId);
-        await cloud.cloudHooks.checkQuota(orgId, runningCount);
-      } catch (err) {
-        if (err instanceof cloud.QuotaExceededError) {
-          logger.warn("Quota exceeded, skipping scheduled run", {
-            scheduleId,
-            packageId,
-            orgId,
-            reason: err.message,
-          });
-          await failSchedule(err.message, actor);
-          return;
-        }
-        logger.error("Unexpected error during quota check for schedule", {
-          scheduleId,
-          packageId,
-          error: err instanceof Error ? err.message : String(err),
-        });
-        await failSchedule(
-          `Quota check error: ${err instanceof Error ? err.message : String(err)}`,
-          actor,
-        );
-        return;
-      }
-    }
-
-    // Extract just the profileId map (strip source field)
-    const profileIdMap = Object.fromEntries(
-      Object.entries(providerProfiles).map(([k, v]) => [k, v.profileId]),
-    );
-
-    // Create run record with schedule_id and version
-    await createRun(
-      runId,
-      packageId,
-      actor,
-      orgId,
-      input ?? null,
-      scheduleId,
-      packageVersionId ?? undefined,
-      connectionProfileId,
-      proxyLabel ?? undefined,
-      modelLabel ?? undefined,
-      modelSource ?? undefined,
-      undefined,
-      profileIdMap,
-    );
 
     logger.info("Triggering scheduled run", {
       runId,
@@ -401,23 +324,6 @@ async function triggerScheduledRun(
       scheduleId,
       connectionProfileId,
       orgId,
-    });
-
-    // Fire-and-forget (catch to prevent unhandled rejection)
-    executeAgentInBackground(
-      runId,
-      orgId,
-      agent,
-      promptContext,
-      agentPackage,
-      undefined,
-      undefined,
-      modelSource,
-    ).catch((err) => {
-      logger.error("Unhandled error in scheduled run", {
-        runId,
-        error: err instanceof Error ? err.message : String(err),
-      });
     });
   } catch (err) {
     logger.error("Failed to trigger schedule", {

--- a/apps/api/src/services/webhooks.ts
+++ b/apps/api/src/services/webhooks.ts
@@ -23,7 +23,7 @@ import { prefixedId } from "../lib/ids.ts";
 // Constants
 // ---------------------------------------------------------------------------
 
-export const webhookEventSchema = z.enum([
+const webhookEventSchema = z.enum([
   "run.started",
   "run.completed",
   "run.failed",
@@ -31,9 +31,9 @@ export const webhookEventSchema = z.enum([
   "run.cancelled",
 ]);
 
-export type WebhookEventType = z.infer<typeof webhookEventSchema>;
+type WebhookEventType = z.infer<typeof webhookEventSchema>;
 
-export const webhookEventsSchema = z.array(webhookEventSchema).min(1);
+const webhookEventsSchema = z.array(webhookEventSchema).min(1);
 
 /** Delays per attempt (attempt 1 = immediate, attempt 2 = 30s, etc.) */
 const RETRY_DELAYS_MS = [30_000, 300_000, 1_800_000, 3_600_000, 7_200_000, 10_800_000, 14_400_000];
@@ -94,7 +94,7 @@ function toWebhookResponse(row: {
 /**
  * Validate webhook URL — must be HTTPS (http://localhost in dev), not SSRF.
  */
-export function validateWebhookUrl(url: string): void {
+function validateWebhookUrl(url: string): void {
   let parsed: URL;
   try {
     parsed = new URL(url);
@@ -139,7 +139,7 @@ async function sign(secret: string, content: string): Promise<string> {
   return `v1,${Buffer.from(hasher.digest()).toString("base64")}`;
 }
 
-export async function buildSignedHeaders(
+async function buildSignedHeaders(
   eventId: string,
   timestamp: number,
   body: string,

--- a/apps/api/src/services/webhooks.ts
+++ b/apps/api/src/services/webhooks.ts
@@ -601,3 +601,29 @@ export async function shutdownWebhookWorker(): Promise<void> {
   await deliveryQueue?.shutdown();
   deliveryQueue = null;
 }
+
+/**
+ * Fire-and-forget webhook dispatch for run status changes.
+ * Shared by the run route (POST /run) and the scheduler (triggerScheduledRun).
+ */
+export function dispatchRunWebhook(
+  orgId: string,
+  status: string,
+  runId: string,
+  packageId: string,
+  extra?: Record<string, unknown>,
+  applicationId?: string | null,
+): void {
+  const eventType = `run.${status}` as WebhookEventType;
+  dispatchWebhookEvents(
+    orgId,
+    eventType,
+    { id: runId, packageId, status, ...extra },
+    applicationId,
+  ).catch((err) => {
+    logger.warn("Webhook dispatch failed", {
+      runId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+}

--- a/apps/api/test/integration/services/package-versions.test.ts
+++ b/apps/api/test/integration/services/package-versions.test.ts
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeEach } from "bun:test";
+import { and, eq } from "drizzle-orm";
+import { db } from "@appstrate/db/client";
+import { packageVersions } from "@appstrate/db/schema";
 import { truncateAll } from "../../helpers/db.ts";
 import { createTestUser } from "../../helpers/auth.ts";
 import { createTestOrg } from "../../helpers/auth.ts";
@@ -9,10 +12,6 @@ import {
   createPackageVersion,
   listPackageVersions,
   getLatestVersionId,
-  yankVersion,
-  addDistTag,
-  removeDistTag,
-  getMatchingDistTags,
   getVersionCount,
   getVersionInfo,
   getLatestVersionCreatedAt,
@@ -193,7 +192,11 @@ describe("package-versions service", () => {
       const before = await listPackageVersions(pkg.id);
       expect(before[0]!.yanked).toBe(false);
 
-      await yankVersion(pkg.id, "1.0.0");
+      // Directly mark as yanked via DB (yankVersion was removed — no route exposes it)
+      await db
+        .update(packageVersions)
+        .set({ yanked: true })
+        .where(and(eq(packageVersions.packageId, pkg.id), eq(packageVersions.version, "1.0.0")));
 
       const after = await listPackageVersions(pkg.id);
       expect(after[0]!.yanked).toBe(true);
@@ -227,69 +230,6 @@ describe("package-versions service", () => {
     });
   });
 
-  // ── yankVersion ───────────────────────────────────────────
-
-  describe("yankVersion", () => {
-    it("sets yanked=true on the target version", async () => {
-      const pkg = await seedPackage({ orgId, id: `@${orgSlug}/yank-agent` });
-
-      await createPackageVersion({
-        packageId: pkg.id,
-        version: "1.0.0",
-        integrity: "sha256-abc",
-        artifactSize: 1024,
-        manifest: { name: pkg.id, version: "1.0.0", type: "agent" },
-        orgId,
-        createdBy: userId,
-      });
-
-      const yanked = await yankVersion(pkg.id, "1.0.0");
-      expect(yanked).toBe(true);
-
-      const versions = await listPackageVersions(pkg.id);
-      expect(versions[0]!.yanked).toBe(true);
-    });
-
-    it("returns false for a non-existent version", async () => {
-      const pkg = await seedPackage({ orgId, id: `@${orgSlug}/no-yank` });
-
-      const result = await yankVersion(pkg.id, "9.9.9");
-      expect(result).toBe(false);
-    });
-
-    it("reassigns latest dist-tag when the current latest is yanked", async () => {
-      const pkg = await seedPackage({ orgId, id: `@${orgSlug}/reassign-agent` });
-      const base = {
-        packageId: pkg.id,
-        integrity: "sha256-abc",
-        artifactSize: 1024,
-        manifest: { name: pkg.id, type: "agent" } as Record<string, unknown>,
-        orgId,
-        createdBy: userId,
-      };
-
-      const v1 = await createPackageVersion({
-        ...base,
-        version: "1.0.0",
-        manifest: { ...base.manifest, version: "1.0.0" },
-      });
-      const v2 = await createPackageVersion({
-        ...base,
-        version: "2.0.0",
-        manifest: { ...base.manifest, version: "2.0.0" },
-      });
-
-      // latest should point to v2
-      expect(await getLatestVersionId(pkg.id)).toBe(v2!.id);
-
-      await yankVersion(pkg.id, "2.0.0");
-
-      // After yanking v2, latest should fall back to v1
-      const newLatest = await getLatestVersionId(pkg.id);
-      expect(newLatest).toBe(v1!.id);
-    });
-  });
-
   // ── getVersionCount ───────────────────────────────────────
 
   describe("getVersionCount", () => {
@@ -308,140 +248,6 @@ describe("package-versions service", () => {
       });
 
       expect(await getVersionCount(pkg.id)).toBe(1);
-    });
-  });
-
-  // ── addDistTag / removeDistTag ────────────────────────────
-
-  describe("addDistTag", () => {
-    it("adds a custom dist-tag to a version", async () => {
-      const pkg = await seedPackage({ orgId, id: `@${orgSlug}/tag-agent` });
-
-      const v1 = await createPackageVersion({
-        packageId: pkg.id,
-        version: "1.0.0",
-        integrity: "sha256-abc",
-        artifactSize: 1024,
-        manifest: { name: pkg.id, version: "1.0.0", type: "agent" },
-        orgId,
-        createdBy: userId,
-      });
-
-      await addDistTag(pkg.id, "beta", v1!.id);
-
-      const tags = await getMatchingDistTags(pkg.id, "1.0.0");
-      expect(tags).toContain("beta");
-      expect(tags).toContain("latest");
-    });
-
-    it("throws when setting the protected latest tag", async () => {
-      const pkg = await seedPackage({ orgId, id: `@${orgSlug}/prot-tag` });
-
-      const v1 = await createPackageVersion({
-        packageId: pkg.id,
-        version: "1.0.0",
-        integrity: "sha256-abc",
-        artifactSize: 1024,
-        manifest: { name: pkg.id, version: "1.0.0", type: "agent" },
-        orgId,
-        createdBy: userId,
-      });
-
-      await expect(addDistTag(pkg.id, "latest", v1!.id)).rejects.toThrow(
-        "The 'latest' tag cannot be set manually",
-      );
-    });
-
-    it("throws for an invalid tag name", async () => {
-      const pkg = await seedPackage({ orgId, id: `@${orgSlug}/inv-tag` });
-
-      const v1 = await createPackageVersion({
-        packageId: pkg.id,
-        version: "1.0.0",
-        integrity: "sha256-abc",
-        artifactSize: 1024,
-        manifest: { name: pkg.id, version: "1.0.0", type: "agent" },
-        orgId,
-        createdBy: userId,
-      });
-
-      await expect(addDistTag(pkg.id, "", v1!.id)).rejects.toThrow();
-    });
-
-    it("moves a dist-tag to a different version on re-add", async () => {
-      const pkg = await seedPackage({ orgId, id: `@${orgSlug}/move-tag` });
-      const base = {
-        packageId: pkg.id,
-        integrity: "sha256-abc",
-        artifactSize: 1024,
-        manifest: { name: pkg.id, type: "agent" } as Record<string, unknown>,
-        orgId,
-        createdBy: userId,
-      };
-
-      const v1 = await createPackageVersion({
-        ...base,
-        version: "1.0.0",
-        manifest: { ...base.manifest, version: "1.0.0" },
-      });
-      const v2 = await createPackageVersion({
-        ...base,
-        version: "2.0.0",
-        manifest: { ...base.manifest, version: "2.0.0" },
-      });
-
-      await addDistTag(pkg.id, "stable", v1!.id);
-
-      let tags = await getMatchingDistTags(pkg.id, "1.0.0");
-      expect(tags).toContain("stable");
-
-      // Move stable to v2
-      await addDistTag(pkg.id, "stable", v2!.id);
-
-      tags = await getMatchingDistTags(pkg.id, "1.0.0");
-      expect(tags).not.toContain("stable");
-
-      tags = await getMatchingDistTags(pkg.id, "2.0.0");
-      expect(tags).toContain("stable");
-    });
-  });
-
-  describe("removeDistTag", () => {
-    it("removes a custom dist-tag", async () => {
-      const pkg = await seedPackage({ orgId, id: `@${orgSlug}/rm-tag` });
-
-      const v1 = await createPackageVersion({
-        packageId: pkg.id,
-        version: "1.0.0",
-        integrity: "sha256-abc",
-        artifactSize: 1024,
-        manifest: { name: pkg.id, version: "1.0.0", type: "agent" },
-        orgId,
-        createdBy: userId,
-      });
-
-      await addDistTag(pkg.id, "canary", v1!.id);
-      let tags = await getMatchingDistTags(pkg.id, "1.0.0");
-      expect(tags).toContain("canary");
-
-      await removeDistTag(pkg.id, "canary");
-      tags = await getMatchingDistTags(pkg.id, "1.0.0");
-      expect(tags).not.toContain("canary");
-    });
-
-    it("throws when removing the protected latest tag", async () => {
-      const pkg = await seedPackage({ orgId, id: `@${orgSlug}/rm-latest` });
-
-      await expect(removeDistTag(pkg.id, "latest")).rejects.toThrow(
-        "The 'latest' tag cannot be removed",
-      );
-    });
-
-    it("is a no-op when removing a non-existent tag", async () => {
-      const pkg = await seedPackage({ orgId, id: `@${orgSlug}/rm-noop` });
-
-      // Should not throw
-      await removeDistTag(pkg.id, "nonexistent");
     });
   });
 

--- a/apps/web/src/hooks/use-agent-readiness.ts
+++ b/apps/web/src/hooks/use-agent-readiness.ts
@@ -3,7 +3,7 @@
 import { useMemo } from "react";
 import type { AgentDetail, OrgModelInfo } from "@appstrate/shared-types";
 import type { JSONSchemaObject } from "@appstrate/core/form";
-import { isPromptEmpty, findMissingDependencies } from "@appstrate/shared-types";
+import { isPromptEmpty, findMissingDependencies } from "@appstrate/core/validation";
 
 export function useAgentReadiness(
   detail: AgentDetail | undefined,

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -477,3 +477,24 @@ export function validateToolSource(source: string): ToolSourceValidationResult {
 
   return { valid: errors.length === 0, errors, warnings };
 }
+
+// ─────────────────────────────────────────────
+// Agent readiness utilities
+// ─────────────────────────────────────────────
+
+/** Check if a prompt is empty or whitespace-only. */
+export function isPromptEmpty(prompt: string): boolean {
+  return prompt.trim().length === 0;
+}
+
+/**
+ * Find IDs declared in `required` but missing from `installed`.
+ * Works for both skills and tools.
+ */
+export function findMissingDependencies(
+  required: Record<string, string>,
+  installedIds: string[],
+): string[] {
+  const installed = new Set(installedIds);
+  return Object.keys(required).filter((id) => !installed.has(id));
+}

--- a/packages/db/src/notify.ts
+++ b/packages/db/src/notify.ts
@@ -57,22 +57,6 @@ export async function createNotifyTriggers(db: Db): Promise<void> {
     $$ LANGUAGE plpgsql
   `);
 
-  // Drop legacy triggers from pre-rename era (flow→agent, execution→run).
-  // The old execution_logs_notify_trigger references NEW.execution_id which no longer exists,
-  // causing every INSERT into run_logs to fail.
-  await db.execute(drizzleSql`
-    DROP TRIGGER IF EXISTS executions_notify_trigger ON runs
-  `);
-  await db.execute(drizzleSql`
-    DROP TRIGGER IF EXISTS execution_logs_notify_trigger ON run_logs
-  `);
-  await db.execute(drizzleSql`
-    DROP FUNCTION IF EXISTS notify_execution_change()
-  `);
-  await db.execute(drizzleSql`
-    DROP FUNCTION IF EXISTS notify_execution_log_insert()
-  `);
-
   // Create triggers (drop first to avoid duplicates)
   await db.execute(drizzleSql`
     DROP TRIGGER IF EXISTS runs_notify_trigger ON runs

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -97,25 +97,6 @@ export interface OrgInvitation {
 
 import type { JSONSchemaObject, SchemaWrapper } from "@appstrate/core/form";
 
-// --- Agent Readiness Utilities ---
-
-/** Check if a prompt is empty or whitespace-only. */
-export function isPromptEmpty(prompt: string): boolean {
-  return prompt.trim().length === 0;
-}
-
-/**
- * Find IDs declared in `required` but missing from `installed`.
- * Works for both skills and tools.
- */
-export function findMissingDependencies(
-  required: Record<string, string>,
-  installedIds: string[],
-): string[] {
-  const installed = new Set(installedIds);
-  return Object.keys(required).filter((id) => !installed.has(id));
-}
-
 // --- Connection Types ---
 
 /** Connection record as returned by the API (no encrypted credentials). */


### PR DESCRIPTION
## Summary

- **Extract shared run pipeline** (`services/run-pipeline.ts`) — build context, quota check, create run, and execute are now a single code path used by both the POST /run route and the scheduler. Eliminates ~80 lines of duplicated logic and the source of recent error-handling inconsistencies.
- **Extract `dispatchRunWebhook()`** from a local wrapper in runs.ts to a shared export in webhooks.ts — scheduler now uses it with proper error logging instead of silent catch-all.
- **Remove dead exports**: `yankVersion()`, `addDistTag()`, `removeDistTag()` from package-versions.ts (no route exposes them), `resolveVersionManifest`, `VersionDetail` interface, `CreateVersionError`/`CreateVersionResult` types.
- **Un-export internal webhook symbols**: `webhookEventSchema`, `webhookEventsSchema`, `WebhookEventType`, `validateWebhookUrl`, `buildSignedHeaders`.
- **Move utility functions** (`isPromptEmpty`, `findMissingDependencies`) from `@appstrate/shared-types` to `@appstrate/core/validation` where manifest logic belongs.
- **Extract `extractManifestSchemas()`** helper — replaces duplicated schema extraction in env-builder and agent-readiness.
- **Remove legacy trigger cleanup** from notify.ts (15 lines of DROP TRIGGER for pre-migration triggers — no production data).

Net: **-281 lines** across 13 files (+319 / -600).

## Test plan

- [x] `bun run check` passes (8/8 packages)
- [x] `bun test apps/api/test/unit/` passes (396 tests)
- [x] Pre-push hooks pass (typecheck + eslint + prettier + OpenAPI + system packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)