### PR TITLE
fix: copy e2e/package.json in Dockerfile deps stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY packages/emails/package.json packages/emails/
 COPY packages/env/package.json packages/env/
 COPY runtime-pi/package.json runtime-pi/
 COPY runtime-pi/sidecar/package.json runtime-pi/sidecar/
+COPY e2e/package.json e2e/
 COPY patches/ patches/
 
 RUN bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Add missing `COPY e2e/package.json e2e/` to Dockerfile deps stage
- The `e2e` workspace was listed in `package.json` workspaces but not copied, causing `bun install --frozen-lockfile` to fail in Docker builds

## Test plan

- [x] `bash scripts/docker-check.sh` passes all 4 stages
- [x] `bun run check` passes

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>