### PR TITLE
fix: use 127.0.0.1 in Docker healthchecks (IPv6 resolution bug)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -109,7 +109,7 @@ EXPOSE 3000
 ENV NODE_ENV=production
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
-  CMD wget -q -O /dev/null http://localhost:3000/ || exit 1
+  CMD wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["bun", "apps/api/src/index.ts"]

--- a/runtime-pi/sidecar/Dockerfile
+++ b/runtime-pi/sidecar/Dockerfile
@@ -23,6 +23,6 @@ USER nobody
 EXPOSE 8080 8081
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
-  CMD wget -q -O /dev/null http://localhost:8080/ || exit 1
+  CMD wget -q -O /dev/null http://127.0.0.1:8080/ || exit 1
 
 ENTRYPOINT ["/usr/local/bin/sidecar"]


### PR DESCRIPTION
## Summary
- Alpine resolves `localhost` to `::1` (IPv6) first, but Bun listens on `0.0.0.0` (IPv4 only)
- Healthcheck `wget http://localhost:3000/` fails with "Connection refused"
- Traefik returns 503 because the container is unhealthy
- Fix: use `127.0.0.1` instead of `localhost` in all Dockerfile healthchecks

## Impact
- **Production outage**: app.appstrate.com returning 503 after v1.0.0-alpha.32 deploy
- This was likely always broken but only surfaced now (possibly new Alpine/Docker version)

🤖 Generated with [Claude Code](https://claude.com/claude-code)