### PR TITLE
feat(core): centralize FORMAT_TO_HTML_INPUT_TYPE in core/form

### DIFF
--- a/apps/web/src/components/input-fields.tsx
+++ b/apps/web/src/components/input-fields.tsx
@@ -6,7 +6,7 @@ import { JsonFieldEditor } from "./json-field-editor";
 import { MultiSelectField } from "./multi-select";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
-import { schemaToFields, type SchemaWrapper, type FieldDescriptor } from "@appstrate/core/form";
+import { schemaToFields, toHtmlInputType, type SchemaWrapper } from "@appstrate/core/form";
 
 interface InputFieldsProps {
   schema: SchemaWrapper;
@@ -16,30 +16,6 @@ interface InputFieldsProps {
   onFileChange?: (key: string, files: File[]) => void;
   idPrefix?: string;
   errors?: Record<string, string>;
-}
-
-/** Map JSON Schema format → HTML input type for string fields. */
-const FORMAT_TO_INPUT_TYPE: Record<string, FormFieldType> = {
-  email: "email",
-  "idn-email": "email",
-  uri: "url",
-  url: "url",
-  date: "date",
-  "date-time": "datetime-local",
-  time: "time",
-  color: "color",
-  password: "password",
-};
-
-/** Resolve the HTML input type from a FieldDescriptor. */
-function toFormFieldType(field: FieldDescriptor): FormFieldType {
-  if (field.type === "number" || field.type === "integer") return "number";
-  if (field.type === "textarea") return "textarea";
-  // Format-based resolution for text fields
-  if (field.type === "text" && field.format) {
-    return FORMAT_TO_INPUT_TYPE[field.format] ?? "text";
-  }
-  return "text";
 }
 
 export function InputFields({
@@ -133,7 +109,7 @@ export function InputFields({
         }
 
         // text, textarea, number, integer, enum, and format-based fields → FormField
-        const formType = toFormFieldType(field);
+        const formType = toHtmlInputType(field) as FormFieldType;
         const v = field.validation;
 
         return (

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/core/src/form.ts
+++ b/packages/core/src/form.ts
@@ -147,6 +147,31 @@ export interface FieldError {
   params?: Record<string, unknown>;
 }
 
+// ─── HTML Input Type Resolution ─────────────────────────────────────────────
+
+/** Map JSON Schema format → HTML input type for string fields. */
+export const FORMAT_TO_HTML_INPUT_TYPE: Readonly<Record<string, string>> = {
+  email: "email",
+  "idn-email": "email",
+  uri: "url",
+  url: "url",
+  date: "date",
+  "date-time": "datetime-local",
+  time: "time",
+  color: "color",
+  password: "password",
+};
+
+/** Resolve the HTML input type from a FieldDescriptor. */
+export function toHtmlInputType(field: FieldDescriptor): string {
+  if (field.type === "number" || field.type === "integer") return "number";
+  if (field.type === "textarea") return "textarea";
+  if (field.type === "text" && field.format) {
+    return FORMAT_TO_HTML_INPUT_TYPE[field.format] ?? "text";
+  }
+  return "text";
+}
+
 // ─── Internal helpers ────────────────────────────────────────────────────────
 
 /** Extract the list of required field names from a JSON Schema object. */


### PR DESCRIPTION
## Summary
- Extract `FORMAT_TO_HTML_INPUT_TYPE` constant and `toHtmlInputType()` resolver from duplicated UI code into `@appstrate/core/form`
- Remove local `FORMAT_TO_INPUT_TYPE` + `toFormFieldType` from `apps/web/src/components/input-fields.tsx` — now imports from core
- Bump `@appstrate/core` to 2.10.5

## Test plan
- [x] `bun run check` passes (tsc + eslint + prettier + OpenAPI)
- [ ] Verify form rendering unchanged in agent editor (all field types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)