### PR TITLE
chore: bump sidecar hono to ^4.11.9

### DIFF
--- a/runtime-pi/sidecar/package.json
+++ b/runtime-pi/sidecar/package.json
@@ -6,6 +6,6 @@
     "test": "bun test"
   },
   "dependencies": {
-    "hono": "^4.0.0"
+    "hono": "^4.11.9"
   }
 }


### PR DESCRIPTION
## Summary
- Bump sidecar `hono` from `^4.0.0` to `^4.11.9` to align with the rest of the monorepo

## Test plan
- [x] `bun run check` passes
- [ ] Sidecar proxy works correctly in agent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)