### PR TITLE
fix(openapi): document run enrichment fields in Run schema

### DIFF
--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -410,6 +410,10 @@ export const schemas = {
         type: ["string", "null"],
         description: "End-user ID (eu_ prefix) if executed on behalf of an end-user",
       },
+      apiKeyId: {
+        type: ["string", "null"],
+        description: "API key ID that triggered the run (null for dashboard/schedule runs)",
+      },
       applicationId: {
         type: ["string", "null"],
         description: "Application ID (app_ prefix) that owns this run",
@@ -418,6 +422,22 @@ export const schemas = {
         type: ["object", "null"],
         description: "Additional metadata (e.g. creditsUsed in cloud mode)",
         additionalProperties: true,
+      },
+      userName: {
+        type: ["string", "null"],
+        description: "Display name of the user who triggered the run (from profiles table)",
+      },
+      endUserName: {
+        type: ["string", "null"],
+        description: "Display name of the end-user (name or externalId fallback)",
+      },
+      apiKeyName: {
+        type: ["string", "null"],
+        description: "Name of the API key that triggered the run",
+      },
+      scheduleName: {
+        type: ["string", "null"],
+        description: "Name of the schedule that triggered the run",
       },
     },
   },

--- a/apps/web/src/components/input-fields.tsx
+++ b/apps/web/src/components/input-fields.tsx
@@ -6,7 +6,7 @@ import { JsonFieldEditor } from "./json-field-editor";
 import { MultiSelectField } from "./multi-select";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
-import { schemaToFields, type SchemaWrapper, type FieldDescriptor } from "@appstrate/core/form";
+import { schemaToFields, toHtmlInputType, type SchemaWrapper } from "@appstrate/core/form";
 
 interface InputFieldsProps {
   schema: SchemaWrapper;
@@ -16,30 +16,6 @@ interface InputFieldsProps {
   onFileChange?: (key: string, files: File[]) => void;
   idPrefix?: string;
   errors?: Record<string, string>;
-}
-
-/** Map JSON Schema format → HTML input type for string fields. */
-const FORMAT_TO_INPUT_TYPE: Record<string, FormFieldType> = {
-  email: "email",
-  "idn-email": "email",
-  uri: "url",
-  url: "url",
-  date: "date",
-  "date-time": "datetime-local",
-  time: "time",
-  color: "color",
-  password: "password",
-};
-
-/** Resolve the HTML input type from a FieldDescriptor. */
-function toFormFieldType(field: FieldDescriptor): FormFieldType {
-  if (field.type === "number" || field.type === "integer") return "number";
-  if (field.type === "textarea") return "textarea";
-  // Format-based resolution for text fields
-  if (field.type === "text" && field.format) {
-    return FORMAT_TO_INPUT_TYPE[field.format] ?? "text";
-  }
-  return "text";
 }
 
 export function InputFields({
@@ -133,7 +109,7 @@ export function InputFields({
         }
 
         // text, textarea, number, integer, enum, and format-based fields → FormField
-        const formType = toFormFieldType(field);
+        const formType = toHtmlInputType(field) as FormFieldType;
         const v = field.validation;
 
         return (

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/core/src/form.ts
+++ b/packages/core/src/form.ts
@@ -147,6 +147,31 @@ export interface FieldError {
   params?: Record<string, unknown>;
 }
 
+// ─── HTML Input Type Resolution ─────────────────────────────────────────────
+
+/** Map JSON Schema format → HTML input type for string fields. */
+export const FORMAT_TO_HTML_INPUT_TYPE: Readonly<Record<string, string>> = {
+  email: "email",
+  "idn-email": "email",
+  uri: "url",
+  url: "url",
+  date: "date",
+  "date-time": "datetime-local",
+  time: "time",
+  color: "color",
+  password: "password",
+};
+
+/** Resolve the HTML input type from a FieldDescriptor. */
+export function toHtmlInputType(field: FieldDescriptor): string {
+  if (field.type === "number" || field.type === "integer") return "number";
+  if (field.type === "textarea") return "textarea";
+  if (field.type === "text" && field.format) {
+    return FORMAT_TO_HTML_INPUT_TYPE[field.format] ?? "text";
+  }
+  return "text";
+}
+
 // ─── Internal helpers ────────────────────────────────────────────────────────
 
 /** Extract the list of required field names from a JSON Schema object. */

--- a/runtime-pi/sidecar/package.json
+++ b/runtime-pi/sidecar/package.json
@@ -6,6 +6,6 @@
     "test": "bun test"
   },
   "dependencies": {
-    "hono": "^4.0.0"
+    "hono": "^4.11.9"
   }
 }


### PR DESCRIPTION
## Summary

- Add `apiKeyId`, `userName`, `endUserName`, `apiKeyName`, `scheduleName` to the `Run` component schema in `apps/api/src/openapi/schemas.ts`.
- Fields are already enriched at runtime (LEFT JOIN in `services/state/runs.ts`, `apiKeyId` set on insert in `routes/runs.ts`) and already documented in `baseline.json`, but were missing from the hand-written schema.

## Why this drifted

Commit `1341fbd1` (#63) added these 20 lines to `baseline.json` without touching `schemas.ts`. Likely a stray `openapi:baseline` run that captured a state where the fields existed in the schema, followed by a rebase/revert that lost the schema-side change while keeping the regenerated baseline.

## Why CI didn't catch it

1. **`openapi:diff` is not wired into CI.** `.github/workflows/check.yml` only runs `bun run check` (turbo typecheck + eslint + prettier + `verify-openapi.ts` + `build-system-packages.ts`). `detect-breaking-changes.ts` (the script that compares current spec vs baseline) has to be invoked manually via `bun run openapi:diff`, which nobody did.
2. **`verify-openapi.ts` doesn't inspect responses.** Its four steps cover endpoint count, structural validation, Redocly lint, and Zod↔OpenAPI alignment on **request bodies only**. A field returned by a service but absent from the component schema is invisible to it.
3. **No test covers the `Run` response shape** against the component schema.

Follow-up coming in a separate PR on `feat/platform-modules`: wire `openapi:diff` into the CI check workflow so future baseline drifts fail the build.

## Test plan

- [x] `bun run verify:openapi` passes
- [x] `bun run openapi:diff` resolves the 4 breaking changes on `GET /api/runs/{id}` (1 unrelated info-level change remains: new 500 status on `POST /api/agents/{scope}/{name}/run`)
- [x] `bunx tsc --noEmit` clean in `apps/api`

🤖 Generated with [Claude Code](https://claude.com/claude-code)