### PR TITLE
fix(connections): stop flagging needs_reconnection on agent-side 401s

### DIFF
--- a/apps/api/src/routes/internal.ts
+++ b/apps/api/src/routes/internal.ts
@@ -15,12 +15,39 @@ import {
   resolveCredentialsForProxy,
   forceRefreshCredentials,
   getProviderCredentialId,
+  getConnection,
+  RefreshError,
 } from "@appstrate/connect";
 import { resolveManifestProviders } from "../lib/manifest-utils.ts";
 import { unauthorized, forbidden, notFound, invalidRequest, internalError } from "../lib/errors.ts";
 import { actorFromIds, type Actor } from "../lib/actor.ts";
 
 export const reportAuthFailureSchema = z.object({ providerId: z.string().min(1) });
+
+/**
+ * Safety margin used when deciding whether a stored access token is still
+ * "fresh enough" that a forced refresh would be wasteful. The sidecar calls
+ * the refresh endpoint on any upstream 401; if the stored token has more
+ * than this much lifetime remaining, the 401 cannot be an expiry issue and
+ * must come from the agent's request itself (wrong header, wrong endpoint,
+ * missing scope) — so we skip the refresh entirely. Keeping a full minute
+ * absorbs reasonable clock skew between this server and the OAuth provider.
+ */
+const REFRESH_FRESHNESS_THRESHOLD_MS = 60_000;
+
+/**
+ * Returns true when the stored access token still has enough lifetime left
+ * that refreshing it would be pointless. Null / missing / unparseable
+ * `expiresAt` (providers without `expires_in`, legacy connections, non-OAuth2
+ * auth modes) returns false — we fall back to the existing refresh behavior
+ * in that case.
+ */
+export function isTokenFresh(expiresAt: string | Date | null | undefined): boolean {
+  if (!expiresAt) return false;
+  const ts = expiresAt instanceof Date ? expiresAt.getTime() : Date.parse(expiresAt);
+  if (Number.isNaN(ts)) return false;
+  return ts - Date.now() > REFRESH_FRESHNESS_THRESHOLD_MS;
+}
 
 /**
  * Verify the run token from the Authorization header.
@@ -213,6 +240,36 @@ export function createInternalRouter() {
     if (!credentialId) {
       throw notFound(`No provider credentials configured for '${providerId}' in application`);
     }
+
+    // Skip the OAuth refresh round-trip if the stored token still has
+    // significant lifetime left. A 401 on a demonstrably-fresh token cannot
+    // be an expiry issue — it must come from the agent's request itself
+    // (wrong header, wrong endpoint, missing scope). Refreshing here would
+    // burn provider rate limits, add latency, and churn rotating
+    // refresh_tokens for no benefit.
+    const connection = await getConnection(db, profileId, providerId, run.orgId, credentialId);
+    if (connection && isTokenFresh(connection.expiresAt)) {
+      const passthrough = await resolveCredentialsForProxy(
+        db,
+        profileId,
+        providerId,
+        run.orgId,
+        credentialId,
+      );
+      if (!passthrough) {
+        throw notFound(`No credentials for provider '${providerId}'`);
+      }
+
+      logger.info("Skipping refresh — stored token still fresh", {
+        runId,
+        providerId,
+        profileId,
+        expiresInMs: Date.parse(connection.expiresAt!) - Date.now(),
+      });
+
+      return c.json(passthrough);
+    }
+
     try {
       const result = await forceRefreshCredentials(
         db,
@@ -228,31 +285,66 @@ export function createInternalRouter() {
       logger.info("Forced credential refresh", { runId, providerId, profileId });
       return c.json(result);
     } catch (err) {
-      // Refresh failed (invalid_grant, network error) — flag the connection
-      await db
-        .update(userProviderConnections)
-        .set({ needsReconnection: true, updatedAt: new Date() })
-        .where(
-          and(
-            eq(userProviderConnections.profileId, profileId),
-            eq(userProviderConnections.providerId, providerId),
-            eq(userProviderConnections.orgId, run.orgId),
-            eq(userProviderConnections.providerCredentialId, credentialId),
-          ),
-        );
+      // Only a definitive "refresh_token is dead" signal (RFC 6749 §5.2:
+      // HTTP 400 + body.error === "invalid_grant") justifies flagging the
+      // connection. Transient failures (network, 5xx, timeout, non-JSON,
+      // other OAuth error codes) must not flag — the credential might still
+      // be valid and the initial 401 that triggered this refresh may have
+      // come from a malformed agent request, not a dead token.
+      if (err instanceof RefreshError && err.kind === "revoked") {
+        await db
+          .update(userProviderConnections)
+          .set({ needsReconnection: true, updatedAt: new Date() })
+          .where(
+            and(
+              eq(userProviderConnections.profileId, profileId),
+              eq(userProviderConnections.providerId, providerId),
+              eq(userProviderConnections.orgId, run.orgId),
+              eq(userProviderConnections.providerCredentialId, credentialId),
+            ),
+          );
 
-      logger.warn("Forced refresh failed, connection flagged for reconnection", {
+        logger.warn("Refresh token revoked, connection flagged for reconnection", {
+          runId,
+          providerId,
+          profileId,
+          status: err.status,
+        });
+
+        throw unauthorized(`Token refresh failed for provider '${providerId}': credential revoked`);
+      }
+
+      logger.warn("Transient refresh failure, connection left unchanged", {
         runId,
         providerId,
         profileId,
+        kind: err instanceof RefreshError ? err.kind : "unknown",
+        status: err instanceof RefreshError ? err.status : undefined,
         error: err instanceof Error ? err.message : String(err),
       });
 
-      throw unauthorized(`Token refresh failed for provider '${providerId}'`);
+      throw unauthorized(`Token refresh failed for provider '${providerId}' (transient)`);
     }
   });
 
   // POST /internal/connections/report-auth-failure — sidecar reports upstream 401
+  //
+  // A single 401 on an agent-generated request is NOT reliable evidence that
+  // the stored credential is dead. LLM agents frequently produce malformed
+  // requests (wrong header name, wrong auth scheme, wrong endpoint, missing
+  // API version header, wrong HTTP method) that providers reject with 401
+  // even when the token is perfectly valid. Flagging the connection on that
+  // basis forces users to reconnect unnecessarily and blocks all subsequent
+  // runs via dependency-validation.
+  //
+  // The only reliable "credential is dead" signal is a failed token refresh
+  // with HTTP 400 + body.error === "invalid_grant" (RFC 6749 §5.2), handled
+  // in the /credentials/:scope/:name/refresh route above.
+  //
+  // This endpoint is kept for telemetry — the sidecar still reports the
+  // failure so we can surface patterns in logs (provider returning 401
+  // frequently, specific agent generating malformed requests) — but it
+  // never mutates the connection.
   router.post("/connections/report-auth-failure", async (c) => {
     const { runId, run } = await verifyRunToken(c);
     const body = await c.req.json();
@@ -261,38 +353,16 @@ export function createInternalRouter() {
       throw invalidRequest("Missing or invalid providerId");
     }
     const { providerId } = parsed.data;
-
     const profileId = run.providerProfileIds?.[providerId];
-    if (!profileId) {
-      logger.warn("Auth failure report for unknown provider profile", { runId, providerId });
-      return c.json({ flagged: false });
-    }
 
-    const credentialId = await getProviderCredentialId(db, run.applicationId, providerId);
-    if (!credentialId) {
-      logger.warn("No provider credential found for auth failure report", { runId, providerId });
-      return c.json({ flagged: false });
-    }
-
-    await db
-      .update(userProviderConnections)
-      .set({ needsReconnection: true, updatedAt: new Date() })
-      .where(
-        and(
-          eq(userProviderConnections.profileId, profileId),
-          eq(userProviderConnections.providerId, providerId),
-          eq(userProviderConnections.orgId, run.orgId),
-          eq(userProviderConnections.providerCredentialId, credentialId),
-        ),
-      );
-
-    logger.info("Connection flagged for reconnection after upstream 401", {
+    logger.info("Upstream 401 reported by sidecar (connection not flagged)", {
       runId,
       providerId,
-      profileId,
+      profileId: profileId ?? null,
+      reason: "single-request 401 is ambiguous (agent syntax error vs dead credential)",
     });
 
-    return c.json({ flagged: true });
+    return c.json({ flagged: false });
   });
 
   return router;

--- a/apps/api/test/integration/routes/internal.test.ts
+++ b/apps/api/test/integration/routes/internal.test.ts
@@ -4,8 +4,16 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import { getTestApp } from "../../helpers/app.ts";
 import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
-import { seedAgent, seedRun } from "../../helpers/seed.ts";
+import {
+  seedAgent,
+  seedRun,
+  seedConnectionProfile,
+  seedConnectionForApp,
+} from "../../helpers/seed.ts";
 import { signRunToken } from "../../../src/lib/run-token.ts";
+import { db } from "../../helpers/db.ts";
+import { userProviderConnections } from "@appstrate/db/schema";
+import { and, eq } from "drizzle-orm";
 
 const app = getTestApp();
 
@@ -267,6 +275,170 @@ describe("Internal API", () => {
       });
 
       expect(res.status).toBe(404);
+    });
+  });
+
+  // ─── POST /internal/credentials/:scope/:name/refresh ─────────
+
+  describe("POST /internal/credentials/:scope/:name/refresh", () => {
+    const providerId = "@internalorg/gmail";
+
+    async function seedRunWithProfile(expiresAt: string | null): Promise<{
+      runToken: string;
+      profileId: string;
+    }> {
+      const profile = await seedConnectionProfile({
+        userId: ctx.user.id,
+        name: "Default",
+        isDefault: true,
+      });
+      await seedConnectionForApp(
+        profile.id,
+        providerId,
+        ctx.orgId,
+        ctx.defaultAppId,
+        { api_key: "stored-key-xyz" },
+        { expiresAt },
+      );
+      const run = await seedRun({
+        packageId: pkgId,
+        orgId: ctx.orgId,
+        applicationId: ctx.defaultAppId,
+        userId: ctx.user.id,
+        status: "running",
+        providerProfileIds: { [providerId]: profile.id },
+      });
+      return { runToken: signRunToken(run.id), profileId: profile.id };
+    }
+
+    it("returns 401 without token", async () => {
+      const res = await app.request(`/internal/credentials/${providerId}/refresh`, {
+        method: "POST",
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it("skips the refresh when the stored token is still fresh", async () => {
+      // 30 minutes of lifetime left — well above the 60s safety margin
+      const freshExpiry = new Date(Date.now() + 30 * 60_000).toISOString();
+      const { runToken, profileId } = await seedRunWithProfile(freshExpiry);
+
+      const rowBefore = (
+        await db
+          .select()
+          .from(userProviderConnections)
+          .where(
+            and(
+              eq(userProviderConnections.profileId, profileId),
+              eq(userProviderConnections.providerId, providerId),
+            ),
+          )
+      )[0]!;
+
+      const res = await app.request(`/internal/credentials/${providerId}/refresh`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${runToken}` },
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { credentials: Record<string, string> };
+      expect(body.credentials).toBeDefined();
+
+      // The connection row must be untouched — no updatedAt bump, no
+      // needsReconnection flag, no re-encryption.
+      const rowAfter = (
+        await db
+          .select()
+          .from(userProviderConnections)
+          .where(
+            and(
+              eq(userProviderConnections.profileId, profileId),
+              eq(userProviderConnections.providerId, providerId),
+            ),
+          )
+      )[0]!;
+      expect(rowAfter.updatedAt.getTime()).toBe(rowBefore.updatedAt.getTime());
+      expect(rowAfter.credentialsEncrypted).toBe(rowBefore.credentialsEncrypted);
+      expect(rowAfter.needsReconnection).toBe(false);
+    });
+
+    it("falls through to the refresh path when expiresAt is null", async () => {
+      // No expiresAt → isTokenFresh returns false → proceeds to
+      // forceRefreshCredentials. For an api_key-style connection with no
+      // provider definition, the refresh path returns the current credentials
+      // unchanged (no throw, no mutation) — so we just verify the request
+      // completes successfully.
+      const { runToken } = await seedRunWithProfile(null);
+
+      const res = await app.request(`/internal/credentials/${providerId}/refresh`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${runToken}` },
+      });
+
+      expect(res.status).toBe(200);
+    });
+
+    it("returns 404 when the provider is not mapped to a profile in the run", async () => {
+      // Run without providerProfileIds — refresh has no profile to resolve.
+      const res = await app.request(`/internal/credentials/${providerId}/refresh`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${runningToken}` },
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ─── POST /internal/connections/report-auth-failure ──────────
+
+  describe("POST /internal/connections/report-auth-failure", () => {
+    const providerId = "@internalorg/gmail";
+
+    it("logs the failure but does NOT mutate the connection", async () => {
+      // A 401 reported by the sidecar is ambiguous (agent error vs dead
+      // credential) and must never flag needsReconnection on its own.
+      const profile = await seedConnectionProfile({
+        userId: ctx.user.id,
+        name: "Default",
+        isDefault: true,
+      });
+      await seedConnectionForApp(profile.id, providerId, ctx.orgId, ctx.defaultAppId, {
+        api_key: "stored-key",
+      });
+      const run = await seedRun({
+        packageId: pkgId,
+        orgId: ctx.orgId,
+        applicationId: ctx.defaultAppId,
+        userId: ctx.user.id,
+        status: "running",
+        providerProfileIds: { [providerId]: profile.id },
+      });
+      const token = signRunToken(run.id);
+
+      const res = await app.request("/internal/connections/report-auth-failure", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ providerId }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { flagged: boolean };
+      expect(body.flagged).toBe(false);
+
+      const row = (
+        await db
+          .select()
+          .from(userProviderConnections)
+          .where(
+            and(
+              eq(userProviderConnections.profileId, profile.id),
+              eq(userProviderConnections.providerId, providerId),
+            ),
+          )
+      )[0]!;
+      expect(row.needsReconnection).toBe(false);
     });
   });
 });

--- a/apps/api/test/unit/is-token-fresh.test.ts
+++ b/apps/api/test/unit/is-token-fresh.test.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "bun:test";
+import { isTokenFresh } from "../../src/routes/internal.ts";
+
+const SEC = 1_000;
+const MIN = 60 * SEC;
+
+describe("isTokenFresh", () => {
+  it("returns false for null", () => {
+    expect(isTokenFresh(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isTokenFresh(undefined)).toBe(false);
+  });
+
+  it("returns false for an unparseable string", () => {
+    expect(isTokenFresh("not-a-date")).toBe(false);
+  });
+
+  it("returns false when expiresAt is in the past", () => {
+    const pastIso = new Date(Date.now() - 5 * MIN).toISOString();
+    expect(isTokenFresh(pastIso)).toBe(false);
+  });
+
+  it("returns false when expiresAt is exactly now", () => {
+    expect(isTokenFresh(new Date())).toBe(false);
+  });
+
+  it("returns false when expiresAt is within the 60s safety margin", () => {
+    const iso = new Date(Date.now() + 30 * SEC).toISOString();
+    expect(isTokenFresh(iso)).toBe(false);
+  });
+
+  it("returns false exactly at the threshold boundary (60s)", () => {
+    // >, not >= — exactly 60s remaining should NOT count as fresh
+    const iso = new Date(Date.now() + 60 * SEC).toISOString();
+    expect(isTokenFresh(iso)).toBe(false);
+  });
+
+  it("returns true when expiresAt is beyond the threshold", () => {
+    const iso = new Date(Date.now() + 61 * SEC).toISOString();
+    expect(isTokenFresh(iso)).toBe(true);
+  });
+
+  it("returns true when expiresAt is 5 minutes away", () => {
+    const iso = new Date(Date.now() + 5 * MIN).toISOString();
+    expect(isTokenFresh(iso)).toBe(true);
+  });
+
+  it("returns true when expiresAt is 1 hour away (typical OAuth2 token)", () => {
+    const iso = new Date(Date.now() + 60 * MIN).toISOString();
+    expect(isTokenFresh(iso)).toBe(true);
+  });
+
+  it("accepts a Date instance directly", () => {
+    expect(isTokenFresh(new Date(Date.now() + 10 * MIN))).toBe(true);
+    expect(isTokenFresh(new Date(Date.now() - 10 * MIN))).toBe(false);
+  });
+});

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -37,6 +37,9 @@ export type { InitiateOAuthResult, OAuthCallbackResult } from "./oauth.ts";
 export { initiateOAuth1, handleOAuth1Callback } from "./oauth1.ts";
 export type { OAuth1CallbackResult } from "./oauth1.ts";
 
+// Token refresh
+export { RefreshError } from "./token-refresh.ts";
+
 // Credentials
 export {
   getConnection,

--- a/packages/connect/src/token-refresh.ts
+++ b/packages/connect/src/token-refresh.ts
@@ -20,6 +20,36 @@ export interface RefreshContext {
 }
 
 /**
+ * Error thrown by forceRefresh when the OAuth token refresh call fails.
+ *
+ * `kind` discriminates between two cases that callers MUST treat differently:
+ *
+ * - `"revoked"`: the OAuth server responded with `HTTP 400` + body
+ *   `{ "error": "invalid_grant" }` per RFC 6749 §5.2. This is the only
+ *   reliable signal that the refresh token is dead and the user must
+ *   reconnect. Callers should set `needsReconnection = true`.
+ *
+ * - `"transient"`: every other failure mode (network error, timeout, 5xx,
+ *   non-JSON body, other 4xx, other OAuth error codes). The credential
+ *   might still be valid — callers MUST NOT flag the connection, and should
+ *   just fail the current request. Flagging on transient errors produces
+ *   false positives that force users to reconnect unnecessarily, especially
+ *   when the initial 401 that triggered the refresh came from a malformed
+ *   agent request (wrong header name, wrong auth scheme, wrong endpoint).
+ */
+export class RefreshError extends Error {
+  constructor(
+    message: string,
+    public readonly kind: "revoked" | "transient",
+    public readonly status?: number,
+    public readonly body?: string,
+  ) {
+    super(message);
+    this.name = "RefreshError";
+  }
+}
+
+/**
  * Force a token refresh regardless of expiry.
  * Returns refreshed credentials, or current credentials if no refresh token / not OAuth2.
  * Throws if the refresh request itself fails (invalid_grant, network error).
@@ -86,19 +116,45 @@ async function doRefresh(
       signal: AbortSignal.timeout(30_000),
     });
   } catch (err) {
-    throw new Error(`Token refresh network error for '${providerId}': ${extractErrorMessage(err)}`);
+    throw new RefreshError(
+      `Token refresh network error for '${providerId}': ${extractErrorMessage(err)}`,
+      "transient",
+    );
   }
 
   if (!response.ok) {
     const text = await response.text();
-    throw new Error(`Token refresh failed for '${providerId}': ${response.status} ${text}`);
+    // Per RFC 6749 §5.2, a dead refresh_token is signaled by HTTP 400 +
+    // body {"error": "invalid_grant"}. Any other failure (5xx, 401, 403,
+    // other 4xx, non-JSON body, body without an `error` field, other OAuth
+    // error codes like invalid_client/invalid_scope) is treated as transient.
+    let kind: "revoked" | "transient" = "transient";
+    if (response.status === 400) {
+      try {
+        const parsed = JSON.parse(text) as { error?: unknown };
+        if (parsed && typeof parsed === "object" && parsed.error === "invalid_grant") {
+          kind = "revoked";
+        }
+      } catch {
+        // Non-JSON body on 400 — not a revocation signal
+      }
+    }
+    throw new RefreshError(
+      `Token refresh failed for '${providerId}': ${response.status} ${text}`,
+      kind,
+      response.status,
+      text,
+    );
   }
 
   let tokenData: Record<string, unknown>;
   try {
     tokenData = (await response.json()) as Record<string, unknown>;
   } catch {
-    throw new Error(`Token refresh returned non-JSON response for '${providerId}'`);
+    throw new RefreshError(
+      `Token refresh returned non-JSON response for '${providerId}'`,
+      "transient",
+    );
   }
 
   const parsed = parseTokenResponse(

--- a/packages/connect/test/token-refresh.test.ts
+++ b/packages/connect/test/token-refresh.test.ts
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import type { Db } from "@appstrate/db/client";
+import { forceRefresh, RefreshError, type RefreshContext } from "../src/token-refresh.ts";
+import { encryptCredentials } from "../src/encryption.ts";
+
+// A stub db that throws if anything attempts to touch it.
+// All failure cases must throw BEFORE the success path that writes to the DB.
+const stubDb = new Proxy(
+  {},
+  {
+    get() {
+      throw new Error("stubDb should not be called on failure paths");
+    },
+  },
+) as unknown as Db;
+
+const encryptedCreds = encryptCredentials({
+  access_token: "old_access",
+  refresh_token: "old_refresh",
+});
+
+const ctx: RefreshContext = {
+  tokenUrl: "https://oauth.example.com/token",
+  clientId: "client_id",
+  clientSecret: "client_secret",
+};
+
+const originalFetch = globalThis.fetch;
+
+function mockFetchOnce(response: Response | Promise<Response> | (() => never)) {
+  globalThis.fetch = mock(async () => {
+    if (typeof response === "function") response();
+    return response as Response;
+  }) as unknown as typeof fetch;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function textResponse(status: number, body: string): Response {
+  return new Response(body, { status, headers: { "Content-Type": "text/plain" } });
+}
+
+describe("forceRefresh — error classification", () => {
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  // ── "revoked" cases (flag needsReconnection) ─────────────────
+
+  it('400 + {"error":"invalid_grant"} → kind = "revoked"', async () => {
+    mockFetchOnce(jsonResponse(400, { error: "invalid_grant" }));
+
+    try {
+      await forceRefresh(stubDb, "conn_1", "prov", encryptedCreds, ctx);
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RefreshError);
+      expect((err as RefreshError).kind).toBe("revoked");
+      expect((err as RefreshError).status).toBe(400);
+    }
+  });
+
+  it('400 + {"error":"invalid_grant","error_description":"..."} (Google format) → "revoked"', async () => {
+    mockFetchOnce(
+      jsonResponse(400, {
+        error: "invalid_grant",
+        error_description: "Token has been expired or revoked.",
+      }),
+    );
+
+    try {
+      await forceRefresh(stubDb, "conn_2", "prov", encryptedCreds, ctx);
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RefreshError);
+      expect((err as RefreshError).kind).toBe("revoked");
+    }
+  });
+
+  // ── "transient" cases (do NOT flag) ──────────────────────────
+
+  it('400 + {"error":"invalid_client"} → "transient" (config problem, not dead credential)', async () => {
+    mockFetchOnce(jsonResponse(400, { error: "invalid_client" }));
+
+    try {
+      await forceRefresh(stubDb, "conn_3", "prov", encryptedCreds, ctx);
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RefreshError);
+      expect((err as RefreshError).kind).toBe("transient");
+    }
+  });
+
+  it('400 + {"error":"invalid_scope"} → "transient"', async () => {
+    mockFetchOnce(jsonResponse(400, { error: "invalid_scope" }));
+
+    try {
+      await forceRefresh(stubDb, "conn_4", "prov", encryptedCreds, ctx);
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect((err as RefreshError).kind).toBe("transient");
+    }
+  });
+
+  it("400 with non-JSON body → transient", async () => {
+    mockFetchOnce(textResponse(400, "Bad Request"));
+
+    try {
+      await forceRefresh(stubDb, "conn_5", "prov", encryptedCreds, ctx);
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect((err as RefreshError).kind).toBe("transient");
+    }
+  });
+
+  it("400 + JSON body without error field → transient", async () => {
+    mockFetchOnce(jsonResponse(400, { message: "something went wrong" }));
+
+    try {
+      await forceRefresh(stubDb, "conn_6", "prov", encryptedCreds, ctx);
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect((err as RefreshError).kind).toBe("transient");
+    }
+  });
+
+  it('401 + {"error":"invalid_grant"} → transient (status must be 400)', async () => {
+    mockFetchOnce(jsonResponse(401, { error: "invalid_grant" }));
+
+    try {
+      await forceRefresh(stubDb, "conn_7", "prov", encryptedCreds, ctx);
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect((err as RefreshError).kind).toBe("transient");
+      expect((err as RefreshError).status).toBe(401);
+    }
+  });
+
+  it("500 → transient", async () => {
+    mockFetchOnce(textResponse(500, "Internal Server Error"));
+
+    try {
+      await forceRefresh(stubDb, "conn_8", "prov", encryptedCreds, ctx);
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect((err as RefreshError).kind).toBe("transient");
+      expect((err as RefreshError).status).toBe(500);
+    }
+  });
+
+  it("502 → transient", async () => {
+    mockFetchOnce(textResponse(502, "Bad Gateway"));
+
+    try {
+      await forceRefresh(stubDb, "conn_9", "prov", encryptedCreds, ctx);
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect((err as RefreshError).kind).toBe("transient");
+    }
+  });
+
+  it("network error (fetch throws) → transient", async () => {
+    globalThis.fetch = mock(async () => {
+      throw new TypeError("fetch failed");
+    }) as unknown as typeof fetch;
+
+    try {
+      await forceRefresh(stubDb, "conn_10", "prov", encryptedCreds, ctx);
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RefreshError);
+      expect((err as RefreshError).kind).toBe("transient");
+      expect((err as RefreshError).status).toBeUndefined();
+    }
+  });
+
+  it("200 with non-JSON body → transient (success but unparseable)", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response("not json", {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        }),
+    ) as unknown as typeof fetch;
+
+    try {
+      await forceRefresh(stubDb, "conn_11", "prov", encryptedCreds, ctx);
+      throw new Error("expected to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(RefreshError);
+      expect((err as RefreshError).kind).toBe("transient");
+    }
+  });
+});
+
+describe("forceRefresh — no refresh context", () => {
+  it("returns current credentials when refreshContext is omitted", async () => {
+    const result = await forceRefresh(stubDb, "conn_noctx", "prov", encryptedCreds);
+    expect(result.access_token).toBe("old_access");
+    expect(result.refresh_token).toBe("old_refresh");
+  });
+});


### PR DESCRIPTION
## Summary

Prevents false-positive \`needs_reconnection\` flags caused by malformed agent requests. Previously, any 401 returned by a provider during an agent run could flag the connection as dead, blocking every subsequent run until the user reconnected manually — even when the credential was perfectly valid and the root cause was the agent using the wrong header name, wrong auth scheme, wrong endpoint, or missing API version header.

Three layers of protection, aligned with RFC 6749 §5.2:

1. **Skip the refresh round-trip entirely when the stored token is still fresh.** New \`isTokenFresh\` helper reads the existing \`expiresAt\` column. If the token has >60s of lifetime left, a 401 cannot be an expiry issue — it must come from the agent's request. The platform returns the current credentials to the sidecar without calling the OAuth server, saving provider quota, latency, and avoiding churn on rotating refresh tokens.

2. **Classify token-refresh failures strictly.** New \`RefreshError\` class with \`kind: "revoked" | "transient"\`. Only \`HTTP 400\` + \`body.error === "invalid_grant"\` produces \`"revoked"\` (the sole reliable dead-credential signal per RFC 6749 §5.2). Network errors, timeouts, 5xx, non-JSON bodies, and every other OAuth error code are \`"transient"\` and **never** flag the connection.

3. **\`POST /internal/connections/report-auth-failure\` is now log-only.** A single upstream 401 after a retry is too ambiguous to mutate state on its own. The endpoint remains in place so we can surface patterns in logs (provider returning 401 frequently, specific agent generating malformed requests), but it no longer touches \`needsReconnection\`.

### Behaviour after the fix

Scenario: agent does \`curl -H "X-Authorization: Bearer {{access_token}}"\` (wrong header name).

\`\`\`
1. Agent request → sidecar /proxy → upstream 401
2. Sidecar POST /internal/credentials/.../refresh
3. Platform: isTokenFresh(expiresAt) === true
   → log "Skipping refresh — stored token still fresh"
   → return current creds (no call to provider's token endpoint)
4. Sidecar retries with same creds → upstream 401 (header still wrong)
5. Sidecar POST /connections/report-auth-failure
   → log "Upstream 401 reported by sidecar (connection not flagged)"
   → return { flagged: false }
6. Sidecar passes the 401 to the agent → agent sees its error in the HTTP response

Zero OAuth calls, zero flag, subsequent runs continue on a healthy credential.
\`\`\`

The only path that still flags \`needs_reconnection\` is a real \`invalid_grant\` response from the OAuth server's token endpoint, which is the RFC-compliant proof that the refresh token is dead.

## Files

| File | Change |
|---|---|
| \`packages/connect/src/token-refresh.ts\` | New \`RefreshError\` class, RFC 6749 §5.2 classification in \`doRefresh\` |
| \`packages/connect/src/index.ts\` | Re-export \`RefreshError\` |
| \`apps/api/src/routes/internal.ts\` | \`isTokenFresh\` helper + freshness guard in \`/credentials/.../refresh\` + discriminated catch + \`report-auth-failure\` no-op |
| \`packages/connect/test/token-refresh.test.ts\` | **New** — 12 classification tests |
| \`apps/api/test/unit/is-token-fresh.test.ts\` | **New** — 11 helper tests |
| \`apps/api/test/integration/routes/internal.test.ts\` | +5 integration tests (skip-refresh, null-expiry fall-through, 401, missing profile, report-auth-failure no-op) |

No DB migration. No sidecar changes. No frontend changes. Non-OAuth2 providers (api_key, basic, custom) are unaffected — they already couldn't reach the flagging path.

## Test plan

- [x] \`bun run check\` (tsc + eslint + prettier + verify-openapi) — all 13 tasks pass
- [x] \`bun test apps/api/test/unit/is-token-fresh.test.ts\` — 11/11 pass
- [x] \`bun test packages/connect/test/token-refresh.test.ts\` — 12/12 pass
- [x] \`bun test apps/api/test/integration/routes/internal.test.ts\` — 21/21 pass (existing + new)
- [x] \`bun test apps/api/test/integration/services/app-connection-scoping.test.ts\` — 56/56 pass (no regression)
- [ ] Manual: trigger a run with an agent that sends a bad header, verify no \`needs_reconnection\` flag and no OAuth token-endpoint call in logs
- [ ] Manual: revoke refresh token on provider side (e.g. Google account security), verify connection is correctly flagged via \`invalid_grant\`

## Risks

- **Silent revocation inside the token lifetime window**: if a user revokes access on the provider side *before* the stored \`expiresAt\`, the sidecar will keep returning the revoked token until expiry. Each request will 401 and pass through cleanly — the run fails with a visible error, nothing gets flagged. Same behaviour as before for non-OAuth2 providers; no regression for OAuth2.
- **Clock skew > 60s**: if this server and the OAuth provider diverge by more than one minute, the freshness guard could skip a refresh on a token that's actually expired. NTP handles this in practice. Increase \`REFRESH_FRESHNESS_THRESHOLD_MS\` if needed.
- **Providers emitting short-lived tokens (<2 min)**: the fixed 60s threshold is too aggressive. No current provider does this; we can make the threshold dynamic later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)