### PR TITLE
chore(core): bump to 2.10.6

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to `@appstrate/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.6] — 2026-04-11
+
+### Added
+
+- `module` export — `AppstrateModule` contract, `ModuleManifest`, `ModuleInitContext`, hook & event type maps. Enables external modules to implement the Appstrate module system without depending on the API package.
+
+### Changed
+
+- Updated `Run` schema with enrichment fields (`userName`, `endUserName`, `apiKeyName`, `scheduleName`).
+
 ## [2.10.3] — 2026-04-02
 
 ### Changed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "2.10.5",
+  "version": "2.10.6",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/core/schema/provider.schema.json
+++ b/packages/core/schema/provider.schema.json
@@ -106,6 +106,20 @@
             },
             "tokenUrl": {
               "type": "string"
+            },
+            "tokenAuthMethod": {
+              "type": "string",
+              "enum": [
+                "client_secret_post",
+                "client_secret_basic"
+              ]
+            },
+            "tokenContentType": {
+              "type": "string",
+              "enum": [
+                "application/x-www-form-urlencoded",
+                "application/json"
+              ]
             }
           },
           "required": [
@@ -143,6 +157,26 @@
           },
           "required": [
             "schema"
+          ],
+          "additionalProperties": {}
+        },
+        "credentialTransform": {
+          "type": "object",
+          "properties": {
+            "template": {
+              "type": "string",
+              "minLength": 1
+            },
+            "encoding": {
+              "type": "string",
+              "enum": [
+                "base64"
+              ]
+            }
+          },
+          "required": [
+            "template",
+            "encoding"
           ],
           "additionalProperties": {}
         },


### PR DESCRIPTION
## Summary

- Bump `@appstrate/core` to 2.10.6
- Ships the new `module` export (AppstrateModule contract) from PR #72
- Refresh provider JSON schema from the generator
- Add CHANGELOG entry

## Test plan

- [x] `cd packages/core && bun run check` passes
- [x] `bun run generate:schemas` — only expected provider schema diff
- [x] Root `turbo check` passes (typecheck, lint, format, openapi, breaking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)