### PR TITLE
chore(core): bump to 2.10.7 (fix publish)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "appstrate",
       "dependencies": {
-        "@afps-spec/schema": "^1.2.1",
+        "@afps-spec/schema": "^1.3.1",
         "@appstrate/core": "workspace:*",
         "@electric-sql/pglite": "^0.4.3",
         "ajv": "^8.18.0",
@@ -143,9 +143,9 @@
     },
     "packages/core": {
       "name": "@appstrate/core",
-      "version": "2.10.5",
+      "version": "2.10.7",
       "dependencies": {
-        "@afps-spec/schema": "^1.2.1",
+        "@afps-spec/schema": "^1.3.1",
         "fflate": "^0.8.0",
         "pino": "^10.3.1",
         "semver": "^7.7.1",
@@ -220,7 +220,7 @@
     "@redocly/openapi-core@2.25.2": "patches/@redocly%2Fopenapi-core@2.25.2.patch",
   },
   "packages": {
-    "@afps-spec/schema": ["@afps-spec/schema@1.2.1", "", { "dependencies": { "ajv": "^8.17.1", "semver": "^7.7.4", "zod": "^4.3.6" } }, "sha512-x1t5HSsoqTTuk6m8H+bwg6gkA3JXeTh5USi4/+O7yAUtOVm4QXhHiNBTNupMxpSYcwM7J0mDwoMIzRoTmTPcJA=="],
+    "@afps-spec/schema": ["@afps-spec/schema@1.3.1", "", { "dependencies": { "ajv": "^8.17.1", "semver": "^7.7.4", "zod": "^4.3.6" } }, "sha512-9mkj+GTbuj6mGm1WjNt9cwHhao/7RC1AUIdDagsLBo9By63fEBCf84So6HMCDlC3AuT9VxEdBVJUGYgkXcefLw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.73.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw=="],
 

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "*.{ts,tsx,json,md,yml,yaml}": "prettier --write"
   },
   "dependencies": {
-    "@afps-spec/schema": "^1.2.1",
+    "@afps-spec/schema": "^1.3.1",
     "@appstrate/core": "workspace:*",
     "@electric-sql/pglite": "^0.4.3",
     "ajv": "^8.18.0"

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to `@appstrate/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.7] — 2026-04-11
+
+### Changed
+
+- Bump `@afps-spec/schema` to `^1.3.1` — adds `tokenAuthMethod` and `tokenContentType` fields to the provider OAuth2 config schema.
+- Refresh `schema/provider.schema.json` with the new OAuth2 token handling fields.
+
 ## [2.10.6] — 2026-04-11
 
 ### Added

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "2.10.6",
+  "version": "2.10.7",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",
@@ -60,7 +60,7 @@
     "./module": "./src/module.ts"
   },
   "dependencies": {
-    "@afps-spec/schema": "^1.2.1",
+    "@afps-spec/schema": "^1.3.1",
     "fflate": "^0.8.0",
     "pino": "^10.3.1",
     "semver": "^7.7.1",


### PR DESCRIPTION
## Summary

- Bump `@appstrate/core` to 2.10.7 — 2.10.6 failed to publish
- Bump `@afps-spec/schema` from ^1.2.1 to ^1.3.1 in root + core package.json
- Regenerate `schema/provider.schema.json` against 1.3.1 (adds `tokenAuthMethod` + `tokenContentType`)
- Update bun.lock

## Why

The 2.10.6 publish workflow failed on the "Schemas are stale" check: CI frozen-lockfile installed @afps-spec/schema 1.2.1 but the committed schema file was generated against 1.3.1 locally. Aligning the pin + lockfile fixes it.

## Test plan

- [x] `bun run check` passes (turbo typecheck + lint + format + openapi + breaking + system-packages)
- [x] `bun run generate:schemas` produces no diff after the bump
- [x] Local provider.schema.json matches CI regen output

🤖 Generated with [Claude Code](https://claude.com/claude-code)