### PR TITLE
chore: type org role as OrgRole enum instead of string

### DIFF
--- a/apps/api/src/openapi/paths/organizations.ts
+++ b/apps/api/src/openapi/paths/organizations.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { ASSIGNABLE_ROLES } from "../../services/invitations.ts";
+
 export const organizationsPaths = {
   "/api/orgs": {
     get: {
@@ -230,7 +232,7 @@ export const organizationsPaths = {
               required: ["email", "role"],
               properties: {
                 email: { type: "string", format: "email" },
-                role: { type: "string", enum: ["admin", "member", "viewer"], default: "member" },
+                role: { type: "string", enum: [...ASSIGNABLE_ROLES], default: "member" },
               },
             },
           },
@@ -292,7 +294,7 @@ export const organizationsPaths = {
               type: "object",
               required: ["role"],
               properties: {
-                role: { type: "string", enum: ["viewer", "member", "admin"] },
+                role: { type: "string", enum: [...ASSIGNABLE_ROLES] },
               },
             },
           },
@@ -311,7 +313,7 @@ export const organizationsPaths = {
                 type: "object",
                 properties: {
                   userId: { type: "string" },
-                  role: { type: "string", enum: ["viewer", "member", "admin"] },
+                  role: { type: "string", enum: [...ASSIGNABLE_ROLES] },
                 },
               },
             },
@@ -368,7 +370,7 @@ export const organizationsPaths = {
               type: "object",
               required: ["role"],
               properties: {
-                role: { type: "string", enum: ["viewer", "member", "admin"] },
+                role: { type: "string", enum: [...ASSIGNABLE_ROLES] },
               },
             },
           },
@@ -387,7 +389,7 @@ export const organizationsPaths = {
                 type: "object",
                 properties: {
                   id: { type: "string" },
-                  role: { type: "string", enum: ["viewer", "member", "admin"] },
+                  role: { type: "string", enum: [...ASSIGNABLE_ROLES] },
                 },
               },
             },

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { orgRoleEnum } from "@appstrate/db/schema";
+
+const ORG_ROLES = [...orgRoleEnum.enumValues];
+
 /**
  * All OpenAPI schema definitions (components/schemas).
  */
@@ -89,7 +93,7 @@ export const schemas = {
       id: { type: "string" },
       name: { type: "string" },
       slug: { type: "string" },
-      role: { type: "string", enum: ["owner", "admin", "member"] },
+      role: { type: "string", enum: ORG_ROLES },
       createdAt: { type: "string", format: "date-time", description: "Creation timestamp" },
     },
   },
@@ -100,7 +104,7 @@ export const schemas = {
       userId: { type: "string" },
       displayName: { type: "string" },
       email: { type: "string" },
-      role: { type: "string", enum: ["owner", "admin", "member"] },
+      role: { type: "string", enum: ORG_ROLES },
       joinedAt: { type: "string", format: "date-time" },
     },
   },
@@ -110,7 +114,7 @@ export const schemas = {
     properties: {
       id: { type: "string" },
       email: { type: "string" },
-      role: { type: "string", enum: ["owner", "admin", "member"] },
+      role: { type: "string", enum: ORG_ROLES },
       token: { type: "string" },
       expiresAt: { type: "string", format: "date-time" },
       createdAt: { type: "string", format: "date-time" },

--- a/apps/api/src/routes/invitations.ts
+++ b/apps/api/src/routes/invitations.ts
@@ -12,6 +12,7 @@ import {
   markInvitationAccepted,
   getInviterName,
   getOrgName,
+  type AssignableRole,
 } from "../services/invitations.ts";
 import { addMember } from "../services/organizations.ts";
 
@@ -115,7 +116,7 @@ router.post("/:token/accept", async (c) => {
       });
 
       // Add member to org
-      await addMember(invitation.orgId, newUserId, invitation.role as "member" | "admin");
+      await addMember(invitation.orgId, newUserId, invitation.role as AssignableRole);
 
       await markInvitationAccepted(invitation.id, newUserId);
 
@@ -157,7 +158,7 @@ router.post("/:token/accept", async (c) => {
       });
     }
 
-    await addMember(invitation.orgId, existingUser.id, invitation.role as "member" | "admin");
+    await addMember(invitation.orgId, existingUser.id, invitation.role as AssignableRole);
 
     await markInvitationAccepted(invitation.id, existingUser.id);
 

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -90,7 +90,7 @@ async function validateSSEAuth(c: {
   return {
     userId: session.user.id,
     orgId,
-    role: rows[0].role as OrgRole,
+    role: rows[0].role,
     applicationId,
   };
 }

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -11,6 +11,7 @@ import type { RealtimeEvent } from "../services/realtime.ts";
 import { unauthorized } from "../lib/errors.ts";
 import { validateApiKey } from "../services/api-keys.ts";
 import { validateApplicationInOrg } from "../middleware/app-context.ts";
+import type { OrgRole } from "../types/index.ts";
 
 /** Strip large user-content fields from SSE payloads for non-verbose consumers. */
 function stripPayload(evt: RealtimeEvent): Record<string, unknown> {
@@ -28,7 +29,7 @@ function stripPayload(evt: RealtimeEvent): Record<string, unknown> {
 interface SSEAuthResult {
   userId: string;
   orgId: string;
-  role: string;
+  role: OrgRole;
   applicationId: string;
 }
 
@@ -86,7 +87,12 @@ async function validateSSEAuth(c: {
   const app = await validateApplicationInOrg(applicationId, orgId);
   if (!app) return null;
 
-  return { userId: session.user.id, orgId, role: rows[0].role, applicationId };
+  return {
+    userId: session.user.id,
+    orgId,
+    role: rows[0].role as OrgRole,
+    applicationId,
+  };
 }
 
 /** Open an SSE stream with a subscriber filter, verbose toggle, and ping keep-alive. */

--- a/apps/api/src/services/invitations.ts
+++ b/apps/api/src/services/invitations.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { db } from "@appstrate/db/client";
-import { orgInvitations, organizations, user, profiles } from "@appstrate/db/schema";
+import { orgInvitations, organizations, user, profiles, orgRoleEnum } from "@appstrate/db/schema";
 import { eq, and, lt, desc } from "drizzle-orm";
 import { getEnv } from "@appstrate/env";
 import { getAppConfig } from "../lib/app-config.ts";
@@ -12,6 +12,16 @@ import { logger } from "../lib/logger.ts";
 /** Roles assignable via invitation (excludes owner — transferred, not invited). */
 export const ASSIGNABLE_ROLES = ["viewer", "member", "admin"] as const;
 export type AssignableRole = (typeof ASSIGNABLE_ROLES)[number];
+
+// Compile-time exhaustiveness check: if `orgRoleEnum` gains a new value, this
+// line fails to type-check until it is added to `ASSIGNABLE_ROLES` above (or
+// explicitly excluded like `owner`).
+type _MissingAssignableRoles = Exclude<
+  Exclude<(typeof orgRoleEnum.enumValues)[number], "owner">,
+  AssignableRole
+>;
+const _assertAssignableRolesExhaustive: _MissingAssignableRoles extends never ? true : never = true;
+void _assertAssignableRolesExhaustive;
 
 function generateToken(): string {
   return crypto.randomUUID().replace(/-/g, "") + crypto.randomUUID().replace(/-/g, "");

--- a/apps/api/test/helpers/auth.ts
+++ b/apps/api/test/helpers/auth.ts
@@ -8,6 +8,7 @@
  */
 import { db } from "./db.ts";
 import { organizations, organizationMembers, applications } from "@appstrate/db/schema";
+import type { OrgRole } from "@appstrate/shared-types";
 import { getTestApp } from "./app.ts";
 
 let counter = 0;
@@ -154,7 +155,7 @@ export async function createTestOrg(
 export async function addOrgMember(
   orgId: string,
   userId: string,
-  role: "owner" | "admin" | "member" | "viewer" = "member",
+  role: OrgRole = "member",
 ): Promise<void> {
   await db.insert(organizationMembers).values({ orgId, userId, role });
 }

--- a/apps/api/test/integration/middleware/require-permission.test.ts
+++ b/apps/api/test/integration/middleware/require-permission.test.ts
@@ -20,14 +20,12 @@ import {
 } from "../../helpers/auth.ts";
 import { seedPackage } from "../../helpers/seed.ts";
 import { installPackage } from "../../../src/services/application-packages.ts";
+import type { AssignableRole } from "../../../src/services/invitations.ts";
 
 const app = getTestApp();
 
 /** Build a context for a user with a specific role in the owner's org. */
-async function contextForRole(
-  ownerCtx: TestContext,
-  role: "admin" | "member" | "viewer",
-): Promise<TestContext> {
+async function contextForRole(ownerCtx: TestContext, role: AssignableRole): Promise<TestContext> {
   const user = await createTestUser();
   await addOrgMember(ownerCtx.orgId, user.id, role);
   return { ...ownerCtx, user, cookie: user.cookie };

--- a/apps/api/test/integration/routes/rbac-app-profile-bindings.test.ts
+++ b/apps/api/test/integration/routes/rbac-app-profile-bindings.test.ts
@@ -24,15 +24,13 @@ import {
 import { seedConnectionProfile } from "../../helpers/seed.ts";
 import { db } from "../../helpers/db.ts";
 import { appProfileProviderBindings } from "@appstrate/db/schema";
+import type { AssignableRole } from "../../../src/services/invitations.ts";
 
 const app = getTestApp();
 
 const PROVIDER_ID = "@system/test-provider";
 
-async function contextForRole(
-  ownerCtx: TestContext,
-  role: "admin" | "member" | "viewer",
-): Promise<TestContext> {
+async function contextForRole(ownerCtx: TestContext, role: AssignableRole): Promise<TestContext> {
   const user = await createTestUser();
   await addOrgMember(ownerCtx.orgId, user.id, role);
   return { ...ownerCtx, user, cookie: user.cookie };

--- a/apps/web/src/hooks/use-permissions.ts
+++ b/apps/web/src/hooks/use-permissions.ts
@@ -12,8 +12,8 @@ const ROLE_I18N_KEY: Record<OrgRole, string> = {
 };
 
 /** Get the i18n key for a role label. */
-export function roleI18nKey(role: string): string {
-  return ROLE_I18N_KEY[role as OrgRole] ?? role;
+export function roleI18nKey(role: OrgRole): string {
+  return ROLE_I18N_KEY[role];
 }
 
 /** Assignable roles for invitations (excludes owner). */

--- a/apps/web/src/pages/invite-accept.tsx
+++ b/apps/web/src/pages/invite-accept.tsx
@@ -12,11 +12,12 @@ import { AuthLayout } from "../components/auth-layout";
 import { RegisterForm } from "../components/register-form";
 import { LoginForm } from "../components/login-form";
 import { roleI18nKey } from "../hooks/use-permissions";
+import type { OrgRole } from "@appstrate/shared-types";
 
 interface InviteInfo {
   email: string;
   orgName: string;
-  role: string;
+  role: OrgRole;
   inviterName: string;
   expiresAt: string;
   isNewUser: boolean;

--- a/packages/emails/src/types.ts
+++ b/packages/emails/src/types.ts
@@ -2,6 +2,12 @@
 
 export type SupportedLocale = "fr" | "en";
 
+/**
+ * Organization role. Mirrors the `org_role` enum in @appstrate/db —
+ * kept local so this package stays dependency-free.
+ */
+export type OrgRole = "owner" | "admin" | "member" | "viewer";
+
 export type EmailType = "verification" | "invitation" | "magic-link" | "reset-password";
 
 export interface EmailPropsMap {
@@ -15,7 +21,7 @@ export interface EmailPropsMap {
     inviteUrl: string;
     orgName: string;
     inviterName: string;
-    role: string;
+    role: OrgRole;
     locale: SupportedLocale;
   };
   "magic-link": {


### PR DESCRIPTION
## Summary

- Replace `string`-typed role fields with `OrgRole` / `AssignableRole` across routes, tests, frontend, emails, and OpenAPI schemas
- Fix latent bug in `routes/invitations.ts`: `invitation.role as \"member\" | \"admin\"` omitted `viewer` — now casts to `AssignableRole`
- Fix OpenAPI contract drift in `schemas.ts`: `Organization`, `OrgMember`, `OrgInvitationInfo` were missing `viewer` in their role enum — now derived from `orgRoleEnum.enumValues`
- OpenAPI path schemas for invite/member endpoints now derive from `ASSIGNABLE_ROLES` instead of hard-coded duplicates
- `@appstrate/emails` stays dependency-free — adds a local `OrgRole` type mirroring the DB enum

## Files changed

**Routes & services**
- `apps/api/src/routes/invitations.ts` — cast fix
- `apps/api/src/routes/realtime.ts` — `SSEAuthResult.role: OrgRole`

**Tests**
- `apps/api/test/helpers/auth.ts` — `addOrgMember(role: OrgRole)`
- `apps/api/test/integration/middleware/require-permission.test.ts`
- `apps/api/test/integration/routes/rbac-app-profile-bindings.test.ts`

**Frontend**
- `apps/web/src/hooks/use-permissions.ts` — `roleI18nKey(role: OrgRole)`
- `apps/web/src/pages/invite-accept.tsx` — `InviteInfo.role: OrgRole`

**Emails & OpenAPI**
- `packages/emails/src/types.ts` — local `OrgRole` type
- `apps/api/src/openapi/paths/organizations.ts` — derive from \`ASSIGNABLE_ROLES\`
- `apps/api/src/openapi/schemas.ts` — derive from \`orgRoleEnum.enumValues\` (+ adds missing \`viewer\`)

## Related

A matching PR in `appstrate/cloud` applies the same discipline to the cloud module (new \`src/types.ts\` as local single source of truth).

## Test plan

- [x] \`bun run check\` passes (tsc + eslint + prettier + OpenAPI validation, 204 endpoints)
- [ ] Manual: create an invitation with \`viewer\` role → accept → verify member added with correct role
- [ ] Manual: smoke test org settings page (role badges, role change dropdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)