### PR TITLE
feat(oidc): polymorphic dashboard + end-user OIDC with org-level client UI

### DIFF
--- a/apps/api/src/modules/oidc/index.ts
+++ b/apps/api/src/modules/oidc/index.ts
@@ -20,7 +20,7 @@
  *    in context. Core's strict run-visibility filter then applies.
  *  - `createRouter()` (mounted at the HTTP origin root by the platform)
  *    owns the `/api/oauth/*` admin endpoints, the server-rendered
- *    `/api/oauth/enduser/{login,consent}` pages, and the RFC-compliant
+ *    `/api/oauth/{login,consent}` pages, and the RFC-compliant
  *    `/.well-known/openid-configuration` + `/.well-known/oauth-authorization-server`
  *    discovery endpoints.
  *  - `init()` runs module-owned Drizzle migrations for the Better Auth
@@ -42,7 +42,7 @@ const oidcModule: AppstrateModule = {
 
   async init(ctx: ModuleInitContext) {
     await ctx.applyMigrations("oidc", resolve(import.meta.dir, "drizzle/migrations"), {
-      requireCoreTables: ["end_users", "user", "session"],
+      requireCoreTables: ["end_users", "user", "session", "organizations", "applications"],
     });
   },
 
@@ -55,11 +55,13 @@ const oidcModule: AppstrateModule = {
     return createOidcRouter();
   },
 
-  appScopedPaths: ["/api/oauth"],
-
+  // OIDC admin routes are org-scoped (dashboard clients) — end_user clients
+  // are created with a `referencedApplicationId` passed explicitly in the
+  // request body. No `X-App-Id` header is required.
   publicPaths: [
-    "/api/oauth/enduser/login",
-    "/api/oauth/enduser/consent",
+    "/api/oauth/login",
+    "/api/oauth/consent",
+    "/api/oauth/logout",
     "/.well-known/openid-configuration",
     "/.well-known/oauth-authorization-server",
   ],

--- a/apps/web/src/modules/oidc/components/oauth-client-create-modal.tsx
+++ b/apps/web/src/modules/oidc/components/oauth-client-create-modal.tsx
@@ -24,15 +24,16 @@ const REQUIRED_SCOPES = new Set(["openid", "profile", "email"]);
 interface Props {
   open: boolean;
   onClose: () => void;
+  level?: "org" | "application";
 }
 
 interface FormData {
   name: string;
 }
 
-export function OAuthClientCreateModal({ open, onClose }: Props) {
+export function OAuthClientCreateModal({ open, onClose, level }: Props) {
   const { t } = useTranslation(["settings", "common"]);
-  const createMutation = useCreateOAuthClient();
+  const createMutation = useCreateOAuthClient(level);
   const { data: availableScopes } = useOAuthScopes();
   const [redirectUris, setRedirectUris] = useState<string[]>([""]);
   const [selectedScopes, setSelectedScopes] = useState<Set<string>>(() => new Set(REQUIRED_SCOPES));

--- a/apps/web/src/modules/oidc/components/oauth-clients-tab.tsx
+++ b/apps/web/src/modules/oidc/components/oauth-clients-tab.tsx
@@ -28,9 +28,13 @@ import {
 } from "../hooks/use-oauth-clients";
 import { OAuthClientCreateModal } from "./oauth-client-create-modal";
 
-export function OAuthClientsTab() {
+interface OAuthClientsTabProps {
+  level?: "org" | "application";
+}
+
+export function OAuthClientsTab({ level }: OAuthClientsTabProps) {
   const { t } = useTranslation(["settings", "common"]);
-  const { data, isLoading, error } = useOAuthClients();
+  const { data, isLoading, error } = useOAuthClients(level);
   const [createOpen, setCreateOpen] = useState(false);
 
   if (isLoading) return <LoadingState />;
@@ -60,7 +64,11 @@ export function OAuthClientsTab() {
         </ul>
       )}
 
-      <OAuthClientCreateModal open={createOpen} onClose={() => setCreateOpen(false)} />
+      <OAuthClientCreateModal
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        level={level}
+      />
     </div>
   );
 }

--- a/apps/web/src/modules/oidc/hooks/use-oauth-clients.ts
+++ b/apps/web/src/modules/oidc/hooks/use-oauth-clients.ts
@@ -16,14 +16,17 @@ import type {
 
 export type { OAuthClient, OAuthClientWithSecret };
 
-export function useOAuthClients() {
+export function useOAuthClients(level?: "org" | "application") {
   const orgId = useCurrentOrgId();
   const appId = useCurrentApplicationId();
+  const isOrg = level === "org";
   return useQuery({
-    queryKey: ["oauth-clients", orgId, appId],
+    queryKey: ["oauth-clients", orgId, isOrg ? "org" : appId],
     queryFn: () =>
-      api<{ object: "list"; data: OAuthClient[] }>("/oauth/clients").then((d) => d.data),
-    enabled: !!orgId && !!appId,
+      api<{ object: "list"; data: OAuthClient[] }>("/oauth/clients").then((d) =>
+        level ? d.data.filter((c) => c.level === level) : d.data,
+      ),
+    enabled: isOrg ? !!orgId : !!orgId && !!appId,
   });
 }
 
@@ -43,13 +46,20 @@ export function useOAuthScopes() {
   });
 }
 
-export function useCreateOAuthClient() {
+export function useCreateOAuthClient(level?: "org" | "application") {
   const qc = useQueryClient();
+  const appId = useCurrentApplicationId();
+  const orgId = useCurrentOrgId();
+  const isOrg = level === "org";
   return useMutation({
     mutationFn: async (data: { name: string; redirectUris: string[]; scopes?: string[] }) =>
       api<OAuthClientWithSecret>("/oauth/clients", {
         method: "POST",
-        body: JSON.stringify(data),
+        body: JSON.stringify(
+          isOrg
+            ? { level: "org", referencedOrgId: orgId, ...data }
+            : { level: "application", referencedApplicationId: appId, ...data },
+        ),
       }),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["oauth-clients"] });

--- a/apps/web/src/pages/app-settings-page.tsx
+++ b/apps/web/src/pages/app-settings-page.tsx
@@ -78,7 +78,7 @@ export function AppSettingsPage() {
 
       {tab === "general" && <GeneralTab appId={appId} application={application} />}
       {tab === "profiles" && <AppProfilesTab />}
-      {tab === "oauth" && oidcEnabled && <OAuthClientsTab />}
+      {tab === "oauth" && oidcEnabled && <OAuthClientsTab level="application" />}
     </>
   );
 }

--- a/apps/web/src/pages/org-settings.tsx
+++ b/apps/web/src/pages/org-settings.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/select";
 import { useTabWithHash } from "../hooks/use-tab-with-hash";
 import { useAppConfig } from "../hooks/use-app-config";
+import { OAuthClientsTab } from "../modules/oidc/components/oauth-clients-tab";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "../api";
 import { useOrg } from "../hooks/use-org";
@@ -81,14 +82,16 @@ export function OrgSettingsPage() {
 
   const { features } = useAppConfig();
 
+  const oidcEnabled = !!features.oidc;
   const validTabs = [
     "general",
     "members",
     ...(isAdmin ? ["models" as const] : []),
     ...(isAdmin ? ["proxies" as const] : []),
+    ...(isAdmin && oidcEnabled ? ["oauth" as const] : []),
     ...(features.billing ? ["billing" as const] : []),
   ] as const;
-  type Tab = "general" | "members" | "models" | "proxies" | "billing";
+  type Tab = "general" | "members" | "models" | "proxies" | "oauth" | "billing";
   const [tab, setTab] = useTabWithHash<Tab>(validTabs as readonly Tab[], "general");
   const [editingName, setEditingName] = useState(false);
   const [newName, setNewName] = useState("");
@@ -316,6 +319,7 @@ export function OrgSettingsPage() {
             </TabsTrigger>
             {isAdmin && <TabsTrigger value="models">{t("models.tabTitle")}</TabsTrigger>}
             {isAdmin && <TabsTrigger value="proxies">{t("proxies.tabTitle")}</TabsTrigger>}
+            {isAdmin && oidcEnabled && <TabsTrigger value="oauth">OAuth</TabsTrigger>}
             {features.billing && <TabsTrigger value="billing">{t("billing.tabTitle")}</TabsTrigger>}
           </TabsList>
         </Tabs>
@@ -650,6 +654,8 @@ export function OrgSettingsPage() {
           onRemoveDefault={() => setDefaultProxyMutation.mutate(null)}
         />
       )}
+
+      {tab === "oauth" && oidcEnabled && <OAuthClientsTab level="org" />}
 
       {tab === "billing" && features.billing && <BillingTab />}
 


### PR DESCRIPTION
## Summary
- Add org-level (dashboard) OAuth client support alongside end-user flow
- Discriminated by `level` field in client metadata, `actor_type` claim in access tokens
- Org-level client management UI in org-settings OAuth tab
- Remove dev-seed mechanism — OAuth clients created via UI

### Module changes
- **Schema**: add `level`, `referencedOrgId` columns to `oauth_client`
- **Claims**: `buildDashboardClaims` (org membership check, `org_role`)
- **Strategy**: polymorphic resolve (`dashboard_user` vs `end_user` actor_type)
- **Routes**: org-level client CRUD, custom `/api/oauth/logout` endpoint
- **Branding**: resolve from org or app depending on client level
- **Scopes**: `scopesToPermissions` supports both actor types
- **Pages**: login/consent polymorphic by client level
- **UI**: OAuth tab in org-settings for org-level clients

### Also included
- Webhooks module aligned with module system refactor
- Core `AppstrateModule` interface extended with new extension points

## Test plan
- [ ] Create org-level OAuth client from org-settings → OAuth tab
- [ ] Create app-level OAuth client from app-settings → OAuth tab (unchanged)
- [ ] Portal authenticates via org-level client (`actor_type: dashboard_user`)
- [ ] End-user flow via app-level client (`actor_type: end_user`) unchanged
- [ ] Logout clears BA cookie via `/api/oauth/logout`

🤖 Generated with [Claude Code](https://claude.com/claude-code)