### PR TITLE
fix(pr-102): address review — atomic claim, strict size, shared Ajv, dedicated signing secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,7 @@ PORT=3000
 # Auth — ⚠️ DEV ONLY — regenerate for production: openssl rand -hex 32
 BETTER_AUTH_SECRET=appstrate-dev-auth-secret-do-not-use-in-production
 RUN_TOKEN_SECRET=appstrate-dev-token-secret-do-not-use-in-production
+UPLOAD_SIGNING_SECRET=appstrate-dev-upload-secret-do-not-use-in-production
 
 # Credential encryption — ⚠️ DEV ONLY — regenerate for production: openssl rand -base64 32
 CONNECTION_ENCRYPTION_KEY=jChGxOEG1YjCtrkrTYhO7FFdIKaHpe/j1PBY/LqID6s=

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,3 +35,4 @@ jobs:
         env:
           BETTER_AUTH_SECRET: ci-dummy-secret
           CONNECTION_ENCRYPTION_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+          UPLOAD_SIGNING_SECRET: ci-dummy-upload-signing-secret

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -98,6 +98,7 @@ jobs:
         env:
           BETTER_AUTH_SECRET: e2e-ci-secret-that-is-at-least-32-characters
           CONNECTION_ENCRYPTION_KEY: Y2FzgQmlgIRocYT1VUWM+73fQ5zOTPB8sHJxTh1x4qI=
+          UPLOAD_SIGNING_SECRET: e2e-ci-upload-signing-secret
           # E2E suite seeds webhooks (cascade deletion, cross-app/org isolation,
           # UI org switching). The webhooks module is opt-in via MODULES
           # since PR #72 — without this the webhook routes 404 and 12 specs fail.

--- a/apps/api/src/lib/boot.ts
+++ b/apps/api/src/lib/boot.ts
@@ -5,7 +5,7 @@ import { db, isEmbeddedDb, getPGliteClient, reservePgConnection } from "@appstra
 import { packages, packageVersions } from "@appstrate/db/schema";
 import { expireOldInvitations } from "../services/invitations.ts";
 import { cleanupExpiredKeys } from "../services/api-keys.ts";
-import { cleanupExpiredUploads } from "../services/uploads.ts";
+import { cleanupExpiredUploads, startUploadGc } from "../services/uploads.ts";
 import { createNotifyTriggers } from "@appstrate/db/notify";
 import { logger } from "./logger.ts";
 import { loadModules, getModules, getModuleContributions } from "./modules/module-loader.ts";
@@ -203,6 +203,9 @@ export async function boot(): Promise<void> {
   ];
 
   await Promise.all(parallelInits);
+
+  // Kick off the recurring upload sweep once initial cleanup is scheduled.
+  startUploadGc();
 }
 
 /**

--- a/apps/api/src/lib/shutdown.ts
+++ b/apps/api/src/lib/shutdown.ts
@@ -12,6 +12,7 @@ import {
 } from "../services/run-tracker.ts";
 import { shutdownScheduleWorker } from "../services/scheduler.ts";
 import { getOrchestrator } from "../services/orchestrator/index.ts";
+import { stopUploadGc } from "../services/uploads.ts";
 
 const SHUTDOWN_TIMEOUT_MS = 30_000;
 
@@ -24,6 +25,7 @@ export function createShutdownHandler(setShuttingDown: () => void): () => Promis
     setShuttingDown();
 
     logger.info("Shutdown initiated, stopping sidecar pool...");
+    stopUploadGc();
     await getOrchestrator().shutdown();
 
     // Unsubscribe from cancel channel before draining to avoid processing

--- a/apps/api/src/routes/uploads.ts
+++ b/apps/api/src/routes/uploads.ts
@@ -74,7 +74,7 @@ export function createUploadContentRouter() {
     const token = c.req.query("token");
     if (!token) throw unauthorized("missing upload token");
     const env = getEnv();
-    const payload = verifyFsUploadToken(token, env.UPLOAD_SIGNING_SECRET ?? env.BETTER_AUTH_SECRET);
+    const payload = verifyFsUploadToken(token, env.UPLOAD_SIGNING_SECRET);
     if (!payload) throw unauthorized("invalid or expired upload token");
 
     // Normalize both sides: strip parameters (charset, boundary, …) and

--- a/apps/api/src/routes/uploads.ts
+++ b/apps/api/src/routes/uploads.ts
@@ -74,11 +74,17 @@ export function createUploadContentRouter() {
     const token = c.req.query("token");
     if (!token) throw unauthorized("missing upload token");
     const env = getEnv();
-    const payload = verifyFsUploadToken(token, env.BETTER_AUTH_SECRET);
+    const payload = verifyFsUploadToken(token, env.UPLOAD_SIGNING_SECRET ?? env.BETTER_AUTH_SECRET);
     if (!payload) throw unauthorized("invalid or expired upload token");
 
+    // Normalize both sides: strip parameters (charset, boundary, …) and
+    // lowercase. Prevents "application/pdf" vs "application/pdf; charset=…"
+    // from mismatching, and catches attackers padding the signed MIME with
+    // extra params.
+    const normalize = (v: string) => v.split(";")[0]?.trim().toLowerCase() ?? "";
     const declaredType = c.req.header("content-type");
-    if (payload.m && declaredType && declaredType.split(";")[0]?.trim() !== payload.m) {
+    const signedMime = normalize(payload.m);
+    if (signedMime && declaredType && normalize(declaredType) !== signedMime) {
       throw invalidRequest(`Content-Type '${declaredType}' does not match signed '${payload.m}'`);
     }
 

--- a/apps/api/src/services/input-parser.ts
+++ b/apps/api/src/services/input-parser.ts
@@ -38,7 +38,12 @@ function getArrayItems(prop: JSONSchema7): JSONSchema7 | undefined {
   return prop.items;
 }
 
-function collectUploadRefs(
+/**
+ * Walk the schema, find file-shaped properties, and validate that each
+ * matching input value is an `upload://` URI (or an array of them). Pure —
+ * exported for unit tests, has no I/O.
+ */
+export function collectUploadRefs(
   schema: JSONSchemaObject,
   input: Record<string, unknown>,
 ): { fieldName: string; uri: string }[] {

--- a/apps/api/src/services/schema.ts
+++ b/apps/api/src/services/schema.ts
@@ -1,21 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import Ajv2020 from "ajv/dist/2020.js";
-import addFormatsImport from "ajv-formats";
-
-// ajv-formats ships a CJS default-export under an ESM wrapper; the named
-// type exposed by @types/ajv-formats expects AJV's Ajv (draft-07) class.
-// We use the 2020-12 vocabulary here so we cast through `unknown` — the
-// runtime shape is a function(Ajv instance), which matches either draft.
-const addFormats = addFormatsImport as unknown as (ajv: Ajv2020) => Ajv2020;
+import { createAjv } from "@appstrate/core/ajv";
 import { isFileField, type JSONSchemaObject, type JSONSchema7 } from "@appstrate/core/form";
 import { scopedNameRegex } from "@appstrate/core/validation";
 import { normalizeConfigForValidation } from "../lib/agent-readiness-utils.ts";
 
 // --- AJV runtime validation ---
-
-const ajv = new Ajv2020({ coerceTypes: true, allErrors: true, strict: false });
-addFormats(ajv);
+//
+// Shared Ajv2020 + ajv-formats factory — mirrors the frontend RJSF validator so
+// client- and server-side validation agree. See packages/core/src/ajv.ts.
+const ajv = createAjv({ coerceTypes: true });
 
 // --- Section C: Validation functions ---
 

--- a/apps/api/src/services/uploads.ts
+++ b/apps/api/src/services/uploads.ts
@@ -15,7 +15,7 @@
  *  - Expiry window (default 15 min) + GC worker removes orphans
  */
 
-import { and, eq, lt, isNull, inArray } from "drizzle-orm";
+import { and, eq, lt, isNull, inArray, sql } from "drizzle-orm";
 import { fileTypeFromBuffer } from "file-type";
 import { db } from "@appstrate/db/client";
 import { uploads } from "@appstrate/db/schema";
@@ -156,27 +156,65 @@ export async function createUpload(params: CreateUploadParams): Promise<CreateUp
 // ---------------------------------------------------------------------------
 
 /**
- * Look up an upload row, verify ownership + freshness, download the payload,
- * sniff the MIME via magic bytes, and mark it consumed.
+ * MIME prefixes/values where `file-type` cannot sniff a signature — these
+ * formats have no magic bytes (plain text, JSON, CSV, XML source, JS, etc.).
+ * For these we skip the sniff check and trust the declared mime. Callers
+ * that need strict binary validation should declare a concrete binary MIME
+ * (application/pdf, image/*, etc.) which `file-type` can identify.
+ */
+function isUnsniffableMime(mime: string): boolean {
+  if (mime.startsWith("text/")) return true;
+  if (mime === "application/json") return true;
+  if (mime === "application/xml" || mime === "application/x-yaml") return true;
+  if (mime === "application/javascript" || mime === "application/ecmascript") return true;
+  return false;
+}
+
+/**
+ * Look up an upload row, verify ownership + freshness, claim it atomically,
+ * download the payload, and sniff the MIME via magic bytes.
  *
- * Throws `invalidRequest` / `notFound` with stable codes — callers map them
- * back to RFC 9457 problem responses via the error handler.
+ * The claim (`UPDATE … WHERE consumedAt IS NULL RETURNING`) is what prevents
+ * the TOCTOU double-consume — two concurrent runs posting the same URI will
+ * see exactly one winning row.
+ *
+ * Throws `invalidRequest` / `notFound` / `conflict` / `gone` with stable
+ * codes — callers map them back to RFC 9457 problem responses.
  */
 export async function consumeUpload(
   uploadId: string,
   ctx: { orgId: string; applicationId: string },
 ): Promise<ConsumedUpload> {
+  // Pre-check so we can return the right shape of error (not-found vs
+  // cross-tenant vs already-consumed vs expired). The atomic claim below
+  // is what makes concurrent calls safe — this SELECT is just UX.
   const [row] = await db.select().from(uploads).where(eq(uploads.id, uploadId)).limit(1);
   if (!row) throw notFound(`Upload '${uploadId}' not found`);
   if (row.orgId !== ctx.orgId || row.applicationId !== ctx.applicationId) {
     // Hide cross-tenant existence
     throw notFound(`Upload '${uploadId}' not found`);
   }
-  if (row.consumedAt) {
-    throw conflict("upload_consumed", `Upload '${uploadId}' has already been consumed`);
-  }
   if (row.expiresAt.getTime() < Date.now()) {
     throw gone("upload_expired", `Upload '${uploadId}' has expired`);
+  }
+
+  // Atomic claim: only the caller whose UPDATE flips NULL → now() proceeds.
+  // Any racing caller gets zero rows back and is reported as already-consumed.
+  const claimed = await db
+    .update(uploads)
+    .set({ consumedAt: new Date() })
+    .where(
+      and(
+        eq(uploads.id, uploadId),
+        eq(uploads.orgId, ctx.orgId),
+        eq(uploads.applicationId, ctx.applicationId),
+        isNull(uploads.consumedAt),
+        sql`${uploads.expiresAt} >= now()`,
+      ),
+    )
+    .returning({ id: uploads.id });
+  if (claimed.length === 0) {
+    throw conflict("upload_consumed", `Upload '${uploadId}' has already been consumed`);
   }
 
   const [bucket, ...rest] = row.storageKey.split("/");
@@ -188,18 +226,35 @@ export async function consumeUpload(
 
   const buffer = Buffer.from(data);
 
+  // Reject mismatched size outright — an attacker can declare 1KB in the
+  // pre-signed request and PUT 100MB if the storage adapter doesn't enforce
+  // ContentLength at sign time (S3 currently does not).
+  if (buffer.length !== row.size) {
+    logger.warn("upload size mismatch on consume", {
+      uploadId,
+      declared: row.size,
+      actual: buffer.length,
+    });
+    throw invalidRequest(
+      `Upload '${uploadId}' size mismatch: declared ${row.size} bytes, got ${buffer.length}`,
+    );
+  }
+
   // Magic-byte MIME check (file-type reads first ~4100 bytes).
   //
-  // When the manifest declares a specific binary MIME (e.g. application/pdf,
-  // image/png), we require `file-type` to recognise the bytes AND match. This
-  // closes the "client declares PDF, uploads plain text" hole — `file-type`
-  // returns undefined for text and an attacker-controlled payload would
-  // otherwise slip through.
+  // When the manifest declares a concrete binary MIME (application/pdf,
+  // image/png, …), we require `file-type` to recognise the bytes AND match.
+  // This closes the "client declares PDF, uploads plain text" hole.
   //
-  // `application/octet-stream` is the explicit "any blob" marker — we accept
-  // whatever the client sent without sniffing.
-  const sniffed = await fileTypeFromBuffer(buffer);
-  if (row.mime && row.mime !== "application/octet-stream") {
+  // Two escape hatches:
+  //  - `application/octet-stream` is the explicit "any blob" marker.
+  //  - Text-ish MIMEs (text/*, application/json, application/xml, …) have
+  //    no magic signature, so `file-type` always returns undefined for them.
+  //    Strict matching would reject every legitimate text upload. We trust
+  //    the declared MIME for these — manifests that need binary-grade
+  //    validation must declare a sniffable MIME.
+  if (row.mime && row.mime !== "application/octet-stream" && !isUnsniffableMime(row.mime)) {
+    const sniffed = await fileTypeFromBuffer(buffer);
     if (!sniffed || sniffed.mime !== row.mime) {
       logger.warn("upload mime mismatch on consume", {
         uploadId,
@@ -213,15 +268,6 @@ export async function consumeUpload(
       );
     }
   }
-  if (buffer.length !== row.size) {
-    logger.warn("upload size mismatch on consume", {
-      uploadId,
-      declared: row.size,
-      actual: buffer.length,
-    });
-  }
-
-  await db.update(uploads).set({ consumedAt: new Date() }).where(eq(uploads.id, uploadId));
 
   return {
     id: uploadId,
@@ -265,32 +311,75 @@ export async function writeFsUploadContent(
  * Returns the number of rows removed.
  */
 export async function cleanupExpiredUploads(): Promise<number> {
-  const now = new Date();
-  const expired = await db
-    .select({ id: uploads.id, storageKey: uploads.storageKey })
-    .from(uploads)
-    .where(and(lt(uploads.expiresAt, now), isNull(uploads.consumedAt)))
-    .limit(500);
+  let totalRemoved = 0;
+  // Drain in batches — a long-running instance may accumulate more than the
+  // per-query cap between sweeps.
+  while (true) {
+    const expired = await db
+      .select({ id: uploads.id, storageKey: uploads.storageKey })
+      .from(uploads)
+      .where(and(lt(uploads.expiresAt, new Date()), isNull(uploads.consumedAt)))
+      .limit(500);
 
-  if (expired.length === 0) return 0;
+    if (expired.length === 0) break;
 
-  await Promise.all(
-    expired.map(async (row) => {
-      const [bucket, ...rest] = row.storageKey.split("/");
-      if (!bucket || rest.length === 0) return;
-      try {
-        await storageDelete(bucket, rest.join("/"));
-      } catch (err) {
-        logger.warn("failed to delete expired upload storage", {
-          uploadId: row.id,
+    await Promise.all(
+      expired.map(async (row) => {
+        const [bucket, ...rest] = row.storageKey.split("/");
+        if (!bucket || rest.length === 0) return;
+        try {
+          await storageDelete(bucket, rest.join("/"));
+        } catch (err) {
+          logger.warn("failed to delete expired upload storage", {
+            uploadId: row.id,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }),
+    );
+
+    const ids = expired.map((r) => r.id);
+    await db.delete(uploads).where(inArray(uploads.id, ids));
+    totalRemoved += expired.length;
+    if (expired.length < 500) break;
+  }
+  return totalRemoved;
+}
+
+// ---------------------------------------------------------------------------
+// Periodic GC timer
+// ---------------------------------------------------------------------------
+
+/** How often the background sweep runs. Aligned with the 15-min expiry window. */
+const UPLOAD_GC_INTERVAL_MS = 15 * 60 * 1000;
+
+let gcTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start a background sweep that drains expired unconsumed uploads on a fixed
+ * interval. Safe to call multiple times — a no-op after the first.
+ */
+export function startUploadGc(): void {
+  if (gcTimer) return;
+  gcTimer = setInterval(() => {
+    cleanupExpiredUploads()
+      .then((count) => {
+        if (count > 0) logger.info("Removed expired unconsumed uploads", { count });
+      })
+      .catch((err) => {
+        logger.warn("Periodic upload GC failed", {
           error: err instanceof Error ? err.message : String(err),
         });
-      }
-    }),
-  );
+      });
+  }, UPLOAD_GC_INTERVAL_MS);
+  // Don't hold the event loop open for this timer alone.
+  gcTimer.unref?.();
+}
 
-  const ids = expired.map((r) => r.id);
-  await db.delete(uploads).where(inArray(uploads.id, ids));
-
-  return expired.length;
+/** Stop the background sweep. Called from the shutdown handler. */
+export function stopUploadGc(): void {
+  if (gcTimer) {
+    clearInterval(gcTimer);
+    gcTimer = null;
+  }
 }

--- a/apps/api/test/integration/services/upload-consume.test.ts
+++ b/apps/api/test/integration/services/upload-consume.test.ts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration tests for `consumeUpload` — exercise the atomic claim that
+ * prevents two concurrent runs from consuming the same upload:// URI, plus
+ * cross-tenant isolation and the expired/missing-binary paths.
+ *
+ * Uses a real Postgres + filesystem storage; no routes exercised.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { db } from "@appstrate/db/client";
+import { uploads } from "@appstrate/db/schema";
+import { truncateAll } from "../../helpers/db.ts";
+import { createTestContext } from "../../helpers/auth.ts";
+import { consumeUpload } from "../../../src/services/uploads.ts";
+import { uploadFile as storagePut } from "@appstrate/db/storage";
+import { ApiError } from "../../../src/lib/errors.ts";
+
+const UPLOAD_BUCKET = "uploads";
+const PDF_BYTES = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a]); // %PDF-1.4\n
+
+async function seedUpload(
+  ctx: { orgId: string; applicationId: string },
+  opts: {
+    id: string;
+    bytes: Buffer;
+    mime?: string;
+    expiresInSec?: number;
+    skipStoragePut?: boolean;
+    sizeOverride?: number;
+  },
+): Promise<string> {
+  const storagePath = `${ctx.applicationId}/${opts.id}/file.pdf`;
+  const storageKey = `${UPLOAD_BUCKET}/${storagePath}`;
+  if (!opts.skipStoragePut) {
+    await storagePut(UPLOAD_BUCKET, storagePath, opts.bytes);
+  }
+  await db.insert(uploads).values({
+    id: opts.id,
+    orgId: ctx.orgId,
+    applicationId: ctx.applicationId,
+    createdBy: null,
+    storageKey,
+    name: "file.pdf",
+    mime: opts.mime ?? "application/pdf",
+    size: opts.sizeOverride ?? opts.bytes.length,
+    expiresAt: new Date(Date.now() + (opts.expiresInSec ?? 900) * 1000),
+  });
+  return opts.id;
+}
+
+describe("consumeUpload", () => {
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it("concurrent consume of the same upload: exactly one wins", async () => {
+    const ctx = await createTestContext({ orgSlug: "org-race" });
+    const id = "upl_race_1";
+    await seedUpload(
+      { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      { id, bytes: PDF_BYTES },
+    );
+
+    const settled = await Promise.allSettled([
+      consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId }),
+      consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId }),
+    ]);
+    const fulfilled = settled.filter((s) => s.status === "fulfilled");
+    const rejected = settled.filter((s) => s.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    const err = (rejected[0] as PromiseRejectedResult).reason;
+    expect(err).toBeInstanceOf(ApiError);
+    expect((err as ApiError).status).toBe(409);
+  });
+
+  it("a second sequential consume fails with 409 conflict", async () => {
+    const ctx = await createTestContext({ orgSlug: "org-seq" });
+    const id = "upl_seq_1";
+    await seedUpload(
+      { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      { id, bytes: PDF_BYTES },
+    );
+    await consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId });
+    try {
+      await consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId });
+      throw new Error("expected to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).status).toBe(409);
+    }
+  });
+
+  it("cross-org consume reports not-found (hides existence)", async () => {
+    const owner = await createTestContext({ orgSlug: "org-owner" });
+    const other = await createTestContext({ orgSlug: "org-other" });
+    const id = "upl_cross_1";
+    await seedUpload(
+      { orgId: owner.orgId, applicationId: owner.defaultAppId },
+      { id, bytes: PDF_BYTES },
+    );
+    try {
+      await consumeUpload(id, { orgId: other.orgId, applicationId: other.defaultAppId });
+      throw new Error("expected to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).status).toBe(404);
+    }
+  });
+
+  it("expired upload reports 410 gone", async () => {
+    const ctx = await createTestContext({ orgSlug: "org-expired" });
+    const id = "upl_expired_1";
+    await seedUpload(
+      { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      { id, bytes: PDF_BYTES, expiresInSec: -10 },
+    );
+    try {
+      await consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId });
+      throw new Error("expected to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).status).toBe(410);
+    }
+  });
+
+  it("size mismatch is rejected (prevents declared-small / uploaded-huge abuse)", async () => {
+    const ctx = await createTestContext({ orgSlug: "org-size" });
+    const id = "upl_size_1";
+    await seedUpload(
+      { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      { id, bytes: PDF_BYTES, sizeOverride: 1 },
+    );
+    try {
+      await consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId });
+      throw new Error("expected to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).status).toBe(400);
+      expect((e as ApiError).message).toContain("size mismatch");
+    }
+  });
+
+  it("missing storage binary reports a clear 400", async () => {
+    const ctx = await createTestContext({ orgSlug: "org-missing" });
+    const id = "upl_missing_1";
+    await seedUpload(
+      { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      { id, bytes: PDF_BYTES, skipStoragePut: true },
+    );
+    try {
+      await consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId });
+      throw new Error("expected to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).status).toBe(400);
+    }
+  });
+
+  it("text/plain upload is accepted even when file-type cannot sniff it", async () => {
+    const ctx = await createTestContext({ orgSlug: "org-text" });
+    const id = "upl_text_1";
+    const bytes = Buffer.from("hello world\n", "utf-8");
+    await seedUpload(
+      { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      { id, bytes, mime: "text/plain" },
+    );
+    const consumed = await consumeUpload(id, {
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+    });
+    expect(consumed.size).toBe(bytes.length);
+    expect(consumed.mime).toBe("text/plain");
+  });
+
+  it("declared-pdf but text bytes is rejected on magic-byte sniffing", async () => {
+    const ctx = await createTestContext({ orgSlug: "org-spoof" });
+    const id = "upl_spoof_1";
+    const bytes = Buffer.from("this is not a pdf", "utf-8");
+    await seedUpload(
+      { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      { id, bytes, mime: "application/pdf" },
+    );
+    try {
+      await consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId });
+      throw new Error("expected to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).status).toBe(400);
+      expect((e as ApiError).message.toLowerCase()).toContain("mime");
+    }
+  });
+});

--- a/apps/api/test/unit/input-parser-uploads.test.ts
+++ b/apps/api/test/unit/input-parser-uploads.test.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the pure upload-reference collector used by the run-request
+ * input parser. Covers the dispatch logic between single-file and array-of-files
+ * fields, plus the error shapes emitted when the client submits the wrong type.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { collectUploadRefs } from "../../src/services/input-parser.ts";
+import { ApiError } from "../../src/lib/errors.ts";
+import type { JSONSchemaObject } from "@appstrate/core/form";
+
+const singleFileSchema: JSONSchemaObject = {
+  type: "object",
+  properties: {
+    doc: { type: "string", format: "uri", contentMediaType: "application/pdf" },
+    title: { type: "string" },
+  },
+};
+
+const arrayFileSchema: JSONSchemaObject = {
+  type: "object",
+  properties: {
+    docs: {
+      type: "array",
+      items: { type: "string", format: "uri", contentMediaType: "application/pdf" },
+      maxItems: 5,
+    },
+  },
+};
+
+describe("collectUploadRefs — single-file fields", () => {
+  it("picks up a valid upload:// URI", () => {
+    const refs = collectUploadRefs(singleFileSchema, { doc: "upload://upl_abc", title: "t" });
+    expect(refs).toEqual([{ fieldName: "doc", uri: "upload://upl_abc" }]);
+  });
+
+  it("ignores the field when the value is null or missing", () => {
+    expect(collectUploadRefs(singleFileSchema, { title: "t" })).toEqual([]);
+    expect(collectUploadRefs(singleFileSchema, { doc: null, title: "t" })).toEqual([]);
+  });
+
+  it("rejects a non-URI string on a single-file field", () => {
+    try {
+      collectUploadRefs(singleFileSchema, { doc: "just-a-name.pdf" });
+      throw new Error("expected to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).status).toBe(400);
+      expect((e as ApiError).message).toContain("doc");
+    }
+  });
+
+  it("rejects an array on a single-file field", () => {
+    try {
+      collectUploadRefs(singleFileSchema, { doc: ["upload://upl_x"] });
+      throw new Error("expected to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+    }
+  });
+
+  it("skips non-file siblings without inspecting them", () => {
+    const refs = collectUploadRefs(singleFileSchema, { doc: "upload://upl_1", title: 42 });
+    expect(refs).toHaveLength(1);
+  });
+});
+
+describe("collectUploadRefs — array-of-files fields", () => {
+  it("emits one ref per URI in order", () => {
+    const refs = collectUploadRefs(arrayFileSchema, {
+      docs: ["upload://upl_1", "upload://upl_2"],
+    });
+    expect(refs).toEqual([
+      { fieldName: "docs", uri: "upload://upl_1" },
+      { fieldName: "docs", uri: "upload://upl_2" },
+    ]);
+  });
+
+  it("accepts an empty array", () => {
+    expect(collectUploadRefs(arrayFileSchema, { docs: [] })).toEqual([]);
+  });
+
+  it("ignores the field when missing or null", () => {
+    expect(collectUploadRefs(arrayFileSchema, {})).toEqual([]);
+    expect(collectUploadRefs(arrayFileSchema, { docs: null })).toEqual([]);
+  });
+
+  it("rejects a scalar value on an array field", () => {
+    try {
+      collectUploadRefs(arrayFileSchema, { docs: "upload://upl_x" });
+      throw new Error("expected to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).message).toContain("array");
+    }
+  });
+
+  it("rejects any non-URI entry inside the array", () => {
+    try {
+      collectUploadRefs(arrayFileSchema, {
+        docs: ["upload://upl_1", "not-a-uri"],
+      });
+      throw new Error("expected to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).message).toContain("docs");
+    }
+  });
+});
+
+describe("collectUploadRefs — schemas without file fields", () => {
+  it("returns [] when no property matches the file shape", () => {
+    const schema: JSONSchemaObject = {
+      type: "object",
+      properties: { name: { type: "string" }, count: { type: "number" } },
+    };
+    expect(collectUploadRefs(schema, { name: "x", count: 3 })).toEqual([]);
+  });
+
+  it("returns [] for a schema with no properties at all", () => {
+    expect(collectUploadRefs({ type: "object" } as JSONSchemaObject, {})).toEqual([]);
+  });
+});

--- a/apps/web/src/components/schema-form/index.tsx
+++ b/apps/web/src/components/schema-form/index.tsx
@@ -68,8 +68,16 @@ export interface SchemaFormProps extends Omit<
   children?: ReactNode;
 }
 
+/**
+ * Submit-button rendering is controlled by a single signal:
+ * `ui:submitButtonOptions.norender`. When `showSubmitButton` is false (default)
+ * we set `norender: true` and let RJSF render whatever `children` the caller
+ * passes as a footer (or nothing). We never additionally pass `<></>` children —
+ * forwarding a non-null child and setting `norender` simultaneously was the
+ * redundant signal the review flagged.
+ */
 export const SchemaForm = forwardRef<RjsfForm, SchemaFormProps>(function SchemaForm(
-  { wrapper, showSubmitButton, children, uiSchema: extraUi, ...rest },
+  { wrapper, showSubmitButton = false, children, uiSchema: extraUi, ...rest },
   ref,
 ) {
   const mapped = mapAfpsToRjsf(wrapper);
@@ -89,7 +97,7 @@ export const SchemaForm = forwardRef<RjsfForm, SchemaFormProps>(function SchemaF
       templates={templates}
       {...rest}
     >
-      {children ?? (showSubmitButton ? undefined : <></>)}
+      {children}
     </RjsfForm>
   );
 });

--- a/apps/web/src/components/schema-form/validator.ts
+++ b/apps/web/src/components/schema-form/validator.ts
@@ -1,17 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
-// Shared Ajv2020 + ajv-formats validator for RJSF, matching the backend.
-// Split into its own module so the SchemaForm component file only exports
-// React components (satisfies react-refresh/only-export-components).
+// Shared Ajv2020 + ajv-formats validator for RJSF, matching the backend via
+// the single factory in `@appstrate/core/ajv`. The awkward `unknown` cast at
+// the ajv-formats / ajv/dist/2020 boundary lives there, not here.
 
 import { customizeValidator } from "@rjsf/validator-ajv8";
-import Ajv2020 from "ajv/dist/2020.js";
+import { AjvClass } from "@appstrate/core/ajv";
 
-// @rjsf/validator-ajv8 types AjvClass as the draft-07 Ajv constructor. Ajv2020
-// is wire-compatible at runtime but needs a cast at the boundary.
 export const schemaFormValidator = customizeValidator({
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  AjvClass: Ajv2020 as unknown as any,
+  AjvClass,
   ajvOptionsOverrides: { strict: false },
   ajvFormatOptions: {},
 });

--- a/bun.lock
+++ b/bun.lock
@@ -158,7 +158,8 @@
       "version": "2.10.7",
       "dependencies": {
         "@afps-spec/schema": "^1.3.1",
-        "@aws-sdk/s3-request-presigner": "^3.1030.0",
+        "ajv": "^8.18.0",
+        "ajv-formats": "^3.0.1",
         "fflate": "^0.8.0",
         "pino": "^10.3.1",
         "semver": "^7.7.1",
@@ -166,11 +167,13 @@
       },
       "peerDependencies": {
         "@aws-sdk/client-s3": "^3",
+        "@aws-sdk/s3-request-presigner": "^3",
         "hono": "^4.12.9",
         "typescript": "^5",
       },
       "optionalPeers": [
         "@aws-sdk/client-s3",
+        "@aws-sdk/s3-request-presigner",
         "hono",
       ],
     },
@@ -322,8 +325,6 @@
 
     "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.7", "@smithy/config-resolver": "^4.4.14", "@smithy/node-config-provider": "^4.3.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg=="],
 
-    "@aws-sdk/s3-request-presigner": ["@aws-sdk/s3-request-presigner@3.1030.0", "", { "dependencies": { "@aws-sdk/signature-v4-multi-region": "^3.996.16", "@aws-sdk/types": "^3.973.7", "@aws-sdk/util-format-url": "^3.972.9", "@smithy/middleware-endpoint": "^4.4.29", "@smithy/protocol-http": "^5.3.13", "@smithy/smithy-client": "^4.12.9", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-rLM1DjBb9QlQwijKGtVSfWGi2gEz8yYj244RRWsPoGAhl57xKS0OGq6MygP/UYTPVc6r5qr4a8Gq1wos4QxnVw=="],
-
     "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.16", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "^3.972.28", "@aws-sdk/types": "^3.973.7", "@smithy/protocol-http": "^5.3.13", "@smithy/signature-v4": "^5.3.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-EMdXYB4r/k5RWq86fugjRhid5JA+Z6MpS7n4sij4u5/C+STrkvuf9aFu41rJA9MjUzxCLzv8U2XL8cH2GSRYpQ=="],
 
     "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1019.0", "", { "dependencies": { "@aws-sdk/core": "^3.973.25", "@aws-sdk/nested-clients": "^3.996.16", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-OF+2RfRmUKyjzrRWlDcyju3RBsuqcrYDQ8TwrJg8efcOotMzuZN4U9mpVTIdATpmEc4lWNZBMSjPzrGm6JPnAQ=="],
@@ -334,7 +335,7 @@
 
     "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.6", "", { "dependencies": { "@aws-sdk/types": "^3.973.7", "@smithy/types": "^4.14.0", "@smithy/url-parser": "^4.2.13", "@smithy/util-endpoints": "^3.3.4", "tslib": "^2.6.2" } }, "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg=="],
 
-    "@aws-sdk/util-format-url": ["@aws-sdk/util-format-url@3.972.9", "", { "dependencies": { "@aws-sdk/types": "^3.973.7", "@smithy/querystring-builder": "^4.2.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-fNJXHrs0ZT7Wx0KGIqKv7zLxlDXt2vqjx9z6oKUQFmpE5o4xxnSryvVHfHpIifYHWKz94hFccIldJ0YSZjlCBw=="],
+    "@aws-sdk/util-format-url": ["@aws-sdk/util-format-url@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/querystring-builder": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A=="],
 
     "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
 
@@ -2182,8 +2183,6 @@
 
     "@aws-sdk/middleware-websocket/@aws-sdk/types": ["@aws-sdk/types@3.973.6", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw=="],
 
-    "@aws-sdk/middleware-websocket/@aws-sdk/util-format-url": ["@aws-sdk/util-format-url@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/querystring-builder": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A=="],
-
     "@aws-sdk/middleware-websocket/@smithy/eventstream-serde-browser": ["@smithy/eventstream-serde-browser@4.2.12", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A=="],
 
     "@aws-sdk/middleware-websocket/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.3.15", "", { "dependencies": { "@smithy/protocol-http": "^5.3.12", "@smithy/querystring-builder": "^4.2.12", "@smithy/types": "^4.13.1", "@smithy/util-base64": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A=="],
@@ -2265,6 +2264,12 @@
     "@aws-sdk/token-providers/@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.4.7", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw=="],
 
     "@aws-sdk/token-providers/@smithy/types": ["@smithy/types@4.13.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g=="],
+
+    "@aws-sdk/util-format-url/@aws-sdk/types": ["@aws-sdk/types@3.973.6", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw=="],
+
+    "@aws-sdk/util-format-url/@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg=="],
+
+    "@aws-sdk/util-format-url/@smithy/types": ["@smithy/types@4.13.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -2499,8 +2504,6 @@
     "@aws-sdk/client-bedrock-runtime/@smithy/util-defaults-mode-node/@smithy/property-provider": ["@smithy/property-provider@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A=="],
 
     "@aws-sdk/client-bedrock-runtime/@smithy/util-retry/@smithy/service-error-classification": ["@smithy/service-error-classification@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1" } }, "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ=="],
-
-    "@aws-sdk/middleware-websocket/@aws-sdk/util-format-url/@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg=="],
 
     "@aws-sdk/middleware-websocket/@smithy/eventstream-serde-browser/@smithy/eventstream-serde-universal": ["@smithy/eventstream-serde-universal@4.2.12", "", { "dependencies": { "@smithy/eventstream-codec": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -184,6 +184,7 @@
         "@appstrate/emails": "workspace:*",
         "@appstrate/env": "workspace:*",
         "@aws-sdk/client-s3": "^3.1030.0",
+        "@aws-sdk/s3-request-presigner": "^3.1030.0",
         "@better-auth/drizzle-adapter": "^1.5.3",
         "@electric-sql/pglite": "^0.4.4",
         "better-auth": "^1.6.0",
@@ -325,6 +326,8 @@
 
     "@aws-sdk/region-config-resolver": ["@aws-sdk/region-config-resolver@3.972.11", "", { "dependencies": { "@aws-sdk/types": "^3.973.7", "@smithy/config-resolver": "^4.4.14", "@smithy/node-config-provider": "^4.3.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-6Q8B1dcx6BBqUTY1Mc/eROKA0FImEEY5VPSd6AGPEUf0ErjExz4snVqa9kNJSoVDV1rKaNf3qrWojgcKW+SdDg=="],
 
+    "@aws-sdk/s3-request-presigner": ["@aws-sdk/s3-request-presigner@3.1030.0", "", { "dependencies": { "@aws-sdk/signature-v4-multi-region": "^3.996.16", "@aws-sdk/types": "^3.973.7", "@aws-sdk/util-format-url": "^3.972.9", "@smithy/middleware-endpoint": "^4.4.29", "@smithy/protocol-http": "^5.3.13", "@smithy/smithy-client": "^4.12.9", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-rLM1DjBb9QlQwijKGtVSfWGi2gEz8yYj244RRWsPoGAhl57xKS0OGq6MygP/UYTPVc6r5qr4a8Gq1wos4QxnVw=="],
+
     "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.16", "", { "dependencies": { "@aws-sdk/middleware-sdk-s3": "^3.972.28", "@aws-sdk/types": "^3.973.7", "@smithy/protocol-http": "^5.3.13", "@smithy/signature-v4": "^5.3.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-EMdXYB4r/k5RWq86fugjRhid5JA+Z6MpS7n4sij4u5/C+STrkvuf9aFu41rJA9MjUzxCLzv8U2XL8cH2GSRYpQ=="],
 
     "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1019.0", "", { "dependencies": { "@aws-sdk/core": "^3.973.25", "@aws-sdk/nested-clients": "^3.996.16", "@aws-sdk/types": "^3.973.6", "@smithy/property-provider": "^4.2.12", "@smithy/shared-ini-file-loader": "^4.4.7", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-OF+2RfRmUKyjzrRWlDcyju3RBsuqcrYDQ8TwrJg8efcOotMzuZN4U9mpVTIdATpmEc4lWNZBMSjPzrGm6JPnAQ=="],
@@ -335,7 +338,7 @@
 
     "@aws-sdk/util-endpoints": ["@aws-sdk/util-endpoints@3.996.6", "", { "dependencies": { "@aws-sdk/types": "^3.973.7", "@smithy/types": "^4.14.0", "@smithy/url-parser": "^4.2.13", "@smithy/util-endpoints": "^3.3.4", "tslib": "^2.6.2" } }, "sha512-2nUQ+2ih7CShuKHpGSIYvvAIOHy52dOZguYG36zptBukhw6iFwcvGfG0tes0oZFWQqEWvgZe9HLWaNlvXGdOrg=="],
 
-    "@aws-sdk/util-format-url": ["@aws-sdk/util-format-url@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/querystring-builder": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A=="],
+    "@aws-sdk/util-format-url": ["@aws-sdk/util-format-url@3.972.9", "", { "dependencies": { "@aws-sdk/types": "^3.973.7", "@smithy/querystring-builder": "^4.2.13", "@smithy/types": "^4.14.0", "tslib": "^2.6.2" } }, "sha512-fNJXHrs0ZT7Wx0KGIqKv7zLxlDXt2vqjx9z6oKUQFmpE5o4xxnSryvVHfHpIifYHWKz94hFccIldJ0YSZjlCBw=="],
 
     "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
 
@@ -2183,6 +2186,8 @@
 
     "@aws-sdk/middleware-websocket/@aws-sdk/types": ["@aws-sdk/types@3.973.6", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw=="],
 
+    "@aws-sdk/middleware-websocket/@aws-sdk/util-format-url": ["@aws-sdk/util-format-url@3.972.8", "", { "dependencies": { "@aws-sdk/types": "^3.973.6", "@smithy/querystring-builder": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A=="],
+
     "@aws-sdk/middleware-websocket/@smithy/eventstream-serde-browser": ["@smithy/eventstream-serde-browser@4.2.12", "", { "dependencies": { "@smithy/eventstream-serde-universal": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A=="],
 
     "@aws-sdk/middleware-websocket/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.3.15", "", { "dependencies": { "@smithy/protocol-http": "^5.3.12", "@smithy/querystring-builder": "^4.2.12", "@smithy/types": "^4.13.1", "@smithy/util-base64": "^4.3.2", "tslib": "^2.6.2" } }, "sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A=="],
@@ -2264,12 +2269,6 @@
     "@aws-sdk/token-providers/@smithy/shared-ini-file-loader": ["@smithy/shared-ini-file-loader@4.4.7", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw=="],
 
     "@aws-sdk/token-providers/@smithy/types": ["@smithy/types@4.13.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g=="],
-
-    "@aws-sdk/util-format-url/@aws-sdk/types": ["@aws-sdk/types@3.973.6", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw=="],
-
-    "@aws-sdk/util-format-url/@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg=="],
-
-    "@aws-sdk/util-format-url/@smithy/types": ["@smithy/types@4.13.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -2504,6 +2503,8 @@
     "@aws-sdk/client-bedrock-runtime/@smithy/util-defaults-mode-node/@smithy/property-provider": ["@smithy/property-provider@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A=="],
 
     "@aws-sdk/client-bedrock-runtime/@smithy/util-retry/@smithy/service-error-classification": ["@smithy/service-error-classification@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1" } }, "sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ=="],
+
+    "@aws-sdk/middleware-websocket/@aws-sdk/util-format-url/@smithy/querystring-builder": ["@smithy/querystring-builder@4.2.12", "", { "dependencies": { "@smithy/types": "^4.13.1", "@smithy/util-uri-escape": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg=="],
 
     "@aws-sdk/middleware-websocket/@smithy/eventstream-serde-browser/@smithy/eventstream-serde-universal": ["@smithy/eventstream-serde-universal@4.2.12", "", { "dependencies": { "@smithy/eventstream-codec": "^4.2.12", "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,6 +156,7 @@ services:
       - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:?Set BETTER_AUTH_SECRET in .env}
       - CONNECTION_ENCRYPTION_KEY=${CONNECTION_ENCRYPTION_KEY:?Set CONNECTION_ENCRYPTION_KEY in .env}
       - RUN_TOKEN_SECRET=${RUN_TOKEN_SECRET:-}
+      - UPLOAD_SIGNING_SECRET=${UPLOAD_SIGNING_SECRET:?Set UPLOAD_SIGNING_SECRET in .env}
       # ── Database / Redis ──
       - DATABASE_URL=postgresql://${POSTGRES_USER:?Set POSTGRES_USER in .env}:${POSTGRES_PASSWORD}@appstrate-postgres:5432/appstrate
       - REDIS_URL=redis://appstrate-redis:6379

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,7 @@
   "exports": {
     "./logger": "./src/logger.ts",
     "./env": "./src/env.ts",
+    "./ajv": "./src/ajv.ts",
     "./storage": "./src/storage.ts",
     "./storage-s3": "./src/storage-s3.ts",
     "./storage-fs": "./src/storage-fs.ts",
@@ -62,7 +63,8 @@
   },
   "dependencies": {
     "@afps-spec/schema": "^1.3.1",
-    "@aws-sdk/s3-request-presigner": "^3.1030.0",
+    "ajv": "^8.18.0",
+    "ajv-formats": "^3.0.1",
     "fflate": "^0.8.0",
     "pino": "^10.3.1",
     "semver": "^7.7.1",
@@ -70,11 +72,15 @@
   },
   "peerDependencies": {
     "@aws-sdk/client-s3": "^3",
+    "@aws-sdk/s3-request-presigner": "^3",
     "hono": "^4.12.9",
     "typescript": "^5"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/client-s3": {
+      "optional": true
+    },
+    "@aws-sdk/s3-request-presigner": {
       "optional": true
     },
     "hono": {

--- a/packages/core/src/ajv.ts
+++ b/packages/core/src/ajv.ts
@@ -1,0 +1,49 @@
+// Copyright 2025-2026 Appstrate
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared Ajv2020 + ajv-formats factory.
+ *
+ * Both the backend (apps/api validation) and the frontend (RJSF validator)
+ * need an Ajv instance configured identically so client- and server-side
+ * validation agree on the same JSON Schema 2020-12 dialect. The awkward
+ * `unknown` casts required at the ajv-formats + ajv/dist/2020 boundary live
+ * here once, instead of being duplicated at every call site.
+ */
+
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormatsImport from "ajv-formats";
+
+// ajv-formats ships a CJS default-export under an ESM wrapper; the named type
+// exposed by @types/ajv-formats expects AJV's Ajv (draft-07) class. The 2020-12
+// class is runtime-compatible. Cast through `unknown` once and forget.
+const addFormats = addFormatsImport as unknown as (ajv: Ajv2020) => Ajv2020;
+
+/** Options passed through to Ajv2020 on construction. */
+export interface CreateAjvOptions {
+  /** Coerce string → number/boolean on input. Default: false. */
+  coerceTypes?: boolean;
+  /** Report all errors instead of stopping at the first. Default: true. */
+  allErrors?: boolean;
+  /** `strict: false` is the Appstrate-wide default — manifests carry UI hints
+   *  that AJV would otherwise reject. */
+  strict?: boolean;
+}
+
+/** Build an Ajv2020 instance with ajv-formats registered. */
+export function createAjv(opts: CreateAjvOptions = {}): Ajv2020 {
+  const ajv = new Ajv2020({
+    coerceTypes: opts.coerceTypes ?? false,
+    allErrors: opts.allErrors ?? true,
+    strict: opts.strict ?? false,
+  });
+  addFormats(ajv);
+  return ajv;
+}
+
+/** Exposed for callers that need the concrete class (e.g. RJSF's
+ *  `customizeValidator({ AjvClass })`). Cast-site is encapsulated here. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const AjvClass = Ajv2020 as unknown as any;
+
+export type { Ajv2020 };

--- a/packages/core/src/storage-s3.ts
+++ b/packages/core/src/storage-s3.ts
@@ -108,11 +108,13 @@ export function createS3Storage(config: S3StorageConfig): Storage {
     ): Promise<UploadUrlDescriptor> {
       const expiresIn = opts?.expiresIn ?? 900;
       const key = makeKey(bucket, path);
+      // ContentLength is intentionally NOT signed — S3 would then require the
+      // PUT to send exactly that many bytes, breaking any client-declared vs.
+      // actual size mismatch. Size is enforced server-side on consume instead.
       const cmd = new PutObjectCommand({
         Bucket: config.bucket,
         Key: key,
         ...(opts?.mime ? { ContentType: opts.mime } : {}),
-        ...(opts?.maxSize ? { ContentLength: opts.maxSize } : {}),
       });
       const url = await getSignedUrl(client, cmd, { expiresIn });
       // Client must echo the same Content-Type declared in the signature.

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -21,6 +21,7 @@
     "@appstrate/emails": "workspace:*",
     "@appstrate/env": "workspace:*",
     "@aws-sdk/client-s3": "^3.1030.0",
+    "@aws-sdk/s3-request-presigner": "^3.1030.0",
     "@better-auth/drizzle-adapter": "^1.5.3",
     "@electric-sql/pglite": "^0.4.4",
     "better-auth": "^1.6.0",

--- a/packages/db/src/storage.ts
+++ b/packages/db/src/storage.ts
@@ -21,7 +21,7 @@ function getStore(): Storage {
     store = createFileSystemStorage({
       basePath: env.FS_STORAGE_PATH,
       uploadBaseUrl: env.APP_URL,
-      uploadSecret: env.UPLOAD_SIGNING_SECRET ?? env.BETTER_AUTH_SECRET,
+      uploadSecret: env.UPLOAD_SIGNING_SECRET,
     });
   }
 

--- a/packages/db/src/storage.ts
+++ b/packages/db/src/storage.ts
@@ -21,7 +21,7 @@ function getStore(): Storage {
     store = createFileSystemStorage({
       basePath: env.FS_STORAGE_PATH,
       uploadBaseUrl: env.APP_URL,
-      uploadSecret: env.BETTER_AUTH_SECRET,
+      uploadSecret: env.UPLOAD_SIGNING_SECRET ?? env.BETTER_AUTH_SECRET,
     });
   }
 

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -21,10 +21,10 @@ const envSchema = z
     // PGlite data directory (used when DATABASE_URL is absent)
     PGLITE_DATA_DIR: z.string().default("./data/pglite"),
     BETTER_AUTH_SECRET: z.string().min(1, "BETTER_AUTH_SECRET is required"),
-    // Dedicated HMAC secret for FS upload-sink tokens. When absent, falls back
-    // to BETTER_AUTH_SECRET — set this explicitly so rotating auth secrets
-    // does not invalidate in-flight uploads (and vice versa).
-    UPLOAD_SIGNING_SECRET: z.string().min(16).optional(),
+    // Dedicated HMAC secret for FS upload-sink tokens. Separate from
+    // BETTER_AUTH_SECRET so the two can be rotated independently and a
+    // compromise of one does not affect the other.
+    UPLOAD_SIGNING_SECRET: z.string().min(16, "UPLOAD_SIGNING_SECRET must be at least 16 chars"),
     // S3 storage (optional — falls back to filesystem when S3_BUCKET is absent)
     S3_BUCKET: z.string().optional(),
     S3_REGION: z.string().optional(),

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -21,6 +21,10 @@ const envSchema = z
     // PGlite data directory (used when DATABASE_URL is absent)
     PGLITE_DATA_DIR: z.string().default("./data/pglite"),
     BETTER_AUTH_SECRET: z.string().min(1, "BETTER_AUTH_SECRET is required"),
+    // Dedicated HMAC secret for FS upload-sink tokens. When absent, falls back
+    // to BETTER_AUTH_SECRET — set this explicitly so rotating auth secrets
+    // does not invalidate in-flight uploads (and vice versa).
+    UPLOAD_SIGNING_SECRET: z.string().min(16).optional(),
     // S3 storage (optional — falls back to filesystem when S3_BUCKET is absent)
     S3_BUCKET: z.string().optional(),
     S3_REGION: z.string().optional(),

--- a/test/setup/preload.ts
+++ b/test/setup/preload.ts
@@ -49,6 +49,7 @@ const TEST_REDIS_URL = process.env.TEST_REDIS_URL ?? "redis://localhost:6380";
 process.env.DATABASE_URL = TEST_DATABASE_URL;
 process.env.REDIS_URL = TEST_REDIS_URL;
 process.env.BETTER_AUTH_SECRET = "test-secret-at-least-32-chars-long-for-hmac";
+process.env.UPLOAD_SIGNING_SECRET = "test-upload-signing-secret-at-least-16-chars";
 process.env.CONNECTION_ENCRYPTION_KEY = Buffer.from("0123456789abcdef0123456789abcdef").toString(
   "base64",
 ); // 32 bytes


### PR DESCRIPTION
Stacked on top of #102 — addresses every point from the review.

## Correctness
- **TOCTOU in `consumeUpload`** → atomic claim via `UPDATE … WHERE consumedAt IS NULL … RETURNING`. Two concurrent runs referencing the same `upload://` URI now resolve to exactly one winner + one `409 conflict`; pre-check retained for tenant-scoped 404/410 UX.
- **S3 `ContentLength` in presigned PUT** → removed. Signing `ContentLength` forced the client to PUT *exactly* that many bytes, breaking any declared-vs-actual size mismatch.
- **Size mismatch on consume** → hard reject (was warn-only). Prevents declared-1KB / uploaded-100MB abuse when the storage adapter does not enforce `ContentLength` at sign time.

## MIME handling
- **Text/JSON/XML/YAML/JS MIMEs** → bypass magic-byte sniffing (`file-type` returns `undefined` for them; strict matching rejected every legitimate text upload).
- **Content-Type vs signed MIME** → normalize both sides of the FS-sink check (strip params, lowercase). Handles `application/pdf; charset=…` and blocks padded-MIME attacks.

## Reliability
- **Periodic upload GC** → `setInterval` sweep every 15 min (aligned with default expiry), batches drain loops, stopped cleanly on shutdown. A long-running instance no longer accumulates orphans between restarts.

## Config & DX
- **`UPLOAD_SIGNING_SECRET`** → new required env var, dedicated HMAC secret for FS upload-sink tokens. No fallback to `BETTER_AUTH_SECRET` (different domain). Declared in `.env.example` and `docker-compose.yml`.
- **Shared Ajv2020 factory** in `@appstrate/core/ajv` → single cast site for the `ajv-formats` / `ajv/dist/2020` boundary, consumed by both `apps/api` schema validation and the RJSF validator so client + server agree.
- **`@aws-sdk/s3-request-presigner`** moved to optional peer dep (mirrors `@aws-sdk/client-s3`) — core no longer pulls it for non-S3 consumers.
- **`SchemaForm` submit suppression** driven by one signal (`ui:submitButtonOptions.norender`) instead of dual `norender` + empty children.

## Test coverage
- `test/unit/input-parser-uploads.test.ts` — 12 pure tests for `collectUploadRefs`: single-file vs array-of-files dispatch, error shapes, no-op paths.
- `test/integration/services/upload-consume.test.ts` — 8 integration tests against real Postgres + FS storage: **concurrent claim race**, cross-tenant 404, 410 expired, size-mismatch reject, missing binary, text-MIME accept, PDF-spoof reject, sequential 409.

All 25 tests green; `bun run check` clean (typecheck + lint + format + OpenAPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)