### PR TITLE
fix(docker): bump bun to 1.3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Install dependencies ──────────────────────────────────
-FROM --platform=${TARGETPLATFORM:-linux/amd64} oven/bun:1.3.9-alpine AS deps
+FROM --platform=${TARGETPLATFORM:-linux/amd64} oven/bun:1.3.11-alpine AS deps
 
 LABEL org.opencontainers.image.source="https://github.com/appstrate/appstrate"
 LABEL org.opencontainers.image.description="Appstrate — Open-source platform for running autonomous AI agents in sandboxed Docker containers"
@@ -25,7 +25,7 @@ COPY patches/ patches/
 RUN bun install --frozen-lockfile
 
 # ── Stage 2: Build ────────────────────────────────────────────────
-FROM --platform=${TARGETPLATFORM:-linux/amd64} oven/bun:1.3.9-alpine AS build
+FROM --platform=${TARGETPLATFORM:-linux/amd64} oven/bun:1.3.11-alpine AS build
 
 WORKDIR /app
 
@@ -44,7 +44,7 @@ COPY . .
 RUN bun run build
 
 # ── Stage 3: Production image ─────────────────────────────────────
-FROM --platform=${TARGETPLATFORM:-linux/amd64} oven/bun:1.3.9-alpine
+FROM --platform=${TARGETPLATFORM:-linux/amd64} oven/bun:1.3.11-alpine
 
 WORKDIR /app
 

--- a/runtime-pi/Dockerfile
+++ b/runtime-pi/Dockerfile
@@ -1,5 +1,5 @@
 # ── Stage 1: Install dependencies ─────────────────────────────────
-FROM --platform=${TARGETPLATFORM:-linux/amd64} oven/bun:1.3.9-alpine AS deps
+FROM --platform=${TARGETPLATFORM:-linux/amd64} oven/bun:1.3.11-alpine AS deps
 
 LABEL org.opencontainers.image.source="https://github.com/appstrate/appstrate"
 LABEL org.opencontainers.image.description="Appstrate Pi — AI agent runtime for ephemeral agent runs"
@@ -16,7 +16,7 @@ RUN bun install --production && \
     rm -rf node_modules/@types
 
 # ── Stage 2: Runtime ─────────────────────────────────────────────
-FROM --platform=${TARGETPLATFORM:-linux/amd64} oven/bun:1.3.9-alpine
+FROM --platform=${TARGETPLATFORM:-linux/amd64} oven/bun:1.3.11-alpine
 
 RUN apk add --no-cache git curl ca-certificates unzip python3 py3-pip bash
 

--- a/runtime-pi/sidecar/Dockerfile
+++ b/runtime-pi/sidecar/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${TARGETPLATFORM:-linux/amd64} oven/bun:1.3.9-alpine AS builder
+FROM --platform=${TARGETPLATFORM:-linux/amd64} oven/bun:1.3.11-alpine AS builder
 
 LABEL org.opencontainers.image.source="https://github.com/appstrate/appstrate"
 LABEL org.opencontainers.image.description="Appstrate Sidecar — Credential-isolating HTTP proxy for agent containers"


### PR DESCRIPTION
Lockfile was regenerated with bun 1.3.11 and fails `bun install --production` on 1.3.9 with 'lockfile had changes, but lockfile is frozen'. Bump all 3 Dockerfiles to match.