### PR TITLE
fix(sidecar): regenerate stale bun.lock

### DIFF
--- a/runtime-pi/sidecar/bun.lock
+++ b/runtime-pi/sidecar/bun.lock
@@ -5,11 +5,11 @@
     "": {
       "name": "appstrate-sidecar",
       "dependencies": {
-        "hono": "^4.0.0",
+        "hono": "^4.12.12",
       },
     },
   },
   "packages": {
-    "hono": ["hono@4.12.0", "", {}, "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA=="],
+    "hono": ["hono@4.12.12", "", {}, "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="],
   }
 }


### PR DESCRIPTION
Same cause as PR #105 — sidecar lockfile was stale, failing frozen-lockfile in Docker build.