### PR TITLE
fix(storage-s3): add S3_PUBLIC_ENDPOINT for presigned URLs

### DIFF
--- a/packages/core/src/storage-s3.ts
+++ b/packages/core/src/storage-s3.ts
@@ -21,6 +21,8 @@ export interface S3StorageConfig {
   region: string;
   /** Custom endpoint URL for S3-compatible services (MinIO, R2). Enables path-style access. */
   endpoint?: string;
+  /** Public endpoint used only for presigned URLs. Falls back to `endpoint` when unset. */
+  publicEndpoint?: string;
 }
 
 /** S3 SDK error shape used for status code and name checks. */
@@ -37,6 +39,17 @@ export function createS3Storage(config: S3StorageConfig): Storage {
     region: config.region,
     ...(config.endpoint ? { endpoint: config.endpoint, forcePathStyle: true } : {}),
   });
+
+  // Separate client for presigned URLs when a public endpoint is provided.
+  // The browser needs a URL it can reach, while the server-side SDK keeps
+  // talking to the internal endpoint.
+  const presignClient = config.publicEndpoint
+    ? new S3Client({
+        region: config.region,
+        endpoint: config.publicEndpoint,
+        forcePathStyle: true,
+      })
+    : client;
 
   function makeKey(bucket: string, filePath: string): string {
     const key = `${bucket}/${filePath}`.replace(/\/+/g, "/");
@@ -156,7 +169,7 @@ export function createS3Storage(config: S3StorageConfig): Storage {
         Key: key,
         ...(opts?.mime ? { ContentType: opts.mime } : {}),
       });
-      const url = await getSignedUrl(client, cmd, { expiresIn });
+      const url = await getSignedUrl(presignClient, cmd, { expiresIn });
       // Client must echo the same Content-Type declared in the signature.
       const headers: Record<string, string> = {};
       if (opts?.mime) headers["Content-Type"] = opts.mime;

--- a/packages/db/src/storage.ts
+++ b/packages/db/src/storage.ts
@@ -21,6 +21,7 @@ function getStore(): Storage {
       bucket: env.S3_BUCKET,
       region: env.S3_REGION!,
       endpoint: env.S3_ENDPOINT,
+      publicEndpoint: env.S3_PUBLIC_ENDPOINT,
     });
   } else {
     store = createFileSystemStorage({

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -29,6 +29,10 @@ const envSchema = z
     S3_BUCKET: z.string().optional(),
     S3_REGION: z.string().optional(),
     S3_ENDPOINT: z.string().optional(),
+    // Public-facing S3 endpoint used only for presigned URLs served to browsers.
+    // Falls back to S3_ENDPOINT when unset. Set this when S3_ENDPOINT points at
+    // an internal Docker hostname unreachable from the browser (e.g. MinIO).
+    S3_PUBLIC_ENDPOINT: z.string().optional(),
     // Filesystem storage path (used when S3_BUCKET is absent)
     FS_STORAGE_PATH: z.string().default("./data/storage"),
 


### PR DESCRIPTION
Browser upload fails when S3_ENDPOINT is an internal Docker hostname. Introduce S3_PUBLIC_ENDPOINT used only for presigning; falls back to S3_ENDPOINT when unset.