### PR TITLE
fix(auth): disable BA cookieCache to stop 5-min logouts

### DIFF
--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -505,10 +505,15 @@ function buildAuth(
     session: {
       expiresIn: 60 * 60 * 24 * 7, // 7 days
       updateAge: 60 * 60 * 24, // Refresh every 24h
-      cookieCache: {
-        enabled: true,
-        maxAge: 5 * 60, // 5 minutes
-      },
+      // Disabled to work around BA 1.6 issue #7607 — when `session_data`
+      // expires (at `maxAge`), BA fails to regenerate it from the still-valid
+      // `session_token` under certain plugin configurations, logging the
+      // user out at the next request. Still open in 1.6.3.
+      // Re-enable once the upstream bug is fixed. Cost of disabling: one
+      // extra DB query per authenticated request (negligible at our scale).
+      // Verified none of our plugins (`@better-auth/oauth-provider`, `jwt`)
+      // depend on `session_data` — only `email-otp` does, which we don't use.
+      cookieCache: { enabled: false },
       additionalFields: {
         // Denormalized from `user.realm` by `databaseHooks.session.create.before`.
         // Same reason as `user.additionalFields.realm`: BA's adapter strips


### PR DESCRIPTION
**Bug**: Users logged out every ~5 minutes on production.

**Root cause**: Better Auth 1.6 [issue #7607](https://github.com/better-auth/better-auth/issues/7607) (still open in 1.6.3) — when `session_data` cookie expires, BA fails to regenerate it from the still-valid `session_token` under certain plugin configurations.

**Fix**: Disable `cookieCache` entirely. At our scale (small team) the perf cost (one extra DB `SELECT` per authenticated request) is negligible. Revocation becomes immediate. Re-enable once upstream fixes the bug.

**Plugin safety**: Only `email-otp` uses `session_data` directly. We ship `@better-auth/oauth-provider` + `jwt`; neither depends on the cache cookie.

**Alternatives evaluated**:
- `maxAge = expiresIn` (7d): keeps cache but revoked sessions linger up to 7d in browsers. Rejected.
- `maxAge = updateAge` (24h): exposes the bug daily. Rejected.

Refs: #7607, #2115, [BA session docs](https://better-auth.com/docs/concepts/session-management)