### PR TITLE
fix(ci): seed SYSTEM_PROVIDER_KEYS for E2E

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,11 @@ jobs:
           # UI org switching). The webhooks module is opt-in via MODULES
           # since PR #72 — without this the webhook routes 404 and 12 specs fail.
           MODULES: webhooks
+          # Default system model so run-acceptance passes in specs that POST
+          # /agents/:id/run (e.g. upload-flow). The run pipeline only needs a
+          # resolvable model at acceptance time — the dummy apiKey is never
+          # called because RUN_ADAPTER=process doesn't actually hit the LLM.
+          SYSTEM_PROVIDER_KEYS: '[{"id":"e2e","label":"E2E","api":"anthropic-messages","baseUrl":"https://example.invalid","apiKey":"e2e-dummy","models":[{"modelId":"claude-sonnet-4-5","label":"E2E Default","isDefault":true}]}]'
 
       - name: Upload test report
         if: failure()


### PR DESCRIPTION
E2E has been failing on main since #102 — the upload-flow specs POST /agents/:id/run which requires a resolvable LLM model. CI env had none, so every run was rejected with `model_not_configured` (400).

Seed a dummy `SYSTEM_PROVIDER_KEYS` with `isDefault: true`. Run acceptance now passes; the LLM is never actually invoked (`RUN_ADAPTER=process` + the agent's trivial prompt).