### PR TITLE
fix(oidc): delegate logout cookie deletion to BA signOut

### DIFF
--- a/apps/api/src/modules/oidc/auth/api.ts
+++ b/apps/api/src/modules/oidc/auth/api.ts
@@ -70,6 +70,12 @@ interface JwksArgs {
   headers: Headers;
 }
 
+interface SignOutArgs {
+  headers: Headers;
+  request?: Request;
+  asResponse?: boolean;
+}
+
 export interface OidcAuthApi {
   signInEmail(args: SignInEmailArgs): Promise<Response | unknown>;
   signUpEmail(args: SignUpEmailArgs): Promise<Response | unknown>;
@@ -77,6 +83,7 @@ export interface OidcAuthApi {
   requestPasswordReset(args: RequestPasswordResetArgs): Promise<Response | unknown>;
   resetPassword(args: ResetPasswordArgs): Promise<Response | unknown>;
   oauth2Consent(args: OAuth2ConsentArgs): Promise<Response | unknown>;
+  signOut(args: SignOutArgs): Promise<Response | unknown>;
   getOpenIdConfig(args: DiscoveryArgs): Promise<unknown>;
   getOAuthServerConfig(args: DiscoveryArgs): Promise<unknown>;
   getJwks(args: JwksArgs): Promise<{ keys?: jose.JWK[] } | null>;

--- a/apps/api/src/modules/oidc/routes.ts
+++ b/apps/api/src/modules/oidc/routes.ts
@@ -1892,18 +1892,34 @@ export function createOidcRouter() {
   // Better Auth's /oauth2/end-session deletes the session from the DB
   // but does NOT clear the `better-auth.session_token` cookie. This
   // leaves a stale cookie that breaks the next authorize request
-  // ("session no longer exists"). This custom GET route clears the
-  // cookie and redirects to the post_logout_redirect_uri.
+  // ("session no longer exists"). This custom GET route delegates cookie
+  // cleanup to BA's `signOut` (which also invalidates the DB row) and
+  // forwards its Set-Cookie headers — the only source of truth for the
+  // exact cookie name/Domain/Secure attributes BA used at creation time.
+  // Manually crafting the deletion header silently breaks when
+  // `crossSubDomainCookies` / `__Secure-` prefix / `Domain=` are in play.
   // Satellites call this instead of /oauth2/end-session directly.
 
   router.get("/api/oauth/logout", rateLimitByIp(30), async (c: Context<AppEnv>) => {
     const postLogoutUri = c.req.query("post_logout_redirect_uri");
     const clientId = c.req.query("client_id");
 
-    // Clear the BA session cookie so the next authorize starts fresh.
-    c.header("set-cookie", "better-auth.session_token=; Path=/; HttpOnly; Max-Age=0", {
-      append: true,
-    });
+    // Delegate cookie deletion + DB session invalidation to BA. Forward
+    // every Set-Cookie verbatim so attributes match the originals.
+    try {
+      const signOutResponse = (await getOidcAuthApi().signOut({
+        headers: c.req.raw.headers,
+        request: c.req.raw,
+        asResponse: true,
+      })) as Response;
+      forwardOAuthSessionCookies(c, signOutResponse, true);
+    } catch (err) {
+      // Already-expired sessions throw — proceed with the redirect anyway.
+      logger.warn("oidc: signOut threw, continuing logout redirect", {
+        module: "oidc",
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
 
     // Validate redirect URI against the client's registered post-logout URIs
     // to prevent open redirect attacks (OWASP). Fall back to "/" if no URI,


### PR DESCRIPTION
## Summary
- The custom \`/api/oauth/logout\` route was clearing \`better-auth.session_token=\` with bare attributes, but the actual cookie in production is \`__Secure-better-auth.session_token\` (Secure, Domain set via \`crossSubDomainCookies\`). Browsers see the deletion as a different cookie and keep the original — sessions never end.
- Bug was masked while \`cookieCache\` was enabled (the companion JWT cookie expired short enough to force reauth) and surfaced after #108 disabled the cache.
- Fix: delegate to \`auth.api.signOut({ asResponse: true })\` and forward Set-Cookie verbatim. BA owns the cookie name/attributes and also invalidates the session row in the DB.

## Test plan
- [x] Reproduced via Playwright on app.appstrate.com: direct GET \`/api/oauth/logout?...\` redirects to /login then SPA bounces back to / because session is still valid
- [x] Confirmed actual cookie name is \`__Secure-better-auth.session_token\` (Firefox + Chromium contexts)
- [x] tsc clean
- [ ] Post-deploy: click "Déconnexion" in app, confirm landing on /login and \`__Secure-better-auth.session_token\` cleared in DevTools