### PR TITLE
fix(provider-editor): remove duplicate credentials schema section

### DIFF
--- a/apps/web/src/components/provider-editor/provider-editor-inner.tsx
+++ b/apps/web/src/components/provider-editor/provider-editor-inner.tsx
@@ -744,15 +744,6 @@ export function ProviderEditorInner({ initialState, isEdit, packageId }: Provide
                 />
               </div>
 
-              {/* Credential schema — lets users define multi-field credentials
-                  (email + api_key, etc.) referenced by credentialTransform. */}
-              <SchemaSection
-                title={t("providers.form.sectionCredentials")}
-                mode="credentials"
-                fields={credentialFields}
-                onChange={onCredentialFieldsChange}
-              />
-
               {/* Credential transform — template-based pre-encoding (AFPS §7.4) */}
               <div className="text-muted-foreground mt-2 text-sm font-medium">
                 {t("providers.form.sectionCredentialTransform")}


### PR DESCRIPTION
## Summary
- The credentials `SchemaSection` was rendered twice in `api_key` auth mode: once via the generic `isCredentialMode(authMode)` branch (which already covers `api_key`/`basic`/`custom`), and again inside the `api_key`-specific branch below the `credentialFieldName`/`credentialHeaderName`/`credentialHeaderPrefix` fields.
- Drop the duplicate so the section appears once, cleanly ordered: credentials schema → API key injection routing → credential transform.

## Test plan
- [ ] Open the provider editor, switch auth mode to `api_key` → verify only one "Champs d'identifications" section is rendered
- [ ] Verify the same for `basic` and `custom` auth modes (unaffected, still one section)
- [ ] Verify `oauth2`/`oauth1` modes are unaffected