### PR TITLE
chore(core): bump to 2.10.8

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to `@appstrate/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.8] — 2026-04-15
+
+### Added
+
+- `form` export — AFPS `SchemaWrapper` to RJSF mapper (`mapAfpsToRjsf`), file-field detection helpers (`isFileField`, `isMultipleFileField`), `asJSONSchemaObject` cast helper. Used by the new `@appstrate/ui/schema-form` package.
+- `storage-s3`: support `S3_PUBLIC_ENDPOINT` for presigned URLs served behind a public domain distinct from the internal S3 endpoint.
+
+### Changed
+
+- Internal cleanup of `validation.ts` / `storage.ts` test surface.
+
 ## [2.10.7] — 2026-04-11
 
 ### Changed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "2.10.7",
+  "version": "2.10.8",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- Patch bump `@appstrate/core` 2.10.7 → 2.10.8
- CHANGELOG entry covers the `form` export (AFPS→RJSF mapper, used by `@appstrate/ui/schema-form`) and `S3_PUBLIC_ENDPOINT` support shipped since 2.10.7.

Once merged, tag `core@2.10.8` to trigger npm publish via `.github/workflows/publish-core.yml`.

## Test plan

- [x] Version aligns with CHANGELOG
- [ ] Tag `core@2.10.8` after merge → CI publishes to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)