### PR TITLE
fix(ui): add @types/bun for publish typecheck

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -156,7 +156,7 @@
     },
     "packages/core": {
       "name": "@appstrate/core",
-      "version": "2.10.7",
+      "version": "2.10.8",
       "dependencies": {
         "@afps-spec/schema": "^1.3.1",
         "ajv": "^8.18.0",
@@ -229,6 +229,7 @@
         "@rjsf/core": "^6.4.2",
         "@rjsf/utils": "^6.4.2",
         "@rjsf/validator-ajv8": "^6.4.2",
+        "@types/bun": "^1.3.9",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "lucide-react": "^1.8.0",
@@ -242,7 +243,7 @@
         "@rjsf/core": "^6",
         "@rjsf/utils": "^6",
         "@rjsf/validator-ajv8": "^6",
-        "lucide-react": "^1 || >=0.400.0",
+        "lucide-react": ">=0.400.0",
         "react": "^19",
         "react-dom": "^19",
         "react-select": "^5",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@appstrate/core": "workspace:*",
+    "@types/bun": "^1.3.9",
     "@rjsf/core": "^6.4.2",
     "@rjsf/utils": "^6.4.2",
     "@rjsf/validator-ajv8": "^6.4.2",


### PR DESCRIPTION
## Summary

- The `publish-ui` workflow runs `tsc --noEmit` from `packages/ui` and the tsconfig includes `test/`, which imports `bun:test`. Workspace-hoisted `@types/bun` was not picked up in CI → publish failed for `ui@1.0.0`.
- Add `@types/bun` as a direct devDep of `@appstrate/ui`.

After merge, re-tag a `ui@1.0.1` (or move `ui@1.0.0` if not yet on npm) to retry publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)