### PR TITLE
fix(docker): re-run bun install in build stage for Vite 8 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,11 @@ COPY --from=deps /app/packages/ui/node_modules ./packages/ui/node_modules
 
 COPY . .
 
+# Re-link workspace packages after COPY overwrites symlinks. Without this,
+# Rolldown (Vite 8) can't resolve transitive deps like i18next via the broken
+# apps/web/node_modules/i18next → /app/node_modules/.bun/i18next@X symlink.
+RUN bun install --frozen-lockfile
+
 RUN bun run build
 
 # ── Stage 3: Production image ─────────────────────────────────────


### PR DESCRIPTION
## Summary

After the better-auth 1.6.4 + i18next 26.0.5 bumps in #119, `docker-check.sh` fails with:

```
Error: [vite]: Rolldown failed to resolve import "i18next" from "/app/apps/web/src/i18n.ts"
```

The `COPY --from=deps /app/node_modules` doesn't fully preserve the symlink tree to the `.bun/` cache — Rolldown (Vite 8) can't follow symlinks like `apps/web/node_modules/i18next → .bun/i18next@26.0.5+.../node_modules/i18next`.

Fix: add `bun install --frozen-lockfile` in the build stage to rebuild the symlink tree. No extra download — everything is already in the cached layer.

## Test plan

- [x] `bash scripts/docker-check.sh` passes locally (build succeeds + import resolution check)
- [x] `bun run check` passes (14/14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)