### PR TITLE
fix(ci): make installer-pages branch bootstrap idempotent

### DIFF
--- a/.github/workflows/publish-installer.yml
+++ b/.github/workflows/publish-installer.yml
@@ -67,8 +67,19 @@ jobs:
         run: |
           mkdir -p pages
           cd pages
-          git init -b installer-pages
-          git remote add origin "https://github.com/${{ github.repository }}.git"
+          # actions/checkout may have partially initialized .git and origin
+          # before failing — make both steps idempotent.
+          if [ ! -d .git ]; then
+            git init -b installer-pages
+          else
+            git checkout -B installer-pages 2>/dev/null || true
+          fi
+          REPO_URL="https://github.com/${{ github.repository }}.git"
+          if git remote get-url origin >/dev/null 2>&1; then
+            git remote set-url origin "$REPO_URL"
+          else
+            git remote add origin "$REPO_URL"
+          fi
 
       - name: Sync rendered files
         run: |


### PR DESCRIPTION
## Summary

First publish of v1.0.0-alpha.46 failed with:

```
error: remote origin already exists.
Error: Process completed with exit code 3.
```

Root cause: `actions/checkout@` with `continue-on-error: true` partially initializes `.git` and `origin` in `pages/` before failing (when the branch doesn't exist). The subsequent `git init -b installer-pages` re-init works (warning only), but `git remote add origin` fails because origin is already set.

Fix: make both `git init` and `git remote add origin` idempotent.

## Test plan

- [x] Checks pass locally
- [ ] Next release tag successfully bootstraps installer-pages