### PR TITLE
fix(docker): healthchecks falsely report containers unhealthy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,7 +199,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     healthcheck:
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://localhost:3000/ || exit 1"]
+      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/runtime-pi/sidecar/Dockerfile
+++ b/runtime-pi/sidecar/Dockerfile
@@ -23,6 +23,6 @@ USER nobody
 EXPOSE 8080 8081
 
 HEALTHCHECK --interval=10s --timeout=5s --start-period=5s --retries=3 \
-  CMD wget -q -O /dev/null http://127.0.0.1:8080/ || exit 1
+  CMD wget -q -O /dev/null http://127.0.0.1:8080/health || exit 1
 
 ENTRYPOINT ["/usr/local/bin/sidecar"]


### PR DESCRIPTION
## Problem

Discovered during self-hosting verification on v1.0.0-alpha.47. All containers showed \`unhealthy\` in \`docker ps\` even though the app worked end-to-end (signup + agent run succeeded). Two separate healthcheck bugs:

### 1. \`docker-compose.yml\` appstrate healthcheck — IPv4/IPv6 mismatch

\`\`\`yaml
test: [\"CMD-SHELL\", \"wget -q -O /dev/null http://localhost:3000/ || exit 1\"]
\`\`\`

In Alpine, \`localhost\` resolves to \`::1\` (IPv6 first), but Bun binds only to \`0.0.0.0\` (IPv4). Every probe returns \`Connection refused\`.

### 2. \`runtime-pi/sidecar/Dockerfile\` — probes wrong path

\`\`\`dockerfile
CMD wget -q -O /dev/null http://127.0.0.1:8080/ || exit 1
\`\`\`

The sidecar Hono app exposes \`/health\` (see \`app.ts:76\`) but no \`/\` route → 404. BusyBox wget exits 1 on 4xx → healthcheck fails.

## Impact

Orchestrators (Coolify, Docker Swarm, Kubernetes) may restart containers believing them dead, causing:
- Unnecessary app restarts in production
- Sidecar pool thrashing (pool rebuild on every check)
- Spurious alerts

## Fix

- appstrate HC: \`localhost\` → \`127.0.0.1\`
- sidecar HC: \`/\` → \`/health\`

## Verification

\`\`\`sh
# Before
docker exec appstrate-appstrate-1 wget -q -O /dev/null http://localhost:3000/
# wget: can't connect to remote host: Connection refused

# After
docker exec appstrate-appstrate-1 wget -q -O /dev/null http://127.0.0.1:3000/
# exit=0 ✅

docker exec appstrate-sidecar-pool-XXX wget -q -O /dev/null http://127.0.0.1:8080/health
# exit=0 ✅
\`\`\`

## Test plan

- [ ] After merge + next release, verify \`docker ps\` shows \`(healthy)\` for appstrate and sidecar containers in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)