### PR TITLE
fix(providers): unify credential key contract across layers

### DIFF
--- a/apps/api/src/routes/providers.ts
+++ b/apps/api/src/routes/providers.ts
@@ -182,8 +182,14 @@ const credentialRefinement = (data: CredentialRefinementInput, ctx: z.Refinement
       },
     },
   });
-  for (const msg of errors) {
-    ctx.addIssue({ code: "custom", path: ["credentials"], message: msg });
+  for (const err of errors) {
+    const path: (string | number)[] =
+      err.field === "fieldName"
+        ? ["credentialFieldName"]
+        : err.key !== undefined
+          ? ["credentialSchema", "properties", err.key]
+          : ["credentialSchema"];
+    ctx.addIssue({ code: "custom", path, message: err.message });
   }
 };
 

--- a/apps/api/src/routes/providers.ts
+++ b/apps/api/src/routes/providers.ts
@@ -19,7 +19,10 @@ import {
   parseBody,
   systemEntityForbidden,
 } from "../lib/errors.ts";
-import { getDefaultAdminCredentialSchema } from "@appstrate/core/validation";
+import {
+  getDefaultAdminCredentialSchema,
+  validateProviderCredentialKeys,
+} from "@appstrate/core/validation";
 import { getProviderCredentialId } from "@appstrate/connect";
 import { db } from "@appstrate/db/client";
 import { packageToProviderConfig } from "../lib/provider-config.ts";
@@ -111,7 +114,7 @@ function buildProviderDefinition(data: {
   return definition;
 }
 
-export const createProviderSchema = z.object({
+const baseProviderSchema = z.object({
   id: z.string().min(1, "id is required"),
   displayName: z.string().min(1, "displayName is required"),
   version: z.string().optional(),
@@ -157,7 +160,38 @@ export const createProviderSchema = z.object({
     .optional(),
 });
 
-export const updateProviderSchema = createProviderSchema.omit({ id: true });
+/**
+ * Cross-field refinement: credential schema keys and fieldName must match the
+ * canonical {@link CREDENTIAL_KEY_RE} pattern and fieldName must reference an
+ * existing property. Rule is shared with {@link validateManifest} so ZIP
+ * imports and direct API writes enforce the exact same contract.
+ */
+interface CredentialRefinementInput {
+  authMode: string;
+  credentialSchema?: Record<string, unknown>;
+  credentialFieldName?: string;
+}
+
+const credentialRefinement = (data: CredentialRefinementInput, ctx: z.RefinementCtx) => {
+  const errors = validateProviderCredentialKeys({
+    definition: {
+      authMode: data.authMode,
+      credentials: {
+        schema: data.credentialSchema,
+        fieldName: data.credentialFieldName,
+      },
+    },
+  });
+  for (const msg of errors) {
+    ctx.addIssue({ code: "custom", path: ["credentials"], message: msg });
+  }
+};
+
+export const createProviderSchema = baseProviderSchema.superRefine(credentialRefinement);
+
+export const updateProviderSchema = baseProviderSchema
+  .omit({ id: true })
+  .superRefine(credentialRefinement);
 
 export const configureCredentialsSchema = z.object({
   credentials: z.record(z.string(), z.string().min(1)).optional(),

--- a/apps/api/src/services/adapters/prompt-builder.ts
+++ b/apps/api/src/services/adapters/prompt-builder.ts
@@ -146,17 +146,14 @@ export function buildEnrichedPrompt(ctx: PromptContext): string {
           | undefined) ?? {};
       const varEntries = Object.entries(props);
 
-      // OAuth2/oauth1/api_key and basic all have a well-defined primary field
+      // OAuth2/oauth1/api_key/basic all have a well-defined primary field
       // (resolved by getCredentialFieldName). `custom` providers with no
       // explicit fieldName don't — fall back to listing all schema variables.
-      const explicitFieldName = provider.credentialFieldName;
       const resolvedFieldName =
-        explicitFieldName ??
-        (provider.authMode === "api_key" || provider.authMode === "basic"
+        provider.credentialFieldName ??
+        (provider.authMode !== "custom"
           ? getCredentialFieldName(provider as ProviderDefinition)
-          : provider.authMode !== "custom"
-            ? getCredentialFieldName(provider as ProviderDefinition)
-            : undefined);
+          : undefined);
 
       if (resolvedFieldName) {
         const headerName = provider.credentialHeaderName ?? "Authorization";

--- a/apps/api/src/services/adapters/prompt-builder.ts
+++ b/apps/api/src/services/adapters/prompt-builder.ts
@@ -140,24 +140,41 @@ export function buildEnrichedPrompt(ctx: PromptContext): string {
 
       sections.push(`- **${displayName}** (provider ID: \`${provider.id}\`)`);
 
-      // For providers with credentialSchema, show all credential variables
-      if (provider.credentialSchema) {
-        const props =
-          (provider.credentialSchema.properties as Record<string, { description?: string }>) ?? {};
-        const varNames = Object.keys(props);
-        const varDescriptions = varNames.map((name) => {
-          const desc = props[name]?.description ?? name;
-          return `\`{{${name}}}\` — ${desc}`;
-        });
-        if (varDescriptions.length > 0) {
-          sections.push(`  Credentials: ${varDescriptions.join(", ")}`);
-        }
-      } else {
-        // OAuth2 / API key — single credential field with header info
-        const fieldName = getCredentialFieldName(provider as ProviderDefinition);
+      const props =
+        (provider.credentialSchema?.properties as
+          | Record<string, { description?: string }>
+          | undefined) ?? {};
+      const varEntries = Object.entries(props);
+
+      // OAuth2/oauth1/api_key and basic all have a well-defined primary field
+      // (resolved by getCredentialFieldName). `custom` providers with no
+      // explicit fieldName don't — fall back to listing all schema variables.
+      const explicitFieldName = provider.credentialFieldName;
+      const resolvedFieldName =
+        explicitFieldName ??
+        (provider.authMode === "api_key" || provider.authMode === "basic"
+          ? getCredentialFieldName(provider as ProviderDefinition)
+          : provider.authMode !== "custom"
+            ? getCredentialFieldName(provider as ProviderDefinition)
+            : undefined);
+
+      if (resolvedFieldName) {
         const headerName = provider.credentialHeaderName ?? "Authorization";
         const headerPrefix = provider.credentialHeaderPrefix ?? "Bearer ";
-        sections.push(`  Auth: \`${headerName}: ${headerPrefix}{{${fieldName}}}\``);
+        sections.push(`  Auth: \`${headerName}: ${headerPrefix}{{${resolvedFieldName}}}\``);
+
+        const extraVars = varEntries
+          .filter(([name]) => name !== resolvedFieldName)
+          .map(([name, prop]) => `\`{{${name}}}\` — ${prop?.description ?? name}`);
+        if (extraVars.length > 0) {
+          sections.push(`  Other credential vars: ${extraVars.join(", ")}`);
+        }
+      } else if (varEntries.length > 0) {
+        // Custom provider with no primary field — list all declared credentials.
+        const varDescriptions = varEntries.map(
+          ([name, prop]) => `\`{{${name}}}\` — ${prop?.description ?? name}`,
+        );
+        sections.push(`  Credentials: ${varDescriptions.join(", ")}`);
       }
 
       if (provider.hasProviderDoc) {

--- a/apps/api/src/services/connection-manager/credentials.ts
+++ b/apps/api/src/services/connection-manager/credentials.ts
@@ -12,13 +12,18 @@ export async function saveApiKeyConnection(
   orgId: string,
   applicationId: string,
 ): Promise<void> {
-  const providerCredentialId = await resolveProviderCredentialId(applicationId, provider);
+  // Fire both lookups concurrently — they hit independent tables
+  // (applicationProviderCredentials vs packages) and neither depends on the
+  // other. Avoids adding a sequential round-trip on the connect hot path.
+  const [providerCredentialId, providerDef] = await Promise.all([
+    resolveProviderCredentialId(applicationId, provider),
+    getProviderOrThrow(db, orgId, provider),
+  ]);
 
   // Store the key under the field name declared by the provider (defaults to
   // "api_key" for api_key mode). This must match the key the sidecar resolves
   // at request time via buildSidecarCredentials — otherwise {{field}} stays
   // unsubstituted in outbound headers.
-  const providerDef = await getProviderOrThrow(db, orgId, provider);
   const fieldName = getCredentialFieldName(providerDef);
 
   await saveConnection(

--- a/apps/api/src/services/connection-manager/credentials.ts
+++ b/apps/api/src/services/connection-manager/credentials.ts
@@ -2,7 +2,7 @@
 
 import { db } from "@appstrate/db/client";
 import { logger } from "../../lib/logger.ts";
-import { saveConnection } from "@appstrate/connect";
+import { getCredentialFieldName, getProviderOrThrow, saveConnection } from "@appstrate/connect";
 import { resolveProviderCredentialId } from "./helpers.ts";
 
 export async function saveApiKeyConnection(
@@ -14,16 +14,23 @@ export async function saveApiKeyConnection(
 ): Promise<void> {
   const providerCredentialId = await resolveProviderCredentialId(applicationId, provider);
 
+  // Store the key under the field name declared by the provider (defaults to
+  // "api_key" for api_key mode). This must match the key the sidecar resolves
+  // at request time via buildSidecarCredentials — otherwise {{field}} stays
+  // unsubstituted in outbound headers.
+  const providerDef = await getProviderOrThrow(db, orgId, provider);
+  const fieldName = getCredentialFieldName(providerDef);
+
   await saveConnection(
     db,
     profileId,
     provider,
     orgId,
-    { api_key: apiKey },
+    { [fieldName]: apiKey },
     { providerCredentialId },
   );
 
-  logger.info("API key connection saved", { provider, profileId, orgId });
+  logger.info("API key connection saved", { provider, profileId, orgId, fieldName });
 }
 
 export async function saveCredentialsConnection(

--- a/apps/api/test/integration/routes/providers.test.ts
+++ b/apps/api/test/integration/routes/providers.test.ts
@@ -315,6 +315,60 @@ describe("Providers API", () => {
 
       expect(res.status).toBe(404);
     });
+
+    it("rejects credential schemas with non-canonical keys (hyphen)", async () => {
+      await app.request("/api/providers", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          id: `@${ctx.org.slug}/put-hyphen`,
+          displayName: "Put Hyphen",
+          authMode: "api_key",
+        }),
+      });
+
+      const res = await app.request(`/api/providers/@${ctx.org.slug}/put-hyphen`, {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          displayName: "Put Hyphen",
+          authMode: "api_key",
+          credentialSchema: {
+            type: "object",
+            properties: { "api-key": { type: "string" } },
+          },
+          credentialFieldName: "api-key",
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects credentialFieldName not declared in credentialSchema", async () => {
+      await app.request("/api/providers", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          id: `@${ctx.org.slug}/put-mismatch`,
+          displayName: "Put Mismatch",
+          authMode: "api_key",
+        }),
+      });
+
+      const res = await app.request(`/api/providers/@${ctx.org.slug}/put-mismatch`, {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          displayName: "Put Mismatch",
+          authMode: "api_key",
+          credentialSchema: {
+            type: "object",
+            properties: { api_key: { type: "string" } },
+          },
+          credentialFieldName: "token",
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
   });
 
   // ─── PUT /api/providers/credentials — invalidateConnections ──

--- a/apps/api/test/integration/routes/providers.test.ts
+++ b/apps/api/test/integration/routes/providers.test.ts
@@ -126,10 +126,10 @@ describe("Providers API", () => {
           authMode: "api_key",
           credentialSchema: {
             type: "object",
-            properties: { apiKey: { type: "string" } },
-            required: ["apiKey"],
+            properties: { api_key: { type: "string" } },
+            required: ["api_key"],
           },
-          credentialFieldName: "apiKey",
+          credentialFieldName: "api_key",
           credentialHeaderName: "X-API-Key",
         }),
       });
@@ -137,6 +137,42 @@ describe("Providers API", () => {
       expect(res.status).toBe(201);
       const body = (await res.json()) as any;
       expect(body.id).toBe(`@${ctx.org.slug}/new-api-provider`);
+    });
+
+    it("rejects credential schemas with non-canonical keys (hyphen)", async () => {
+      const res = await app.request("/api/providers", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          id: `@${ctx.org.slug}/hyphen-provider`,
+          displayName: "Hyphen",
+          authMode: "api_key",
+          credentialSchema: {
+            type: "object",
+            properties: { "api-key": { type: "string" } },
+          },
+          credentialFieldName: "api-key",
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects credentialFieldName not declared in credentialSchema", async () => {
+      const res = await app.request("/api/providers", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          id: `@${ctx.org.slug}/mismatch-provider`,
+          displayName: "Mismatch",
+          authMode: "api_key",
+          credentialSchema: {
+            type: "object",
+            properties: { api_key: { type: "string" } },
+          },
+          credentialFieldName: "token",
+        }),
+      });
+      expect(res.status).toBe(400);
     });
 
     it("returns 400 for invalid body (missing displayName)", async () => {

--- a/apps/api/test/integration/services/connection-manager.test.ts
+++ b/apps/api/test/integration/services/connection-manager.test.ts
@@ -103,6 +103,21 @@ describe("connection-manager", () => {
         id: "@system/test-provider",
         type: "provider",
         source: "system",
+        draftManifest: {
+          name: "@system/test-provider",
+          version: "1.0.0",
+          type: "provider",
+          definition: {
+            authMode: "api_key",
+            credentials: {
+              schema: {
+                type: "object",
+                properties: { api_key: { type: "string" } },
+              },
+              fieldName: "api_key",
+            },
+          },
+        },
       });
       await seedProviderCredentials({ applicationId, providerId: "@system/test-provider" });
       await saveApiKeyConnection(
@@ -136,6 +151,21 @@ describe("connection-manager", () => {
         id: "@system/test-provider",
         type: "provider",
         source: "system",
+        draftManifest: {
+          name: "@system/test-provider",
+          version: "1.0.0",
+          type: "provider",
+          definition: {
+            authMode: "api_key",
+            credentials: {
+              schema: {
+                type: "object",
+                properties: { api_key: { type: "string" } },
+              },
+              fieldName: "api_key",
+            },
+          },
+        },
       });
       await seedProviderCredentials({ applicationId, providerId: "@system/test-provider" });
       await saveApiKeyConnection(

--- a/apps/api/test/unit/prompt-builder.test.ts
+++ b/apps/api/test/unit/prompt-builder.test.ts
@@ -514,6 +514,66 @@ describe("buildEnrichedPrompt — provider documentation", () => {
     // The primary var does NOT appear in `Other credential vars` (deduplicated)
     expect(prompt).not.toContain("Other credential vars");
   });
+
+  it("emits the Auth line for custom providers with an explicit credentialFieldName", () => {
+    // `custom` authMode has no default primary field, but the Auth header is
+    // still meaningful when the manifest explicitly declares one. Extra schema
+    // vars are listed separately for the agent to reference.
+    const ctx = baseContext({
+      tokens: { "@test/multi": "tok" },
+      providers: [
+        {
+          id: "@test/multi",
+          displayName: "Multi-Cred",
+          authMode: "custom",
+          credentialFieldName: "token",
+          credentialHeaderName: "X-Foo",
+          credentialHeaderPrefix: "Bearer ",
+          credentialSchema: {
+            properties: {
+              token: { description: "Primary bearer token" },
+              region: { description: "Region code" },
+            },
+          },
+          authorizedUris: ["https://api.multi.example/*"],
+        },
+      ],
+    });
+
+    const prompt = buildEnrichedPrompt(ctx);
+    expect(prompt).toContain("X-Foo: Bearer {{token}}");
+    expect(prompt).toContain("Other credential vars");
+    expect(prompt).toContain("{{region}}");
+    expect(prompt).toContain("Region code");
+  });
+
+  it("lists all schema vars (no Auth line) for custom providers with no credentialFieldName", () => {
+    // Fallback branch: custom provider with a schema but no primary field —
+    // the agent sees every declared variable, no Auth hint.
+    const ctx = baseContext({
+      tokens: { "@test/bare": "tok" },
+      providers: [
+        {
+          id: "@test/bare",
+          displayName: "Bare Custom",
+          authMode: "custom",
+          credentialSchema: {
+            properties: {
+              user: { description: "Username" },
+              pass: { description: "Password" },
+            },
+          },
+          authorizedUris: ["https://api.bare.example/*"],
+        },
+      ],
+    });
+
+    const prompt = buildEnrichedPrompt(ctx);
+    expect(prompt).not.toContain("Auth:");
+    expect(prompt).toContain("Credentials:");
+    expect(prompt).toContain("{{user}}");
+    expect(prompt).toContain("{{pass}}");
+  });
 });
 
 // ─── Documents/files ────────────────────────────────────────

--- a/apps/api/test/unit/prompt-builder.test.ts
+++ b/apps/api/test/unit/prompt-builder.test.ts
@@ -485,6 +485,35 @@ describe("buildEnrichedPrompt — provider documentation", () => {
     expect(prompt).toContain("API Key");
     expect(prompt).toContain("Secret Token");
   });
+
+  it("emits the Auth line alongside extra vars for api_key providers with a credentialSchema", () => {
+    // Regression: previously the `if (credentialSchema)` branch omitted the
+    // Auth line entirely for api_key providers that declared a schema (which
+    // the provider editor does by default), leaving the agent without any
+    // header/prefix hint.
+    const ctx = baseContext({
+      tokens: { "@test/fathom": "tok" },
+      providers: [
+        {
+          id: "@test/fathom",
+          displayName: "Fathom",
+          authMode: "api_key",
+          credentialFieldName: "api_key",
+          credentialHeaderName: "X-Api-Key",
+          credentialHeaderPrefix: "",
+          credentialSchema: {
+            properties: { api_key: { description: "API key" } },
+          },
+          authorizedUris: ["https://api.fathom.ai/*"],
+        },
+      ],
+    });
+
+    const prompt = buildEnrichedPrompt(ctx);
+    expect(prompt).toContain("X-Api-Key: {{api_key}}");
+    // The primary var does NOT appear in `Other credential vars` (deduplicated)
+    expect(prompt).not.toContain("Other credential vars");
+  });
 });
 
 // ─── Documents/files ────────────────────────────────────────

--- a/apps/web/src/components/agent-editor/schema-section.tsx
+++ b/apps/web/src/components/agent-editor/schema-section.tsx
@@ -24,7 +24,8 @@ import {
   arrayMove,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import { toSlug, toLiveSlug } from "../../lib/strings";
+import { toSlug, toLiveSlug, toCredentialKey, toLiveCredentialKey } from "../../lib/strings";
+import { CREDENTIAL_KEY_RE } from "@appstrate/core/validation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -129,6 +130,16 @@ function SortableFieldCard({
   const isString = field.type === "string" && !isFile;
   const isArray = field.type === "array";
 
+  // Credential keys must match the sidecar substitution contract (underscore-based,
+  // no hyphens) — agent/tool input/config keys stay slug-based (hyphen-based,
+  // URL-safe). See @appstrate/core/validation#CREDENTIAL_KEY_RE.
+  const keyTransform =
+    mode === "credentials"
+      ? { live: toLiveCredentialKey, final: toCredentialKey }
+      : { live: toLiveSlug, final: toSlug };
+  const keyIsInvalid =
+    mode === "credentials" && field.key.length > 0 && !CREDENTIAL_KEY_RE.test(field.key);
+
   return (
     <div
       ref={setNodeRef}
@@ -149,10 +160,13 @@ function SortableFieldCard({
           type="text"
           placeholder={t("editor.fieldKey")}
           value={field.key}
-          onChange={(e) => onUpdate(index, { key: toLiveSlug(e.target.value) })}
-          onBlur={() => onUpdate(index, { key: toSlug(field.key) })}
-          className="h-7 w-[120px] min-w-0 shrink-0 font-mono text-xs"
+          onChange={(e) => onUpdate(index, { key: keyTransform.live(e.target.value) })}
+          onBlur={() => onUpdate(index, { key: keyTransform.final(field.key) })}
+          className={`h-7 w-[120px] min-w-0 shrink-0 font-mono text-xs ${
+            keyIsInvalid ? "border-destructive focus-visible:ring-destructive" : ""
+          }`}
           disabled={readOnly}
+          aria-invalid={keyIsInvalid || undefined}
         />
         <Select
           value={field.type}

--- a/apps/web/src/components/provider-editor/provider-editor-inner.tsx
+++ b/apps/web/src/components/provider-editor/provider-editor-inner.tsx
@@ -37,6 +37,7 @@ import { ContentEditor } from "../package-editor/content-editor";
 import { AFPS_SCHEMA_URLS, type AvailableScope } from "@appstrate/core/validation";
 import { providerSchema } from "@appstrate/core/schemas";
 import type { JSONSchemaObject } from "@appstrate/core/form";
+import { toCredentialKey } from "../../lib/strings";
 
 type ProviderEditorTab = "general" | "auth" | "uris" | "content" | "json";
 
@@ -111,9 +112,38 @@ function writeCredentialsToDef(
   const next: Record<string, unknown> = { ...def };
   const wrapper = fieldsToSchema(fields, "credentials");
   if (wrapper) {
-    next.credentials = { schema: wrapper.schema };
+    const existing = (def.credentials ?? {}) as Record<string, unknown>;
+    next.credentials = { ...existing, schema: wrapper.schema };
   } else {
     delete next.credentials;
+  }
+  return next;
+}
+
+/** Patch `definition.credentials` (canonical nested shape). */
+function patchCredentialsInDef(
+  def: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  const existing = (def.credentials ?? {}) as Record<string, unknown>;
+  return { ...def, credentials: { ...existing, ...patch } };
+}
+
+/**
+ * Migrate legacy flat `definition.credentialFieldName` to canonical nested
+ * `definition.credentials.fieldName` on load. Produces a manifest in the
+ * canonical shape so saves don't re-introduce the flat form.
+ */
+function migrateLegacyFieldName(def: Record<string, unknown>): Record<string, unknown> {
+  if (!("credentialFieldName" in def)) return def;
+  const flat = def.credentialFieldName as string | undefined;
+  const next: Record<string, unknown> = { ...def };
+  delete next.credentialFieldName;
+  if (flat) {
+    const existing = (next.credentials ?? {}) as Record<string, unknown>;
+    if (existing.fieldName === undefined) {
+      next.credentials = { ...existing, fieldName: flat };
+    }
   }
   return next;
 }
@@ -127,30 +157,40 @@ function normalizeProviderInitialState(initial: ProviderEditorState): {
   state: ProviderEditorState;
   credentialFields: SchemaField[];
 } {
-  const def = getDef(initial.manifest);
+  // Migrate any legacy flat credentialFieldName into the canonical nested shape
+  // on load. Subsequent writes use patchCredentialsInDef.
+  const migratedDef = migrateLegacyFieldName(getDef(initial.manifest));
+  const migratedManifest = { ...initial.manifest, definition: migratedDef };
+  const migratedState: ProviderEditorState =
+    migratedDef === getDef(initial.manifest) ? initial : { ...initial, manifest: migratedManifest };
+
+  const def = migratedDef;
   const authMode = (def.authMode as string) || "oauth2";
   const creds = def.credentials as { schema?: JSONSchemaObject } | undefined;
 
   if (!isCredentialMode(authMode)) {
-    return { state: initial, credentialFields: [] };
+    return { state: migratedState, credentialFields: [] };
   }
 
   if (creds?.schema) {
     return {
-      state: initial,
+      state: migratedState,
       credentialFields: schemaToFields(creds.schema, "credentials"),
     };
   }
 
   const seeded = makeDefaultCredentialFields(authMode);
   if (seeded.length === 0) {
-    return { state: initial, credentialFields: [] };
+    return { state: migratedState, credentialFields: [] };
   }
 
   return {
     state: {
-      ...initial,
-      manifest: { ...initial.manifest, definition: writeCredentialsToDef(def, seeded) },
+      ...migratedState,
+      manifest: {
+        ...migratedState.manifest,
+        definition: writeCredentialsToDef(def, seeded),
+      },
     },
     credentialFields: seeded,
   };
@@ -712,8 +752,22 @@ export function ProviderEditorInner({ initialState, isEdit, packageId }: Provide
                 <Input
                   id="pe-credFieldName"
                   type="text"
-                  value={(def.credentialFieldName as string) ?? ""}
-                  onChange={(e) => patchDef({ credentialFieldName: e.target.value })}
+                  value={
+                    ((def.credentials as Record<string, unknown> | undefined)?.fieldName as
+                      | string
+                      | undefined) ?? ""
+                  }
+                  onChange={(e) =>
+                    setState((s) => ({
+                      ...s,
+                      manifest: {
+                        ...s.manifest,
+                        definition: patchCredentialsInDef(getDef(s.manifest), {
+                          fieldName: toCredentialKey(e.target.value),
+                        }),
+                      },
+                    }))
+                  }
                   placeholder={credentialFields[0]?.key || "api_key"}
                 />
               </div>
@@ -904,9 +958,11 @@ export function ProviderEditorInner({ initialState, isEdit, packageId }: Provide
           key={jsonEditorKey}
           value={state.manifest}
           onApply={(manifest) => {
-            setState((s) => ({ ...s, manifest }));
-            // Sync credential fields from manifest
-            const creds = getDef(manifest).credentials as { schema?: JSONSchemaObject } | undefined;
+            const migratedDef = migrateLegacyFieldName(getDef(manifest));
+            const canonical = { ...manifest, definition: migratedDef };
+            setState((s) => ({ ...s, manifest: canonical }));
+            // Sync credential fields from the migrated definition
+            const creds = migratedDef.credentials as { schema?: JSONSchemaObject } | undefined;
             setCredentialFields(creds?.schema ? schemaToFields(creds.schema, "credentials") : []);
             setActiveTab("general");
           }}

--- a/apps/web/src/components/provider-editor/provider-editor-inner.tsx
+++ b/apps/web/src/components/provider-editor/provider-editor-inner.tsx
@@ -26,11 +26,11 @@ import { MetadataSection, type MetadataState } from "../agent-editor/metadata-se
 import { SchemaSection, type SchemaField } from "../agent-editor/schema-section";
 import {
   schemaToFields,
-  fieldsToSchema,
   manifestToMetadata,
   metadataToManifestPatch,
   getManifestName,
 } from "../agent-editor/utils";
+import { writeCredentialsToDef, patchCredentialsInDef, migrateLegacyFieldName } from "./utils";
 import { SectionCard } from "../section-card";
 import { EditorShell } from "../editor-shell";
 import { ContentEditor } from "../package-editor/content-editor";
@@ -102,50 +102,6 @@ function makeDefaultCredentialFields(mode: CredentialMode): SchemaField[] {
     case "custom":
       return [];
   }
-}
-
-/** Return a new definition with `credentials` written from fields, or removed if empty. */
-function writeCredentialsToDef(
-  def: Record<string, unknown>,
-  fields: SchemaField[],
-): Record<string, unknown> {
-  const next: Record<string, unknown> = { ...def };
-  const wrapper = fieldsToSchema(fields, "credentials");
-  if (wrapper) {
-    const existing = (def.credentials ?? {}) as Record<string, unknown>;
-    next.credentials = { ...existing, schema: wrapper.schema };
-  } else {
-    delete next.credentials;
-  }
-  return next;
-}
-
-/** Patch `definition.credentials` (canonical nested shape). */
-function patchCredentialsInDef(
-  def: Record<string, unknown>,
-  patch: Record<string, unknown>,
-): Record<string, unknown> {
-  const existing = (def.credentials ?? {}) as Record<string, unknown>;
-  return { ...def, credentials: { ...existing, ...patch } };
-}
-
-/**
- * Migrate legacy flat `definition.credentialFieldName` to canonical nested
- * `definition.credentials.fieldName` on load. Produces a manifest in the
- * canonical shape so saves don't re-introduce the flat form.
- */
-function migrateLegacyFieldName(def: Record<string, unknown>): Record<string, unknown> {
-  if (!("credentialFieldName" in def)) return def;
-  const flat = def.credentialFieldName as string | undefined;
-  const next: Record<string, unknown> = { ...def };
-  delete next.credentialFieldName;
-  if (flat) {
-    const existing = (next.credentials ?? {}) as Record<string, unknown>;
-    if (existing.fieldName === undefined) {
-      next.credentials = { ...existing, fieldName: flat };
-    }
-  }
-  return next;
 }
 
 /**

--- a/apps/web/src/components/provider-editor/test/utils.test.ts
+++ b/apps/web/src/components/provider-editor/test/utils.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "bun:test";
+import { migrateLegacyFieldName, patchCredentialsInDef } from "../utils";
+
+describe("migrateLegacyFieldName", () => {
+  it("returns the same object when no flat field is present", () => {
+    const def = { authMode: "api_key", credentials: { fieldName: "api_key" } };
+    expect(migrateLegacyFieldName(def)).toBe(def);
+  });
+
+  it("lifts flat credentialFieldName into nested credentials.fieldName", () => {
+    const out = migrateLegacyFieldName({
+      authMode: "api_key",
+      credentialFieldName: "api_key",
+    });
+    expect(out).toEqual({
+      authMode: "api_key",
+      credentials: { fieldName: "api_key" },
+    });
+    expect("credentialFieldName" in out).toBe(false);
+  });
+
+  it("preserves an existing nested fieldName (canonical wins)", () => {
+    const out = migrateLegacyFieldName({
+      authMode: "api_key",
+      credentialFieldName: "old_key",
+      credentials: { fieldName: "new_key", schema: { type: "object" } },
+    });
+    expect(out.credentials).toEqual({
+      fieldName: "new_key",
+      schema: { type: "object" },
+    });
+    expect("credentialFieldName" in out).toBe(false);
+  });
+
+  it("drops the flat key without setting nested when flat value is empty", () => {
+    const out = migrateLegacyFieldName({
+      authMode: "api_key",
+      credentialFieldName: "",
+    });
+    expect("credentialFieldName" in out).toBe(false);
+    expect(out.credentials).toBeUndefined();
+  });
+
+  it("drops the flat key without setting nested when flat value is undefined", () => {
+    const out = migrateLegacyFieldName({
+      authMode: "api_key",
+      credentialFieldName: undefined,
+    });
+    expect("credentialFieldName" in out).toBe(false);
+    expect(out.credentials).toBeUndefined();
+  });
+
+  it("preserves the existing credentials.schema when migrating", () => {
+    const schema = {
+      type: "object",
+      properties: { api_key: { type: "string" } },
+    };
+    const out = migrateLegacyFieldName({
+      authMode: "api_key",
+      credentialFieldName: "api_key",
+      credentials: { schema },
+    });
+    expect(out.credentials).toEqual({
+      schema,
+      fieldName: "api_key",
+    });
+  });
+
+  it("does not mutate the input definition", () => {
+    const input = {
+      authMode: "api_key",
+      credentialFieldName: "api_key",
+      credentials: { schema: { type: "object" } },
+    };
+    const snapshot = JSON.parse(JSON.stringify(input));
+    migrateLegacyFieldName(input);
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("patchCredentialsInDef", () => {
+  it("creates credentials when absent", () => {
+    expect(patchCredentialsInDef({ authMode: "api_key" }, { fieldName: "api_key" })).toEqual({
+      authMode: "api_key",
+      credentials: { fieldName: "api_key" },
+    });
+  });
+
+  it("merges into existing credentials", () => {
+    const out = patchCredentialsInDef(
+      { authMode: "api_key", credentials: { schema: { type: "object" } } },
+      { fieldName: "api_key" },
+    );
+    expect(out.credentials).toEqual({
+      schema: { type: "object" },
+      fieldName: "api_key",
+    });
+  });
+
+  it("overwrites existing keys in the patch", () => {
+    const out = patchCredentialsInDef({ credentials: { fieldName: "old" } }, { fieldName: "new" });
+    expect((out.credentials as Record<string, unknown>).fieldName).toBe("new");
+  });
+});

--- a/apps/web/src/components/provider-editor/utils.ts
+++ b/apps/web/src/components/provider-editor/utils.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { fieldsToSchema } from "../agent-editor/utils";
+import type { SchemaField } from "../agent-editor/schema-section";
+
+/** Return a new definition with `credentials` written from fields, or removed if empty. */
+export function writeCredentialsToDef(
+  def: Record<string, unknown>,
+  fields: SchemaField[],
+): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...def };
+  const wrapper = fieldsToSchema(fields, "credentials");
+  if (wrapper) {
+    const existing = (def.credentials ?? {}) as Record<string, unknown>;
+    next.credentials = { ...existing, schema: wrapper.schema };
+  } else {
+    delete next.credentials;
+  }
+  return next;
+}
+
+/** Patch `definition.credentials` (canonical nested shape). */
+export function patchCredentialsInDef(
+  def: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  const existing = (def.credentials ?? {}) as Record<string, unknown>;
+  return { ...def, credentials: { ...existing, ...patch } };
+}
+
+/**
+ * Migrate legacy flat `definition.credentialFieldName` to canonical nested
+ * `definition.credentials.fieldName` on load. Produces a manifest in the
+ * canonical shape so saves don't re-introduce the flat form.
+ *
+ * Canonical wins: if both forms exist, the nested `credentials.fieldName` is
+ * preserved and the flat field is dropped silently.
+ */
+export function migrateLegacyFieldName(def: Record<string, unknown>): Record<string, unknown> {
+  if (!("credentialFieldName" in def)) return def;
+  const flat = def.credentialFieldName as string | undefined;
+  const next: Record<string, unknown> = { ...def };
+  delete next.credentialFieldName;
+  if (flat) {
+    const existing = (next.credentials ?? {}) as Record<string, unknown>;
+    if (existing.fieldName === undefined) {
+      next.credentials = { ...existing, fieldName: flat };
+    }
+  }
+  return next;
+}

--- a/apps/web/src/lib/strings.ts
+++ b/apps/web/src/lib/strings.ts
@@ -26,6 +26,10 @@ export function toLiveSlug(value: string): string {
  * Underscores are preserved (unlike {@link toSlug}) because the sidecar
  * substitution regex (`\w+`) does not match hyphens. Use in credentials mode
  * of `SchemaSection` and in the provider editor field-name input.
+ *
+ * Guarantees the output is either empty or matches `CREDENTIAL_KEY_RE` — in
+ * particular, strips any leading non-letter characters (digits, underscores)
+ * so the pattern's `^[a-z]` anchor is never violated.
  */
 export function toCredentialKey(value: string): string {
   return value
@@ -33,7 +37,8 @@ export function toCredentialKey(value: string): string {
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
     .replace(/[^a-z0-9_]+/g, "_")
-    .replace(/^_+|_+$/g, "");
+    .replace(/^[^a-z]+/, "")
+    .replace(/_+$/, "");
 }
 
 /** Like toCredentialKey but keeps trailing underscores — use during typing. */
@@ -43,5 +48,5 @@ export function toLiveCredentialKey(value: string): string {
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
     .replace(/[^a-z0-9_]+/g, "_")
-    .replace(/^_+/, "");
+    .replace(/^[^a-z]+/, "");
 }

--- a/apps/web/src/lib/strings.ts
+++ b/apps/web/src/lib/strings.ts
@@ -18,3 +18,30 @@ export function toLiveSlug(value: string): string {
     .replace(/[^a-z0-9-]+/g, "-")
     .replace(/^-+/, "");
 }
+
+/**
+ * Canonicalize a provider credential schema key — matches the contract in
+ * `@appstrate/core/validation#CREDENTIAL_KEY_RE` (`^[a-z][a-z0-9_]*$`).
+ *
+ * Underscores are preserved (unlike {@link toSlug}) because the sidecar
+ * substitution regex (`\w+`) does not match hyphens. Use in credentials mode
+ * of `SchemaSection` and in the provider editor field-name input.
+ */
+export function toCredentialKey(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+/** Like toCredentialKey but keeps trailing underscores — use during typing. */
+export function toLiveCredentialKey(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9_]+/g, "_")
+    .replace(/^_+/, "");
+}

--- a/apps/web/src/lib/test/strings.test.ts
+++ b/apps/web/src/lib/test/strings.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "bun:test";
+import { toCredentialKey, toLiveCredentialKey } from "../strings";
+import { CREDENTIAL_KEY_RE } from "@appstrate/core/validation";
+
+describe("toCredentialKey", () => {
+  it("preserves already-canonical keys", () => {
+    expect(toCredentialKey("api_key")).toBe("api_key");
+    expect(toCredentialKey("token")).toBe("token");
+  });
+
+  it("hyphens become underscores", () => {
+    expect(toCredentialKey("api-key")).toBe("api_key");
+  });
+
+  it("lowercases uppercase input", () => {
+    expect(toCredentialKey("Api-Key")).toBe("api_key");
+  });
+
+  it("strips leading digits so output matches CREDENTIAL_KEY_RE", () => {
+    const out = toCredentialKey("1password");
+    expect(out).toBe("password");
+    expect(CREDENTIAL_KEY_RE.test(out)).toBe(true);
+  });
+
+  it("strips leading underscores produced by non-letter prefixes", () => {
+    const out = toCredentialKey("--api-key");
+    expect(out).toBe("api_key");
+    expect(CREDENTIAL_KEY_RE.test(out)).toBe(true);
+  });
+
+  it("returns empty string when input has no letters at all", () => {
+    expect(toCredentialKey("1234")).toBe("");
+    expect(toCredentialKey("___")).toBe("");
+  });
+
+  it("output is always empty or a valid CREDENTIAL_KEY_RE match", () => {
+    for (const sample of ["1abc", "9_token", "API-Key", "a", "a1_b", "__foo__", "é@key"]) {
+      const out = toCredentialKey(sample);
+      if (out !== "") {
+        expect(CREDENTIAL_KEY_RE.test(out)).toBe(true);
+      }
+    }
+  });
+});
+
+describe("toLiveCredentialKey", () => {
+  it("preserves trailing underscores during typing", () => {
+    expect(toLiveCredentialKey("api_")).toBe("api_");
+  });
+
+  it("strips leading digits so prefix matches CREDENTIAL_KEY_RE", () => {
+    expect(toLiveCredentialKey("1key")).toBe("key");
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "2.10.8",
+  "version": "2.11.0",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -314,8 +314,8 @@ export function buildProviderDefinitionFromManifest(
     credentialSchema: credentials?.schema as Record<string, unknown> | undefined,
     // Canonical shape: definition.credentials.fieldName.
     // Back-compat fallback: a flat `definition.credentialFieldName` was briefly
-    // produced by the provider editor UI. Remove once the migration script has
-    // landed in every deployed environment.
+    // produced by the provider editor UI. Drop in @appstrate/core@2.12.0 once
+    // every deployed environment has run scripts/migrations/migrate-credential-field-name.ts.
     credentialFieldName:
       (credentials?.fieldName as string | undefined) ??
       (rawDef.credentialFieldName as string | undefined),

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -142,6 +142,69 @@ export const providerManifestSchema = afpsProviderManifestSchema.safeExtend({
 export type ProviderManifest = z.infer<typeof providerManifestSchema>;
 
 /**
+ * Canonical credential key pattern — shared by the provider schema editor,
+ * the AFPS validation, the Zod route schemas and the migration script.
+ *
+ * Matches the `\w+` regex used by the sidecar substitution engine
+ * (`runtime-pi/sidecar/helpers.ts`) and by `buildSidecarCredentials` /
+ * `evaluateCredentialTransform` in `@appstrate/connect`. Keys produced by
+ * the UI must round-trip through those engines without escaping.
+ */
+export const CREDENTIAL_KEY_RE = /^[a-z][a-z0-9_]*$/;
+
+/**
+ * Validate credential-related fields on a provider manifest definition.
+ * Pure function — returns human-readable error messages (empty array = valid).
+ *
+ * Rules (api_key / basic / custom only — OAuth modes don't declare credentials):
+ *  - `definition.credentials.schema.properties` keys match {@link CREDENTIAL_KEY_RE}
+ *  - `definition.credentials.fieldName` (when present) matches the pattern
+ *  - `fieldName` references an existing property in the schema
+ *
+ * Called from:
+ *  - {@link validateManifest} (ZIP import + package update)
+ *  - `routes/providers.ts` Zod schemas (POST / PUT)
+ *  - migration script
+ */
+export function validateProviderCredentialKeys(manifest: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+  const def = (manifest.definition ?? {}) as Record<string, unknown>;
+  const authMode = def.authMode as string | undefined;
+
+  if (authMode !== "api_key" && authMode !== "basic" && authMode !== "custom") {
+    return errors;
+  }
+
+  const credentials = def.credentials as Record<string, unknown> | undefined;
+  const schema = credentials?.schema as Record<string, unknown> | undefined;
+  const properties = (schema?.properties ?? {}) as Record<string, unknown>;
+  const propertyKeys = Object.keys(properties);
+
+  for (const key of propertyKeys) {
+    if (!CREDENTIAL_KEY_RE.test(key)) {
+      errors.push(
+        `definition.credentials.schema.properties: key "${key}" must match ${CREDENTIAL_KEY_RE} (lowercase letters, digits and underscores; must start with a letter)`,
+      );
+    }
+  }
+
+  const fieldName = credentials?.fieldName as string | undefined;
+  if (fieldName !== undefined) {
+    if (!CREDENTIAL_KEY_RE.test(fieldName)) {
+      errors.push(
+        `definition.credentials.fieldName: "${fieldName}" must match ${CREDENTIAL_KEY_RE}`,
+      );
+    } else if (propertyKeys.length > 0 && !propertyKeys.includes(fieldName)) {
+      errors.push(
+        `definition.credentials.fieldName: "${fieldName}" is not declared in definition.credentials.schema.properties`,
+      );
+    }
+  }
+
+  return errors;
+}
+
+/**
  * OAuth2 token-endpoint auth method, `tokenContentType` and
  * `credentialTransform` are part of AFPS v1 (§7.2 and §7.4). Types are
  * derived from the canonical Zod enums so appstrate cannot drift.
@@ -249,7 +312,13 @@ export function buildProviderDefinitionFromManifest(
       : {}),
     // Credential fields (from definition.credentials)
     credentialSchema: credentials?.schema as Record<string, unknown> | undefined,
-    credentialFieldName: credentials?.fieldName as string | undefined,
+    // Canonical shape: definition.credentials.fieldName.
+    // Back-compat fallback: a flat `definition.credentialFieldName` was briefly
+    // produced by the provider editor UI. Remove once the migration script has
+    // landed in every deployed environment.
+    credentialFieldName:
+      (credentials?.fieldName as string | undefined) ??
+      (rawDef.credentialFieldName as string | undefined),
     // Transport fields (from definition level — cross-cutting, implementation-specific)
     credentialHeaderName: rawDef.credentialHeaderName as string | undefined,
     credentialHeaderPrefix: rawDef.credentialHeaderPrefix as string | undefined,
@@ -328,11 +397,19 @@ function parseWithSchema(
   raw: unknown,
 ): ValidateManifestResult {
   const result = schema.safeParse(raw);
-  if (result.success) {
-    return { valid: true, errors: [], manifest: result.data };
+  if (!result.success) {
+    const errors = result.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`);
+    return { valid: false, errors };
   }
-  const errors = result.error.issues.map((issue) => `${issue.path.join(".")}: ${issue.message}`);
-  return { valid: false, errors };
+
+  if (schema === providerManifestSchema) {
+    const credentialErrors = validateProviderCredentialKeys(result.data as Record<string, unknown>);
+    if (credentialErrors.length > 0) {
+      return { valid: false, errors: credentialErrors };
+    }
+  }
+
+  return { valid: true, errors: [], manifest: result.data };
 }
 
 /**

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -143,7 +143,7 @@ export type ProviderManifest = z.infer<typeof providerManifestSchema>;
 
 /**
  * Canonical credential key pattern — shared by the provider schema editor,
- * the AFPS validation, the Zod route schemas and the migration script.
+ * the AFPS validation and the Zod route schemas.
  *
  * Matches the `\w+` regex used by the sidecar substitution engine
  * (`runtime-pi/sidecar/helpers.ts`) and by `buildSidecarCredentials` /
@@ -153,8 +153,22 @@ export type ProviderManifest = z.infer<typeof providerManifestSchema>;
 export const CREDENTIAL_KEY_RE = /^[a-z][a-z0-9_]*$/;
 
 /**
+ * Structured error emitted by {@link validateProviderCredentialKeys}. The
+ * `field` discriminator lets callers (e.g. Zod refinements) route the issue
+ * to the right input path instead of a generic `credentials` bucket.
+ */
+export interface CredentialKeyError {
+  /** Which conceptual field failed. */
+  field: "schemaKey" | "fieldName";
+  /** Offending schema property key — only set when `field === "schemaKey"`. */
+  key?: string;
+  /** Human-readable message suitable for direct display. */
+  message: string;
+}
+
+/**
  * Validate credential-related fields on a provider manifest definition.
- * Pure function — returns human-readable error messages (empty array = valid).
+ * Pure function — returns structured errors (empty array = valid).
  *
  * Rules (api_key / basic / custom only — OAuth modes don't declare credentials):
  *  - `definition.credentials.schema.properties` keys match {@link CREDENTIAL_KEY_RE}
@@ -164,10 +178,11 @@ export const CREDENTIAL_KEY_RE = /^[a-z][a-z0-9_]*$/;
  * Called from:
  *  - {@link validateManifest} (ZIP import + package update)
  *  - `routes/providers.ts` Zod schemas (POST / PUT)
- *  - migration script
  */
-export function validateProviderCredentialKeys(manifest: Record<string, unknown>): string[] {
-  const errors: string[] = [];
+export function validateProviderCredentialKeys(
+  manifest: Record<string, unknown>,
+): CredentialKeyError[] {
+  const errors: CredentialKeyError[] = [];
   const def = (manifest.definition ?? {}) as Record<string, unknown>;
   const authMode = def.authMode as string | undefined;
 
@@ -182,26 +197,42 @@ export function validateProviderCredentialKeys(manifest: Record<string, unknown>
 
   for (const key of propertyKeys) {
     if (!CREDENTIAL_KEY_RE.test(key)) {
-      errors.push(
-        `definition.credentials.schema.properties: key "${key}" must match ${CREDENTIAL_KEY_RE} (lowercase letters, digits and underscores; must start with a letter)`,
-      );
+      errors.push({
+        field: "schemaKey",
+        key,
+        message: `key "${key}" must match ${CREDENTIAL_KEY_RE} (lowercase letters, digits and underscores; must start with a letter)`,
+      });
     }
   }
 
   const fieldName = credentials?.fieldName as string | undefined;
   if (fieldName !== undefined) {
     if (!CREDENTIAL_KEY_RE.test(fieldName)) {
-      errors.push(
-        `definition.credentials.fieldName: "${fieldName}" must match ${CREDENTIAL_KEY_RE}`,
-      );
+      errors.push({
+        field: "fieldName",
+        message: `"${fieldName}" must match ${CREDENTIAL_KEY_RE}`,
+      });
     } else if (propertyKeys.length > 0 && !propertyKeys.includes(fieldName)) {
-      errors.push(
-        `definition.credentials.fieldName: "${fieldName}" is not declared in definition.credentials.schema.properties`,
-      );
+      errors.push({
+        field: "fieldName",
+        message: `"${fieldName}" is not declared in definition.credentials.schema.properties`,
+      });
     }
   }
 
   return errors;
+}
+
+/**
+ * Format a {@link CredentialKeyError} into the dotted `path: message` shape
+ * used by {@link validateManifest}'s flat string error list.
+ */
+export function formatCredentialKeyError(error: CredentialKeyError): string {
+  const path =
+    error.field === "schemaKey"
+      ? "definition.credentials.schema.properties"
+      : "definition.credentials.fieldName";
+  return `${path}: ${error.message}`;
 }
 
 /**
@@ -312,10 +343,10 @@ export function buildProviderDefinitionFromManifest(
       : {}),
     // Credential fields (from definition.credentials)
     credentialSchema: credentials?.schema as Record<string, unknown> | undefined,
-    // Canonical shape: definition.credentials.fieldName.
-    // Back-compat fallback: a flat `definition.credentialFieldName` was briefly
-    // produced by the provider editor UI. Drop in @appstrate/core@2.12.0 once
-    // every deployed environment has run scripts/migrations/migrate-credential-field-name.ts.
+    // Canonical shape: definition.credentials.fieldName. Back-compat fallback
+    // accepts the flat `definition.credentialFieldName` briefly produced by the
+    // provider editor UI — existing rows keep working; the UI migrates them to
+    // the nested form on the next save.
     credentialFieldName:
       (credentials?.fieldName as string | undefined) ??
       (rawDef.credentialFieldName as string | undefined),
@@ -405,7 +436,7 @@ function parseWithSchema(
   if (schema === providerManifestSchema) {
     const credentialErrors = validateProviderCredentialKeys(result.data as Record<string, unknown>);
     if (credentialErrors.length > 0) {
-      return { valid: false, errors: credentialErrors };
+      return { valid: false, errors: credentialErrors.map(formatCredentialKeyError) };
     }
   }
 

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -7,6 +7,9 @@ import {
   validateToolSource,
   extractManifestMetadata,
   getDefaultAdminCredentialSchema,
+  validateProviderCredentialKeys,
+  CREDENTIAL_KEY_RE,
+  buildProviderDefinitionFromManifest,
 } from "../src/validation.ts";
 import type { Manifest } from "../src/validation.ts";
 
@@ -529,9 +532,10 @@ describe("validateManifest", () => {
         credentials: {
           schema: {
             type: "object",
-            properties: { apiKey: { type: "string", description: "API Key" } },
-            required: ["apiKey"],
+            properties: { api_key: { type: "string", description: "API Key" } },
+            required: ["api_key"],
           },
+          fieldName: "api_key",
         },
         credentialHeaderName: "Authorization",
         credentialHeaderPrefix: "Bearer ",
@@ -573,6 +577,130 @@ describe("validateManifest", () => {
 
     const cfg = m.providersConfiguration as Record<string, Record<string, unknown>>;
     expect(cfg["@test/google"]!.customConfigField).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────
+// validateProviderCredentialKeys
+// ─────────────────────────────────────────────
+
+describe("validateProviderCredentialKeys", () => {
+  test("oauth2 / oauth1 are not constrained (no credentials block)", () => {
+    expect(validateProviderCredentialKeys({ definition: { authMode: "oauth2" } })).toEqual([]);
+    expect(validateProviderCredentialKeys({ definition: { authMode: "oauth1" } })).toEqual([]);
+  });
+
+  test("canonical api_key manifest passes", () => {
+    const errors = validateProviderCredentialKeys({
+      definition: {
+        authMode: "api_key",
+        credentials: {
+          schema: { type: "object", properties: { api_key: { type: "string" } } },
+          fieldName: "api_key",
+        },
+      },
+    });
+    expect(errors).toEqual([]);
+  });
+
+  test("hyphen in schema property key is rejected", () => {
+    const errors = validateProviderCredentialKeys({
+      definition: {
+        authMode: "api_key",
+        credentials: {
+          schema: { type: "object", properties: { "api-key": { type: "string" } } },
+          fieldName: "api-key",
+        },
+      },
+    });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((e) => e.includes("api-key"))).toBe(true);
+  });
+
+  test("fieldName not matching schema properties is rejected", () => {
+    const errors = validateProviderCredentialKeys({
+      definition: {
+        authMode: "api_key",
+        credentials: {
+          schema: { type: "object", properties: { api_key: { type: "string" } } },
+          fieldName: "token",
+        },
+      },
+    });
+    expect(errors.some((e) => e.includes("not declared"))).toBe(true);
+  });
+
+  test("fieldName with illegal characters is rejected", () => {
+    const errors = validateProviderCredentialKeys({
+      definition: {
+        authMode: "api_key",
+        credentials: {
+          schema: { type: "object", properties: {} },
+          fieldName: "Api-Key",
+        },
+      },
+    });
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  test("validateManifest propagates credential errors for provider manifests", () => {
+    const result = validateManifest(
+      validProviderManifest({
+        definition: {
+          authMode: "api_key",
+          credentials: {
+            schema: { type: "object", properties: { "api-key": { type: "string" } } },
+          },
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  test("CREDENTIAL_KEY_RE sanity", () => {
+    expect(CREDENTIAL_KEY_RE.test("api_key")).toBe(true);
+    expect(CREDENTIAL_KEY_RE.test("token")).toBe(true);
+    expect(CREDENTIAL_KEY_RE.test("api-key")).toBe(false);
+    expect(CREDENTIAL_KEY_RE.test("Api_Key")).toBe(false);
+    expect(CREDENTIAL_KEY_RE.test("_leading")).toBe(false);
+    expect(CREDENTIAL_KEY_RE.test("1leading")).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────
+// buildProviderDefinitionFromManifest — compat read path
+// ─────────────────────────────────────────────
+
+describe("buildProviderDefinitionFromManifest", () => {
+  test("reads nested credentials.fieldName (canonical)", () => {
+    const resolved = buildProviderDefinitionFromManifest("@test/p", {
+      definition: {
+        authMode: "api_key",
+        credentials: { fieldName: "token" },
+      },
+    });
+    expect(resolved.credentialFieldName).toBe("token");
+  });
+
+  test("falls back to legacy flat definition.credentialFieldName", () => {
+    const resolved = buildProviderDefinitionFromManifest("@test/p", {
+      definition: {
+        authMode: "api_key",
+        credentialFieldName: "legacy_key",
+      },
+    });
+    expect(resolved.credentialFieldName).toBe("legacy_key");
+  });
+
+  test("nested canonical wins over legacy flat when both present", () => {
+    const resolved = buildProviderDefinitionFromManifest("@test/p", {
+      definition: {
+        authMode: "api_key",
+        credentials: { fieldName: "canonical" },
+        credentialFieldName: "legacy",
+      },
+    });
+    expect(resolved.credentialFieldName).toBe("canonical");
   });
 });
 

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -614,7 +614,9 @@ describe("validateProviderCredentialKeys", () => {
       },
     });
     expect(errors.length).toBeGreaterThan(0);
-    expect(errors.some((e) => e.includes("api-key"))).toBe(true);
+    const schemaErr = errors.find((e) => e.field === "schemaKey");
+    expect(schemaErr?.key).toBe("api-key");
+    expect(schemaErr?.message).toContain("api-key");
   });
 
   test("fieldName not matching schema properties is rejected", () => {
@@ -627,7 +629,8 @@ describe("validateProviderCredentialKeys", () => {
         },
       },
     });
-    expect(errors.some((e) => e.includes("not declared"))).toBe(true);
+    const fieldErr = errors.find((e) => e.field === "fieldName");
+    expect(fieldErr?.message).toContain("not declared");
   });
 
   test("fieldName with illegal characters is rejected", () => {
@@ -641,6 +644,50 @@ describe("validateProviderCredentialKeys", () => {
       },
     });
     expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]?.field).toBe("fieldName");
+  });
+
+  test("custom authMode with no credentials block passes (no schema to validate)", () => {
+    expect(validateProviderCredentialKeys({ definition: { authMode: "custom" } })).toEqual([]);
+  });
+
+  test("custom authMode with empty schema.properties and no fieldName passes", () => {
+    const errors = validateProviderCredentialKeys({
+      definition: {
+        authMode: "custom",
+        credentials: { schema: { type: "object", properties: {} } },
+      },
+    });
+    expect(errors).toEqual([]);
+  });
+
+  test("custom authMode with empty schema.properties accepts any canonical fieldName", () => {
+    // When no properties are declared, membership check is skipped — the
+    // fieldName only needs to satisfy the pattern. Pins intentional leniency.
+    const errors = validateProviderCredentialKeys({
+      definition: {
+        authMode: "custom",
+        credentials: {
+          schema: { type: "object", properties: {} },
+          fieldName: "any_key",
+        },
+      },
+    });
+    expect(errors).toEqual([]);
+  });
+
+  test("custom authMode still rejects non-canonical fieldName even with empty schema", () => {
+    const errors = validateProviderCredentialKeys({
+      definition: {
+        authMode: "custom",
+        credentials: {
+          schema: { type: "object", properties: {} },
+          fieldName: "Api-Key",
+        },
+      },
+    });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]?.field).toBe("fieldName");
   });
 
   test("validateManifest propagates credential errors for provider manifests", () => {


### PR DESCRIPTION
## Summary

Fixes three compounding bugs that caused custom `api_key` providers to silently break at runtime (reported in field: the `@tractr/fathom` provider — manifest stored `api-key` under `credentials.schema.properties` but `api_key` under flat `credentialFieldName`, and the agent never saw an `Auth:` line).

### Root cause

The credential-key concept had **seven** inconsistent contracts across the stack:

| Layer | Rule |
|---|---|
| UI slugifier (`SchemaSection`) | `[a-z0-9-]+` — hyphen-only |
| UI `credentialFieldName` input | Free text, no validation |
| Sidecar substitution regex | `\w+` — underscore-only (opposite!) |
| UI save path | `definition.credentialFieldName` (flat) |
| POST `/api/providers` builder | `definition.credentials.fieldName` (nested) |
| Core resolver | Reads nested |
| AFPS schema | Any string |

Result: the UI produced hyphenated keys under a flat field the runtime never read; the sidecar couldn't substitute those keys even if it had read them.

### Fix

One canonical rule (`CREDENTIAL_KEY_RE = /^[a-z][a-z0-9_]*$/`) in `@appstrate/core/validation`, shared by:
- `validateManifest` (ZIP import + `PUT /packages`)
- Zod `superRefine` on `POST`/`PUT /api/providers`
- Provider editor form (`SchemaSection`, `credentialFieldName` input)

One canonical manifest shape (`definition.credentials.{schema,fieldName}`), with a temporary compat read-path for the legacy flat form (to be removed after data migration).

### Changes

- **Core** — `CREDENTIAL_KEY_RE` + `validateProviderCredentialKeys` helper; compat fallback in `buildProviderDefinitionFromManifest`.
- **API routes** — `superRefine` on provider create/update, same helper.
- **Runtime** — `saveApiKeyConnection` stores under the provider's resolved `fieldName` (no more hardcoded `api_key`); `prompt-builder` always emits the `Auth:` header line and lists schema vars separately.
- **UI** — new `toCredentialKey`/`toLiveCredentialKey` transforms that preserve `_`; `SchemaSection` shows `aria-invalid` + red border on non-canonical keys in credentials mode; provider editor writes the canonical nested shape and migrates the legacy flat form on load + on JSON-tab apply.
- **Tests** — `validateProviderCredentialKeys`, compat read-path, prompt-builder `Auth:` regression, POST /api/providers rejects hyphenated keys and unreferenced `fieldName`.

### Data migration

Run out-of-band on the server — not committed to the repo per request.

## Test plan

- [x] `bun run check` (typecheck + OpenAPI validation + Prettier)
- [x] `bun test packages/core` (290 pass)
- [x] `bun test packages/connect` (57 pass)
- [x] `bun test apps/api/test/unit` (460 pass)
- [x] `bun test apps/api/test/integration` (806 pass)
- [ ] Manually verify: edit an existing custom `api_key` provider in the UI, save, trigger an agent run, confirm outbound header carries the real key (not `{{placeholder}}`).
- [ ] Run the out-of-band migration script against a staging snapshot before prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)