### PR TITLE
refactor(providers): extract editor helpers + tighten prompt-builder fallback

### DIFF
--- a/apps/api/src/services/adapters/prompt-builder.ts
+++ b/apps/api/src/services/adapters/prompt-builder.ts
@@ -146,17 +146,14 @@ export function buildEnrichedPrompt(ctx: PromptContext): string {
           | undefined) ?? {};
       const varEntries = Object.entries(props);
 
-      // OAuth2/oauth1/api_key and basic all have a well-defined primary field
+      // OAuth2/oauth1/api_key/basic all have a well-defined primary field
       // (resolved by getCredentialFieldName). `custom` providers with no
       // explicit fieldName don't — fall back to listing all schema variables.
-      const explicitFieldName = provider.credentialFieldName;
       const resolvedFieldName =
-        explicitFieldName ??
-        (provider.authMode === "api_key" || provider.authMode === "basic"
+        provider.credentialFieldName ??
+        (provider.authMode !== "custom"
           ? getCredentialFieldName(provider as ProviderDefinition)
-          : provider.authMode !== "custom"
-            ? getCredentialFieldName(provider as ProviderDefinition)
-            : undefined);
+          : undefined);
 
       if (resolvedFieldName) {
         const headerName = provider.credentialHeaderName ?? "Authorization";

--- a/apps/api/test/integration/routes/providers.test.ts
+++ b/apps/api/test/integration/routes/providers.test.ts
@@ -315,6 +315,60 @@ describe("Providers API", () => {
 
       expect(res.status).toBe(404);
     });
+
+    it("rejects credential schemas with non-canonical keys (hyphen)", async () => {
+      await app.request("/api/providers", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          id: `@${ctx.org.slug}/put-hyphen`,
+          displayName: "Put Hyphen",
+          authMode: "api_key",
+        }),
+      });
+
+      const res = await app.request(`/api/providers/@${ctx.org.slug}/put-hyphen`, {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          displayName: "Put Hyphen",
+          authMode: "api_key",
+          credentialSchema: {
+            type: "object",
+            properties: { "api-key": { type: "string" } },
+          },
+          credentialFieldName: "api-key",
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects credentialFieldName not declared in credentialSchema", async () => {
+      await app.request("/api/providers", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          id: `@${ctx.org.slug}/put-mismatch`,
+          displayName: "Put Mismatch",
+          authMode: "api_key",
+        }),
+      });
+
+      const res = await app.request(`/api/providers/@${ctx.org.slug}/put-mismatch`, {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          displayName: "Put Mismatch",
+          authMode: "api_key",
+          credentialSchema: {
+            type: "object",
+            properties: { api_key: { type: "string" } },
+          },
+          credentialFieldName: "token",
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
   });
 
   // ─── PUT /api/providers/credentials — invalidateConnections ──

--- a/apps/web/src/components/provider-editor/provider-editor-inner.tsx
+++ b/apps/web/src/components/provider-editor/provider-editor-inner.tsx
@@ -26,11 +26,11 @@ import { MetadataSection, type MetadataState } from "../agent-editor/metadata-se
 import { SchemaSection, type SchemaField } from "../agent-editor/schema-section";
 import {
   schemaToFields,
-  fieldsToSchema,
   manifestToMetadata,
   metadataToManifestPatch,
   getManifestName,
 } from "../agent-editor/utils";
+import { writeCredentialsToDef, patchCredentialsInDef, migrateLegacyFieldName } from "./utils";
 import { SectionCard } from "../section-card";
 import { EditorShell } from "../editor-shell";
 import { ContentEditor } from "../package-editor/content-editor";
@@ -102,50 +102,6 @@ function makeDefaultCredentialFields(mode: CredentialMode): SchemaField[] {
     case "custom":
       return [];
   }
-}
-
-/** Return a new definition with `credentials` written from fields, or removed if empty. */
-function writeCredentialsToDef(
-  def: Record<string, unknown>,
-  fields: SchemaField[],
-): Record<string, unknown> {
-  const next: Record<string, unknown> = { ...def };
-  const wrapper = fieldsToSchema(fields, "credentials");
-  if (wrapper) {
-    const existing = (def.credentials ?? {}) as Record<string, unknown>;
-    next.credentials = { ...existing, schema: wrapper.schema };
-  } else {
-    delete next.credentials;
-  }
-  return next;
-}
-
-/** Patch `definition.credentials` (canonical nested shape). */
-function patchCredentialsInDef(
-  def: Record<string, unknown>,
-  patch: Record<string, unknown>,
-): Record<string, unknown> {
-  const existing = (def.credentials ?? {}) as Record<string, unknown>;
-  return { ...def, credentials: { ...existing, ...patch } };
-}
-
-/**
- * Migrate legacy flat `definition.credentialFieldName` to canonical nested
- * `definition.credentials.fieldName` on load. Produces a manifest in the
- * canonical shape so saves don't re-introduce the flat form.
- */
-function migrateLegacyFieldName(def: Record<string, unknown>): Record<string, unknown> {
-  if (!("credentialFieldName" in def)) return def;
-  const flat = def.credentialFieldName as string | undefined;
-  const next: Record<string, unknown> = { ...def };
-  delete next.credentialFieldName;
-  if (flat) {
-    const existing = (next.credentials ?? {}) as Record<string, unknown>;
-    if (existing.fieldName === undefined) {
-      next.credentials = { ...existing, fieldName: flat };
-    }
-  }
-  return next;
 }
 
 /**

--- a/apps/web/src/components/provider-editor/test/utils.test.ts
+++ b/apps/web/src/components/provider-editor/test/utils.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "bun:test";
+import { migrateLegacyFieldName, patchCredentialsInDef } from "../utils";
+
+describe("migrateLegacyFieldName", () => {
+  it("returns the same object when no flat field is present", () => {
+    const def = { authMode: "api_key", credentials: { fieldName: "api_key" } };
+    expect(migrateLegacyFieldName(def)).toBe(def);
+  });
+
+  it("lifts flat credentialFieldName into nested credentials.fieldName", () => {
+    const out = migrateLegacyFieldName({
+      authMode: "api_key",
+      credentialFieldName: "api_key",
+    });
+    expect(out).toEqual({
+      authMode: "api_key",
+      credentials: { fieldName: "api_key" },
+    });
+    expect("credentialFieldName" in out).toBe(false);
+  });
+
+  it("preserves an existing nested fieldName (canonical wins)", () => {
+    const out = migrateLegacyFieldName({
+      authMode: "api_key",
+      credentialFieldName: "old_key",
+      credentials: { fieldName: "new_key", schema: { type: "object" } },
+    });
+    expect(out.credentials).toEqual({
+      fieldName: "new_key",
+      schema: { type: "object" },
+    });
+    expect("credentialFieldName" in out).toBe(false);
+  });
+
+  it("drops the flat key without setting nested when flat value is empty", () => {
+    const out = migrateLegacyFieldName({
+      authMode: "api_key",
+      credentialFieldName: "",
+    });
+    expect("credentialFieldName" in out).toBe(false);
+    expect(out.credentials).toBeUndefined();
+  });
+
+  it("drops the flat key without setting nested when flat value is undefined", () => {
+    const out = migrateLegacyFieldName({
+      authMode: "api_key",
+      credentialFieldName: undefined,
+    });
+    expect("credentialFieldName" in out).toBe(false);
+    expect(out.credentials).toBeUndefined();
+  });
+
+  it("preserves the existing credentials.schema when migrating", () => {
+    const schema = {
+      type: "object",
+      properties: { api_key: { type: "string" } },
+    };
+    const out = migrateLegacyFieldName({
+      authMode: "api_key",
+      credentialFieldName: "api_key",
+      credentials: { schema },
+    });
+    expect(out.credentials).toEqual({
+      schema,
+      fieldName: "api_key",
+    });
+  });
+
+  it("does not mutate the input definition", () => {
+    const input = {
+      authMode: "api_key",
+      credentialFieldName: "api_key",
+      credentials: { schema: { type: "object" } },
+    };
+    const snapshot = JSON.parse(JSON.stringify(input));
+    migrateLegacyFieldName(input);
+    expect(input).toEqual(snapshot);
+  });
+});
+
+describe("patchCredentialsInDef", () => {
+  it("creates credentials when absent", () => {
+    expect(patchCredentialsInDef({ authMode: "api_key" }, { fieldName: "api_key" })).toEqual({
+      authMode: "api_key",
+      credentials: { fieldName: "api_key" },
+    });
+  });
+
+  it("merges into existing credentials", () => {
+    const out = patchCredentialsInDef(
+      { authMode: "api_key", credentials: { schema: { type: "object" } } },
+      { fieldName: "api_key" },
+    );
+    expect(out.credentials).toEqual({
+      schema: { type: "object" },
+      fieldName: "api_key",
+    });
+  });
+
+  it("overwrites existing keys in the patch", () => {
+    const out = patchCredentialsInDef({ credentials: { fieldName: "old" } }, { fieldName: "new" });
+    expect((out.credentials as Record<string, unknown>).fieldName).toBe("new");
+  });
+});

--- a/apps/web/src/components/provider-editor/utils.ts
+++ b/apps/web/src/components/provider-editor/utils.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { fieldsToSchema } from "../agent-editor/utils";
+import type { SchemaField } from "../agent-editor/schema-section";
+
+/** Return a new definition with `credentials` written from fields, or removed if empty. */
+export function writeCredentialsToDef(
+  def: Record<string, unknown>,
+  fields: SchemaField[],
+): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...def };
+  const wrapper = fieldsToSchema(fields, "credentials");
+  if (wrapper) {
+    const existing = (def.credentials ?? {}) as Record<string, unknown>;
+    next.credentials = { ...existing, schema: wrapper.schema };
+  } else {
+    delete next.credentials;
+  }
+  return next;
+}
+
+/** Patch `definition.credentials` (canonical nested shape). */
+export function patchCredentialsInDef(
+  def: Record<string, unknown>,
+  patch: Record<string, unknown>,
+): Record<string, unknown> {
+  const existing = (def.credentials ?? {}) as Record<string, unknown>;
+  return { ...def, credentials: { ...existing, ...patch } };
+}
+
+/**
+ * Migrate legacy flat `definition.credentialFieldName` to canonical nested
+ * `definition.credentials.fieldName` on load. Produces a manifest in the
+ * canonical shape so saves don't re-introduce the flat form.
+ *
+ * Canonical wins: if both forms exist, the nested `credentials.fieldName` is
+ * preserved and the flat field is dropped silently.
+ */
+export function migrateLegacyFieldName(def: Record<string, unknown>): Record<string, unknown> {
+  if (!("credentialFieldName" in def)) return def;
+  const flat = def.credentialFieldName as string | undefined;
+  const next: Record<string, unknown> = { ...def };
+  delete next.credentialFieldName;
+  if (flat) {
+    const existing = (next.credentials ?? {}) as Record<string, unknown>;
+    if (existing.fieldName === undefined) {
+      next.credentials = { ...existing, fieldName: flat };
+    }
+  }
+  return next;
+}

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -314,8 +314,8 @@ export function buildProviderDefinitionFromManifest(
     credentialSchema: credentials?.schema as Record<string, unknown> | undefined,
     // Canonical shape: definition.credentials.fieldName.
     // Back-compat fallback: a flat `definition.credentialFieldName` was briefly
-    // produced by the provider editor UI. Remove once the migration script has
-    // landed in every deployed environment.
+    // produced by the provider editor UI. Drop in @appstrate/core@2.12.0 once
+    // every deployed environment has run scripts/migrations/migrate-credential-field-name.ts.
     credentialFieldName:
       (credentials?.fieldName as string | undefined) ??
       (rawDef.credentialFieldName as string | undefined),


### PR DESCRIPTION
## Summary
- Extract `writeCredentialsToDef`, `patchCredentialsInDef`, `migrateLegacyFieldName` from `provider-editor-inner.tsx` into a dedicated `provider-editor/utils.ts` with unit coverage (10 tests).
- Collapse the redundant `authMode === "api_key" || "basic"` branch in `prompt-builder.ts` now that `getCredentialFieldName` handles every non-custom mode uniformly.
- Add PUT regression tests for hyphenated credential keys and `credentialFieldName`/schema mismatch.
- Tidy the compat-removal comment in `@appstrate/core` (pin to `2.12.0` + reference the migration playbook).

Stacked on top of #133.

## Test plan
- [x] `bun run check` (turbo + OpenAPI 229/229)
- [x] `cd apps/web && bun test src/components/provider-editor/test/` → 10 pass
- [ ] Reviewer: confirm the PUT test additions cover the intended write-boundary invariants

🤖 Generated with [Claude Code](https://claude.com/claude-code)