### PR TITLE
chore(installer): add minisign signing pubkey

### DIFF
--- a/scripts/appstrate.pub
+++ b/scripts/appstrate.pub
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key 1EF2FF084226C4FA
+RWT6xCZCCP/yHolAgDuDqBssxUflw7gInlZlaXEfQ4cFi5XN0KCtKr0e


### PR DESCRIPTION
## Summary

- Adds `scripts/appstrate.pub` — minisign public key for installer signature verification
- Key fingerprint: `1EF2FF084226C4FA`
- Public key value: `RWT6xCZCCP/yHolAgDuDqBssxUflw7gInlZlaXEfQ4cFi5XN0KCtKr0e`

## Why

Completes the bootstrap for PR #135's minisign signing path. Once this is merged AND the GitHub secrets (`MINISIGN_SECRET_KEY`, `MINISIGN_PASSWORD`) are configured, the next tag push will:

1. Sign `install.sh` with minisign → publish `install.sh.minisig`
2. Substitute this pubkey into `verify.sh` at publish time
3. Publish `appstrate.pub` to `get.appstrate.dev`

Users can then opt into the verified install path:

```bash
curl -fsSL https://get.appstrate.dev/verify.sh | bash
```

## Trust anchor review

This file is a **trust anchor** — every future installer signature will be verified against it. Please confirm:

- [ ] The key fingerprint (`1EF2FF084226C4FA`) matches what was generated offline on the maintainer's trusted machine
- [ ] The private key (`appstrate.key`) + passphrase are backed up securely
- [ ] Rotation procedure is documented in `examples/self-hosting/README.md` (it is)

## Test plan

- [ ] CI green (workflow-lint + test-install paths)
- [ ] After merge + secrets configured: trigger `publish-installer.yml` via `workflow_dispatch` on an existing tag
- [ ] `curl -fsSL https://get.appstrate.dev/verify.sh | bash` completes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)