### PR TITLE
fix(web): restore API keys link in settings

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -356,10 +356,6 @@ export function App() {
             {/* App-scoped routes (read applicationId from store, like orgId) */}
             <Route path="/end-users" element={<EndUsersPage />} />
             <Route
-              path="/api-keys"
-              element={<Navigate to="/org-settings/app/api-keys" replace />}
-            />
-            <Route
               path="/app-settings"
               element={<Navigate to="/org-settings/app/general" replace />}
             />

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -355,7 +355,10 @@ export function App() {
             )}
             {/* App-scoped routes (read applicationId from store, like orgId) */}
             <Route path="/end-users" element={<EndUsersPage />} />
-            <Route path="/api-keys" element={<ApiKeysPage />} />
+            <Route
+              path="/api-keys"
+              element={<Navigate to="/org-settings/app/api-keys" replace />}
+            />
             <Route
               path="/app-settings"
               element={<Navigate to="/org-settings/app/general" replace />}
@@ -371,6 +374,7 @@ export function App() {
               <Route path="billing" element={<OrgSettingsBillingPage />} />
               <Route path="app/general" element={<OrgSettingsAppGeneralPage />} />
               <Route path="app/profiles" element={<OrgSettingsAppProfilesPage />} />
+              <Route path="app/api-keys" element={<ApiKeysPage />} />
               <Route path="app/auth" element={<OrgSettingsAppAuthPage />} />
               <Route path="app/oauth" element={<OrgSettingsAppOauthPage />} />
             </Route>

--- a/apps/web/src/components/nav-org.tsx
+++ b/apps/web/src/components/nav-org.tsx
@@ -13,7 +13,6 @@ import {
   Webhook,
   Loader2,
   Users,
-  KeyRound,
 } from "lucide-react";
 import { useUnreadCount } from "../hooks/use-notifications";
 import { useAgents } from "../hooks/use-packages";
@@ -57,7 +56,6 @@ export function NavOrg() {
       ? [{ path: "/webhooks", label: t("nav.webhooks"), icon: Webhook }]
       : []),
     ...(isAdmin ? [{ path: "/end-users", label: t("nav.endUsers"), icon: Users }] : []),
-    ...(isAdmin ? [{ path: "/api-keys", label: t("nav.apiKeys"), icon: KeyRound }] : []),
   ];
 
   const renderItems = (items: typeof automationItems) =>

--- a/apps/web/src/components/package-detail/agent-tabs.tsx
+++ b/apps/web/src/components/package-detail/agent-tabs.tsx
@@ -314,7 +314,7 @@ export function AgentApiTab({ packageId }: { packageId: string }) {
               <span className="text-muted-foreground shrink-0 text-xs">{t("api.keyMasked")}</span>
             )}
           </div>
-          <Link to="/org-settings#api-keys" className="text-primary text-xs hover:underline">
+          <Link to="/org-settings/app/api-keys" className="text-primary text-xs hover:underline">
             {t("api.manageKeys")}
           </Link>
         </div>

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -28,7 +28,6 @@
   "nav.import": "Import",
   "nav.settings": "Organization settings",
   "nav.endUsers": "End-Users",
-  "nav.apiKeys": "API Keys",
   "nav.webhooks": "Webhooks",
   "nav.library": "Library",
   "nav.catalog": "Catalog",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -407,7 +407,6 @@
   "oauthClients.signupRoleOption.admin": "Admin",
   "oauthClients.signupRoleOption.viewer": "Viewer",
   "orgSettings.tabApiKeys": "API Keys",
-  "apiKeys.pageTitle": "API Keys",
   "apiKeys.createTitle": "Create API Key",
   "apiKeys.createBtn": "New API key",
   "apiKeys.created": "API Key Created",

--- a/apps/web/src/locales/fr/common.json
+++ b/apps/web/src/locales/fr/common.json
@@ -28,7 +28,6 @@
   "nav.import": "Importer",
   "nav.settings": "Paramètres",
   "nav.endUsers": "End-Users",
-  "nav.apiKeys": "Clés API",
   "nav.webhooks": "Webhooks",
   "nav.library": "Bibliothèque",
   "nav.catalog": "Catalogue",

--- a/apps/web/src/locales/fr/settings.json
+++ b/apps/web/src/locales/fr/settings.json
@@ -407,7 +407,6 @@
   "oauthClients.signupRoleOption.admin": "Administrateur",
   "oauthClients.signupRoleOption.viewer": "Lecteur",
   "orgSettings.tabApiKeys": "Clés API",
-  "apiKeys.pageTitle": "Clés API",
   "apiKeys.createTitle": "Créer une clé API",
   "apiKeys.createBtn": "Nouvelle clé API",
   "apiKeys.created": "Clé API créée",

--- a/apps/web/src/pages/api-keys-page.tsx
+++ b/apps/web/src/pages/api-keys-page.tsx
@@ -9,7 +9,6 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useCurrentApplicationId } from "../hooks/use-current-application";
 import { useApiKeys, useAvailableScopes, useRevokeApiKey } from "../hooks/use-api-keys";
-import { PageHeader } from "../components/page-header";
 import { LoadingState, ErrorState, EmptyState } from "../components/page-states";
 import { ApiKeyCreateModal } from "../components/api-key-create-modal";
 import type { ApiKeyInfo } from "@appstrate/shared-types";
@@ -48,28 +47,18 @@ export function ApiKeysPage() {
   };
 
   return (
-    <div className="p-6">
-      <PageHeader
-        title={t("settings:apiKeys.pageTitle")}
-        emoji="🔑"
-        breadcrumbs={[
-          { label: t("nav.orgSection", { ns: "common" }), href: "/" },
-          { label: t("settings:apiKeys.pageTitle") },
-        ]}
-        actions={
-          <>
-            <a
-              href="/api/docs"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-primary text-sm no-underline hover:underline"
-            >
-              {t("settings:apiKeys.swaggerLink")}
-            </a>
-            <Button onClick={() => setCreateOpen(true)}>{t("settings:apiKeys.createBtn")}</Button>
-          </>
-        }
-      />
+    <div>
+      <div className="mb-4 flex items-center justify-end gap-4">
+        <a
+          href="/api/docs"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-primary text-sm no-underline hover:underline"
+        >
+          {t("settings:apiKeys.swaggerLink")}
+        </a>
+        <Button onClick={() => setCreateOpen(true)}>{t("settings:apiKeys.createBtn")}</Button>
+      </div>
 
       {apiKeys && apiKeys.length > 0 ? (
         <div className="flex flex-col gap-3">

--- a/apps/web/src/pages/org-settings/layout.tsx
+++ b/apps/web/src/pages/org-settings/layout.tsx
@@ -136,7 +136,6 @@ export function OrgSettingsLayout() {
         proxies: "/org-settings/proxies",
         oauth: "/org-settings/oauth",
         billing: "/org-settings/billing",
-        "api-keys": "/org-settings/app/api-keys",
       }}
       sections={sections}
     />

--- a/apps/web/src/pages/org-settings/layout.tsx
+++ b/apps/web/src/pages/org-settings/layout.tsx
@@ -89,6 +89,11 @@ export function OrgSettingsLayout() {
                 label: t("appSettings.tabProfiles"),
               },
               {
+                to: "/org-settings/app/api-keys",
+                icon: KeyRound,
+                label: t("orgSettings.tabApiKeys"),
+              },
+              {
                 to: "/org-settings/app/auth",
                 icon: Shield,
                 label: t("appSettings.tabAuth"),
@@ -131,6 +136,7 @@ export function OrgSettingsLayout() {
         proxies: "/org-settings/proxies",
         oauth: "/org-settings/oauth",
         billing: "/org-settings/billing",
+        "api-keys": "/org-settings/app/api-keys",
       }}
       sections={sections}
     />


### PR DESCRIPTION
## Summary
- Move the API keys management page into the org-settings sidebar (Application section) so it has a discoverable entry point again
- Update the in-app `agent-tabs` link to point at the new path
- Drop the now-redundant standalone `/api-keys` sidebar entry and its i18n keys

## Context
After the settings layout refactor (#100), API keys could only be reached via the top-level sidebar entry — the `Link to="/org-settings#api-keys"` in the agent API tab was dead (no matching section/hash), and there was no entry point inside the unified settings.

## Changes
- Mount `ApiKeysPage` at `/org-settings/app/api-keys`
- Add "Clés API" item to the Application section of `org-settings/layout.tsx`
- Fix `/org-settings#api-keys` link in `agent-tabs.tsx` to the new path
- Remove the `/api-keys` entry from `nav-org.tsx` (it lives in settings now)
- Drop standalone `PageHeader` from `ApiKeysPage` (now provided by `SettingsLayout`); inline the doc link + create button
- Drop dead i18n keys (`nav.apiKeys`, `apiKeys.pageTitle`) and the `/api-keys` + `#api-keys` legacy redirects — no internal link points there anymore

⚠️ **Breaking URL change**: old bookmarks to `/api-keys` or `/org-settings#api-keys` will 404. No internal caller references them, but external links (docs, emails, user bookmarks) should be updated.

## Test plan
- [ ] `bun run typecheck` passes (verified locally)
- [ ] Navigate to `/org-settings`, confirm "Clés API" appears in the Application section
- [ ] Click through → lands on `/org-settings/app/api-keys`, list + create work
- [ ] Agent detail → API tab → "Gérer les clés" link navigates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)