### PR TITLE
fix(installer): reliable port detection + harden test infra

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -188,13 +188,24 @@ detect_environment() {
 }
 
 port_in_use() {
-  local p=$1
+  local p=$1 out
   if command_exists lsof; then
-    lsof -iTCP:"$p" -sTCP:LISTEN -Pn >/dev/null 2>&1
+    # lsof's exit code is unreliable as a "match found" signal: on macOS +
+    # Docker Desktop (and other envs), it regularly exits non-zero because
+    # it hit permission-denied errors while scanning unrelated sockets —
+    # even when it successfully printed the listener we care about. Check
+    # stdout instead, which is the only thing we actually care about.
+    out=$(lsof -iTCP:"$p" -sTCP:LISTEN -Pn 2>/dev/null || true)
+    [ -n "$out" ]
   elif command_exists ss; then
-    ss -lnt "sport = :$p" 2>/dev/null | grep -q LISTEN
+    # Capture output first to decouple ss's exit code from grep's — with
+    # pipefail enabled, an ss failure (old syntax, missing caps) would
+    # mask a legitimate grep match and report the port as free.
+    out=$(ss -lnt "sport = :$p" 2>/dev/null || true)
+    [[ "$out" == *LISTEN* ]]
   elif command_exists netstat; then
-    netstat -lnt 2>/dev/null | awk '{print $4}' | grep -qE "[:.]${p}$"
+    out=$(netstat -lnt 2>/dev/null || true)
+    echo "$out" | awk '{print $4}' | grep -qE "[:.]${p}$"
   else
     # Bash builtin: /dev/tcp is a pseudo-device, no external dependency.
     # Only probes 127.0.0.1 — services bound to other interfaces are not
@@ -221,9 +232,13 @@ prepare_workdir() {
   LOG_FILE="$APPSTRATE_DIR/install-$(date +%Y%m%d-%H%M%S).log"
   : >"$LOG_FILE"
   chmod 600 "$LOG_FILE"
-  # Rotate old logs — keep last 5
+  # Rotate old logs — keep last 5. Sort by filename (names embed ISO
+  # timestamps, so lexicographic = chronological) rather than mtime: some
+  # filesystems (Alpine tmpfs, older ext4 without nsec) have 1-second mtime
+  # granularity, which makes `ls -t` non-deterministic when multiple logs
+  # land in the same second.
   # shellcheck disable=SC2012
-  ls -t "$APPSTRATE_DIR"/install-*.log 2>/dev/null | tail -n +6 | xargs rm -f 2>/dev/null || true
+  ls -1r "$APPSTRATE_DIR"/install-*.log 2>/dev/null | tail -n +6 | xargs rm -f 2>/dev/null || true
   log "Working directory: $APPSTRATE_DIR"
 
   # Disk space check
@@ -271,7 +286,7 @@ download_assets() {
     ts=$(date +%Y%m%d-%H%M%S)
     cp "$APPSTRATE_DIR/docker-compose.yml" "$APPSTRATE_DIR/docker-compose.yml.bak-$ts"
     # shellcheck disable=SC2012
-    ls -t "$APPSTRATE_DIR"/docker-compose.yml.bak-* 2>/dev/null | tail -n +4 | xargs rm -f 2>/dev/null || true
+    ls -1r "$APPSTRATE_DIR"/docker-compose.yml.bak-* 2>/dev/null | tail -n +4 | xargs rm -f 2>/dev/null || true
   fi
   mv "$tmpdir/docker-compose.yml" "$APPSTRATE_DIR/docker-compose.yml"
   mv "$tmpdir/.env.example" "$APPSTRATE_DIR/.env.example"
@@ -300,7 +315,7 @@ handle_env_file() {
       chmod 600 "$APPSTRATE_DIR/.env"
       # Rotate old .env backups — keep last 3
       # shellcheck disable=SC2012
-      ls -t "$APPSTRATE_DIR"/.env.bak-* 2>/dev/null | tail -n +4 | xargs rm -f 2>/dev/null || true
+      ls -1r "$APPSTRATE_DIR"/.env.bak-* 2>/dev/null | tail -n +4 | xargs rm -f 2>/dev/null || true
       ;;
     noop) : ;;
   esac
@@ -471,9 +486,12 @@ rollback_upgrade() {
 
   local latest_compose latest_env
   # shellcheck disable=SC2012
-  latest_compose=$(ls -t "$APPSTRATE_DIR"/docker-compose.yml.bak-* 2>/dev/null | head -1)
+  # Sort by filename (ISO timestamps in names) rather than mtime — same
+  # reason as the rotation logic in prepare_workdir: 1-second mtime
+  # granularity on some filesystems would make `ls -t` non-deterministic.
+  latest_compose=$(ls -1r "$APPSTRATE_DIR"/docker-compose.yml.bak-* 2>/dev/null | head -1)
   # shellcheck disable=SC2012
-  latest_env=$(ls -t "$APPSTRATE_DIR"/.env.bak-* 2>/dev/null | head -1)
+  latest_env=$(ls -1r "$APPSTRATE_DIR"/.env.bak-* 2>/dev/null | head -1)
 
   if [ -z "$latest_compose" ] || [ -z "$latest_env" ]; then
     return 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -187,35 +187,53 @@ detect_environment() {
   fi
 }
 
+lsof_usable() {
+  # Busybox's lsof applet (Alpine, minimal containers) ignores all filter
+  # flags (-iTCP:PORT, -sTCP:LISTEN) and dumps every open file instead —
+  # useless for port detection and would false-positive any match on the
+  # output. Distinguish via `lsof -v`: real GNU/BSD lsof prints a version
+  # banner, busybox ignores the flag and dumps files.
+  command_exists lsof || return 1
+  case "$(LC_ALL=C lsof -v 2>&1)" in
+    *"lsof version"*) return 0 ;;
+  esac
+  return 1
+}
+
 port_in_use() {
   local p=$1 out
-  if command_exists lsof; then
+  if lsof_usable; then
     # lsof's exit code is unreliable as a "match found" signal: on macOS +
     # Docker Desktop (and other envs), it regularly exits non-zero because
     # it hit permission-denied errors while scanning unrelated sockets —
-    # even when it successfully printed the listener we care about. Check
-    # stdout instead, which is the only thing we actually care about.
+    # even when it successfully printed the listener we care about. Match
+    # the "(LISTEN)" tag GNU/BSD lsof prints for listening sockets instead
+    # of relying on exit code or stdout non-emptiness.
     out=$(lsof -iTCP:"$p" -sTCP:LISTEN -Pn 2>/dev/null || true)
-    [ -n "$out" ]
-  elif command_exists ss; then
+    [[ "$out" == *"(LISTEN)"* ]]
+    return
+  fi
+  if command_exists ss; then
     # Capture output first to decouple ss's exit code from grep's — with
     # pipefail enabled, an ss failure (old syntax, missing caps) would
     # mask a legitimate grep match and report the port as free.
     out=$(ss -lnt "sport = :$p" 2>/dev/null || true)
     [[ "$out" == *LISTEN* ]]
-  elif command_exists netstat; then
+    return
+  fi
+  if command_exists netstat; then
     out=$(netstat -lnt 2>/dev/null || true)
     echo "$out" | awk '{print $4}' | grep -qE "[:.]${p}$"
-  else
-    # Bash builtin: /dev/tcp is a pseudo-device, no external dependency.
-    # Only probes 127.0.0.1 — services bound to other interfaces are not
-    # detected, but that matches the installer's intent (localhost:PORT).
-    (exec 3<>/dev/tcp/127.0.0.1/"$p") 2>/dev/null && {
-      exec 3<&- 3>&-
-      return 0
-    }
-    return 1
+    return
   fi
+  # Bash builtin: /dev/tcp is a pseudo-device, no external dependency.
+  # Only probes 127.0.0.1 — services bound to other interfaces are not
+  # detected, but that matches the installer's intent (localhost:PORT).
+  (exec 3<>/dev/tcp/127.0.0.1/"$p") 2>/dev/null && {
+    exec 3<&- 3>&-
+    return 0
+  }
+  return 1
 }
 
 acquire_lock() {

--- a/test/install/install.bats
+++ b/test/install/install.bats
@@ -238,8 +238,14 @@ except Exception:
 }
 
 @test "port_in_use: lsof branch detects listener with clean exit=0 + match on stdout" {
-  # Happy path for the lsof branch: exit 0, output contains a match.
+  # Happy path for the lsof branch: exit 0, output contains a (LISTEN) row.
   lsof() {
+    case "$1" in
+      -v)
+        echo "lsof version information: revision: 4.99" >&2
+        return 0
+        ;;
+    esac
     printf 'COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\n'
     printf 'appstrat 1234 user 3u IPv4 0x1 0t0 TCP *:3000 (LISTEN)\n'
     return 0
@@ -253,12 +259,18 @@ except Exception:
   [ "$status" -eq 0 ]
 }
 
-@test "port_in_use: lsof branch still detects listener when exit=1 with match on stdout" {
+@test "port_in_use: lsof branch still detects listener when exit=1 with (LISTEN) row on stdout" {
   # BUG REPRO: on macOS + Docker Desktop (and other envs), lsof regularly
   # prints a valid listener on stdout AND exits non-zero because it hit
   # permission-denied errors while scanning unrelated sockets/processes.
   # port_in_use must rely on output, not on lsof's exit code.
   lsof() {
+    case "$1" in
+      -v)
+        echo "lsof version information: revision: 4.99" >&2
+        return 0
+        ;;
+    esac
     printf 'COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\n'
     printf 'com.docke 999 root 42u IPv6 0x1 0t0 TCP *:3000 (LISTEN)\n'
     return 1
@@ -271,17 +283,80 @@ except Exception:
   [ "$status" -eq 0 ]
 }
 
-@test "port_in_use: lsof branch returns free when no output (regardless of exit code)" {
-  # No listener → no output. Exit code alone is ambiguous (1 on both
+@test "port_in_use: lsof branch returns free when no (LISTEN) row (regardless of exit code)" {
+  # No listener → no (LISTEN) row. Exit code alone is ambiguous (1 on both
   # "no match" and "match + permission noise"), so the correct signal is
-  # empty stdout.
-  lsof() { return 1; }
+  # the literal "(LISTEN)" substring GNU/BSD lsof prints for listeners.
+  lsof() {
+    case "$1" in
+      -v)
+        echo "lsof version information: revision: 4.99" >&2
+        return 0
+        ;;
+    esac
+    return 1
+  }
   export -f lsof
   command_exists() { case "$1" in lsof) return 0 ;; *) return 1 ;; esac; }
   export -f command_exists
 
   run port_in_use 3000
   [ "$status" -eq 1 ]
+}
+
+@test "lsof_usable: returns 0 when lsof prints GNU-style version banner" {
+  lsof() { echo "lsof version information: revision: 4.99" >&2; return 0; }
+  export -f lsof
+  command_exists() { case "$1" in lsof) return 0 ;; *) return 1 ;; esac; }
+  export -f command_exists
+  lsof_usable
+}
+
+@test "lsof_usable: returns 1 for busybox applet (no version banner, dumps files)" {
+  # Busybox's lsof ignores `-v` and dumps open-file lines like:
+  #   1	/bin/busybox	0	/dev/null
+  # None of them contain "lsof version".
+  lsof() {
+    echo "1	/bin/busybox	0	/dev/null"
+    echo "1	/bin/busybox	1	pipe:[12345]"
+    return 0
+  }
+  export -f lsof
+  command_exists() { case "$1" in lsof) return 0 ;; *) return 1 ;; esac; }
+  export -f command_exists
+  ! lsof_usable
+}
+
+@test "lsof_usable: returns 1 when lsof is absent" {
+  command_exists() { return 1; }
+  export -f command_exists
+  ! lsof_usable
+}
+
+@test "port_in_use: skips busybox lsof and falls through to ss" {
+  # When lsof is busybox's applet, port_in_use must NOT invoke it (would
+  # false-positive on the file dump). It should fall through to the next
+  # available detector — here, a stubbed ss reporting a LISTEN row.
+  lsof() {
+    # If this is ever called by port_in_use, fail loudly.
+    echo "BUSYBOX_LSOF_INVOKED" >&2
+    echo "1	/bin/busybox	0	/dev/null"
+    return 0
+  }
+  export -f lsof
+  ss() {
+    printf 'State Recv-Q Send-Q Local Address:Port Peer Address:Port\n'
+    printf 'LISTEN 0 128 0.0.0.0:3000 0.0.0.0:*\n'
+  }
+  export -f ss
+  command_exists() { case "$1" in lsof | ss) return 0 ;; *) return 1 ;; esac; }
+  export -f command_exists
+
+  run port_in_use 3000
+  [ "$status" -eq 0 ]
+  # Busybox lsof should never have been invoked (lsof_usable gates it out).
+  # Check its sentinel didn't leak into stderr.
+  [[ "$output" != *"BUSYBOX_LSOF_INVOKED"* ]]
 }
 
 # ─── resolve_docker_gid (pure helper, no Docker/FS access) ───────────────────

--- a/test/install/install.bats
+++ b/test/install/install.bats
@@ -13,15 +13,23 @@ setup() {
   export APPSTRATE_VERSION="v1.0.0"
   export APPSTRATE_PORT=3000
   export NO_COLOR=1
-  # Source script — guarded do_install will not auto-execute.
-  # set +e before source so the import itself doesn't abort on non-fatal errors.
-  set +e
+  # Capture bats' own ERR/EXIT traps BEFORE sourcing — the script installs
+  # its own on_error/cleanup_tmp handlers that clobber bats' test-reporting
+  # machinery. Without this, assertion failures inside tests are silently
+  # swallowed and bats emits "Executed N instead of expected M" warnings
+  # instead of proper "not ok" lines.
+  BATS_SAVED_ERR_TRAP=$(trap -p ERR)
+  BATS_SAVED_EXIT_TRAP=$(trap -p EXIT)
   # shellcheck disable=SC1091
   source "$REPO_ROOT/scripts/install.sh"
-  # The sourced script runs `set -euo pipefail` which re-enables -e in this shell.
-  # Disable it again + clear the ERR trap so tests can assert on failures.
-  set +eo pipefail
-  trap - ERR
+  # install.sh sets `set -euo pipefail`. Drop pipefail (tests use `| grep -q`
+  # where grep's exit=1 on "no match" is the legitimate signal, not a failure).
+  # Keep `set -e` + `set -E` so assertion failures in functions propagate.
+  set +o pipefail
+  set -eE
+  # Restore bats' traps — overriding the script's on_error/cleanup_tmp.
+  eval "${BATS_SAVED_ERR_TRAP:-trap - ERR}"
+  eval "${BATS_SAVED_EXIT_TRAP:-trap - EXIT}"
 }
 
 teardown() {
@@ -101,8 +109,8 @@ teardown() {
 
 @test "generate_fresh_env permissions are 600" {
   generate_fresh_env
-  perms=$(stat -f '%Lp' "$APPSTRATE_DIR/.env" 2>/dev/null \
-       || stat -c '%a' "$APPSTRATE_DIR/.env")
+  perms=$(stat -c '%a' "$APPSTRATE_DIR/.env" 2>/dev/null \
+       || stat -f '%Lp' "$APPSTRATE_DIR/.env" 2>/dev/null)
   [ "$perms" = "600" ]
 }
 
@@ -227,6 +235,53 @@ except Exception:
   kill "$PID" 2>/dev/null || true
   wait "$PID" 2>/dev/null || true
   [ "$status" -eq 0 ]
+}
+
+@test "port_in_use: lsof branch detects listener with clean exit=0 + match on stdout" {
+  # Happy path for the lsof branch: exit 0, output contains a match.
+  lsof() {
+    printf 'COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\n'
+    printf 'appstrat 1234 user 3u IPv4 0x1 0t0 TCP *:3000 (LISTEN)\n'
+    return 0
+  }
+  export -f lsof
+  # Only lsof exists — avoids falling through to ss/netstat.
+  command_exists() { case "$1" in lsof) return 0 ;; *) return 1 ;; esac; }
+  export -f command_exists
+
+  run port_in_use 3000
+  [ "$status" -eq 0 ]
+}
+
+@test "port_in_use: lsof branch still detects listener when exit=1 with match on stdout" {
+  # BUG REPRO: on macOS + Docker Desktop (and other envs), lsof regularly
+  # prints a valid listener on stdout AND exits non-zero because it hit
+  # permission-denied errors while scanning unrelated sockets/processes.
+  # port_in_use must rely on output, not on lsof's exit code.
+  lsof() {
+    printf 'COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME\n'
+    printf 'com.docke 999 root 42u IPv6 0x1 0t0 TCP *:3000 (LISTEN)\n'
+    return 1
+  }
+  export -f lsof
+  command_exists() { case "$1" in lsof) return 0 ;; *) return 1 ;; esac; }
+  export -f command_exists
+
+  run port_in_use 3000
+  [ "$status" -eq 0 ]
+}
+
+@test "port_in_use: lsof branch returns free when no output (regardless of exit code)" {
+  # No listener → no output. Exit code alone is ambiguous (1 on both
+  # "no match" and "match + permission noise"), so the correct signal is
+  # empty stdout.
+  lsof() { return 1; }
+  export -f lsof
+  command_exists() { case "$1" in lsof) return 0 ;; *) return 1 ;; esac; }
+  export -f command_exists
+
+  run port_in_use 3000
+  [ "$status" -eq 1 ]
 }
 
 # ─── resolve_docker_gid (pure helper, no Docker/FS access) ───────────────────
@@ -494,7 +549,7 @@ EOF
   [ -d "$APPSTRATE_DIR" ]
   [ -n "$LOG_FILE" ]
   [ -f "$LOG_FILE" ]
-  perms=$(stat -f '%Lp' "$LOG_FILE" 2>/dev/null \
-       || stat -c '%a' "$LOG_FILE")
+  perms=$(stat -c '%a' "$LOG_FILE" 2>/dev/null \
+       || stat -f '%Lp' "$LOG_FILE" 2>/dev/null)
   [ "$perms" = "600" ]
 }


### PR DESCRIPTION
## Summary

A user reported that `install.sh` failed to detect port 3000 already in use. Investigation surfaced **four** distinct bugs, each documented below with root cause + fix.

### 1. `port_in_use()` trusted lsof's exit code

`port_in_use()` used `lsof ... >/dev/null 2>&1` and consumed only lsof's exit code. On macOS + Docker Desktop (and other envs), lsof regularly exits non-zero because of permission-denied noise while scanning unrelated sockets — **even when it correctly printed the listener we care about on stdout**. Same pattern on the `ss` branch under `pipefail`.

**Fix**: match on the literal `(LISTEN)` tag GNU/BSD lsof prints, not on exit code. Decoupled `ss`'s exit code from `grep`'s by capturing output first.

### 2. Busybox `lsof` applet dumps everything

CI on `bats/bats:1.11.0` (Alpine) exposed this: `/usr/bin/lsof → /bin/busybox`. Busybox's lsof applet **ignores all filter flags** (`-iTCP:PORT`, `-sTCP:LISTEN`) and dumps every open file in the system. My first attempt (`[ -n "$out" ]`) then saw the dump and reported every port as in use.

**Fix**: added `lsof_usable()` helper that probes `lsof -v`. Real GNU/BSD lsof prints a `"lsof version"` banner; busybox ignores `-v` and dumps files. When busybox is detected, fall through to `ss`/`netstat`/`/dev/tcp`.

Defense in depth: even if `lsof_usable` ever returned a false positive, the tightened `*"(LISTEN)"*` output match would still filter out busybox's file dump.

### 3. `install.bats` silently passed all assertions

The original setup was:

```bash
set +eo pipefail
trap - ERR
```

This disabled bats' failure detection entirely. Verified: `[ 1 -eq 0 ]` reported `ok`, `false` reported `ok`. **Most existing tests were silent no-ops.**

Root cause: the script installs its own `on_error` (ERR trap) and `cleanup_tmp` (EXIT trap). When a bats test body fails, those traps clobber bats' test-reporting machinery — `on_error` calls `exit 1`, killing the test shell before bats can emit `not ok`.

**Fix**: save bats' ERR/EXIT traps before sourcing, restore them after. Keep `set -eE`, drop `pipefail` (tests legitimately use `| grep -q` patterns).

### 4. Latent bugs surfaced once assertions started firing

- **`ls -t` non-deterministic on Alpine tmpfs**: 1-second mtime granularity makes `sleep 0.1` between backups insufficient to differentiate them, so `ls -t | head -1` picked an arbitrary file. Switched to `ls -1r` at all 5 backup/rotation sites in `install.sh` — the filenames embed ISO timestamps, so lexicographic = chronological and is stable across filesystems.
- **`stat -f '%Lp' || stat -c '%a'` corrupts on busybox**: busybox's `stat -f` treats `%Lp` as a filename argument and dumps filesystem info to stdout (exit 1), so `||` appends `600` from the GNU form and the command substitution gets garbage + `600` suffix. Flipped order to try GNU/busybox `-c` first, BSD `-f` as fallback.

## Test Plan

- [x] New test `port_in_use: lsof branch still detects listener when exit=1 with (LISTEN) row on stdout` reproduces the user's bug (verified red on current code, green after fix).
- [x] New tests `lsof_usable` (3 scenarios: GNU banner, busybox applet, missing).
- [x] New test `port_in_use: skips busybox lsof and falls through to ss`.
- [x] Bats setup fix: 49/49 green (previously 31 silent-passes + 14 aborted).
- [x] Shellcheck clean, shfmt clean.
- [x] CI: unit-bats ✓, static ✓, publish-dry-run ✓, validate-dind ✓, e2e ✓, CodeQL ✓.

## Risk Analysis

| Change | Risk | Mitigation |
|---|---|---|
| Match `(LISTEN)` instead of non-empty output | Miss a non-standard lsof that omits the tag | Format stable for 20+ years across GNU/BSD |
| `lsof_usable` probe adds one `lsof -v` call per port check | Latency (~10ms × 6 calls max) | Acceptable, `lsof -v` doesn't scan sockets |
| `ls -1r` instead of `ls -t` | Requires filename-embedded timestamps | Script always creates backups with `date +%Y%m%d-%H%M%S` → ISO format |
| Stricter test setup catches real failures | May surface more latent bugs in future PRs | Good — previously all assertions were no-ops |

Trade-offs all clearly favor the user.

## Commits

1. `fix(installer): reliable port detection + harden test infra` — initial fix + test infra + ls -t and stat fixes
2. `fix(installer): detect and skip busybox lsof applet` — CI regression fix for Alpine

🤖 Generated with [Claude Code](https://claude.com/claude-code)