### PR TITLE
refactor(inline-runs): hoist providerProfilesSchema to module scope

### DIFF
--- a/apps/api/src/services/inline-run-preflight.ts
+++ b/apps/api/src/services/inline-run-preflight.ts
@@ -52,6 +52,8 @@ export interface InlineRunPreflightResult {
   proxyIdOverride: string | null;
 }
 
+const providerProfilesSchema = z.record(z.string(), z.uuid()).optional();
+
 export async function runInlinePreflight(params: {
   orgId: string;
   applicationId: string;
@@ -78,7 +80,6 @@ export async function runInlinePreflight(params: {
   const prompt = body.prompt as string;
 
   // ----- 2. Body-field validation -----
-  const providerProfilesSchema = z.record(z.string(), z.uuid()).optional();
   const providerProfilesOverride = providerProfilesSchema.safeParse(body.providerProfiles);
   if (!providerProfilesOverride.success) {
     throw invalidRequest("providerProfiles must map providerId → profileUUID", "providerProfiles");


### PR DESCRIPTION
## Summary

Small follow-up to #144 — moves the `providerProfilesSchema` Zod schema from inside `runInlinePreflight()` to module scope so it's not rebuilt on every call.

Trivial perf win; also matches how other Zod schemas in the codebase are declared.

## Test plan

- [x] tsc passes
- [x] pre-commit hooks (eslint + prettier) pass
- [x] Existing inline-run unit tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)