### PR TITLE
fix(sidecar): preserve binary bytes in /proxy response body

### DIFF
--- a/runtime-pi/sidecar/app.ts
+++ b/runtime-pi/sidecar/app.ts
@@ -410,14 +410,17 @@ export function createApp(deps: AppDeps): Hono {
     }
 
     // 9. Forward upstream response transparently (pass-through proxy)
-    const responseText = await targetRes.text();
+    // Read as ArrayBuffer (not text) so non-UTF-8 bytes in binary bodies
+    // (PDF, images, archives) are preserved byte-for-byte. Truncation is
+    // applied by byte length to match the actual payload size.
+    const responseBytes = await targetRes.arrayBuffer();
     const requestedMaxSize = parseInt(c.req.header("x-max-response-size") || "0", 10);
     const maxSize =
       requestedMaxSize > 0
         ? Math.min(requestedMaxSize, ABSOLUTE_MAX_RESPONSE_SIZE)
         : MAX_RESPONSE_SIZE;
-    const truncated = responseText.length > maxSize;
-    const text = truncated ? responseText.slice(0, maxSize) : responseText;
+    const truncated = responseBytes.byteLength > maxSize;
+    const body = truncated ? responseBytes.slice(0, maxSize) : responseBytes;
 
     const contentType = targetRes.headers.get("content-type") || "application/octet-stream";
     const responseHeaders: Record<string, string> = { "Content-Type": contentType };
@@ -443,7 +446,7 @@ export function createApp(deps: AppDeps): Hono {
       }).catch(() => {});
     }
 
-    return c.body(text, targetRes.status, responseHeaders);
+    return c.body(body, targetRes.status, responseHeaders);
   });
 
   return app;

--- a/runtime-pi/sidecar/test/app.test.ts
+++ b/runtime-pi/sidecar/test/app.test.ts
@@ -854,6 +854,91 @@ describe("ALL /proxy — binary body integrity", () => {
     expect(res.status).toBe(200);
     expect(bodyIsArrayBuffer).toBe(true);
   });
+
+  it("preserves binary response bytes (PDF-like payload) byte-for-byte", async () => {
+    // PDF header + bytes that are invalid UTF-8. If the sidecar decodes the
+    // upstream response via .text(), these bytes become U+FFFD (0xEF 0xBF 0xBD)
+    // and the resulting buffer grows, breaking binary file downloads.
+    const pdfLike = new Uint8Array([
+      0x25,
+      0x50,
+      0x44,
+      0x46,
+      0x2d,
+      0x31,
+      0x2e,
+      0x34, // "%PDF-1.4"
+      0x0a, // LF
+      0xff,
+      0xfe,
+      0x80,
+      0xc0,
+      0xc1, // invalid UTF-8 sequences
+      0x00,
+      0x01,
+      0x02, // null bytes
+      0x25,
+      0x25,
+      0x45,
+      0x4f,
+      0x46, // "%%EOF"
+    ]);
+
+    const fetchFn = mock(
+      async () =>
+        new Response(pdfLike, {
+          status: 200,
+          headers: { "Content-Type": "application/pdf" },
+        }),
+    );
+    const app = createApp(makeDeps({ fetchFn }));
+    const res = await app.request("/proxy", {
+      method: "GET",
+      headers: {
+        "X-Provider": "gmail",
+        "X-Target": "https://api.example.com/files/abc/download",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/pdf");
+    const received = new Uint8Array(await res.arrayBuffer());
+    expect(received.byteLength).toBe(pdfLike.byteLength);
+    expect(received).toEqual(pdfLike);
+  });
+
+  it("does not corrupt binary response even when truncation is triggered", async () => {
+    // 60KB binary payload beyond MAX_RESPONSE_SIZE; first 50KB must survive byte-for-byte.
+    const total = 60_000;
+    const payload = new Uint8Array(total);
+    for (let i = 0; i < total; i++) {
+      payload[i] = i % 256; // includes all byte values 0x00–0xff
+    }
+
+    const fetchFn = mock(
+      async () =>
+        new Response(payload, {
+          status: 200,
+          headers: { "Content-Type": "application/octet-stream" },
+        }),
+    );
+    const app = createApp(makeDeps({ fetchFn }));
+    const res = await app.request("/proxy", {
+      method: "GET",
+      headers: {
+        "X-Provider": "gmail",
+        "X-Target": "https://api.example.com/blob",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Truncated")).toBe("true");
+    const received = new Uint8Array(await res.arrayBuffer());
+    expect(received.byteLength).toBe(50_000);
+    expect(received[0]).toBe(0x00);
+    expect(received[0xff]).toBe(0xff);
+    expect(received[49_999]).toBe(49_999 % 256);
+  });
 });
 
 // --- ALL /llm/* — LLM reverse proxy ---


### PR DESCRIPTION
## Summary

- Read upstream response as `ArrayBuffer` instead of decoding via `.text()` in `runtime-pi/sidecar/app.ts` — non-UTF-8 bytes in binary bodies (PDF, images, XLSX, archives) are now preserved byte-for-byte
- Truncation now applied by byte length (matches actual payload size)
- Mirrors the `/llm/*` proxy in the same file, and the symmetric fix on the request side (#50)

Credit to @otarbes (#151) for the patch and regression tests.

Closes #149

## Test plan

- [x] Added 2 regression tests in `runtime-pi/sidecar/test/app.test.ts` (`ALL /proxy — binary body integrity` block):
  - Preserves PDF-like payload with invalid UTF-8 sequences byte-for-byte
  - Truncates binary payload by byte count (50 KB), not inflated char count
- [x] Confirmed both tests fail against the buggy code (22→32 bytes, 60 KB→99 920 bytes)
- [x] Both tests pass after the fix (69/69 in `test/app.test.ts`)
- [x] Full sidecar suite: 139/139 pass
- [x] Full runtime-pi suite: 151/151 pass
- [x] `bun run check` (monorepo): all 14 tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)