### PR TITLE
fix(api): aggregate validation errors across every endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,22 +27,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - ESLint `no-unused-vars` upgraded from `warn` to `error`
 - All workspace packages extend shared `tsconfig.base.json`
 - Enabled TypeScript type-checking on `runtime-pi` (previously disabled via `noCheck: true`)
-- **BREAKING (API contract)**: `parseBody` helper — used by ~64 call sites
-  across ~20 route files (including modules) — now emits
-  `code: "validation_failed"` instead of
-  `code: "invalid_request"` on body-validation failures, and populates
-  `errors[]` with every Zod issue instead of setting the top-level `param`
-  field on the first one. Clients that branch on `code === "invalid_request"`
-  or read `body.param` for body-validation errors must be updated to handle
+- **BREAKING (API contract)**: `parseBody` helper — used by ~80 call sites
+  across ~22 route files (core routes + `webhooks` and `oidc` modules) — now
+  emits `code: "validation_failed"` instead of `code: "invalid_request"` on
+  body-validation failures, and populates `errors[]` with every Zod issue
+  instead of setting the top-level `param` field on the first one. Clients
+  that branch on `code === "invalid_request"` or read `body.param` for
+  body-validation errors must be updated to handle
   `code === "validation_failed"` and read the per-field `errors[]` array.
   Non-body validation errors (auth, app context, rate limits) continue to
   use their existing codes unchanged.
+- **BREAKING (API contract)**: `validateAgentReadiness` now emits
+  `code: "invalid_config"` for config-schema failures instead of the legacy
+  `config_incomplete`, aligning with the inline-preflight stage that already
+  used `invalid_config`. The field name and message are unchanged. Clients
+  branching on `code === "config_incomplete"` must be updated.
 - `validateAgentDependencies` parallelises provider checks via `Promise.all`
   across `isProviderEnabled`, `getProviderCredentialId`, and
   `getConnectionStatus`. The pre-existing check-type precedence (enabled →
   profile → credential → status → scope) is preserved; within each check
   type, the thrown error still follows `providers` iteration order. Happy-
   path latency is reduced.
+- `ValidationFieldError` entries now carry an optional `title` (human-
+  readable). Throwing wrappers (`validateAgentReadiness`,
+  `validateAgentDependencies`, inline-preflight fail-fast) use it so the
+  `Problem.title` field keeps its historical wording (e.g. "Empty Prompt")
+  instead of surfacing the machine code.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `test` and `lint` tasks in Turborepo pipeline
 - Root `bun test` script
 - Explicit `exports` field in `@appstrate/connect` and `@appstrate/shared-types`
+- RFC 9457 `errors[]` array populated on every 400 validation response so a
+  single round-trip lists every problem (manifest, config, input, providers)
+  instead of surfacing them one at a time.
+- `POST /api/runs/inline/validate` runs preflight in `accumulate` mode,
+  returning the full list of validation errors in one response.
 
 ### Changed
 
@@ -22,6 +27,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - ESLint `no-unused-vars` upgraded from `warn` to `error`
 - All workspace packages extend shared `tsconfig.base.json`
 - Enabled TypeScript type-checking on `runtime-pi` (previously disabled via `noCheck: true`)
+- **BREAKING (API contract)**: `parseBody` helper — used by ~84 call sites
+  across 21 routes — now emits `code: "validation_failed"` instead of
+  `code: "invalid_request"` on body-validation failures, and populates
+  `errors[]` with every Zod issue instead of setting the top-level `param`
+  field on the first one. Clients that branch on `code === "invalid_request"`
+  or read `body.param` for body-validation errors must be updated to handle
+  `code === "validation_failed"` and read the per-field `errors[]` array.
+  Non-body validation errors (auth, app context, rate limits) continue to
+  use their existing codes unchanged.
+- `validateAgentDependencies` parallelises provider checks via `Promise.all`
+  across `isProviderEnabled`, `getProviderCredentialId`, and
+  `getConnectionStatus`. Error ordering within each check type follows
+  `providers` iteration order; when a run has failures across different
+  check types (e.g. one provider disabled, another missing a profile), the
+  thrown error now matches the fixed check-type precedence (enabled →
+  profile → credential → status → scope) rather than the provider the
+  sequential loop happened to reach first. Happy-path latency is reduced.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - ESLint `no-unused-vars` upgraded from `warn` to `error`
 - All workspace packages extend shared `tsconfig.base.json`
 - Enabled TypeScript type-checking on `runtime-pi` (previously disabled via `noCheck: true`)
-- **BREAKING (API contract)**: `parseBody` helper — used by ~84 call sites
-  across 21 routes — now emits `code: "validation_failed"` instead of
+- **BREAKING (API contract)**: `parseBody` helper — used by ~64 call sites
+  across ~20 route files (including modules) — now emits
+  `code: "validation_failed"` instead of
   `code: "invalid_request"` on body-validation failures, and populates
   `errors[]` with every Zod issue instead of setting the top-level `param`
   field on the first one. Clients that branch on `code === "invalid_request"`
@@ -38,12 +39,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   use their existing codes unchanged.
 - `validateAgentDependencies` parallelises provider checks via `Promise.all`
   across `isProviderEnabled`, `getProviderCredentialId`, and
-  `getConnectionStatus`. Error ordering within each check type follows
-  `providers` iteration order; when a run has failures across different
-  check types (e.g. one provider disabled, another missing a profile), the
-  thrown error now matches the fixed check-type precedence (enabled →
-  profile → credential → status → scope) rather than the provider the
-  sequential loop happened to reach first. Happy-path latency is reduced.
+  `getConnectionStatus`. The pre-existing check-type precedence (enabled →
+  profile → credential → status → scope) is preserved; within each check
+  type, the thrown error still follows `providers` iteration order. Happy-
+  path latency is reduced.
 
 ### Removed
 

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -31,6 +31,12 @@ export interface ValidationFieldError {
   field: string;
   code: string;
   message: string;
+  /**
+   * Human-readable title. Preserved so throwing wrappers can surface the
+   * historical title (e.g. "Empty Prompt") in fail-fast mode instead of the
+   * machine code. Optional — Zod-originated entries don't carry one.
+   */
+  title?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -201,14 +207,23 @@ export function systemEntityForbidden(type: string, id: string, verb = "modify")
 
 import type { z } from "zod";
 
-/** Convert Zod issues to the RFC 9457 `errors[]` entries we expose to clients. */
+/**
+ * Convert Zod issues to the RFC 9457 `errors[]` entries we expose to clients.
+ *
+ * The Zod issue path fully identifies the offending field. `fallbackField` is
+ * only used when Zod reports an empty path (i.e. the root body failed before
+ * any key could be inspected) — it matches the historical semantic of
+ * `parseBody`'s third argument, which named the primary field being parsed.
+ * Concatenating the fallback with the Zod path would double-up names
+ * (`"apiKey.apiKey"`) for every parseBody caller, so we deliberately don't.
+ */
 export function zodIssuesToFieldErrors(
   issues: readonly z.core.$ZodIssue[],
-  pathPrefix?: string,
+  fallbackField?: string,
 ): ValidationFieldError[] {
   return issues.map((issue) => {
     const path = issue.path.map(String).join(".");
-    const field = pathPrefix ? (path ? `${pathPrefix}.${path}` : pathPrefix) : path;
+    const field = path || fallbackField || "";
     return { field, code: issue.code, message: issue.message };
   });
 }
@@ -216,7 +231,8 @@ export function zodIssuesToFieldErrors(
 /**
  * Parse a request body with a Zod schema. On failure throws a 400 with every
  * issue populated in `errors[]` so clients receive all problems in one call.
- * The optional `param` is used as a path prefix for nested schema context.
+ * The optional `param` is a fallback used when Zod reports an empty path —
+ * never as a prefix on top of a resolved path.
  */
 export function parseBody<T extends z.ZodType>(
   schema: T,

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -208,6 +208,74 @@ export function systemEntityForbidden(type: string, id: string, verb = "modify")
 import type { z } from "zod";
 
 /**
+ * Closed set of public field-error codes. We deliberately do NOT propagate
+ * raw Zod codes (which are internal to the validation library and may change
+ * between major versions) — instead every Zod issue is mapped to one of
+ * these stable codes. Clients can safely branch on them.
+ */
+export type FieldErrorCode =
+  | "required"
+  | "invalid_type"
+  | "invalid_format"
+  | "out_of_range"
+  | "unknown_field"
+  | "invalid_value"
+  | "invalid_union"
+  | "invalid_key"
+  | "invalid_element"
+  | "invalid_request";
+
+function mapZodCode(issue: z.core.$ZodIssue): FieldErrorCode {
+  // `invalid_type` with `received: undefined` is the Zod way of saying
+  // "missing required field" — surface a dedicated `required` code so
+  // clients don't have to inspect the `received` property to tell the two
+  // cases apart.
+  if (issue.code === "invalid_type" && (issue as { received?: unknown }).received === "undefined") {
+    return "required";
+  }
+  switch (issue.code) {
+    case "invalid_type":
+      return "invalid_type";
+    case "too_big":
+    case "too_small":
+    case "not_multiple_of":
+      return "out_of_range";
+    case "invalid_format":
+      return "invalid_format";
+    case "unrecognized_keys":
+      return "unknown_field";
+    case "invalid_union":
+      return "invalid_union";
+    case "invalid_key":
+      return "invalid_key";
+    case "invalid_element":
+      return "invalid_element";
+    case "invalid_value":
+    case "custom":
+      return "invalid_value";
+    default:
+      return "invalid_request";
+  }
+}
+
+/**
+ * Render a path segment array using bracket notation for numeric indices
+ * (`items[0].name`) so consumers can disambiguate array indices from string
+ * keys that happen to be all-digits. Mirrors Stripe's `param` convention.
+ */
+function renderFieldPath(path: readonly PropertyKey[]): string {
+  let out = "";
+  for (const seg of path) {
+    if (typeof seg === "number" || (typeof seg === "string" && /^\d+$/.test(seg))) {
+      out += `[${seg}]`;
+    } else {
+      out += out === "" ? String(seg) : `.${String(seg)}`;
+    }
+  }
+  return out;
+}
+
+/**
  * Convert Zod issues to the RFC 9457 `errors[]` entries we expose to clients.
  *
  * The Zod issue path fully identifies the offending field. `fallbackField` is
@@ -216,15 +284,19 @@ import type { z } from "zod";
  * `parseBody`'s third argument, which named the primary field being parsed.
  * Concatenating the fallback with the Zod path would double-up names
  * (`"apiKey.apiKey"`) for every parseBody caller, so we deliberately don't.
+ *
+ * When neither a path nor a fallback is available the field defaults to
+ * `"body"` rather than the empty string, so clients always receive a usable
+ * pointer.
  */
 export function zodIssuesToFieldErrors(
   issues: readonly z.core.$ZodIssue[],
   fallbackField?: string,
 ): ValidationFieldError[] {
   return issues.map((issue) => {
-    const path = issue.path.map(String).join(".");
-    const field = path || fallbackField || "";
-    return { field, code: issue.code, message: issue.message };
+    const path = renderFieldPath(issue.path);
+    const field = path || fallbackField || "body";
+    return { field, code: mapZodCode(issue), message: issue.message };
   });
 }
 

--- a/apps/api/src/lib/errors.ts
+++ b/apps/api/src/lib/errors.ts
@@ -109,6 +109,29 @@ export function invalidRequest(detail: string, param?: string): ApiError {
   });
 }
 
+/**
+ * Aggregate multiple validation errors into a single 400 response.
+ * Sets `code: "validation_failed"` and populates the RFC 9457 `errors[]` array,
+ * so clients can surface every problem in one round-trip. `detail` defaults to
+ * a human-readable summary derived from the first entry plus a count.
+ */
+export function validationFailed(errors: ValidationFieldError[], detail?: string): ApiError {
+  const summary =
+    detail ??
+    (errors.length === 0
+      ? "Validation failed"
+      : errors.length === 1
+        ? `${errors[0]!.field}: ${errors[0]!.message}`
+        : `${errors[0]!.field}: ${errors[0]!.message} (+${errors.length - 1} more)`);
+  return new ApiError({
+    status: 400,
+    code: "validation_failed",
+    title: "Validation Failed",
+    detail: summary,
+    errors,
+  });
+}
+
 export function unauthorized(detail: string): ApiError {
   return new ApiError({
     status: 401,
@@ -178,7 +201,23 @@ export function systemEntityForbidden(type: string, id: string, verb = "modify")
 
 import type { z } from "zod";
 
-/** Parse a request body with a Zod schema, throwing invalidRequest on failure. */
+/** Convert Zod issues to the RFC 9457 `errors[]` entries we expose to clients. */
+export function zodIssuesToFieldErrors(
+  issues: readonly z.core.$ZodIssue[],
+  pathPrefix?: string,
+): ValidationFieldError[] {
+  return issues.map((issue) => {
+    const path = issue.path.map(String).join(".");
+    const field = pathPrefix ? (path ? `${pathPrefix}.${path}` : pathPrefix) : path;
+    return { field, code: issue.code, message: issue.message };
+  });
+}
+
+/**
+ * Parse a request body with a Zod schema. On failure throws a 400 with every
+ * issue populated in `errors[]` so clients receive all problems in one call.
+ * The optional `param` is used as a path prefix for nested schema context.
+ */
 export function parseBody<T extends z.ZodType>(
   schema: T,
   body: unknown,
@@ -186,7 +225,7 @@ export function parseBody<T extends z.ZodType>(
 ): z.output<T> {
   const parsed = schema.safeParse(body);
   if (!parsed.success) {
-    throw invalidRequest(parsed.error.issues[0]!.message, param);
+    throw validationFailed(zodIssuesToFieldErrors(parsed.error.issues, param));
   }
   return parsed.data;
 }

--- a/apps/api/src/lib/field-errors.ts
+++ b/apps/api/src/lib/field-errors.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared parser for the `"path: message"` error strings produced by
+ * `@appstrate/core/validation` helpers (`validateManifest`,
+ * `validateInlineManifest`, …).
+ *
+ * Both `routes/packages.ts` and `services/inline-run-preflight.ts` ingest
+ * these strings and need to fold them into RFC 9457 `ValidationFieldError`
+ * entries. Keeping the split logic here avoids drift — the regex deliberately
+ * anchors on a strict path-like prefix (alphanumerics, dots, brackets) so
+ * messages containing `": "` (quoted regex patterns, nested examples) are
+ * never truncated mid-string.
+ */
+
+import type { ValidationFieldError } from "./errors.ts";
+
+const PATH_PREFIX_RE = /^([A-Za-z_][A-Za-z0-9_.[\]]*): (.+)$/s;
+
+export interface PathMessageParseOptions {
+  /** `code` attached to every generated entry. */
+  code: string;
+  /** `title` attached to every generated entry. */
+  title: string;
+  /**
+   * Prefix prepended to the parsed path. Use `"manifest."` when the raw
+   * strings omit the top-level qualifier (e.g. direct output of
+   * `validateManifest`). Leave empty when the caller already prefixes the
+   * path upstream (e.g. `validateInlineManifest`).
+   */
+  fieldPrefix?: string;
+  /**
+   * Field name to use when the raw string has no path-like prefix. Defaults
+   * to `"manifest"` — the common case for both callers today.
+   */
+  fallbackField?: string;
+}
+
+/** Parse a single `"path: message"` string into a structured field error. */
+export function parsePathMessage(raw: string, opts: PathMessageParseOptions): ValidationFieldError {
+  const { code, title, fieldPrefix = "", fallbackField = "manifest" } = opts;
+  const match = PATH_PREFIX_RE.exec(raw);
+  if (!match) return { field: fallbackField, code, title, message: raw };
+  return { field: `${fieldPrefix}${match[1]!}`, code, title, message: match[2]! };
+}
+
+/** Parse every `"path: message"` string in the array. */
+export function parsePathMessages(
+  errors: readonly string[],
+  opts: PathMessageParseOptions,
+): ValidationFieldError[] {
+  return errors.map((raw) => parsePathMessage(raw, opts));
+}

--- a/apps/api/src/openapi/responses.ts
+++ b/apps/api/src/openapi/responses.ts
@@ -53,17 +53,43 @@ export const responses = {
     },
   },
   ValidationError: {
-    description: "Validation error",
+    description:
+      'Validation error. Body-level failures emit `code: "validation_failed"` ' +
+      "with a populated `errors[]` array listing every offending field in one " +
+      "response. Single-field failures outside the body (query params, headers) " +
+      'still use `code: "invalid_request"` with the `param` pointer.',
     content: {
       "application/problem+json": {
         schema: { $ref: "#/components/schemas/ProblemDetail" },
-        example: {
-          type: "https://docs.appstrate.dev/errors/invalid-request",
-          title: "Invalid Request",
-          status: 400,
-          detail: "Field is required",
-          code: "invalid_request",
-          requestId: "req_abc123",
+        examples: {
+          aggregated: {
+            summary: "Multiple body fields failed validation",
+            value: {
+              type: "https://docs.appstrate.dev/errors/validation-failed",
+              title: "Validation Failed",
+              status: 400,
+              detail: "name: Required (+2 more)",
+              code: "validation_failed",
+              requestId: "req_abc123",
+              errors: [
+                { field: "name", code: "invalid_type", message: "Required" },
+                { field: "email", code: "invalid_format", message: "Invalid email" },
+                { field: "age", code: "invalid_type", message: "Expected number" },
+              ],
+            },
+          },
+          singleField: {
+            summary: "Single non-body field failed validation",
+            value: {
+              type: "https://docs.appstrate.dev/errors/invalid-request",
+              title: "Invalid Request",
+              status: 400,
+              detail: "Field is required",
+              code: "invalid_request",
+              param: "limit",
+              requestId: "req_abc123",
+            },
+          },
         },
       },
     },

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -72,31 +72,13 @@ import {
   validationFailed,
   type ValidationFieldError,
 } from "../lib/errors.ts";
+import { parsePathMessages } from "../lib/field-errors.ts";
 
-/**
- * Convert `@appstrate/core/validation` "path: message" strings to field
- * entries. The split is anchored on a strict path-like prefix
- * (alphanumeric, dots, brackets) so messages containing `": "` (e.g. quoted
- * regex patterns or nested examples) are not truncated.
- */
-const MANIFEST_PATH_PREFIX_RE = /^([A-Za-z_][A-Za-z0-9_.[\]]*): (.+)$/s;
 function manifestErrorsToFieldErrors(errors: string[]): ValidationFieldError[] {
-  return errors.map((raw) => {
-    const m = MANIFEST_PATH_PREFIX_RE.exec(raw);
-    if (!m) {
-      return {
-        field: "manifest",
-        code: "invalid_manifest",
-        title: "Invalid Manifest",
-        message: raw,
-      };
-    }
-    return {
-      field: `manifest.${m[1]!}`,
-      code: "invalid_manifest",
-      title: "Invalid Manifest",
-      message: m[2]!,
-    };
+  return parsePathMessages(errors, {
+    code: "invalid_manifest",
+    title: "Invalid Manifest",
+    fieldPrefix: "manifest.",
   });
 }
 

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -73,11 +73,17 @@ import {
   type ValidationFieldError,
 } from "../lib/errors.ts";
 
-/** Convert `@appstrate/core/validation` "path: message" strings to field entries. */
+/**
+ * Convert `@appstrate/core/validation` "path: message" strings to field
+ * entries. The split is anchored on a strict path-like prefix
+ * (alphanumeric, dots, brackets) so messages containing `": "` (e.g. quoted
+ * regex patterns or nested examples) are not truncated.
+ */
+const MANIFEST_PATH_PREFIX_RE = /^([A-Za-z_][A-Za-z0-9_.[\]]*): (.+)$/s;
 function manifestErrorsToFieldErrors(errors: string[]): ValidationFieldError[] {
   return errors.map((raw) => {
-    const idx = raw.indexOf(": ");
-    if (idx === -1) {
+    const m = MANIFEST_PATH_PREFIX_RE.exec(raw);
+    if (!m) {
       return {
         field: "manifest",
         code: "invalid_manifest",
@@ -86,10 +92,10 @@ function manifestErrorsToFieldErrors(errors: string[]): ValidationFieldError[] {
       };
     }
     return {
-      field: `manifest.${raw.slice(0, idx)}`,
+      field: `manifest.${m[1]!}`,
       code: "invalid_manifest",
       title: "Invalid Manifest",
-      message: raw.slice(idx + 2),
+      message: m[2]!,
     };
   });
 }

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -69,7 +69,22 @@ import {
   conflict,
   internalError,
   parseBody,
+  validationFailed,
+  type ValidationFieldError,
 } from "../lib/errors.ts";
+
+/** Convert `@appstrate/core/validation` "path: message" strings to field entries. */
+function manifestErrorsToFieldErrors(errors: string[]): ValidationFieldError[] {
+  return errors.map((raw) => {
+    const idx = raw.indexOf(": ");
+    if (idx === -1) return { field: "manifest", code: "invalid_manifest", message: raw };
+    return {
+      field: `manifest.${raw.slice(0, idx)}`,
+      code: "invalid_manifest",
+      message: raw.slice(idx + 2),
+    };
+  });
+}
 
 // ═══════════════════════════════════════════════
 // Shared helpers for package CRUD routes
@@ -396,12 +411,7 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
       // Validate manifest
       const manifestResult = validateManifest(manifest);
       if (!manifestResult.valid) {
-        throw new ApiError({
-          status: 400,
-          code: "invalid_manifest",
-          title: "Invalid Manifest",
-          detail: manifestResult.errors[0] ?? "Invalid manifest",
-        });
+        throw validationFailed(manifestErrorsToFieldErrors(manifestResult.errors));
       }
       const validatedManifest = manifestResult.manifest;
 
@@ -412,7 +422,13 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
       if (rcfg.validateContent) {
         const validation = rcfg.validateContent(content);
         if (!validation.valid) {
-          throw invalidRequest(validation.errors[0] ?? "Validation failed");
+          throw validationFailed(
+            validation.errors.map((message) => ({
+              field: "content",
+              code: "invalid_content",
+              message,
+            })),
+          );
         }
       }
 
@@ -423,7 +439,13 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
       if (rcfg.validateSource && sourceCode) {
         const validation = rcfg.validateSource(sourceCode);
         if (!validation.valid) {
-          throw invalidRequest(validation.errors[0] ?? "Validation failed");
+          throw validationFailed(
+            validation.errors.map((message) => ({
+              field: "sourceCode",
+              code: "invalid_source",
+              message,
+            })),
+          );
         }
       }
 
@@ -509,12 +531,7 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
     if (parsed.manifest) {
       const manifestResult = validateManifest(parsed.manifest);
       if (!manifestResult.valid) {
-        throw new ApiError({
-          status: 400,
-          code: "invalid_manifest",
-          title: "Invalid Manifest",
-          detail: manifestResult.errors[0] ?? "Invalid manifest",
-        });
+        throw validationFailed(manifestErrorsToFieldErrors(manifestResult.errors));
       }
     }
 
@@ -522,7 +539,13 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
     if (rcfg.validateContent) {
       const validation = rcfg.validateContent(parsed.content);
       if (!validation.valid) {
-        throw invalidRequest(validation.errors[0] ?? "Validation failed");
+        throw validationFailed(
+          validation.errors.map((message) => ({
+            field: "content",
+            code: "invalid_content",
+            message,
+          })),
+        );
       }
       warnings = validation.warnings;
     }
@@ -688,12 +711,7 @@ function makeUpdateHandler(rcfg: PackageRouteConfig) {
     // Validate manifest
     const manifestResult = validateManifest(manifest);
     if (!manifestResult.valid) {
-      throw new ApiError({
-        status: 400,
-        code: "invalid_manifest",
-        title: "Invalid Manifest",
-        detail: manifestResult.errors[0] ?? "Invalid manifest",
-      });
+      throw validationFailed(manifestErrorsToFieldErrors(manifestResult.errors));
     }
 
     // Ensure ID immutability (all types)
@@ -712,7 +730,13 @@ function makeUpdateHandler(rcfg: PackageRouteConfig) {
     if (rcfg.validateContent && content) {
       const validation = rcfg.validateContent(content);
       if (!validation.valid) {
-        throw invalidRequest(validation.errors[0] ?? "Validation failed");
+        throw validationFailed(
+          validation.errors.map((message) => ({
+            field: "content",
+            code: "invalid_content",
+            message,
+          })),
+        );
       }
       warnings = validation.warnings;
     }
@@ -725,7 +749,13 @@ function makeUpdateHandler(rcfg: PackageRouteConfig) {
       if (rcfg.validateSource) {
         const validation = rcfg.validateSource(sourceCode);
         if (!validation.valid) {
-          throw invalidRequest(validation.errors[0] ?? "Validation failed");
+          throw validationFailed(
+            validation.errors.map((message) => ({
+              field: "sourceCode",
+              code: "invalid_source",
+              message,
+            })),
+          );
         }
       }
     }

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -77,10 +77,18 @@ import {
 function manifestErrorsToFieldErrors(errors: string[]): ValidationFieldError[] {
   return errors.map((raw) => {
     const idx = raw.indexOf(": ");
-    if (idx === -1) return { field: "manifest", code: "invalid_manifest", message: raw };
+    if (idx === -1) {
+      return {
+        field: "manifest",
+        code: "invalid_manifest",
+        title: "Invalid Manifest",
+        message: raw,
+      };
+    }
     return {
       field: `manifest.${raw.slice(0, idx)}`,
       code: "invalid_manifest",
+      title: "Invalid Manifest",
       message: raw.slice(idx + 2),
     };
   });
@@ -426,6 +434,7 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
             validation.errors.map((message) => ({
               field: "content",
               code: "invalid_content",
+              title: "Invalid Content",
               message,
             })),
           );
@@ -443,6 +452,7 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
             validation.errors.map((message) => ({
               field: "sourceCode",
               code: "invalid_source",
+              title: "Invalid Source",
               message,
             })),
           );
@@ -543,6 +553,7 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
           validation.errors.map((message) => ({
             field: "content",
             code: "invalid_content",
+            title: "Invalid Content",
             message,
           })),
         );
@@ -734,6 +745,7 @@ function makeUpdateHandler(rcfg: PackageRouteConfig) {
           validation.errors.map((message) => ({
             field: "content",
             code: "invalid_content",
+            title: "Invalid Content",
             message,
           })),
         );
@@ -753,6 +765,7 @@ function makeUpdateHandler(rcfg: PackageRouteConfig) {
             validation.errors.map((message) => ({
               field: "sourceCode",
               code: "invalid_source",
+              title: "Invalid Source",
               message,
             })),
           );

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -793,7 +793,7 @@ export function createRunsRouter() {
       const actor = getActor(c);
       const body = await c.req.json<InlineRunBody>();
 
-      await runInlinePreflight({ orgId, applicationId, actor, body });
+      await runInlinePreflight({ orgId, applicationId, actor, body, mode: "accumulate" });
 
       return c.json({ ok: true });
     },

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -15,7 +15,7 @@ import { isValidCron } from "../lib/cron.ts";
 import { validateInput, schemaHasFileFields } from "../services/schema.ts";
 import { requireAgent } from "../middleware/guards.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
-import { forbidden, invalidRequest, notFound, parseBody } from "../lib/errors.ts";
+import { forbidden, invalidRequest, notFound, parseBody, validationFailed } from "../lib/errors.ts";
 import { rateLimit } from "../middleware/rate-limit.ts";
 import { getAccessibleProfile } from "../services/connection-profiles.ts";
 import { getActor } from "../lib/actor.ts";
@@ -95,8 +95,13 @@ export function createSchedulesRouter() {
       if (inputSchema) {
         const inputValidation = validateInput(data.input, asJSONSchemaObject(inputSchema));
         if (!inputValidation.valid) {
-          const first = inputValidation.errors[0]!;
-          throw invalidRequest(first.message, first.field);
+          throw validationFailed(
+            inputValidation.errors.map((e) => ({
+              field: e.field ? `input.${e.field}` : "input",
+              code: "invalid_input",
+              message: e.message,
+            })),
+          );
         }
       }
 

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -99,6 +99,7 @@ export function createSchedulesRouter() {
             inputValidation.errors.map((e) => ({
               field: e.field ? `input.${e.field}` : "input",
               code: "invalid_input",
+              title: "Invalid Input",
               message: e.message,
             })),
           );

--- a/apps/api/src/services/agent-readiness.ts
+++ b/apps/api/src/services/agent-readiness.ts
@@ -18,6 +18,14 @@ export interface AgentReadinessParams {
   orgId: string;
   config?: Record<string, unknown>;
   applicationId: string;
+  /**
+   * Skip individual checks already performed by an upstream validator. Used
+   * by the inline-run preflight, which validates `prompt` via the manifest
+   * structural check and `config` via AJV at its own stage, then calls
+   * readiness for the remaining dependency checks. Avoids emitting duplicate
+   * entries for the same field in `accumulate` mode.
+   */
+  skip?: { prompt?: boolean; config?: boolean };
 }
 
 /**
@@ -30,14 +38,15 @@ export interface AgentReadinessParams {
 export async function collectAgentReadinessErrors(
   params: AgentReadinessParams,
 ): Promise<ValidationFieldError[]> {
-  const { agent, providerProfiles, orgId, config, applicationId } = params;
+  const { agent, providerProfiles, orgId, config, applicationId, skip } = params;
   const { manifest } = agent;
   const errors: ValidationFieldError[] = [];
 
-  if (isPromptEmpty(agent.prompt)) {
+  if (!skip?.prompt && isPromptEmpty(agent.prompt)) {
     errors.push({
       field: "prompt",
       code: "empty_prompt",
+      title: "Empty Prompt",
       message: "Agent prompt is empty",
     });
   }
@@ -50,6 +59,7 @@ export async function collectAgentReadinessErrors(
     errors.push({
       field: `dependencies.skills.${skillId}`,
       code: "missing_skill",
+      title: "Missing Skill",
       message: `Required skill '${skillId}' is not installed`,
     });
   }
@@ -62,6 +72,7 @@ export async function collectAgentReadinessErrors(
     errors.push({
       field: `dependencies.tools.${toolId}`,
       code: "missing_tool",
+      title: "Missing Tool",
       message: `Required tool '${toolId}' is not installed`,
     });
   }
@@ -71,7 +82,7 @@ export async function collectAgentReadinessErrors(
     ...(await collectDependencyErrors(manifestProviders, providerProfiles, orgId, applicationId)),
   );
 
-  if (config) {
+  if (!skip?.config && config) {
     const { config: configSchema } = extractManifestSchemas(manifest);
     const effectiveSchema = configSchema ?? { type: "object" as const, properties: {} };
     const configValidation = validateConfig(config, effectiveSchema);
@@ -79,7 +90,8 @@ export async function collectAgentReadinessErrors(
       for (const e of configValidation.errors) {
         errors.push({
           field: e.field ? `config.${e.field}` : "config",
-          code: "config_incomplete",
+          code: "invalid_config",
+          title: "Invalid Config",
           message: e.message,
         });
       }
@@ -92,7 +104,8 @@ export async function collectAgentReadinessErrors(
 /**
  * Validate that an agent is ready for a run. Delegates to
  * `collectAgentReadinessErrors` and throws the first error, preserving the
- * historical fail-fast contract (single ApiError with the original code).
+ * historical fail-fast contract (single ApiError with the original code and
+ * human-readable title carried on the field entry).
  */
 export async function validateAgentReadiness(params: AgentReadinessParams): Promise<void> {
   const errors = await collectAgentReadinessErrors(params);
@@ -101,7 +114,7 @@ export async function validateAgentReadiness(params: AgentReadinessParams): Prom
   throw new ApiError({
     status: 400,
     code: first.code,
-    title: first.code,
+    title: first.title ?? first.code,
     detail: first.message,
   });
 }

--- a/apps/api/src/services/agent-readiness.ts
+++ b/apps/api/src/services/agent-readiness.ts
@@ -6,11 +6,82 @@
  */
 
 import type { LoadedPackage, ProviderProfileMap } from "../types/index.ts";
-import { validateAgentDependencies } from "./dependency-validation.ts";
+import { validateAgentDependencies, collectDependencyErrors } from "./dependency-validation.ts";
 import { validateConfig } from "./schema.ts";
 import { resolveManifestProviders, extractManifestSchemas } from "../lib/manifest-utils.ts";
 import { isPromptEmpty, findMissingDependencies } from "@appstrate/core/validation";
-import { ApiError } from "../lib/errors.ts";
+import { ApiError, type ValidationFieldError } from "../lib/errors.ts";
+
+/**
+ * Collect every readiness error as structured field entries (non-throwing).
+ * Used by accumulate-mode preflight. The throwing wrapper below raises the
+ * first error with the original code, preserving backwards compatibility.
+ */
+export async function collectAgentReadinessErrors(params: {
+  agent: LoadedPackage;
+  providerProfiles: ProviderProfileMap;
+  orgId: string;
+  config?: Record<string, unknown>;
+  applicationId: string;
+}): Promise<ValidationFieldError[]> {
+  const { agent, providerProfiles, orgId, config, applicationId } = params;
+  const { manifest } = agent;
+  const errors: ValidationFieldError[] = [];
+
+  if (isPromptEmpty(agent.prompt)) {
+    errors.push({
+      field: "prompt",
+      code: "empty_prompt",
+      message: "Agent prompt is empty",
+    });
+  }
+
+  const missingSkills = findMissingDependencies(
+    manifest.dependencies?.skills ?? {},
+    agent.skills.map((s) => s.id),
+  );
+  for (const skillId of missingSkills) {
+    errors.push({
+      field: `dependencies.skills.${skillId}`,
+      code: "missing_skill",
+      message: `Required skill '${skillId}' is not installed`,
+    });
+  }
+
+  const missingTools = findMissingDependencies(
+    (manifest.dependencies?.tools ?? {}) as Record<string, string>,
+    agent.tools.map((e) => e.id),
+  );
+  for (const toolId of missingTools) {
+    errors.push({
+      field: `dependencies.tools.${toolId}`,
+      code: "missing_tool",
+      message: `Required tool '${toolId}' is not installed`,
+    });
+  }
+
+  const manifestProviders = resolveManifestProviders(manifest);
+  errors.push(
+    ...(await collectDependencyErrors(manifestProviders, providerProfiles, orgId, applicationId)),
+  );
+
+  if (config) {
+    const { config: configSchema } = extractManifestSchemas(manifest);
+    const effectiveSchema = configSchema ?? { type: "object" as const, properties: {} };
+    const configValidation = validateConfig(config, effectiveSchema);
+    if (!configValidation.valid) {
+      for (const e of configValidation.errors) {
+        errors.push({
+          field: e.field ? `config.${e.field}` : "config",
+          code: "config_incomplete",
+          message: e.message,
+        });
+      }
+    }
+  }
+
+  return errors;
+}
 
 /**
  * Validate that an agent is ready for a run.

--- a/apps/api/src/services/agent-readiness.ts
+++ b/apps/api/src/services/agent-readiness.ts
@@ -89,18 +89,6 @@ export async function collectAgentReadinessErrors(
   return errors;
 }
 
-const CODE_TITLES: Record<string, string> = {
-  empty_prompt: "Empty Prompt",
-  missing_skill: "Missing Skill",
-  missing_tool: "Missing Tool",
-  provider_not_enabled: "Provider Not Enabled",
-  provider_not_configured: "Provider Not Configured",
-  needs_reconnection: "Needs Reconnection",
-  scope_insufficient: "Scope Insufficient",
-  dependency_not_satisfied: "Dependency Not Satisfied",
-  config_incomplete: "Config Incomplete",
-};
-
 /**
  * Validate that an agent is ready for a run. Delegates to
  * `collectAgentReadinessErrors` and throws the first error, preserving the
@@ -113,7 +101,7 @@ export async function validateAgentReadiness(params: AgentReadinessParams): Prom
   throw new ApiError({
     status: 400,
     code: first.code,
-    title: CODE_TITLES[first.code] ?? "Validation Failed",
+    title: first.code,
     detail: first.message,
   });
 }

--- a/apps/api/src/services/agent-readiness.ts
+++ b/apps/api/src/services/agent-readiness.ts
@@ -6,24 +6,30 @@
  */
 
 import type { LoadedPackage, ProviderProfileMap } from "../types/index.ts";
-import { validateAgentDependencies, collectDependencyErrors } from "./dependency-validation.ts";
+import { collectDependencyErrors } from "./dependency-validation.ts";
 import { validateConfig } from "./schema.ts";
 import { resolveManifestProviders, extractManifestSchemas } from "../lib/manifest-utils.ts";
 import { isPromptEmpty, findMissingDependencies } from "@appstrate/core/validation";
 import { ApiError, type ValidationFieldError } from "../lib/errors.ts";
 
-/**
- * Collect every readiness error as structured field entries (non-throwing).
- * Used by accumulate-mode preflight. The throwing wrapper below raises the
- * first error with the original code, preserving backwards compatibility.
- */
-export async function collectAgentReadinessErrors(params: {
+export interface AgentReadinessParams {
   agent: LoadedPackage;
   providerProfiles: ProviderProfileMap;
   orgId: string;
   config?: Record<string, unknown>;
   applicationId: string;
-}): Promise<ValidationFieldError[]> {
+}
+
+/**
+ * Collect every readiness error as structured field entries (non-throwing).
+ *
+ * Single source of truth for readiness checks — the throwing wrapper
+ * `validateAgentReadiness` delegates to this. Order matches the historical
+ * fail-fast sequence: prompt → skills → tools → provider deps → config.
+ */
+export async function collectAgentReadinessErrors(
+  params: AgentReadinessParams,
+): Promise<ValidationFieldError[]> {
   const { agent, providerProfiles, orgId, config, applicationId } = params;
   const { manifest } = agent;
   const errors: ValidationFieldError[] = [];
@@ -83,83 +89,31 @@ export async function collectAgentReadinessErrors(params: {
   return errors;
 }
 
+const CODE_TITLES: Record<string, string> = {
+  empty_prompt: "Empty Prompt",
+  missing_skill: "Missing Skill",
+  missing_tool: "Missing Tool",
+  provider_not_enabled: "Provider Not Enabled",
+  provider_not_configured: "Provider Not Configured",
+  needs_reconnection: "Needs Reconnection",
+  scope_insufficient: "Scope Insufficient",
+  dependency_not_satisfied: "Dependency Not Satisfied",
+  config_incomplete: "Config Incomplete",
+};
+
 /**
- * Validate that an agent is ready for a run.
- * Checks are ordered cheapest-first, fail-fast on first error.
- *
- * 1. Empty prompt
- * 2. Missing required skills
- * 3. Missing required tools
- * 4. Provider dependencies (delegates to validateAgentDependencies)
- * 5. Config validation (if config provided)
- *
- * Throws ApiError on first validation failure.
+ * Validate that an agent is ready for a run. Delegates to
+ * `collectAgentReadinessErrors` and throws the first error, preserving the
+ * historical fail-fast contract (single ApiError with the original code).
  */
-export async function validateAgentReadiness(params: {
-  agent: LoadedPackage;
-  providerProfiles: ProviderProfileMap;
-  orgId: string;
-  config?: Record<string, unknown>;
-  applicationId: string;
-}): Promise<void> {
-  const { agent, providerProfiles, orgId, config, applicationId } = params;
-  const { manifest } = agent;
-
-  // 1. Empty prompt
-  if (isPromptEmpty(agent.prompt)) {
-    throw new ApiError({
-      status: 400,
-      code: "empty_prompt",
-      title: "Empty Prompt",
-      detail: "Agent prompt is empty",
-    });
-  }
-
-  // 2. Missing skills
-  const missingSkills = findMissingDependencies(
-    manifest.dependencies?.skills ?? {},
-    agent.skills.map((s) => s.id),
-  );
-  if (missingSkills.length > 0) {
-    throw new ApiError({
-      status: 400,
-      code: "missing_skill",
-      title: "Missing Skill",
-      detail: `Required skill '${missingSkills[0]}' is not installed`,
-    });
-  }
-
-  // 3. Missing tools
-  const missingTools = findMissingDependencies(
-    (manifest.dependencies?.tools ?? {}) as Record<string, string>,
-    agent.tools.map((e) => e.id),
-  );
-  if (missingTools.length > 0) {
-    throw new ApiError({
-      status: 400,
-      code: "missing_tool",
-      title: "Missing Tool",
-      detail: `Required tool '${missingTools[0]}' is not installed`,
-    });
-  }
-
-  // 4. Provider dependencies
-  const manifestProviders = resolveManifestProviders(manifest);
-  await validateAgentDependencies(manifestProviders, providerProfiles, orgId, applicationId);
-
-  // 5. Config validation
-  if (config) {
-    const { config: configSchema } = extractManifestSchemas(manifest);
-    const effectiveSchema = configSchema ?? { type: "object" as const, properties: {} };
-    const configValidation = validateConfig(config, effectiveSchema);
-    if (!configValidation.valid) {
-      const first = configValidation.errors[0]!;
-      throw new ApiError({
-        status: 400,
-        code: "config_incomplete",
-        title: "Config Incomplete",
-        detail: `Parameter '${first.field}' is required`,
-      });
-    }
-  }
+export async function validateAgentReadiness(params: AgentReadinessParams): Promise<void> {
+  const errors = await collectAgentReadinessErrors(params);
+  if (errors.length === 0) return;
+  const first = errors[0]!;
+  throw new ApiError({
+    status: 400,
+    code: first.code,
+    title: CODE_TITLES[first.code] ?? "Validation Failed",
+    detail: first.message,
+  });
 }

--- a/apps/api/src/services/dependency-validation.ts
+++ b/apps/api/src/services/dependency-validation.ts
@@ -10,7 +10,7 @@ import type { ConnectionStatus } from "./connection-manager/index.ts";
 import { isProviderEnabled, getProviderCredentialId } from "@appstrate/connect";
 import { db } from "@appstrate/db/client";
 import type { AgentProviderRequirement, ProviderProfileMap } from "../types/index.ts";
-import { ApiError } from "../lib/errors.ts";
+import { ApiError, type ValidationFieldError } from "../lib/errors.ts";
 
 export interface DependencyValidationDeps {
   isProviderEnabled: (providerId: string, applicationId: string) => Promise<boolean>;
@@ -37,6 +37,120 @@ const defaultDeps: DependencyValidationDeps = {
 };
 
 /**
+ * Collect every unsatisfied-dependency error as structured field entries.
+ * Used by accumulate-mode preflight to surface multiple providers' issues in
+ * one response. The throwing variant below delegates here and raises the first.
+ */
+export async function collectDependencyErrors(
+  providers: AgentProviderRequirement[],
+  providerProfiles: ProviderProfileMap,
+  orgId: string,
+  applicationId: string,
+  deps: DependencyValidationDeps = defaultDeps,
+): Promise<ValidationFieldError[]> {
+  const errors: ValidationFieldError[] = [];
+
+  // Check provider enabled status
+  const uniqueProviders = [...new Set(providers.map((s) => s.id))];
+  const enabledChecks = await Promise.all(
+    uniqueProviders.map((id) => deps.isProviderEnabled(id, applicationId)),
+  );
+  const disabled = new Set<string>();
+  for (let i = 0; i < uniqueProviders.length; i++) {
+    if (!enabledChecks[i]) {
+      const id = uniqueProviders[i]!;
+      disabled.add(id);
+      errors.push({
+        field: `providers.${id}`,
+        code: "provider_not_enabled",
+        message: `Provider '${id}' is not configured`,
+      });
+    }
+  }
+
+  // Missing profiles
+  const missingProfile = new Set<string>();
+  for (const provider of providers) {
+    if (disabled.has(provider.id)) continue;
+    if (!providerProfiles[provider.id]) {
+      missingProfile.add(provider.id);
+      errors.push({
+        field: `providers.${provider.id}`,
+        code: "dependency_not_satisfied",
+        message: `Provider '${provider.id}' is not connected`,
+      });
+    }
+  }
+
+  // Credential ids — only for providers that passed the two checks above
+  const checkable = providers.filter((p) => !disabled.has(p.id) && !missingProfile.has(p.id));
+  const credentialIds = await Promise.all(
+    checkable.map((p) => deps.getProviderCredentialId(applicationId, p.id)),
+  );
+  const withCredentials: Array<{ provider: AgentProviderRequirement; credentialId: string }> = [];
+  for (let i = 0; i < checkable.length; i++) {
+    const provider = checkable[i]!;
+    const credentialId = credentialIds[i];
+    if (!credentialId) {
+      errors.push({
+        field: `providers.${provider.id}`,
+        code: "provider_not_configured",
+        message: `Provider '${provider.id}' is no longer configured for this application`,
+      });
+    } else {
+      withCredentials.push({ provider, credentialId });
+    }
+  }
+
+  const statuses = await Promise.all(
+    withCredentials.map(({ provider, credentialId }) =>
+      deps.getConnectionStatus(
+        provider.id,
+        providerProfiles[provider.id]!.profileId,
+        orgId,
+        credentialId,
+      ),
+    ),
+  );
+
+  for (let i = 0; i < withCredentials.length; i++) {
+    const provider = withCredentials[i]!.provider;
+    const conn = statuses[i]!;
+
+    if (conn.status === "not_connected") {
+      errors.push({
+        field: `providers.${provider.id}`,
+        code: "dependency_not_satisfied",
+        message: `Provider '${provider.id}' is not connected`,
+      });
+      continue;
+    }
+
+    if (conn.status === "needs_reconnection") {
+      errors.push({
+        field: `providers.${provider.id}`,
+        code: "needs_reconnection",
+        message: `Provider '${provider.id}' needs to be reconnected (provider configuration changed)`,
+      });
+      continue;
+    }
+
+    if (provider.scopes && provider.scopes.length > 0 && conn.scopesGranted) {
+      const scopeResult = deps.validateScopes(conn.scopesGranted, provider.scopes);
+      if (!scopeResult.sufficient) {
+        errors.push({
+          field: `providers.${provider.id}`,
+          code: "scope_insufficient",
+          message: `Provider '${provider.id}' requires additional permissions: ${scopeResult.missing.join(", ")}`,
+        });
+      }
+    }
+  }
+
+  return errors;
+}
+
+/**
  * Validate that all required provider dependencies are satisfied.
  * providerProfiles maps providerId → connectionProfileId.
  * Throws ApiError on first unsatisfied dependency.
@@ -48,88 +162,35 @@ export async function validateAgentDependencies(
   applicationId: string,
   deps: DependencyValidationDeps = defaultDeps,
 ): Promise<void> {
-  // Check provider enabled status
-  const uniqueProviders = [...new Set(providers.map((s) => s.id))];
-  for (const providerId of uniqueProviders) {
-    const enabled = await deps.isProviderEnabled(providerId, applicationId);
-    if (!enabled) {
-      throw new ApiError({
-        status: 400,
-        code: "provider_not_enabled",
-        title: "Provider Not Enabled",
-        detail: `Provider '${providerId}' is not configured`,
-      });
-    }
-  }
-
-  // Check for missing profiles first (no async needed)
-  for (const provider of providers) {
-    const entry = providerProfiles[provider.id];
-    if (!entry) {
-      throw new ApiError({
-        status: 400,
-        code: "dependency_not_satisfied",
-        title: "Dependency Not Satisfied",
-        detail: `Provider '${provider.id}' is not connected`,
-      });
-    }
-  }
-
-  // Resolve providerCredentialIds and fetch connection statuses in parallel
-  const credentialIds = await Promise.all(
-    providers.map((p) => deps.getProviderCredentialId(applicationId, p.id)),
+  const errors = await collectDependencyErrors(
+    providers,
+    providerProfiles,
+    orgId,
+    applicationId,
+    deps,
   );
+  if (errors.length === 0) return;
+  const first = errors[0]!;
+  throw new ApiError({
+    status: 400,
+    code: first.code,
+    title: codeToTitle(first.code),
+    detail: first.message,
+  });
+}
 
-  // Fail fast if any provider credential is missing from this application
-  for (let i = 0; i < providers.length; i++) {
-    if (!credentialIds[i]) {
-      throw new ApiError({
-        status: 400,
-        code: "provider_not_configured",
-        title: "Provider Not Configured",
-        detail: `Provider '${providers[i]!.id}' is no longer configured for this application`,
-      });
-    }
-  }
-
-  const statuses = await Promise.all(
-    providers.map((p, i) =>
-      deps.getConnectionStatus(p.id, providerProfiles[p.id]!.profileId, orgId, credentialIds[i]!),
-    ),
-  );
-
-  for (let i = 0; i < providers.length; i++) {
-    const provider = providers[i]!;
-    const conn = statuses[i]!;
-
-    if (conn.status === "not_connected") {
-      throw new ApiError({
-        status: 400,
-        code: "dependency_not_satisfied",
-        title: "Dependency Not Satisfied",
-        detail: `Provider '${provider.id}' is not connected`,
-      });
-    }
-
-    if (conn.status === "needs_reconnection") {
-      throw new ApiError({
-        status: 400,
-        code: "needs_reconnection",
-        title: "Needs Reconnection",
-        detail: `Provider '${provider.id}' needs to be reconnected (provider configuration changed)`,
-      });
-    }
-
-    if (provider.scopes && provider.scopes.length > 0 && conn.scopesGranted) {
-      const scopeResult = deps.validateScopes(conn.scopesGranted, provider.scopes);
-      if (!scopeResult.sufficient) {
-        throw new ApiError({
-          status: 400,
-          code: "scope_insufficient",
-          title: "Scope Insufficient",
-          detail: `Provider '${provider.id}' requires additional permissions: ${scopeResult.missing.join(", ")}`,
-        });
-      }
-    }
+function codeToTitle(code: string): string {
+  switch (code) {
+    case "provider_not_enabled":
+      return "Provider Not Enabled";
+    case "provider_not_configured":
+      return "Provider Not Configured";
+    case "needs_reconnection":
+      return "Needs Reconnection";
+    case "scope_insufficient":
+      return "Scope Insufficient";
+    case "dependency_not_satisfied":
+    default:
+      return "Dependency Not Satisfied";
   }
 }

--- a/apps/api/src/services/dependency-validation.ts
+++ b/apps/api/src/services/dependency-validation.ts
@@ -174,23 +174,7 @@ export async function validateAgentDependencies(
   throw new ApiError({
     status: 400,
     code: first.code,
-    title: codeToTitle(first.code),
+    title: first.code,
     detail: first.message,
   });
-}
-
-function codeToTitle(code: string): string {
-  switch (code) {
-    case "provider_not_enabled":
-      return "Provider Not Enabled";
-    case "provider_not_configured":
-      return "Provider Not Configured";
-    case "needs_reconnection":
-      return "Needs Reconnection";
-    case "scope_insufficient":
-      return "Scope Insufficient";
-    case "dependency_not_satisfied":
-    default:
-      return "Dependency Not Satisfied";
-  }
 }

--- a/apps/api/src/services/dependency-validation.ts
+++ b/apps/api/src/services/dependency-validation.ts
@@ -50,7 +50,9 @@ export async function collectDependencyErrors(
 ): Promise<ValidationFieldError[]> {
   const errors: ValidationFieldError[] = [];
 
-  // Check provider enabled status
+  // Check provider enabled status. Deduplicate by id so we run one query per
+  // distinct provider and avoid emitting the same error twice when a provider
+  // is declared with multiple scope sets in the same manifest.
   const uniqueProviders = [...new Set(providers.map((s) => s.id))];
   const enabledChecks = await Promise.all(
     uniqueProviders.map((id) => deps.isProviderEnabled(id, applicationId)),
@@ -63,75 +65,89 @@ export async function collectDependencyErrors(
       errors.push({
         field: `providers.${id}`,
         code: "provider_not_enabled",
+        title: "Provider Not Enabled",
         message: `Provider '${id}' is not configured`,
       });
     }
   }
 
-  // Missing profiles
+  // Missing profiles — iterate unique ids so duplicated requirements don't
+  // produce duplicate entries for the same provider.
   const missingProfile = new Set<string>();
-  for (const provider of providers) {
-    if (disabled.has(provider.id)) continue;
-    if (!providerProfiles[provider.id]) {
-      missingProfile.add(provider.id);
+  for (const id of uniqueProviders) {
+    if (disabled.has(id)) continue;
+    if (!providerProfiles[id]) {
+      missingProfile.add(id);
       errors.push({
-        field: `providers.${provider.id}`,
+        field: `providers.${id}`,
         code: "dependency_not_satisfied",
-        message: `Provider '${provider.id}' is not connected`,
+        title: "Dependency Not Satisfied",
+        message: `Provider '${id}' is not connected`,
       });
     }
   }
 
-  // Credential ids — only for providers that passed the two checks above
-  const checkable = providers.filter((p) => !disabled.has(p.id) && !missingProfile.has(p.id));
+  // Credential ids — only for providers that passed the two checks above.
+  // One lookup per unique provider; scope checks below still iterate the
+  // full `providers` list to validate each declared scope set.
+  const checkableIds = uniqueProviders.filter((id) => !disabled.has(id) && !missingProfile.has(id));
   const credentialIds = await Promise.all(
-    checkable.map((p) => deps.getProviderCredentialId(applicationId, p.id)),
+    checkableIds.map((id) => deps.getProviderCredentialId(applicationId, id)),
   );
-  const withCredentials: Array<{ provider: AgentProviderRequirement; credentialId: string }> = [];
-  for (let i = 0; i < checkable.length; i++) {
-    const provider = checkable[i]!;
+  const credentialById = new Map<string, string>();
+  for (let i = 0; i < checkableIds.length; i++) {
+    const id = checkableIds[i]!;
     const credentialId = credentialIds[i];
     if (!credentialId) {
       errors.push({
-        field: `providers.${provider.id}`,
+        field: `providers.${id}`,
         code: "provider_not_configured",
-        message: `Provider '${provider.id}' is no longer configured for this application`,
+        title: "Provider Not Configured",
+        message: `Provider '${id}' is no longer configured for this application`,
       });
     } else {
-      withCredentials.push({ provider, credentialId });
+      credentialById.set(id, credentialId);
     }
   }
 
+  // Status lookup is per-provider, but scope validation is per-requirement
+  // (a provider may be declared with several scope sets).
+  const statusIds = [...credentialById.keys()];
   const statuses = await Promise.all(
-    withCredentials.map(({ provider, credentialId }) =>
-      deps.getConnectionStatus(
-        provider.id,
-        providerProfiles[provider.id]!.profileId,
-        orgId,
-        credentialId,
-      ),
+    statusIds.map((id) =>
+      deps.getConnectionStatus(id, providerProfiles[id]!.profileId, orgId, credentialById.get(id)!),
     ),
   );
+  const statusById = new Map(statusIds.map((id, i) => [id, statuses[i]!] as const));
 
-  for (let i = 0; i < withCredentials.length; i++) {
-    const provider = withCredentials[i]!.provider;
-    const conn = statuses[i]!;
+  const statusErrorEmitted = new Set<string>();
+  for (const provider of providers) {
+    const conn = statusById.get(provider.id);
+    if (!conn) continue;
 
     if (conn.status === "not_connected") {
-      errors.push({
-        field: `providers.${provider.id}`,
-        code: "dependency_not_satisfied",
-        message: `Provider '${provider.id}' is not connected`,
-      });
+      if (!statusErrorEmitted.has(provider.id)) {
+        statusErrorEmitted.add(provider.id);
+        errors.push({
+          field: `providers.${provider.id}`,
+          code: "dependency_not_satisfied",
+          title: "Dependency Not Satisfied",
+          message: `Provider '${provider.id}' is not connected`,
+        });
+      }
       continue;
     }
 
     if (conn.status === "needs_reconnection") {
-      errors.push({
-        field: `providers.${provider.id}`,
-        code: "needs_reconnection",
-        message: `Provider '${provider.id}' needs to be reconnected (provider configuration changed)`,
-      });
+      if (!statusErrorEmitted.has(provider.id)) {
+        statusErrorEmitted.add(provider.id);
+        errors.push({
+          field: `providers.${provider.id}`,
+          code: "needs_reconnection",
+          title: "Needs Reconnection",
+          message: `Provider '${provider.id}' needs to be reconnected (provider configuration changed)`,
+        });
+      }
       continue;
     }
 
@@ -141,6 +157,7 @@ export async function collectDependencyErrors(
         errors.push({
           field: `providers.${provider.id}`,
           code: "scope_insufficient",
+          title: "Scope Insufficient",
           message: `Provider '${provider.id}' requires additional permissions: ${scopeResult.missing.join(", ")}`,
         });
       }
@@ -153,7 +170,8 @@ export async function collectDependencyErrors(
 /**
  * Validate that all required provider dependencies are satisfied.
  * providerProfiles maps providerId → connectionProfileId.
- * Throws ApiError on first unsatisfied dependency.
+ * Throws ApiError on first unsatisfied dependency, preserving the
+ * historical human-readable title (carried on each field entry).
  */
 export async function validateAgentDependencies(
   providers: AgentProviderRequirement[],
@@ -174,7 +192,7 @@ export async function validateAgentDependencies(
   throw new ApiError({
     status: 400,
     code: first.code,
-    title: first.code,
+    title: first.title ?? first.code,
     detail: first.message,
   });
 }

--- a/apps/api/src/services/inline-manifest-validation.ts
+++ b/apps/api/src/services/inline-manifest-validation.ts
@@ -71,16 +71,23 @@ export function validateInlineManifest(
   }
 
   // --- 4. Structural AFPS validation (dispatches by `type` field) ---
+  // On failure we record the errors but continue — dep-count and URI caps
+  // read the raw manifest shape and don't need the parsed result, so surfacing
+  // them alongside structural errors gives callers a single-round-trip view.
   const structural = validateManifest(input.manifest);
   if (!structural.valid) {
     for (const e of structural.errors) errors.push(`manifest.${e}`);
-    return { valid: false, errors };
   }
 
-  const manifest = structural.manifest as Manifest;
+  const manifest = structural.valid ? (structural.manifest as Manifest) : undefined;
 
   // --- 5. Dependency count caps ---
-  const { skillIds, toolIds, providerIds } = extractDepsFromManifest(manifest);
+  // `extractDepsFromManifest` walks the typed shape. For unparsed manifests we
+  // fall back to a best-effort view of `input.manifest` so dep-count and
+  // URI-cap violations still surface when structural validation fails.
+  const { skillIds, toolIds, providerIds } = extractDepsFromManifest(
+    (manifest ?? input.manifest) as Partial<Manifest>,
+  );
   if (skillIds.length > limits.max_skills) {
     errors.push(
       `manifest.dependencies.skills: too many (${skillIds.length} > ${limits.max_skills})`,
@@ -131,5 +138,5 @@ export function validateInlineManifest(
     return { valid: false, errors };
   }
 
-  return { valid: true, errors: [], manifest, canonicalManifestJson: canonical };
+  return { valid: true, errors: [], manifest: manifest!, canonicalManifestJson: canonical };
 }

--- a/apps/api/src/services/inline-manifest-validation.ts
+++ b/apps/api/src/services/inline-manifest-validation.ts
@@ -82,12 +82,22 @@ export function validateInlineManifest(
   const manifest = structural.valid ? (structural.manifest as Manifest) : undefined;
 
   // --- 5. Dependency count caps ---
-  // `extractDepsFromManifest` walks the typed shape. For unparsed manifests we
-  // fall back to a best-effort view of `input.manifest` so dep-count and
-  // URI-cap violations still surface when structural validation fails.
-  const { skillIds, toolIds, providerIds } = extractDepsFromManifest(
-    (manifest ?? input.manifest) as Partial<Manifest>,
-  );
+  // `extractDepsFromManifest` is defensive (it routes every read through
+  // `asRecord`) so this call should never throw on malformed input. The
+  // try/catch is belt-and-suspenders: if a future refactor relaxes the
+  // helper's tolerance, a malformed `dependencies` payload still surfaces a
+  // structured error instead of bubbling a TypeError to the request handler.
+  let skillIds: string[] = [];
+  let toolIds: string[] = [];
+  let providerIds: string[] = [];
+  try {
+    const deps = extractDepsFromManifest((manifest ?? input.manifest) as Partial<Manifest>);
+    skillIds = deps.skillIds;
+    toolIds = deps.toolIds;
+    providerIds = deps.providerIds;
+  } catch {
+    errors.push("manifest.dependencies: malformed shape");
+  }
   if (skillIds.length > limits.max_skills) {
     errors.push(
       `manifest.dependencies.skills: too many (${skillIds.length} > ${limits.max_skills})`,

--- a/apps/api/src/services/inline-manifest-validation.ts
+++ b/apps/api/src/services/inline-manifest-validation.ts
@@ -134,9 +134,9 @@ export function validateInlineManifest(
     );
   }
 
-  if (errors.length > 0) {
+  if (errors.length > 0 || !manifest) {
     return { valid: false, errors };
   }
 
-  return { valid: true, errors: [], manifest: manifest!, canonicalManifestJson: canonical };
+  return { valid: true, errors: [], manifest, canonicalManifestJson: canonical };
 }

--- a/apps/api/src/services/inline-run-preflight.ts
+++ b/apps/api/src/services/inline-run-preflight.ts
@@ -37,6 +37,7 @@ import {
   type ValidationFieldError,
 } from "../lib/errors.ts";
 import { asJSONSchemaObject } from "@appstrate/core/form";
+import { logger } from "../lib/logger.ts";
 import { validateConfig, validateInput } from "./schema.ts";
 import { validateInlineManifest } from "./inline-manifest-validation.ts";
 import { buildShadowLoadedPackage, generateShadowPackageId } from "./inline-run.ts";
@@ -191,13 +192,16 @@ export async function runInlinePreflight(params: {
       // network timeout, programmer error) must bubble as-is so the error
       // handler emits a 5xx and alerting fires.
       if (mode === "fail-fast" || !(err instanceof ApiError)) throw err;
-      push([apiErrorToField(err, "providers")]);
+      push(apiErrorToFields(err, "providers"));
       providerProfiles = {};
     }
 
-    // In accumulate mode, stages 1–3 already covered prompt (via the manifest
-    // structural check) and config (via AJV at stage 3). Tell readiness to
-    // skip those so the same field never appears twice in `errors[]`.
+    // In accumulate mode, stage 3 already validated config via AJV against
+    // the manifest schema — tell readiness to skip its config check so the
+    // same field never appears twice in `errors[]`. Prompt is NOT skipped:
+    // stage 1's structural check only validates prompt type and byte size,
+    // not emptiness, so readiness remains the single source for the
+    // `empty_prompt` signal.
     if (mode === "fail-fast") {
       await validateAgentReadiness({
         agent: probeAgent,
@@ -214,7 +218,7 @@ export async function runInlinePreflight(params: {
           orgId,
           config: effectiveConfig,
           applicationId,
-          skip: { prompt: true, config: true },
+          skip: { config: true },
         }),
       );
     }
@@ -226,9 +230,16 @@ export async function runInlinePreflight(params: {
 
   // Guaranteed non-null: accumulate mode throws above when manifest is
   // missing (structural errors were collected), and fail-fast throws at
-  // stage 1 before reaching this point. The internalError() serialises as
-  // a proper 500 RFC 9457 response if the invariant ever breaks.
+  // stage 1 before reaching this point. If we ever land here it means a
+  // structural failure produced zero error messages — a real bug. Log it
+  // so the regression is diagnosable rather than masked behind a 500.
   if (!manifest) {
+    logger.error("preflight invariant broken: reached return without a parsed manifest", {
+      orgId,
+      applicationId,
+      mode,
+      accumulated: accumulated.length,
+    });
     throw internalError();
   }
 
@@ -244,30 +255,40 @@ export async function runInlinePreflight(params: {
   };
 }
 
-/** Parse an inline-manifest error string (`"path: message"`) into a field entry. */
+/**
+ * Parse an inline-manifest error string (`"path: message"`) into a field entry.
+ *
+ * `validateManifest` returns flat strings, so we reconstruct the structured
+ * shape here. The split is anchored on a strict path-like prefix
+ * (alphanumeric, dots, brackets) so messages that themselves contain `": "`
+ * (e.g. quoted regex patterns) don't truncate the human-readable part.
+ */
+const PATH_PREFIX_RE = /^([A-Za-z_][A-Za-z0-9_.[\]]*): (.+)$/s;
 function toFieldError(raw: string, code: string): ValidationFieldError {
-  const idx = raw.indexOf(": ");
-  if (idx === -1)
-    return { field: "manifest", code, title: "Invalid Inline Manifest", message: raw };
-  return {
-    field: raw.slice(0, idx),
-    code,
-    title: "Invalid Inline Manifest",
-    message: raw.slice(idx + 2),
-  };
+  const m = PATH_PREFIX_RE.exec(raw);
+  if (!m) return { field: "manifest", code, title: "Invalid Inline Manifest", message: raw };
+  return { field: m[1]!, code, title: "Invalid Inline Manifest", message: m[2]! };
 }
 
 /**
- * Fold a caught ApiError into a ValidationFieldError.
+ * Fold a caught ApiError into one or more ValidationFieldError entries.
+ *
+ * If the caught error already carries a populated `errors[]` (e.g. a nested
+ * helper that aggregates multiple problems), we forward those entries as-is
+ * so we don't collapse rich detail into a single line. Otherwise we synth a
+ * single entry from `param` / `code` / `title` / `message`.
  *
  * Callers MUST have already verified `err instanceof ApiError` — non-ApiError
  * instances represent infrastructure failures and should never reach here.
  */
-function apiErrorToField(err: ApiError, fallbackField: string): ValidationFieldError {
-  return {
-    field: err.param ?? fallbackField,
-    code: err.code,
-    title: err.title,
-    message: err.message,
-  };
+function apiErrorToFields(err: ApiError, fallbackField: string): ValidationFieldError[] {
+  if (err.fieldErrors && err.fieldErrors.length > 0) return err.fieldErrors;
+  return [
+    {
+      field: err.param ?? fallbackField,
+      code: err.code,
+      title: err.title,
+      message: err.message,
+    },
+  ];
 }

--- a/apps/api/src/services/inline-run-preflight.ts
+++ b/apps/api/src/services/inline-run-preflight.ts
@@ -80,22 +80,12 @@ export async function runInlinePreflight(params: {
   const { orgId, applicationId, actor, body, mode = "fail-fast" } = params;
 
   // In accumulate mode we gather problems from every independent stage and
-  // throw once at the end. The shape of individual entries matches every
-  // other `validation_failed` response emitted by the platform.
+  // throw once at the end. In fail-fast mode stages throw as soon as they
+  // detect a problem. `push` is a pure accumulator; every throw site is
+  // explicit so the caller sees which stage raised and with which code/title.
   const accumulated: ValidationFieldError[] = [];
-  const collect = (errs: ValidationFieldError[], throwCode?: string): void => {
-    if (errs.length === 0) return;
-    if (mode === "fail-fast") {
-      const code = throwCode ?? "validation_failed";
-      throw new ApiError({
-        status: 400,
-        code,
-        title: code,
-        detail: `${errs[0]!.field}: ${errs[0]!.message}`,
-        errors: errs,
-      });
-    }
-    accumulated.push(...errs);
+  const push = (errs: ValidationFieldError[]): void => {
+    if (errs.length > 0) accumulated.push(...errs);
   };
 
   // ----- 1. Manifest shape -----
@@ -105,10 +95,17 @@ export async function runInlinePreflight(params: {
     limits: getInlineRunLimits(),
   });
   if (!validated.valid) {
-    collect(
-      validated.errors.map((e) => toFieldError(e, "invalid_inline_manifest")),
-      "invalid_inline_manifest",
-    );
+    const entries = validated.errors.map((e) => toFieldError(e, "invalid_inline_manifest"));
+    if (mode === "fail-fast") {
+      throw new ApiError({
+        status: 400,
+        code: "invalid_inline_manifest",
+        title: "Invalid Inline Manifest",
+        detail: validated.errors.join("; "),
+        errors: entries,
+      });
+    }
+    push(entries);
   }
 
   // A parsed manifest is only available when structural validation passed.
@@ -120,7 +117,9 @@ export async function runInlinePreflight(params: {
   // ----- 2. Body-field validation -----
   const providerProfilesParsed = providerProfilesSchema.safeParse(body.providerProfiles);
   if (!providerProfilesParsed.success) {
-    collect(zodIssuesToFieldErrors(providerProfilesParsed.error.issues, "providerProfiles"));
+    const entries = zodIssuesToFieldErrors(providerProfilesParsed.error.issues, "providerProfiles");
+    if (mode === "fail-fast") throw validationFailed(entries);
+    push(entries);
   }
   const providerProfilesOverride = providerProfilesParsed.success
     ? providerProfilesParsed.data
@@ -143,13 +142,14 @@ export async function runInlinePreflight(params: {
     if (configSchema) {
       const cv = validateConfig(effectiveConfig, asJSONSchemaObject(configSchema));
       if (!cv.valid) {
-        collect(
-          cv.errors.map((e) => ({
-            field: e.field ? `config.${e.field}` : "config",
-            code: "invalid_config",
-            message: e.message,
-          })),
-        );
+        const entries: ValidationFieldError[] = cv.errors.map((e) => ({
+          field: e.field ? `config.${e.field}` : "config",
+          code: "invalid_config",
+          title: "Invalid Config",
+          message: e.message,
+        }));
+        if (mode === "fail-fast") throw validationFailed(entries);
+        push(entries);
       }
     }
 
@@ -157,13 +157,14 @@ export async function runInlinePreflight(params: {
     if (inputSchema) {
       const iv = validateInput(effectiveInput ?? undefined, asJSONSchemaObject(inputSchema));
       if (!iv.valid) {
-        collect(
-          iv.errors.map((e) => ({
-            field: e.field ? `input.${e.field}` : "input",
-            code: "invalid_input",
-            message: e.message,
-          })),
-        );
+        const entries: ValidationFieldError[] = iv.errors.map((e) => ({
+          field: e.field ? `input.${e.field}` : "input",
+          code: "invalid_input",
+          title: "Invalid Input",
+          message: e.message,
+        }));
+        if (mode === "fail-fast") throw validationFailed(entries);
+        push(entries);
       }
     }
   }
@@ -190,10 +191,13 @@ export async function runInlinePreflight(params: {
       // network timeout, programmer error) must bubble as-is so the error
       // handler emits a 5xx and alerting fires.
       if (mode === "fail-fast" || !(err instanceof ApiError)) throw err;
-      accumulated.push(apiErrorToField(err, "providers"));
+      push([apiErrorToField(err, "providers")]);
       providerProfiles = {};
     }
 
+    // In accumulate mode, stages 1–3 already covered prompt (via the manifest
+    // structural check) and config (via AJV at stage 3). Tell readiness to
+    // skip those so the same field never appears twice in `errors[]`.
     if (mode === "fail-fast") {
       await validateAgentReadiness({
         agent: probeAgent,
@@ -203,14 +207,15 @@ export async function runInlinePreflight(params: {
         applicationId,
       });
     } else {
-      accumulated.push(
-        ...(await collectAgentReadinessErrors({
+      push(
+        await collectAgentReadinessErrors({
           agent: probeAgent,
           providerProfiles,
           orgId,
           config: effectiveConfig,
           applicationId,
-        })),
+          skip: { prompt: true, config: true },
+        }),
       );
     }
   }
@@ -242,8 +247,14 @@ export async function runInlinePreflight(params: {
 /** Parse an inline-manifest error string (`"path: message"`) into a field entry. */
 function toFieldError(raw: string, code: string): ValidationFieldError {
   const idx = raw.indexOf(": ");
-  if (idx === -1) return { field: "manifest", code, message: raw };
-  return { field: raw.slice(0, idx), code, message: raw.slice(idx + 2) };
+  if (idx === -1)
+    return { field: "manifest", code, title: "Invalid Inline Manifest", message: raw };
+  return {
+    field: raw.slice(0, idx),
+    code,
+    title: "Invalid Inline Manifest",
+    message: raw.slice(idx + 2),
+  };
 }
 
 /**
@@ -256,6 +267,7 @@ function apiErrorToField(err: ApiError, fallbackField: string): ValidationFieldE
   return {
     field: err.param ?? fallbackField,
     code: err.code,
+    title: err.title,
     message: err.message,
   };
 }

--- a/apps/api/src/services/inline-run-preflight.ts
+++ b/apps/api/src/services/inline-run-preflight.ts
@@ -10,25 +10,35 @@
  *   4. Provider profile resolution (reads DB, no writes)
  *   5. Agent readiness (prompt, skills, tools, provider deps, config)
  *
- * Used by:
- *   - POST /api/runs/inline — calls this, then inserts the shadow row and
- *     fires the pipeline. Running it first means invalid manifests no longer
- *     leave orphan shadow rows.
- *   - POST /api/runs/inline/validate — calls this, returns 200 on success.
+ * Two modes:
+ *   - "fail-fast" (default) — throws on the first failing stage. Used by
+ *     POST /api/runs/inline; running the pipeline with partial validation
+ *     would be pointless, so early exit saves work.
+ *   - "accumulate" — runs every stage that is independent of the previous
+ *     one's output, collects ValidationFieldError entries from all of them,
+ *     and throws a single `validation_failed` with every problem surfaced.
+ *     Used by POST /api/runs/inline/validate, whose entire purpose is to let
+ *     developers iterate on a manifest in one round-trip.
  *
  * Throws `ApiError` on any failure (same shape the routes already emit).
  */
 import { z } from "zod";
 import type { Actor } from "../lib/actor.ts";
 import type { AgentManifest, ProviderProfileMap } from "../types/index.ts";
-import { ApiError, invalidRequest } from "../lib/errors.ts";
+import {
+  ApiError,
+  invalidRequest,
+  validationFailed,
+  zodIssuesToFieldErrors,
+  type ValidationFieldError,
+} from "../lib/errors.ts";
 import { asJSONSchemaObject } from "@appstrate/core/form";
 import { validateConfig, validateInput } from "./schema.ts";
 import { validateInlineManifest } from "./inline-manifest-validation.ts";
 import { buildShadowLoadedPackage, generateShadowPackageId } from "./inline-run.ts";
 import { getInlineRunLimits } from "./run-limits.ts";
 import { resolveManifestProviders } from "../lib/manifest-utils.ts";
-import { validateAgentReadiness } from "./agent-readiness.ts";
+import { validateAgentReadiness, collectAgentReadinessErrors } from "./agent-readiness.ts";
 import { resolveActorProfileContext, resolveProviderProfiles } from "./connection-profiles.ts";
 
 export interface InlineRunBody {
@@ -59,8 +69,14 @@ export async function runInlinePreflight(params: {
   applicationId: string;
   actor: Actor | null;
   body: InlineRunBody;
+  mode?: "fail-fast" | "accumulate";
 }): Promise<InlineRunPreflightResult> {
-  const { orgId, applicationId, actor, body } = params;
+  const { orgId, applicationId, actor, body, mode = "fail-fast" } = params;
+
+  // In accumulate mode we gather problems from every independent stage and
+  // throw once at the end. The shape of individual entries matches every
+  // other `validation_failed` response emitted by the platform.
+  const accumulated: ValidationFieldError[] = [];
 
   // ----- 1. Manifest shape -----
   const validated = validateInlineManifest({
@@ -69,82 +85,182 @@ export async function runInlinePreflight(params: {
     limits: getInlineRunLimits(),
   });
   if (!validated.valid) {
-    throw new ApiError({
-      status: 400,
-      code: "invalid_inline_manifest",
-      title: "Invalid Inline Manifest",
-      detail: validated.errors.join("; "),
-    });
+    if (mode === "fail-fast") {
+      throw new ApiError({
+        status: 400,
+        code: "invalid_inline_manifest",
+        title: "Invalid Inline Manifest",
+        detail: validated.errors.join("; "),
+        errors: validated.errors.map((e) => toFieldError(e, "invalid_inline_manifest")),
+      });
+    }
+    for (const err of validated.errors) {
+      accumulated.push(toFieldError(err, "invalid_inline_manifest"));
+    }
   }
-  const manifest = validated.manifest as AgentManifest;
-  const prompt = body.prompt as string;
+
+  // A parsed manifest is only available when structural validation passed.
+  // Later stages that strictly need it (AJV config/input schemas, readiness)
+  // are gated on this in accumulate mode; fail-fast has already thrown.
+  const manifest = validated.valid ? (validated.manifest as AgentManifest) : undefined;
+  const prompt = typeof body.prompt === "string" ? body.prompt : "";
 
   // ----- 2. Body-field validation -----
-  const providerProfilesOverride = providerProfilesSchema.safeParse(body.providerProfiles);
-  if (!providerProfilesOverride.success) {
-    throw invalidRequest("providerProfiles must map providerId → profileUUID", "providerProfiles");
+  const providerProfilesParsed = providerProfilesSchema.safeParse(body.providerProfiles);
+  if (!providerProfilesParsed.success) {
+    if (mode === "fail-fast") {
+      throw invalidRequest(
+        "providerProfiles must map providerId → profileUUID",
+        "providerProfiles",
+      );
+    }
+    accumulated.push(
+      ...zodIssuesToFieldErrors(providerProfilesParsed.error.issues, "providerProfiles"),
+    );
   }
+  const providerProfilesOverride = providerProfilesParsed.success
+    ? providerProfilesParsed.data
+    : undefined;
   const modelIdOverride = body.modelId ?? null;
   const proxyIdOverride = body.proxyId ?? null;
 
   // ----- 3. config + input against manifest schemas (AJV) -----
-  const configSchema = manifest.config?.schema;
   const effectiveConfig =
     body.config && typeof body.config === "object" && !Array.isArray(body.config)
       ? (body.config as Record<string, unknown>)
       : {};
-  if (configSchema) {
-    const cv = validateConfig(effectiveConfig, asJSONSchemaObject(configSchema));
-    if (!cv.valid) {
-      throw invalidRequest(`config: ${cv.errors?.[0]?.message ?? "invalid"}`, "config");
-    }
-  }
-
-  const inputSchema = manifest.input?.schema;
   const effectiveInput =
     body.input && typeof body.input === "object" && !Array.isArray(body.input)
       ? (body.input as Record<string, unknown>)
       : null;
-  if (inputSchema) {
-    const iv = validateInput(effectiveInput ?? undefined, asJSONSchemaObject(inputSchema));
-    if (!iv.valid) {
-      throw invalidRequest(`input: ${iv.errors?.[0]?.message ?? "invalid"}`, "input");
+
+  if (manifest) {
+    const configSchema = manifest.config?.schema;
+    if (configSchema) {
+      const cv = validateConfig(effectiveConfig, asJSONSchemaObject(configSchema));
+      if (!cv.valid) {
+        if (mode === "fail-fast") {
+          throw validationFailed(
+            cv.errors.map((e) => ({
+              field: e.field ? `config.${e.field}` : "config",
+              code: "invalid_config",
+              message: e.message,
+            })),
+          );
+        }
+        for (const e of cv.errors) {
+          accumulated.push({
+            field: e.field ? `config.${e.field}` : "config",
+            code: "invalid_config",
+            message: e.message,
+          });
+        }
+      }
+    }
+
+    const inputSchema = manifest.input?.schema;
+    if (inputSchema) {
+      const iv = validateInput(effectiveInput ?? undefined, asJSONSchemaObject(inputSchema));
+      if (!iv.valid) {
+        if (mode === "fail-fast") {
+          throw validationFailed(
+            iv.errors.map((e) => ({
+              field: e.field ? `input.${e.field}` : "input",
+              code: "invalid_input",
+              message: e.message,
+            })),
+          );
+        }
+        for (const e of iv.errors) {
+          accumulated.push({
+            field: e.field ? `input.${e.field}` : "input",
+            code: "invalid_input",
+            message: e.message,
+          });
+        }
+      }
     }
   }
 
   // ----- 4. Provider profile resolution + readiness -----
-  // Internal-only shadow (throwaway id, never persisted): we need a
-  // LoadedPackage shape to call resolveActorProfileContext +
-  // validateAgentReadiness, but nothing below leaks this id back to the
-  // caller — they build the real LoadedPackage from the inserted shadowId.
-  // `resolveActorProfileContext` looks up per-agent overrides by id and
-  // will simply miss (no such package exists yet) — intended for preflight.
-  const probeAgent = buildShadowLoadedPackage(generateShadowPackageId(), manifest, prompt);
+  // These stages require a parsed manifest. In accumulate mode, skip cleanly
+  // when structural validation failed — the manifest-shape errors already
+  // explain why. Fail-fast has thrown long before reaching here.
+  let providerProfiles: ProviderProfileMap = {};
+  if (manifest) {
+    const probeAgent = buildShadowLoadedPackage(generateShadowPackageId(), manifest, prompt);
+    const { defaultUserProfileId } = await resolveActorProfileContext(actor, probeAgent.id);
 
-  const { defaultUserProfileId } = await resolveActorProfileContext(actor, probeAgent.id);
-  const providerProfiles = await resolveProviderProfiles(
-    resolveManifestProviders(manifest),
-    defaultUserProfileId,
-    providerProfilesOverride.data,
-    null,
-    applicationId,
-  );
-  await validateAgentReadiness({
-    agent: probeAgent,
-    providerProfiles,
-    orgId,
-    config: effectiveConfig,
-    applicationId,
-  });
+    try {
+      providerProfiles = await resolveProviderProfiles(
+        resolveManifestProviders(manifest),
+        defaultUserProfileId,
+        providerProfilesOverride,
+        null,
+        applicationId,
+      );
+    } catch (err) {
+      if (mode === "fail-fast") throw err;
+      accumulated.push(apiErrorToField(err, "providers"));
+      providerProfiles = {};
+    }
+
+    if (mode === "fail-fast") {
+      await validateAgentReadiness({
+        agent: probeAgent,
+        providerProfiles,
+        orgId,
+        config: effectiveConfig,
+        applicationId,
+      });
+    } else {
+      accumulated.push(
+        ...(await collectAgentReadinessErrors({
+          agent: probeAgent,
+          providerProfiles,
+          orgId,
+          config: effectiveConfig,
+          applicationId,
+        })),
+      );
+    }
+  }
+
+  if (mode === "accumulate" && accumulated.length > 0) {
+    throw validationFailed(accumulated);
+  }
 
   return {
-    manifest,
+    manifest: manifest!,
     prompt,
     effectiveConfig,
     effectiveInput,
     providerProfiles,
-    providerProfilesOverride: providerProfilesOverride.data,
+    providerProfilesOverride,
     modelIdOverride,
     proxyIdOverride,
+  };
+}
+
+/** Parse an inline-manifest error string (`"path: message"`) into a field entry. */
+function toFieldError(raw: string, code: string): ValidationFieldError {
+  const idx = raw.indexOf(": ");
+  if (idx === -1) return { field: "manifest", code, message: raw };
+  return { field: raw.slice(0, idx), code, message: raw.slice(idx + 2) };
+}
+
+/** Best-effort conversion of a caught ApiError into a ValidationFieldError. */
+function apiErrorToField(err: unknown, fallbackField: string): ValidationFieldError {
+  if (err instanceof ApiError) {
+    return {
+      field: err.param ?? fallbackField,
+      code: err.code,
+      message: err.message,
+    };
+  }
+  return {
+    field: fallbackField,
+    code: "internal_error",
+    message: err instanceof Error ? err.message : String(err),
   };
 }

--- a/apps/api/src/services/inline-run-preflight.ts
+++ b/apps/api/src/services/inline-run-preflight.ts
@@ -20,6 +20,10 @@
  *     Used by POST /api/runs/inline/validate, whose entire purpose is to let
  *     developers iterate on a manifest in one round-trip.
  *
+ * Infrastructure errors (DB, Redis, Docker) always bubble up as-is — they
+ * are never converted into ValidationFieldError entries. Only `ApiError`
+ * instances raised by validation helpers are folded into the accumulator.
+ *
  * Throws `ApiError` on any failure (same shape the routes already emit).
  */
 import { z } from "zod";
@@ -27,7 +31,6 @@ import type { Actor } from "../lib/actor.ts";
 import type { AgentManifest, ProviderProfileMap } from "../types/index.ts";
 import {
   ApiError,
-  invalidRequest,
   validationFailed,
   zodIssuesToFieldErrors,
   type ValidationFieldError,
@@ -64,12 +67,14 @@ export interface InlineRunPreflightResult {
 
 const providerProfilesSchema = z.record(z.string(), z.uuid()).optional();
 
+type Mode = "fail-fast" | "accumulate";
+
 export async function runInlinePreflight(params: {
   orgId: string;
   applicationId: string;
   actor: Actor | null;
   body: InlineRunBody;
-  mode?: "fail-fast" | "accumulate";
+  mode?: Mode;
 }): Promise<InlineRunPreflightResult> {
   const { orgId, applicationId, actor, body, mode = "fail-fast" } = params;
 
@@ -77,6 +82,19 @@ export async function runInlinePreflight(params: {
   // throw once at the end. The shape of individual entries matches every
   // other `validation_failed` response emitted by the platform.
   const accumulated: ValidationFieldError[] = [];
+  const collect = (errs: ValidationFieldError[], throwCode?: string): void => {
+    if (errs.length === 0) return;
+    if (mode === "fail-fast") {
+      throw new ApiError({
+        status: 400,
+        code: throwCode ?? "validation_failed",
+        title: throwCode ? codeToTitle(throwCode) : "Validation Failed",
+        detail: `${errs[0]!.field}: ${errs[0]!.message}`,
+        errors: errs,
+      });
+    }
+    accumulated.push(...errs);
+  };
 
   // ----- 1. Manifest shape -----
   const validated = validateInlineManifest({
@@ -85,18 +103,10 @@ export async function runInlinePreflight(params: {
     limits: getInlineRunLimits(),
   });
   if (!validated.valid) {
-    if (mode === "fail-fast") {
-      throw new ApiError({
-        status: 400,
-        code: "invalid_inline_manifest",
-        title: "Invalid Inline Manifest",
-        detail: validated.errors.join("; "),
-        errors: validated.errors.map((e) => toFieldError(e, "invalid_inline_manifest")),
-      });
-    }
-    for (const err of validated.errors) {
-      accumulated.push(toFieldError(err, "invalid_inline_manifest"));
-    }
+    collect(
+      validated.errors.map((e) => toFieldError(e, "invalid_inline_manifest")),
+      "invalid_inline_manifest",
+    );
   }
 
   // A parsed manifest is only available when structural validation passed.
@@ -108,15 +118,7 @@ export async function runInlinePreflight(params: {
   // ----- 2. Body-field validation -----
   const providerProfilesParsed = providerProfilesSchema.safeParse(body.providerProfiles);
   if (!providerProfilesParsed.success) {
-    if (mode === "fail-fast") {
-      throw invalidRequest(
-        "providerProfiles must map providerId → profileUUID",
-        "providerProfiles",
-      );
-    }
-    accumulated.push(
-      ...zodIssuesToFieldErrors(providerProfilesParsed.error.issues, "providerProfiles"),
-    );
+    collect(zodIssuesToFieldErrors(providerProfilesParsed.error.issues, "providerProfiles"));
   }
   const providerProfilesOverride = providerProfilesParsed.success
     ? providerProfilesParsed.data
@@ -139,22 +141,13 @@ export async function runInlinePreflight(params: {
     if (configSchema) {
       const cv = validateConfig(effectiveConfig, asJSONSchemaObject(configSchema));
       if (!cv.valid) {
-        if (mode === "fail-fast") {
-          throw validationFailed(
-            cv.errors.map((e) => ({
-              field: e.field ? `config.${e.field}` : "config",
-              code: "invalid_config",
-              message: e.message,
-            })),
-          );
-        }
-        for (const e of cv.errors) {
-          accumulated.push({
+        collect(
+          cv.errors.map((e) => ({
             field: e.field ? `config.${e.field}` : "config",
             code: "invalid_config",
             message: e.message,
-          });
-        }
+          })),
+        );
       }
     }
 
@@ -162,22 +155,13 @@ export async function runInlinePreflight(params: {
     if (inputSchema) {
       const iv = validateInput(effectiveInput ?? undefined, asJSONSchemaObject(inputSchema));
       if (!iv.valid) {
-        if (mode === "fail-fast") {
-          throw validationFailed(
-            iv.errors.map((e) => ({
-              field: e.field ? `input.${e.field}` : "input",
-              code: "invalid_input",
-              message: e.message,
-            })),
-          );
-        }
-        for (const e of iv.errors) {
-          accumulated.push({
+        collect(
+          iv.errors.map((e) => ({
             field: e.field ? `input.${e.field}` : "input",
             code: "invalid_input",
             message: e.message,
-          });
-        }
+          })),
+        );
       }
     }
   }
@@ -200,7 +184,10 @@ export async function runInlinePreflight(params: {
         applicationId,
       );
     } catch (err) {
-      if (mode === "fail-fast") throw err;
+      // Only ApiError is a validation signal. Everything else (DB outage,
+      // network timeout, programmer error) must bubble as-is so the error
+      // handler emits a 5xx and alerting fires.
+      if (mode === "fail-fast" || !(err instanceof ApiError)) throw err;
       accumulated.push(apiErrorToField(err, "providers"));
       providerProfiles = {};
     }
@@ -230,8 +217,15 @@ export async function runInlinePreflight(params: {
     throw validationFailed(accumulated);
   }
 
+  // Guaranteed non-null: accumulate mode throws above when manifest is
+  // missing (structural errors were collected), and fail-fast throws at
+  // stage 1 before reaching this point.
+  if (!manifest) {
+    throw new Error("runInlinePreflight: reached success path without a manifest");
+  }
+
   return {
-    manifest: manifest!,
+    manifest,
     prompt,
     effectiveConfig,
     effectiveInput,
@@ -249,18 +243,23 @@ function toFieldError(raw: string, code: string): ValidationFieldError {
   return { field: raw.slice(0, idx), code, message: raw.slice(idx + 2) };
 }
 
-/** Best-effort conversion of a caught ApiError into a ValidationFieldError. */
-function apiErrorToField(err: unknown, fallbackField: string): ValidationFieldError {
-  if (err instanceof ApiError) {
-    return {
-      field: err.param ?? fallbackField,
-      code: err.code,
-      message: err.message,
-    };
-  }
+/**
+ * Fold a caught ApiError into a ValidationFieldError.
+ *
+ * Callers MUST have already verified `err instanceof ApiError` — non-ApiError
+ * instances represent infrastructure failures and should never reach here.
+ */
+function apiErrorToField(err: ApiError, fallbackField: string): ValidationFieldError {
   return {
-    field: fallbackField,
-    code: "internal_error",
-    message: err instanceof Error ? err.message : String(err),
+    field: err.param ?? fallbackField,
+    code: err.code,
+    message: err.message,
   };
+}
+
+function codeToTitle(code: string): string {
+  return code
+    .split("_")
+    .map((w) => (w.length === 0 ? w : w[0]!.toUpperCase() + w.slice(1)))
+    .join(" ");
 }

--- a/apps/api/src/services/inline-run-preflight.ts
+++ b/apps/api/src/services/inline-run-preflight.ts
@@ -36,6 +36,7 @@ import {
   zodIssuesToFieldErrors,
   type ValidationFieldError,
 } from "../lib/errors.ts";
+import { parsePathMessage } from "../lib/field-errors.ts";
 import { asJSONSchemaObject } from "@appstrate/core/form";
 import { logger } from "../lib/logger.ts";
 import { validateConfig, validateInput } from "./schema.ts";
@@ -256,18 +257,11 @@ export async function runInlinePreflight(params: {
 }
 
 /**
- * Parse an inline-manifest error string (`"path: message"`) into a field entry.
- *
- * `validateManifest` returns flat strings, so we reconstruct the structured
- * shape here. The split is anchored on a strict path-like prefix
- * (alphanumeric, dots, brackets) so messages that themselves contain `": "`
- * (e.g. quoted regex patterns) don't truncate the human-readable part.
+ * Parse an inline-manifest error string into a field entry. `validateInlineManifest`
+ * already prefixes paths with `manifest.`, so no extra prefix is needed here.
  */
-const PATH_PREFIX_RE = /^([A-Za-z_][A-Za-z0-9_.[\]]*): (.+)$/s;
 function toFieldError(raw: string, code: string): ValidationFieldError {
-  const m = PATH_PREFIX_RE.exec(raw);
-  if (!m) return { field: "manifest", code, title: "Invalid Inline Manifest", message: raw };
-  return { field: m[1]!, code, title: "Invalid Inline Manifest", message: m[2]! };
+  return parsePathMessage(raw, { code, title: "Invalid Inline Manifest" });
 }
 
 /**
@@ -278,10 +272,13 @@ function toFieldError(raw: string, code: string): ValidationFieldError {
  * so we don't collapse rich detail into a single line. Otherwise we synth a
  * single entry from `param` / `code` / `title` / `message`.
  *
- * Callers MUST have already verified `err instanceof ApiError` — non-ApiError
- * instances represent infrastructure failures and should never reach here.
+ * The runtime `instanceof` guard re-throws any non-ApiError — infrastructure
+ * failures (DB, Redis, Docker) must surface as 5xx, never as a 400
+ * `validation_failed`. Call sites check the same invariant before calling
+ * here; the guard is belt-and-suspenders for future callers.
  */
-function apiErrorToFields(err: ApiError, fallbackField: string): ValidationFieldError[] {
+function apiErrorToFields(err: unknown, fallbackField: string): ValidationFieldError[] {
+  if (!(err instanceof ApiError)) throw err;
   if (err.fieldErrors && err.fieldErrors.length > 0) return err.fieldErrors;
   return [
     {

--- a/apps/api/src/services/inline-run-preflight.ts
+++ b/apps/api/src/services/inline-run-preflight.ts
@@ -31,6 +31,7 @@ import type { Actor } from "../lib/actor.ts";
 import type { AgentManifest, ProviderProfileMap } from "../types/index.ts";
 import {
   ApiError,
+  internalError,
   validationFailed,
   zodIssuesToFieldErrors,
   type ValidationFieldError,
@@ -85,10 +86,11 @@ export async function runInlinePreflight(params: {
   const collect = (errs: ValidationFieldError[], throwCode?: string): void => {
     if (errs.length === 0) return;
     if (mode === "fail-fast") {
+      const code = throwCode ?? "validation_failed";
       throw new ApiError({
         status: 400,
-        code: throwCode ?? "validation_failed",
-        title: throwCode ? codeToTitle(throwCode) : "Validation Failed",
+        code,
+        title: code,
         detail: `${errs[0]!.field}: ${errs[0]!.message}`,
         errors: errs,
       });
@@ -219,9 +221,10 @@ export async function runInlinePreflight(params: {
 
   // Guaranteed non-null: accumulate mode throws above when manifest is
   // missing (structural errors were collected), and fail-fast throws at
-  // stage 1 before reaching this point.
+  // stage 1 before reaching this point. The internalError() serialises as
+  // a proper 500 RFC 9457 response if the invariant ever breaks.
   if (!manifest) {
-    throw new Error("runInlinePreflight: reached success path without a manifest");
+    throw internalError();
   }
 
   return {
@@ -255,11 +258,4 @@ function apiErrorToField(err: ApiError, fallbackField: string): ValidationFieldE
     code: err.code,
     message: err.message,
   };
-}
-
-function codeToTitle(code: string): string {
-  return code
-    .split("_")
-    .map((w) => (w.length === 0 ? w : w[0]!.toUpperCase() + w.slice(1)))
-    .join(" ");
 }

--- a/apps/api/src/services/input-parser.ts
+++ b/apps/api/src/services/input-parser.ts
@@ -13,7 +13,7 @@ import type { Context } from "hono";
 import type { UploadedFile } from "./adapters/types.ts";
 import { isFileField, type JSONSchemaObject, type JSONSchema7 } from "@appstrate/core/form";
 import { validateInput } from "./schema.ts";
-import { invalidRequest } from "../lib/errors.ts";
+import { invalidRequest, validationFailed } from "../lib/errors.ts";
 import { consumeUpload, isUploadUri, parseUploadUri } from "./uploads.ts";
 
 export interface ParsedInput {
@@ -116,8 +116,13 @@ export async function parseRequestInput(
 
     const inputValidation = validateInput(input, inputSchema);
     if (!inputValidation.valid) {
-      const first = inputValidation.errors[0]!;
-      throw invalidRequest(first.message, first.field);
+      throw validationFailed(
+        inputValidation.errors.map((e) => ({
+          field: e.field ? `input.${e.field}` : "input",
+          code: "invalid_input",
+          message: e.message,
+        })),
+      );
     }
   }
 

--- a/apps/api/src/services/input-parser.ts
+++ b/apps/api/src/services/input-parser.ts
@@ -120,6 +120,7 @@ export async function parseRequestInput(
         inputValidation.errors.map((e) => ({
           field: e.field ? `input.${e.field}` : "input",
           code: "invalid_input",
+          title: "Invalid Input",
           message: e.message,
         })),
       );

--- a/apps/api/test/integration/routes/inline-run-validate.test.ts
+++ b/apps/api/test/integration/routes/inline-run-validate.test.ts
@@ -160,6 +160,37 @@ describe("POST /api/runs/inline/validate", () => {
     expect(fields.some((f) => f.startsWith("input"))).toBe(true);
   });
 
+  it("aggregates structural manifest errors with dep-cap violations", async () => {
+    // The manifest is missing `type`, which breaks AFPS dispatch and emits
+    // base-schema issues (name/version/type). At the same time the provider
+    // deps exceed `max_authorized_uris` — a cap that reads the raw manifest
+    // shape and must surface alongside structural errors, not after a short-
+    // circuit. This is the regression guard for the fall-through change in
+    // `inline-manifest-validation.ts` and `packages/core/validation.ts`.
+    const providers: Record<string, string> = {};
+    for (let i = 0; i < 200; i++) providers[`@test/provider-${i}`] = "1.0.0";
+    const manifest = {
+      // `type` intentionally omitted to trigger base-schema aggregation
+      name: "@inline/broken",
+      version: "0.0.0",
+      schemaVersion: "1.0",
+      dependencies: { skills: {}, tools: {}, providers },
+    };
+
+    const res = await post({ manifest, prompt: "hi" });
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as {
+      code?: string;
+      errors?: { field: string; code: string; message: string }[];
+    };
+    expect(body.code).toBe("validation_failed");
+    const messages = (body.errors ?? []).map((e) => `${e.field}: ${e.message}`).join("\n");
+    // Structural failure surfaces (missing type) AND the dep-cap still fires.
+    expect(messages).toMatch(/manifest\.type/i);
+    expect(messages).toMatch(/providers.*too many|dependencies\.providers/i);
+  });
+
   it("rejects unauthenticated requests with 401", async () => {
     const res = await app.request("/api/runs/inline/validate", {
       method: "POST",

--- a/apps/api/test/integration/routes/inline-run-validate.test.ts
+++ b/apps/api/test/integration/routes/inline-run-validate.test.ts
@@ -118,6 +118,48 @@ describe("POST /api/runs/inline/validate", () => {
     expect(body.detail ?? "").toMatch(/input/i);
   });
 
+  it("accumulates errors from multiple stages in one response", async () => {
+    // Empty prompt + bad config + bad input — three independent stages must
+    // all contribute to the errors[] array. This is the entire purpose of
+    // accumulate mode: one round-trip, every problem listed.
+    const manifest = validManifest() as Record<string, unknown>;
+    manifest.config = {
+      schema: {
+        type: "object",
+        properties: { maxBullets: { type: "integer", minimum: 1 } },
+        required: ["maxBullets"],
+      },
+    };
+    manifest.input = {
+      schema: {
+        type: "object",
+        properties: { text: { type: "string", minLength: 5 } },
+        required: ["text"],
+      },
+    };
+
+    const res = await post({
+      manifest,
+      prompt: "",
+      config: {},
+      input: { text: "no" },
+    });
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as {
+      code?: string;
+      errors?: { field: string; code: string; message: string }[];
+    };
+    expect(body.code).toBe("validation_failed");
+    expect(Array.isArray(body.errors)).toBe(true);
+
+    const fields = (body.errors ?? []).map((e) => e.field);
+    // One entry per stage at minimum: prompt, config, input.
+    expect(fields.some((f) => f.startsWith("prompt"))).toBe(true);
+    expect(fields.some((f) => f.startsWith("config"))).toBe(true);
+    expect(fields.some((f) => f.startsWith("input"))).toBe(true);
+  });
+
   it("rejects unauthenticated requests with 401", async () => {
     const res = await app.request("/api/runs/inline/validate", {
       method: "POST",

--- a/apps/api/test/integration/routes/inline-run-validate.test.ts
+++ b/apps/api/test/integration/routes/inline-run-validate.test.ts
@@ -74,10 +74,17 @@ describe("POST /api/runs/inline/validate", () => {
   });
 
   it("returns 400 with invalid_inline_manifest on a malformed manifest", async () => {
+    // Accumulate mode wraps every per-stage code under the top-level
+    // `validation_failed`. The structural-stage code is preserved on each
+    // entry so clients can still branch on it.
     const res = await post({ manifest: { type: "agent" }, prompt: "hi" });
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { code?: string; detail?: string };
-    expect(body.code).toBe("invalid_inline_manifest");
+    const body = (await res.json()) as {
+      code?: string;
+      errors?: { code: string }[];
+    };
+    expect(body.code).toBe("validation_failed");
+    expect((body.errors ?? []).some((e) => e.code === "invalid_inline_manifest")).toBe(true);
   });
 
   it("returns 400 when config fails the manifest's config schema", async () => {

--- a/apps/api/test/integration/routes/inline-run-validate.test.ts
+++ b/apps/api/test/integration/routes/inline-run-validate.test.ts
@@ -191,6 +191,48 @@ describe("POST /api/runs/inline/validate", () => {
     expect(messages).toMatch(/providers.*too many|dependencies\.providers/i);
   });
 
+  it("does not duplicate config errors across preflight stages", async () => {
+    // Regression guard: stage 3 (AJV against manifest.config.schema) and
+    // stage 4 (agent-readiness) used to both validate config in accumulate
+    // mode, producing two entries for the same field under different codes.
+    // Readiness now receives { skip: { config: true } }, so a single config
+    // violation must appear exactly once in errors[].
+    const manifest = validManifest() as Record<string, unknown>;
+    manifest.config = {
+      schema: {
+        type: "object",
+        properties: { maxBullets: { type: "integer", minimum: 1 } },
+        required: ["maxBullets"],
+      },
+    };
+
+    const res = await post({ manifest, prompt: "hi", config: {} });
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as {
+      errors?: { field: string; code: string; message: string }[];
+    };
+    const configEntries = (body.errors ?? []).filter((e) => e.field.startsWith("config"));
+    expect(configEntries.length).toBe(1);
+    // And the remaining code must be the stage-3 one, not the legacy
+    // readiness code (`config_incomplete` has been retired in favour of
+    // `invalid_config`).
+    expect(configEntries[0]!.code).toBe("invalid_config");
+  });
+
+  it("does not duplicate prompt errors across preflight stages", async () => {
+    // Same regression guard for prompt: stage 1 (manifest structural) flags
+    // an empty prompt, readiness used to re-flag it. Now skipped in
+    // accumulate mode; only one `prompt`-scoped entry must surface.
+    const res = await post({ manifest: validManifest(), prompt: "" });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as {
+      errors?: { field: string; code: string; message: string }[];
+    };
+    const promptEntries = (body.errors ?? []).filter((e) => e.field === "prompt");
+    expect(promptEntries.length).toBe(1);
+  });
+
   it("rejects unauthenticated requests with 401", async () => {
     const res = await app.request("/api/runs/inline/validate", {
       method: "POST",

--- a/apps/api/test/unit/agent-readiness.test.ts
+++ b/apps/api/test/unit/agent-readiness.test.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for agent-readiness.
+ *
+ * Focus: validateAgentReadiness (throwing) must delegate to
+ * collectAgentReadinessErrors (collector) with no drift. A single source
+ * of truth means a new check added to the collector must automatically
+ * surface in the throwing variant's output.
+ *
+ * These tests exercise paths with no provider dependencies so no DB is
+ * touched — collectDependencyErrors([]) short-circuits before any query.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { ApiError } from "../../src/lib/errors.ts";
+import {
+  collectAgentReadinessErrors,
+  validateAgentReadiness,
+} from "../../src/services/agent-readiness.ts";
+import type { AgentManifest, LoadedPackage } from "../../src/types/index.ts";
+
+function buildManifest(overrides: Partial<AgentManifest> = {}): AgentManifest {
+  return {
+    name: "@test/readiness",
+    displayName: "Readiness Test",
+    version: "0.1.0",
+    type: "agent",
+    description: "Test",
+    schemaVersion: "1.0",
+    dependencies: { skills: {}, tools: {}, providers: {} },
+    ...overrides,
+  } as AgentManifest;
+}
+
+function buildAgent(overrides: Partial<LoadedPackage> = {}): LoadedPackage {
+  return {
+    id: "@test/readiness",
+    manifest: buildManifest(),
+    prompt: "do the thing",
+    skills: [],
+    tools: [],
+    source: "local",
+    ...overrides,
+  };
+}
+
+describe("collectAgentReadinessErrors", () => {
+  it("returns empty array for a ready agent", async () => {
+    const errors = await collectAgentReadinessErrors({
+      agent: buildAgent(),
+      providerProfiles: {},
+      orgId: "org-1",
+      applicationId: "app-1",
+    });
+    expect(errors).toEqual([]);
+  });
+
+  it("flags empty prompt with code: empty_prompt", async () => {
+    const errors = await collectAgentReadinessErrors({
+      agent: buildAgent({ prompt: "" }),
+      providerProfiles: {},
+      orgId: "org-1",
+      applicationId: "app-1",
+    });
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+    expect(errors[0]).toMatchObject({
+      field: "prompt",
+      code: "empty_prompt",
+    });
+  });
+
+  it("flags missing skills + missing tools together", async () => {
+    const manifest = buildManifest({
+      dependencies: {
+        skills: { "@test/skill-a": "1.0.0" },
+        tools: { "@test/tool-a": "1.0.0" },
+        providers: {},
+      },
+    });
+
+    const errors = await collectAgentReadinessErrors({
+      agent: buildAgent({ manifest, skills: [], tools: [] }),
+      providerProfiles: {},
+      orgId: "org-1",
+      applicationId: "app-1",
+    });
+
+    const codes = errors.map((e) => e.code);
+    expect(codes).toContain("missing_skill");
+    expect(codes).toContain("missing_tool");
+  });
+
+  it("aggregates empty prompt + missing skill in stable order", async () => {
+    const manifest = buildManifest({
+      dependencies: {
+        skills: { "@test/skill-a": "1.0.0" },
+        tools: {},
+        providers: {},
+      },
+    });
+
+    const errors = await collectAgentReadinessErrors({
+      agent: buildAgent({ prompt: "", manifest }),
+      providerProfiles: {},
+      orgId: "org-1",
+      applicationId: "app-1",
+    });
+
+    // Prompt check runs before skills — order defines the first-thrown error.
+    expect(errors[0]?.code).toBe("empty_prompt");
+    expect(errors.some((e) => e.code === "missing_skill")).toBe(true);
+  });
+});
+
+describe("validateAgentReadiness (throwing)", () => {
+  it("succeeds silently when the collector returns no errors", async () => {
+    await validateAgentReadiness({
+      agent: buildAgent(),
+      providerProfiles: {},
+      orgId: "org-1",
+      applicationId: "app-1",
+    });
+  });
+
+  it("throws the first collected error with the matching ApiError code + title", async () => {
+    // Empty prompt → collector's first entry is { code: "empty_prompt" }.
+    // The throwing variant MUST preserve that code (backward compat) and
+    // look up the human-readable title from the CODE_TITLES table.
+    try {
+      await validateAgentReadiness({
+        agent: buildAgent({ prompt: "" }),
+        providerProfiles: {},
+        orgId: "org-1",
+        applicationId: "app-1",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      const apiErr = err as ApiError;
+      expect(apiErr.status).toBe(400);
+      expect(apiErr.code).toBe("empty_prompt");
+      expect(apiErr.title).toBe("Empty Prompt");
+    }
+  });
+
+  it("maps missing_skill code to Missing Skill title", async () => {
+    const manifest = buildManifest({
+      dependencies: {
+        skills: { "@test/skill-a": "1.0.0" },
+        tools: {},
+        providers: {},
+      },
+    });
+
+    try {
+      await validateAgentReadiness({
+        agent: buildAgent({ manifest, skills: [] }),
+        providerProfiles: {},
+        orgId: "org-1",
+        applicationId: "app-1",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      const apiErr = err as ApiError;
+      expect(apiErr.code).toBe("missing_skill");
+      expect(apiErr.title).toBe("Missing Skill");
+      expect(apiErr.message).toContain("@test/skill-a");
+    }
+  });
+});

--- a/apps/api/test/unit/agent-readiness.test.ts
+++ b/apps/api/test/unit/agent-readiness.test.ts
@@ -123,10 +123,9 @@ describe("validateAgentReadiness (throwing)", () => {
     });
   });
 
-  it("throws the first collected error with the matching ApiError code + title", async () => {
+  it("throws the first collected error with the matching ApiError code", async () => {
     // Empty prompt → collector's first entry is { code: "empty_prompt" }.
-    // The throwing variant MUST preserve that code (backward compat) and
-    // look up the human-readable title from the CODE_TITLES table.
+    // The throwing variant MUST preserve that code (backward compat).
     try {
       await validateAgentReadiness({
         agent: buildAgent({ prompt: "" }),
@@ -140,11 +139,10 @@ describe("validateAgentReadiness (throwing)", () => {
       const apiErr = err as ApiError;
       expect(apiErr.status).toBe(400);
       expect(apiErr.code).toBe("empty_prompt");
-      expect(apiErr.title).toBe("Empty Prompt");
     }
   });
 
-  it("maps missing_skill code to Missing Skill title", async () => {
+  it("propagates missing_skill code with the skill id in the message", async () => {
     const manifest = buildManifest({
       dependencies: {
         skills: { "@test/skill-a": "1.0.0" },
@@ -165,7 +163,6 @@ describe("validateAgentReadiness (throwing)", () => {
       expect(err).toBeInstanceOf(ApiError);
       const apiErr = err as ApiError;
       expect(apiErr.code).toBe("missing_skill");
-      expect(apiErr.title).toBe("Missing Skill");
       expect(apiErr.message).toContain("@test/skill-a");
     }
   });

--- a/apps/api/test/unit/agent-readiness.test.ts
+++ b/apps/api/test/unit/agent-readiness.test.ts
@@ -166,4 +166,56 @@ describe("validateAgentReadiness (throwing)", () => {
       expect(apiErr.message).toContain("@test/skill-a");
     }
   });
+
+  it("preserves the human-readable title on the thrown ApiError", async () => {
+    // Regression guard: the throwing wrapper must surface the historical
+    // title ("Empty Prompt") instead of the machine code — UI clients display
+    // `Problem.title` and would otherwise render "empty_prompt".
+    try {
+      await validateAgentReadiness({
+        agent: buildAgent({ prompt: "" }),
+        providerProfiles: {},
+        orgId: "org-1",
+        applicationId: "app-1",
+      });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).title).toBe("Empty Prompt");
+    }
+  });
+});
+
+describe("collectAgentReadinessErrors — skip option", () => {
+  it("skips the prompt check when skip.prompt is true", async () => {
+    const errors = await collectAgentReadinessErrors({
+      agent: buildAgent({ prompt: "" }),
+      providerProfiles: {},
+      orgId: "org-1",
+      applicationId: "app-1",
+      skip: { prompt: true },
+    });
+    expect(errors.some((e) => e.code === "empty_prompt")).toBe(false);
+  });
+
+  it("skips the config check when skip.config is true", async () => {
+    const manifest = buildManifest({
+      config: {
+        schema: {
+          type: "object",
+          properties: { maxBullets: { type: "integer", minimum: 1 } },
+          required: ["maxBullets"],
+        },
+      },
+    } as Partial<AgentManifest>);
+    const errors = await collectAgentReadinessErrors({
+      agent: buildAgent({ manifest }),
+      providerProfiles: {},
+      orgId: "org-1",
+      applicationId: "app-1",
+      config: {},
+      skip: { config: true },
+    });
+    expect(errors.some((e) => e.code === "invalid_config")).toBe(false);
+  });
 });

--- a/apps/api/test/unit/dependency-validation.test.ts
+++ b/apps/api/test/unit/dependency-validation.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect } from "bun:test";
 import { ApiError } from "../../src/lib/errors.ts";
 import {
+  collectDependencyErrors,
   validateAgentDependencies,
   type DependencyValidationDeps,
 } from "../../src/services/dependency-validation.ts";
@@ -206,5 +207,142 @@ describe("validateAgentDependencies", () => {
     };
 
     await validateAgentDependencies(providers, profiles, "org-1", "app-1", deps);
+  });
+});
+
+describe("collectDependencyErrors — multi-scope-set dedup", () => {
+  // Regression guard for the dedup invariants in `collectDependencyErrors`.
+  // A single manifest may declare the same provider twice with different
+  // scope sets (e.g. a core agent asking for `read` plus a delegated helper
+  // asking for `read write`). Each stage of the collector has its own
+  // dedup strategy — this suite pins each one so a future refactor can't
+  // regress them silently:
+  //
+  //   1. `enabled` checks iterate `uniqueProviders` → one query per id
+  //   2. `missing profile` set → one entry per id
+  //   3. status errors (`not_connected`, `needs_reconnection`) gated by
+  //      `statusErrorEmitted` → one entry per id
+  //   4. scope checks iterate the FULL `providers` list — a provider
+  //      declared twice with DIFFERENT missing-scope sets produces TWO
+  //      scope-insufficient entries (by design: each requirement is its
+  //      own violation, and the caller may want to see both).
+
+  it("emits one provider_not_enabled per provider even when declared with multiple scope sets", async () => {
+    let enabledCallCount = 0;
+    const deps = createMockDeps({
+      isProviderEnabled: async () => {
+        enabledCallCount++;
+        return false;
+      },
+    });
+    const providers = [
+      { id: "@test/gmail", scopes: ["read"] },
+      { id: "@test/gmail", scopes: ["read", "write"] },
+      { id: "@test/gmail", scopes: ["send"] },
+    ];
+    const profiles = profileMap({ "@test/gmail": "p1" });
+
+    const errors = await collectDependencyErrors(providers, profiles, "org-1", "app-1", deps);
+    expect(enabledCallCount).toBe(1);
+    const enabledErrors = errors.filter((e) => e.code === "provider_not_enabled");
+    expect(enabledErrors).toHaveLength(1);
+    expect(enabledErrors[0]!.field).toBe("providers.@test/gmail");
+  });
+
+  it("emits one dependency_not_satisfied per provider when the profile is missing", async () => {
+    const deps = createMockDeps();
+    const providers = [
+      { id: "@test/clickup", scopes: ["read"] },
+      { id: "@test/clickup", scopes: ["write"] },
+    ];
+    const profiles: ProviderProfileMap = {};
+
+    const errors = await collectDependencyErrors(providers, profiles, "org-1", "app-1", deps);
+    const notSatisfied = errors.filter((e) => e.code === "dependency_not_satisfied");
+    expect(notSatisfied).toHaveLength(1);
+    expect(notSatisfied[0]!.field).toBe("providers.@test/clickup");
+  });
+
+  it("emits one not_connected per provider even when declared twice", async () => {
+    let statusCallCount = 0;
+    const deps = createMockDeps({
+      getConnectionStatus: async (provider) => {
+        statusCallCount++;
+        return { provider, status: "not_connected" as const };
+      },
+    });
+    const providers = [
+      { id: "@test/stripe", scopes: ["read"] },
+      { id: "@test/stripe", scopes: ["read", "write"] },
+    ];
+    const profiles = profileMap({ "@test/stripe": "p1" });
+
+    const errors = await collectDependencyErrors(providers, profiles, "org-1", "app-1", deps);
+    // One status query (deduped) — scope checks don't re-query.
+    expect(statusCallCount).toBe(1);
+    const notConnected = errors.filter((e) => e.code === "dependency_not_satisfied");
+    expect(notConnected).toHaveLength(1);
+  });
+
+  it("emits one needs_reconnection per provider even when declared twice", async () => {
+    const deps = createMockDeps({
+      getConnectionStatus: async (provider) => ({
+        provider,
+        status: "needs_reconnection" as const,
+        scopesGranted: ["read"],
+      }),
+    });
+    const providers = [
+      { id: "@test/gmail", scopes: ["read"] },
+      { id: "@test/gmail", scopes: ["read", "write"] },
+    ];
+    const profiles = profileMap({ "@test/gmail": "p1" });
+
+    const errors = await collectDependencyErrors(providers, profiles, "org-1", "app-1", deps);
+    const needsRecon = errors.filter((e) => e.code === "needs_reconnection");
+    expect(needsRecon).toHaveLength(1);
+  });
+
+  it("emits one scope_insufficient per distinct requirement (NOT deduped)", async () => {
+    // Scope violations are per-requirement, not per-provider: two different
+    // scope sets each missing a different scope yield two entries. This is
+    // intentional — callers need to see every missing scope set to guide
+    // reconnection UX.
+    const deps = createMockDeps({
+      validateScopes: (_granted, required) => ({
+        sufficient: false,
+        missing: required.filter((s) => s !== "read"),
+      }),
+    });
+    const providers = [
+      { id: "@test/gmail", scopes: ["read", "write"] },
+      { id: "@test/gmail", scopes: ["read", "send"] },
+    ];
+    const profiles = profileMap({ "@test/gmail": "p1" });
+
+    const errors = await collectDependencyErrors(providers, profiles, "org-1", "app-1", deps);
+    const scopeErrors = errors.filter((e) => e.code === "scope_insufficient");
+    expect(scopeErrors).toHaveLength(2);
+    expect(scopeErrors[0]!.message).toContain("write");
+    expect(scopeErrors[1]!.message).toContain("send");
+  });
+
+  it("runs one credential lookup per provider even when declared twice", async () => {
+    let credentialCallCount = 0;
+    const deps = createMockDeps({
+      getProviderCredentialId: async () => {
+        credentialCallCount++;
+        return "cred-id";
+      },
+    });
+    const providers = [
+      { id: "@test/gmail", scopes: ["read"] },
+      { id: "@test/gmail", scopes: ["write"] },
+      { id: "@test/gmail", scopes: ["send"] },
+    ];
+    const profiles = profileMap({ "@test/gmail": "p1" });
+
+    await collectDependencyErrors(providers, profiles, "org-1", "app-1", deps);
+    expect(credentialCallCount).toBe(1);
   });
 });

--- a/apps/api/test/unit/error-handler.test.ts
+++ b/apps/api/test/unit/error-handler.test.ts
@@ -5,6 +5,7 @@ import { Hono } from "hono";
 import type { AppEnv } from "../../src/types/index.ts";
 import { requestId } from "../../src/middleware/request-id.ts";
 import { errorHandler } from "../../src/middleware/error-handler.ts";
+import { z } from "zod";
 import {
   ApiError,
   invalidRequest,
@@ -13,6 +14,8 @@ import {
   unauthorized,
   conflict,
   gone,
+  parseBody,
+  validationFailed,
 } from "../../src/lib/errors.ts";
 
 function createApp() {
@@ -43,6 +46,53 @@ describe("errorHandler middleware", () => {
     expect(typeof body.requestId).toBe("string");
     expect((body.requestId as string).startsWith("req_")).toBe(true);
     expect((body.instance as string).startsWith("urn:appstrate:request:req_")).toBe(true);
+  });
+
+  it("parseBody surfaces every Zod issue in errors[]", async () => {
+    const app = createApp();
+    const schema = z.object({
+      name: z.string(),
+      email: z.email(),
+      age: z.number().int(),
+    });
+    app.post("/test", async (c) => {
+      const body = await c.req.json();
+      parseBody(schema, body);
+      return c.json({ ok: true });
+    });
+
+    const res = await app.request("/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "not-an-email", age: "oops" }),
+    });
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as any;
+    expect(body.code).toBe("validation_failed");
+    const errors = body.errors as { field: string; code: string; message: string }[];
+    const fields = errors.map((e) => e.field);
+    expect(fields).toContain("name");
+    expect(fields).toContain("email");
+    expect(fields).toContain("age");
+    expect(errors.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("validationFailed helper composes summary and preserves entries", async () => {
+    const app = createApp();
+    app.get("/test", () => {
+      throw validationFailed([
+        { field: "a", code: "required", message: "a is required" },
+        { field: "b", code: "required", message: "b is required" },
+      ]);
+    });
+
+    const res = await app.request("/test");
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.code).toBe("validation_failed");
+    expect(body.detail).toContain("+1 more");
+    expect((body.errors as unknown[]).length).toBe(2);
   });
 
   it("errors array via ApiError constructor", async () => {

--- a/apps/api/test/unit/error-handler.test.ts
+++ b/apps/api/test/unit/error-handler.test.ts
@@ -48,6 +48,50 @@ describe("errorHandler middleware", () => {
     expect((body.instance as string).startsWith("urn:appstrate:request:req_")).toBe(true);
   });
 
+  it("parseBody does not double-prefix the field when Zod has a resolved path", async () => {
+    // Regression guard: the `param` argument is a FALLBACK for empty paths,
+    // not a prefix. Historically callers passed e.g. `parseBody(schema, body,
+    // "apiKey")` expecting `body.param === "apiKey"`. Concatenating the arg
+    // onto the Zod path would yield `"apiKey.apiKey"` for every such call.
+    const app = createApp();
+    const schema = z.object({ apiKey: z.string().min(1) });
+    app.post("/test", async (c) => {
+      parseBody(schema, await c.req.json(), "apiKey");
+      return c.json({ ok: true });
+    });
+    const res = await app.request("/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ apiKey: "" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    const fields = (body.errors as { field: string }[]).map((e) => e.field);
+    expect(fields).toContain("apiKey");
+    expect(fields).not.toContain("apiKey.apiKey");
+  });
+
+  it("parseBody uses the fallback field when Zod reports an empty path", async () => {
+    // When the whole body fails to parse (e.g. not an object), Zod's path
+    // is empty — the caller-provided `param` acts as the field name so the
+    // error still points somewhere meaningful.
+    const app = createApp();
+    const schema = z.string().min(1);
+    app.post("/test", async (c) => {
+      parseBody(schema, await c.req.json(), "name");
+      return c.json({ ok: true });
+    });
+    const res = await app.request("/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(123),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    const fields = (body.errors as { field: string }[]).map((e) => e.field);
+    expect(fields).toContain("name");
+  });
+
   it("parseBody surfaces every Zod issue in errors[]", async () => {
     const app = createApp();
     const schema = z.object({

--- a/apps/api/test/unit/inline-manifest-validation.test.ts
+++ b/apps/api/test/unit/inline-manifest-validation.test.ts
@@ -171,6 +171,25 @@ describe("validateInlineManifest — structural", () => {
     expect(result.valid).toBe(false);
     expect(result.errors.join(" ")).toContain("@scope/name");
   });
+
+  it("aggregates structural and cap errors in one pass", () => {
+    // Structural failure (bad name) must NOT short-circuit cap checks — we
+    // want every problem surfaced so the caller can fix them together.
+    const tight = { ...defaults, max_skills: 1 };
+    const skills: Record<string, string> = {
+      "@sys/skill-a": "1.0.0",
+      "@sys/skill-b": "1.0.0",
+    };
+    const result = validateInlineManifest({
+      manifest: baseManifest({ name: "bad-name-no-scope", dependencies: { skills } }),
+      prompt: "ok",
+      limits: tight,
+    });
+    expect(result.valid).toBe(false);
+    const joined = result.errors.join(" | ");
+    expect(joined).toContain("name");
+    expect(joined).toContain("skills: too many");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to `@appstrate/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.11.0] — Unreleased
+
+### Changed
+
+- `validateManifest(raw)` — when the input has no `type` field, validation
+  now falls through to the base `manifestSchema` and returns every
+  missing/invalid field Zod reports, instead of short-circuiting on a
+  single `"type: Required field is missing"` string. Consumers that
+  aggregate `result.errors` (e.g. joining with `"; "`) are unaffected.
+  Consumers that asserted on the exact single-string output must update
+  their expectations.
+
 ## [2.10.8] — 2026-04-15
 
 ### Added

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -464,7 +464,9 @@ export function validateManifest(raw: unknown): ValidateManifestResult {
               : manifestSchema;
     return parseWithSchema(schema, raw);
   }
-  return { valid: false, errors: ["type: Required field is missing"] };
+  // No `type` field — run the base schema so every missing-field error is
+  // surfaced in a single pass (instead of short-circuiting on `type` alone).
+  return parseWithSchema(manifestSchema, raw);
 }
 
 function stripQuotes(value: string): string {

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -107,11 +107,26 @@ describe("validateManifest", () => {
     expect(result.errors.length).toBeGreaterThan(0);
   });
 
-  test("missing type field returns explicit error", () => {
+  test("missing type field surfaces all base-schema errors", () => {
+    // Without a `type`, validateManifest falls through to the base schema and
+    // lets Zod aggregate every missing/invalid field in one pass, instead of
+    // short-circuiting on `type` alone.
     const { type: _, ...noType } = validAgentManifest();
     const result = validateManifest(noType);
     expect(result.valid).toBe(false);
-    expect(result.errors).toEqual(["type: Required field is missing"]);
+    expect(result.errors.some((e) => e.startsWith("type:"))).toBe(true);
+  });
+
+  test("empty manifest surfaces every missing base field at once", () => {
+    // The base `manifestSchema` requires name/version/type. Without `type`,
+    // dispatch falls through to the base schema and Zod emits all three
+    // missing-field errors together instead of stopping on `type`.
+    const result = validateManifest({});
+    expect(result.valid).toBe(false);
+    const fields = result.errors.map((e) => e.split(":")[0]);
+    expect(fields).toContain("type");
+    expect(fields).toContain("name");
+    expect(fields).toContain("version");
   });
 
   test("invalid scoped name format", () => {


### PR DESCRIPTION
Closes #143.

## Summary

- Populates RFC 9457 `errors[]` across the whole API so a single 400 response lists every problem (manifest, config, input, providers) instead of one at a time.
- `parseBody` now emits every Zod issue — fixes ~84 call sites across 21 routes in one go.
- Adds `runInlinePreflight({ mode: "accumulate" })` used by `/api/runs/inline/validate`; the main `/api/runs/inline` route keeps `fail-fast` (no point firing a pipeline with partial validation).
- Fall-through in `validateManifest` when `type` is missing — Zod now aggregates base-level errors instead of short-circuiting.
- `validateInlineManifest` no longer early-returns after structural failure; dep/URI caps run alongside.
- AJV call sites (agent-readiness, input-parser, schedules) enumerate all errors instead of `errors[0]`.
- `packages.ts` manifest endpoints surface every field at once.

## Key files

| File | Change |
|---|---|
| `apps/api/src/lib/errors.ts` | `validationFailed()`, `zodIssuesToFieldErrors()`, multi-issue `parseBody` |
| `packages/core/src/validation.ts` | Fall-through to base schema on missing `type` |
| `apps/api/src/services/inline-run-preflight.ts` | `mode` param + cross-stage accumulation |
| `apps/api/src/services/inline-manifest-validation.ts` | Remove early return |
| `apps/api/src/services/dependency-validation.ts` | New `collectDependencyErrors()` |
| `apps/api/src/services/agent-readiness.ts` | New `collectAgentReadinessErrors()` |
| `apps/api/src/services/input-parser.ts` | Enumerate AJV errors |
| `apps/api/src/routes/{runs,schedules,packages}.ts` | Wire accumulate mode / enumerate errors |

## Example (issue #143 repro)

Before:
```json
{ "code": "invalid_inline_manifest", "detail": "manifest.type: Required field is missing" }
```

After (empty manifest):
```json
{
  "code": "validation_failed",
  "title": "Validation Failed",
  "status": 400,
  "errors": [
    { "field": "manifest.type",    "code": "invalid_inline_manifest", "message": "..." },
    { "field": "manifest.name",    "code": "invalid_inline_manifest", "message": "..." },
    { "field": "manifest.version", "code": "invalid_inline_manifest", "message": "..." }
  ]
}
```

## Test plan

- [x] `bun run check` — typecheck + ESLint + Prettier + OpenAPI validation + 39 system packages (all 14 tasks green)
- [x] `packages/core` test suite — 295 passing (including new empty-manifest aggregation assertion)
- [x] New unit tests for `parseBody` multi-error, `validationFailed` helper, inline-manifest aggregation
- [ ] Full `bun test` (requires Docker; port 5433 currently held by an unrelated container locally — will run in CI)
- [ ] Manual repro: `POST /api/runs/inline/validate` with `{"manifest":{},"prompt":"hi"}` returns ≥3 entries in `errors[]`
- [ ] Manual repro: any `parseBody` route (e.g. `POST /api/webhooks`) with ≥2 invalid fields returns both in `errors[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)