### PR TITLE
fix(oidc): reconcile instance client redirect URIs with APP_URL on boot

### DIFF
--- a/apps/api/src/modules/oidc/README.md
+++ b/apps/api/src/modules/oidc/README.md
@@ -310,6 +310,12 @@ DELETE FROM oauth_clients WHERE client_id = 'admin-dashboard';
 
 …then edit the env and restart. All active sessions for that client are invalidated, which is the correct loud behavior for a production change.
 
+### Auto-provisioned platform client — `APP_URL` reconciliation
+
+The platform SPA client (auto-provisioned by `ensureInstanceClient()`, `clientId` prefixed `oauth_`) follows a **different** policy than env-declared satellites: its `redirectUris` / `postLogoutRedirectUris` are silently reconciled against `APP_URL` on every boot. Same `client_id`, so outstanding tokens and live sessions remain valid. A `warn` log is emitted when an update actually happens.
+
+Why different: satellite URIs are operator-owned and drift must be loud; the platform client's URIs are entirely derived from `APP_URL` and have no operator-owned degree of freedom, so letting the DB diverge only produces breakage (the dashboard loops on `/api/auth/oauth2/authorize` and hits the per-IP rate limit). Changing `APP_URL` + restart is the supported path for domain moves and for fixing a placeholder URL set on first boot.
+
 ### Token shape
 
 Tokens minted for env-provisioned instance clients carry `actor_type: "user"` and no `org_id` claim. Satellites resolve the current org per-request via the `X-Org-Id` header — identical to the platform dashboard SPA. See `auth/strategy.ts → resolveInstanceUser` (`deferOrgResolution: true`).

--- a/apps/api/src/modules/oidc/services/oauth-admin.ts
+++ b/apps/api/src/modules/oidc/services/oauth-admin.ts
@@ -43,6 +43,7 @@ import { db } from "@appstrate/db/client";
 import { applications } from "@appstrate/db/schema";
 import { oauthClient } from "../schema.ts";
 import { prefixedId } from "../../../lib/ids.ts";
+import { logger } from "../../../lib/logger.ts";
 import { APPSTRATE_SCOPES } from "../auth/scopes.ts";
 import { isValidRedirectUri } from "./redirect-uri.ts";
 
@@ -557,14 +558,72 @@ export async function getInstanceClientId(): Promise<string | null> {
   return row?.clientId ?? null;
 }
 
+function sameStringSet(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  for (const v of b) {
+    if (!set.has(v)) return false;
+  }
+  return true;
+}
+
 /**
  * Auto-provision the instance-level OIDC client for the platform SPA.
- * Idempotent — returns the existing clientId if one already exists.
+ *
+ * Idempotent on presence AND reconciles `redirectUris` /
+ * `postLogoutRedirectUris` against the current `APP_URL` on every boot.
+ * When the operator changes `APP_URL` (domain move, placeholder → real
+ * URL on first setup), the existing row is updated in place — same
+ * `client_id`, so outstanding tokens and live sessions remain valid.
+ *
+ * Without this reconciliation the dashboard SPA would loop on
+ * `/api/auth/oauth2/authorize` after a URL change and eventually hit
+ * the per-IP rate limit (see `auth/guards.ts` `AUTHORIZE_RL_POINTS`),
+ * forcing operators to wipe the DB to recover.
+ *
  * Called from `oidcModule.init()` at boot.
  */
 export async function ensureInstanceClient(appUrl: string): Promise<string> {
-  const existing = await getInstanceClientId();
-  if (existing) return existing;
+  const expectedRedirectUris = [`${appUrl}/auth/callback`];
+  const expectedPostLogoutRedirectUris = [appUrl, `${appUrl}/login`];
+
+  const [existing] = await db
+    .select({
+      clientId: oauthClient.clientId,
+      redirectUris: oauthClient.redirectUris,
+      postLogoutRedirectUris: oauthClient.postLogoutRedirectUris,
+    })
+    .from(oauthClient)
+    .where(eq(oauthClient.level, "instance"))
+    .orderBy(asc(oauthClient.createdAt))
+    .limit(1);
+
+  if (existing) {
+    const storedPostLogout = existing.postLogoutRedirectUris ?? [];
+    const redirectDrift = !sameStringSet(existing.redirectUris, expectedRedirectUris);
+    const postLogoutDrift = !sameStringSet(storedPostLogout, expectedPostLogoutRedirectUris);
+    if (redirectDrift || postLogoutDrift) {
+      await db
+        .update(oauthClient)
+        .set({
+          redirectUris: expectedRedirectUris,
+          postLogoutRedirectUris: expectedPostLogoutRedirectUris,
+          updatedAt: new Date(),
+        })
+        .where(eq(oauthClient.clientId, existing.clientId));
+      cacheInvalidate(existing.clientId);
+      logger.warn("OIDC platform client redirect URIs updated to match APP_URL", {
+        module: "oidc",
+        clientId: existing.clientId,
+        appUrl,
+        redirectUrisFrom: existing.redirectUris,
+        redirectUrisTo: expectedRedirectUris,
+        postLogoutRedirectUrisFrom: storedPostLogout,
+        postLogoutRedirectUrisTo: expectedPostLogoutRedirectUris,
+      });
+    }
+    return existing.clientId;
+  }
 
   // The platform auto-provisioned instance client opts into open signup at
   // boot so a fresh Appstrate install can register its first user. Every
@@ -574,8 +633,8 @@ export async function ensureInstanceClient(appUrl: string): Promise<string> {
   const created = await createClient({
     level: "instance",
     name: "Appstrate Platform",
-    redirectUris: [`${appUrl}/auth/callback`],
-    postLogoutRedirectUris: [appUrl, `${appUrl}/login`],
+    redirectUris: expectedRedirectUris,
+    postLogoutRedirectUris: expectedPostLogoutRedirectUris,
     scopes: ["openid", "profile", "email", "offline_access"],
     isFirstParty: true,
     allowSignup: true,

--- a/apps/api/src/modules/oidc/services/oauth-admin.ts
+++ b/apps/api/src/modules/oidc/services/oauth-admin.ts
@@ -581,11 +581,40 @@ function sameStringSet(a: readonly string[], b: readonly string[]): boolean {
  * the per-IP rate limit (see `auth/guards.ts` `AUTHORIZE_RL_POINTS`),
  * forcing operators to wipe the DB to recover.
  *
+ * ## Concurrency
+ *
+ * The SELECT+UPDATE is not transactional. Under multi-replica boot, both
+ * replicas may detect drift and both issue the UPDATE — benign, since
+ * both compute the exact same `expectedRedirectUris` from the same
+ * `APP_URL` env var (last-write-wins with identical payloads). No
+ * coordination primitive required.
+ *
+ * ## Cache propagation across replicas
+ *
+ * `cacheInvalidate()` only clears the local per-process cache (see
+ * `CLIENT_CACHE_TTL_MS`). Other replicas may serve stale URIs from
+ * their local cache for up to one TTL window (~30s). Acceptable in
+ * practice because reconciliation only happens at boot, and all
+ * replicas boot with the same `APP_URL` and therefore reconcile
+ * independently — the old cached value never gets exercised.
+ *
  * Called from `oidcModule.init()` at boot.
  */
 export async function ensureInstanceClient(appUrl: string): Promise<string> {
-  const expectedRedirectUris = [`${appUrl}/auth/callback`];
-  const expectedPostLogoutRedirectUris = [appUrl, `${appUrl}/login`];
+  // Normalize: strip trailing slash(es) so `APP_URL=https://x.com/` does
+  // not produce `https://x.com//auth/callback`. Reconciliation on an
+  // already-created-with-trailing-slash row will also now converge to
+  // the normalized form.
+  const normalizedAppUrl = appUrl.replace(/\/+$/, "");
+  const expectedRedirectUris = [`${normalizedAppUrl}/auth/callback`];
+  const expectedPostLogoutRedirectUris = [normalizedAppUrl, `${normalizedAppUrl}/login`];
+
+  // Same validation policy as the create path below (and as every other
+  // callsite of `assertValidRedirectUris`): reject loopback-in-prod,
+  // bad schemes, etc. Keeps the update path from silently writing a
+  // value the create path would refuse, should `isValidRedirectUri`
+  // ever tighten its rules.
+  assertValidRedirectUris(expectedRedirectUris);
 
   const [existing] = await db
     .select({
@@ -615,7 +644,7 @@ export async function ensureInstanceClient(appUrl: string): Promise<string> {
       logger.warn("OIDC platform client redirect URIs updated to match APP_URL", {
         module: "oidc",
         clientId: existing.clientId,
-        appUrl,
+        appUrl: normalizedAppUrl,
         redirectUrisFrom: existing.redirectUris,
         redirectUrisTo: expectedRedirectUris,
         postLogoutRedirectUrisFrom: storedPostLogout,

--- a/apps/api/src/modules/oidc/test/integration/services/instance-client.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/instance-client.test.ts
@@ -167,6 +167,45 @@ describe("ensureInstanceClient", () => {
       .limit(1);
     expect(after!.updatedAt!.getTime()).toBe(originalUpdatedAt);
   });
+
+  it("normalizes a trailing slash on APP_URL", async () => {
+    const { ensureInstanceClient } = await import("../../../services/oauth-admin.ts");
+    const clientId = await ensureInstanceClient("https://example.com/");
+
+    const [row] = await db
+      .select()
+      .from(oauthClient)
+      .where(eq(oauthClient.clientId, clientId))
+      .limit(1);
+    expect(row!.redirectUris).toEqual(["https://example.com/auth/callback"]);
+    expect(row!.postLogoutRedirectUris).toEqual([
+      "https://example.com",
+      "https://example.com/login",
+    ]);
+
+    // Idempotent: boot again without the slash → no-op (not a drift)
+    const sameAgain = await ensureInstanceClient("https://example.com");
+    expect(sameAgain).toBe(clientId);
+    const [after] = await db
+      .select()
+      .from(oauthClient)
+      .where(eq(oauthClient.clientId, clientId))
+      .limit(1);
+    expect(after!.redirectUris).toEqual(["https://example.com/auth/callback"]);
+  });
+
+  it("rejects APP_URL that would produce an invalid redirect URI", async () => {
+    const { ensureInstanceClient, OAuthAdminValidationError } =
+      await import("../../../services/oauth-admin.ts");
+    // `javascript:` scheme is rejected by isValidRedirectUri
+    let thrown: unknown = null;
+    try {
+      await ensureInstanceClient("javascript:alert(1)//evil");
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(OAuthAdminValidationError);
+  });
 });
 
 // ─── cachedTrustedClients snapshot ────────────────────────────────────────────

--- a/apps/api/src/modules/oidc/test/integration/services/instance-client.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/instance-client.test.ts
@@ -122,6 +122,51 @@ describe("ensureInstanceClient", () => {
     const rows = await db.select().from(oauthClient).where(eq(oauthClient.level, "instance"));
     expect(rows).toHaveLength(1);
   });
+
+  it("reconciles redirect URIs when APP_URL changes between boots", async () => {
+    const { ensureInstanceClient } = await import("../../../services/oauth-admin.ts");
+    const original = await ensureInstanceClient("https://old.example.com");
+
+    const reconciled = await ensureInstanceClient("https://new.example.com");
+    expect(reconciled).toBe(original); // Same clientId — tokens stay valid
+
+    const [row] = await db
+      .select()
+      .from(oauthClient)
+      .where(eq(oauthClient.clientId, original))
+      .limit(1);
+    expect(row!.redirectUris).toEqual(["https://new.example.com/auth/callback"]);
+    expect(row!.postLogoutRedirectUris).toEqual([
+      "https://new.example.com",
+      "https://new.example.com/login",
+    ]);
+
+    // Still only one instance client
+    const rows = await db.select().from(oauthClient).where(eq(oauthClient.level, "instance"));
+    expect(rows).toHaveLength(1);
+  });
+
+  it("does not touch unchanged rows when APP_URL is unchanged", async () => {
+    const { ensureInstanceClient } = await import("../../../services/oauth-admin.ts");
+    await ensureInstanceClient("http://localhost:3000");
+
+    const [before] = await db
+      .select()
+      .from(oauthClient)
+      .where(eq(oauthClient.level, "instance"))
+      .limit(1);
+    expect(before!.updatedAt).not.toBeNull();
+    const originalUpdatedAt = before!.updatedAt!.getTime();
+
+    await ensureInstanceClient("http://localhost:3000");
+
+    const [after] = await db
+      .select()
+      .from(oauthClient)
+      .where(eq(oauthClient.level, "instance"))
+      .limit(1);
+    expect(after!.updatedAt!.getTime()).toBe(originalUpdatedAt);
+  });
 });
 
 // ─── cachedTrustedClients snapshot ────────────────────────────────────────────


### PR DESCRIPTION
Closes #145.

## Summary

- `ensureInstanceClient()` was idempotent on **presence only**, so changing `APP_URL` after first boot left the platform OIDC client's `redirectUris` / `postLogoutRedirectUris` pointing at the old URL. The dashboard SPA then looped on `/api/auth/oauth2/authorize`, hit the per-IP rate limit (`AUTHORIZE_RL_POINTS` in `auth/guards.ts`), and the only recovery path was `docker compose down --volumes` — unacceptable for a live instance.
- Now detect drift between the stored URIs and the values derived from the current `APP_URL`, update the row in place, invalidate the per-client cache, and log a `warn`. The `client_id` is preserved so outstanding tokens and live sessions remain valid.
- Policy divergence vs. env-declared satellites is intentional and documented: satellite drift is loud (boot fails), platform-client drift is silent (reconciled). Satellite URIs are operator-owned; the platform client's URIs are entirely derived from `APP_URL` and have no operator-owned degree of freedom.

## Hardening (second commit)

- **Trailing slash normalization**: `APP_URL=https://x.com/` no longer yields `https://x.com//auth/callback`. Fixed for both the create and the reconcile paths.
- **Validation on the update path**: call `assertValidRedirectUris` before the UPDATE with the same policy as the create path, so the reconciler cannot silently write a value the create path would refuse.
- **Concurrency + cache** semantics documented inline: multi-replica boot is benign (last-write-wins with identical payloads); local cache TTL (~30s) is acceptable because all replicas boot from the same `APP_URL` and reconcile independently.

## Changes

- `apps/api/src/modules/oidc/services/oauth-admin.ts` — drift detection + in-place update + URL normalization + validation inside `ensureInstanceClient()`.
- `apps/api/src/modules/oidc/test/integration/services/instance-client.test.ts` — 5 new tests covering drift reconciliation, no-op idempotence, trailing-slash normalization, rebook idempotence after normalization, and invalid-URI rejection.
- `apps/api/src/modules/oidc/README.md` — new subsection explaining the platform-client policy and why it differs from `OIDC_INSTANCE_CLIENTS` drift handling.

## Test plan

- [x] `bun test apps/api/src/modules/oidc/test/integration/services/instance-client.test.ts` — 17/17 pass
- [x] `tsc --noEmit` clean on touched files
- [x] `eslint` / `prettier --check` clean on touched files
- [x] Manual repro covered by the integration tests (`reconciles redirect URIs when APP_URL changes between boots` exercises the exact #145 scenario at the service level — SQL row inspection confirms URIs updated and `clientId` preserved)