### PR TITLE
test(install): cover APP_URL drift OIDC reconciliation + fix port reuse

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -431,6 +431,93 @@ jobs:
             --env-file /tmp/appstrate-e2e/.env logs --tail 30
           exit 1
 
+      # Regression for #145 / fix in #157: when APP_URL changes between boots,
+      # the platform OIDC client's `redirect_uris` must be reconciled in place
+      # (same client_id, no DB wipe required). Snapshots the oauth_clients row,
+      # edits .env (APP_URL/TRUSTED_ORIGINS/PORT → drift port), re-runs the
+      # installer, then asserts via SQL that URIs were updated and the
+      # client_id was preserved. Re-uses the post-rollback healthy stack on
+      # port 3000.
+      - name: APP_URL drift → OIDC reconciliation
+        run: |
+          set -euo pipefail
+
+          pg_query() {
+            docker exec -i appstrate-postgres-1 \
+              psql -U appstrate -d appstrate -tA -c "$1"
+          }
+          instance_row() {
+            pg_query "SELECT client_id || '|' || array_to_string(redirect_uris, ',') || '|' || array_to_string(post_logout_redirect_uris, ',') FROM oauth_clients WHERE level='instance' ORDER BY created_at ASC LIMIT 1;"
+          }
+
+          before=$(instance_row)
+          [ -n "$before" ] || { echo "✗ no instance-level oauth_clients row"; exit 1; }
+          before_id=$(printf '%s' "$before" | cut -d'|' -f1)
+          before_redirect=$(printf '%s' "$before" | cut -d'|' -f2)
+          before_post=$(printf '%s' "$before" | cut -d'|' -f3)
+          echo "before: client_id=$before_id redirect_uris=$before_redirect"
+          [ "$before_redirect" = "http://localhost:3000/auth/callback" ] \
+            || { echo "✗ unexpected initial redirect_uris: $before_redirect"; exit 1; }
+          [ "$before_post" = "http://localhost:3000,http://localhost:3000/login" ] \
+            || { echo "✗ unexpected initial post_logout_redirect_uris: $before_post"; exit 1; }
+
+          echo "── Editing .env: APP_URL/TRUSTED_ORIGINS/PORT → 3001 ──"
+          awk -v from=3000 -v to=3001 '
+            /^APP_URL=/         { sub(":" from, ":" to); print; next }
+            /^TRUSTED_ORIGINS=/ { sub(":" from, ":" to); print; next }
+            /^PORT=/            { print "PORT=" to; next }
+            { print }
+          ' /tmp/appstrate-e2e/.env > /tmp/appstrate-e2e/.env.new
+          mv /tmp/appstrate-e2e/.env.new /tmp/appstrate-e2e/.env
+          chmod 600 /tmp/appstrate-e2e/.env
+
+          echo "── Re-running installer on port 3001 (compose recreates container) ──"
+          APPSTRATE_DIR=/tmp/appstrate-e2e \
+          APPSTRATE_PORT=3001 \
+          APPSTRATE_QUIET=1 \
+          APPSTRATE_VERSION=local \
+          APPSTRATE_ASSETS_DIR=${{ github.workspace }}/examples/self-hosting \
+            bash /tmp/install.sh
+
+          echo "── Probing http://localhost:3001 (max 60s) ──"
+          deadline=$((SECONDS + 60))
+          while [ $SECONDS -lt $deadline ]; do
+            if curl -fsS --max-time 3 http://localhost:3001/ >/dev/null 2>&1; then
+              break
+            fi
+            sleep 2
+          done
+          curl -fsS --max-time 3 http://localhost:3001/ >/dev/null 2>&1 \
+            || { echo "✗ not responding on 3001"; docker logs appstrate-appstrate-1 --tail 30; exit 1; }
+
+          after=$(instance_row)
+          after_id=$(printf '%s' "$after" | cut -d'|' -f1)
+          after_redirect=$(printf '%s' "$after" | cut -d'|' -f2)
+          after_post=$(printf '%s' "$after" | cut -d'|' -f3)
+          echo "after:  client_id=$after_id redirect_uris=$after_redirect"
+
+          [ "$after_id" = "$before_id" ] \
+            || { echo "✗ client_id changed (was $before_id, now $after_id) — outstanding tokens would be invalidated"; exit 1; }
+          [ "$after_redirect" = "http://localhost:3001/auth/callback" ] \
+            || { echo "✗ redirect_uris not reconciled: $after_redirect"; exit 1; }
+          [ "$after_post" = "http://localhost:3001,http://localhost:3001/login" ] \
+            || { echo "✗ post_logout_redirect_uris not reconciled: $after_post"; exit 1; }
+          echo "✓ URIs reconciled, client_id preserved"
+
+          # Pino's worker transport flushes asynchronously — poll with a deadline.
+          deadline=$((SECONDS + 15))
+          while [ $SECONDS -lt $deadline ]; do
+            if docker logs appstrate-appstrate-1 2>&1 \
+              | grep -q "OIDC platform client redirect URIs updated to match APP_URL"; then
+              echo "✓ reconcile log line emitted"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "✗ reconcile log line not found within 15s"
+          docker logs appstrate-appstrate-1 --tail 40
+          exit 1
+
       - name: Teardown
         if: always()
         run: |

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -169,8 +169,18 @@ detect_environment() {
   command_exists curl || fatal "curl not found"
   command_exists openssl || fatal "openssl not found"
 
-  # Port (auto-fallback in non-interactive mode = always for piped install)
+  # Port (auto-fallback in non-interactive mode = always for piped install).
+  #
+  # Re-install on the same port: the existing .env pins PORT to the same value,
+  # which means the running platform container is the reason the port shows as
+  # busy. Falling back to a different port here would point wait_for_health at
+  # an empty port and time out the upgrade/noop. Detect this case and reuse.
   if port_in_use "$APPSTRATE_PORT"; then
+    if [ -f "$APPSTRATE_DIR/.env" ] &&
+      grep -qE "^PORT=$APPSTRATE_PORT$" "$APPSTRATE_DIR/.env" 2>/dev/null; then
+      ok "Port $APPSTRATE_PORT in use by existing install — reusing"
+      return
+    fi
     local original=$APPSTRATE_PORT
     for p in 3001 3002 3003 3010 8080; do
       if ! port_in_use "$p"; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -176,8 +176,12 @@ detect_environment() {
   # busy. Falling back to a different port here would point wait_for_health at
   # an empty port and time out the upgrade/noop. Detect this case and reuse.
   if port_in_use "$APPSTRATE_PORT"; then
+    # `-Fx` = fixed-string (no regex meta interpretation) full-line match.
+    # APPSTRATE_PORT is already validated as numeric by the time we get here,
+    # but using a fixed-string match keeps this robust against any future
+    # change to upstream validation.
     if [ -f "$APPSTRATE_DIR/.env" ] &&
-      grep -qE "^PORT=$APPSTRATE_PORT$" "$APPSTRATE_DIR/.env" 2>/dev/null; then
+      grep -qFx "PORT=$APPSTRATE_PORT" "$APPSTRATE_DIR/.env" 2>/dev/null; then
       ok "Port $APPSTRATE_PORT in use by existing install — reusing"
       return
     fi

--- a/scripts/test-install-local.sh
+++ b/scripts/test-install-local.sh
@@ -8,7 +8,8 @@
 #   3. Runs install.sh with assets from ./examples/self-hosting (no GitHub roundtrip)
 #   4. Probes http://localhost:$PORT
 #   5. Re-runs to verify noop behavior
-#   6. Uninstalls + cleans up local image tags
+#   6. APP_URL drift → OIDC redirect-URI reconciliation (regression for #145)
+#   7. Uninstalls + cleans up local image tags
 #
 # Usage:
 #   ./scripts/test-install-local.sh                      # default: port 3999
@@ -16,6 +17,7 @@
 #   ./scripts/test-install-local.sh --keep               # don't uninstall at the end
 #   ./scripts/test-install-local.sh --no-build           # skip rebuild (reuse :local)
 #   ./scripts/test-install-local.sh --runtime-tag X.Y.Z  # which pi/sidecar to alias
+#   DRIFT_PORT=4500 ./scripts/test-install-local.sh      # override drift port (default: PORT+1)
 
 set -euo pipefail
 
@@ -23,6 +25,7 @@ PORT=3999
 KEEP=0
 BUILD=1
 RUNTIME_TAG="${APPSTRATE_RUNTIME_TAG:-latest}"
+DRIFT_PORT=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -51,6 +54,9 @@ done
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 TAG="local"
 WORKDIR="/tmp/appstrate-localtest"
+# Second port used to exercise the APP_URL drift / OIDC reconciliation step.
+# Defaults to PORT+1; user can override via env if that port is busy.
+DRIFT_PORT="${DRIFT_PORT:-$((PORT + 1))}"
 
 cyan() { printf "\033[0;36m%s\033[0m\n" "$*"; }
 green() { printf "\033[0;32m%s\033[0m\n" "$*"; }
@@ -131,12 +137,148 @@ else
   exit 1
 fi
 
+# ── 6. APP_URL drift → OIDC redirect-URI reconciliation (regression for #145)
+#
+# Exercises the install-script flow for the operator scenario fixed in PR #157:
+# operator changes APP_URL after first boot (port move, custom domain, …),
+# expects the platform OIDC client's `redirect_uris` to be reconciled in place
+# (same client_id, no DB wipe required).
+#
+# Steps:
+#   a. Snapshot the original instance-client row from `oauth_clients`.
+#   b. Verify URIs match the originally-installed APP_URL.
+#   c. Edit .env (APP_URL / TRUSTED_ORIGINS / PORT all → DRIFT_PORT).
+#   d. Re-run install.sh on DRIFT_PORT — compose recreates the platform
+#      container with the new port mapping, ensureInstanceClient() reconciles.
+#   e. Verify the row's URIs now match DRIFT_PORT and client_id is preserved.
+#   f. Verify the reconcile log line was emitted.
+cyan "── 6. APP_URL drift → OIDC redirect-URI reconciliation"
+
+pg_query() {
+  # tuples-only, unaligned, no row count — single value out
+  docker exec -i appstrate-postgres-1 \
+    psql -U appstrate -d appstrate -tA -c "$1"
+}
+
+instance_client_row() {
+  pg_query "SELECT client_id || '|' || array_to_string(redirect_uris, ',') || '|' || array_to_string(post_logout_redirect_uris, ',') FROM oauth_clients WHERE level='instance' ORDER BY created_at ASC LIMIT 1;"
+}
+
+before=$(instance_client_row)
+if [ -z "$before" ]; then
+  red "✗ no instance-level oauth_clients row found after fresh install"
+  exit 1
+fi
+before_client_id=$(printf '%s' "$before" | cut -d'|' -f1)
+before_redirect=$(printf '%s' "$before" | cut -d'|' -f2)
+before_post_logout=$(printf '%s' "$before" | cut -d'|' -f3)
+green "  before: client_id=$before_client_id redirect_uris=$before_redirect"
+
+want_before="http://localhost:$PORT/auth/callback"
+if [ "$before_redirect" != "$want_before" ]; then
+  red "✗ unexpected initial redirect_uris: got '$before_redirect', want '$want_before'"
+  exit 1
+fi
+want_before_post="http://localhost:$PORT,http://localhost:$PORT/login"
+if [ "$before_post_logout" != "$want_before_post" ]; then
+  red "✗ unexpected initial post_logout_redirect_uris: got '$before_post_logout', want '$want_before_post'"
+  exit 1
+fi
+
+cyan "── 6a. Editing .env: APP_URL/TRUSTED_ORIGINS/PORT → $DRIFT_PORT"
+# Use awk for cross-platform in-place edit (BSD vs GNU sed differences).
+awk -v from="$PORT" -v to="$DRIFT_PORT" '
+  /^APP_URL=/         { sub(":" from, ":" to); print; next }
+  /^TRUSTED_ORIGINS=/ { sub(":" from, ":" to); print; next }
+  /^PORT=/            { print "PORT=" to; next }
+  { print }
+' "$WORKDIR/.env" >"$WORKDIR/.env.new"
+mv "$WORKDIR/.env.new" "$WORKDIR/.env"
+chmod 600 "$WORKDIR/.env"
+
+cyan "── 6b. Re-running installer on port $DRIFT_PORT (compose recreates container)"
+RENDERED2=$(mktemp)
+sed "s|__APPSTRATE_VERSION__|$TAG|g" scripts/install.sh >"$RENDERED2"
+chmod +x "$RENDERED2"
+APPSTRATE_DIR="$WORKDIR" APPSTRATE_PORT="$DRIFT_PORT" APPSTRATE_QUIET=1 \
+  APPSTRATE_VERSION="$TAG" APPSTRATE_ASSETS_DIR="$REPO_ROOT/examples/self-hosting" \
+  "$RENDERED2" >/tmp/run3.log 2>&1 || {
+  red "✗ install.sh failed on drift port $DRIFT_PORT — log tail:"
+  tail -30 /tmp/run3.log
+  exit 1
+}
+rm -f "$RENDERED2"
+
+cyan "── 6c. Probing http://localhost:$DRIFT_PORT (max 30s)"
+deadline=$(($(date +%s) + 30))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  if curl -fsS --max-time 3 "http://localhost:$DRIFT_PORT" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+curl -fsS --max-time 3 "http://localhost:$DRIFT_PORT" >/dev/null 2>&1 || {
+  red "✗ Not responding on $DRIFT_PORT after 30s — recent appstrate logs:"
+  docker logs appstrate-appstrate-1 --tail 30 2>&1 || true
+  exit 1
+}
+
+cyan "── 6d. Verifying oauth_clients row was reconciled"
+after=$(instance_client_row)
+after_client_id=$(printf '%s' "$after" | cut -d'|' -f1)
+after_redirect=$(printf '%s' "$after" | cut -d'|' -f2)
+after_post_logout=$(printf '%s' "$after" | cut -d'|' -f3)
+green "  after:  client_id=$after_client_id redirect_uris=$after_redirect"
+
+want_after="http://localhost:$DRIFT_PORT/auth/callback"
+want_after_post="http://localhost:$DRIFT_PORT,http://localhost:$DRIFT_PORT/login"
+if [ "$after_client_id" != "$before_client_id" ]; then
+  red "✗ client_id changed after reconciliation (was '$before_client_id', now '$after_client_id') — outstanding tokens would be invalidated"
+  exit 1
+fi
+if [ "$after_redirect" != "$want_after" ]; then
+  red "✗ redirect_uris not reconciled: got '$after_redirect', want '$want_after'"
+  exit 1
+fi
+if [ "$after_post_logout" != "$want_after_post" ]; then
+  red "✗ post_logout_redirect_uris not reconciled: got '$after_post_logout', want '$want_after_post'"
+  exit 1
+fi
+green "✓ redirect_uris + post_logout_redirect_uris reconciled, client_id preserved"
+
+cyan "── 6e. Checking platform logs for reconcile warn line"
+# Pino's worker transport flushes stdout asynchronously — the reconcile warn
+# is emitted during oidcModule.init() but may land in `docker logs` a few
+# hundred ms after the HTTP listener becomes healthy. Poll with a deadline
+# rather than fail on the first miss. Snapshot to a file each iteration so a
+# failure message can show what was actually visible at the time of grep.
+deadline=$(($(date +%s) + 15))
+found=0
+snap=/tmp/appstrate-localtest-platform-logs.txt
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  docker logs appstrate-appstrate-1 >"$snap" 2>&1 || true
+  if grep -q "OIDC platform client redirect URIs updated to match APP_URL" "$snap"; then
+    found=1
+    break
+  fi
+  sleep 1
+done
+if [ "$found" -eq 1 ]; then
+  green "✓ reconcile log line emitted"
+else
+  red "✗ expected 'OIDC platform client redirect URIs updated to match APP_URL' log line not found within 15s"
+  red "  (snapshot has $(wc -l <"$snap") lines, OIDC matches: $(grep -c "OIDC" "$snap" || true))"
+  red "  (recent platform logs follow)"
+  tail -40 "$snap" || true
+  exit 1
+fi
+
 if [ "$KEEP" -eq 1 ]; then
-  green "✓ Done — install kept at $WORKDIR (port $PORT)."
+  green "✓ Done — install kept at $WORKDIR (port $DRIFT_PORT)."
   green "  Stop:   docker compose -f $WORKDIR/docker-compose.yml down"
   green "  Purge:  docker compose -f $WORKDIR/docker-compose.yml down -v && rm -rf $WORKDIR"
 else
-  cyan "── 6. Cleanup"
+  cyan "── 7. Cleanup"
   cleanup_workdir
   for img in appstrate appstrate-pi appstrate-sidecar; do
     docker rmi "ghcr.io/appstrate/$img:$TAG" >/dev/null 2>&1 || true

--- a/scripts/test-install-local.sh
+++ b/scripts/test-install-local.sh
@@ -16,7 +16,7 @@
 #   ./scripts/test-install-local.sh --port 8080
 #   ./scripts/test-install-local.sh --keep               # don't uninstall at the end
 #   ./scripts/test-install-local.sh --no-build           # skip rebuild (reuse :local)
-#   ./scripts/test-install-local.sh --runtime-tag X.Y.Z  # which pi/sidecar to alias
+#   ./scripts/test-install-local.sh --runtime-tag X.Y.Z  # which pi/sidecar to alias (default: highest local tag)
 #   DRIFT_PORT=4500 ./scripts/test-install-local.sh      # override drift port (default: PORT+1)
 
 set -euo pipefail
@@ -24,7 +24,11 @@ set -euo pipefail
 PORT=3999
 KEEP=0
 BUILD=1
-RUNTIME_TAG="${APPSTRATE_RUNTIME_TAG:-latest}"
+# `latest` is NOT published on GHCR for the runtime images, so leave the
+# default empty and resolve it later (auto-detect from local images, falling
+# back to a fail-fast hint). Explicit `--runtime-tag X.Y.Z` or
+# `APPSTRATE_RUNTIME_TAG=X.Y.Z` short-circuits the resolver.
+RUNTIME_TAG="${APPSTRATE_RUNTIME_TAG:-}"
 DRIFT_PORT=""
 
 while [ $# -gt 0 ]; do
@@ -69,6 +73,30 @@ cleanup_workdir() {
   rm -rf "$WORKDIR" 2>/dev/null || true
 }
 
+resolve_runtime_tag() {
+  # GHCR has no `:latest` tag for appstrate-pi / appstrate-sidecar — picking
+  # the highest-versioned local tag that exists for BOTH images keeps the
+  # script usable out-of-the-box. Fail-fast with an actionable hint when
+  # nothing is locally available rather than letting `docker pull :latest`
+  # explode mid-step.
+  local pi_tags sidecar_tags candidates pick
+  pi_tags=$(docker images --format '{{.Tag}}' ghcr.io/appstrate/appstrate-pi 2>/dev/null |
+    grep -v '^<none>$' | grep -v "^$TAG\$" | sort -V -u)
+  sidecar_tags=$(docker images --format '{{.Tag}}' ghcr.io/appstrate/appstrate-sidecar 2>/dev/null |
+    grep -v '^<none>$' | grep -v "^$TAG\$" | sort -V -u)
+  candidates=$(comm -12 <(printf '%s\n' "$pi_tags") <(printf '%s\n' "$sidecar_tags") | sort -V)
+  pick=$(printf '%s\n' "$candidates" | tail -1)
+  if [ -z "$pick" ]; then
+    red "No local tag found for both ghcr.io/appstrate/appstrate-pi and …-sidecar."
+    red "Pull a published version, e.g.:"
+    red "  docker pull ghcr.io/appstrate/appstrate-pi:1.0.0-alpha.52"
+    red "  docker pull ghcr.io/appstrate/appstrate-sidecar:1.0.0-alpha.52"
+    red "Then re-run, or pass --runtime-tag X.Y.Z explicitly."
+    exit 1
+  fi
+  printf '%s' "$pick"
+}
+
 cd "$REPO_ROOT"
 
 cyan "── 0. Pre-flight"
@@ -89,7 +117,12 @@ else
   cyan "── 1. Skipping build (image present, --no-build)"
 fi
 
-cyan "── 2. Aliasing pi/sidecar runtime images ($RUNTIME_TAG → $TAG)"
+if [ -z "$RUNTIME_TAG" ]; then
+  RUNTIME_TAG=$(resolve_runtime_tag)
+  cyan "── 2. Auto-detected runtime tag: $RUNTIME_TAG (override with --runtime-tag)"
+else
+  cyan "── 2. Aliasing pi/sidecar runtime images ($RUNTIME_TAG → $TAG)"
+fi
 for img in appstrate-pi appstrate-sidecar; do
   if ! docker image inspect "ghcr.io/appstrate/$img:$RUNTIME_TAG" >/dev/null 2>&1; then
     docker pull "ghcr.io/appstrate/$img:$RUNTIME_TAG"


### PR DESCRIPTION
## Summary

- Adds **step 6** to `scripts/test-install-local.sh` that exercises end-to-end the operator scenario fixed in #157 (closes #145): change `APP_URL` between boots and verify the platform OIDC client's `redirect_uris` are reconciled in place.
- Fixes a pre-existing **port-fallback false-positive in `install.sh`** that broke every re-install (the platform container itself holds the port → fallback → wait_for_health probes an empty port → timeout). The bug was masked by the prior test harness swallowing exit codes.

## What the new step asserts

After the existing fresh-install + noop check, step 6:

1. Snapshots the `oauth_clients` instance row (client_id + redirect_uris + post_logout_redirect_uris).
2. Verifies URIs match the originally-installed `APP_URL`.
3. Edits `.env` to point `APP_URL` / `TRUSTED_ORIGINS` / `PORT` at a new port (default `PORT+1`, override via `DRIFT_PORT=`).
4. Re-runs `install.sh` — compose recreates the platform container with the new port mapping.
5. Probes `http://localhost:$DRIFT_PORT` for health.
6. Re-queries `oauth_clients` and asserts: (a) `redirect_uris` and `post_logout_redirect_uris` reflect the new `APP_URL`, (b) `client_id` is preserved (so outstanding tokens remain valid), (c) the reconcile warn log line was emitted by the platform.

This is the install-script-level companion to the integration tests already shipped in #157 (`apps/api/src/modules/oidc/test/integration/services/instance-client.test.ts`).

## install.sh fix

The port-in-use check in `detect_environment()` would unconditionally trigger the fallback loop on a re-install — the platform container holds the configured port, so it always looks "busy". The fallback would pick a different port (e.g. 3001) while compose continued binding to the original (from `.env`'s unchanged `PORT=`), and `wait_for_health` then probed the empty fallback port and timed out.

Fix: when the existing `.env` already pins `PORT` to this value, treat "busy" as "we own it" and skip the fallback.

```diff
   if port_in_use "$APPSTRATE_PORT"; then
+    if [ -f "$APPSTRATE_DIR/.env" ] &&
+      grep -qE "^PORT=$APPSTRATE_PORT$" "$APPSTRATE_DIR/.env" 2>/dev/null; then
+      ok "Port $APPSTRATE_PORT in use by existing install — reusing"
+      return
+    fi
     local original=$APPSTRATE_PORT
     ...
```

This bug had been silent because `test-install-local.sh` previously piped through `tee` without `pipefail`, so the script's failing exit code was swallowed. Step 5 ("noop check") was de-facto skipped.

## Notes

- Pino's worker transport flushes asynchronously; the OIDC reconcile warn is emitted before the HTTP listener becomes healthy but lands in `docker logs` a few seconds later. Step 6e polls with a 15s deadline.
- The default `--runtime-tag latest` for `appstrate-pi` / `appstrate-sidecar` doesn't exist on GHCR — pre-existing limitation, not addressed here. Users (and CI) should pass an explicit `--runtime-tag` matching a published version.

## Test plan

- [x] `./scripts/test-install-local.sh --no-build --runtime-tag 1.0.0-alpha.52` — all 7 steps green
- [x] `bash -n scripts/install.sh scripts/test-install-local.sh` — clean
- [x] Drift step verifies reconciliation via SQL (independent of the log line) AND via the warn log (defense-in-depth for operator visibility)