### PR TITLE
docs(firecracker): ADR-007 + 5-phase implementation spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ storage/
 
 docs/*
 !docs/adr/
+!docs/specs/
 flows/*
 
 claudedocs/

--- a/docs/adr/ADR-007-firecracker-orchestrator.md
+++ b/docs/adr/ADR-007-firecracker-orchestrator.md
@@ -1,0 +1,120 @@
+# ADR-007: Firecracker MicroVM Orchestrator (Tier 4)
+
+## Status
+
+Proposed — approved for implementation via phased rollout (Phase 1-5).
+
+## Context
+
+Appstrate currently supports two execution backends behind the `ContainerOrchestrator` interface (`apps/api/src/services/orchestrator/interface.ts`):
+
+- **Docker** (`docker-orchestrator.ts`) — production, container-based isolation via Linux namespaces + cgroups
+- **Process** (`process-orchestrator.ts`) — dev-only, Bun subprocesses, no isolation
+
+The platform runs user-provided AI agent code, including tools that execute arbitrary shell commands and skills loaded from third-party AFPS packages. Docker provides adequate isolation for the current OSS deployment model, but three requirements push toward a stronger boundary:
+
+1. **Isolation** — Enterprise tenants running multi-tenant workloads need kernel-level separation. A container escape via a kernel exploit crosses into host / other tenants; a microVM escape would require a hypervisor exploit (significantly higher bar).
+2. **Compliance** — Customers with SOC2 / ISO 27001 / FedRAMP obligations need attestable, signed artifacts for the runtime, immutable rootfs, per-run audit trails, and cryptographic evidence of isolation.
+3. **Cold-start latency** — Firecracker snapshot restore (~50-100ms) beats fresh Docker container cold start (~500-1500ms) for the sidecar. The agent VM cold boot is comparable to Docker today.
+
+The three drivers are compatible if and only if snapshots are taken of **pristine pre-warmed state** (kernel + runtime loaded, before any tenant data enters the VM) and never of dirty runtime state — the AWS Lambda SnapStart pattern.
+
+## Decision
+
+Add a **Firecracker microVM orchestrator** as a third execution backend, opt-in behind a new `RUN_ADAPTER=firecracker` mode. Introduce **Tier 4** as a new progressive infrastructure tier (after Tier 3 / Docker), targeting hosts with KVM + `CAP_NET_ADMIN` available (bare-metal, nested-virt cloud instances, enterprise on-prem).
+
+Docker remains the default production backend. Firecracker is not a replacement; it is a parallel implementation selected per-deployment via env var.
+
+### Core architectural decisions
+
+| #   | Decision                                                                             | Rationale                                                                                                                                                                                                                                                                                                   |
+| --- | ------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **Use the jailer in all modes** (no raw Firecracker)                                 | Drops privileges, applies cgroup + namespace isolation, chroots the VMM. Officially required for production.                                                                                                                                                                                                |
+| 2   | **Two microVMs per run** (sidecar + agent, mirroring Docker)                         | Preserves the existing credential-isolation invariant (ADR-003): agent never sees raw credentials, has no `RUN_TOKEN` / `PLATFORM_API_URL`. Fusing would void the boundary without adding guarantees.                                                                                                       |
+| 3   | **Sidecar VM snapshot pool, agent VM cold boot** (MVP)                               | Sidecar state is tenant-agnostic → snapshottable. Agent state is tenant-specific (`AGENT_PROMPT`, package, skills) → fresh boot. Delivers the cold-start win where it matters (sidecar is on the critical path of every request) without refactoring `runtime-pi`.                                          |
+| 4   | **Pristine snapshot pattern** for any future agent snapshot                          | Snapshot is taken once per image version, of an empty pre-warmed VM. Tenant data enters only _after_ restore. Preserves isolation + compliance compatibility.                                                                                                                                               |
+| 5   | **CI-built, cosign-signed rootfs** (`.ext4`) as the only accepted artifact in Tier 4 | No runtime conversion, no containerd. Pipeline: `buildx --output type=local` → `tar2ext4` → `cosign sign` → GHCR artifact. ~200 LOC vs ~2000 for firecracker-containerd.                                                                                                                                    |
+| 6   | **`PI_IMAGE` override hard-fails in Tier 4** (MVP)                                   | A security tier cannot silently ignore user config. Users who need custom images stay on Tier 3. A `CustomImageProvisioner` plugin path is reserved for post-MVP.                                                                                                                                           |
+| 7   | **Workspace storage: per-run virtio drive** (ext4, reflink-cloned from template)     | Imprevisible write volume per run (git clone, unzip, LLM-generated files). Fresh file per run = zero inter-tenant leak. reflink-clone is instant (CoW) on XFS/btrfs hosts, `cp` fallback otherwise.                                                                                                         |
+| 8   | **File injection: dedicated read-only `/inputs` drive**                              | Inputs (AFPS package, uploads) are separated from the mutable workspace. Drive is hashable → signed audit trail per run. Agent copies what it needs from `/inputs` into `/workspace`.                                                                                                                       |
+| 9   | **Networking: per-run bridge + static IPs + `/etc/hosts` injection** (MVP)           | 1:1 mapping with Docker DNS-alias pattern. Agent keeps `fetch("http://sidecar:8080/proxy")` unchanged — zero modification to runtime-pi. Sidecar has a second TAP on an egress bridge with NAT; agent's single TAP is on a dead-end bridge (no route out). vsock migration is roadmapped — see Iterability. |
+| 10  | **Logs: two virtio-console devices**                                                 | `ttyS0` carries kernel + init (debug). `/dev/hvc1` carries app stdout (clean JSON-line stream for the platform parser). Kernel noise never interleaves with app output. Pattern used by AWS Lambda, Fly Machines, Modal.                                                                                    |
+| 11  | **Init: custom minimal binary (~80 LOC)**, not systemd                               | systemd in a microVM is ~20MB RAM + ~200ms boot for features we don't need. Custom init mounts `/inputs` + `/workspace`, redirects stdout to `hvc1`, execs Bun.                                                                                                                                             |
+| 12  | **Orphan recovery: DB registry + jailer chroot sweep**                               | Mirrors `cleanupOrphanedContainers()` in `docker.ts`. Double-sided check: DB rows for active runs → verify jailer chroot + API socket; filesystem scan → verify DB references. Firecracker is stateless; the platform owns reconciliation.                                                                  |
+
+### Threat model
+
+**In scope (Firecracker mitigates):**
+
+- Kernel-exploit-based container escape (VM boundary vs namespace boundary)
+- Cross-tenant state leak via shared kernel structures
+- Process-level side-channel attacks across tenants on the same host
+
+**Out of scope (Firecracker does not mitigate):**
+
+- Abuse of `authorizedUris` via the sidecar — same attack surface as Docker; sidecar is the boundary
+- Compromised sidecar — same blast radius as Docker (agent trusts the sidecar)
+- Hypervisor exploits — residual risk, partially mitigated by the jailer + seccomp
+- Host compromise — out of scope for any container/VM technology
+
+**Compliance coverage added:**
+
+- Signed rootfs + signed sidecar snapshot → attestable runtime artifacts
+- Hashed `/inputs` drive per run → tamper-evident input trail
+- Per-VM cgroup accounting (via jailer) → per-tenant resource attribution for billing/audit
+
+## Iterability foundations
+
+These must be posed during Phase 1-2 to keep future optimizations as isolated PRs:
+
+1. **`VmProvisioner` interface** — abstracts "how a VM is prepared" (cold boot vs snapshot restore vs custom). Phase 1 ships `ColdBootProvisioner`. Agent snapshot (deferred) ships as `SnapshotProvisioner` — no orchestrator refactor needed.
+2. **Extensible signed manifest** — rootfs manifest is JSON with named hash slots. Adding `agent_snapshot_hash` or `sidecar_snapshot_hash` later is additive.
+3. **Mode-agnostic orphan recovery** — scanner doesn't care whether a VM is cold-booted or snapshot-restored; it checks DB reference + jailer chroot + socket liveness.
+4. **Granular audit events** — `vm.provisioned`, `vm.started`, `vm.stopped`, each with a `source` field (`"cold" | "snapshot"`). MVP emits `"cold"` always; later modes hook in without schema change.
+5. **Sidecar HTTP listener is injectable** — `runtime-pi/sidecar/server.ts` takes a listener factory as a dependency, not `Bun.serve` in hard-code. Swapping to a vsock listener post-MVP = injection change, no rewrite.
+6. **`CustomImageProvisioner` plugin path** — image resolution goes through a `RootfsProvider` interface; MVP ships `SignedReleaseProvider` only. Adding custom-image support later = new provider, not a refactor.
+
+## Out of scope for this ADR (deferred decisions)
+
+- **Agent VM snapshot (pre-loaded SDK)** — level 2 of the pristine snapshot strategy. Ship cold boot first, measure, optimize in Phase 5+ if the cold-start budget is not met.
+- **Per-agent snapshots** — level 3. Only justifiable with data showing a small set of agents dominates runtime volume.
+- **vsock for sidecar↔agent** — post-MVP. Bridge + static IP is SOTA for this MVP. vsock listener abstraction posed in Phase 2 unlocks this later.
+- **User-provided custom `PI_IMAGE` in Tier 4** — post-MVP, requires cosign verification of user-signed rootfs. MVP hard-fails.
+- **Remote attestation (vTPM, measured boot)** — full enterprise compliance pack. Not natively supported by Firecracker; PR-based, +300-800ms, +5-10% steady-state. Defer until a customer requires it contractually.
+- **Production-grade CI tests with real KVM** — MVP relies on mocks. Real-KVM CI requires a dedicated runner (bare-metal or nested-virt GitHub Actions). Post-MVP.
+
+## Consequences
+
+**Positive:**
+
+- Third execution backend unlocks Enterprise tier (KVM-equipped hosts) with kernel-level isolation
+- Compliance-grade audit trail: signed runtime, hashed inputs, per-VM resource attribution
+- Sidecar cold-start improved by ~500ms-1s (snapshot restore vs fresh container)
+- `ContainerOrchestrator` abstraction validated by a third implementation — confirms the interface is load-bearing, not over-fitted
+- Phased rollout (Phase 1-5) allows shipping value incrementally; each phase has its own acceptance criteria
+
+**Negative:**
+
+- Three execution backends to maintain (Docker, Process, Firecracker) — test coverage burden, conceptual overhead for contributors
+- CI cannot exercise the full Firecracker path without dedicated KVM runners (MVP uses mocks)
+- Host requirements narrow the deployment footprint in Tier 4 (KVM + CAP_NET_ADMIN + bridge-capable host)
+- Image build pipeline in CI adds a parallel artifact (`rootfs.ext4`) alongside the Docker image
+- TAP device management is a new operational concern (leak recovery, unique naming, FD limits)
+- Boot kernel + custom init are new maintenance surfaces; kernel CVEs require prompt rebuilds
+
+**Neutral:**
+
+- `runtime-pi` is unchanged in the MVP — agent code, SDK, JSON-line stdout protocol all stay identical
+- `ContainerOrchestrator` interface is unchanged — existing callers don't know they're running on Firecracker
+- Tier 4 is opt-in, off by default — zero impact on OSS self-hosters on Tier 0-3
+
+## References
+
+- Issue [#159](https://github.com/appstrate/appstrate/issues/159) — original RFC
+- [ADR-003](./ADR-003-sidecar-credential-isolation.md) — credential isolation invariant, preserved by decision #2
+- [Firecracker design](https://github.com/firecracker-microvm/firecracker/blob/main/docs/design.md)
+- [Firecracker jailer](https://github.com/firecracker-microvm/firecracker/blob/main/docs/jailer.md)
+- [Firecracker snapshots](https://github.com/firecracker-microvm/firecracker/blob/main/docs/snapshotting/snapshot-support.md)
+- [tar2ext4 (Microsoft hcsshim)](https://github.com/microsoft/hcsshim/tree/main/ext4/tar2ext4) — reference for the CI conversion step
+- [cosign](https://github.com/sigstore/cosign) — artifact signing
+- `docs/specs/PHASE_1_FIRECRACKER_SKELETON.md` — implementation spec for the first phase

--- a/docs/specs/PHASE_1_FIRECRACKER_SKELETON.md
+++ b/docs/specs/PHASE_1_FIRECRACKER_SKELETON.md
@@ -1,0 +1,868 @@
+# Phase 1 — Firecracker Orchestrator Skeleton
+
+**Status:** Ready for implementation
+**Prerequisites:** [ADR-007](../adr/ADR-007-firecracker-orchestrator.md) read and understood
+**Estimate:** 2-3 days / ~800 LOC including tests
+**Phase of:** 5-phase Firecracker rollout (see ADR-007)
+
+---
+
+## 1. Purpose
+
+This phase delivers a **no-op Firecracker orchestrator skeleton** that:
+
+- Compiles and satisfies the full `ContainerOrchestrator` interface
+- Is selectable via `RUN_ADAPTER=firecracker`
+- Passes a mirror of the existing Docker orchestrator test suite using mocks for the host-privileged operations (KVM, TAP, jailer)
+- Ships the iterability foundations required by ADR-007 (§Iterability) so later phases are additive PRs, not refactors
+
+**This phase does NOT:**
+
+- Launch a real microVM (Phase 2)
+- Touch the host network or TAP devices for real (Phase 3)
+- Parse serial console logs (Phase 4)
+- Include snapshots, VM pool, image cache, or real orphan recovery (Phase 5)
+- Modify `runtime-pi/` or the sidecar
+- Build any CI artifacts (that lives in Phase 2 alongside the first real boot)
+
+The goal is a **testable contract** that the rest of the codebase can rely on, and a skeleton that Phase 2 fills in.
+
+---
+
+## 2. Success criteria
+
+Phase 1 is complete when **all** of the following hold:
+
+1. `bun run check` passes from monorepo root (tsc + eslint + prettier + verify-openapi).
+2. `bun test apps/api/test/unit/services/firecracker` passes with ≥ 10 new unit tests.
+3. `bun test apps/api/test/integration/services/firecracker-orchestrator.test.ts` passes with the full `ContainerOrchestrator` contract exercised against a `MockFirecrackerHost`.
+4. Setting `RUN_ADAPTER=firecracker` in a fresh `.env` boots the platform without crashing; `bun run dev` logs `Firecracker orchestrator initialized (mock host)` and serves `/api/health` 200.
+5. Setting `RUN_ADAPTER=firecracker` with `PI_IMAGE` overridden to a non-default value fails boot with a clear RFC 9457 error: `"Tier 4 requires the signed Appstrate runtime image. Custom PI_IMAGE is not supported in this tier."`
+6. `getOrchestrator()` returns a `FirecrackerOrchestrator` instance when the mode is `firecracker`.
+7. `CHANGELOG.md` entry added under the current unreleased section.
+8. No existing Docker/Process tests regress.
+
+---
+
+## 3. File tree to create
+
+All paths are relative to the repo root (`appstrate/`).
+
+```
+apps/api/src/services/orchestrator/
+├── firecracker-orchestrator.ts        (NEW, ~350 LOC) — the class implementing ContainerOrchestrator
+├── index.ts                           (MODIFY) — add "firecracker" case to factory
+└── types.ts                           (MODIFY) — add FirecrackerWorkloadHandle, FirecrackerIsolationBoundary types
+
+apps/api/src/services/firecracker/
+├── host.ts                            (NEW, ~80 LOC) — FirecrackerHost interface (real/mock split)
+├── mock-host.ts                       (NEW, ~150 LOC) — in-memory mock implementation, used in tests + dev-without-KVM
+├── jailer.ts                          (NEW, ~50 LOC) — STUB — real impl in Phase 2; Phase 1 throws from all methods
+├── tap-manager.ts                     (NEW, ~60 LOC) — STUB — fake TAP names, no real netlink in Phase 1
+├── vm-provisioner.ts                  (NEW, ~80 LOC) — VmProvisioner interface + ColdBootProvisioner (stub)
+├── audit.ts                           (NEW, ~40 LOC) — emit `vm.provisioned`, `vm.started`, `vm.stopped` via logger
+└── constants.ts                       (NEW, ~20 LOC) — sizes, paths, timeouts
+
+apps/api/src/infra/
+└── mode.ts                            (MODIFY) — extend getExecutionMode() return type + switch
+
+packages/env/src/
+└── index.ts                           (MODIFY) — add FIRECRACKER_* env vars + hard-fail refine for PI_IMAGE
+
+apps/api/src/lib/
+└── boot.ts                            (MODIFY) — dispatch Firecracker init alongside Docker init
+
+apps/api/test/unit/services/firecracker/
+├── host.test.ts                       (NEW) — MockFirecrackerHost contract tests
+├── vm-provisioner.test.ts             (NEW) — ColdBootProvisioner returns expected shape
+└── audit.test.ts                      (NEW) — audit events emitted at the right hooks
+
+apps/api/test/integration/services/
+└── firecracker-orchestrator.test.ts   (NEW, ~200 LOC) — full ContainerOrchestrator contract against mock host
+
+.env.example                           (MODIFY) — document new env vars
+CHANGELOG.md                           (MODIFY) — add unreleased entry
+```
+
+---
+
+## 4. Environment variables
+
+Add to `packages/env/src/index.ts` (`envSchema` object):
+
+```ts
+// Firecracker (Tier 4, opt-in — requires KVM + CAP_NET_ADMIN on the host)
+FIRECRACKER_BINARY: z.string().default("/usr/bin/firecracker"),
+FIRECRACKER_JAILER_BINARY: z.string().default("/usr/bin/jailer"),
+FIRECRACKER_KERNEL_PATH: z.string().default("/var/lib/appstrate/firecracker/vmlinux"),
+FIRECRACKER_ROOTFS_PATH: z.string().default("/var/lib/appstrate/firecracker/runtime-pi.ext4"),
+FIRECRACKER_SIDECAR_ROOTFS_PATH: z.string().default("/var/lib/appstrate/firecracker/sidecar.ext4"),
+FIRECRACKER_JAILER_CHROOT_BASE: z.string().default("/srv/jailer"),
+FIRECRACKER_WORKSPACE_TEMPLATE_PATH: z.string().default("/var/lib/appstrate/firecracker/workspace-template.ext4"),
+FIRECRACKER_WORKSPACE_SIZE_GB: z.coerce.number().int().min(1).max(500).default(10),
+FIRECRACKER_VM_POOL_SIZE: z.coerce.number().int().min(0).default(2),
+FIRECRACKER_BRIDGE_NAME: z.string().default("appstrate-br0"),
+FIRECRACKER_BRIDGE_SUBNET: z.string().default("10.200.0.0/16"),
+// MVP: mock host when set — no real KVM/TAP syscalls. Defaults to true until Phase 2.
+FIRECRACKER_MOCK_HOST: z
+  .string()
+  .default("true")
+  .transform((v) => v === "true" || v === "1"),
+```
+
+Extend the existing `RUN_ADAPTER` enum:
+
+```ts
+RUN_ADAPTER: z.enum(["docker", "process", "firecracker"]).default("process"),
+```
+
+Add a refine after the existing ones to enforce the hard-fail on custom `PI_IMAGE` in Tier 4:
+
+```ts
+.refine(
+  (env) =>
+    env.RUN_ADAPTER !== "firecracker" || env.PI_IMAGE === "appstrate-pi:latest",
+  {
+    message:
+      "Tier 4 (RUN_ADAPTER=firecracker) requires the signed Appstrate runtime image. " +
+      "Custom PI_IMAGE is not supported in this tier. Use RUN_ADAPTER=docker for custom images.",
+    path: ["PI_IMAGE"],
+  },
+)
+```
+
+Update `.env.example` with a Firecracker section:
+
+```sh
+# ─── Firecracker (Tier 4 — Enterprise, KVM required) ─────────
+# Enable by setting RUN_ADAPTER=firecracker. Requires /dev/kvm + CAP_NET_ADMIN.
+# Firecracker is OFF by default. Tier 4 is opt-in.
+# PI_IMAGE cannot be overridden in Tier 4 — use Tier 3 (Docker) for custom images.
+
+# FIRECRACKER_BINARY=/usr/bin/firecracker
+# FIRECRACKER_JAILER_BINARY=/usr/bin/jailer
+# FIRECRACKER_KERNEL_PATH=/var/lib/appstrate/firecracker/vmlinux
+# FIRECRACKER_ROOTFS_PATH=/var/lib/appstrate/firecracker/runtime-pi.ext4
+# FIRECRACKER_SIDECAR_ROOTFS_PATH=/var/lib/appstrate/firecracker/sidecar.ext4
+# FIRECRACKER_JAILER_CHROOT_BASE=/srv/jailer
+# FIRECRACKER_WORKSPACE_TEMPLATE_PATH=/var/lib/appstrate/firecracker/workspace-template.ext4
+# FIRECRACKER_WORKSPACE_SIZE_GB=10
+# FIRECRACKER_VM_POOL_SIZE=2
+# FIRECRACKER_BRIDGE_NAME=appstrate-br0
+# FIRECRACKER_BRIDGE_SUBNET=10.200.0.0/16
+# FIRECRACKER_MOCK_HOST=true  # Phase 1: always true. Phase 2+: false on KVM-equipped hosts.
+```
+
+---
+
+## 5. Execution mode extension
+
+**Modify `apps/api/src/infra/mode.ts`:**
+
+```ts
+export function getExecutionMode(): "docker" | "process" | "firecracker" {
+  const adapter = getEnv().RUN_ADAPTER;
+  if (adapter === "process") return "process";
+  if (adapter === "firecracker") return "firecracker";
+  return "docker";
+}
+```
+
+**Modify `apps/api/src/services/orchestrator/index.ts`:**
+
+```ts
+import { FirecrackerOrchestrator } from "./firecracker-orchestrator.ts";
+
+function createOrchestrator(): ContainerOrchestrator {
+  const mode = getExecutionMode();
+  if (mode === "process") return new ProcessOrchestrator();
+  if (mode === "firecracker") return new FirecrackerOrchestrator();
+  return new DockerOrchestrator();
+}
+```
+
+---
+
+## 6. Types to add
+
+**Modify `apps/api/src/services/orchestrator/types.ts`** — append at the bottom, do not modify existing types:
+
+```ts
+// ─── Firecracker-specific types ──────────────────────────────
+
+/** Opaque handle for a microVM. `id` is the jailer VM id (UUID). */
+export interface FirecrackerWorkloadHandle extends WorkloadHandle {
+  readonly id: string; // VM id (UUID, used as jailer chroot dir name)
+  readonly runId: string;
+  readonly role: string; // "sidecar" | "agent"
+  readonly socketPath: string; // absolute path to the Firecracker API socket
+  readonly chrootPath: string; // absolute path to the jailer chroot for this VM
+}
+
+/** Isolation boundary for a run. `id` is the bridge network name (Linux bridge) */
+export interface FirecrackerIsolationBoundary extends IsolationBoundary {
+  readonly id: string; // bridge name, e.g. "fc-br-{runId-truncated}"
+  readonly name: string; // human-readable
+  readonly subnet: string; // e.g. "10.200.42.0/30" (one /30 per run — enough for sidecar + agent + gateway)
+}
+```
+
+Note: these extend the base interfaces. Callers that only rely on `id / runId / role` on the base `WorkloadHandle` don't need to change.
+
+---
+
+## 7. Core interfaces
+
+### 7.1 `apps/api/src/services/firecracker/host.ts`
+
+Abstracts the host-privileged operations. The real implementation ships in Phase 2. Phase 1 implements only the mock.
+
+```ts
+// SPDX-License-Identifier: Apache-2.0
+
+export interface FirecrackerHost {
+  /** One-time initialization: verify KVM/jailer presence, create bridge, ensure chroot base exists. */
+  initialize(): Promise<void>;
+
+  /** Graceful shutdown: stop all running VMs, release bridge, close sockets. */
+  shutdown(): Promise<void>;
+
+  /** Create a new VM in the jailer chroot. Returns the API socket path. Does NOT start the VM. */
+  createVm(spec: CreateVmSpec): Promise<CreatedVm>;
+
+  /** Start a created VM (sends `InstanceStart` via the Firecracker API socket). */
+  startVm(vmId: string): Promise<void>;
+
+  /** Stop a VM (sends `SendCtrlAltDel` or `InstanceHalt`, with fallback to SIGKILL). Idempotent. */
+  stopVm(vmId: string, timeoutSeconds?: number): Promise<void>;
+
+  /** Remove the VM artifacts (chroot, socket, drives). Idempotent. */
+  removeVm(vmId: string): Promise<void>;
+
+  /** Wait for the VM to exit. Returns the exit code reported by init (via a side-channel file in Phase 2). */
+  waitForExit(vmId: string): Promise<number>;
+
+  /** Stream app logs from /dev/hvc1 (mocked in Phase 1, real in Phase 4). */
+  streamLogs(vmId: string, signal?: AbortSignal): AsyncGenerator<string>;
+
+  /** List all VM chroots that look orphaned (no active run ref). */
+  listCandidateOrphans(): Promise<string[]>;
+
+  /** Create a Linux bridge + subnet for a run. Returns the bridge name. */
+  createBridge(name: string, subnet: string): Promise<void>;
+
+  /** Remove a Linux bridge. Idempotent. */
+  removeBridge(name: string): Promise<void>;
+
+  /** Attach a new TAP device to a VM and to a bridge. */
+  attachTap(vmId: string, bridgeName: string, ip: string): Promise<string>; // returns TAP name
+
+  /** Create a workspace drive (ext4 file) for the run. Uses reflink-clone from template when available. */
+  createWorkspaceDrive(runId: string, sizeGb: number): Promise<string>; // returns absolute path
+
+  /** Create an inputs drive (ext4 file containing AFPS + uploads). Returns path + content hash. */
+  createInputsDrive(
+    runId: string,
+    files: { name: string; content: Buffer }[],
+  ): Promise<{ path: string; sha256: string }>;
+
+  /** Remove a drive file. Idempotent. */
+  removeDrive(path: string): Promise<void>;
+}
+
+export interface CreateVmSpec {
+  vmId: string;
+  role: "sidecar" | "agent";
+  kernelPath: string;
+  rootfsPath: string;
+  workspaceDrivePath?: string; // agent only
+  inputsDrivePath?: string; // agent only
+  memoryMib: number;
+  vcpus: number;
+  env: Record<string, string>; // passed via kernel cmdline or MMDS
+}
+
+export interface CreatedVm {
+  vmId: string;
+  socketPath: string;
+  chrootPath: string;
+}
+```
+
+### 7.2 `apps/api/src/services/firecracker/mock-host.ts`
+
+An in-memory implementation. All state is in maps. No filesystem writes outside `/tmp`. Never shells out.
+
+Required behaviors:
+
+- `initialize()` / `shutdown()`: flip an internal `initialized` flag; idempotent.
+- `createVm()`: generate a `socketPath = /tmp/fc-mock/{vmId}/firecracker.socket`, create the directory, return the spec.
+- `startVm()` / `stopVm()` / `removeVm()`: update internal state map (`created` → `running` → `stopped` → `removed`).
+- `waitForExit()`: resolves with `0` when `stopVm` has been called, otherwise hangs until `signal` aborts.
+- `streamLogs()`: yields a fixed canned sequence of 3 mock JSON lines then ends.
+- `listCandidateOrphans()`: returns the content of the internal state map filtered by age (all VMs created > 5 min ago).
+- `createBridge()` / `removeBridge()`: maintain a set.
+- `attachTap()`: returns `"tap-mock-{vmId-short}"`.
+- `createWorkspaceDrive()` / `createInputsDrive()`: write a 1-byte placeholder file under `/tmp/fc-mock/drives/` and compute a real sha256 of the concatenated file contents for inputs.
+- `removeDrive()`: `fs.unlink` + swallow ENOENT.
+
+Keep this simple. The mock exists so `FirecrackerOrchestrator` behavior can be tested end-to-end without any host privileges.
+
+### 7.3 `apps/api/src/services/firecracker/vm-provisioner.ts`
+
+```ts
+// SPDX-License-Identifier: Apache-2.0
+
+import type { FirecrackerHost, CreatedVm } from "./host.ts";
+
+export type ProvisioningSource = "cold" | "snapshot";
+
+export interface VmProvisioner {
+  /** Provision a VM ready to be started. Source indicates whether a cold boot or snapshot restore was used. */
+  provision(spec: ProvisionSpec): Promise<ProvisionedVm>;
+}
+
+export interface ProvisionSpec {
+  runId: string;
+  role: "sidecar" | "agent";
+  env: Record<string, string>;
+  memoryMib: number;
+  vcpus: number;
+  workspaceDrivePath?: string;
+  inputsDrivePath?: string;
+}
+
+export interface ProvisionedVm extends CreatedVm {
+  source: ProvisioningSource;
+}
+
+/** Phase 1: the only implementation. Cold boots a fresh VM with no snapshot. */
+export class ColdBootProvisioner implements VmProvisioner {
+  constructor(
+    private readonly host: FirecrackerHost,
+    private readonly config: { kernelPath: string; agentRootfs: string; sidecarRootfs: string },
+  ) {}
+
+  async provision(spec: ProvisionSpec): Promise<ProvisionedVm> {
+    const vmId = crypto.randomUUID();
+    const rootfs = spec.role === "sidecar" ? this.config.sidecarRootfs : this.config.agentRootfs;
+    const vm = await this.host.createVm({
+      vmId,
+      role: spec.role,
+      kernelPath: this.config.kernelPath,
+      rootfsPath: rootfs,
+      workspaceDrivePath: spec.workspaceDrivePath,
+      inputsDrivePath: spec.inputsDrivePath,
+      memoryMib: spec.memoryMib,
+      vcpus: spec.vcpus,
+      env: spec.env,
+    });
+    return { ...vm, source: "cold" };
+  }
+}
+```
+
+### 7.4 `apps/api/src/services/firecracker/audit.ts`
+
+```ts
+// SPDX-License-Identifier: Apache-2.0
+
+import { logger } from "../../lib/logger.ts";
+import type { ProvisioningSource } from "./vm-provisioner.ts";
+
+export type VmAuditEvent =
+  | {
+      type: "vm.provisioned";
+      vmId: string;
+      runId: string;
+      role: string;
+      source: ProvisioningSource;
+    }
+  | { type: "vm.started"; vmId: string; runId: string; role: string }
+  | {
+      type: "vm.stopped";
+      vmId: string;
+      runId: string;
+      role: string;
+      exitCode: number;
+      durationMs: number;
+    };
+
+export function emitVmAudit(event: VmAuditEvent): void {
+  logger.info("firecracker.audit", event);
+}
+```
+
+Phase 1: audit events go through the platform logger. Phase 5: add a sink to `packages/db` for persistent audit trail.
+
+### 7.5 `apps/api/src/services/firecracker/constants.ts`
+
+```ts
+// SPDX-License-Identifier: Apache-2.0
+
+export const SIDECAR_VM_MEMORY_MIB = 128;
+export const SIDECAR_VM_VCPUS = 1; // note: Firecracker vCPU count must be integer
+export const AGENT_VM_MEMORY_MIB = 512;
+export const AGENT_VM_VCPUS = 1;
+
+export const VM_STOP_TIMEOUT_SECONDS = 10;
+export const ORPHAN_SCAN_MIN_AGE_SECONDS = 300;
+
+// Per-run subnet is a /30 inside the platform subnet: 4 IPs = network, gateway (bridge), sidecar, agent.
+export const PER_RUN_SUBNET_MASK = 30;
+
+export const SIDECAR_STATIC_IP_OFFSET = 2; // x.x.x.2
+export const AGENT_STATIC_IP_OFFSET = 3; // x.x.x.3
+```
+
+---
+
+## 8. `FirecrackerOrchestrator` — implementation blueprint
+
+The class lives in `apps/api/src/services/orchestrator/firecracker-orchestrator.ts`. It mirrors the structure of `DockerOrchestrator` (read `docker-orchestrator.ts` first — every method in `FirecrackerOrchestrator` should have a 1:1 counterpart).
+
+```ts
+// SPDX-License-Identifier: Apache-2.0
+
+import { getEnv } from "@appstrate/env";
+import { logger } from "../../lib/logger.ts";
+import type { ContainerOrchestrator } from "./interface.ts";
+import type {
+  WorkloadHandle,
+  WorkloadSpec,
+  IsolationBoundary,
+  SidecarConfig,
+  CleanupReport,
+  StopResult,
+  FirecrackerWorkloadHandle,
+  FirecrackerIsolationBoundary,
+} from "./types.ts";
+import { FirecrackerHost } from "../firecracker/host.ts";
+import { MockFirecrackerHost } from "../firecracker/mock-host.ts";
+import { ColdBootProvisioner, type VmProvisioner } from "../firecracker/vm-provisioner.ts";
+import { emitVmAudit } from "../firecracker/audit.ts";
+import {
+  SIDECAR_VM_MEMORY_MIB,
+  SIDECAR_VM_VCPUS,
+  AGENT_VM_MEMORY_MIB,
+  AGENT_VM_VCPUS,
+  VM_STOP_TIMEOUT_SECONDS,
+  PER_RUN_SUBNET_MASK,
+  SIDECAR_STATIC_IP_OFFSET,
+  AGENT_STATIC_IP_OFFSET,
+} from "../firecracker/constants.ts";
+
+export class FirecrackerOrchestrator implements ContainerOrchestrator {
+  private readonly host: FirecrackerHost;
+  private readonly provisioner: VmProvisioner;
+  private readonly activeVms = new Map<string, FirecrackerWorkloadHandle[]>(); // runId → handles
+
+  constructor(host?: FirecrackerHost) {
+    const env = getEnv();
+    this.host =
+      host ?? (env.FIRECRACKER_MOCK_HOST ? new MockFirecrackerHost() : this.realHostOrThrow());
+    this.provisioner = new ColdBootProvisioner(this.host, {
+      kernelPath: env.FIRECRACKER_KERNEL_PATH,
+      agentRootfs: env.FIRECRACKER_ROOTFS_PATH,
+      sidecarRootfs: env.FIRECRACKER_SIDECAR_ROOTFS_PATH,
+    });
+  }
+
+  private realHostOrThrow(): FirecrackerHost {
+    throw new Error(
+      "Real FirecrackerHost not implemented in Phase 1. Set FIRECRACKER_MOCK_HOST=true (default) or wait for Phase 2.",
+    );
+  }
+
+  async initialize(): Promise<void> {
+    await this.host.initialize();
+    logger.info("Firecracker orchestrator initialized", {
+      mock: getEnv().FIRECRACKER_MOCK_HOST,
+    });
+  }
+
+  async shutdown(): Promise<void> {
+    await this.host.shutdown();
+  }
+
+  async ensureImages(_images: string[]): Promise<void> {
+    // No-op in Phase 1: Tier 4 uses signed rootfs artifacts downloaded in Phase 2.
+    // PI_IMAGE override is already rejected at env validation — see packages/env.
+  }
+
+  async cleanupOrphans(): Promise<CleanupReport> {
+    const candidates = await this.host.listCandidateOrphans();
+    for (const vmId of candidates) {
+      await this.host.removeVm(vmId).catch((err) =>
+        logger.warn("Failed to remove orphan VM", {
+          vmId,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    }
+    return { workloads: candidates.length, isolationBoundaries: 0 };
+  }
+
+  async createIsolationBoundary(runId: string): Promise<IsolationBoundary> {
+    // Bridge name: `fc-br-{first 8 chars of runId}` — bridges are limited to 15 chars on Linux.
+    const shortId = runId.replace(/-/g, "").slice(0, 8);
+    const bridgeName = `fc-br-${shortId}`;
+    const subnet = this.allocateSubnet(runId);
+    await this.host.createBridge(bridgeName, subnet);
+    return { id: bridgeName, name: bridgeName, subnet } satisfies FirecrackerIsolationBoundary;
+  }
+
+  async removeIsolationBoundary(boundary: IsolationBoundary): Promise<void> {
+    await this.host.removeBridge(boundary.id);
+  }
+
+  async createSidecar(
+    runId: string,
+    boundary: IsolationBoundary,
+    config: SidecarConfig,
+  ): Promise<WorkloadHandle> {
+    const subnet = (boundary as FirecrackerIsolationBoundary).subnet;
+    const sidecarIp = this.ipWithOffset(subnet, SIDECAR_STATIC_IP_OFFSET);
+
+    const env: Record<string, string> = {
+      PORT: "8080",
+      PLATFORM_API_URL: config.platformApiUrl,
+    };
+    if (config.runToken) env.RUN_TOKEN = config.runToken;
+    if (config.proxyUrl) env.PROXY_URL = config.proxyUrl;
+    if (config.llm) {
+      env.PI_BASE_URL = config.llm.baseUrl;
+      env.PI_API_KEY = config.llm.apiKey;
+      env.PI_PLACEHOLDER = config.llm.placeholder;
+    }
+
+    const vm = await this.provisioner.provision({
+      runId,
+      role: "sidecar",
+      env,
+      memoryMib: SIDECAR_VM_MEMORY_MIB,
+      vcpus: SIDECAR_VM_VCPUS,
+    });
+    emitVmAudit({
+      type: "vm.provisioned",
+      vmId: vm.vmId,
+      runId,
+      role: "sidecar",
+      source: vm.source,
+    });
+
+    await this.host.attachTap(vm.vmId, boundary.id, sidecarIp);
+
+    const handle: FirecrackerWorkloadHandle = {
+      id: vm.vmId,
+      runId,
+      role: "sidecar",
+      socketPath: vm.socketPath,
+      chrootPath: vm.chrootPath,
+    };
+    this.track(handle);
+    return handle;
+  }
+
+  async createWorkload(spec: WorkloadSpec, boundary: IsolationBoundary): Promise<WorkloadHandle> {
+    const subnet = (boundary as FirecrackerIsolationBoundary).subnet;
+    const agentIp = this.ipWithOffset(subnet, AGENT_STATIC_IP_OFFSET);
+    const sidecarIp = this.ipWithOffset(subnet, SIDECAR_STATIC_IP_OFFSET);
+
+    const workspaceDrivePath = await this.host.createWorkspaceDrive(
+      spec.runId,
+      getEnv().FIRECRACKER_WORKSPACE_SIZE_GB,
+    );
+
+    let inputsDrivePath: string | undefined;
+    if (spec.files && spec.files.items.length > 0) {
+      const inputs = await this.host.createInputsDrive(spec.runId, spec.files.items);
+      inputsDrivePath = inputs.path;
+      emitVmAudit({
+        type: "vm.provisioned",
+        vmId: `inputs-${spec.runId}`,
+        runId: spec.runId,
+        role: "inputs-drive",
+        source: "cold",
+      });
+    }
+
+    const env: Record<string, string> = {
+      ...spec.env,
+      SIDECAR_URL: `http://sidecar:8080`, // resolves via /etc/hosts injection (see note)
+      SIDECAR_IP: sidecarIp, // fallback direct IP
+    };
+
+    const vm = await this.provisioner.provision({
+      runId: spec.runId,
+      role: "agent",
+      env,
+      memoryMib: spec.resources.memoryBytes / (1024 * 1024),
+      vcpus: Math.max(1, Math.floor(spec.resources.nanoCpus / 1_000_000_000)),
+      workspaceDrivePath,
+      inputsDrivePath,
+    });
+    emitVmAudit({
+      type: "vm.provisioned",
+      vmId: vm.vmId,
+      runId: spec.runId,
+      role: "agent",
+      source: vm.source,
+    });
+
+    await this.host.attachTap(vm.vmId, boundary.id, agentIp);
+
+    const handle: FirecrackerWorkloadHandle = {
+      id: vm.vmId,
+      runId: spec.runId,
+      role: spec.role,
+      socketPath: vm.socketPath,
+      chrootPath: vm.chrootPath,
+    };
+    this.track(handle);
+    return handle;
+  }
+
+  async startWorkload(handle: WorkloadHandle): Promise<void> {
+    await this.host.startVm(handle.id);
+    emitVmAudit({ type: "vm.started", vmId: handle.id, runId: handle.runId, role: handle.role });
+  }
+
+  async stopWorkload(handle: WorkloadHandle, timeoutSeconds?: number): Promise<void> {
+    const start = Date.now();
+    await this.host.stopVm(handle.id, timeoutSeconds ?? VM_STOP_TIMEOUT_SECONDS);
+    emitVmAudit({
+      type: "vm.stopped",
+      vmId: handle.id,
+      runId: handle.runId,
+      role: handle.role,
+      exitCode: 0,
+      durationMs: Date.now() - start,
+    });
+  }
+
+  async removeWorkload(handle: WorkloadHandle): Promise<void> {
+    await this.host.removeVm(handle.id);
+    this.untrack(handle);
+  }
+
+  async waitForExit(handle: WorkloadHandle): Promise<number> {
+    return this.host.waitForExit(handle.id);
+  }
+
+  async *streamLogs(handle: WorkloadHandle, signal?: AbortSignal): AsyncGenerator<string> {
+    yield* this.host.streamLogs(handle.id, signal);
+  }
+
+  async stopByRunId(runId: string, timeoutSeconds?: number): Promise<StopResult> {
+    const handles = this.activeVms.get(runId);
+    if (!handles || handles.length === 0) return "not_found";
+    const results = await Promise.allSettled(
+      handles.map((h) => this.stopWorkload(h, timeoutSeconds)),
+    );
+    return results.some((r) => r.status === "fulfilled") ? "stopped" : "already_stopped";
+  }
+
+  // ─── Helpers ───
+
+  private track(handle: FirecrackerWorkloadHandle): void {
+    const list = this.activeVms.get(handle.runId) ?? [];
+    list.push(handle);
+    this.activeVms.set(handle.runId, list);
+  }
+
+  private untrack(handle: WorkloadHandle): void {
+    const list = this.activeVms.get(handle.runId);
+    if (!list) return;
+    const idx = list.findIndex((h) => h.id === handle.id);
+    if (idx >= 0) list.splice(idx, 1);
+    if (list.length === 0) this.activeVms.delete(handle.runId);
+  }
+
+  private allocateSubnet(runId: string): string {
+    // Deterministic /30 allocation inside FIRECRACKER_BRIDGE_SUBNET.
+    // Phase 1: naive hash-based allocator. Phase 3 replaces with a real allocator backed by DB.
+    const baseSubnet = getEnv().FIRECRACKER_BRIDGE_SUBNET;
+    const [base] = baseSubnet.split("/");
+    const octets = base.split(".").map(Number);
+    // Hash runId to 14 bits for the third octet range (keeps /30 inside /16)
+    const hash = [...runId].reduce((acc, c) => (acc * 31 + c.charCodeAt(0)) >>> 0, 0);
+    const thirdOctet = hash & 0xff;
+    const fourthOctet = ((hash >>> 8) & 0x3f) << 2; // /30 alignment
+    return `${octets[0]}.${octets[1]}.${thirdOctet}.${fourthOctet}/${PER_RUN_SUBNET_MASK}`;
+  }
+
+  private ipWithOffset(subnet: string, offset: number): string {
+    const [base] = subnet.split("/");
+    const octets = base.split(".").map(Number);
+    return `${octets[0]}.${octets[1]}.${octets[2]}.${octets[3] + offset}`;
+  }
+}
+```
+
+**Important notes about this skeleton:**
+
+- **DNS/hosts injection** is deferred to Phase 2. In Phase 1 the `SIDECAR_URL` env variable is set but `/etc/hosts` isn't actually injected because there's no real VM yet. The mock host accepts the env dict and stores it for test assertions.
+- **TAP attachment** is a no-op in the mock (returns a fake name). Real TAP + netlink wiring lands in Phase 3.
+- **`waitForExit` exit code** is always 0 from the mock. Real exit-code plumbing via the init binary lands in Phase 4.
+- The `allocateSubnet` helper is deliberately hacky. A proper allocator with DB persistence and collision handling lands in Phase 3. This one is good enough to unblock Phase 1 tests.
+- `createSidecar` does NOT implement the sidecar pool in Phase 1. Pool lives in Phase 5 (after the first real boot in Phase 2-4 validates end-to-end behavior). This means every Firecracker sidecar in Phase 1 is a fresh cold boot — acceptable because we're testing the contract, not latency.
+
+---
+
+## 9. Boot integration
+
+**Modify `apps/api/src/lib/boot.ts`** — the orchestrator factory already handles mode selection; verify the boot sequence initializes the orchestrator regardless of mode. The current line ~154-174 likely already does:
+
+```ts
+const orchestrator = getOrchestrator();
+await orchestrator.initialize();
+```
+
+No change needed beyond confirming this. If the boot sequence is Docker-specific at any point, factor it out behind the orchestrator interface.
+
+**Cleanup orphans:** the existing boot calls `cleanupOrphans()` on the orchestrator — Firecracker's implementation stubs it via the mock host, which returns an empty list in Phase 1.
+
+---
+
+## 10. Test strategy
+
+### 10.1 Unit tests
+
+File: `apps/api/test/unit/services/firecracker/host.test.ts`
+
+Contract tests for `MockFirecrackerHost`:
+
+- `initialize()` is idempotent
+- `createVm()` returns distinct socket paths for distinct `vmId` inputs
+- `startVm()` on a non-existent `vmId` throws
+- `stopVm()` on an already-stopped VM is a no-op (no throw)
+- `waitForExit()` resolves with 0 after `stopVm()` is called
+- `streamLogs()` yields exactly 3 lines then completes
+- `listCandidateOrphans()` returns VMs older than `ORPHAN_SCAN_MIN_AGE_SECONDS`
+- `createInputsDrive()` returns a real sha256 of the concatenated inputs (seed with known bytes → assert known hash)
+
+File: `apps/api/test/unit/services/firecracker/vm-provisioner.test.ts`
+
+- `ColdBootProvisioner` passes through spec → host.createVm
+- Returns `source: "cold"`
+- Uses sidecar rootfs when `role === "sidecar"`, agent rootfs otherwise
+
+File: `apps/api/test/unit/services/firecracker/audit.test.ts`
+
+- `emitVmAudit` calls `logger.info` with `firecracker.audit` + the event
+- Event shapes match the TypeScript discriminated union
+
+### 10.2 Integration tests
+
+File: `apps/api/test/integration/services/firecracker-orchestrator.test.ts`
+
+**These tests run against `MockFirecrackerHost` injected into the orchestrator constructor.** No real Firecracker, no KVM, no root. They must pass in the existing test preload (no changes required to `test/setup/preload.ts` in Phase 1).
+
+Test cases (mirror Docker orchestrator coverage where applicable):
+
+```ts
+describe("FirecrackerOrchestrator", () => {
+  let orch: FirecrackerOrchestrator;
+  let host: MockFirecrackerHost;
+
+  beforeEach(async () => {
+    host = new MockFirecrackerHost();
+    orch = new FirecrackerOrchestrator(host);
+    await orch.initialize();
+  });
+
+  afterEach(async () => {
+    await orch.shutdown();
+  });
+
+  it("initialize is idempotent");
+  it("createIsolationBoundary returns a unique bridge name per runId");
+  it("createSidecar produces a handle with socketPath + chrootPath");
+  it("createSidecar passes platformApiUrl and runToken into env");
+  it("createWorkload injects files as an inputs drive when files are present");
+  it("createWorkload skips inputs drive when no files");
+  it("startWorkload emits vm.started audit event");
+  it("stopWorkload emits vm.stopped with durationMs");
+  it("stopByRunId stops all tracked handles for that runId");
+  it("stopByRunId returns 'not_found' for unknown runId");
+  it("cleanupOrphans removes all candidate orphans from the mock host");
+  it("removeIsolationBoundary calls host.removeBridge exactly once");
+  it("waitForExit returns 0 after stopWorkload");
+});
+```
+
+### 10.3 End-to-end smoke test
+
+Add a single test under `apps/api/test/integration/run-pipeline/` that:
+
+1. Sets `process.env.RUN_ADAPTER = "firecracker"` + `FIRECRACKER_MOCK_HOST = "true"`
+2. Resets the env cache (`_resetCacheForTesting()`)
+3. Calls `getOrchestrator()` → asserts it's a `FirecrackerOrchestrator`
+4. Calls the full `run-pipeline.ts` flow against a simple agent
+5. Asserts logs + audit events are produced
+
+This verifies the factory wiring and the boot contract.
+
+---
+
+## 11. Implementation order (recommended)
+
+Sequential — each step unblocks the next.
+
+1. **Env vars** (`packages/env/src/index.ts`) + `.env.example`. Verify `bun run check` passes.
+2. **Types** (`orchestrator/types.ts`) — append the new handle/boundary types.
+3. **Constants + audit + provisioner interface** (`services/firecracker/{constants,audit,vm-provisioner}.ts`).
+4. **`FirecrackerHost` interface** (`services/firecracker/host.ts`).
+5. **`MockFirecrackerHost`** (`services/firecracker/mock-host.ts`) + its unit tests — you should be able to run the host tests in isolation now.
+6. **`ColdBootProvisioner`** + its unit test.
+7. **`FirecrackerOrchestrator` skeleton** — compile it against the mock host, no tests yet.
+8. **Factory update** (`orchestrator/index.ts`) + **mode extension** (`infra/mode.ts`).
+9. **Orchestrator integration tests** — the big one.
+10. **E2E smoke test** — the factory selects it and boot succeeds.
+11. **`CHANGELOG.md`** entry.
+12. **Run `bun run check` + `bun test` from monorepo root.** All must pass.
+
+---
+
+## 12. What Phase 2 will add (for context, not this PR)
+
+Phase 1 deliberately stubs everything privileged. Phase 2 adds:
+
+- Real `FirecrackerHost` implementation (`services/firecracker/real-host.ts`) that shells out to `jailer` + `firecracker` binaries.
+- Jailer config builder in `services/firecracker/jailer.ts` (cgroup limits, chroot, seccomp profile, netns).
+- Real VM lifecycle via HTTP over the API socket (`PUT /boot-source`, `PUT /drives`, `PUT /network-interfaces`, `PUT /machine-config`, `PUT /actions` with `InstanceStart`).
+- Custom init binary (Go, ~80 LOC) baked into the rootfs — mounts `/inputs` + `/workspace`, redirects stdout to `/dev/hvc1`, execs the sidecar/agent entrypoint.
+- CI workflow `.github/workflows/publish-firecracker-rootfs.yml` that builds + signs + publishes `runtime-pi.ext4` and `sidecar.ext4` to GHCR.
+- Platform-side download + cosign verification + content-addressed cache.
+
+None of this is in scope for Phase 1. Reviewers should reject any PR that tries to smuggle it in.
+
+---
+
+## 13. Risks + mitigations (Phase 1 only)
+
+| Risk                                                    | Likelihood    | Mitigation                                                                                                                               |
+| ------------------------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Mock host drifts from real behavior → Phase 2 surprises | High          | Phase 2 PR must include contract tests that run identically against real + mock. If they diverge, the mock is wrong.                     |
+| Factory returns wrong orchestrator in tests (env cache) | Medium        | Always call `_resetCacheForTesting()` after mutating `process.env.RUN_ADAPTER` in tests.                                                 |
+| `PI_IMAGE` refine blocks valid local dev                | Low           | Refine only fires when `RUN_ADAPTER=firecracker`. Default (`process`) is untouched.                                                      |
+| Subnet collision between runs                           | Low (Phase 1) | Naive hash allocator has a ~1% collision rate at 50 concurrent runs. Acceptable for the mock. Phase 3 replaces with DB-backed allocator. |
+| TAP name collisions if bridge name collides             | Low           | Bridge name = `fc-br-{8 chars of runId}`. UUID collision at 8 chars is 1 in ~4 billion — acceptable.                                     |
+
+---
+
+## 14. Reviewer checklist
+
+A reviewer merging Phase 1 should verify:
+
+- [ ] All files listed in §3 exist and are under 400 LOC each (keep them focused).
+- [ ] `FirecrackerOrchestrator` method signatures match `ContainerOrchestrator` exactly — no new public methods, no skipped methods.
+- [ ] No dynamic `import()` or subprocess spawn anywhere in the Phase 1 code. Phase 1 is pure TypeScript + mock state.
+- [ ] The `PI_IMAGE` refine is present and triggers only when `RUN_ADAPTER=firecracker`.
+- [ ] `getOrchestrator()` in `orchestrator/index.ts` explicitly handles all three modes (no fallthrough to Docker for `firecracker`).
+- [ ] Mock host files never write outside `/tmp`.
+- [ ] No changes to `runtime-pi/`, `packages/db/`, `packages/ui/`, `packages/core/`, or `apps/web/`. Phase 1 is API-side only.
+- [ ] No changes to existing orchestrator files beyond the two explicit modifications in §5-6.
+- [ ] Docker orchestrator tests still pass.
+- [ ] `CHANGELOG.md` entry is written.

--- a/docs/specs/PHASE_2_FIRECRACKER_REAL_BOOT.md
+++ b/docs/specs/PHASE_2_FIRECRACKER_REAL_BOOT.md
@@ -1,0 +1,279 @@
+# Phase 2 — Real VM Boot via Firecracker API
+
+> **⚠️ Spec non figée.** Ce document capture l'intention et les décisions prises en Phase 0 (voir [ADR-007](../adr/ADR-007-firecracker-orchestrator.md)). L'agent qui implémente cette phase est **invité à challenger** toute décision qui s'avère inapplicable, sous-optimale, ou rendue obsolète par ce qui a été appris en Phase 1. Les décisions stratégiques de l'ADR restent valides, mais les choix tactiques (structure de fichiers, APIs internes, découpage des tests) sont ajustables. Toute déviation majeure doit être notée dans le PR et synchronisée avec l'ADR.
+
+**Status:** Pending Phase 1 completion
+**Prerequisites:** Phase 1 merged. Host with `/dev/kvm` + `CAP_NET_ADMIN` for manual validation. `jailer` + `firecracker` binaries installed.
+**Estimate:** 5-7 days / ~1500 LOC + CI workflow
+**Phase of:** 5-phase Firecracker rollout (see ADR-007)
+
+---
+
+## 1. Purpose
+
+Replace the `MockFirecrackerHost` with a real implementation that:
+
+- Shells out to `jailer` and `firecracker` binaries for real VM lifecycle
+- Boots a real Linux microVM with a signed rootfs produced in CI
+- Runs a custom init binary that mounts drives, sets up console redirection, and exec's the payload (`entrypoint.ts` for agent, `server.ts` for sidecar)
+- Completes a full agent run end-to-end on a KVM-equipped host with `RUN_ADAPTER=firecracker` + `FIRECRACKER_MOCK_HOST=false`
+
+Networking is deliberately minimal in Phase 2 — just enough for the sidecar to reach the platform and the agent to reach the sidecar. Per-run bridges, static IP allocation, and NAT land in Phase 3.
+
+---
+
+## 2. Success criteria
+
+1. CI workflow `.github/workflows/publish-firecracker-rootfs.yml` builds + signs + publishes `runtime-pi.ext4` + `sidecar.ext4` to GHCR on `v*` tags.
+2. Custom init binary (Go, `runtime-pi/init/`) is baked into both rootfs artifacts.
+3. `RealFirecrackerHost` implements the full `FirecrackerHost` interface from Phase 1 against real binaries.
+4. Contract tests from Phase 1 pass identically against `RealFirecrackerHost` on a KVM-equipped runner.
+5. On a dev machine with KVM: `RUN_ADAPTER=firecracker FIRECRACKER_MOCK_HOST=false bun run dev` + a sample agent run produces the same output stream as Tier 3 (Docker).
+6. Exit codes from the agent propagate correctly to the platform.
+7. Kernel boot log never leaks into the app stdout stream (separated consoles work).
+8. CI rootfs artifacts are content-addressed (SHA256 in filename) and cosign-signed.
+
+---
+
+## 3. File tree
+
+```
+.github/workflows/
+└── publish-firecracker-rootfs.yml     (NEW) — CI builds + signs rootfs on tag
+
+runtime-pi/
+├── Dockerfile                         (MODIFY) — add init binary to /sbin/init
+├── init/                              (NEW DIR)
+│   ├── go.mod                         (NEW)
+│   ├── init.go                        (NEW, ~80 LOC) — the custom init binary
+│   └── README.md                      (NEW) — boot protocol documentation
+
+runtime-pi/sidecar/
+├── Dockerfile                         (MODIFY) — add init binary to /sbin/init
+└── (no other changes)
+
+scripts/
+└── build-firecracker-rootfs.sh        (NEW, ~60 LOC) — local build helper (mirrors CI steps)
+
+apps/api/src/services/firecracker/
+├── real-host.ts                       (NEW, ~500 LOC) — RealFirecrackerHost
+├── firecracker-api.ts                 (NEW, ~200 LOC) — HTTP client for the Firecracker API socket
+├── jailer.ts                          (MODIFY — real impl) — jailer command builder + process launcher
+├── rootfs-resolver.ts                 (NEW, ~80 LOC) — reads FIRECRACKER_ROOTFS_PATH or downloads from GHCR + verifies cosign signature
+└── process-supervisor.ts              (NEW, ~100 LOC) — spawn + track jailer child processes, clean up on platform shutdown
+
+apps/api/src/services/orchestrator/
+└── firecracker-orchestrator.ts        (MODIFY) — replace `realHostOrThrow()` with real instantiation
+
+packages/env/src/
+└── index.ts                           (MODIFY) — add FIRECRACKER_ROOTFS_URL, FIRECRACKER_COSIGN_KEY
+
+apps/api/test/integration/services/
+└── firecracker-real-boot.test.ts      (NEW, gated on CI runner labels) — end-to-end real boot test
+```
+
+---
+
+## 4. Custom init binary (`runtime-pi/init/init.go`)
+
+The init binary is PID 1 inside every Firecracker VM. It is deliberately minimal — ~80 LOC of Go, statically compiled.
+
+**Responsibilities (in order):**
+
+1. Mount `/proc`, `/sys`, `/dev/pts`, `/tmp` (tmpfs) using syscall `Mount`.
+2. Detect role from `/proc/cmdline` (kernel cmdline contains `appstrate.role=agent` or `appstrate.role=sidecar`).
+3. **Agent only:** mount `/inputs` (read-only) from `/dev/vdb` and `/workspace` (read-write) from `/dev/vdc`.
+4. **Sidecar only:** no drives beyond rootfs.
+5. Redirect stdout to `/dev/hvc1` (the app-log virtio-console). Leave stderr on `/dev/console` (→ `ttyS0`, kernel + debug).
+6. Parse env vars from `/proc/cmdline` (format: `appstrate.env.KEY=VALUE` — URL-decoded). Copy them into the payload's environment.
+7. `exec` the payload:
+   - Agent: `/usr/local/bin/bun run /runtime/entrypoint.ts`
+   - Sidecar: `/usr/local/bin/bun run /runtime/sidecar-server.ts`
+8. On payload exit, write the exit code to `/dev/vdd` (a 16-byte side-channel block device — see §6) then `reboot()` syscall.
+
+**Why Go:** single static binary, no libc, fits in ~2MB, boots fast. Alternatives (shell script, Rust) are acceptable if they meet the same contract. **Document the choice in the PR description** if you deviate.
+
+**Security:** init must `setuid(0)` then immediately drop any ambient capabilities it doesn't need. The payload itself runs as a dedicated non-root user baked into the rootfs (`pi:pi`, uid 1000) — init switches user before exec.
+
+---
+
+## 5. Firecracker API client
+
+`apps/api/src/services/firecracker/firecracker-api.ts` wraps the HTTP-over-unix-socket API exposed by the Firecracker process. The pattern follows `apps/api/src/services/docker.ts`: raw `fetch()` via unix socket, no dockerode-equivalent dependency.
+
+Required RPCs:
+
+| Method  | Path                       | Purpose                                                                                        |
+| ------- | -------------------------- | ---------------------------------------------------------------------------------------------- |
+| `PUT`   | `/boot-source`             | Set kernel + cmdline                                                                           |
+| `PUT`   | `/drives/rootfs`           | Attach rootfs.ext4 (read-only)                                                                 |
+| `PUT`   | `/drives/inputs`           | Attach inputs drive (agent only, read-only)                                                    |
+| `PUT`   | `/drives/workspace`        | Attach workspace drive (agent only, read-write)                                                |
+| `PUT`   | `/drives/exit-code`        | Attach 16-byte block device for exit-code side channel                                         |
+| `PUT`   | `/network-interfaces/eth0` | Attach TAP (actual TAP lifecycle in Phase 3; Phase 2 uses a trivial loopback or static config) |
+| `PUT`   | `/vsock`                   | (deferred to post-MVP)                                                                         |
+| `PUT`   | `/machine-config`          | Set memory + vCPUs                                                                             |
+| `PUT`   | `/actions`                 | `{"action_type": "InstanceStart"}`                                                             |
+| `PATCH` | `/machine-config`          | For snapshot restore (Phase 5)                                                                 |
+
+Include a retry loop with exponential backoff when the API socket isn't yet available (Firecracker takes ~10ms to create it after process start).
+
+---
+
+## 6. Exit-code side-channel
+
+Firecracker doesn't expose a clean "VM exited with code N" primitive — the init binary must write it somewhere the platform can read.
+
+**Mechanism:** attach a 16-byte sparse file as `/dev/vdd`. The init writes the exit code as a fixed-format string (`exit=%d\n`) to this block device before calling `reboot()`. The platform reads the file after VM shutdown.
+
+**`waitForExit(vmId)` implementation:**
+
+1. Poll the Firecracker API `/` endpoint for `state: "Stopped"` (with 500ms interval + AbortSignal).
+2. On stop, read the exit-code file from the jailer chroot.
+3. Parse `exit=N\n` → return N.
+4. On parse failure or missing file → return -1 (signals abnormal termination).
+
+---
+
+## 7. Rootfs pipeline (CI)
+
+`.github/workflows/publish-firecracker-rootfs.yml`:
+
+**Trigger:** `push: tags: ['v*']` (same cadence as main Docker image).
+
+**Steps per rootfs (agent + sidecar, two parallel matrix jobs):**
+
+1. Checkout repo, install Go, build `runtime-pi/init/init.go` as a static binary.
+2. `docker buildx build --platform linux/amd64 --output type=local,dest=./layers -f runtime-pi/Dockerfile .`
+3. Copy the init binary into `./layers/sbin/init`.
+4. `tar -cf rootfs.tar -C ./layers .`
+5. Run `tar2ext4 -i rootfs.tar -o runtime-pi-<version>.ext4` (use the Microsoft hcsshim binary or build from source — see references).
+6. `cosign sign-blob --key ${COSIGN_KEY} --output-signature rootfs.sig runtime-pi-<version>.ext4`
+7. `sha256sum runtime-pi-<version>.ext4 > rootfs.sha256`
+8. Upload to GHCR as an OCI artifact with media type `application/vnd.appstrate.rootfs.ext4`.
+9. Publish a JSON manifest at `runtime-pi-<version>.manifest.json` containing: version, commit sha, rootfs sha256, signature path, kernel version expected, init binary sha256.
+
+**Kernel:** Phase 2 uses the upstream Firecracker recommended vmlinux (pinned SHA256). The kernel build is separate from the rootfs pipeline — checked in as a build input in `runtime-pi/kernel/vmlinux.sha256`. Document the kernel sourcing in the PR.
+
+**Local build:** `scripts/build-firecracker-rootfs.sh` mirrors the CI steps for dev machines. No signing in local mode.
+
+---
+
+## 8. Host-side download + verify (`rootfs-resolver.ts`)
+
+On boot (inside `FirecrackerOrchestrator.initialize()`):
+
+1. If `FIRECRACKER_ROOTFS_PATH` points to an existing local file, use it as-is (dev convenience).
+2. Otherwise, download from `FIRECRACKER_ROOTFS_URL` (GHCR OCI artifact).
+3. Verify cosign signature against `FIRECRACKER_COSIGN_KEY` (public key, path or raw PEM).
+4. Verify sha256 matches the manifest.
+5. Cache at `/var/lib/appstrate/firecracker/<sha256>.ext4`.
+6. Log the resolved version for audit.
+
+Reject boot if verification fails. No fallback, no degraded mode.
+
+---
+
+## 9. Env var additions
+
+```ts
+FIRECRACKER_ROOTFS_URL: z.string().optional(),
+FIRECRACKER_SIDECAR_ROOTFS_URL: z.string().optional(),
+FIRECRACKER_COSIGN_KEY: z.string().optional(),
+FIRECRACKER_KERNEL_URL: z.string().optional(),
+FIRECRACKER_SKIP_SIGNATURE_VERIFICATION: z
+  .string()
+  .default("false")
+  .transform((v) => v === "true" || v === "1"),
+```
+
+Add a refine: if `NODE_ENV=production` and `RUN_ADAPTER=firecracker` and `FIRECRACKER_MOCK_HOST=false`, then `FIRECRACKER_COSIGN_KEY` must be set AND `FIRECRACKER_SKIP_SIGNATURE_VERIFICATION` must be `false`. Dev can skip.
+
+---
+
+## 10. Tests
+
+### 10.1 Unit tests
+
+- `firecracker-api.test.ts` — mock the unix socket `fetch`, verify each RPC produces the expected JSON body.
+- `jailer.test.ts` — command-builder snapshot tests (given a config, verify the argv + env).
+- `rootfs-resolver.test.ts` — verify sha mismatch throws, missing signature throws, cached file is reused.
+- `init/init_test.go` — unit tests for cmdline parsing, env extraction.
+
+### 10.2 Integration tests (gated)
+
+`firecracker-real-boot.test.ts` runs only on self-hosted runners labeled `kvm-enabled`. Skipped elsewhere with `test.skipIf(!hasKvm())`.
+
+Test cases:
+
+- Boot a sidecar VM → it responds `200` on `/health` via the host-mapped port (Phase 2 uses port-forward, Phase 3 uses TAP).
+- Boot an agent VM with inputs drive → it reads the inputs, runs `entrypoint.ts`, exits cleanly.
+- Agent exit code `1` is captured and returned by `waitForExit()`.
+- Kernel boot log is visible on `streamDebugLogs(vmId)` but absent from `streamLogs(vmId)` (which reads hvc1).
+- Shutdown is clean: jailer chroot removed, no FD leaks.
+
+### 10.3 Contract conformity
+
+The Phase 1 integration tests (`firecracker-orchestrator.test.ts`) must pass identically with `host = new RealFirecrackerHost()` on KVM-enabled runners. If they don't, the mock in Phase 1 was wrong — **fix the mock**, don't diverge the tests.
+
+---
+
+## 11. Implementation order
+
+1. Write `init/init.go` + tests, build as static binary. Verify it boots in a standalone Firecracker VM manually.
+2. Modify `runtime-pi/Dockerfile` (+ sidecar Dockerfile) to bake in the init.
+3. Write `scripts/build-firecracker-rootfs.sh` and produce a local `runtime-pi.ext4`. Boot it manually via raw `firecracker` CLI to validate.
+4. Write `firecracker-api.ts` + unit tests.
+5. Write `jailer.ts` (real impl) + unit tests.
+6. Write `rootfs-resolver.ts` + unit tests.
+7. Write `process-supervisor.ts` — child process tracking, cleanup on parent shutdown.
+8. Write `real-host.ts` — glue layer implementing `FirecrackerHost`.
+9. Wire into `FirecrackerOrchestrator` via `realHostOrThrow()` → `new RealFirecrackerHost()`.
+10. Write the CI workflow. Tag a test release, verify artifacts on GHCR, verify cosign signature.
+11. Run Phase 1 integration suite against `RealFirecrackerHost` on a KVM runner. Fix any divergence.
+12. Write `firecracker-real-boot.test.ts` end-to-end.
+13. Update `.env.example` + `CHANGELOG.md`.
+
+---
+
+## 12. Non-goals (explicitly deferred)
+
+- Per-run bridges, TAP allocation, NAT, DNS → Phase 3
+- `/dev/hvc1` log streaming implementation (Phase 2 uses stderr for everything, acceptable for first boot) → Phase 4
+- Inputs drive mounting + hashing → Phase 4 (Phase 2 passes `/inputs` empty)
+- Workspace drive reflink template → Phase 4 (Phase 2 uses plain mkfs)
+- Sidecar snapshot pool → Phase 5
+- Orphan recovery with DB reconciliation → Phase 5
+- vsock, MMDS, custom CPU templates → post-MVP
+
+---
+
+## 13. Risks
+
+| Risk                                            | Mitigation                                                                                    |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Init binary bugs cause boot loops               | Boot tests on a local QEMU-KVM first, never land an untested init in the rootfs               |
+| Firecracker API contract drift between versions | Pin Firecracker binary version in env (`FIRECRACKER_VERSION_CHECK`) and fail-fast on mismatch |
+| Jailer chroot leaks accumulate                  | Phase 5 adds real cleanup; Phase 2 operators must manually prune on restart                   |
+| CI cosign key handling                          | Use GitHub OIDC + Sigstore keyless signing to avoid managing a long-lived key                 |
+| Kernel CVEs require rebuild                     | Kernel pinned in manifest; subscribe to `kernel-cve@` list + document rebuild SLA             |
+
+---
+
+## 14. Reviewer checklist
+
+- [ ] CI workflow produces signed artifacts on a test tag
+- [ ] Init binary is reproducibly built (same input → same sha256)
+- [ ] `RealFirecrackerHost` passes the Phase 1 contract suite
+- [ ] Sample agent run completes on a KVM-equipped dev machine
+- [ ] Exit codes propagate correctly for both success and failure
+- [ ] No Phase 3/4/5 scope creep in the PR
+
+## 15. References
+
+- [Firecracker API spec](https://github.com/firecracker-microvm/firecracker/blob/main/src/api_server/swagger/firecracker.yaml)
+- [Firecracker jailer](https://github.com/firecracker-microvm/firecracker/blob/main/docs/jailer.md)
+- [tar2ext4 (Microsoft hcsshim)](https://github.com/microsoft/hcsshim/tree/main/ext4/tar2ext4)
+- [Sigstore cosign keyless signing](https://docs.sigstore.dev/cosign/signing/signing_with_blobs/)
+- [Phase 1 spec](./PHASE_1_FIRECRACKER_SKELETON.md) — prerequisite
+- [ADR-007](../adr/ADR-007-firecracker-orchestrator.md) — architectural decisions

--- a/docs/specs/PHASE_3_FIRECRACKER_NETWORKING.md
+++ b/docs/specs/PHASE_3_FIRECRACKER_NETWORKING.md
@@ -1,0 +1,324 @@
+# Phase 3 — Production Networking (TAP + Bridges + Isolation)
+
+> **⚠️ Spec non figée.** Ce document capture l'intention et les décisions prises en Phase 0 (voir [ADR-007](../adr/ADR-007-firecracker-orchestrator.md)). L'agent qui implémente cette phase est **invité à challenger** toute décision qui s'avère inapplicable, sous-optimale, ou rendue obsolète par ce qui a été appris en Phases 1-2. Les décisions stratégiques de l'ADR restent valides, mais les choix tactiques (allocation de sous-réseaux, format TAP, wiring netlink) sont ajustables. Toute déviation majeure doit être notée dans le PR et synchronisée avec l'ADR.
+
+**Status:** Pending Phase 2 completion
+**Prerequisites:** Phase 2 merged. Real VMs booting. KVM host with `CAP_NET_ADMIN` for dev validation.
+**Estimate:** 4-6 days / ~800 LOC
+
+---
+
+## 1. Purpose
+
+Replace the Phase 2 "trivial loopback or static config" networking with the full ADR-007 model:
+
+- **One Linux bridge per run** (`fc-br-{runId8}`), internal (no NAT), agent lives here
+- **One global egress bridge** with NAT masquerade, sidecar has a second TAP here
+- **Per-run `/30` subnet allocation** with DB-backed ledger (no collision, survives restarts)
+- **`/etc/hosts` injection** so the agent's `fetch("http://sidecar:8080/proxy")` resolves unchanged
+- **TAP lifecycle** tied to jailer netns: created before VM start, torn down on VM stop
+- **FD-budget enforcement** — reject new runs when the host's TAP budget is exhausted
+
+This phase delivers the isolation guarantee that matches Docker's dual-network pattern (ADR-003 compatible).
+
+---
+
+## 2. Success criteria
+
+1. Agent VM on a per-run internal bridge has **no route to the host** (verified by `traceroute 8.8.8.8` failing from inside the agent).
+2. Sidecar VM reaches the platform API + LLM providers via the egress bridge (verified by `curl` to platform succeeding).
+3. Agent resolves `sidecar` to the correct static IP via `/etc/hosts` and can `curl http://sidecar:8080/health` successfully.
+4. 50 concurrent runs on the same host create 50 distinct bridges + 100 TAPs with zero collisions.
+5. On platform crash + restart, orphaned TAPs + bridges are reclaimed via the cleanup path (Phase 5 completes the full reconciliation, Phase 3 handles the netlink side).
+6. Subnet ledger persists in DB and recovers after restart (allocations re-enter the pool if their run is terminal).
+7. A run attempting to start when the TAP budget is exhausted fails fast with a clear RFC 9457 error.
+
+---
+
+## 3. File tree
+
+```
+apps/api/src/services/firecracker/
+├── network/
+│   ├── bridge-manager.ts              (NEW, ~120 LOC) — create/delete Linux bridges via netlink (rtnetlink bindings or ip(8) shell-out)
+│   ├── tap-manager.ts                 (MODIFY — real impl) — create TAP, attach to bridge, attach to VM netns
+│   ├── nat-manager.ts                 (NEW, ~80 LOC) — iptables/nftables rules for the egress bridge
+│   ├── subnet-allocator.ts            (NEW, ~100 LOC) — DB-backed /30 allocator with LISTEN/NOTIFY for cross-instance coordination
+│   ├── hosts-file.ts                  (NEW, ~40 LOC) — build an /etc/hosts fragment, write to inputs drive or via kernel cmdline
+│   └── fd-budget.ts                   (NEW, ~60 LOC) — check /proc/sys/fs/file-max + current open FDs, enforce TAP budget
+
+apps/api/src/services/firecracker/
+├── real-host.ts                       (MODIFY) — wire in the real network managers, replace Phase 2 stubs
+
+packages/db/src/schema/
+└── firecracker.ts                     (NEW) — Drizzle schema for firecracker_subnet_allocations
+
+packages/db/
+└── drizzle/migrations/                (NEW migration) — create firecracker_subnet_allocations table
+
+apps/api/src/lib/
+└── boot.ts                            (MODIFY) — reclaim abandoned subnet allocations on startup
+
+apps/api/test/integration/services/firecracker/
+├── bridge-manager.test.ts             (NEW, KVM-gated)
+├── subnet-allocator.test.ts           (NEW, DB-backed, no KVM required)
+├── tap-manager.test.ts                (NEW, KVM-gated)
+└── networking-e2e.test.ts             (NEW, KVM-gated) — end-to-end connectivity checks
+```
+
+---
+
+## 4. Subnet allocation
+
+A naive hash allocator (Phase 1) collides at ~50 concurrent runs. Phase 3 replaces it with a DB-backed ledger.
+
+### 4.1 Schema
+
+```ts
+// packages/db/src/schema/firecracker.ts
+import { pgTable, uuid, text, timestamp, index, uniqueIndex } from "drizzle-orm/pg-core";
+
+export const firecrackerSubnetAllocations = pgTable(
+  "firecracker_subnet_allocations",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    runId: uuid("run_id").notNull(),
+    subnet: text("subnet").notNull(), // e.g. "10.200.42.0/30"
+    bridgeName: text("bridge_name").notNull(),
+    allocatedAt: timestamp("allocated_at").notNull().defaultNow(),
+    releasedAt: timestamp("released_at"),
+  },
+  (t) => ({
+    uniqueActiveSubnet: uniqueIndex("uq_active_subnet")
+      .on(t.subnet)
+      .where(sql`released_at IS NULL`),
+    runIdIdx: index("idx_subnet_run").on(t.runId),
+  }),
+);
+```
+
+The partial-unique index makes the allocation atomic: two concurrent inserts with the same subnet fail cleanly, and the allocator retries with the next free slot.
+
+### 4.2 Algorithm
+
+```
+allocate(runId):
+  for attempt in 0..MAX_ATTEMPTS:
+    subnet = next_candidate(FIRECRACKER_BRIDGE_SUBNET)  // walks the /16 in /30 steps
+    try:
+      INSERT INTO firecracker_subnet_allocations (run_id, subnet, bridge_name) VALUES (...)
+      return subnet
+    except UniqueViolation:
+      continue
+  throw CapacityExhausted
+
+release(runId):
+  UPDATE firecracker_subnet_allocations SET released_at = NOW() WHERE run_id = $1 AND released_at IS NULL
+```
+
+On boot: `reclaimAbandonedAllocations()` marks all allocations whose `runId` references a terminal run (status in `success|failed|timeout|cancelled`) as released.
+
+### 4.3 /30 math
+
+Each run gets a `/30` inside the platform-wide bridge subnet (default `10.200.0.0/16`). A `/30` = 4 IPs:
+
+| Offset | Purpose                    |
+| ------ | -------------------------- |
+| .0     | Network                    |
+| .1     | Gateway (bridge host-side) |
+| .2     | Sidecar                    |
+| .3     | Agent                      |
+
+`/16` provides 16384 simultaneous runs — plenty even for Enterprise density.
+
+---
+
+## 5. Bridge + TAP lifecycle
+
+### 5.1 Bridge creation (per run)
+
+```
+createBridge(name, subnet):
+  ip link add name ${name} type bridge
+  ip addr add ${gateway_ip}/30 dev ${name}
+  ip link set ${name} up
+```
+
+Bridge is `internal` for the agent-facing side — no default route, no NAT. This is a kernel-level firewall guarantee, not an iptables rule.
+
+### 5.2 Egress bridge (global, created at boot)
+
+```
+createEgressBridge():
+  ip link add name ${FIRECRACKER_EGRESS_BRIDGE} type bridge  // e.g. "fc-egress"
+  ip addr add ${egress_gateway}/24 dev ${FIRECRACKER_EGRESS_BRIDGE}
+  ip link set ${FIRECRACKER_EGRESS_BRIDGE} up
+  # NAT masquerade for outbound
+  iptables -t nat -A POSTROUTING -s ${egress_subnet} -o ${host_external_if} -j MASQUERADE
+  iptables -A FORWARD -i ${FIRECRACKER_EGRESS_BRIDGE} -o ${host_external_if} -j ACCEPT
+  iptables -A FORWARD -i ${host_external_if} -o ${FIRECRACKER_EGRESS_BRIDGE} -m state --state RELATED,ESTABLISHED -j ACCEPT
+```
+
+Sidecar's second TAP attaches here. Agent never attaches here.
+
+**Preferred library:** use `ip` / `iptables` binaries via shell-out for Phase 3 (matches what the `docker.ts` service does). Proper netlink bindings (rtnetlink crate or nl library) are a post-MVP optimization — shell-out is simpler, debuggable, and fast enough (~5-10ms per operation).
+
+### 5.3 TAP attachment
+
+```
+createTap(vmId, bridgeName, vmIp):
+  tap_name = "fc-tap-${vmId[:8]}"          // 15-char limit
+  ip tuntap add mode tap name ${tap_name}
+  ip link set ${tap_name} master ${bridgeName}
+  ip link set ${tap_name} up
+  return tap_name
+```
+
+TAP is then passed to Firecracker via `PUT /network-interfaces/eth0` with the host-dev = tap_name + guest MAC.
+
+**Cleanup:** on VM stop, `ip link delete ${tap_name}`. Idempotent. On platform crash, orphan sweep (see §7).
+
+### 5.4 TAP name collision
+
+`fc-tap-{8 chars of vmId}` — UUIDv4 collision at 8 chars is 1 in ~4B. If you ever see one in prod, you have bigger problems. Still, the `ip tuntap add` will fail EEXIST and the caller must retry with a fresh `vmId` + audit the event.
+
+---
+
+## 6. `/etc/hosts` injection for the agent
+
+The agent's env has `SIDECAR_URL=http://sidecar:8080` (set by `FirecrackerOrchestrator.createWorkload`). The VM must resolve `sidecar` to the correct `.2` IP of its per-run subnet.
+
+**Mechanism:** the inputs drive (Phase 4) includes a file `/etc/hosts.appstrate` with `${sidecar_ip}  sidecar`. The init binary (Phase 2) cat's this file into `/etc/hosts` before exec'ing the payload.
+
+Alternative considered: MMDS-over-http with a boot-time hook. Rejected as overkill — `/etc/hosts` is simpler and works identically in Docker.
+
+**Ship order:** Phase 3 prepares the IP + writes the hosts fragment. Phase 4 implements the inputs drive + init logic to consume it. Phase 3 can test by poking the file directly into the agent's rootfs overlay for its own tests.
+
+---
+
+## 7. TAP orphan cleanup
+
+Phase 5 owns the full VM orphan reconciliation. Phase 3 owns the network-layer sweep:
+
+```
+cleanupNetworkOrphans():
+  // List all TAPs matching our naming pattern
+  for tap in `ip -j link show` where name ~= /^fc-tap-[0-9a-f]{8}$/:
+    if tap.vmId not in active DB runs:
+      ip link delete ${tap.name}
+
+  // List all bridges matching our naming pattern
+  for bridge in `ip -j link show type bridge` where name ~= /^fc-br-[0-9a-f]{8}$/:
+    if bridge.runId not in active DB runs:
+      ip link delete ${bridge.name}
+```
+
+Called from `FirecrackerOrchestrator.cleanupOrphans()` alongside the VM sweep.
+
+---
+
+## 8. FD budget enforcement
+
+Each run consumes:
+
+- 2 TAP devices (one per VM, each TAP = 1 FD on the host)
+- 2 Firecracker processes (each ~10-20 FDs for sockets, drives, API)
+- 1 bridge (1 FD)
+
+Rough upper bound: ~50 FDs per run. At 50 concurrent runs = 2500 FDs. Default `fs.file-max` is typically 1M+ — safe. But default `ulimit -n` on the Appstrate process is often 1024 — **we must raise it at boot**.
+
+```
+checkFdBudget():
+  current = count of FDs open by the platform process
+  limit = getrlimit(RLIMIT_NOFILE).soft
+  if limit - current < FD_SAFETY_MARGIN (default 500):
+    reject new run with ERROR_FD_EXHAUSTED
+```
+
+Log a warning at boot if `limit < 65536`. Consider auto-raising via `setrlimit(RLIMIT_NOFILE)` at startup if running as root (post-jailer drop).
+
+---
+
+## 9. Env additions
+
+```ts
+FIRECRACKER_EGRESS_BRIDGE: z.string().default("fc-egress"),
+FIRECRACKER_EGRESS_SUBNET: z.string().default("10.201.0.0/24"),
+FIRECRACKER_HOST_EXTERNAL_IF: z.string().default("eth0"),  // masquerade out-interface
+FIRECRACKER_FD_SAFETY_MARGIN: z.coerce.number().int().min(0).default(500),
+FIRECRACKER_MAX_CONCURRENT_RUNS: z.coerce.number().int().min(1).default(50),  // soft cap, refuse beyond
+```
+
+---
+
+## 10. Tests
+
+### 10.1 DB-only (no KVM)
+
+- `subnet-allocator.test.ts`:
+  - Allocates unique subnets for N concurrent inserts.
+  - Retries on UniqueViolation.
+  - `release()` marks released, subsequent allocation can reuse.
+  - `reclaimAbandoned()` frees allocations tied to terminal runs.
+  - Throws `CapacityExhausted` when `/16` is full (use a tiny subnet for this test).
+
+### 10.2 KVM-gated
+
+- `bridge-manager.test.ts`: create, query via `ip link show`, delete. Idempotent.
+- `tap-manager.test.ts`: create TAP, verify it appears in the bridge, delete, verify removed.
+- `networking-e2e.test.ts`:
+  - Start a sidecar VM + agent VM pair.
+  - From agent: `curl http://sidecar:8080/health` succeeds.
+  - From agent: `curl http://8.8.8.8` fails (timeout, no route).
+  - From sidecar: `curl https://api.anthropic.com` succeeds (through NAT).
+  - Stop the run, verify both TAPs + the bridge are gone.
+
+### 10.3 Failure paths
+
+- Allocator exhausted → run creation returns a clean error (HTTP 503 with problem+json).
+- FD budget exhausted → same.
+- `ip link delete` fails during cleanup → logged, does not block other cleanups.
+
+---
+
+## 11. Implementation order
+
+1. `firecracker_subnet_allocations` migration + Drizzle schema.
+2. `subnet-allocator.ts` + tests (no KVM required).
+3. Boot integration: `reclaimAbandonedAllocations()` called from `FirecrackerOrchestrator.initialize()`.
+4. `bridge-manager.ts` + `tap-manager.ts` + `nat-manager.ts`.
+5. Wire into `RealFirecrackerHost` replacing the Phase 2 stubs.
+6. `fd-budget.ts` + integration with run-creation pipeline.
+7. KVM-gated integration tests.
+8. Update `.env.example` + `CHANGELOG.md`.
+
+---
+
+## 12. Risks
+
+| Risk                                                  | Mitigation                                                                                                                       |
+| ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| iptables rules conflict with user's firewall          | Use a dedicated chain (`FIRECRACKER_FORWARD`, `FIRECRACKER_POSTROUTING`) + document in self-hosting guide                        |
+| TAP leak under crash pressure                         | Orphan sweep runs both at boot + hourly via a scheduler job                                                                      |
+| Subnet exhaustion at scale                            | Default `/16` holds 16384 concurrent runs. Alert at 75% utilization. Document how to widen to `/12` for larger deployments       |
+| `ip` binary version differences (iproute2 variants)   | Pin expected version in health check, fail-fast with clear error                                                                 |
+| Concurrent boot of platform replicas fight for bridge | Egress bridge creation is idempotent (check-then-create), guarded by a Postgres advisory lock (`pg_advisory_lock(4200)` on boot) |
+
+---
+
+## 13. Reviewer checklist
+
+- [ ] Agent VM cannot reach 8.8.8.8 or the host (hard isolation verified)
+- [ ] Sidecar VM can reach the platform + LLM APIs (egress verified)
+- [ ] `/etc/hosts` resolves `sidecar` correctly in the agent
+- [ ] 50 concurrent runs work without collision or FD exhaustion
+- [ ] Orphan sweep removes abandoned TAPs + bridges at boot
+- [ ] Subnet allocator is atomic under concurrent load (stress-tested)
+- [ ] No iptables rules leak into the host's default tables
+
+## 14. References
+
+- [Firecracker network setup](https://github.com/firecracker-microvm/firecracker/blob/main/docs/network-setup.md)
+- [iproute2 man pages](https://man7.org/linux/man-pages/man8/ip.8.html)
+- [ADR-003](../adr/ADR-003-sidecar-credential-isolation.md) — dual-network pattern being replicated
+- [Phase 2 spec](./PHASE_2_FIRECRACKER_REAL_BOOT.md) — prerequisite

--- a/docs/specs/PHASE_4_FIRECRACKER_LOGS_AND_FILES.md
+++ b/docs/specs/PHASE_4_FIRECRACKER_LOGS_AND_FILES.md
@@ -1,0 +1,368 @@
+# Phase 4 — Log Plumbing, File Injection, Drive Lifecycle
+
+> **⚠️ Spec non figée.** Ce document capture l'intention et les décisions prises en Phase 0 (voir [ADR-007](../adr/ADR-007-firecracker-orchestrator.md)). L'agent qui implémente cette phase est **invité à challenger** toute décision qui s'avère inapplicable, sous-optimale, ou rendue obsolète par ce qui a été appris en Phases 1-3. Les décisions stratégiques de l'ADR restent valides, mais les choix tactiques (format des drives, protocole de stream, détails de l'init) sont ajustables. Toute déviation majeure doit être notée dans le PR et synchronisée avec l'ADR.
+
+**Status:** Pending Phase 3 completion
+**Prerequisites:** Phase 3 merged. Real networking functional. VMs reachable from the platform.
+**Estimate:** 4-5 days / ~900 LOC
+
+---
+
+## 1. Purpose
+
+Deliver the full runtime contract for a Firecracker-hosted agent run:
+
+- **Clean app log stream** via `/dev/hvc1` (second virtio-console), isolated from kernel + init noise on `ttyS0`
+- **`/inputs` drive** — read-only ext4 containing AFPS package + user uploads + `/etc/hosts.appstrate`, mounted by init
+- **`/workspace` drive** — ext4 reflink-cloned from a template at VM create time, writable, mounted at `/workspace` in the agent VM
+- **Exit-code side-channel** wired end-to-end (init → side-channel block device → platform)
+- **Drive hashing** for audit trail: every inputs drive produces a sha256 stored in the run record
+
+After Phase 4, a Firecracker-hosted run is behaviorally indistinguishable from a Docker-hosted run from the platform's perspective — same stdout stream, same exit code, same file injection semantics.
+
+---
+
+## 2. Success criteria
+
+1. Platform-side parser of `/dev/hvc1` produces identical JSON-line output to what Docker's `streamLogs()` produces today for the same agent run.
+2. Kernel boot messages never leak into the app log stream.
+3. `/inputs` drive is mounted read-only inside the agent VM; writes to it fail.
+4. `/workspace` drive is mounted read-write; writes persist during the run; drive file is deleted after run completion.
+5. Workspace drive creation takes <20ms on XFS/btrfs hosts (reflink path) and <100ms on ext4/other hosts (full copy fallback).
+6. Exit code from the agent's `process.exit(N)` is reported accurately by `waitForExit()`.
+7. Inputs drive sha256 is persisted in a new `runs.inputs_drive_sha256` column.
+8. A run with zero inputs still boots cleanly (empty `/inputs`).
+
+---
+
+## 3. File tree
+
+```
+runtime-pi/init/
+├── init.go                            (MODIFY) — add /dev/hvc1 redirect, drive mounts, /etc/hosts merge, exit-code side-channel write
+
+apps/api/src/services/firecracker/
+├── drives/
+│   ├── workspace-drive.ts             (NEW, ~120 LOC) — create + reflink template + cleanup
+│   ├── inputs-drive.ts                (NEW, ~150 LOC) — build ext4 with tar2ext4 from in-memory files + sha256
+│   ├── template-builder.ts            (NEW, ~50 LOC) — create the workspace template ext4 once at boot
+│   └── reflink.ts                     (NEW, ~40 LOC) — detect FS support (ioctl FICLONE), fall back to copy
+├── logs/
+│   ├── hvc1-reader.ts                 (NEW, ~100 LOC) — read /dev/pts/N side of the virtio-console, yield lines
+│   ├── debug-console-reader.ts        (NEW, ~40 LOC) — read ttyS0 for debug, exposed via admin API only
+│   └── line-buffer.ts                 (NEW, ~50 LOC) — assemble partial reads into complete lines
+├── real-host.ts                       (MODIFY) — wire in drive managers + log readers; remove Phase 2 stubs
+
+packages/db/src/schema/runs.ts
+└── (MODIFY) — add inputs_drive_sha256 column
+
+packages/db/drizzle/migrations/
+└── (NEW migration) — add runs.inputs_drive_sha256
+
+apps/api/src/services/firecracker/
+├── host.ts                            (MODIFY) — refine createInputsDrive signature to return { path, sha256 }
+
+apps/api/test/unit/services/firecracker/
+├── line-buffer.test.ts                (NEW)
+├── reflink.test.ts                    (NEW, skipped if FS doesn't support FICLONE)
+└── inputs-drive-builder.test.ts       (NEW) — in-memory build + hash validation
+
+apps/api/test/integration/services/firecracker/
+├── drive-lifecycle.test.ts            (NEW, KVM-gated or tmpfs-gated) — create + mount (loopback) + verify content
+├── log-streaming.test.ts              (NEW, KVM-gated) — boot VM that writes to hvc1, verify platform reads lines
+└── exit-code.test.ts                  (NEW, KVM-gated) — agent exits with N, waitForExit returns N
+```
+
+---
+
+## 4. `/dev/hvc1` log streaming
+
+### 4.1 VM-side setup (init binary)
+
+The init binary (from Phase 2) now:
+
+1. Opens `/dev/hvc1` write-only.
+2. `dup2(fd, 1)` — redirect stdout of the payload.
+3. Leaves `stderr` attached to `/dev/console` (ttyS0) — kernel + init debug go there.
+
+The payload (`entrypoint.ts` for agent, `server.ts` for sidecar) writes JSON lines via `console.log` → goes to `/dev/hvc1`. **Zero change to `runtime-pi/entrypoint.ts`.**
+
+### 4.2 Host-side setup
+
+Firecracker API `PUT /vsock` → no, we use virtio-console:
+
+```json
+{
+  "type": "Virtio",
+  "console": "Pipe", // or "Socket", see Firecracker config
+  "output": "<path-to-host-side-fd-or-socket>"
+}
+```
+
+Firecracker 1.4+ supports multiple virtio-console devices via `PUT /virtio-console/N`. For Phase 4, use the unix-pipe backend: Firecracker creates a pipe pair at boot, the host reads from one end while the VM writes to the other.
+
+**Alternative if virtio-console is unstable:** use a serial device (`ttyS1`) instead of virtio-console. Firecracker has better long-term support for serial. Document the choice.
+
+### 4.3 Reader implementation
+
+`hvc1-reader.ts`:
+
+```ts
+export async function* readHvc1(vmId: string, signal?: AbortSignal): AsyncGenerator<string> {
+  const pipePath = hvc1PipePath(vmId); // resolved from jailer chroot
+  const stream = Bun.file(pipePath).stream();
+  const reader = stream.getReader();
+  const buffer = new LineBuffer();
+
+  try {
+    while (true) {
+      if (signal?.aborted) return;
+      const { done, value } = await reader.read();
+      if (done) return;
+      buffer.push(value);
+      yield* buffer.drainLines();
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+```
+
+`line-buffer.ts` handles partial-read reassembly (a single write from the VM may be split across two reads on the host).
+
+### 4.4 Platform wiring
+
+`FirecrackerOrchestrator.streamLogs(handle)` → `host.streamLogs(handle.id)` → `readHvc1(vmId)`.
+
+Same callers as Docker (`run-pipeline.ts`). No changes outside the orchestrator.
+
+---
+
+## 5. Workspace drive
+
+### 5.1 Template build (once at boot)
+
+```
+buildWorkspaceTemplate():
+  path = FIRECRACKER_WORKSPACE_TEMPLATE_PATH
+  if exists(path): return path
+  dd if=/dev/zero of=${path} bs=1M count=0 seek=${SIZE_GB}K  // sparse
+  mkfs.ext4 -F -q ${path}
+  return path
+```
+
+Template is built once (boot-time check), reused across all runs.
+
+### 5.2 Per-run creation
+
+```
+createWorkspaceDrive(runId):
+  target = /var/lib/appstrate/firecracker/workspaces/${runId}.ext4
+  if supportsReflink(target's parent dir):
+    cp --reflink=always ${template} ${target}   // ~1ms
+  else:
+    cp ${template} ${target}                    // ~50-200ms depending on size + disk speed
+  return target
+```
+
+`supportsReflink()`: try `ioctl FICLONE` on a test pair, cache the result per directory.
+
+### 5.3 Cleanup
+
+```
+removeWorkspaceDrive(path):
+  fs.unlink(path)  // tolerate ENOENT
+```
+
+Called from `FirecrackerOrchestrator.removeWorkload` after VM removal.
+
+### 5.4 Sparse file gotcha
+
+The workspace is 10GB sparse — only the blocks written by the VM actually consume host disk. A typical run writes <100MB. Don't warn at "10GB workspace created" — it's mostly air.
+
+Monitor _actual_ usage via `du --apparent-size=false` in observability.
+
+---
+
+## 6. `/inputs` drive
+
+### 6.1 Build
+
+Files come in as `{ name, content: Buffer }[]` (from the `WorkloadSpec.files` field of `createWorkload`).
+
+```
+createInputsDrive(runId, files):
+  1. mkdir /tmp/inputs-${runId}
+  2. for each file: write to /tmp/inputs-${runId}/${file.name}
+  3. also write /tmp/inputs-${runId}/etc/hosts.appstrate  (from Phase 3 subnet info)
+  4. tar -cf /tmp/inputs-${runId}.tar -C /tmp/inputs-${runId} .
+  5. tar2ext4 -i /tmp/inputs-${runId}.tar -o /var/lib/appstrate/firecracker/inputs/${runId}.ext4 -readonly
+  6. sha256 = hash of the .ext4 file
+  7. rm -rf /tmp/inputs-${runId}{,.tar}
+  8. return { path, sha256 }
+```
+
+Size: bounded by `WorkloadSpec.files` size + 4KB ext4 overhead. Typical runs: 1-20MB.
+
+### 6.2 Mount inside the VM (init)
+
+```go
+// init.go excerpt
+syscall.Mount("/dev/vdb", "/inputs", "ext4", syscall.MS_RDONLY, "")
+
+// Merge /etc/hosts fragment
+if _, err := os.Stat("/inputs/etc/hosts.appstrate"); err == nil {
+    hostsFragment, _ := os.ReadFile("/inputs/etc/hosts.appstrate")
+    existing, _ := os.ReadFile("/etc/hosts")
+    os.WriteFile("/etc/hosts", append(existing, hostsFragment...), 0644)
+}
+```
+
+### 6.3 Audit trail
+
+Add to `runs` table:
+
+```ts
+// packages/db/src/schema/runs.ts
+inputsDriveSha256: text("inputs_drive_sha256"),
+```
+
+`FirecrackerOrchestrator.createWorkload` stores the sha256 via an injected update callback (keep the orchestrator DB-free by passing a callback in the constructor, see §9).
+
+---
+
+## 7. Exit code side-channel
+
+Wired end-to-end:
+
+1. Init (Phase 2) writes `exit=N\n` to `/dev/vdd`.
+2. Phase 4 properly attaches `/dev/vdd` as a 16-byte sparse file at VM create time (Phase 2 stubbed this).
+3. Host-side reader (Phase 4 real impl): on `state: "Stopped"`, read the file, parse, return N.
+
+Drive attach spec:
+
+```
+PUT /drives/exit-code
+{
+  "drive_id": "exit-code",
+  "path_on_host": "/srv/jailer/firecracker/${vmId}/root/exit-code",
+  "is_read_only": false,
+  "is_root_device": false
+}
+```
+
+Before VM start: `truncate -s 16 /srv/jailer/firecracker/${vmId}/root/exit-code` (creates a 16-byte sparse file; init fills it).
+
+After VM stop: `read exit-code`, parse, delete.
+
+---
+
+## 8. Env additions
+
+No new env vars in Phase 4. All paths are derived from existing `FIRECRACKER_*` env. Keep `packages/env/src/index.ts` untouched unless a knob genuinely needs to be configurable.
+
+---
+
+## 9. Orchestrator changes
+
+`FirecrackerOrchestrator` receives a `RunUpdater` callback in its constructor:
+
+```ts
+export interface RunUpdater {
+  setInputsDriveSha256(runId: string, sha256: string): Promise<void>;
+}
+
+export class FirecrackerOrchestrator implements ContainerOrchestrator {
+  constructor(host?: FirecrackerHost, updater?: RunUpdater) {
+    // ...
+    this.updater = updater ?? defaultRunUpdater;
+  }
+}
+```
+
+`defaultRunUpdater` lives in `apps/api/src/services/firecracker/run-updater.ts` and imports `db` + the runs schema. The orchestrator itself remains DB-free for testability.
+
+Alternative: emit the sha256 via the audit log (Phase 1 mechanism) and have a listener in `run-pipeline.ts` persist it. This decouples even further but adds an eventing dependency. **Pick whichever fits existing patterns in the codebase** — check how `run-pipeline.ts` persists run metadata today.
+
+---
+
+## 10. Tests
+
+### 10.1 Unit (no KVM, no Firecracker)
+
+- `line-buffer.test.ts`: push arbitrary chunks, verify line assembly matches Node's readline semantics.
+- `inputs-drive-builder.test.ts`: build an inputs drive from a fixed file set, verify sha256 is deterministic.
+- `reflink.test.ts`: detect FS capability, fall back gracefully.
+
+### 10.2 Integration (loopback mount, no KVM)
+
+- `drive-lifecycle.test.ts`:
+  - Build inputs drive → mount via `mount -o loop` → assert files present + read-only.
+  - Create workspace drive → mount via `mount -o loop` → assert empty + writable.
+  - Verify reflink cloning is faster than 20ms (on XFS/btrfs).
+
+### 10.3 KVM-gated
+
+- `log-streaming.test.ts`:
+  - Boot a VM that writes 1000 JSON lines to hvc1.
+  - Read them via `streamLogs()`, verify order + completeness + no kernel noise.
+- `exit-code.test.ts`:
+  - Boot agent VM that exits with code 0 → waitForExit → 0.
+  - Boot agent VM that exits with code 42 → waitForExit → 42.
+  - Boot agent VM that panics → waitForExit → non-zero, no hang.
+
+---
+
+## 11. Implementation order
+
+1. Modify `init.go`: add hvc1 redirect, drive mounts, hosts fragment, exit-code write. Test in isolation.
+2. Update the CI rootfs pipeline (Phase 2 workflow) to include the new init. Regenerate `runtime-pi.ext4`.
+3. `line-buffer.ts` + `hvc1-reader.ts` + unit tests.
+4. `template-builder.ts` + `reflink.ts` + `workspace-drive.ts` + unit tests.
+5. `inputs-drive.ts` + unit tests.
+6. Wire into `RealFirecrackerHost` (replace Phase 2 stubs).
+7. `inputs_drive_sha256` migration + `RunUpdater` wiring.
+8. KVM-gated integration tests.
+9. Contract re-run: Phase 1 integration suite against the updated real host. All must still pass.
+10. Update `CHANGELOG.md`.
+
+---
+
+## 12. Non-goals
+
+- Snapshots, VM pool, image cache → Phase 5
+- User-uploaded files into the inputs drive beyond the `WorkloadSpec.files` array → existing upload flow (Docker has it, inherit semantics)
+- Log persistence to DB — already handled by `run_logs` at the `run-pipeline` layer, orchestrator just streams
+- Workspace persistence across runs — intentionally ephemeral, matches Docker
+
+---
+
+## 13. Risks
+
+| Risk                                                        | Mitigation                                                                                             |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| virtio-console implementation varies by Firecracker version | Pin Firecracker version in health check; fall back to `ttyS1` if virtio-console fails                  |
+| Large inputs drive blows tmpfs in `/tmp` build area         | Fail fast if `spec.files` total > `FIRECRACKER_INPUTS_MAX_BYTES` (default 50MB). Match Docker's limits |
+| reflink not supported → full copy → slow cold start         | Log warning at boot + instrumentation metric. Operators can pick XFS/btrfs for speed                   |
+| init mount bugs leave the VM in a bad state                 | Test the init in a QEMU harness before baking into the rootfs                                          |
+| hvc1 pipe fills up if platform reader is slow               | Set a bounded in-memory buffer + log a warning when it saturates                                       |
+| sha256 computation on large inputs slow                     | Stream the hash during the tar→ext4 conversion, not after                                              |
+
+---
+
+## 14. Reviewer checklist
+
+- [ ] Platform sees zero kernel noise in the app log stream
+- [ ] Inputs drive is mounted RO in the agent; writes fail
+- [ ] Workspace drive writes persist during the run, drive deleted after
+- [ ] Exit codes propagate (0, 42, non-zero-on-panic)
+- [ ] `runs.inputs_drive_sha256` populated
+- [ ] Reflink used when supported, fallback works on ext4
+- [ ] Phase 1 contract tests still pass against the updated host
+
+## 15. References
+
+- [Firecracker virtio-console](https://github.com/firecracker-microvm/firecracker/blob/main/docs/api_requests/README.md)
+- [Linux FICLONE ioctl](https://man7.org/linux/man-pages/man2/ioctl_ficlone.2.html)
+- [tar2ext4](https://github.com/microsoft/hcsshim/tree/main/ext4/tar2ext4)
+- [Phase 3 spec](./PHASE_3_FIRECRACKER_NETWORKING.md) — prerequisite

--- a/docs/specs/PHASE_5_FIRECRACKER_PRODUCTION.md
+++ b/docs/specs/PHASE_5_FIRECRACKER_PRODUCTION.md
@@ -1,0 +1,435 @@
+# Phase 5 — Production Hardening (Snapshots, Pool, Orphan Recovery, Observability)
+
+> **⚠️ Spec non figée.** Ce document capture l'intention et les décisions prises en Phase 0 (voir [ADR-007](../adr/ADR-007-firecracker-orchestrator.md)). L'agent qui implémente cette phase est **invité à challenger** toute décision qui s'avère inapplicable, sous-optimale, ou rendue obsolète par ce qui a été appris en Phases 1-4. C'est la phase la plus ouverte — les mesures de perf et de stabilité collectées en Phases 2-4 doivent **guider les priorités** ici plutôt que suivre aveuglément le plan. Toute déviation majeure doit être notée dans le PR et synchronisée avec l'ADR.
+
+**Status:** Pending Phases 1-4 completion
+**Prerequisites:** Phases 1-4 merged. Real VMs booting, networking functional, logs + drives wired. At least 1 week of soak testing with mock or dev traffic against Phases 1-4.
+**Estimate:** 6-10 days / ~1200 LOC (high variance — scope may shrink based on Phase 4 measurements)
+
+---
+
+## 1. Purpose
+
+Bring the Firecracker backend from functional to production-grade:
+
+- **Sidecar snapshot pool** — pre-warmed microVMs restored from a signed snapshot, mirroring `sidecar-pool.ts` for Docker
+- **Full orphan recovery** — DB registry + jailer chroot scan, resilient to platform crashes
+- **Image cache with cosign verification** — shared across restarts, content-addressed
+- **Observability** — metrics (counter, gauge, histogram), structured audit events, admin API for debug
+- **Rate limits + resource caps** — honor `PLATFORM_RUN_LIMITS` at the VM level
+- **Graceful shutdown** — no orphan VMs, no in-flight runs lost
+
+**Everything before this phase exists to make this phase possible.** The goal is Tier 4 parity with Tier 3 (Docker) in stability, operability, and latency — without compromising the isolation/compliance gains Firecracker buys.
+
+---
+
+## 2. Open decision (to revisit before starting)
+
+ADR-007 §3 decision #3 picks **sidecar snapshot pool + agent cold boot** for the MVP. Phase 4's measurements may challenge this:
+
+- If agent cold boot measures **> 1.5s p50**, agent snapshot becomes valuable → add a `SnapshotProvisioner` for the agent runtime here (Level 2 of ADR-007).
+- If agent cold boot is **< 800ms p50**, keep the MVP model and defer agent snapshots.
+- If sidecar snapshot restore is unstable (incompatibility with `runtime-pi/sidecar/`), fall back to sidecar VM pool with cold boot (still a pre-warm, slower restore).
+
+**Action for the implementer:** run the benchmarks documented in §6 on a realistic host before deciding which optimizations ship in Phase 5. Update this spec's §4 scope accordingly.
+
+---
+
+## 3. Success criteria
+
+1. Sidecar snapshot pool pre-warms `FIRECRACKER_VM_POOL_SIZE` sidecar VMs at boot. Acquiring one takes < 150ms p99.
+2. On platform crash + restart: all orphan VMs, TAPs, bridges, drives, and jailer chroots are cleaned up within 30s of boot.
+3. Running VMs for active in-flight runs are reconciled (not killed) on restart — the run continues to its natural end.
+4. Image cache: a given rootfs version is downloaded + verified once per host. Subsequent runs reuse.
+5. Cosign verification failures hard-block boot with a clear error.
+6. Metrics exported: `firecracker_vm_provision_duration_seconds`, `firecracker_vm_active_count`, `firecracker_tap_count`, `firecracker_subnet_allocations_in_use`, `firecracker_rootfs_verification_duration_seconds`.
+7. Admin API: `GET /api/internal/firecracker/state` returns (admin-only) a snapshot of active VMs + pool + allocations for debug.
+8. `PLATFORM_RUN_LIMITS` (`timeout_ceiling_seconds`, `max_concurrent_per_org`) enforced at the orchestrator layer before VM creation.
+9. Graceful shutdown drains in-flight runs within `FIRECRACKER_SHUTDOWN_TIMEOUT_SECONDS` or kills them cleanly.
+10. ≥ 24h soak test on staging with synthetic traffic (100 runs/hour) shows zero resource leaks (FDs, TAPs, drives, subnets).
+
+---
+
+## 4. File tree
+
+```
+apps/api/src/services/firecracker/
+├── pool/
+│   ├── sidecar-snapshot-pool.ts       (NEW, ~250 LOC) — mirrors sidecar-pool.ts, snapshot-based
+│   ├── snapshot-capture.ts            (NEW, ~100 LOC) — one-time capture of a pristine sidecar VM for the pool
+│   ├── snapshot-restore.ts            (NEW, ~150 LOC) — restore from snapshot, reconfigure per-run
+│   └── pool-metrics.ts                (NEW, ~40 LOC)
+├── image/
+│   ├── rootfs-cache.ts                (NEW, ~120 LOC) — content-addressed local cache
+│   ├── rootfs-download.ts             (NEW, ~80 LOC) — OCI pull from GHCR
+│   └── cosign-verifier.ts             (NEW, ~80 LOC) — wraps `cosign verify-blob` or uses a Bun-native lib
+├── recovery/
+│   ├── vm-registry.ts                 (NEW, ~120 LOC) — DB-backed VM registry with liveness check
+│   ├── orphan-scanner.ts              (NEW, ~100 LOC) — filesystem sweep of jailer chroots
+│   └── reattach.ts                    (NEW, ~80 LOC) — reconnect to VMs of active runs on restart
+├── observability/
+│   ├── metrics.ts                     (NEW, ~80 LOC) — Prometheus metrics
+│   ├── admin-state.ts                 (NEW, ~60 LOC) — /api/internal/firecracker/state handler
+│   └── audit-sink.ts                  (NEW, ~60 LOC) — persist vm.* audit events to a new firecracker_audit_events table
+
+apps/api/src/services/firecracker/
+├── real-host.ts                       (MODIFY) — wire in pool, cache, recovery
+├── vm-provisioner.ts                  (MODIFY) — add SnapshotRestoreProvisioner (for sidecar at minimum, optionally agent)
+
+apps/api/src/services/
+├── run-limits.ts                      (MODIFY) — check FIRECRACKER_MAX_CONCURRENT_RUNS + TAP budget pre-creation
+
+apps/api/src/routes/
+└── internal.ts                        (MODIFY) — add /firecracker/state endpoint, admin-only
+
+packages/db/src/schema/
+└── firecracker.ts                     (MODIFY) — add firecracker_vm_registry + firecracker_audit_events tables
+
+apps/api/src/lib/
+└── boot.ts                            (MODIFY) — boot-time recovery sequence
+
+apps/api/test/integration/services/firecracker/
+├── pool.test.ts                       (NEW, KVM-gated)
+├── orphan-recovery.test.ts            (NEW, KVM-gated)
+├── reattach.test.ts                   (NEW, KVM-gated)
+├── image-cache.test.ts                (NEW, no KVM required)
+└── graceful-shutdown.test.ts          (NEW, KVM-gated)
+
+.github/workflows/
+└── firecracker-soak.yml               (NEW) — nightly 30-minute soak test on a KVM runner
+```
+
+---
+
+## 5. Sidecar snapshot pool
+
+### 5.1 One-time capture
+
+The platform ships with a **canonical snapshot** captured during the rootfs CI pipeline (Phase 2 workflow extended):
+
+1. Boot a sidecar VM with a "snapshotting" cmdline flag.
+2. Sidecar code (aware of the flag) starts its HTTP server, binds the port, **pauses before accepting traffic**.
+3. Firecracker API: `PUT /snapshot/create` with `{"snapshot_type": "Full", "snapshot_path": "/tmp/sidecar.snap", "mem_file_path": "/tmp/sidecar.mem"}`.
+4. Capture artifact = `(snap file, mem file)`. Sign both with cosign.
+5. Publish alongside `sidecar.ext4`.
+
+Alternative: capture on the host at first boot, cache locally. Simpler but non-reproducible across hosts. **Prefer CI capture** for compliance (signed, auditable, identical across hosts).
+
+### 5.2 Pool structure
+
+Mirror `apps/api/src/services/sidecar-pool.ts`:
+
+```ts
+interface PooledSidecarVm {
+  vmId: string;
+  socketPath: string;
+  chrootPath: string;
+  configSecret: string;
+  hostPort: number;  // pre-exposed for the /configure call
+}
+
+const pool: PooledSidecarVm[] = [];
+
+async function replenish(): Promise<void> {
+  const needed = FIRECRACKER_VM_POOL_SIZE - pool.length;
+  if (needed <= 0) return;
+  for (const _ of range(needed)) {
+    const vm = await restoreSnapshot();
+    pool.push(vm);
+  }
+}
+
+async function acquireSidecarVm(runId, runSubnet, config): Promise<FirecrackerWorkloadHandle> {
+  const entry = pool.pop();
+  if (!entry) return createFresh(runId, runSubnet, config);
+
+  // Configure via /configure just like Docker today
+  await fetch(`http://${host}:${entry.hostPort}/configure`, {
+    method: "POST",
+    body: JSON.stringify({ runToken, platformApiUrl, ... }),
+  });
+
+  // Attach to the per-run bridge
+  await attachTap(entry.vmId, bridgeName, sidecarIp);
+
+  scheduleReplenish();
+  return toHandle(entry, runId);
+}
+```
+
+### 5.3 Restore
+
+`restoreSnapshot()`:
+
+1. Generate new `vmId`, create jailer chroot.
+2. Copy snap + mem files into chroot.
+3. Start Firecracker pointing at the snap — `PUT /snapshot/load`.
+4. Attach a pre-allocated TAP on a standby "pool" bridge (similar to `appstrate-sidecar-pool` network in Docker).
+5. Wait for the sidecar HTTP server to respond healthy on `/health`.
+6. Return the pool entry.
+
+Target latency: **p99 < 150ms from `acquireSidecarVm()` to ready handle**.
+
+### 5.4 Invalidation
+
+Snapshot is version-bound. When `sidecar.ext4` version changes, regenerate the snapshot in CI. The manifest includes both rootfs hash + snap hash — platform detects mismatch at boot and refuses to use a stale snap.
+
+---
+
+## 6. Performance benchmarks (run before deciding scope)
+
+Create `apps/api/scripts/bench-firecracker.ts` that measures:
+
+| Metric                                                   | Target                                                   | Escalation if missed                                                       |
+| -------------------------------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------- |
+| Sidecar snapshot restore → ready                         | p50 < 100ms, p99 < 150ms                                 | If > 300ms, investigate snapshot content — it may carry unnecessary memory |
+| Agent cold boot → first LLM call                         | p50 < 1.5s, p99 < 3s                                     | If > 3s, consider Level 2 agent snapshot                                   |
+| Workspace drive creation (reflink)                       | < 5ms                                                    | If > 20ms, check FS and mount options                                      |
+| Inputs drive creation (10MB files)                       | < 300ms                                                  | If > 1s, review tar2ext4 config                                            |
+| Cold boot memory footprint                               | < 200MB RSS (total: platform + Firecracker + init + Bun) | If > 400MB, audit init + kernel size                                       |
+| 100 concurrent runs (mixed sidecar restore + agent cold) | 0% error, p99 latency per run < 5s                       | If any errors, revisit FD budget / subnet allocator / bridge contention    |
+
+Record results in `docs/specs/PHASE_5_BENCHMARKS.md` (new file). Use the numbers to finalize Phase 5 scope before coding.
+
+---
+
+## 7. Orphan recovery (full impl)
+
+### 7.1 DB registry
+
+New table:
+
+```ts
+export const firecrackerVmRegistry = pgTable("firecracker_vm_registry", {
+  vmId: text("vm_id").primaryKey(),
+  runId: uuid("run_id"), // null = pool VM
+  role: text("role").notNull(),
+  chrootPath: text("chroot_path").notNull(),
+  socketPath: text("socket_path").notNull(),
+  tapName: text("tap_name"),
+  bridgeName: text("bridge_name"),
+  status: text("status").notNull(), // "starting" | "running" | "stopping" | "stopped"
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  lastHeartbeat: timestamp("last_heartbeat"),
+});
+```
+
+Write on every lifecycle transition. Delete on clean removal.
+
+### 7.2 Boot-time reconciliation
+
+```
+reconcileOnBoot():
+  // 1. DB → filesystem sweep
+  activeRunsVms = SELECT vm_id, run_id, chroot_path FROM firecracker_vm_registry
+                  JOIN runs ON runs.id = run_id
+                  WHERE runs.status IN ('pending', 'running')
+
+  for vm in activeRunsVms:
+    if chroot exists AND API socket responds:
+      reattach(vm)  // VM is still alive, continue the run
+    else:
+      markRunFailed(vm.run_id, reason: "vm crashed during platform outage")
+      cleanupVmArtifacts(vm)
+
+  // 2. Filesystem → DB sweep
+  allChroots = ls /srv/jailer/firecracker/
+  for chroot in allChroots:
+    if chroot.vm_id not in firecrackerVmRegistry:
+      killVmIfRunning(chroot)
+      rm -rf chroot
+
+  // 3. Orphan bridges/TAPs (Phase 3 logic, called here too)
+  cleanupNetworkOrphans()
+```
+
+### 7.3 Reattach
+
+If a VM survived the platform outage (rare but possible — platform dies, VM keeps running):
+
+1. Verify the jailer chroot exists + API socket responds.
+2. Re-establish log streaming via `readHvc1(vmId)` (picks up mid-stream).
+3. Update `status` in the registry.
+4. Let the existing run continue.
+
+Reattach requires the Firecracker pipe / socket to survive the platform crash. Document limitations in the self-hosting guide.
+
+---
+
+## 8. Image cache
+
+`apps/api/src/services/firecracker/image/rootfs-cache.ts`:
+
+```
+ensureRootfs(manifestUrl):
+  manifest = fetch(manifestUrl)
+  cachePath = /var/lib/appstrate/firecracker/cache/${manifest.sha256}.ext4
+  if exists(cachePath) AND sha256(cachePath) == manifest.sha256:
+    return cachePath  // hit
+
+  // miss — download + verify
+  download(manifest.url, cachePath)
+  cosignVerify(cachePath, manifest.signature, FIRECRACKER_COSIGN_KEY)
+  if sha256(cachePath) != manifest.sha256:
+    throw "integrity mismatch"
+
+  return cachePath
+```
+
+LRU eviction when the cache exceeds `FIRECRACKER_CACHE_MAX_GB` (default 20GB). Never evict in-use rootfs (refcount).
+
+Platform boot ensures the configured rootfs version is cached before accepting traffic.
+
+---
+
+## 9. Metrics + admin API
+
+### 9.1 Prometheus metrics
+
+Expose via the existing metrics endpoint (if any — otherwise add `GET /api/internal/metrics`):
+
+- `firecracker_vm_provision_duration_seconds{source="cold|snapshot", role="sidecar|agent"}` — histogram
+- `firecracker_vm_active_count{role}` — gauge
+- `firecracker_tap_count` — gauge
+- `firecracker_subnet_allocations_in_use` — gauge
+- `firecracker_sidecar_pool_size` / `_target_size` — gauges
+- `firecracker_rootfs_verification_duration_seconds` — histogram
+- `firecracker_orphan_cleanup_total{result="success|failure"}` — counter
+
+### 9.2 Admin state endpoint
+
+```
+GET /api/internal/firecracker/state
+Authorization: admin-only
+
+Response: {
+  pool: { target: N, current: M, entries: [{ vmId, age, healthy }] },
+  activeRuns: [{ runId, vms: [...], networking: {...} }],
+  cache: { entries: [{ sha256, size, lastUsed }], totalBytes },
+  subnets: { allocated: N, capacity: M },
+  host: { kernel, firecrackerVersion, kvmAvailable, fdBudget },
+}
+```
+
+Use for debug during incident response.
+
+---
+
+## 10. Rate limits + graceful shutdown
+
+### 10.1 Pre-creation caps
+
+Extend `services/run-limits.ts`:
+
+- Reject if `firecracker_vm_active_count > FIRECRACKER_MAX_CONCURRENT_RUNS * 2` (sidecar + agent per run).
+- Reject if `tap_count > FIRECRACKER_MAX_CONCURRENT_RUNS * 2 + pool_size`.
+- Reject if host FD margin below threshold.
+- Reject if subnet ledger full.
+
+All rejections return 429 with problem+json + `Retry-After`.
+
+### 10.2 Graceful shutdown
+
+`FirecrackerOrchestrator.shutdown()`:
+
+1. Stop accepting new runs (existing `run-tracker.ts` gate).
+2. Wait for in-flight runs up to `FIRECRACKER_SHUTDOWN_TIMEOUT_SECONDS` (default 60s).
+3. For remaining runs: send `InstanceHalt` via API, mark registry + run records.
+4. Drain sidecar pool (destroy all pool VMs).
+5. Remove egress bridge + iptables rules.
+6. Close all DB connections.
+
+Timeout default of 60s balances shutdown speed with run completion. Document override in self-hosting.
+
+---
+
+## 11. Soak test
+
+`.github/workflows/firecracker-soak.yml`:
+
+- Nightly schedule
+- Provision a KVM-enabled GitHub Actions runner (self-hosted or Actions Runner Controller with nested virt)
+- Run 30 minutes of synthetic agent traffic at 100 runs/hour
+- Collect metrics; fail build if:
+  - any VM leaked (active count at end != active count at start)
+  - any TAP leaked
+  - p99 latency > 5s
+  - error rate > 0.5%
+
+Post-soak, upload metrics + logs to an artifact for review.
+
+---
+
+## 12. Env additions
+
+```ts
+FIRECRACKER_CACHE_MAX_GB: z.coerce.number().int().min(1).default(20),
+FIRECRACKER_SHUTDOWN_TIMEOUT_SECONDS: z.coerce.number().int().min(1).default(60),
+FIRECRACKER_HEARTBEAT_INTERVAL_SECONDS: z.coerce.number().int().min(1).default(30),
+FIRECRACKER_ORPHAN_SCAN_INTERVAL_SECONDS: z.coerce.number().int().min(60).default(3600),  // hourly
+```
+
+---
+
+## 13. Implementation order (suggestion — adapt based on benchmarks)
+
+1. Run the benchmarks from §6 against Phases 1-4. Record results.
+2. Decide scope: sidecar snapshot pool always, agent snapshot **only if** cold boot fails targets.
+3. `firecracker_vm_registry` + `firecracker_audit_events` tables + migrations.
+4. Orphan recovery (registry + scanner + reattach). Ship this **first** — biggest stability win.
+5. Image cache + cosign verification. Ship second — compliance blocker.
+6. Sidecar snapshot pool — requires CI changes to capture the snapshot alongside the rootfs.
+7. Metrics + admin API.
+8. Rate limits + graceful shutdown.
+9. Soak workflow.
+10. Documentation: self-hosting guide for Tier 4, troubleshooting runbook.
+
+---
+
+## 14. Risks
+
+| Risk                                                    | Mitigation                                                                                                                                                    |
+| ------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Snapshot restore incompatible across kernel versions    | Pin kernel version in snapshot manifest; regenerate on kernel bump                                                                                            |
+| Reattach after platform crash leaves inconsistent state | Fail-fast if any registry invariant violated; mark affected runs failed                                                                                       |
+| Cache grows unboundedly                                 | LRU eviction + max-size env var                                                                                                                               |
+| Soak test flakiness masks real leaks                    | Monitor trend over 7 days, not one-off                                                                                                                        |
+| Cosign key compromised                                  | Use keyless signing (Sigstore OIDC) in CI; revoke via manifest rotation                                                                                       |
+| Pool snapshot carries sensitive state                   | Capture from a fully-generic sidecar with no real credentials loaded; verify via test that `runToken`, `platformApiUrl` are empty in the snapshot memory dump |
+| Nested virt on cloud hosts unstable                     | Document required host types per provider (AWS .metal, GCP nested-virt, Hetzner bare-metal, etc.)                                                             |
+
+---
+
+## 15. Reviewer checklist
+
+- [ ] Benchmarks ran; results in `PHASE_5_BENCHMARKS.md`
+- [ ] Sidecar pool acquire p99 < 150ms
+- [ ] Orphan recovery sweeps cleanly on forced kill + restart
+- [ ] Image cache reuses existing verified rootfs
+- [ ] Admin state endpoint works and is admin-only
+- [ ] 24h soak shows zero leaks
+- [ ] Graceful shutdown completes within timeout
+- [ ] Metrics exposed and scrape-able
+- [ ] Self-hosting docs updated for Tier 4
+- [ ] CHANGELOG + release notes drafted
+
+## 16. References
+
+- [Firecracker snapshot support](https://github.com/firecracker-microvm/firecracker/blob/main/docs/snapshotting/snapshot-support.md)
+- [Sigstore keyless signing](https://docs.sigstore.dev/cosign/signing/overview/)
+- [AWS Lambda SnapStart paper](https://www.usenix.org/conference/nsdi23/presentation/brooker) — reference pattern for pristine snapshots
+- [Phase 4 spec](./PHASE_4_FIRECRACKER_LOGS_AND_FILES.md) — prerequisite
+- [ADR-007](../adr/ADR-007-firecracker-orchestrator.md) — architectural decisions, especially §Iterability
+
+---
+
+## 17. After Phase 5
+
+Tier 4 is production-ready. Remaining roadmap items (not scheduled):
+
+- **Agent snapshot pre-loaded** (Level 2 pristine snapshot) if not shipped in Phase 5
+- **vsock migration** for sidecar↔agent (listener abstraction posed in Phase 1)
+- **Custom `PI_IMAGE`** via `CustomImageProvisioner` plugin path
+- **Remote attestation** (vTPM) for contractual compliance
+- **Per-agent snapshots** (Level 3) — only with data justifying it
+- **K8s/Firecracker hybrid** via the `ContainerOrchestrator` interface (a Kata-style K8s backend would implement the same interface)


### PR DESCRIPTION
## Summary

Closes #159. Captures Phase 0 design for the Firecracker microVM orchestrator as a documentation-only PR, to unblock implementation PRs (Phase 1-5).

- **ADR-007** — 12 strategic decisions with rationale (jailer, 2 VMs per run, pristine snapshot pattern, CI-signed rootfs, per-run bridges + static IPs, two virtio-consoles, custom init, DB-backed orphan recovery), plus threat model and iterability foundations.
- **Phase 1-5 specs** — detailed implementation guides under \`docs/specs/PHASE_*\`, each gated on the previous and each opening with a *"⚠️ Spec non figée"* notice authorizing the implementer to challenge tactical choices while preserving ADR decisions.

All decisions were reconciled around three drivers: **kernel-level isolation**, **compliance** (signed artifacts, hashed inputs, per-VM audit), and **cold-start latency** (via sidecar snapshot pool, agent cold boot for MVP).

## Scope split across the 5 phases

| Phase | Focus | Estimate |
|-------|-------|----------|
| 1 | Skeleton + mock host, full \`ContainerOrchestrator\` contract testable without KVM | 2-3 d / 800 LOC |
| 2 | Real jailer/firecracker, custom Go init, CI-signed rootfs pipeline | 5-7 d / 1500 LOC |
| 3 | Per-run bridges + TAPs + DB-backed subnet allocator + NAT + /etc/hosts injection | 4-6 d / 800 LOC |
| 4 | /dev/hvc1 app logs, /inputs + /workspace drives (reflink), exit-code side-channel | 4-5 d / 900 LOC |
| 5 | Sidecar snapshot pool, orphan recovery, image cache, observability, soak | 6-10 d / 1200 LOC |

**Total:** ~21-31 dev days for a production-ready Tier 4 backend, coherent with the RFC's original 4-6 week estimate.

## Key architectural choices captured in ADR-007

- **Tier 4 = opt-in** behind \`RUN_ADAPTER=firecracker\`. Docker remains the default production backend.
- **2 microVMs per run** (sidecar + agent) — preserves ADR-003 credential-isolation invariant. Fusion explicitly rejected.
- **Pristine snapshot pattern only** — snapshots taken of pre-warmed empty VMs, never of dirty runtime state. Reconciles cold-start with isolation + compliance.
- **CI-built signed rootfs** via \`buildx → tar2ext4 → cosign → GHCR\`. ~200 LOC pipeline, no containerd.
- **\`PI_IMAGE\` override hard-fails in Tier 4** (MVP). Custom images stay on Tier 3.
- **Two virtio-consoles** — ttyS0 for kernel/debug, /dev/hvc1 for clean app JSON-line stream.
- **Custom ~80 LOC Go init** instead of systemd.

## Test plan

- [ ] Read ADR-007 top-to-bottom — verify all 12 decisions have clear rationale
- [ ] Read Phase 1 spec — verify success criteria are concrete and an agent could implement from zero
- [ ] Verify each Phase 2-5 spec opens with the "Spec non figée" notice
- [ ] Confirm no runtime code is modified (docs-only PR)
- [ ] Confirm cross-references between documents are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)