### PR TITLE
Review follow-ups: CLI device-flow security + install UX

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ env:
 permissions:
   contents: write
   packages: write
+  # SLSA build provenance via `actions/attest-build-provenance` runs on
+  # the CLI binaries in `sign-cli` — keeps the supply-chain attestation
+  # attached to the release alongside the minisign-signed checksums.
+  id-token: write
+  attestations: write
 
 jobs:
   build-and-push:
@@ -139,8 +144,104 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
+  # ─── CLI supply-chain: minisign-signed checksums + SLSA provenance ────────
+  #
+  # Closes the trust chain from `get.appstrate.dev` down to the running
+  # CLI binary. The published `bootstrap.sh` downloads the binary from
+  # this release + the `checksums.txt` + `checksums.txt.minisig` produced
+  # here, verifies the signature against `scripts/appstrate.pub` (shipped
+  # alongside), and refuses to exec the binary unless its SHA-256
+  # matches. Without this job the bootstrapper has no cryptographic
+  # anchor and the whole curl | bash path degrades to TLS-only trust.
+  sign-cli:
+    name: Sign CLI binaries
+    needs: build-cli
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Download CLI binaries
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          path: cli-binaries
+          merge-multiple: false
+
+      - name: Stage binaries
+        id: stage
+        run: |
+          # Each artifact extracts into its own subdir — flatten into a
+          # single directory so checksum + signing steps see one tree.
+          mkdir -p out
+          find cli-binaries -type f -name 'appstrate-*' -exec cp {} out/ \;
+          ls -la out/
+          # Fail fast if any expected target is missing — the release
+          # should not ship with a partial binary set.
+          for asset in appstrate-darwin-arm64 appstrate-darwin-x64 \
+                       appstrate-linux-x64 appstrate-linux-arm64; do
+            if [ ! -f "out/$asset" ]; then
+              echo "::error::Missing CLI binary: $asset"
+              exit 1
+            fi
+          done
+
+      - name: Generate checksums
+        run: |
+          cd out
+          # `shasum -a 256` output format matches what `sha256sum -c`
+          # expects, so `bootstrap.sh` can verify with either tool.
+          sha256sum appstrate-* > checksums.txt
+          cat checksums.txt
+
+      - name: Sign checksums with minisign
+        env:
+          MINISIGN_SECRET_KEY: ${{ secrets.MINISIGN_SECRET_KEY }}
+          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
+          VERSION: ${{ github.ref_name }}
+        run: |
+          # Secrets are required: we intentionally fail rather than ship
+          # a release with unsigned binaries. Mixed signed/unsigned
+          # releases would force `bootstrap.sh` to tolerate missing
+          # signatures, which defeats the whole verification flow.
+          if [ -z "${MINISIGN_SECRET_KEY:-}" ] || [ -z "${MINISIGN_PASSWORD:-}" ]; then
+            echo "::error::MINISIGN_SECRET_KEY + MINISIGN_PASSWORD secrets must be set."
+            echo "::error::Rotation SOP: docs/adr/ADR-006-cli-device-flow-monorepo.md"
+            exit 1
+          fi
+          sudo apt-get update -qq && sudo apt-get install -y -qq minisign
+          umask 077
+          printf '%s' "$MINISIGN_SECRET_KEY" > /tmp/minisign.key
+          printf '%s\n' "$MINISIGN_PASSWORD" | \
+            minisign -S -s /tmp/minisign.key \
+              -t "appstrate CLI $VERSION" \
+              -m out/checksums.txt
+          rm -f /tmp/minisign.key
+          # Ship the public key next to the signed checksums so air-gapped
+          # users and second-party mirrors have everything they need in
+          # one place. `scripts/appstrate.pub` is the source of truth;
+          # copying to `out/` just avoids a second checkout on the
+          # consumer side.
+          cp scripts/appstrate.pub out/appstrate.pub
+
+      - name: Attest CLI binary provenance (SLSA)
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: out/appstrate-*
+
+      - name: Upload signed bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: cli-signed-bundle
+          path: |
+            out/checksums.txt
+            out/checksums.txt.minisig
+            out/appstrate.pub
+          if-no-files-found: error
+          retention-days: 7
+
   release:
-    needs: [build-and-push, build-cli]
+    needs: [build-and-push, build-cli, sign-cli]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -156,6 +257,12 @@ jobs:
           # Each artifact is extracted into its own subdir under `path`;
           # flatten by globbing in the release step below.
           merge-multiple: false
+
+      - name: Download signed bundle
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: cli-signed-bundle
+          path: cli-signed
 
       - name: Generate release notes
         id: notes
@@ -193,5 +300,11 @@ jobs:
         with:
           body: ${{ steps.notes.outputs.body }}
           # Flatten the per-artifact subdirs into a single glob so every
-          # CLI binary lands as a top-level asset on the release.
-          files: cli-binaries/*/appstrate-*
+          # CLI binary lands as a top-level asset on the release, then
+          # append the signed checksum bundle so `bootstrap.sh` can
+          # verify integrity + provenance before chmod+x on a fresh host.
+          files: |
+            cli-binaries/*/appstrate-*
+            cli-signed/checksums.txt
+            cli-signed/checksums.txt.minisig
+            cli-signed/appstrate.pub

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,10 @@ jobs:
           - runner: macos-14
             target: bun-darwin-arm64
             asset: appstrate-darwin-arm64
+          # `macos-15-intel` is GitHub's last Intel-mac runner (macos-13
+          # retired 2025-12). When it follows, drop the darwin-x64 row
+          # and ship only darwin-arm64 — Intel Macs are a rounding error
+          # on the CLI install curve by then. Tracked in ADR-006.
           - runner: macos-15-intel
             target: bun-darwin-x64
             asset: appstrate-darwin-x64
@@ -124,6 +128,21 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Stamp release version into CLI package.json
+        working-directory: apps/cli
+        run: |
+          # `lib/version.ts` imports `package.json` statically so
+          # `bun build --compile` bakes whatever version is on disk at
+          # build time. Repo default is `0.0.0` (dev). Overwrite with
+          # the tag being released so the shipped binary reports the
+          # matching semver on `appstrate --version`. jq is installed
+          # on both ubuntu-latest and macos-14/macos-15-intel runner
+          # images by default.
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
+          grep '"version"' package.json
+
       - name: Compile CLI binary
         working-directory: apps/cli
         run: |
@@ -132,9 +151,18 @@ jobs:
             src/cli.ts \
             --outfile=${{ matrix.asset }}
 
-      - name: Smoke-test binary (--help)
+      - name: Smoke-test binary (--help + --version)
         working-directory: apps/cli
-        run: ./${{ matrix.asset }} --help
+        run: |
+          ./${{ matrix.asset }} --help
+          REPORTED=$(./${{ matrix.asset }} --version)
+          EXPECTED="${GITHUB_REF_NAME#v}"
+          echo "Binary reports: $REPORTED / expected: $EXPECTED"
+          if [ "$REPORTED" != "$EXPECTED" ]; then
+            echo "::error::Version mismatch — compiled binary reports '$REPORTED', tag is '$EXPECTED'."
+            echo "::error::Check that the 'Stamp release version' step ran before 'Compile CLI binary'."
+            exit 1
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -165,3 +165,173 @@ jobs:
           echo "$TAMPER_OUT" | grep -qE "(Signature verification FAILED|tampered)" \
             || { echo "::error::verify.sh did not report tampering"; exit 1; }
           echo "✓ tamper path OK"
+
+  # End-to-end exercise of bootstrap.sh's internal verification path:
+  # fetches checksums.txt + .minisig, verifies minisign against the
+  # baked-in pubkey, verifies SHA-256 of the binary, installs, execs.
+  # We stage a fake release on a local HTTP server + rewrite bootstrap.sh's
+  # URL_BASE + pubkey constant so the trust chain uses our throwaway keypair.
+  # This guards against regressions in the checksum/signature gate that
+  # otherwise only surface after a real tag push.
+  #
+  # All scenarios run in ONE step because each `run:` block spawns a fresh
+  # shell (the background HTTP server + `trap` don't persist across steps).
+  bootstrap-verify-dry-run:
+    runs-on: ubuntu-latest
+    needs: [static, workflow-lint]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Install minisign
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq minisign
+
+      - name: Exercise bootstrap.sh verification path end-to-end
+        run: |
+          set -euo pipefail
+
+          # ── Stage a fake release tree served under /release/* ──────────
+          ROOT="$GITHUB_WORKSPACE/served"
+          mkdir -p "$ROOT/release"
+
+          # Fake CLI binary: prints a marker so we can assert bootstrap
+          # actually exec'd it at the tail of the trust chain.
+          cat > "$ROOT/release/appstrate-linux-x64" <<'CLI'
+          #!/usr/bin/env bash
+          echo "FAKE_CLI_RAN subcommand=$1"
+          exit 0
+          CLI
+          chmod +x "$ROOT/release/appstrate-linux-x64"
+
+          # Checksum manifest — `<hash>  <filename>` format matches the
+          # GNU `sha256sum -c` input format bootstrap.sh uses.
+          (cd "$ROOT/release" && sha256sum appstrate-linux-x64 > checksums.txt)
+
+          # Throwaway signing key (CI-friendly, unencrypted).
+          umask 077
+          minisign -G -W -f -p /tmp/dry.pub -s /tmp/dry.key
+          minisign -S -s /tmp/dry.key -t "dry-run" -m "$ROOT/release/checksums.txt"
+          cp "$ROOT/release/checksums.txt.minisig" "$ROOT/release/checksums.txt.minisig.signed"
+
+          PUBKEY=$(grep -v '^untrusted' /tmp/dry.pub | head -1 | tr -d '\n')
+
+          # ── Rewrite bootstrap.sh: URL_BASE → localhost, pubkey → ours ──
+          # `latest` and pinned paths both hit the same served dir because
+          # we only maintain one release tree.
+          # shellcheck disable=SC2016  # `${VERSION}` is literal in the sed pattern
+          sed \
+            -e "s|__APPSTRATE_VERSION__|v1.0.0-dry|g" \
+            -e 's|https://github.com/appstrate/appstrate-oss/releases/latest/download|http://localhost:8766/release|' \
+            -e 's|https://github.com/appstrate/appstrate-oss/releases/download/${VERSION}|http://localhost:8766/release|' \
+            -e "s|APPSTRATE_MINISIGN_PUBKEY=\"[^\"]*\"|APPSTRATE_MINISIGN_PUBKEY=\"${PUBKEY}\"|" \
+            scripts/bootstrap.sh > /tmp/bootstrap.sh
+          bash -n /tmp/bootstrap.sh
+
+          grep -q "http://localhost:8766/release" /tmp/bootstrap.sh \
+            || { echo "::error::URL_BASE rewrite did not take effect"; exit 1; }
+          grep -q "APPSTRATE_MINISIGN_PUBKEY=\"${PUBKEY}\"" /tmp/bootstrap.sh \
+            || { echo "::error::pubkey rewrite did not take effect"; exit 1; }
+
+          # ── Start the HTTP server for the whole job ───────────────────
+          cd "$ROOT"
+          python3 -m http.server 8766 >/tmp/httpd.log 2>&1 &
+          SERVER=$!
+          trap 'kill $SERVER 2>/dev/null || true; rm -f /tmp/dry.key' EXIT
+          sleep 1
+
+          # ── Scenario 1: happy path ────────────────────────────────────
+          echo "::group::happy path"
+          export APPSTRATE_BIN_DIR="$GITHUB_WORKSPACE/bin"
+          export PATH="$APPSTRATE_BIN_DIR:$PATH"
+
+          OUT=$(bash /tmp/bootstrap.sh 2>&1)
+          echo "$OUT"
+          echo "$OUT" | grep -q "Integrity + provenance verified" \
+            || { echo "::error::bootstrap did not emit the verified banner"; exit 1; }
+          echo "$OUT" | grep -q "FAKE_CLI_RAN subcommand=install" \
+            || { echo "::error::bootstrap did not exec the installed binary"; exit 1; }
+          test -x "$APPSTRATE_BIN_DIR/appstrate"
+          echo "::endgroup::"
+          echo "✓ happy path OK"
+
+          # ── Scenario 2: tampered binary ───────────────────────────────
+          echo "::group::tampered binary"
+          cp "$ROOT/release/appstrate-linux-x64" "$ROOT/release/appstrate-linux-x64.bak"
+          echo "echo TAMPERED" >> "$ROOT/release/appstrate-linux-x64"
+          set +e
+          TAMPER_OUT=$(APPSTRATE_BIN_DIR="$GITHUB_WORKSPACE/bin-tampered" \
+            bash /tmp/bootstrap.sh 2>&1)
+          rc=$?
+          set -e
+          echo "$TAMPER_OUT"
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::bootstrap executed a tampered binary"; exit 1
+          fi
+          echo "$TAMPER_OUT" | grep -qE "SHA-256 mismatch|does NOT match" \
+            || { echo "::error::bootstrap did not report the SHA-256 mismatch"; exit 1; }
+          # Restore for subsequent scenarios.
+          mv "$ROOT/release/appstrate-linux-x64.bak" "$ROOT/release/appstrate-linux-x64"
+          echo "::endgroup::"
+          echo "✓ tampered-binary path OK"
+
+          # ── Scenario 3: tampered checksums.txt (signature mismatch) ──
+          echo "::group::tampered checksums"
+          cp "$ROOT/release/checksums.txt" "$ROOT/release/checksums.txt.bak"
+          echo "deadbeef  appstrate-linux-x64" > "$ROOT/release/checksums.txt"
+          set +e
+          SIG_OUT=$(APPSTRATE_BIN_DIR="$GITHUB_WORKSPACE/bin-sig" \
+            bash /tmp/bootstrap.sh 2>&1)
+          rc=$?
+          set -e
+          echo "$SIG_OUT"
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::bootstrap accepted a tampered checksums.txt"; exit 1
+          fi
+          echo "$SIG_OUT" | grep -qE "Signature verification FAILED|signed by the Appstrate key" \
+            || { echo "::error::bootstrap did not report signature failure"; exit 1; }
+          mv "$ROOT/release/checksums.txt.bak" "$ROOT/release/checksums.txt"
+          echo "::endgroup::"
+          echo "✓ tampered-checksums path OK"
+
+          # ── Scenario 4: minisign missing from PATH (fail closed) ─────
+          echo "::group::minisign missing"
+          # Strip /usr/bin (where minisign lives on Ubuntu) but keep enough
+          # for curl + sh builtins + sha256sum (all in /usr/bin, so we also
+          # need to shadow minisign by pointing PATH elsewhere and relying
+          # on an explicit denylist). Simpler: create a PATH with only the
+          # minimum required tools, symlinked explicitly.
+          NOBIN="$GITHUB_WORKSPACE/no-minisign-path"
+          mkdir -p "$NOBIN"
+          for b in curl bash grep sed tr head cat mkdir mktemp rm install chmod cd cp ln sha256sum sudo uname tee printf; do
+            if command -v "$b" >/dev/null 2>&1; then
+              ln -sf "$(command -v "$b")" "$NOBIN/$b" 2>/dev/null || true
+            fi
+          done
+          set +e
+          NOMINI_OUT=$(PATH="$NOBIN" APPSTRATE_BIN_DIR="$GITHUB_WORKSPACE/bin-nomini" \
+            bash /tmp/bootstrap.sh 2>&1)
+          rc=$?
+          set -e
+          echo "$NOMINI_OUT"
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::bootstrap proceeded without minisign available"; exit 1
+          fi
+          echo "$NOMINI_OUT" | grep -q "minisign is required" \
+            || { echo "::error::bootstrap did not emit the minisign-missing hint"; exit 1; }
+          echo "::endgroup::"
+          echo "✓ missing-minisign path OK"
+
+          # ── Scenario 5: APPSTRATE_SKIP_VERIFY=1 bypass (warns + proceeds) ─
+          echo "::group::skip-verify bypass"
+          APPSTRATE_BIN_DIR="$GITHUB_WORKSPACE/bin-skip" \
+          APPSTRATE_SKIP_VERIFY=1 \
+          PATH="$GITHUB_WORKSPACE/bin-skip:$PATH" \
+            bash /tmp/bootstrap.sh > /tmp/skip.out 2>&1
+          SKIP_OUT=$(cat /tmp/skip.out)
+          echo "$SKIP_OUT"
+          echo "$SKIP_OUT" | grep -q "APPSTRATE_SKIP_VERIFY=1" \
+            || { echo "::error::skip-verify did not emit the warning banner"; exit 1; }
+          echo "$SKIP_OUT" | grep -q "FAKE_CLI_RAN" \
+            || { echo "::error::skip-verify did not exec the binary"; exit 1; }
+          echo "::endgroup::"
+          echo "✓ skip-verify path OK"

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -232,6 +232,18 @@ jobs:
           grep -q "APPSTRATE_MINISIGN_PUBKEY=\"${PUBKEY}\"" /tmp/bootstrap.sh \
             || { echo "::error::pubkey rewrite did not take effect"; exit 1; }
 
+          # ── Pre-create the install destinations ──────────────────────
+          # bootstrap.sh calls `install -m 0755 …` which does NOT create
+          # intermediate directories; we need each $APPSTRATE_BIN_DIR to
+          # exist up-front or `install` exits non-zero before the happy
+          # banner is printed (which would swallow the output via $(…)).
+          mkdir -p \
+            "$GITHUB_WORKSPACE/bin" \
+            "$GITHUB_WORKSPACE/bin-tampered" \
+            "$GITHUB_WORKSPACE/bin-sig" \
+            "$GITHUB_WORKSPACE/bin-nomini" \
+            "$GITHUB_WORKSPACE/bin-skip"
+
           # ── Start the HTTP server for the whole job ───────────────────
           cd "$ROOT"
           python3 -m http.server 8766 >/tmp/httpd.log 2>&1 &
@@ -244,8 +256,16 @@ jobs:
           export APPSTRATE_BIN_DIR="$GITHUB_WORKSPACE/bin"
           export PATH="$APPSTRATE_BIN_DIR:$PATH"
 
+          # Run with `set +e` around the capture so a failing bootstrap
+          # still surfaces its stdout/stderr in the log instead of being
+          # killed silently by `set -e` at the `OUT=$(...)` assignment.
+          set +e
           OUT=$(bash /tmp/bootstrap.sh 2>&1)
+          rc=$?
+          set -e
           echo "$OUT"
+          test "$rc" -eq 0 \
+            || { echo "::error::bootstrap exited $rc on the happy path"; exit 1; }
           echo "$OUT" | grep -q "Integrity + provenance verified" \
             || { echo "::error::bootstrap did not emit the verified banner"; exit 1; }
           echo "$OUT" | grep -q "FAKE_CLI_RAN subcommand=install" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,13 @@ jobs:
       - name: Run unit tests
         run: bun test apps/api/test/unit/ runtime-pi/ packages/connect/ packages/ui/
 
+      # CLI tests live in a separate workspace with its own bunfig.toml
+      # (no Docker preload needed), so we run them from that directory to
+      # pick up the right config and keep them fast.
+      - name: Run CLI unit tests
+        working-directory: apps/cli
+        run: bun test
+
   integration:
     name: Integration tests
     if: contains(github.event.pull_request.labels.*.name, 'integration')

--- a/apps/api/src/modules/oidc/auth/guards.ts
+++ b/apps/api/src/modules/oidc/auth/guards.ts
@@ -33,7 +33,7 @@
  */
 
 import { createAuthMiddleware, APIError, getSessionFromCtx } from "better-auth/api";
-import { eq } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 import type { RateLimiterAbstract } from "rate-limiter-flexible";
 import { db } from "@appstrate/db/client";
 import { getRateLimiterFactory } from "../../../infra/index.ts";
@@ -60,6 +60,15 @@ const REVOKE_RL_POINTS = 60;
 // rarely called more than once per login; 10/min/IP is a loose ceiling.
 const DEVICE_CODE_RL_POINTS = 10;
 const DEVICE_TOKEN_RL_POINTS = 30;
+// Per-row brute-force lockout on `/device/approve` + `/device/deny`.
+// Covers the post-lookup attack path: once an attacker knows a valid
+// user_code (leaked / shoulder-surfed / partial disclosure) they cannot
+// keep retrying realm mismatches across different accounts until one
+// lands in the right audience. 5 failed attempts retire the row — the
+// legit user requests a fresh code and keeps the happy-path cost to a
+// single browser click. Pure brute-force of the 20⁸ user-code space is
+// separately constrained by the per-IP rate limits on these endpoints.
+const MAX_APPROVE_ATTEMPTS = 5;
 
 /**
  * Per-client_id brute-force limit on `/oauth2/token`. Complements the
@@ -349,6 +358,43 @@ async function enforceDeviceApproveRealm(ctx: {
   // Unknown code / already-processed / expired — defer to BA's own
   // handler (runs next) to produce the canonical error response.
   if (!record || !record.clientId || record.status !== "pending") return;
+
+  // Atomically bump the per-row attempt counter BEFORE the realm check
+  // runs so every probe counts, including cross-audience attempts that
+  // the guard below will refuse. The counter is returned post-increment
+  // so we can lock the row at the exact threshold without a read-modify-
+  // write window. When a legit user succeeds, BA's handler flips the
+  // status to `approved` right after this hook returns — further probes
+  // fail at the status check above, not at the counter.
+  const [bumped] = await db
+    .update(deviceCode)
+    .set({ attempts: sql`${deviceCode.attempts} + 1` })
+    .where(eq(deviceCode.userCode, cleanUserCode))
+    .returning({ attempts: deviceCode.attempts });
+
+  if (bumped && bumped.attempts > MAX_APPROVE_ATTEMPTS) {
+    // Retire the row so even a later correct-realm attempt (whether the
+    // legit user or the attacker's last guess) is refused. Guarded with
+    // `status = 'pending'` so we don't clobber a row that BA's handler
+    // just flipped to `approved` in a parallel request.
+    await db
+      .update(deviceCode)
+      .set({ status: "denied" })
+      .where(and(eq(deviceCode.userCode, cleanUserCode), eq(deviceCode.status, "pending")));
+    logger.warn("oidc: device approve locked out after too many failed attempts", {
+      module: "oidc",
+      audit: true,
+      event: "cli.device.approve.locked_out",
+      clientId: record.clientId,
+      userId: session.user.id,
+      attempts: bumped.attempts,
+    });
+    throw new APIError("FORBIDDEN", {
+      error: "access_denied",
+      error_description:
+        "Too many failed approval attempts for this device code. Request a new code from the CLI.",
+    });
+  }
 
   const [client] = await db
     .select({ metadata: oauthClient.metadata, level: oauthClient.level })

--- a/apps/api/src/modules/oidc/drizzle/migrations/0005_device_code_attempts.sql
+++ b/apps/api/src/modules/oidc/drizzle/migrations/0005_device_code_attempts.sql
@@ -1,0 +1,18 @@
+-- OIDC module: brute-force lockout counter on device codes.
+--
+-- Adds an `attempts` counter that the realm guard on `/device/approve`
+-- (and `/device/deny`) increments on every approval attempt. At the
+-- threshold (see `MAX_APPROVE_ATTEMPTS` in `auth/guards.ts`) the row
+-- transitions to `status = 'denied'` so further approves — including
+-- the legit user's — are refused. The legit flow requires a fresh code.
+--
+-- The counter covers the post-lookup part of the attack path: once a
+-- user_code is known (leaked via log forwarding, shoulder surf, partial
+-- disclosure via the consent page, etc.) an attacker cannot retry realm
+-- mismatches indefinitely across different accounts hoping to find one
+-- in the right audience. Pure guess-the-code-from-cold remains limited
+-- by the per-IP rate limits on `/device/approve` + `/activate*` and by
+-- the ~34.6 bits of entropy in the 20⁸ generated user-code space.
+
+ALTER TABLE "device_codes"
+  ADD COLUMN IF NOT EXISTS "attempts" integer NOT NULL DEFAULT 0;

--- a/apps/api/src/modules/oidc/drizzle/migrations/meta/_journal.json
+++ b/apps/api/src/modules/oidc/drizzle/migrations/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1776600000000,
       "tag": "0004_device_codes",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1776800000000,
+      "tag": "0005_device_code_attempts",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/modules/oidc/openapi/paths.ts
+++ b/apps/api/src/modules/oidc/openapi/paths.ts
@@ -911,7 +911,17 @@ export const oidcPaths = {
           name: "user_code",
           in: "query",
           required: false,
-          schema: { type: "string" },
+          schema: {
+            type: "string",
+            // Mirrors the HTML form `pattern` in `pages/activate.ts` +
+            // the generator's alphabet in `auth/plugins.ts::USER_CODE_ALPHABET`
+            // (GitHub-style: no vowels, no visually-ambiguous pairs, no
+            // digits). The server accepts either casing (it uppercases
+            // before lookup) and the optional `-` inside `XXXX-XXXX` is
+            // stripped. 8 or 9 chars lets us accept the dash-separated
+            // display form AND the raw form in the same schema.
+            pattern: "^[BCDFGHJKLMNPQRSTVWXZbcdfghjklmnpqrstvwxz-]{8,9}$",
+          },
         },
       ],
       responses: {

--- a/apps/api/src/modules/oidc/pages/activate.ts
+++ b/apps/api/src/modules/oidc/pages/activate.ts
@@ -63,7 +63,7 @@ export function renderActivateEntryPage(props: ActivateEntryPageProps): RawHtml 
         autofocus
         required
         inputmode="text"
-        pattern="[A-Za-z-]{8,9}"
+        pattern="[BCDFGHJKLMNPQRSTVWXZbcdfghjklmnpqrstvwxz-]{8,9}"
       />
       <button type="submit">Continuer</button>
     </form>

--- a/apps/api/src/modules/oidc/schema.ts
+++ b/apps/api/src/modules/oidc/schema.ts
@@ -85,6 +85,14 @@ export const deviceCode = pgTable("device_codes", {
     onDelete: "cascade",
   }),
   scope: text("scope"),
+  // Brute-force lockout counter — incremented by the realm guard on
+  // `/device/approve` + `/device/deny`. When it exceeds the threshold
+  // (`MAX_APPROVE_ATTEMPTS` in `auth/guards.ts`), the guard flips the
+  // row to `status = 'denied'` so no one (attacker or legit user) can
+  // approve it anymore — the code is sacrificed and a fresh one must be
+  // requested. See migration 0005_device_code_attempts for the full
+  // rationale and threat model.
+  attempts: integer("attempts").notNull().default(0),
 });
 // No extra indexes on this table: `device_code` / `user_code` lookups
 // go through their UNIQUE B-tree, `client_id` is never used as a query

--- a/apps/api/src/modules/oidc/test/integration/services/device-flow-bruteforce.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/device-flow-bruteforce.test.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Brute-force lockout on `/device/approve` + `/device/deny`.
+ *
+ * Covers the attack surface described in migration 0005: an attacker
+ * who has learned a valid `user_code` (leak, shoulder surf, partial
+ * disclosure) should not be able to retry realm mismatches across many
+ * accounts hoping to find one in the right audience. After
+ * `MAX_APPROVE_ATTEMPTS` failed probes, the row must transition to
+ * `status = 'denied'` so every subsequent approve — including the legit
+ * user's — is refused.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@appstrate/db/client";
+import { user as userTable, session as sessionTable } from "@appstrate/db/schema";
+import { getTestApp } from "../../../../../../test/helpers/app.ts";
+import { truncateAll } from "../../../../../../test/helpers/db.ts";
+import { createTestContext } from "../../../../../../test/helpers/auth.ts";
+import { flushRedis } from "../../../../../../test/helpers/redis.ts";
+import oidcModule from "../../../index.ts";
+import { resetOidcGuardsLimiters } from "../../../auth/guards.ts";
+import { ensureCliClient } from "../../../services/ensure-cli-client.ts";
+import { deviceCode } from "../../../schema.ts";
+
+const app = getTestApp({ modules: [oidcModule] });
+
+async function signUpEndUser(email: string): Promise<string> {
+  const res = await app.request("/api/auth/sign-up/email", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password: "Sup3rSecretPass!", name: "T" }),
+  });
+  expect(res.status).toBe(200);
+  const match = (res.headers.get("set-cookie") ?? "").match(/better-auth\.session_token=([^;]+)/);
+  if (!match) throw new Error("no session cookie");
+  const cookie = `better-auth.session_token=${match[1]}`;
+  const body = (await res.json()) as { user: { id: string } };
+  // Force end-user realm so the approve realm guard refuses — every
+  // attempt hits the counter path, not a BA state flip.
+  await db
+    .update(userTable)
+    .set({ realm: "end_user:app_attacker" })
+    .where(eq(userTable.id, body.user.id));
+  await db
+    .update(sessionTable)
+    .set({ realm: "end_user:app_attacker" })
+    .where(eq(sessionTable.userId, body.user.id));
+  return cookie;
+}
+
+async function requestCode(): Promise<string> {
+  const res = await app.request("/api/auth/device/code", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ client_id: "appstrate-cli", scope: "openid" }),
+  });
+  expect(res.status).toBe(200);
+  return ((await res.json()) as { user_code: string }).user_code;
+}
+
+async function approve(userCode: string, cookie: string): Promise<number> {
+  const res = await app.request("/api/auth/device/approve", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Cookie: cookie },
+    body: JSON.stringify({ userCode }),
+  });
+  return res.status;
+}
+
+describe("device-flow brute-force lockout", () => {
+  beforeEach(async () => {
+    await truncateAll();
+    await flushRedis();
+    resetOidcGuardsLimiters();
+    await createTestContext({ orgSlug: "bruteforce" });
+    await ensureCliClient();
+  });
+
+  it("locks the row after 5 failed realm-mismatch approves", async () => {
+    const cookie = await signUpEndUser("attacker@example.com");
+    const userCode = await requestCode();
+    const clean = userCode.replace(/-/g, "").toUpperCase();
+
+    // First 5 attempts: guard increments + realm check rejects (403).
+    for (let i = 0; i < 5; i++) {
+      expect(await approve(userCode, cookie)).toBe(403);
+      const [row] = await db
+        .select({ status: deviceCode.status, attempts: deviceCode.attempts })
+        .from(deviceCode)
+        .where(eq(deviceCode.userCode, clean))
+        .limit(1);
+      expect(row?.status).toBe("pending");
+      expect(row?.attempts).toBe(i + 1);
+    }
+
+    // 6th attempt: counter increments to 6 (> MAX=5), guard flips to
+    // denied and throws access_denied BEFORE the realm check.
+    expect(await approve(userCode, cookie)).toBe(403);
+    const [locked] = await db
+      .select({ status: deviceCode.status, attempts: deviceCode.attempts })
+      .from(deviceCode)
+      .where(eq(deviceCode.userCode, clean))
+      .limit(1);
+    expect(locked?.status).toBe("denied");
+    expect(locked?.attempts).toBe(6);
+
+    // 7th attempt: row is denied — guard short-circuits at the status
+    // check, doesn't increment, and defers to BA's own error handler.
+    // Counter stays at 6.
+    await approve(userCode, cookie);
+    const [final] = await db
+      .select({ attempts: deviceCode.attempts })
+      .from(deviceCode)
+      .where(eq(deviceCode.userCode, clean))
+      .limit(1);
+    expect(final?.attempts).toBe(6);
+  });
+
+  it("does not count attempts when the user_code does not match a row", async () => {
+    const cookie = await signUpEndUser("nomatch@example.com");
+    await requestCode(); // issue SOME code so the table isn't empty
+    const bogus = "ZZZZZZZZ";
+
+    for (let i = 0; i < 10; i++) {
+      await approve(bogus, cookie);
+    }
+
+    // No row with `ZZZZZZZZ` exists — the atomic UPDATE hit 0 rows and
+    // the counter on the real row was untouched. This is the expected
+    // behaviour: pure cold-brute-force of the 20⁸ user-code space is
+    // defended by the per-IP rate limits, not by this row-level counter.
+    const rows = await db.select({ attempts: deviceCode.attempts }).from(deviceCode);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.attempts).toBe(0);
+  });
+});

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -42,7 +42,19 @@ program
   .option(
     "-p, --profile <name>",
     "Profile to use (overrides APPSTRATE_PROFILE / defaultProfile / 'default').",
-  );
+  )
+  .option(
+    "--insecure",
+    "Allow connecting to a non-HTTPS, non-loopback instance. Your bearer token will be transmitted in plaintext — only use on a trusted network. Equivalent to APPSTRATE_INSECURE=1.",
+  )
+  .hook("preAction", () => {
+    // Hoist `--insecure` into the env so every downstream module that
+    // reads it (instance-url.ts::isInsecureOptIn) sees a single source
+    // of truth — no need to thread the flag through every command.
+    if (program.opts<{ insecure?: boolean }>().insecure) {
+      process.env.APPSTRATE_INSECURE = "1";
+    }
+  });
 
 program
   .command("install")

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -65,9 +65,10 @@ export async function installCommand(opts: InstallOptions): Promise<void> {
 /**
  * Parse `--tier` or drop into an interactive select. `clack`'s
  * `select` with 4 options reads better than free-form text and avoids
- * the "what did I type?" typo recovery.
+ * the "what did I type?" typo recovery. Exported so unit tests can
+ * lock down the validation contract without invoking the prompt.
  */
-async function resolveTier(raw: string | undefined): Promise<Tier> {
+export async function resolveTier(raw: string | undefined): Promise<Tier> {
   if (raw !== undefined) {
     const parsed = Number(raw);
     if (parsed === 0 || parsed === 1 || parsed === 2 || parsed === 3) return parsed as Tier;
@@ -89,7 +90,11 @@ async function resolveTier(raw: string | undefined): Promise<Tier> {
   return chosen;
 }
 
-async function resolveDir(raw: string | undefined): Promise<string> {
+/**
+ * Parse `--dir` or prompt for it, then reject newlines / NUL bytes and
+ * normalize to an absolute path. Exported for unit testing.
+ */
+export async function resolveDir(raw: string | undefined): Promise<string> {
   const chosen = raw ?? (await askText("Install directory", DEFAULT_INSTALL_DIR));
   // `tier0.ts` passes `dir` as an argv positional to `tar`, `curl`,
   // `git`, etc. without a shell wrapper, so interpolation injection is

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -33,6 +33,13 @@ import {
   writeEnvFile as writeTier0Env,
 } from "../lib/install/tier0.ts";
 import { openBrowser } from "../lib/install/os.ts";
+import {
+  detectInstallMode,
+  mergeEnv,
+  backupFiles,
+  restoreBackups,
+  cleanupBackups,
+} from "../lib/install/upgrade.ts";
 import { CLI_VERSION } from "../lib/version.ts";
 
 export interface InstallOptions {
@@ -182,25 +189,77 @@ async function installDockerTier(dir: string, tier: 1 | 2 | 3): Promise<void> {
     throw err;
   }
 
-  // Compose + .env.
-  const writeSpinner = spinner();
-  writeSpinner.start("Writing compose + .env");
-  await writeComposeFile(dir, tier);
-  const envVars = generateEnvForTier(tier, DEFAULT_APP_URL);
-  await writeComposeEnv(dir, renderEnvFile(envVars));
-  writeSpinner.stop(`Wrote ${dir}/docker-compose.yml + .env`);
+  // Upgrade detection: if `dir` already has a `.env` or
+  // `docker-compose.yml` we're overwriting an existing deployment.
+  // Rotating BETTER_AUTH_SECRET or CONNECTION_ENCRYPTION_KEY silently
+  // would invalidate every session and brick every stored OAuth
+  // credential — see `lib/install/upgrade.ts` for the threat model.
+  const { mode, existing } = await detectInstallMode(dir);
+  if (mode === "upgrade") {
+    const proceed = await confirm(
+      `An existing install was detected at ${dir}. Existing secrets (BETTER_AUTH_SECRET, CONNECTION_ENCRYPTION_KEY, POSTGRES_PASSWORD, …) will be preserved; the compose file will be replaced with the Tier ${tier} template. Continue?`,
+    );
+    if (!proceed) throw new Error("Upgrade cancelled.");
+  }
 
-  // Bring stack up.
-  const upSpinner = spinner();
-  upSpinner.start("Starting Appstrate (docker compose up -d)");
-  await dockerComposeUp(dir);
-  upSpinner.stop("Containers up");
+  // Backup BEFORE writing so a rollback is possible all the way back
+  // to "user's last-known-good config". The list we backup is exactly
+  // the set of files we're about to overwrite — backupFiles skips any
+  // that aren't present so a half-installed dir (only `.env`, no
+  // compose) works too.
+  const backedUp = mode === "upgrade" ? await backupFiles(dir, [".env", "docker-compose.yml"]) : [];
 
-  // Healthcheck.
-  const healthSpinner = spinner();
-  healthSpinner.start("Waiting for Appstrate to become healthy");
-  await waitForAppstrate(DEFAULT_APP_URL);
-  healthSpinner.stop("Appstrate is healthy");
+  try {
+    // Compose + .env.
+    const writeSpinner = spinner();
+    writeSpinner.start(
+      mode === "upgrade" ? "Rewriting compose + merging .env" : "Writing compose + .env",
+    );
+    await writeComposeFile(dir, tier);
+    const fresh = generateEnvForTier(tier, DEFAULT_APP_URL);
+    const envVars = mode === "upgrade" ? mergeEnv(existing.existingEnv, fresh) : fresh;
+    await writeComposeEnv(dir, renderEnvFile(envVars));
+    writeSpinner.stop(
+      mode === "upgrade"
+        ? `Rewrote ${dir}/docker-compose.yml (secrets preserved)`
+        : `Wrote ${dir}/docker-compose.yml + .env`,
+    );
+
+    // Bring stack up.
+    const upSpinner = spinner();
+    upSpinner.start("Starting Appstrate (docker compose up -d)");
+    await dockerComposeUp(dir);
+    upSpinner.stop("Containers up");
+
+    // Healthcheck.
+    const healthSpinner = spinner();
+    healthSpinner.start("Waiting for Appstrate to become healthy");
+    await waitForAppstrate(DEFAULT_APP_URL);
+    healthSpinner.stop("Appstrate is healthy");
+
+    // Success — clean up the backup copies. Keep them on any failure
+    // path so the user can restore manually if needed.
+    if (backedUp.length > 0) await cleanupBackups(dir, backedUp);
+  } catch (err) {
+    if (backedUp.length > 0) {
+      // Rollback: restore the user's previous config before re-raising
+      // so they're never left with a broken half-upgraded state.
+      try {
+        await restoreBackups(dir, backedUp);
+      } catch (restoreErr) {
+        const originalMsg = err instanceof Error ? err.message : String(err);
+        const restoreMsg = restoreErr instanceof Error ? restoreErr.message : String(restoreErr);
+        throw new Error(
+          `Upgrade failed (${originalMsg}). Rollback also failed (${restoreMsg}); .backup files are preserved in ${dir} for manual recovery.`,
+        );
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Upgrade failed (${msg}). Original files restored from backup; run \`docker compose up -d\` in ${dir} to resume on the previous config.`,
+      );
+    }
+    throw err;
+  }
 
   await openBrowser(DEFAULT_APP_URL);
   outro(

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -12,7 +12,7 @@
  */
 
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import * as clack from "@clack/prompts";
 import { intro, outro, askText, confirm, spinner, exitWithError } from "../lib/ui.ts";
 import { generateEnvForTier, renderEnvFile, type Tier } from "../lib/install/secrets.ts";
@@ -90,8 +90,18 @@ async function resolveTier(raw: string | undefined): Promise<Tier> {
 }
 
 async function resolveDir(raw: string | undefined): Promise<string> {
-  if (raw !== undefined) return raw;
-  return askText("Install directory", DEFAULT_INSTALL_DIR);
+  const chosen = raw ?? (await askText("Install directory", DEFAULT_INSTALL_DIR));
+  // `tier0.ts` passes `dir` as an argv positional to `tar`, `curl`,
+  // `git`, etc. without a shell wrapper, so interpolation injection is
+  // already ruled out at the spawn layer. But newlines + NUL bytes in
+  // paths are a long-standing source of surprising behaviour in shell
+  // tools that DO iterate paths (bash glob expansion in hand-written
+  // recovery scripts, log aggregators, etc.) — reject them up-front so
+  // the user sees a clear error instead of a mysterious truncation.
+  if (/[\r\n\0]/.test(chosen)) {
+    throw new Error("Install directory must not contain newlines or NUL bytes.");
+  }
+  return resolve(chosen);
 }
 
 async function installTier0(dir: string): Promise<void> {

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -18,6 +18,7 @@ import { intro, outro, askText, spinner, formatUserCode, exitWithError } from ".
 import { readConfig, resolveProfileName, setProfile } from "../lib/config.ts";
 import { saveTokens } from "../lib/keyring.ts";
 import { startDeviceFlow, pollDeviceFlow } from "../lib/device-flow.ts";
+import { normalizeInstance } from "../lib/instance-url.ts";
 import { CLI_USER_AGENT } from "../lib/version.ts";
 
 /** Canonical clientId for the official CLI. Matches `ensureCliClient()` server-side. */
@@ -39,14 +40,23 @@ export async function loginCommand(opts: LoginOptions): Promise<void> {
 
   intro(`Appstrate login — profile "${profileName}"`);
 
-  const instance = (
+  const rawInstance =
     opts.instance ??
     (await askText(
       "Instance URL",
       config.profiles[profileName]?.instance ?? "http://localhost:3000",
-    ))
-  ).trim();
-  const normalizedInstance = instance.endsWith("/") ? instance.slice(0, -1) : instance;
+    ));
+
+  // Validate + strip trailing `/` up front. Throws `InsecureInstanceError`
+  // if the user pointed at a non-loopback `http://` host without
+  // `--insecure` / `APPSTRATE_INSECURE=1` — we surface that via
+  // `exitWithError` like any other terminal failure below.
+  let normalizedInstance: string;
+  try {
+    normalizedInstance = normalizeInstance(rawInstance);
+  } catch (err) {
+    exitWithError(err);
+  }
 
   try {
     await runLogin(profileName, normalizedInstance);

--- a/apps/cli/src/lib/api.ts
+++ b/apps/cli/src/lib/api.ts
@@ -29,6 +29,7 @@
 
 import { loadTokens } from "./keyring.ts";
 import { getProfile, type Profile } from "./config.ts";
+import { normalizeInstance } from "./instance-url.ts";
 import { CLI_USER_AGENT } from "./version.ts";
 
 export class ApiError extends Error {
@@ -47,10 +48,6 @@ export class AuthError extends Error {
     super(message);
     this.name = "AuthError";
   }
-}
-
-function normalizeBase(instance: string): string {
-  return instance.endsWith("/") ? instance.slice(0, -1) : instance;
 }
 
 async function resolveProfileOrThrow(profileName: string): Promise<Profile> {
@@ -107,7 +104,7 @@ export async function apiFetchRaw(
   }
   if (profile.orgId) headers["X-Org-Id"] = profile.orgId;
 
-  return fetch(`${normalizeBase(profile.instance)}${path}`, { ...init, headers });
+  return fetch(`${normalizeInstance(profile.instance)}${path}`, { ...init, headers });
 }
 
 /**

--- a/apps/cli/src/lib/device-flow.ts
+++ b/apps/cli/src/lib/device-flow.ts
@@ -21,6 +21,7 @@
  */
 
 import { setTimeout as delay } from "node:timers/promises";
+import { normalizeInstance } from "./instance-url.ts";
 
 export interface DeviceCodeResponse {
   deviceCode: string;
@@ -83,7 +84,7 @@ export async function startDeviceFlow(
   clientId: string,
   scope: string,
 ): Promise<DeviceCodeResponse> {
-  const res = await fetch(`${normalizeBase(instance)}/api/auth/device/code`, {
+  const res = await fetch(`${normalizeInstance(instance)}/api/auth/device/code`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ client_id: clientId, scope }),
@@ -158,7 +159,7 @@ export async function pollDeviceFlow(
       throw new DeviceFlowError("access_denied", "Polling aborted by caller.", 0);
     }
 
-    const res = await fetch(`${normalizeBase(instance)}/api/auth/device/token`, {
+    const res = await fetch(`${normalizeInstance(instance)}/api/auth/device/token`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body,
@@ -201,10 +202,6 @@ export async function pollDeviceFlow(
     "The device code expired before the user approved it.",
     0,
   );
-}
-
-function normalizeBase(instance: string): string {
-  return instance.endsWith("/") ? instance.slice(0, -1) : instance;
 }
 
 async function parseErrorBody(res: Response): Promise<RawErrorBody> {

--- a/apps/cli/src/lib/device-flow.ts
+++ b/apps/cli/src/lib/device-flow.ts
@@ -122,6 +122,19 @@ export interface PollOptions {
   delayFn?: (ms: number, signal?: AbortSignal) => Promise<void>;
 }
 
+/**
+ * Hard ceiling on the total polling duration, independent of the
+ * `expires_in` the server returns in `/device/code`. A compromised or
+ * misbehaving server could return `expires_in: 86400` and trap the CLI
+ * in a 24-hour loop shipping tokens (or nothing) to whoever replies;
+ * this cap is the belt-and-braces limit on top of the server's own
+ * deadline. 15 minutes leaves comfortable headroom over the BA plugin's
+ * 10-minute default for legitimate slow approvals (user away from
+ * browser for a minute, looking up password, etc.). On reach, the loop
+ * exits with `expired_token` — same terminal state the legit path hits.
+ */
+const MAX_POLL_DURATION_MS = 15 * 60 * 1000;
+
 /** RFC 8628 §3.4 — poll the token endpoint until terminal response or budget exhausted. */
 export async function pollDeviceFlow(
   instance: string,
@@ -129,7 +142,12 @@ export async function pollDeviceFlow(
   clientId: string,
   opts: PollOptions,
 ): Promise<DeviceTokenResponse> {
-  const deadline = Date.now() + opts.expiresIn * 1000;
+  // Use the MIN of the server-suggested `expires_in` and our own hard
+  // ceiling so neither side can push the loop past what the other
+  // considers safe. Tests can still race through with `expiresIn: 0`
+  // because Math.min picks that value.
+  const now = Date.now();
+  const deadline = Math.min(now + opts.expiresIn * 1000, now + MAX_POLL_DURATION_MS);
   // Tests pass `interval: 0` + a no-op `delayFn` to race through the
   // loop; production code would never set either to 0. The `Math.max(0, …)`
   // guard exists only so a pathological `interval: -1` from a misbehaving

--- a/apps/cli/src/lib/install/tier0.ts
+++ b/apps/cli/src/lib/install/tier0.ts
@@ -20,7 +20,7 @@
  * fully populated monorepo in the install dir.
  */
 
-import { mkdir, writeFile, access } from "node:fs/promises";
+import { mkdir, writeFile, access, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
@@ -54,6 +54,13 @@ export function detectBun(): { found: boolean; path: string | null } {
  * installer is a shell script that curls the latest release tarball
  * — we pipe it into `bash` directly without caching, mirroring the
  * documented install path.
+ *
+ * Note on `bash -c`: the command string is a string literal with zero
+ * user-supplied substitution. There is no interpolation of any runtime
+ * value into the shell command, so the shell-injection rules that
+ * apply to `cloneAppstrateSource`'s tarball fallback do not apply
+ * here. If that invariant ever changes, switch this to a tmp-file +
+ * `bash <file>` pattern first.
  */
 export async function installBun(): Promise<void> {
   const res = await runCommand("bash", ["-c", "curl -fsSL https://bun.sh/install | bash"], {
@@ -116,13 +123,26 @@ export async function cloneAppstrateSource(
   const tarballUrl = opts.tarballUrl ?? `${DEFAULT_TARBALL_BASE}/${tagRef}.tar.gz`;
   if (!commandExists("curl") || !commandExists("tar")) throw new GitMissingError();
 
-  const res = await runCommand(
-    "bash",
-    ["-c", `curl -fsSL "${tarballUrl}" | tar -xz --strip-components=1 -C "${dir}"`],
-    { stdio: "inherit" },
-  );
-  if (!res.ok) {
-    throw new Error(`Tarball download failed: ${res.stderr || `exit ${res.exitCode}`}`);
+  // Two distinct spawns instead of `bash -c "curl … | tar … -C <dir>"`.
+  // The shell-piped form interpolated the user-supplied `dir` inside
+  // the bash `-c` string, which meant a dir containing `;`, backticks,
+  // `$(...)`, or newlines would run arbitrary code. We now spawn `curl`
+  // and `tar` directly with `dir` as a positional argv — neither tool
+  // interprets shell metacharacters in arguments.
+  const tmpTarball = join(dir, ".appstrate-source.tar.gz");
+  const dl = await runCommand("curl", ["-fsSL", "-o", tmpTarball, tarballUrl], {
+    stdio: "inherit",
+  });
+  if (!dl.ok) {
+    await unlink(tmpTarball).catch(() => {});
+    throw new Error(`Tarball download failed: ${dl.stderr || `exit ${dl.exitCode}`}`);
+  }
+  const ex = await runCommand("tar", ["-xzf", tmpTarball, "--strip-components=1", "-C", dir], {
+    stdio: "inherit",
+  });
+  await unlink(tmpTarball).catch(() => {});
+  if (!ex.ok) {
+    throw new Error(`Tarball extraction failed: ${ex.stderr || `exit ${ex.exitCode}`}`);
   }
 }
 

--- a/apps/cli/src/lib/install/upgrade.ts
+++ b/apps/cli/src/lib/install/upgrade.ts
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Upgrade + rollback primitives for `appstrate install`.
+ *
+ * Background: the first cut of the new CLI-driven install (ADR-006)
+ * unconditionally overwrote `.env` + `docker-compose.yml`. Re-running
+ * `appstrate install` on an existing deployment therefore rotated
+ * BETTER_AUTH_SECRET (which invalidates every logged-in session) and —
+ * more dangerously — rotated CONNECTION_ENCRYPTION_KEY, which makes
+ * every stored OAuth credential in the DB unreadable. The old
+ * `install.sh` had `determine_install_mode` + `merge_env` +
+ * `rollback_upgrade` to guard against this; this module brings that
+ * behaviour back to the TypeScript implementation.
+ *
+ * Contract:
+ *   1. `detectInstallMode` looks for `<dir>/.env` and
+ *      `<dir>/docker-compose.yml`. Either → `"upgrade"`; neither →
+ *      `"fresh"`. The `.env` content (if present) is parsed and
+ *      returned so the caller can merge-preserve existing secrets.
+ *   2. `mergeEnv(existing, fresh)` gives precedence to the existing
+ *      values. That is *critical*: re-generating secrets breaks
+ *      sessions (BETTER_AUTH_SECRET) AND destroys in-flight data
+ *      (CONNECTION_ENCRYPTION_KEY decrypts the `provider_credentials`
+ *      table — rotate it and every stored OAuth token is bricked).
+ *      New keys introduced by a tier upgrade (e.g. tier 1 → tier 3
+ *      adds MINIO_ROOT_PASSWORD) are carried over from `fresh`.
+ *   3. `backupFiles` + `restoreBackups` wrap an atomic-ish
+ *      backup/restore around the write. On any downstream failure
+ *      (docker compose up, healthcheck timeout, user Ctrl-C) the
+ *      caller restores so the user is never left with a half-written
+ *      config that won't boot with either the old OR the new stack.
+ *
+ * Non-goals: this module does NOT try to run `docker compose up`
+ * against the restored config. The user's stack was already running
+ * before we started; rolling back the files is enough to let them run
+ * `docker compose up -d` themselves from `<dir>`. Attempting an
+ * automatic restart would just add failure modes where we can't
+ * usefully diagnose.
+ */
+
+import { stat, readFile, copyFile, rename, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import type { EnvVars } from "./secrets.ts";
+
+export type InstallMode = "fresh" | "upgrade";
+
+export interface ExistingInstall {
+  /** `<dir>/.env` exists on disk. */
+  hasEnv: boolean;
+  /** `<dir>/docker-compose.yml` exists on disk. */
+  hasCompose: boolean;
+  /** Parsed env vars from `<dir>/.env`; empty when `hasEnv` is false. */
+  existingEnv: EnvVars;
+}
+
+export interface InstallModeResult {
+  mode: InstallMode;
+  existing: ExistingInstall;
+}
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Inspect `dir` to decide whether this invocation is a fresh install
+ * or an upgrade. An upgrade is any dir that already contains an
+ * Appstrate-looking artifact (`.env` or `docker-compose.yml`) —
+ * partial states (only one of the two) also count as upgrades so we
+ * don't silently obliterate a half-installed deployment.
+ */
+export async function detectInstallMode(dir: string): Promise<InstallModeResult> {
+  const envPath = join(dir, ".env");
+  const composePath = join(dir, "docker-compose.yml");
+  const [hasEnv, hasCompose] = await Promise.all([fileExists(envPath), fileExists(composePath)]);
+
+  let existingEnv: EnvVars = {};
+  if (hasEnv) {
+    try {
+      existingEnv = parseEnvFile(await readFile(envPath, "utf8"));
+    } catch {
+      // A `.env` that exists but can't be read is treated as
+      // `existingEnv = {}` so the caller falls back to fresh secrets
+      // for every key. The file is still backed up before overwrite.
+      existingEnv = {};
+    }
+  }
+
+  const mode: InstallMode = hasEnv || hasCompose ? "upgrade" : "fresh";
+  return { mode, existing: { hasEnv, hasCompose, existingEnv } };
+}
+
+/**
+ * Parse a `.env` file body into a flat dict.
+ *
+ * Respects the subset of dotenv syntax the CLI itself emits in
+ * `renderEnvFile`:
+ *   - `# ...` lines ignored
+ *   - blank lines ignored
+ *   - `KEY=VALUE` lines (value is everything after the first `=`)
+ *   - surrounding single or double quotes on VALUE stripped
+ *
+ * We intentionally do NOT implement `$VAR` interpolation, line
+ * continuations, or `export KEY=VALUE` — none of those appear in the
+ * files we write, and silently supporting them would risk recovering a
+ * value that means something different to the consumer (e.g. bun
+ * auto-loads `.env` but doesn't interpolate, so a user who added
+ * `PASSWORD=$SECRET` to their file expects the literal string).
+ */
+export function parseEnvFile(body: string): EnvVars {
+  const out: EnvVars = {};
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq < 1) continue; // no key before `=`, or line is `=foo`
+    const key = line.slice(0, eq).trim();
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) continue; // ignore garbage keys
+    let value = line.slice(eq + 1).trim();
+    if (value.length >= 2) {
+      const first = value[0];
+      const last = value[value.length - 1];
+      if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+        value = value.slice(1, -1);
+      }
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Merge an existing `.env` dict with a freshly-generated one, giving
+ * precedence to the existing values.
+ *
+ * Why existing wins:
+ *   - BETTER_AUTH_SECRET: rotating invalidates every cookie session.
+ *   - CONNECTION_ENCRYPTION_KEY: rotating bricks every encrypted
+ *     credential row in `provider_credentials` (AES-256-GCM auth tag
+ *     check fails, tokens can't be decrypted, org is locked out of
+ *     every connected service).
+ *   - RUN_TOKEN_SECRET / UPLOAD_SIGNING_SECRET: rotating invalidates
+ *     pending runs + signed upload URLs.
+ *   - POSTGRES_PASSWORD / MINIO_ROOT_PASSWORD: rotating requires a
+ *     matching change on the server side too, which is out of scope
+ *     for a re-run of `appstrate install`.
+ *
+ * Keys in `fresh` but not in `existing` are carried over (that's how
+ * a tier-1 → tier-3 upgrade picks up the new MINIO_* entries). Keys
+ * in `existing` but not in `fresh` are also preserved (user additions
+ * like SMTP_HOST stay intact).
+ */
+export function mergeEnv(existing: EnvVars, fresh: EnvVars): EnvVars {
+  return { ...fresh, ...existing };
+}
+
+/**
+ * Copy each of `files` (relative to `dir`, skipping any that don't
+ * exist) to `<name>.backup` in the same dir. Returns the list of
+ * basenames that were actually backed up — the caller passes this to
+ * `restoreBackups` / `cleanupBackups`.
+ *
+ * A single `.backup` suffix (no timestamp) is deliberate: we only
+ * keep ONE previous generation. Timestamped backups accumulate forever
+ * and turn the install dir into a graveyard; the user has `git` or
+ * their own backup story if they want deeper history.
+ */
+export async function backupFiles(dir: string, files: string[]): Promise<string[]> {
+  const backedUp: string[] = [];
+  for (const name of files) {
+    const src = join(dir, name);
+    if (!(await fileExists(src))) continue;
+    const dst = join(dir, `${name}.backup`);
+    await copyFile(src, dst);
+    backedUp.push(name);
+  }
+  return backedUp;
+}
+
+/**
+ * Restore each `<dir>/<name>` from `<dir>/<name>.backup`. The backup
+ * file is preserved after restore — that's belt-and-braces in case
+ * the restore itself is interrupted; a second call to this function
+ * would still work.
+ *
+ * Throws on any single failure. Callers should treat the whole restore
+ * as best-effort and surface the error so the user can investigate.
+ */
+export async function restoreBackups(dir: string, backedUp: string[]): Promise<void> {
+  for (const name of backedUp) {
+    const backup = join(dir, `${name}.backup`);
+    const target = join(dir, name);
+    await copyFile(backup, target);
+  }
+}
+
+/**
+ * Delete the `.backup` files produced by `backupFiles` after a
+ * successful upgrade. Silently swallows missing-file errors — the
+ * goal is to leave a clean dir, not to double-check our own state.
+ */
+export async function cleanupBackups(dir: string, backedUp: string[]): Promise<void> {
+  for (const name of backedUp) {
+    const backup = join(dir, `${name}.backup`);
+    await unlink(backup).catch(() => {});
+  }
+}
+
+/**
+ * Convenience: atomically replace `<dir>/<name>` by writing to a
+ * sibling `.tmp` file and renaming. Used for the `.env` + compose
+ * writes so a crashed/killed process can never leave a half-written
+ * file behind — the rename is atomic on every filesystem we target.
+ *
+ * Kept here (next to the backup helpers) rather than in `tier123.ts`
+ * because the atomicity guarantee is an upgrade-safety feature, not
+ * a tier-specific concern.
+ */
+export async function atomicReplace(path: string, body: string, mode?: number): Promise<void> {
+  const tmp = `${path}.tmp`;
+  const { writeFile } = await import("node:fs/promises");
+  await writeFile(tmp, body, mode !== undefined ? { mode } : undefined);
+  await rename(tmp, path);
+}

--- a/apps/cli/src/lib/instance-url.ts
+++ b/apps/cli/src/lib/instance-url.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Instance URL normalization + HTTPS enforcement.
+ *
+ * The CLI ships a bearer session token on every authenticated request.
+ * Over plaintext `http://` against a non-loopback host, that token is
+ * readable by any network intermediary (corporate egress proxy, captive
+ * portal, compromised Wi-Fi AP) — replay is immediate account takeover.
+ *
+ * Default policy: refuse. Loopback (localhost / 127.0.0.1 / ::1) is
+ * always allowed because the packet never leaves the host. Explicit
+ * opt-in via `APPSTRATE_INSECURE=1` (settable by `appstrate --insecure`)
+ * covers lab setups that terminate TLS at a reverse proxy on a trusted
+ * LAN segment.
+ *
+ * Enforcement runs in two places:
+ *   - `apiFetchRaw` (every authenticated request, defense in depth
+ *     against a hand-edited `config.toml`).
+ *   - `login` command (before the initial `/device/code` call, so the
+ *     user sees the rejection before typing their credentials).
+ *   - `device-flow.ts` helpers (before the device-code and polling
+ *     requests — no bearer token yet, but `/device/token` response
+ *     carries the freshly-minted session we must not leak).
+ */
+
+// `URL.hostname` returns IPv6 literals with brackets in Bun/WHATWG
+// (`new URL("http://[::1]").hostname === "[::1]"`), but we also accept
+// the bare form so consumers that normalize upstream don't get punished.
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+export class InsecureInstanceError extends Error {
+  constructor(public readonly url: string) {
+    super(
+      `Refusing to send credentials to a non-HTTPS, non-loopback instance: ${url}\n` +
+        `  - Use https:// (recommended), or\n` +
+        `  - Pass --insecure / set APPSTRATE_INSECURE=1 to acknowledge the risk.`,
+    );
+    this.name = "InsecureInstanceError";
+  }
+}
+
+/** Strip exactly one trailing `/`. Mirrors the previous duplicated `normalizeBase`. */
+export function stripTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+export function isInsecureOptIn(): boolean {
+  const v = process.env.APPSTRATE_INSECURE;
+  return v === "1" || v === "true";
+}
+
+/**
+ * Validate + normalize an instance URL. Throws `InsecureInstanceError`
+ * for `http://<non-loopback>` without the insecure opt-in. Also rejects
+ * non-http(s) schemes to avoid surprises from `file://`, `ws://`, etc.
+ *
+ * Returns the trimmed URL with any trailing slash stripped. The URL is
+ * returned as-is (no case folding, no default port injection) so the
+ * string the user stored is the string that ends up in request logs.
+ */
+export function normalizeInstance(url: string): string {
+  const trimmed = url.trim();
+  if (!trimmed) {
+    throw new Error("Instance URL is empty.");
+  }
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error(`Invalid instance URL: "${trimmed}"`);
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(
+      `Unsupported instance URL protocol: ${parsed.protocol} (expected http:// or https://).`,
+    );
+  }
+  if (parsed.protocol === "http:" && !isLoopback(parsed.hostname) && !isInsecureOptIn()) {
+    throw new InsecureInstanceError(trimmed);
+  }
+  return stripTrailingSlash(trimmed);
+}
+
+function isLoopback(hostname: string): boolean {
+  return LOOPBACK_HOSTS.has(hostname);
+}

--- a/apps/cli/src/lib/keyring.ts
+++ b/apps/cli/src/lib/keyring.ts
@@ -23,7 +23,8 @@
 
 import { Entry } from "@napi-rs/keyring";
 import { join, dirname } from "node:path";
-import { readFile, writeFile, unlink, mkdir, chmod } from "node:fs/promises";
+import { readFile, writeFile, unlink, mkdir, rename, open } from "node:fs/promises";
+import { setTimeout as delay } from "node:timers/promises";
 import { getConfigDir } from "./config.ts";
 
 export interface Tokens {
@@ -137,12 +138,93 @@ export async function deleteTokens(profile: string): Promise<void> {
 
 // ─── File fallback ───────────────────────────────────────────────────────────
 //
-// One JSON object keyed by profile. Rewriting the full file on every
-// save is fine — this path is exercised only when the keyring is
-// unavailable and writes happen at most once per login.
+// One JSON object keyed by profile. Writes are atomic (tmp + rename) and
+// serialized by a PID-aware advisory lock so two concurrent `appstrate
+// login` invocations targeting different profiles don't clobber each
+// other's entries via the read-modify-write cycle.
 
 interface FileStore {
   [profile: string]: Tokens;
+}
+
+function lockPath(): string {
+  return `${fallbackPath()}.lock`;
+}
+
+/**
+ * Serialize read-modify-write cycles on the credentials file.
+ *
+ * Uses `open(..., "wx")` (O_EXCL + O_CREAT + O_WRONLY) as a primitive
+ * advisory lock and stores the holder's PID inside so we can detect
+ * crashed-and-left-over locks from previous CLI runs. 5-second overall
+ * deadline — credential writes are single-digit milliseconds; anything
+ * longer means a crashed peer or a truly pathological filesystem.
+ */
+async function withLock<T>(fn: () => Promise<T>): Promise<T> {
+  const path = lockPath();
+  await mkdir(dirname(path), { recursive: true, mode: 0o700 });
+
+  const DEADLINE_MS = 5_000;
+  const POLL_MS = 50;
+  const start = Date.now();
+  let staleRecoveryDone = false;
+
+  while (true) {
+    try {
+      const fd = await open(path, "wx", 0o600);
+      try {
+        await fd.writeFile(`${process.pid}\n`);
+      } finally {
+        await fd.close();
+      }
+      break;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+
+      // Lock held — check if the holder is still alive. A single stale
+      // recovery per `withLock` call avoids spinning on a lock file that
+      // a concurrent peer keeps recreating.
+      if (!staleRecoveryDone) {
+        staleRecoveryDone = true;
+        try {
+          const heldBy = parseInt((await readFile(path, "utf-8")).trim(), 10);
+          if (heldBy && !processIsAlive(heldBy)) {
+            await unlink(path).catch(() => {});
+            continue;
+          }
+        } catch {
+          // Lock vanished between EEXIST and readFile — next iteration
+          // will race cleanly for it.
+          continue;
+        }
+      }
+
+      if (Date.now() - start > DEADLINE_MS) {
+        throw new Error(
+          `Timed out acquiring credentials lock ${path}. ` +
+            `If no other appstrate command is running, remove this file manually.`,
+        );
+      }
+      await delay(POLL_MS);
+    }
+  }
+
+  try {
+    return await fn();
+  } finally {
+    await unlink(path).catch(() => {});
+  }
+}
+
+function processIsAlive(pid: number): boolean {
+  try {
+    // `kill(pid, 0)` is the POSIX "process exists" probe — no signal
+    // delivered, throws ESRCH if the PID is gone.
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function readFileStore(): Promise<FileStore> {
@@ -159,22 +241,37 @@ async function readFileStore(): Promise<FileStore> {
   }
 }
 
+/**
+ * Atomic overwrite — tmp file in the same directory, `rename()` over
+ * the target. Matches `lib/config.ts::writeConfig` so the same crash /
+ * Ctrl-C semantics apply to both files: post-crash state is always
+ * either the pre-write contents or the full post-write contents, never
+ * a truncated or partially-written mix.
+ */
 async function writeFileStore(store: FileStore): Promise<void> {
-  const dir = dirname(fallbackPath());
-  await mkdir(dir, { recursive: true, mode: 0o700 });
-  await writeFile(fallbackPath(), JSON.stringify(store, null, 2), { mode: 0o600 });
-  // Re-chmod defensively — umask on some hosts lets writeFile create
-  // files with wider permissions despite the `mode` option.
-  await chmod(fallbackPath(), 0o600).catch(() => {});
+  const target = fallbackPath();
+  await mkdir(dirname(target), { recursive: true, mode: 0o700 });
+  const tmp = `${target}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tmp, JSON.stringify(store, null, 2), { mode: 0o600 });
+  try {
+    await rename(tmp, target);
+  } catch (err) {
+    await unlink(tmp).catch(() => {});
+    throw err;
+  }
 }
 
 async function saveToFile(profile: string, tokens: Tokens): Promise<void> {
-  const store = await readFileStore();
-  store[profile] = tokens;
-  await writeFileStore(store);
+  await withLock(async () => {
+    const store = await readFileStore();
+    store[profile] = tokens;
+    await writeFileStore(store);
+  });
 }
 
 async function loadFromFile(profile: string): Promise<Tokens | null> {
+  // Reads don't need the lock: `writeFileStore` is atomic via rename,
+  // so a concurrent read sees either the old or the new complete file.
   const store = await readFileStore();
   const row = store[profile];
   if (!row) return null;
@@ -184,19 +281,21 @@ async function loadFromFile(profile: string): Promise<Tokens | null> {
 }
 
 async function deleteFromFile(profile: string): Promise<void> {
-  let store: FileStore;
-  try {
-    store = await readFileStore();
-  } catch {
-    return;
-  }
-  if (!(profile in store)) return;
-  delete store[profile];
-  if (Object.keys(store).length === 0) {
-    await unlink(fallbackPath()).catch(() => {});
-    return;
-  }
-  await writeFileStore(store);
+  await withLock(async () => {
+    let store: FileStore;
+    try {
+      store = await readFileStore();
+    } catch {
+      return;
+    }
+    if (!(profile in store)) return;
+    delete store[profile];
+    if (Object.keys(store).length === 0) {
+      await unlink(fallbackPath()).catch(() => {});
+      return;
+    }
+    await writeFileStore(store);
+  });
 }
 
 function parseTokens(raw: string): Tokens | null {

--- a/apps/cli/src/lib/keyring.ts
+++ b/apps/cli/src/lib/keyring.ts
@@ -86,6 +86,41 @@ function classifyKeyringError(err: unknown): "missing-backend" | "entry-missing"
   return "broken";
 }
 
+/**
+ * On Windows, refuse the file fallback entirely: NTFS ACLs do NOT
+ * enforce Unix 0600 permissions, so `fs.chmod(0o600)` is a no-op. A
+ * plaintext credentials file dropped under `%APPDATA%\appstrate\` is
+ * readable by every local user on the machine — bearer token = full
+ * account takeover. Credential Manager is the only acceptable store on
+ * Windows; if it's down, we fail loudly rather than silently fall back
+ * to disk. DPAPI-based encryption would fix this but is out of scope
+ * for v1 (tracked as a follow-up in ADR-006).
+ *
+ * `entry-missing` is a read-path concept ("user hasn't logged in yet")
+ * and never triggers a fallback, so we don't refuse on that case.
+ * Export kept under the `_`-prefix convention for unit testability —
+ * the real `process.platform` can't be faked cleanly in bun:test.
+ */
+export function _shouldRefuseWindowsFallback(platform: string, err: unknown): boolean {
+  if (platform !== "win32") return false;
+  return classifyKeyringError(err) !== "entry-missing";
+}
+
+function refuseWindowsFallback(op: "read" | "write" | "delete", err: unknown): never {
+  const cause = err instanceof Error ? err.message : String(err);
+  throw new Error(
+    `Cannot ${op} Appstrate credentials: Windows Credential Manager is unavailable.\n` +
+      `  Cause: ${cause}\n` +
+      `  The file fallback is disabled on Windows because NTFS ACLs do not\n` +
+      `  enforce Unix 0600 permissions — a plaintext credentials.json would\n` +
+      `  be readable by every local user on this machine.\n\n` +
+      `  Fixes:\n` +
+      `    • Ensure the "Credential Manager" service is running\n` +
+      `      (services.msc → CredentialManager → Start).\n` +
+      `    • Or run the CLI inside WSL, where libsecret handles storage.`,
+  );
+}
+
 function warnBackendOnce(op: "read" | "write" | "delete", err: unknown): void {
   if (_backendWarningEmitted) return;
   _backendWarningEmitted = true;
@@ -102,6 +137,7 @@ export async function saveTokens(profile: string, tokens: Tokens): Promise<void>
     _keyringFactory(profile).setPassword(payload);
     return;
   } catch (err) {
+    if (_shouldRefuseWindowsFallback(process.platform, err)) refuseWindowsFallback("write", err);
     // Entry-missing is a read-path concept — on write, any failure means
     // the backend cannot accept the payload. Only missing-backend is
     // silent; anything else warns once.
@@ -115,12 +151,16 @@ export async function loadTokens(profile: string): Promise<Tokens | null> {
     const raw = _keyringFactory(profile).getPassword();
     if (typeof raw === "string" && raw.length > 0) return parseTokens(raw);
   } catch (err) {
+    if (_shouldRefuseWindowsFallback(process.platform, err)) refuseWindowsFallback("read", err);
     // "No matching entry" on read is normal — the user simply hasn't
     // stored credentials for this profile yet. Missing-backend is the
     // expected fallback trigger. Anything else is worth a warning.
     const kind = classifyKeyringError(err);
     if (kind === "broken") warnBackendOnce("read", err);
   }
+  // Windows never reaches here: the guard above either succeeded on
+  // Credential Manager or threw via `refuseWindowsFallback`.
+  if (process.platform === "win32") return null;
   return loadFromFile(profile);
 }
 
@@ -128,11 +168,15 @@ export async function deleteTokens(profile: string): Promise<void> {
   try {
     _keyringFactory(profile).deletePassword();
   } catch (err) {
+    if (_shouldRefuseWindowsFallback(process.platform, err)) refuseWindowsFallback("delete", err);
     // A missing entry is not an error; the file fallback below still
     // runs so a partial keyring/file divergence is cleaned up. Only
     // warn on genuinely broken backends.
     if (classifyKeyringError(err) === "broken") warnBackendOnce("delete", err);
   }
+  // Windows has no file fallback to clean up — Credential Manager is
+  // the single source of truth there.
+  if (process.platform === "win32") return;
   await deleteFromFile(profile);
 }
 

--- a/apps/cli/src/lib/ui.ts
+++ b/apps/cli/src/lib/ui.ts
@@ -9,6 +9,7 @@
 import * as clack from "@clack/prompts";
 import { DeviceFlowError } from "./device-flow.ts";
 import { ApiError, AuthError } from "./api.ts";
+import { InsecureInstanceError } from "./instance-url.ts";
 
 export function intro(title: string): void {
   clack.intro(title);
@@ -60,6 +61,7 @@ export function formatError(err: unknown): string {
     const base = canonical[err.code] ?? err.message;
     return `${base} (${err.code})`;
   }
+  if (err instanceof InsecureInstanceError) return err.message;
   if (err instanceof AuthError) return err.message;
   if (err instanceof ApiError) return `API error (${err.status}): ${err.message}`;
   if (err instanceof Error) return err.message;

--- a/apps/cli/test/device-flow.test.ts
+++ b/apps/cli/test/device-flow.test.ts
@@ -15,7 +15,7 @@ type Responder = (input: string | URL | Request, init?: RequestInit) => Promise<
 const originalFetch = globalThis.fetch;
 
 function installFetch(responder: Responder): void {
-  globalThis.fetch = responder as typeof fetch;
+  globalThis.fetch = responder as unknown as typeof fetch;
 }
 
 beforeEach(() => {

--- a/apps/cli/test/device-flow.test.ts
+++ b/apps/cli/test/device-flow.test.ts
@@ -187,6 +187,39 @@ describe("pollDeviceFlow", () => {
       pollDeviceFlow("https://app", "dc", "c", { interval: 0, expiresIn: 0 }),
     ).rejects.toMatchObject({ name: "DeviceFlowError", code: "expired_token" });
   });
+
+  it("honors the client-side MAX_POLL_DURATION cap even when the server returns a huge expires_in", async () => {
+    // A misbehaving / compromised server returns `expires_in: 86400`
+    // (24h). Without a client-side ceiling the CLI would keep polling
+    // for a day — the hard cap in `device-flow.ts` caps at 15 minutes.
+    // We can't actually wait 15 minutes; instead assert the deadline
+    // is computed from MIN(server, ceiling) by checking Date.now()
+    // wasn't extended past the ceiling. We do that indirectly by
+    // observing that the loop still terminates quickly under a no-op
+    // delay + `authorization_pending` spam — if the ceiling weren't
+    // applied, `Date.now() < deadline` would stay true for hours.
+    installFetch(async () => jsonResponse(400, { error: "authorization_pending" }));
+
+    // Pin `Date.now` to a moving clock that advances 1 minute per
+    // delay tick. After 16 ticks we've burned 16 minutes — past the
+    // 15-minute ceiling — so the loop must exit.
+    const originalNow = Date.now;
+    let fakeMs = 1_700_000_000_000;
+    Date.now = () => fakeMs;
+    try {
+      await expect(
+        pollDeviceFlow("https://app", "dc", "c", {
+          interval: 0,
+          expiresIn: 86_400, // server claims 24h
+          delayFn: async () => {
+            fakeMs += 60_000;
+          },
+        }),
+      ).rejects.toMatchObject({ name: "DeviceFlowError", code: "expired_token" });
+    } finally {
+      Date.now = originalNow;
+    }
+  });
 });
 
 describe("DeviceFlowError shape", () => {

--- a/apps/cli/test/install.test.ts
+++ b/apps/cli/test/install.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `commands/install.ts` parsing helpers.
+ *
+ * We only exercise the non-interactive branches (`raw !== undefined`).
+ * The interactive clack `select`/`askText` paths require a real TTY
+ * and are exercised by the e2e install smoke test in CI.
+ *
+ * Coverage targets the three safety-critical validations:
+ *   - `resolveTier` rejects anything other than 0/1/2/3 (a stray `--tier
+ *     4` must abort BEFORE `generateEnvForTier` asserts non-exhaustively).
+ *   - `resolveDir` rejects newlines + NUL bytes so no downstream shell
+ *     script / backup tool gets confused (see the threat model comment
+ *     in install.ts).
+ *   - `resolveDir` normalizes to an absolute path so the spawn layer
+ *     in tier0/tier123 gets a stable cwd.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { resolve } from "node:path";
+import { resolveTier, resolveDir } from "../src/commands/install.ts";
+
+describe("resolveTier", () => {
+  it("accepts '0', '1', '2', '3' as literal strings", async () => {
+    expect(await resolveTier("0")).toBe(0);
+    expect(await resolveTier("1")).toBe(1);
+    expect(await resolveTier("2")).toBe(2);
+    expect(await resolveTier("3")).toBe(3);
+  });
+
+  it("rejects out-of-range values", async () => {
+    await expect(resolveTier("4")).rejects.toThrow(/Invalid --tier/);
+    await expect(resolveTier("-1")).rejects.toThrow(/Invalid --tier/);
+  });
+
+  it("rejects non-numeric values", async () => {
+    await expect(resolveTier("standard")).rejects.toThrow(/Invalid --tier/);
+    await expect(resolveTier("1.5")).rejects.toThrow(/Invalid --tier/);
+    await expect(resolveTier("NaN")).rejects.toThrow(/Invalid --tier/);
+  });
+});
+
+describe("resolveDir", () => {
+  it("resolves a relative path to an absolute one", async () => {
+    const out = await resolveDir("./my-install");
+    expect(out).toBe(resolve("./my-install"));
+    expect(out.startsWith("/")).toBe(true);
+  });
+
+  it("leaves an already-absolute path untouched except for normalization", async () => {
+    const out = await resolveDir("/tmp/foo/../foo");
+    expect(out).toBe("/tmp/foo");
+  });
+
+  it("rejects paths containing a newline", async () => {
+    await expect(resolveDir("/tmp/bad\npath")).rejects.toThrow(/newlines or NUL/);
+    await expect(resolveDir("/tmp/bad\rpath")).rejects.toThrow(/newlines or NUL/);
+  });
+
+  it("rejects paths containing a NUL byte", async () => {
+    await expect(resolveDir("/tmp/bad\0path")).rejects.toThrow(/newlines or NUL/);
+  });
+});

--- a/apps/cli/test/install/os.test.ts
+++ b/apps/cli/test/install/os.test.ts
@@ -12,12 +12,19 @@
  *     and returns false on timeout without hanging.
  *   - `commandExists` uses the right platform lookup tool (which/where)
  *     and returns a clean boolean.
- *   - `openBrowser` swallows errors (headless/CI safety).
+ *
+ * Not tested: `openBrowser`. On a dev machine with a GUI it *actually
+ * launches the default browser*, which is a terrible test experience.
+ * The function itself is a three-line try/catch around `open()` — its
+ * only job is to swallow errors on headless hosts, and that's better
+ * exercised by the integration smoke tests in CI (where there's no
+ * browser to launch anyway) than by opening random tabs during `bun
+ * test` on someone's laptop.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { platform } from "node:os";
-import { runCommand, waitForHttp, commandExists, openBrowser } from "../../src/lib/install/os.ts";
+import { runCommand, waitForHttp, commandExists } from "../../src/lib/install/os.ts";
 
 const originalFetch = globalThis.fetch;
 
@@ -130,13 +137,5 @@ describe("waitForHttp", () => {
     const ok = await waitForHttp("http://127.0.0.1:65535/", 5_000);
     expect(ok).toBe(true);
     expect(calls).toBeGreaterThanOrEqual(2);
-  });
-});
-
-describe("openBrowser", () => {
-  it("never throws even if the platform has no GUI", async () => {
-    // `open` on a headless CI container fails silently; the wrapper
-    // swallows. This test just asserts no exception escapes.
-    await openBrowser("http://127.0.0.1:65535");
   });
 });

--- a/apps/cli/test/install/os.test.ts
+++ b/apps/cli/test/install/os.test.ts
@@ -25,7 +25,7 @@ beforeEach(() => {
   // Default stub — each test overrides.
   globalThis.fetch = (async () => {
     throw new Error("no fetch stub installed");
-  }) as typeof fetch;
+  }) as unknown as typeof fetch;
 });
 
 afterEach(() => {
@@ -83,14 +83,14 @@ describe("waitForHttp", () => {
     globalThis.fetch = (async () => {
       calls++;
       return new Response("", { status: 200 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
     const ok = await waitForHttp("http://127.0.0.1:65535/", 3_000);
     expect(ok).toBe(true);
     expect(calls).toBe(1);
   });
 
   it("accepts 3xx redirects as healthy", async () => {
-    globalThis.fetch = (async () => new Response("", { status: 302 })) as typeof fetch;
+    globalThis.fetch = (async () => new Response("", { status: 302 })) as unknown as typeof fetch;
     const ok = await waitForHttp("http://127.0.0.1:65535/", 3_000);
     expect(ok).toBe(true);
   });
@@ -102,7 +102,7 @@ describe("waitForHttp", () => {
       // HEAD → 405, GET → 200
       if (init?.method === "HEAD") return new Response("", { status: 405 });
       return new Response("", { status: 200 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
     const ok = await waitForHttp("http://127.0.0.1:65535/", 3_000);
     expect(ok).toBe(true);
     expect(methods).toEqual(["HEAD", "GET"]);
@@ -111,7 +111,7 @@ describe("waitForHttp", () => {
   it("returns false when the deadline elapses without a healthy response", async () => {
     globalThis.fetch = (async () => {
       throw new TypeError("fetch failed");
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
     const start = Date.now();
     const ok = await waitForHttp("http://127.0.0.1:65535/", 50);
     expect(ok).toBe(false);
@@ -126,7 +126,7 @@ describe("waitForHttp", () => {
       calls++;
       if (calls < 2) throw new TypeError("ECONNREFUSED");
       return new Response("", { status: 200 });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
     const ok = await waitForHttp("http://127.0.0.1:65535/", 5_000);
     expect(ok).toBe(true);
     expect(calls).toBeGreaterThanOrEqual(2);

--- a/apps/cli/test/install/os.test.ts
+++ b/apps/cli/test/install/os.test.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `lib/install/os.ts`.
+ *
+ * The module is deliberately thin — these tests are mostly to protect
+ * the small handful of branches that matter in practice:
+ *   - `runCommand` returns ok=false (not throws) when the binary is
+ *     missing, so callers can short-circuit with a DockerMissing /
+ *     GitMissing error.
+ *   - `waitForHttp` polls until 2xx/3xx, promotes 405 to a GET retry,
+ *     and returns false on timeout without hanging.
+ *   - `commandExists` uses the right platform lookup tool (which/where)
+ *     and returns a clean boolean.
+ *   - `openBrowser` swallows errors (headless/CI safety).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { platform } from "node:os";
+import { runCommand, waitForHttp, commandExists, openBrowser } from "../../src/lib/install/os.ts";
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  // Default stub — each test overrides.
+  globalThis.fetch = (async () => {
+    throw new Error("no fetch stub installed");
+  }) as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("runCommand", () => {
+  it("returns ok=true + exit code 0 on success", async () => {
+    const cmd = platform() === "win32" ? "cmd" : "true";
+    const args = platform() === "win32" ? ["/c", "exit 0"] : [];
+    const res = await runCommand(cmd, args, { stdio: "ignore" });
+    expect(res.ok).toBe(true);
+    expect(res.exitCode).toBe(0);
+  });
+
+  it("returns ok=false + non-zero exit when the command fails", async () => {
+    if (platform() === "win32") return;
+    const res = await runCommand("false", [], { stdio: "ignore" });
+    expect(res.ok).toBe(false);
+    expect(res.exitCode).not.toBe(0);
+  });
+
+  it("returns ok=false + exitCode=-1 when the binary is missing (ENOENT)", async () => {
+    const res = await runCommand("___appstrate_definitely_not_a_binary___", [], {
+      stdio: "ignore",
+    });
+    expect(res.ok).toBe(false);
+    // spawn fires `error` on ENOENT — runCommand maps that to -1.
+    expect(res.exitCode).toBe(-1);
+  });
+
+  it("captures stdout when stdio=pipe", async () => {
+    if (platform() === "win32") return;
+    const res = await runCommand("printf", ["hello"]);
+    expect(res.ok).toBe(true);
+    expect(res.stdout).toBe("hello");
+  });
+});
+
+describe("commandExists", () => {
+  it("returns true for a universally-available shell tool", () => {
+    // `sh` on unix, `cmd` on Windows — both ship by default.
+    const probe = platform() === "win32" ? "cmd" : "sh";
+    expect(commandExists(probe)).toBe(true);
+  });
+
+  it("returns false for a non-existent binary", () => {
+    expect(commandExists("___appstrate_no_such_command_xyz___")).toBe(false);
+  });
+});
+
+describe("waitForHttp", () => {
+  it("returns true on the first 2xx response", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+    const ok = await waitForHttp("http://127.0.0.1:65535/", 3_000);
+    expect(ok).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  it("accepts 3xx redirects as healthy", async () => {
+    globalThis.fetch = (async () => new Response("", { status: 302 })) as typeof fetch;
+    const ok = await waitForHttp("http://127.0.0.1:65535/", 3_000);
+    expect(ok).toBe(true);
+  });
+
+  it("falls back to GET when HEAD returns 405", async () => {
+    const methods: string[] = [];
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      methods.push(init?.method ?? "GET");
+      // HEAD → 405, GET → 200
+      if (init?.method === "HEAD") return new Response("", { status: 405 });
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+    const ok = await waitForHttp("http://127.0.0.1:65535/", 3_000);
+    expect(ok).toBe(true);
+    expect(methods).toEqual(["HEAD", "GET"]);
+  });
+
+  it("returns false when the deadline elapses without a healthy response", async () => {
+    globalThis.fetch = (async () => {
+      throw new TypeError("fetch failed");
+    }) as typeof fetch;
+    const start = Date.now();
+    const ok = await waitForHttp("http://127.0.0.1:65535/", 50);
+    expect(ok).toBe(false);
+    // Deadline is respected within a few seconds (not hours). `waitForHttp`
+    // sleeps 1s between attempts so a 50ms budget completes in well under 2s.
+    expect(Date.now() - start).toBeLessThan(2_000);
+  });
+
+  it("keeps polling through connection errors", async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls++;
+      if (calls < 2) throw new TypeError("ECONNREFUSED");
+      return new Response("", { status: 200 });
+    }) as typeof fetch;
+    const ok = await waitForHttp("http://127.0.0.1:65535/", 5_000);
+    expect(ok).toBe(true);
+    expect(calls).toBeGreaterThanOrEqual(2);
+  });
+});
+
+describe("openBrowser", () => {
+  it("never throws even if the platform has no GUI", async () => {
+    // `open` on a headless CI container fails silently; the wrapper
+    // swallows. This test just asserts no exception escapes.
+    await openBrowser("http://127.0.0.1:65535");
+  });
+});

--- a/apps/cli/test/install/tier0.test.ts
+++ b/apps/cli/test/install/tier0.test.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `lib/install/tier0.ts`.
+ *
+ * Scoped to the side-effect-free surface — the functions that shell out
+ * (installBun, cloneAppstrateSource, runBunInstall, spawnDevServer) are
+ * exercised end-to-end in `test-install.yml` CI jobs rather than stubbed
+ * here, because the value of a unit-level assertion on "curl was called"
+ * is low and the maintenance cost of scripted-subprocess mocks is high.
+ *
+ * What we do want locked down at the unit level:
+ *   - `detectBun` returns a usable `{ found, path }` shape for both
+ *     "bun on PATH" and "bun only in ~/.bun/bin" cases.
+ *   - `writeEnvFile` writes 0600 (matches the Docker-tier contract).
+ *   - Error classes carry actionable messages (no silent empty strings).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, chmod, stat, readFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir, platform } from "node:os";
+import { detectBun, writeEnvFile, GitMissingError, BUN_BIN } from "../../src/lib/install/tier0.ts";
+
+let workDir: string;
+const originalPath = process.env.PATH;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "appstrate-cli-tier0-"));
+});
+
+afterEach(async () => {
+  process.env.PATH = originalPath;
+  await rm(workDir, { recursive: true, force: true });
+});
+
+describe("detectBun", () => {
+  it("returns { found: true, path: 'bun' } when bun is on PATH", async () => {
+    if (platform() === "win32") return;
+    // Shim a fake `bun` and put its directory on PATH.
+    const shimDir = join(workDir, "shim");
+    await mkdir(shimDir, { recursive: true });
+    const shim = join(shimDir, "bun");
+    await writeFile(shim, "#!/usr/bin/env bash\nexit 0\n");
+    await chmod(shim, 0o755);
+    process.env.PATH = `${shimDir}:${originalPath}`;
+    const res = detectBun();
+    expect(res.found).toBe(true);
+    expect(res.path).toBe("bun");
+  });
+
+  it("always returns a usable path string (never null/empty), even when bun is absent", () => {
+    // Contract: the caller treats `path` as a last-resort exec target
+    // when `found` is false, so it must always be a non-empty string.
+    // We don't try to force "bun missing" here — PATH manipulation in
+    // Bun subprocesses is unreliable across platforms, and integration
+    // CI covers the real "no bun" path end-to-end.
+    const res = detectBun();
+    expect(typeof res.path).toBe("string");
+    expect((res.path ?? "").length).toBeGreaterThan(0);
+    // When bun is NOT on PATH, the fallback is ~/.bun/bin/bun; when it
+    // IS on PATH we return the string "bun". Both are valid.
+    expect(res.path === "bun" || res.path === join(BUN_BIN, "bun")).toBe(true);
+  });
+});
+
+describe("writeEnvFile", () => {
+  it("writes the body verbatim to <dir>/.env", async () => {
+    const body = "APP_URL=http://localhost:3000\nBETTER_AUTH_SECRET=abc123\n";
+    await writeEnvFile(workDir, body);
+    const round = await readFile(join(workDir, ".env"), "utf8");
+    expect(round).toBe(body);
+  });
+
+  it("writes with 0600 mode (same contract as the Docker tiers)", async () => {
+    if (platform() === "win32") return;
+    await writeEnvFile(workDir, "BETTER_AUTH_SECRET=x\n");
+    const s = await stat(join(workDir, ".env"));
+     
+    expect(s.mode & 0o777).toBe(0o600);
+  });
+
+  it("does not create the directory (unlike the Docker-tier sibling — Tier 0 clones first)", async () => {
+    // Tier 0 writes `.env` INTO an already-cloned repo. It must NOT
+    // silently materialize a missing parent (that would mask a failed
+    // clone and leave the user with an `.env` but no source). Expect the
+    // write to throw ENOENT.
+    await expect(writeEnvFile(join(workDir, "not-cloned-yet"), "X=1\n")).rejects.toMatchObject({
+      code: "ENOENT",
+    });
+  });
+});
+
+describe("GitMissingError", () => {
+  it("names the curl + tar fallback explicitly", () => {
+    const err = new GitMissingError();
+    expect(err.name).toBe("GitMissingError");
+    expect(err.message).toMatch(/git/);
+    expect(err.message).toMatch(/curl/);
+    expect(err.message).toMatch(/tar/);
+  });
+});

--- a/apps/cli/test/install/tier123.test.ts
+++ b/apps/cli/test/install/tier123.test.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `lib/install/tier123.ts`.
+ *
+ * Covers the Docker-tier install primitives:
+ *   - `writeComposeFile`: the embedded per-tier YAML is materialized
+ *     correctly (tier 1 = postgres only, tier 2 = + redis, tier 3 = + minio).
+ *   - `writeEnvFile`: `.env` is written with 0600 mode so it survives
+ *     backup-tool indexing without leaking BETTER_AUTH_SECRET.
+ *   - `assertDockerAvailable`: when `docker` is absent from PATH it
+ *     raises `DockerMissingError`, and when a fake `docker` on PATH
+ *     returns 0 the probe resolves cleanly. Uses a scratch PATH pointing
+ *     at a tmpdir with an executable shim — no real docker required.
+ *   - `waitForAppstrate`: resolves when `waitForHttp` returns true,
+ *     throws a helpful message otherwise. Exercised indirectly via the
+ *     real `fetch` stub because `waitForHttp` lives in `./os.ts`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, readFile, stat, writeFile, chmod } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir, platform } from "node:os";
+import {
+  writeComposeFile,
+  writeEnvFile,
+  assertDockerAvailable,
+  waitForAppstrate,
+  DockerMissingError,
+} from "../../src/lib/install/tier123.ts";
+
+let workDir: string;
+const originalPath = process.env.PATH;
+const originalFetch = globalThis.fetch;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "appstrate-cli-tier123-"));
+});
+
+afterEach(async () => {
+  process.env.PATH = originalPath;
+  globalThis.fetch = originalFetch;
+  await rm(workDir, { recursive: true, force: true });
+});
+
+describe("writeComposeFile", () => {
+  it("writes tier 1 compose with postgres but no redis / minio", async () => {
+    const dir = join(workDir, "t1");
+    await writeComposeFile(dir, 1);
+    const body = await readFile(join(dir, "docker-compose.yml"), "utf8");
+    expect(body).toMatch(/^\s{2}postgres:/m);
+    expect(body).not.toMatch(/^\s{2}redis:/m);
+    expect(body).not.toMatch(/^\s{2}minio:/m);
+  });
+
+  it("writes tier 2 compose with postgres + redis, no minio", async () => {
+    const dir = join(workDir, "t2");
+    await writeComposeFile(dir, 2);
+    const body = await readFile(join(dir, "docker-compose.yml"), "utf8");
+    expect(body).toMatch(/^\s{2}postgres:/m);
+    expect(body).toMatch(/^\s{2}redis:/m);
+    expect(body).not.toMatch(/^\s{2}minio:/m);
+  });
+
+  it("writes tier 3 compose with postgres + redis + minio", async () => {
+    const dir = join(workDir, "t3");
+    await writeComposeFile(dir, 3);
+    const body = await readFile(join(dir, "docker-compose.yml"), "utf8");
+    expect(body).toMatch(/^\s{2}postgres:/m);
+    expect(body).toMatch(/^\s{2}redis:/m);
+    expect(body).toMatch(/^\s{2}minio:/m);
+  });
+
+  it("creates the install directory if missing (recursive mkdir)", async () => {
+    const nested = join(workDir, "does", "not", "yet", "exist");
+    await writeComposeFile(nested, 1);
+    const body = await readFile(join(nested, "docker-compose.yml"), "utf8");
+    expect(body.length).toBeGreaterThan(0);
+  });
+});
+
+describe("writeEnvFile", () => {
+  it("writes the body verbatim to <dir>/.env", async () => {
+    const body = "FOO=bar\nBAZ=qux\n";
+    await writeEnvFile(workDir, body);
+    const round = await readFile(join(workDir, ".env"), "utf8");
+    expect(round).toBe(body);
+  });
+
+  it("writes with 0600 mode so backup tools can't pick up the secrets", async () => {
+    // Windows ACLs don't map cleanly to Unix chmod bits — skip the
+    // assertion rather than flaky-test on `runs-on: windows-latest`.
+    if (platform() === "win32") return;
+    await writeEnvFile(workDir, "BETTER_AUTH_SECRET=deadbeef\n");
+    const s = await stat(join(workDir, ".env"));
+     
+    expect(s.mode & 0o777).toBe(0o600);
+  });
+});
+
+describe("assertDockerAvailable", () => {
+  it("resolves when a docker shim on PATH exits 0", async () => {
+    // Windows: `spawn` on a plain file without .cmd/.ps1 extension behaves
+    // differently. Skip — we exercise the happy path on every Linux/macOS
+    // runner already.
+    if (platform() === "win32") return;
+    const shimDir = join(workDir, "shim-ok");
+    await mkShim(shimDir, "docker", "#!/usr/bin/env bash\nexit 0\n");
+    process.env.PATH = `${shimDir}:${originalPath}`;
+    await assertDockerAvailable();
+  });
+
+  it("throws DockerMissingError when docker is not on PATH", async () => {
+    // Point PATH at an empty dir → `docker` resolves to nothing, spawn
+    // emits ENOENT → runCommand returns ok:false → assertDockerAvailable
+    // throws. Works cross-platform because an empty dir shadows system PATH.
+    const emptyDir = join(workDir, "empty");
+    await mkShim(emptyDir, ".keep", "");
+    process.env.PATH = emptyDir;
+    await expect(assertDockerAvailable()).rejects.toBeInstanceOf(DockerMissingError);
+  });
+
+  it("throws DockerMissingError when docker is present but the daemon is unreachable", async () => {
+    if (platform() === "win32") return;
+    const shimDir = join(workDir, "shim-daemon-down");
+    // Mirrors the real `docker info` output when the daemon is down
+    // (non-zero exit, stderr noise). assertDockerAvailable only cares
+    // about the exit code.
+    await mkShim(shimDir, "docker", "#!/usr/bin/env bash\necho daemon unreachable >&2\nexit 1\n");
+    process.env.PATH = `${shimDir}:${originalPath}`;
+    await expect(assertDockerAvailable()).rejects.toBeInstanceOf(DockerMissingError);
+  });
+});
+
+describe("waitForAppstrate", () => {
+  it("resolves when the app URL returns 2xx", async () => {
+    globalThis.fetch = (async () => new Response("", { status: 200 })) as typeof fetch;
+    await waitForAppstrate("http://127.0.0.1:65535", 500);
+  });
+
+  it("throws a helpful message when the timeout elapses", async () => {
+    globalThis.fetch = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as typeof fetch;
+    await expect(waitForAppstrate("http://127.0.0.1:65535", 50)).rejects.toThrow(
+      /did not become healthy/i,
+    );
+  });
+});
+
+describe("DockerMissingError", () => {
+  it("carries a user-facing install hint", () => {
+    const err = new DockerMissingError();
+    expect(err.name).toBe("DockerMissingError");
+    expect(err.message).toMatch(/Docker Desktop/i);
+    expect(err.message).toMatch(/Tier 0/i);
+  });
+});
+
+async function mkShim(dir: string, name: string, body: string): Promise<void> {
+  await (await import("node:fs/promises")).mkdir(dir, { recursive: true });
+  const path = join(dir, name);
+  await writeFile(path, body);
+  if (body.length > 0) await chmod(path, 0o755);
+}

--- a/apps/cli/test/install/tier123.test.ts
+++ b/apps/cli/test/install/tier123.test.ts
@@ -93,7 +93,7 @@ describe("writeEnvFile", () => {
     if (platform() === "win32") return;
     await writeEnvFile(workDir, "BETTER_AUTH_SECRET=deadbeef\n");
     const s = await stat(join(workDir, ".env"));
-     
+
     expect(s.mode & 0o777).toBe(0o600);
   });
 });
@@ -134,14 +134,14 @@ describe("assertDockerAvailable", () => {
 
 describe("waitForAppstrate", () => {
   it("resolves when the app URL returns 2xx", async () => {
-    globalThis.fetch = (async () => new Response("", { status: 200 })) as typeof fetch;
+    globalThis.fetch = (async () => new Response("", { status: 200 })) as unknown as typeof fetch;
     await waitForAppstrate("http://127.0.0.1:65535", 500);
   });
 
   it("throws a helpful message when the timeout elapses", async () => {
     globalThis.fetch = (async () => {
       throw new Error("ECONNREFUSED");
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
     await expect(waitForAppstrate("http://127.0.0.1:65535", 50)).rejects.toThrow(
       /did not become healthy/i,
     );

--- a/apps/cli/test/install/upgrade.test.ts
+++ b/apps/cli/test/install/upgrade.test.ts
@@ -1,0 +1,328 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `lib/install/upgrade.ts`.
+ *
+ * These cover the safety-critical upgrade path:
+ *   - mode detection (fresh vs upgrade, with any combination of
+ *     `.env` / `docker-compose.yml` present),
+ *   - `.env` parsing (ignore comments, blanks, quote stripping,
+ *     garbage-key rejection),
+ *   - merge semantics (existing wins for every collision — secrets
+ *     must never rotate on a re-run),
+ *   - backup + restore round-trip (file identity preserved byte-for-
+ *     byte, no timestamp accumulation),
+ *   - atomic replace (the `.tmp` sibling is renamed, not left behind).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, readFile, readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir, platform } from "node:os";
+import {
+  detectInstallMode,
+  parseEnvFile,
+  mergeEnv,
+  backupFiles,
+  restoreBackups,
+  cleanupBackups,
+  atomicReplace,
+} from "../../src/lib/install/upgrade.ts";
+
+let workDir: string;
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "appstrate-cli-upgrade-"));
+});
+
+afterEach(async () => {
+  await rm(workDir, { recursive: true, force: true });
+});
+
+describe("detectInstallMode", () => {
+  it("reports 'fresh' on an empty directory", async () => {
+    const { mode, existing } = await detectInstallMode(workDir);
+    expect(mode).toBe("fresh");
+    expect(existing.hasEnv).toBe(false);
+    expect(existing.hasCompose).toBe(false);
+    expect(existing.existingEnv).toEqual({});
+  });
+
+  it("reports 'upgrade' when only .env is present", async () => {
+    await writeFile(join(workDir, ".env"), "BETTER_AUTH_SECRET=keep-me\n");
+    const { mode, existing } = await detectInstallMode(workDir);
+    expect(mode).toBe("upgrade");
+    expect(existing.hasEnv).toBe(true);
+    expect(existing.hasCompose).toBe(false);
+    expect(existing.existingEnv).toEqual({ BETTER_AUTH_SECRET: "keep-me" });
+  });
+
+  it("reports 'upgrade' when only docker-compose.yml is present (half-installed state)", async () => {
+    await writeFile(join(workDir, "docker-compose.yml"), "services: {}\n");
+    const { mode, existing } = await detectInstallMode(workDir);
+    expect(mode).toBe("upgrade");
+    expect(existing.hasEnv).toBe(false);
+    expect(existing.hasCompose).toBe(true);
+  });
+
+  it("reports 'upgrade' when both are present (typical re-run)", async () => {
+    await writeFile(
+      join(workDir, ".env"),
+      "BETTER_AUTH_SECRET=keep\nCONNECTION_ENCRYPTION_KEY=dont-rotate\n",
+    );
+    await writeFile(join(workDir, "docker-compose.yml"), "services: {}\n");
+    const { mode, existing } = await detectInstallMode(workDir);
+    expect(mode).toBe("upgrade");
+    expect(existing.existingEnv.BETTER_AUTH_SECRET).toBe("keep");
+    expect(existing.existingEnv.CONNECTION_ENCRYPTION_KEY).toBe("dont-rotate");
+  });
+
+  it("degrades gracefully if .env is unreadable (directory, not a file)", async () => {
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(join(workDir, ".env"));
+    const { mode, existing } = await detectInstallMode(workDir);
+    // `.env` exists (as a dir) → upgrade path, but existingEnv is empty.
+    expect(mode).toBe("upgrade");
+    expect(existing.hasEnv).toBe(true);
+    expect(existing.existingEnv).toEqual({});
+  });
+});
+
+describe("parseEnvFile", () => {
+  it("parses plain KEY=value lines", () => {
+    const out = parseEnvFile("FOO=bar\nBAZ=qux\n");
+    expect(out).toEqual({ FOO: "bar", BAZ: "qux" });
+  });
+
+  it("ignores # comments and blank lines", () => {
+    const body = "# top-level header\n\nFOO=bar\n  # indented comment\n\nBAZ=qux\n";
+    expect(parseEnvFile(body)).toEqual({ FOO: "bar", BAZ: "qux" });
+  });
+
+  it("strips surrounding single or double quotes from values", () => {
+    const body = `SINGLE='v1'\nDOUBLE="v2"\nUNQUOTED=v3\n`;
+    expect(parseEnvFile(body)).toEqual({ SINGLE: "v1", DOUBLE: "v2", UNQUOTED: "v3" });
+  });
+
+  it("treats an '=' inside the value as part of the value (only the first '=' is the separator)", () => {
+    // base64 passwords contain `=` padding — must not be mis-split.
+    const out = parseEnvFile("CONNECTION_ENCRYPTION_KEY=AAAAAAAAAAAAAAAA=\n");
+    expect(out.CONNECTION_ENCRYPTION_KEY).toBe("AAAAAAAAAAAAAAAA=");
+  });
+
+  it("rejects keys that don't match the [A-Za-z_][A-Za-z0-9_]* identifier shape", () => {
+    const body = "1FOO=bad\nMY-KEY=also-bad\nGOOD=ok\n";
+    expect(parseEnvFile(body)).toEqual({ GOOD: "ok" });
+  });
+
+  it("handles CRLF line endings", () => {
+    expect(parseEnvFile("FOO=bar\r\nBAZ=qux\r\n")).toEqual({ FOO: "bar", BAZ: "qux" });
+  });
+
+  it("returns an empty dict for empty or whitespace-only input", () => {
+    expect(parseEnvFile("")).toEqual({});
+    expect(parseEnvFile("\n\n  \n")).toEqual({});
+  });
+});
+
+describe("mergeEnv", () => {
+  it("existing values always win over fresh values (secrets must not rotate)", () => {
+    const existing = {
+      BETTER_AUTH_SECRET: "existing-secret",
+      CONNECTION_ENCRYPTION_KEY: "existing-key",
+    };
+    const fresh = {
+      BETTER_AUTH_SECRET: "newly-generated-secret",
+      CONNECTION_ENCRYPTION_KEY: "newly-generated-key",
+    };
+    expect(mergeEnv(existing, fresh)).toEqual({
+      BETTER_AUTH_SECRET: "existing-secret",
+      CONNECTION_ENCRYPTION_KEY: "existing-key",
+    });
+  });
+
+  it("fresh keys that are new (tier 1 → tier 3 adds MINIO_*) are added", () => {
+    const existing = { BETTER_AUTH_SECRET: "x", POSTGRES_PASSWORD: "p" };
+    const fresh = {
+      BETTER_AUTH_SECRET: "should-be-ignored",
+      POSTGRES_PASSWORD: "also-ignored",
+      MINIO_ROOT_PASSWORD: "new-on-tier-3",
+      S3_BUCKET: "appstrate",
+    };
+    const out = mergeEnv(existing, fresh);
+    expect(out.BETTER_AUTH_SECRET).toBe("x");
+    expect(out.POSTGRES_PASSWORD).toBe("p");
+    expect(out.MINIO_ROOT_PASSWORD).toBe("new-on-tier-3");
+    expect(out.S3_BUCKET).toBe("appstrate");
+  });
+
+  it("user-added keys not in fresh are preserved (SMTP_HOST stays)", () => {
+    const existing = { BETTER_AUTH_SECRET: "x", SMTP_HOST: "smtp.example.com" };
+    const fresh = { BETTER_AUTH_SECRET: "y", POSTGRES_PASSWORD: "p" };
+    const out = mergeEnv(existing, fresh);
+    expect(out.SMTP_HOST).toBe("smtp.example.com");
+    expect(out.POSTGRES_PASSWORD).toBe("p");
+    expect(out.BETTER_AUTH_SECRET).toBe("x");
+  });
+
+  it("returns a new object (doesn't mutate either input)", () => {
+    const existing = { A: "1" };
+    const fresh = { B: "2" };
+    const out = mergeEnv(existing, fresh);
+    expect(out).not.toBe(existing);
+    expect(out).not.toBe(fresh);
+    expect(existing).toEqual({ A: "1" });
+    expect(fresh).toEqual({ B: "2" });
+  });
+});
+
+describe("backupFiles + restoreBackups", () => {
+  it("round-trips byte-for-byte including 0600 mode and secret content", async () => {
+    const envBody = "BETTER_AUTH_SECRET=abc\nMINIO_ROOT_PASSWORD=def\n";
+    await writeFile(join(workDir, ".env"), envBody, { mode: 0o600 });
+    await writeFile(join(workDir, "docker-compose.yml"), "services:\n  postgres: {}\n");
+
+    const backedUp = await backupFiles(workDir, [".env", "docker-compose.yml"]);
+    expect(backedUp).toEqual([".env", "docker-compose.yml"]);
+
+    // Overwrite the originals with garbage.
+    await writeFile(join(workDir, ".env"), "WIPED=yes\n");
+    await writeFile(join(workDir, "docker-compose.yml"), "services: {}\n");
+
+    await restoreBackups(workDir, backedUp);
+
+    const restoredEnv = await readFile(join(workDir, ".env"), "utf8");
+    const restoredCompose = await readFile(join(workDir, "docker-compose.yml"), "utf8");
+    expect(restoredEnv).toBe(envBody);
+    expect(restoredCompose).toBe("services:\n  postgres: {}\n");
+  });
+
+  it("skips files that don't exist (half-installed dir)", async () => {
+    // Only .env exists; compose is missing.
+    await writeFile(join(workDir, ".env"), "X=1\n");
+    const backedUp = await backupFiles(workDir, [".env", "docker-compose.yml"]);
+    expect(backedUp).toEqual([".env"]);
+  });
+
+  it("uses a single .backup suffix — never accumulates timestamped files", async () => {
+    await writeFile(join(workDir, ".env"), "X=1\n");
+    await backupFiles(workDir, [".env"]);
+    await backupFiles(workDir, [".env"]);
+    const entries = await readdir(workDir);
+    // One original + one backup — no .backup.2025-… proliferation.
+    expect(entries.sort()).toEqual([".env", ".env.backup"]);
+  });
+
+  it("is a no-op on restore when no backups were taken", async () => {
+    await restoreBackups(workDir, []);
+    // Just assert no throw — dir is untouched.
+    const entries = await readdir(workDir);
+    expect(entries).toEqual([]);
+  });
+});
+
+describe("cleanupBackups", () => {
+  it("removes the .backup files after a successful upgrade", async () => {
+    await writeFile(join(workDir, ".env"), "X=1\n");
+    const backedUp = await backupFiles(workDir, [".env"]);
+    expect((await readdir(workDir)).sort()).toEqual([".env", ".env.backup"]);
+    await cleanupBackups(workDir, backedUp);
+    expect((await readdir(workDir)).sort()).toEqual([".env"]);
+  });
+
+  it("swallows missing-file errors (belt-and-braces)", async () => {
+    // `.env.backup` never existed — cleanup should still succeed.
+    await cleanupBackups(workDir, [".env"]);
+  });
+});
+
+describe("atomicReplace", () => {
+  it("writes the body to the target path", async () => {
+    const target = join(workDir, ".env");
+    await atomicReplace(target, "FOO=bar\n");
+    expect(await readFile(target, "utf8")).toBe("FOO=bar\n");
+  });
+
+  it("honours the mode argument", async () => {
+    if (platform() === "win32") return;
+    const target = join(workDir, ".env");
+    await atomicReplace(target, "SECRET=1\n", 0o600);
+    const s = await stat(target);
+    expect(s.mode & 0o777).toBe(0o600);
+  });
+
+  it("does not leave the .tmp sibling behind on success", async () => {
+    const target = join(workDir, ".env");
+    await atomicReplace(target, "FOO=bar\n");
+    const entries = await readdir(workDir);
+    expect(entries).toEqual([".env"]);
+  });
+
+  it("overwrites an existing target atomically", async () => {
+    const target = join(workDir, ".env");
+    await writeFile(target, "OLD=1\n");
+    await atomicReplace(target, "NEW=1\n");
+    expect(await readFile(target, "utf8")).toBe("NEW=1\n");
+  });
+});
+
+describe("end-to-end upgrade flow (integration)", () => {
+  it("preserves BETTER_AUTH_SECRET + CONNECTION_ENCRYPTION_KEY across a re-run", async () => {
+    // Simulate the critical invariant: the user ran tier 1 once, then
+    // re-runs tier 3. Their session-signing secret and credential-
+    // encryption key MUST NOT change.
+    const originalEnv = [
+      "BETTER_AUTH_SECRET=user-original-session-secret",
+      "CONNECTION_ENCRYPTION_KEY=user-original-encryption-key-base64==",
+      "POSTGRES_PASSWORD=user-original-db-password",
+      "APP_URL=https://my-production.example.com",
+    ].join("\n");
+    await writeFile(join(workDir, ".env"), originalEnv, { mode: 0o600 });
+    await writeFile(join(workDir, "docker-compose.yml"), "# old tier 1 compose\n");
+
+    const { mode, existing } = await detectInstallMode(workDir);
+    expect(mode).toBe("upgrade");
+
+    const freshTier3 = {
+      BETTER_AUTH_SECRET: "newly-generated-and-MUST-be-ignored",
+      CONNECTION_ENCRYPTION_KEY: "newly-generated-and-MUST-be-ignored",
+      POSTGRES_PASSWORD: "newly-generated-and-MUST-be-ignored",
+      APP_URL: "http://localhost:3000",
+      MINIO_ROOT_USER: "appstrate",
+      MINIO_ROOT_PASSWORD: "new-minio-password",
+      S3_BUCKET: "appstrate",
+      S3_REGION: "us-east-1",
+    };
+    const merged = mergeEnv(existing.existingEnv, freshTier3);
+
+    expect(merged.BETTER_AUTH_SECRET).toBe("user-original-session-secret");
+    expect(merged.CONNECTION_ENCRYPTION_KEY).toBe("user-original-encryption-key-base64==");
+    expect(merged.POSTGRES_PASSWORD).toBe("user-original-db-password");
+    expect(merged.APP_URL).toBe("https://my-production.example.com");
+    // New tier 3 keys are introduced.
+    expect(merged.MINIO_ROOT_PASSWORD).toBe("new-minio-password");
+    expect(merged.S3_BUCKET).toBe("appstrate");
+  });
+
+  it("rollback restores the original files byte-for-byte after a failed upgrade", async () => {
+    const originalEnv = "BETTER_AUTH_SECRET=orig\nPOSTGRES_PASSWORD=orig-pg\n";
+    const originalCompose = "# tier 1\nservices:\n  postgres: {}\n";
+    await writeFile(join(workDir, ".env"), originalEnv, { mode: 0o600 });
+    await writeFile(join(workDir, "docker-compose.yml"), originalCompose);
+
+    // Simulate the upgrade start: backup, then overwrite.
+    const backedUp = await backupFiles(workDir, [".env", "docker-compose.yml"]);
+    await writeFile(join(workDir, ".env"), "WIPED=1\n");
+    await writeFile(join(workDir, "docker-compose.yml"), "# new tier 3\n");
+
+    // Simulate downstream failure (docker compose up) — rollback.
+    await restoreBackups(workDir, backedUp);
+
+    expect(await readFile(join(workDir, ".env"), "utf8")).toBe(originalEnv);
+    expect(await readFile(join(workDir, "docker-compose.yml"), "utf8")).toBe(originalCompose);
+    // Backups are kept on the rollback path so the user can inspect.
+    const entries = await readdir(workDir);
+    expect(entries).toContain(".env.backup");
+    expect(entries).toContain("docker-compose.yml.backup");
+  });
+});

--- a/apps/cli/test/instance-url.test.ts
+++ b/apps/cli/test/instance-url.test.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `lib/instance-url.ts` — HTTPS gate for CLI bearer-token
+ * traffic. The module refuses `http://` against a non-loopback host
+ * unless `APPSTRATE_INSECURE=1` is set; tests exercise both the allow
+ * list and the opt-in bypass.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  normalizeInstance,
+  stripTrailingSlash,
+  isInsecureOptIn,
+  InsecureInstanceError,
+} from "../src/lib/instance-url.ts";
+
+const originalEnv = process.env.APPSTRATE_INSECURE;
+
+beforeEach(() => {
+  delete process.env.APPSTRATE_INSECURE;
+});
+
+afterEach(() => {
+  if (originalEnv === undefined) delete process.env.APPSTRATE_INSECURE;
+  else process.env.APPSTRATE_INSECURE = originalEnv;
+});
+
+describe("stripTrailingSlash", () => {
+  it("removes a single trailing slash", () => {
+    expect(stripTrailingSlash("https://a.com/")).toBe("https://a.com");
+  });
+  it("leaves an unslashed URL untouched", () => {
+    expect(stripTrailingSlash("https://a.com")).toBe("https://a.com");
+  });
+});
+
+describe("isInsecureOptIn", () => {
+  it("is false when the env var is unset", () => {
+    expect(isInsecureOptIn()).toBe(false);
+  });
+  it("accepts '1' and 'true'", () => {
+    process.env.APPSTRATE_INSECURE = "1";
+    expect(isInsecureOptIn()).toBe(true);
+    process.env.APPSTRATE_INSECURE = "true";
+    expect(isInsecureOptIn()).toBe(true);
+  });
+  it("rejects any other truthy value", () => {
+    process.env.APPSTRATE_INSECURE = "yes";
+    expect(isInsecureOptIn()).toBe(false);
+  });
+});
+
+describe("normalizeInstance", () => {
+  describe("always allowed", () => {
+    it("accepts https for any host", () => {
+      expect(normalizeInstance("https://appstrate.example.com")).toBe(
+        "https://appstrate.example.com",
+      );
+    });
+    it("accepts http://localhost", () => {
+      expect(normalizeInstance("http://localhost:3000")).toBe("http://localhost:3000");
+    });
+    it("accepts http://127.0.0.1", () => {
+      expect(normalizeInstance("http://127.0.0.1:3000")).toBe("http://127.0.0.1:3000");
+    });
+    it("accepts http://[::1]", () => {
+      expect(normalizeInstance("http://[::1]:3000")).toBe("http://[::1]:3000");
+    });
+    it("trims trailing whitespace + slash", () => {
+      expect(normalizeInstance("  https://a.com/  ")).toBe("https://a.com");
+    });
+  });
+
+  describe("refused by default", () => {
+    it("throws InsecureInstanceError on http://non-loopback", () => {
+      expect(() => normalizeInstance("http://appstrate.example.com")).toThrow(
+        InsecureInstanceError,
+      );
+    });
+    it("throws on http://10.0.0.5 (private LAN — still network)", () => {
+      expect(() => normalizeInstance("http://10.0.0.5:3000")).toThrow(InsecureInstanceError);
+    });
+    it("throws on http://192.168.1.10", () => {
+      expect(() => normalizeInstance("http://192.168.1.10")).toThrow(InsecureInstanceError);
+    });
+  });
+
+  describe("with APPSTRATE_INSECURE=1", () => {
+    beforeEach(() => {
+      process.env.APPSTRATE_INSECURE = "1";
+    });
+    it("allows http://non-loopback", () => {
+      expect(normalizeInstance("http://appstrate.example.com")).toBe(
+        "http://appstrate.example.com",
+      );
+    });
+    it("still refuses unsupported schemes", () => {
+      expect(() => normalizeInstance("file:///etc/passwd")).toThrow();
+      expect(() => normalizeInstance("ws://a.com")).toThrow();
+    });
+  });
+
+  describe("validation", () => {
+    it("throws on empty input", () => {
+      expect(() => normalizeInstance("")).toThrow();
+      expect(() => normalizeInstance("   ")).toThrow();
+    });
+    it("throws on malformed URLs", () => {
+      expect(() => normalizeInstance("not a url")).toThrow();
+      expect(() => normalizeInstance("://missing-scheme")).toThrow();
+    });
+    it("throws on non-http(s) schemes even via loopback", () => {
+      expect(() => normalizeInstance("ftp://localhost")).toThrow();
+    });
+  });
+});

--- a/apps/cli/test/keyring.test.ts
+++ b/apps/cli/test/keyring.test.ts
@@ -152,6 +152,53 @@ describe("keyring fallback path (daemon unavailable)", () => {
   });
 });
 
+describe("concurrent writes via file fallback", () => {
+  beforeEach(() => {
+    FakeKeyring.shouldThrow = true; // force every save onto the file path
+  });
+
+  it("serializes concurrent saves without losing profiles", async () => {
+    // 10 parallel saves, each with a distinct profile name. The lock
+    // must serialize the read-modify-write cycles — without it, later
+    // writers clobber earlier profiles by overwriting a stale snapshot.
+    const saves = Array.from({ length: 10 }, (_, i) =>
+      saveTokens(`profile${i}`, { accessToken: `tok-${i}`, expiresAt: 1000 + i }),
+    );
+    await Promise.all(saves);
+
+    // Every profile must be readable — if the lock were absent, most of
+    // these would return null because the last writer overwrote them.
+    for (let i = 0; i < 10; i++) {
+      expect(await loadTokens(`profile${i}`)).toEqual({
+        accessToken: `tok-${i}`,
+        expiresAt: 1000 + i,
+      });
+    }
+  });
+
+  it("writes are atomic — no torn state on mid-write crash", async () => {
+    // Seed an initial valid state.
+    await saveTokens("existing", { accessToken: "keep", expiresAt: 1 });
+
+    // A crash between `writeFile(tmp)` and `rename(tmp, target)` would
+    // leave `.tmp` files on disk but never a half-written target. We
+    // can't actually crash Bun mid-operation in a unit test, so assert
+    // the invariant that matters: after every `saveTokens`, the target
+    // file parses cleanly as JSON with every previously-written profile
+    // intact.
+    for (let i = 0; i < 5; i++) {
+      await saveTokens(`p${i}`, { accessToken: `t${i}`, expiresAt: i });
+      const { readFile } = await import("node:fs/promises");
+      const raw = await readFile(credentialsPath(), "utf-8");
+      const parsed = JSON.parse(raw) as Record<string, { accessToken: string }>;
+      expect(parsed.existing?.accessToken).toBe("keep");
+      for (let j = 0; j <= i; j++) {
+        expect(parsed[`p${j}`]?.accessToken).toBe(`t${j}`);
+      }
+    }
+  });
+});
+
 describe("corrupt data handling", () => {
   it("returns null for malformed keyring payloads instead of crashing", async () => {
     // Simulate a foreign tool writing junk under our service key.

--- a/apps/cli/test/keyring.test.ts
+++ b/apps/cli/test/keyring.test.ts
@@ -19,6 +19,7 @@ import {
   loadTokens,
   deleteTokens,
   _setKeyringFactoryForTesting,
+  _shouldRefuseWindowsFallback,
   type KeyringHandle,
 } from "../src/lib/keyring.ts";
 
@@ -209,5 +210,34 @@ describe("corrupt data handling", () => {
   it("returns null when required fields are missing", async () => {
     FakeKeyring.store.set("default", JSON.stringify({ accessToken: "t" }));
     expect(await loadTokens("default")).toBeNull();
+  });
+});
+
+describe("Windows fallback refusal", () => {
+  // The in-process platform check is exercised via the exported
+  // `_shouldRefuseWindowsFallback` helper — stubbing
+  // `process.platform` globally is racy with Bun's test runner and
+  // would leak between tests.
+  it("refuses the fallback on win32 when the keyring backend is missing", () => {
+    const err = new Error("Platform secure storage failure");
+    expect(_shouldRefuseWindowsFallback("win32", err)).toBe(true);
+  });
+
+  it("refuses the fallback on win32 when the keyring backend is broken", () => {
+    const err = new Error("Credential Manager RPC call failed");
+    expect(_shouldRefuseWindowsFallback("win32", err)).toBe(true);
+  });
+
+  it("does NOT refuse on win32 when the entry simply doesn't exist yet", () => {
+    // Reads on a fresh install hit this path — no creds stored yet.
+    // The caller just returns null; no fallback needed, no refusal.
+    const err = new Error("No matching entry");
+    expect(_shouldRefuseWindowsFallback("win32", err)).toBe(false);
+  });
+
+  it("never refuses on non-Windows platforms", () => {
+    const err = new Error("Platform secure storage failure");
+    expect(_shouldRefuseWindowsFallback("linux", err)).toBe(false);
+    expect(_shouldRefuseWindowsFallback("darwin", err)).toBe(false);
   });
 });

--- a/apps/cli/test/logout.test.ts
+++ b/apps/cli/test/logout.test.ts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `commands/logout.ts`.
+ *
+ * Contract we care about:
+ *   1. Logout MUST call `POST /api/auth/sign-out` on the profile's
+ *      instance with the Bearer token BEFORE wiping local state —
+ *      otherwise a stolen/backed-up credentials.json would keep
+ *      working against the server after "logout".
+ *   2. If the server is unreachable or returns a non-200 (other than
+ *      401, which is a normal "already revoked"), the local cleanup
+ *      must still complete. A network partition must not leave the
+ *      user locally logged in.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  _setKeyringFactoryForTesting,
+  saveTokens,
+  loadTokens,
+  type KeyringHandle,
+} from "../src/lib/keyring.ts";
+import { setProfile, getProfile } from "../src/lib/config.ts";
+import { logoutCommand } from "../src/commands/logout.ts";
+
+// In-memory keyring — same shape as `keyring.test.ts` but scoped to
+// this file so test isolation stays clean.
+class FakeKeyring implements KeyringHandle {
+  static store = new Map<string, string>();
+  constructor(private profile: string) {}
+  setPassword(v: string): void {
+    FakeKeyring.store.set(this.profile, v);
+  }
+  getPassword(): string | null {
+    return FakeKeyring.store.get(this.profile) ?? null;
+  }
+  deletePassword(): void {
+    FakeKeyring.store.delete(this.profile);
+  }
+}
+
+type FetchCall = { url: string; method: string | undefined; auth: string | null };
+
+let tmpDir: string;
+const originalXdg = process.env.XDG_CONFIG_HOME;
+const originalFetch = globalThis.fetch;
+let fetchCalls: FetchCall[];
+
+function installFetch(responder: (url: string, init?: RequestInit) => Promise<Response>): void {
+  globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    fetchCalls.push({ url, method: init?.method, auth: headers.Authorization ?? null });
+    return responder(url, init);
+  };
+}
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "appstrate-cli-logout-"));
+  process.env.XDG_CONFIG_HOME = tmpDir;
+  FakeKeyring.store.clear();
+  _setKeyringFactoryForTesting((p) => new FakeKeyring(p));
+  fetchCalls = [];
+});
+
+afterEach(async () => {
+  if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = originalXdg;
+  _setKeyringFactoryForTesting(null);
+  globalThis.fetch = originalFetch;
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+async function seedLoggedInProfile(name: string): Promise<void> {
+  await setProfile(name, {
+    instance: "https://app.example.com",
+    userId: "u_1",
+    email: "a@example.com",
+  });
+  await saveTokens(name, {
+    accessToken: "tok-abc",
+    expiresAt: Date.now() + 24 * 60 * 60 * 1000,
+  });
+}
+
+describe("logout", () => {
+  it("calls POST /api/auth/sign-out with the Bearer token before wiping state", async () => {
+    await seedLoggedInProfile("default");
+    installFetch(async () => new Response("", { status: 200 }));
+
+    await logoutCommand({ profile: "default" });
+
+    // Contract #1 — server-side revocation happened.
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]!.url).toBe("https://app.example.com/api/auth/sign-out");
+    expect(fetchCalls[0]!.method).toBe("POST");
+    expect(fetchCalls[0]!.auth).toBe("Bearer tok-abc");
+
+    // Local cleanup happened too.
+    expect(await loadTokens("default")).toBeNull();
+    expect(await getProfile("default")).toBeNull();
+  });
+
+  it("still wipes local state when the server is unreachable", async () => {
+    await seedLoggedInProfile("default");
+    installFetch(async () => {
+      throw new TypeError("fetch failed");
+    });
+
+    await logoutCommand({ profile: "default" });
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(await loadTokens("default")).toBeNull();
+    expect(await getProfile("default")).toBeNull();
+  });
+
+  it("still wipes local state when the server returns 500", async () => {
+    await seedLoggedInProfile("default");
+    installFetch(async () => new Response("oops", { status: 500 }));
+
+    await logoutCommand({ profile: "default" });
+
+    expect(await loadTokens("default")).toBeNull();
+    expect(await getProfile("default")).toBeNull();
+  });
+
+  it("treats 401 from the server as 'already revoked' without warning", async () => {
+    await seedLoggedInProfile("default");
+    installFetch(async () => new Response("", { status: 401 }));
+
+    // The command short-circuits through the AuthError branch of
+    // apiFetchRaw. We can't easily intercept stderr from this harness
+    // without stubbing `process.stderr.write` globally, so just assert
+    // the happy effect: logout completes cleanly and state is wiped.
+    await logoutCommand({ profile: "default" });
+
+    expect(await loadTokens("default")).toBeNull();
+    expect(await getProfile("default")).toBeNull();
+  });
+
+  it("is idempotent when already logged out", async () => {
+    // No tokens, no profile — logout should return cleanly and never
+    // hit the network.
+    installFetch(async () => new Response("", { status: 200 }));
+    await logoutCommand({ profile: "never-logged-in" });
+    expect(fetchCalls).toHaveLength(0);
+  });
+});

--- a/apps/cli/test/logout.test.ts
+++ b/apps/cli/test/logout.test.ts
@@ -51,12 +51,16 @@ const originalFetch = globalThis.fetch;
 let fetchCalls: FetchCall[];
 
 function installFetch(responder: (url: string, init?: RequestInit) => Promise<Response>): void {
-  globalThis.fetch = async (input: string | URL | Request, init?: RequestInit) => {
+  const stub = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
     const url = typeof input === "string" ? input : input.toString();
     const headers = (init?.headers ?? {}) as Record<string, string>;
     fetchCalls.push({ url, method: init?.method, auth: headers.Authorization ?? null });
     return responder(url, init);
   };
+  // Bun's `typeof fetch` now includes a `preconnect` method we don't
+  // need for the stub; cast through unknown so the type narrowing
+  // doesn't force us to reimplement it.
+  globalThis.fetch = stub as unknown as typeof fetch;
 }
 
 beforeEach(async () => {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -50,7 +50,11 @@ esac
 case "$OS" in
   darwin | linux) ;;
   *)
-    echo "Unsupported OS: $OS. Windows users: \`bunx @appstrate/cli install\`." >&2
+    # Windows fallback via `bunx @appstrate/cli` is tracked in
+    # https://github.com/appstrate/appstrate/issues/163 — until the npm
+    # package is published, there is no working install path on Windows
+    # and we fail loud rather than hint at something that doesn't exist.
+    echo "Unsupported OS: $OS. Only darwin and linux are supported today." >&2
     exit 1
     ;;
 esac

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -6,21 +6,33 @@
 # Single responsibility: detect OS + arch, download the matching
 # `appstrate` CLI binary from the GitHub Release whose tag is pinned
 # by `publish-installer.yml` at publish time (or `latest` if this
-# script is being run from a raw source copy), drop it on PATH, and
-# exec `appstrate install` to hand control to the CLI itself.
+# script is being run from a raw source copy), VERIFY its integrity
+# + provenance against a minisign-signed SHA-256 manifest, drop it on
+# PATH, and exec `appstrate install` to hand control to the CLI itself.
 #
 # No install logic lives here — tier selection, secrets generation,
 # compose rendering, healthchecks, and upgrades are all owned by the
-# CLI binary. This script should never need to grow beyond ~30 lines.
+# CLI binary. This script stays small on purpose.
+#
+# Trust chain:
+#   1. `scripts/verify.sh` (served at `get.appstrate.dev/verify.sh`)
+#      verifies the signature on THIS script before executing it. That
+#      is the opt-in wrapper for users who refuse trust-on-TLS at the
+#      `get.appstrate.dev | bash` step.
+#   2. THIS script then downloads + verifies the signature on the
+#      per-release `checksums.txt` against the baked-in public key,
+#      then verifies the SHA-256 of the downloaded binary matches.
+#      The CLI binary is never exec'd until both checks pass.
 #
 # Usage:
 #   curl -fsSL https://get.appstrate.dev | bash
 #   curl -fsSL https://get.appstrate.dev | bash -s -- --tier 3
 #
 # Env overrides:
-#   APPSTRATE_VERSION   Pin a release tag (default: the tag the
-#                       publish pipeline stamped into this script).
-#   APPSTRATE_BIN_DIR   Install location (default: /usr/local/bin).
+#   APPSTRATE_VERSION        Pin a release tag (default: pinned or "latest").
+#   APPSTRATE_BIN_DIR        Install location (default: /usr/local/bin).
+#   APPSTRATE_SKIP_VERIFY=1  Skip signature + checksum verification (CI
+#                            debug only — do NOT set on user machines).
 
 set -euo pipefail
 
@@ -54,25 +66,116 @@ if [[ "$_DEFAULT_VERSION" == __* ]]; then _DEFAULT_VERSION="latest"; fi
 VERSION="${APPSTRATE_VERSION:-$_DEFAULT_VERSION}"
 BIN_DIR="${APPSTRATE_BIN_DIR:-/usr/local/bin}"
 DEST="${BIN_DIR}/appstrate"
+ASSET="appstrate-${OS}-${ARCH}"
+
+# Appstrate minisign public key — baked into the distributed
+# bootstrap.sh so a freshly-bootstrapped machine can verify without a
+# second round-trip. Matches `scripts/appstrate.pub` in the repo; the
+# release workflow signs `checksums.txt` with the matching private key.
+# Rotation SOP: docs/adr/ADR-006-cli-device-flow-monorepo.md.
+APPSTRATE_MINISIGN_PUBKEY="RWT6xCZCCP/yHolAgDuDqBssxUflw7gInlZlaXEfQ4cFi5XN0KCtKr0e"
 
 if [ "$VERSION" = "latest" ]; then
-  URL="https://github.com/appstrate/appstrate-oss/releases/latest/download/appstrate-${OS}-${ARCH}"
+  URL_BASE="https://github.com/appstrate/appstrate-oss/releases/latest/download"
 else
-  URL="https://github.com/appstrate/appstrate-oss/releases/download/${VERSION}/appstrate-${OS}-${ARCH}"
+  URL_BASE="https://github.com/appstrate/appstrate-oss/releases/download/${VERSION}"
+fi
+URL="${URL_BASE}/${ASSET}"
+CHECKSUMS_URL="${URL_BASE}/checksums.txt"
+CHECKSUMS_SIG_URL="${URL_BASE}/checksums.txt.minisig"
+
+# ─── Helpers ────────────────────────────────────────────────────────────────
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+warn()  { printf '\033[0;33m⚠\033[0m  %s\n' "$*" >&2; }
+log()   { printf '\033[0;36m→\033[0m  %s\n' "$*"; }
+err()   { printf '\033[0;31m✗\033[0m  %s\n' "$*" >&2; }
+
+have_sha256sum() { command -v sha256sum >/dev/null 2>&1; }
+have_shasum()    { command -v shasum >/dev/null 2>&1; }
+have_minisign()  { command -v minisign >/dev/null 2>&1; }
+
+# ─── Download + verify ──────────────────────────────────────────────────────
+
+log "Downloading Appstrate CLI ($OS/$ARCH, $VERSION)"
+curl -fsSL "$URL" -o "$TMPDIR/$ASSET"
+
+if [ "${APPSTRATE_SKIP_VERIFY:-0}" = "1" ]; then
+  warn "APPSTRATE_SKIP_VERIFY=1 — integrity + provenance checks skipped."
+  warn "Only use this in controlled CI debug runs. Do NOT set on user machines."
+else
+  # Verification is gated on minisign availability. Without it we can't
+  # cryptographically tie the binary to the Appstrate release key; just
+  # matching a checksum file downloaded over the same TLS channel as the
+  # binary is security theatre (an on-path attacker can rewrite both).
+  # Fail closed — the one-line install command the user just executed
+  # took < 5s; installing minisign via the OS package manager costs
+  # roughly the same.
+  if ! have_minisign; then
+    err "minisign is required to verify the Appstrate CLI download."
+    err "  → macOS:   brew install minisign"
+    err "  → Debian:  sudo apt install minisign"
+    err "  → Alpine:  apk add minisign"
+    err "  → Other:   https://jedisct1.github.io/minisign/"
+    err ""
+    err "To override (NOT recommended, only for CI debug), re-run with"
+    err "  APPSTRATE_SKIP_VERIFY=1 curl -fsSL https://get.appstrate.dev | bash"
+    exit 1
+  fi
+
+  log "Fetching release checksums + signature"
+  curl -fsSL "$CHECKSUMS_URL"     -o "$TMPDIR/checksums.txt"
+  curl -fsSL "$CHECKSUMS_SIG_URL" -o "$TMPDIR/checksums.txt.minisig"
+
+  log "Verifying signature against Appstrate release key"
+  if ! minisign -Vm "$TMPDIR/checksums.txt" -P "$APPSTRATE_MINISIGN_PUBKEY" >/dev/null; then
+    err "Signature verification FAILED."
+    err "  → The checksums manifest was NOT signed by the Appstrate key."
+    err "  → Your download is possibly tampered — do NOT execute."
+    err "  → Report: https://github.com/appstrate/appstrate/issues"
+    exit 1
+  fi
+
+  log "Verifying binary integrity (SHA-256)"
+  # Prefer the GNU tool when available; fall back to BSD `shasum -c`
+  # (default on macOS without coreutils). Both speak the same `<hash>
+  # <filename>` line format so `checksums.txt` is compatible.
+  (
+    cd "$TMPDIR"
+    # Only the line for our asset matters — filtering keeps the tool
+    # from failing on missing sibling binaries we didn't download.
+    grep " ${ASSET}\$" checksums.txt > checksums.local.txt
+    if have_sha256sum; then
+      sha256sum -c --quiet checksums.local.txt
+    elif have_shasum; then
+      shasum -a 256 -c --quiet checksums.local.txt
+    else
+      err "Neither sha256sum nor shasum is available on this system."
+      exit 1
+    fi
+  ) || {
+    err "SHA-256 mismatch — the downloaded binary does NOT match the signed manifest."
+    err "  → This strongly suggests tampering in transit. Do NOT execute."
+    err "  → Report: https://github.com/appstrate/appstrate/issues"
+    exit 1
+  }
+  log "Integrity + provenance verified"
 fi
 
-# `sudo` only if the destination isn't user-writable — skips a
-# pointless auth prompt when /usr/local/bin is already owned by the
-# user (common on macOS Homebrew setups under /opt/homebrew + symlinked
-# /usr/local/bin).
+# ─── Install ────────────────────────────────────────────────────────────────
+
+# `sudo` only if the destination isn't user-writable — skips a pointless
+# auth prompt when /usr/local/bin is already owned by the user (common
+# on macOS Homebrew setups under /opt/homebrew + symlinked /usr/local/bin).
 SUDO=""
 if [ ! -w "$BIN_DIR" ]; then
   SUDO="sudo"
 fi
 
-echo "Downloading Appstrate CLI ($OS/$ARCH, $VERSION)..."
-$SUDO curl -fsSL "$URL" -o "$DEST"
-$SUDO chmod +x "$DEST"
+log "Installing to $DEST"
+$SUDO install -m 0755 "$TMPDIR/$ASSET" "$DEST"
 
-echo "Launching \`appstrate install\`..."
+log "Launching \`appstrate install\`"
 exec appstrate install "$@"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -89,13 +89,13 @@ CHECKSUMS_SIG_URL="${URL_BASE}/checksums.txt.minisig"
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-warn()  { printf '\033[0;33m⚠\033[0m  %s\n' "$*" >&2; }
-log()   { printf '\033[0;36m→\033[0m  %s\n' "$*"; }
-err()   { printf '\033[0;31m✗\033[0m  %s\n' "$*" >&2; }
+warn() { printf '\033[0;33m⚠\033[0m  %s\n' "$*" >&2; }
+log() { printf '\033[0;36m→\033[0m  %s\n' "$*"; }
+err() { printf '\033[0;31m✗\033[0m  %s\n' "$*" >&2; }
 
 have_sha256sum() { command -v sha256sum >/dev/null 2>&1; }
-have_shasum()    { command -v shasum >/dev/null 2>&1; }
-have_minisign()  { command -v minisign >/dev/null 2>&1; }
+have_shasum() { command -v shasum >/dev/null 2>&1; }
+have_minisign() { command -v minisign >/dev/null 2>&1; }
 
 # ─── Download + verify ──────────────────────────────────────────────────────
 
@@ -126,7 +126,7 @@ else
   fi
 
   log "Fetching release checksums + signature"
-  curl -fsSL "$CHECKSUMS_URL"     -o "$TMPDIR/checksums.txt"
+  curl -fsSL "$CHECKSUMS_URL" -o "$TMPDIR/checksums.txt"
   curl -fsSL "$CHECKSUMS_SIG_URL" -o "$TMPDIR/checksums.txt.minisig"
 
   log "Verifying signature against Appstrate release key"
@@ -146,7 +146,7 @@ else
     cd "$TMPDIR"
     # Only the line for our asset matters — filtering keeps the tool
     # from failing on missing sibling binaries we didn't download.
-    grep " ${ASSET}\$" checksums.txt > checksums.local.txt
+    grep " ${ASSET}\$" checksums.txt >checksums.local.txt
     if have_sha256sum; then
       sha256sum -c --quiet checksums.local.txt
     elif have_shasum; then


### PR DESCRIPTION
## Summary

Review follow-ups for #154. Splits into three groups:

### Security fixes (critical)
- **HTTPS enforcement for non-loopback instances** (de81caf9) — Bearer tokens over plaintext HTTP are fatal; opt-out via `--insecure` for dev
- **Device-code bruteforce lockout** (8a89b0ad) — 5 failed approve attempts flip status=denied + audit log
- **Signed releases + verified bootstrap** (633ccf76) — minisign signature over `checksums.txt`, SHA-256 over the binary, baked-in pubkey in `bootstrap.sh`, SLSA attestation via `actions/attest-build-provenance`
- **Atomic writes + advisory lock on credentials file** (c3a5fe11) — PID-aware `O_EXCL` lock, tmp+rename write
- **Refuse file fallback on Windows** (c8f7e9f5) — NTFS ACLs don't map to 0600; fail loud instead of leaking creds
- **Remove shell interpolation from tier0 tarball install** (fc05e154) — argv-separated curl+tar spawn
- **Cap device-flow polling at 15 min** (812f0d72) — client-side ceiling regardless of server `expires_in`
- **Tighten user_code regex** (d01719c1) — match the Crockford alphabet actually used by the generator
- **Stamp CLI version from tag** (6d0f9418) — smoke-test asserts `--version` matches the release tag

### Install-pipeline test coverage
- **Phase A** (2fa73092) — `tier123.test.ts`, `os.test.ts`, `tier0.test.ts`, `install.test.ts` cover every safety-critical branch of the migrated install pipeline. `test-install.yml` adds an end-to-end bootstrap-verify dry run (happy / tampered-binary / tampered-checksums / missing-minisign / skip-verify) against a local HTTP server with a throwaway keypair.
- **fetch-type fix** (88fc2ffe) — Bun 1.3.11's `typeof fetch` now requires `preconnect`; `logout.test.ts` was already broken on `main`, plus the new stubs needed the same `as unknown as typeof fetch` cast.

### Upgrade / rollback (regression fix)
- **Upgrade + rollback** (93ba8018) — Re-running `appstrate install` on an existing deployment would unconditionally regenerate secrets. Rotating `BETTER_AUTH_SECRET` silently invalidated every session; rotating `CONNECTION_ENCRYPTION_KEY` silently bricked every `provider_credentials` row (AES-256-GCM auth-tag mismatch, tokens unrecoverable). New `lib/install/upgrade.ts` restores the `determine_install_mode` / `merge_env` / `rollback_upgrade` semantics the bash installer had: detect → prompt → backup → merge (existing wins) → run → on failure restore.

### CI integration
- `test.yml` unit job now runs the `apps/cli/test/` suite (146 tests) — previously excluded from CI.

## Test plan

- [x] `bun run check` green across all 15 monorepo tasks
- [x] `bun test` in `apps/cli/` → 146 pass
- [x] `actionlint` green on modified workflows
- [x] Local smoke test of `bootstrap.sh` verification path against a local HTTP server with throwaway keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)