### PR TITLE
fix(cli,oidc): accept form-urlencoded on /device/{code,token} per RFC 8628 (closes #166)

### DIFF
--- a/apps/api/src/lib/auth-pipeline.ts
+++ b/apps/api/src/lib/auth-pipeline.ts
@@ -63,8 +63,17 @@ export function applyAuthPipeline(app: Hono<AppEnv>, opts: AuthPipelineOptions):
   const { publicPaths, authStrategies } = opts;
 
   // Mount Better Auth handler — handles signup, signin, session, etc.
-  app.on(["POST", "GET"], "/api/auth/*", (c) => {
-    return getAuth().handler(c.req.raw);
+  //
+  // Device-flow shim: RFC 8628 §3.2 + §3.4 specify
+  // `application/x-www-form-urlencoded` as the required content type for
+  // `/device/code` + `/device/token`, but Better Auth's `better-call`
+  // router currently accepts only JSON. We rewrite form-urlencoded bodies
+  // into JSON on the fly so the server is tolerant of BOTH content types
+  // (RFC-compliant clients succeed, older JSON-sending binaries keep
+  // working). Tracked in https://github.com/appstrate/appstrate/issues/166.
+  app.on(["POST", "GET"], "/api/auth/*", async (c) => {
+    const req = await maybeTransformDeviceFlowFormBody(c.req.raw);
+    return getAuth().handler(req);
   });
 
   // Auth middleware: module strategies → Bearer API key → session cookie.
@@ -273,6 +282,46 @@ export function skipAuth(path: string, publicPaths: Set<string>): boolean {
   if (path === "/api/docs" || path === "/api/openapi.json") return true;
   if (publicPaths.has(path)) return true; // module-contributed public paths
   return false;
+}
+
+/**
+ * Device-flow content-type shim.
+ *
+ * RFC 8628 specifies `application/x-www-form-urlencoded` at `/device/code`
+ * and `/device/token`, but Better Auth's `better-call` router only accepts
+ * JSON. If the incoming request targets one of those two paths with a
+ * form-urlencoded body, we parse the body, rewrite it as JSON, and return
+ * a fresh Request with `Content-Type: application/json`. All other
+ * requests (including the existing JSON clients) pass through unchanged.
+ *
+ * Exported for unit testing — the transform has no side effects.
+ */
+export async function maybeTransformDeviceFlowFormBody(req: Request): Promise<Request> {
+  if (req.method !== "POST") return req;
+  const url = new URL(req.url);
+  if (url.pathname !== "/api/auth/device/code" && url.pathname !== "/api/auth/device/token") {
+    return req;
+  }
+  const contentType = req.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().startsWith("application/x-www-form-urlencoded")) {
+    return req;
+  }
+  const raw = await req.text();
+  const params = new URLSearchParams(raw);
+  const body: Record<string, string> = {};
+  for (const [key, value] of params.entries()) body[key] = value;
+  const headers = new Headers(req.headers);
+  headers.set("content-type", "application/json");
+  // Let fetch/BA recompute the length from the new body.
+  headers.delete("content-length");
+  return new Request(req.url, {
+    method: req.method,
+    headers,
+    body: JSON.stringify(body),
+    // Preserve non-body fields. Request has no `duplex` reflection, but we
+    // already consumed the original body so the replacement is a complete
+    // new request — no streaming to preserve.
+  });
 }
 
 /** Paths that need auth but not org-context (user-scoped or self-resolving). */

--- a/apps/api/src/modules/oidc/openapi/paths.ts
+++ b/apps/api/src/modules/oidc/openapi/paths.ts
@@ -765,10 +765,23 @@ export const oidcPaths = {
       operationId: "deviceAuthorizationCode",
       summary: "Request a device + user code (RFC 8628 §3.2)",
       description:
-        "Initiates a device-authorization grant. The CLI calls this first and receives a short `user_code` to display plus an opaque `device_code` to poll `/api/auth/device/token` with. Mounted by Better Auth's `deviceAuthorization()` plugin; CLI clients are gated by `validateClient` — only OAuth clients registered with the device-code grant are accepted. **Note:** RFC 8628 §3.2 specifies `application/x-www-form-urlencoded`, but Better Auth's `better-call` router only accepts JSON. Third-party clients must send `application/json` to interoperate with this instance.",
+        "Initiates a device-authorization grant. The CLI calls this first and receives a short `user_code` to display plus an opaque `device_code` to poll `/api/auth/device/token` with. Accepts both `application/x-www-form-urlencoded` (RFC 8628 §3.2, preferred) and `application/json` — the server normalizes form-urlencoded bodies to JSON before Better Auth's `deviceAuthorization()` plugin sees them. Clients are gated by `validateClient` — only OAuth clients registered with the device-code grant are accepted.",
       requestBody: {
         required: true,
         content: {
+          "application/x-www-form-urlencoded": {
+            schema: {
+              type: "object",
+              required: ["client_id"],
+              properties: {
+                client_id: { type: "string", description: "Public client identifier." },
+                scope: {
+                  type: "string",
+                  description: "Space-separated scopes. Defaults to the client's registered set.",
+                },
+              },
+            },
+          },
           "application/json": {
             schema: {
               type: "object",
@@ -834,10 +847,24 @@ export const oidcPaths = {
       operationId: "deviceAuthorizationToken",
       summary: "Exchange approved device_code for an access token (RFC 8628 §3.4)",
       description:
-        "Polled by the CLI until the user approves or the code expires. On success, returns a BA session token as `access_token`. The token is opaque (not a JWT) and must be sent back as `Authorization: Bearer <token>` on subsequent requests. **Note:** RFC 8628 §3.4 specifies `application/x-www-form-urlencoded`, but Better Auth's `better-call` router only accepts JSON. Third-party clients must send `application/json` to interoperate with this instance.",
+        "Polled by the CLI until the user approves or the code expires. On success, returns a BA session token as `access_token`. The token is opaque (not a JWT) and must be sent back as `Authorization: Bearer <token>` on subsequent requests. Accepts both `application/x-www-form-urlencoded` (RFC 8628 §3.4, preferred) and `application/json` — the server normalizes form-urlencoded bodies to JSON before Better Auth's `deviceAuthorization()` plugin sees them.",
       requestBody: {
         required: true,
         content: {
+          "application/x-www-form-urlencoded": {
+            schema: {
+              type: "object",
+              required: ["grant_type", "device_code", "client_id"],
+              properties: {
+                grant_type: {
+                  type: "string",
+                  enum: ["urn:ietf:params:oauth:grant-type:device_code"],
+                },
+                device_code: { type: "string" },
+                client_id: { type: "string" },
+              },
+            },
+          },
           "application/json": {
             schema: {
               type: "object",

--- a/apps/api/src/modules/oidc/test/integration/services/device-flow.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/device-flow.test.ts
@@ -151,6 +151,62 @@ describe("device-flow happy path", () => {
     expect(rowAfter).toBeUndefined();
   });
 
+  it("accepts application/x-www-form-urlencoded at /device/code + /device/token (RFC 8628 §3.2/§3.4)", async () => {
+    const { cookie } = await signUpPlatformUser();
+
+    // /device/code with form-urlencoded body — the platform-level shim
+    // rewrites it to JSON before Better Auth's deviceAuthorization()
+    // plugin sees the request.
+    const codeRes = await app.request("/api/auth/device/code", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        client_id: "appstrate-cli",
+        scope: "openid profile email offline_access",
+      }).toString(),
+    });
+    expect(codeRes.status).toBe(200);
+    const code = (await codeRes.json()) as {
+      device_code: string;
+      user_code: string;
+    };
+    expect(code.device_code).toBeTruthy();
+
+    // Approve with the platform user's session so the next /device/token
+    // call returns the access token (not authorization_pending).
+    const approveRes = await app.request("/api/auth/device/approve", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Cookie: cookie },
+      body: JSON.stringify({ userCode: code.user_code }),
+    });
+    expect(approveRes.status).toBe(200);
+
+    // Rewind lastPolledAt so the next poll doesn't trip the §5.5 slow_down
+    // throttle — same rationale as the happy-path test.
+    await db
+      .update(deviceCode)
+      .set({ lastPolledAt: new Date(Date.now() - 10_000) })
+      .where(eq(deviceCode.deviceCode, code.device_code));
+
+    // /device/token with form-urlencoded body.
+    const tokenRes = await app.request("/api/auth/device/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        device_code: code.device_code,
+        client_id: "appstrate-cli",
+      }).toString(),
+    });
+    expect(tokenRes.status).toBe(200);
+    const tokenBody = (await tokenRes.json()) as {
+      access_token: string;
+      token_type: string;
+    };
+    expect(tokenBody.access_token).toBeTruthy();
+    expect(tokenBody.token_type).toBe("Bearer");
+  });
+
   it("rejects unknown client_id with invalid_client", async () => {
     const res = await app.request("/api/auth/device/code", {
       method: "POST",

--- a/apps/api/test/unit/device-flow-formdata-shim.test.ts
+++ b/apps/api/test/unit/device-flow-formdata-shim.test.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `maybeTransformDeviceFlowFormBody` — the platform-level
+ * shim that rewrites `application/x-www-form-urlencoded` bodies on
+ * `/api/auth/device/code` and `/api/auth/device/token` into JSON before
+ * Better Auth's `better-call` router (which only accepts JSON) sees the
+ * request. Belt-and-braces coverage for the pure transform — the
+ * end-to-end wiring is covered by the integration suite.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { maybeTransformDeviceFlowFormBody } from "../../src/lib/auth-pipeline.ts";
+
+function formRequest(url: string, body: Record<string, string>): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(body).toString(),
+  });
+}
+
+describe("maybeTransformDeviceFlowFormBody", () => {
+  it("rewrites form-urlencoded → JSON on /api/auth/device/code", async () => {
+    const original = formRequest("http://host/api/auth/device/code", {
+      client_id: "appstrate-cli",
+      scope: "openid profile email",
+    });
+    const transformed = await maybeTransformDeviceFlowFormBody(original);
+    expect(transformed.headers.get("content-type")).toBe("application/json");
+    const body = (await transformed.json()) as Record<string, string>;
+    expect(body).toEqual({
+      client_id: "appstrate-cli",
+      scope: "openid profile email",
+    });
+  });
+
+  it("rewrites form-urlencoded → JSON on /api/auth/device/token", async () => {
+    const original = formRequest("http://host/api/auth/device/token", {
+      grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+      device_code: "dc_123",
+      client_id: "appstrate-cli",
+    });
+    const transformed = await maybeTransformDeviceFlowFormBody(original);
+    expect(transformed.headers.get("content-type")).toBe("application/json");
+    const body = (await transformed.json()) as Record<string, string>;
+    expect(body.grant_type).toBe("urn:ietf:params:oauth:grant-type:device_code");
+    expect(body.device_code).toBe("dc_123");
+    expect(body.client_id).toBe("appstrate-cli");
+  });
+
+  it("preserves JSON bodies untouched (tolerant server also accepts JSON)", async () => {
+    const original = new Request("http://host/api/auth/device/code", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ client_id: "appstrate-cli" }),
+    });
+    const transformed = await maybeTransformDeviceFlowFormBody(original);
+    // Same instance — no rewrite needed.
+    expect(transformed).toBe(original);
+  });
+
+  it("ignores non-device paths even with form-urlencoded", async () => {
+    const original = formRequest("http://host/api/auth/sign-in/email", {
+      email: "a@b.c",
+      password: "x",
+    });
+    const transformed = await maybeTransformDeviceFlowFormBody(original);
+    expect(transformed).toBe(original);
+  });
+
+  it("ignores non-POST methods on device paths", async () => {
+    const original = new Request("http://host/api/auth/device/code", {
+      method: "GET",
+    });
+    const transformed = await maybeTransformDeviceFlowFormBody(original);
+    expect(transformed).toBe(original);
+  });
+
+  it("tolerates content-type with parameters (charset, boundary)", async () => {
+    const original = new Request("http://host/api/auth/device/code", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded; charset=utf-8" },
+      body: new URLSearchParams({ client_id: "cli" }).toString(),
+    });
+    const transformed = await maybeTransformDeviceFlowFormBody(original);
+    expect(transformed.headers.get("content-type")).toBe("application/json");
+    const body = (await transformed.json()) as Record<string, string>;
+    expect(body.client_id).toBe("cli");
+  });
+
+  it("is case-insensitive on the content-type match", async () => {
+    const original = new Request("http://host/api/auth/device/token", {
+      method: "POST",
+      headers: { "Content-Type": "Application/X-WWW-Form-UrlEncoded" },
+      body: new URLSearchParams({ client_id: "cli" }).toString(),
+    });
+    const transformed = await maybeTransformDeviceFlowFormBody(original);
+    expect(transformed.headers.get("content-type")).toBe("application/json");
+  });
+});

--- a/apps/cli/src/lib/device-flow.ts
+++ b/apps/cli/src/lib/device-flow.ts
@@ -73,21 +73,23 @@ interface RawErrorBody {
 /**
  * RFC 8628 §3.2 — initiate the grant.
  *
- * RFC 8628 specifies `application/x-www-form-urlencoded` for both
- * endpoints, but Better Auth's plugin accepts only JSON (its
- * `better-call` router rejects form-urlencoded with 415 in production).
- * Since both sides ship lockstep-versioned from this monorepo, we send
- * JSON to match the server rather than ask for an upstream RFC fix.
+ * Body is `application/x-www-form-urlencoded` per the spec. The Appstrate
+ * server accepts both form-urlencoded and JSON at these endpoints (a
+ * platform-level shim transforms form-urlencoded → JSON before Better
+ * Auth's `better-call` router sees the request). Sticking to the RFC
+ * content type here keeps the CLI interoperable with any standards-
+ * compliant OIDC server as well.
  */
 export async function startDeviceFlow(
   instance: string,
   clientId: string,
   scope: string,
 ): Promise<DeviceCodeResponse> {
+  const body = new URLSearchParams({ client_id: clientId, scope });
   const res = await fetch(`${normalizeInstance(instance)}/api/auth/device/code`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ client_id: clientId, scope }),
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
   });
   if (!res.ok) {
     const err = await parseErrorBody(res);
@@ -157,13 +159,14 @@ export async function pollDeviceFlow(
     opts.delayFn ??
     ((ms: number, signal?: AbortSignal) => delay(ms, undefined, { signal }).then(() => undefined));
 
-  // JSON body — see the note on `startDeviceFlow` for why we don't use
-  // `application/x-www-form-urlencoded` here despite the RFC wording.
-  const body = JSON.stringify({
+  // Form-urlencoded body per RFC 8628 §3.4. Server accepts both content
+  // types; we stick to the RFC so the CLI interoperates with any
+  // standards-compliant OIDC provider.
+  const body = new URLSearchParams({
     grant_type: "urn:ietf:params:oauth:grant-type:device_code",
     device_code: deviceCode,
     client_id: clientId,
-  });
+  }).toString();
 
   while (Date.now() < deadline) {
     if (opts.signal?.aborted) {
@@ -179,7 +182,7 @@ export async function pollDeviceFlow(
 
     const res = await fetch(`${normalizeInstance(instance)}/api/auth/device/token`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
       body,
     });
 

--- a/apps/cli/test/device-flow.test.ts
+++ b/apps/cli/test/device-flow.test.ts
@@ -34,7 +34,7 @@ function jsonResponse(status: number, body: unknown): Response {
 }
 
 describe("startDeviceFlow", () => {
-  it("posts JSON body and maps snake_case → camelCase", async () => {
+  it("posts form-urlencoded body (RFC 8628 §3.2) and maps snake_case → camelCase", async () => {
     let capturedUrl: string | undefined;
     let capturedBody: string | undefined;
     let capturedContentType: string | null | undefined;
@@ -54,11 +54,10 @@ describe("startDeviceFlow", () => {
 
     const result = await startDeviceFlow("https://app", "appstrate-cli", "openid profile");
     expect(capturedUrl).toBe("https://app/api/auth/device/code");
-    expect(capturedContentType).toBe("application/json");
-    expect(JSON.parse(capturedBody!)).toEqual({
-      client_id: "appstrate-cli",
-      scope: "openid profile",
-    });
+    expect(capturedContentType).toBe("application/x-www-form-urlencoded");
+    const parsed = new URLSearchParams(capturedBody!);
+    expect(parsed.get("client_id")).toBe("appstrate-cli");
+    expect(parsed.get("scope")).toBe("openid profile");
     expect(result).toEqual({
       deviceCode: "dc1",
       userCode: "ABCDEFGH",
@@ -118,6 +117,30 @@ describe("pollDeviceFlow", () => {
       expiresIn: 600,
       scope: "openid profile",
     });
+  });
+
+  it("posts form-urlencoded body (RFC 8628 §3.4) with grant_type + device_code + client_id", async () => {
+    let capturedContentType: string | null | undefined;
+    let capturedBody: string | undefined;
+    installFetch(async (_input, init) => {
+      capturedContentType = (init?.headers as Record<string, string>)?.["Content-Type"];
+      capturedBody = init?.body as string;
+      return jsonResponse(200, {
+        access_token: "tok",
+        token_type: "Bearer",
+        expires_in: 60,
+        scope: "",
+      });
+    });
+    await pollDeviceFlow("https://app", "device-code-123", "appstrate-cli", {
+      interval: 0,
+      expiresIn: 60,
+    });
+    expect(capturedContentType).toBe("application/x-www-form-urlencoded");
+    const parsed = new URLSearchParams(capturedBody!);
+    expect(parsed.get("grant_type")).toBe("urn:ietf:params:oauth:grant-type:device_code");
+    expect(parsed.get("device_code")).toBe("device-code-123");
+    expect(parsed.get("client_id")).toBe("appstrate-cli");
   });
 
   it("loops on authorization_pending then returns the token", async () => {


### PR DESCRIPTION
## Summary

Closes #166. The CLI device-flow no longer deviates from RFC 8628:

- **Server** is now tolerant of both `application/x-www-form-urlencoded` (RFC 8628 §3.2 / §3.4) and `application/json` at `/api/auth/device/code` + `/api/auth/device/token`. A thin shim in `apps/api/src/lib/auth-pipeline.ts` rewrites form-urlencoded bodies to JSON before Better Auth's `better-call` router sees them (BA upstream still only accepts JSON — unchanged).
- **CLI** switched to form-urlencoded as the primary content type so the binary interoperates with any standards-compliant OIDC provider, not just Appstrate instances. Existing JSON-sending CLI binaries in the wild keep working because the shim is purely additive.
- **OpenAPI spec** declares both content types on the two endpoints; the `Note: … must send application/json` deviation prose is dropped.

## Why this direction

Issue #166's original acceptance criterion asked for an upstream Better Auth fix. That's the right long-term move, but it's a hard external blocker. Meanwhile we can achieve every other acceptance criterion today by making the **server tolerant at the platform layer** — a ~40-line pure transform sitting in front of BA's catch-all. The upstream fix can still land later (remove the shim + send form-urlencoded to BA directly) without breaking any client that migrated in the interim.

## Scope

- \`apps/api/src/lib/auth-pipeline.ts\` — \`maybeTransformDeviceFlowFormBody\` (exported for unit coverage), wired inline into the existing BA catch-all. No new route registration, no ordering concerns.
- \`apps/cli/src/lib/device-flow.ts\` — body built with \`URLSearchParams\`; \`Content-Type: application/x-www-form-urlencoded\`. Deviation comments removed.
- \`apps/api/src/modules/oidc/openapi/paths.ts\` — \`requestBody.content\` declares both media types; deviation prose dropped from the endpoint descriptions.
- **Tests**
  - \`apps/api/test/unit/device-flow-formdata-shim.test.ts\` — 7 unit cases covering the pure transform (both paths, JSON passthrough, non-POST, non-device path, content-type with charset, case-insensitive match).
  - \`apps/api/src/modules/oidc/test/integration/services/device-flow.test.ts\` — new integration case that runs the full code → approve → token dance with form-urlencoded bodies end-to-end (hits the real BA plugin through the shim).
  - \`apps/cli/test/device-flow.test.ts\` — updated CLI assertions on the outgoing \`Content-Type\` + body encoding for both \`startDeviceFlow\` and \`pollDeviceFlow\`.

## Acceptance criteria from #166

- [x] CLI sends form-urlencoded as the primary content type
- [x] Server tolerates both content types for backward compat with pre-fix CLI binaries
- [x] OpenAPI spec no longer declares a protocol deviation for these endpoints
- [ ] Better Auth upstream accepts form-urlencoded — still open upstream; tracked via the comment in \`auth-pipeline.ts\`. Once landed, the shim can be removed in a follow-up.
- [ ] ADR-006 updated — the ADR itself never carried a deviation section (the prose lived only in OpenAPI + \`device-flow.ts\`), so no edit needed there.

## Test plan

- [x] \`bun run check\` (turbo check + OpenAPI validation, 237 endpoints)
- [x] \`bun test apps/api/src/modules/oidc apps/cli/test\` — 502 pass, 0 fail
- [x] \`bun test apps/api/test\` — 1450 pass, 0 fail
- [ ] Manual smoke: \`appstrate login\` against a local dev instance (both content-type paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)