### PR TITLE
feat(cli): publish @appstrate/cli to npm

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,89 @@
+name: Publish @appstrate/cli to npm
+
+# The CLI keeps `version: "0.0.0"` in the repo as a dev-build sentinel
+# (see `apps/cli/src/lib/version.ts::DEV_CLI_VERSION`). This workflow
+# rewrites `package.json` from the tag immediately before publishing so
+# a released tarball carries the real version, while source checkouts
+# keep tripping the dev guard that refuses to pull untagged GHCR images.
+
+on:
+  push:
+    tags:
+      - "cli@*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish (manual dispatch only, e.g. 1.0.0-alpha.53)"
+        required: true
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    name: Quality, Tests & Publish
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/cli
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.9"
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+        working-directory: .
+
+      - name: TypeScript type-check
+        run: bun run typecheck
+
+      - name: Tests
+        run: bun run test
+
+      - name: Resolve publish version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${GITHUB_REF_NAME#cli@}"
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not resolve publish version"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Write tag version into package.json
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp
+          mv package.json.tmp package.json
+          echo "Publishing @appstrate/cli@$VERSION"
+          jq '.version' package.json
+
+      - name: Publish to npm
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Smoke-test published version
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          bunx -y "@appstrate/cli@${VERSION}" --help
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          generate_release_notes: true

--- a/apps/cli/LICENSE
+++ b/apps/cli/LICENSE
@@ -1,0 +1,190 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Appstrate
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/apps/cli/NOTICE
+++ b/apps/cli/NOTICE
@@ -1,0 +1,5 @@
+Appstrate CLI
+Copyright 2025-2026 Appstrate
+
+This product includes software developed at
+Appstrate (https://appstrate.dev).

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,9 +4,40 @@
   "description": "Official CLI for Appstrate — install, login, and manage your instance",
   "license": "Apache-2.0",
   "type": "module",
+  "engines": {
+    "bun": ">=1.3.9"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "author": "Appstrate <hello@appstrate.dev>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appstrate/appstrate.git",
+    "directory": "apps/cli"
+  },
+  "homepage": "https://github.com/appstrate/appstrate/tree/main/apps/cli",
+  "bugs": {
+    "url": "https://github.com/appstrate/appstrate/issues"
+  },
+  "keywords": [
+    "appstrate",
+    "cli",
+    "bunx",
+    "device-flow",
+    "oauth",
+    "self-hosting"
+  ],
   "bin": {
     "appstrate": "./src/cli.ts"
   },
+  "files": [
+    "src",
+    "README.md",
+    "LICENSE",
+    "NOTICE"
+  ],
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test test/",


### PR DESCRIPTION
Closes #163.

## Summary
- Adds `.github/workflows/publish-cli.yml` triggered on `cli@*` tag push (+ manual dispatch), mirroring `publish-core.yml` / `publish-ui.yml`
- Aligns `apps/cli/package.json` metadata with `@appstrate/core` / `@appstrate/ui` (`publishConfig.provenance`, `engines.bun`, `files` allowlist, repository/homepage/bugs, keywords)
- Copies `LICENSE` + adds `NOTICE` alongside the CLI sources so npm tarballs ship the Apache-2.0 license inline

## Version strategy

`apps/cli/package.json` keeps `"version": "0.0.0"` in the repo as a dev-build sentinel (`DEV_CLI_VERSION` in `src/lib/version.ts:20`). The guard at `resolveDockerImageTag` (`src/lib/version.ts:34-53`) + the skip at `commands/install.ts:406` both refuse to pull untagged GHCR images when `CLI_VERSION === "0.0.0"` — which is the correct behavior for anyone running the CLI from a source checkout.

The workflow resolves the version from the tag (`cli@X.Y.Z` → `X.Y.Z`), rewrites `package.json.version` with `jq` right before `npm publish`, and publishes with provenance. Source checkouts keep tripping the dev guard; released tarballs carry real versions. Two tests in `test/install/secrets.test.ts` already pin this contract.

## First-release mechanics

The scope `@appstrate/cli` does not yet exist on npm (verified: `npm view @appstrate/cli` → 404). The very first `npm publish` must be done manually from a local clone with `npm publish --access public --provenance` to claim the scope — CI cannot create a scoped package on first push. Every subsequent `cli@*` tag publishes through this workflow using the existing `NPM_TOKEN` secret (same one `publish-core.yml` / `publish-ui.yml` consume).

## Acceptance per #163

- [x] New `.github/workflows/publish-cli.yml` on `cli@*` tags
- [x] Tag → package.json version synchronization (written from tag at publish time)
- [x] `bun test` + `bun run typecheck` before publish
- [x] Smoke test post-publish: `bunx -y @appstrate/cli@<version> --help`
- [x] LICENSE + NOTICE shipped in the tarball (`files` allowlist)
- [ ] Restore `bunx @appstrate/cli install` hint in `bootstrap.sh` — already present at `scripts/bootstrap.sh:70`, no change needed
- [ ] Docs update — deferred to a follow-up once the scope is claimed and a first tag cut

## Verification

- `bun run check` — 15/15 green
- `bun run test` (apps/cli) — 252 pass, 0 fail
- `npm pack --dry-run` — 22 files, 58.9 kB, LICENSE + NOTICE + README + src/ only (no tests, no CI probe)

## Test plan

- [ ] After merge: `cd apps/cli && npm publish --access public --provenance` (manual, first release only, claims scope)
- [ ] Then: `git tag cli@<version> && git push origin cli@<version>` triggers workflow
- [ ] Verify workflow green, `bunx @appstrate/cli@<version> --help` prints usage
- [ ] Separate PR: update root README + self-hosting docs to list `bunx` as Windows / Bun-users alternative

🤖 Generated with [Claude Code](https://claude.com/claude-code)