### PR TITLE
fix(cli): bundle at publish time so npm tarball carries inlined assets

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -72,12 +72,31 @@ jobs:
           echo "Publishing @appstrate/cli@$VERSION"
           jq '.version' package.json
 
+      - name: Pre-publish smoke test (pack + install + run locally)
+        # Build the tarball with `npm pack` (triggers `prepack` →
+        # `bun run build`), install it into a throwaway directory, and
+        # invoke the bin. This mirrors exactly what a consumer gets from
+        # `bunx @appstrate/cli`. If the bundle is broken or missing
+        # inlined assets (the #175 regression), we fail BEFORE polluting
+        # the npm registry — unlike a post-publish smoke test, this
+        # failure mode is recoverable without `npm deprecate`.
+        run: |
+          npm pack
+          TARBALL="$(ls appstrate-cli-*.tgz | head -1)"
+          WORK="$(mktemp -d)"
+          (cd "$WORK" && npm init -y >/dev/null && npm install "${GITHUB_WORKSPACE}/apps/cli/$TARBALL")
+          "$WORK/node_modules/.bin/appstrate" --help
+          rm -rf "$WORK" "$TARBALL" dist
+
       - name: Publish to npm
         run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Smoke-test published version
+      - name: Post-publish smoke test (registry → bunx)
+        # Belt-and-suspenders check: pull from the actual registry and
+        # run via bunx. Catches cases where the tarball is correct but
+        # npm registry metadata is wrong (bin field dropped, etc).
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           bunx -y "@appstrate/cli@${VERSION}" --help

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -30,10 +30,10 @@
     "self-hosting"
   ],
   "bin": {
-    "appstrate": "./src/cli.ts"
+    "appstrate": "./dist/cli.js"
   },
   "files": [
-    "src",
+    "dist",
     "README.md",
     "LICENSE",
     "NOTICE"
@@ -41,7 +41,8 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test test/",
-    "build": "bun build --target=bun --outdir=dist src/cli.ts"
+    "build": "bun build --target=bun --packages external --outdir=dist src/cli.ts",
+    "prepack": "bun run build"
   },
   "dependencies": {
     "@clack/prompts": "^1.2.0",

--- a/apps/cli/test/bundle.test.ts
+++ b/apps/cli/test/bundle.test.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Bundle integrity test.
+ *
+ * `apps/cli/src/lib/install/tier123.ts` imports three docker-compose
+ * templates via Bun's `with { type: "text" }` attribute from
+ * `../../../../../examples/self-hosting/` — a path OUTSIDE the package
+ * directory. That works for the source `.ts` run (dev) AND the compiled
+ * binary (`bun build --compile` in `release.yml`) because the YAML is
+ * resolved at build time in both cases.
+ *
+ * It does NOT work for the npm tarball: `files` in `package.json` is
+ * restricted to the package directory, so the out-of-package YAML never
+ * makes it into the shipped artefact. `package.json::prepack` covers
+ * this by running `bun build --target=bun --packages external` to
+ * produce a bundled `dist/cli.js` with every YAML inlined as a string
+ * literal.
+ *
+ * The 0.0.0 release on npm was broken because it shipped raw `src/` and
+ * `bunx @appstrate/cli --help` exploded with:
+ *
+ *   Cannot find module '../../../../../examples/self-hosting/docker-compose.tier1.yml'
+ *
+ * This test exists so that regression can NEVER ship again. It:
+ *   1. Runs the same `bun run build` command `prepack` triggers.
+ *   2. Asserts the bundle exists with the expected shebang.
+ *   3. Greps the bundle for signatures from each of the three YAML
+ *      templates — if any tier is missing, YAML inlining regressed.
+ *   4. Spawns the bundle with `--help` and asserts it prints usage.
+ *
+ * If this test breaks, `bunx @appstrate/cli` will break for users. Do
+ * not skip or delete — fix the underlying cause.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const cliRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const distDir = join(cliRoot, "dist");
+const bundlePath = join(distDir, "cli.js");
+
+describe("npm bundle", () => {
+  beforeAll(() => {
+    // Match `prepack` exactly — if this command drifts from
+    // `package.json::scripts.build`, the test no longer protects npm
+    // publishes. Keep them in lockstep.
+    const res = spawnSync("bun", ["run", "build"], {
+      cwd: cliRoot,
+      stdio: "pipe",
+    });
+    if (res.status !== 0) {
+      throw new Error(
+        `bun run build failed (exit ${res.status}):\n` +
+          `stdout: ${res.stdout?.toString()}\n` +
+          `stderr: ${res.stderr?.toString()}`,
+      );
+    }
+  });
+
+  afterAll(() => {
+    // Local dev/CI cleanliness — `dist/` is gitignored but leaving it
+    // behind leaks into other test runs that might rebuild and see
+    // stale content.
+    rmSync(distDir, { recursive: true, force: true });
+  });
+
+  it("produces dist/cli.js with a Bun shebang", () => {
+    expect(existsSync(bundlePath)).toBe(true);
+    const head = readFileSync(bundlePath, "utf8").slice(0, 30);
+    // `bunx` / `npm install` chmods bin +x and invokes via the shebang,
+    // so a missing/wrong shebang breaks post-install invocation.
+    expect(head.startsWith("#!/usr/bin/env bun")).toBe(true);
+  });
+
+  it("inlines all three docker-compose tier templates", () => {
+    const bundle = readFileSync(bundlePath, "utf8");
+    // Tier-specific signatures chosen so each string appears in EXACTLY
+    // one of the three YAMLs — a cross-tier match wouldn't prove the
+    // missing tier is actually inlined.
+    //   - Tier 1 adds Postgres only   → `POSTGRES_PASSWORD` (also in 2/3, but absent means broken)
+    //   - Tier 2 adds Redis           → `redis:7-alpine`
+    //   - Tier 3 adds MinIO           → `MINIO_ROOT_PASSWORD`
+    expect(bundle).toContain("POSTGRES_PASSWORD");
+    expect(bundle).toContain("redis:7-alpine");
+    expect(bundle).toContain("MINIO_ROOT_PASSWORD");
+  });
+
+  it("runs --help via the bundle and exits cleanly", () => {
+    const res = spawnSync("bun", [bundlePath, "--help"], {
+      stdio: "pipe",
+      // Isolate from the dev `APPSTRATE_PROFILE` / config so the
+      // command resolution is deterministic across contributor machines.
+      env: { ...process.env, APPSTRATE_PROFILE: "" },
+    });
+    expect(res.status).toBe(0);
+    const out = res.stdout.toString();
+    // `commander` prints this header for the program root — a change
+    // here means the bin entry wasn't the CLI we expected.
+    expect(out).toContain("Usage: appstrate");
+    // Sanity: the four subcommands are wired in — regression if the
+    // bundle is missing a command module.
+    expect(out).toContain("install");
+    expect(out).toContain("login");
+    expect(out).toContain("logout");
+    expect(out).toContain("whoami");
+  });
+});


### PR DESCRIPTION
The 0.0.0 tarball that just landed on npm blows up at runtime:

\`\`\`
$ bunx -y @appstrate/cli@0.0.0 --help
error: Cannot find module '../../../../../examples/self-hosting/docker-compose.tier1.yml'
  from '.../node_modules/@appstrate/cli/src/lib/install/tier123.ts'
\`\`\`

## Why

\`src/lib/install/tier123.ts:16-18\` imports three compose templates out-of-package via Bun's \`with { type: "text" }\` attribute. The compiled binary (\`release.yml\` → \`bun build --compile\`) inlines them at build time, but the npm tarball from #174 shipped raw \`src/\` with a path pointing five levels up — outside the package directory, which npm's \`files\` allowlist cannot reach.

## Fix

Bundle at publish time. This is the standard pattern for npm CLIs (vercel, pnpm, wrangler, create-next-app all publish bundled output) — nothing exotic.

- \`prepack\` runs \`bun run build\` automatically before every \`npm publish\` — no workflow change needed, npm triggers prepack before packing
- \`build\`: \`bun build --target=bun --packages external --outdir=dist src/cli.ts\`
  - Inlines the YAML templates and every local module
  - Keeps \`dependencies\` as runtime \`require\`s so \`@napi-rs/keyring-<platform>\` bindings resolve through the consumer's \`node_modules\` at install time
  - Preserves the \`#!/usr/bin/env bun\` shebang
- \`bin.appstrate\` → \`./dist/cli.js\` (was \`./src/cli.ts\`)
- \`files\` → \`dist\` (was \`src\`)

Local dev (\`bun src/cli.ts …\`) still runs straight from source — the bundle path only matters for the published tarball.

## Verification

| Metric | Before (0.0.0) | After |
|---|---|---|
| Tarball files | 22 (\`src/\` tree) | 5 (\`dist/cli.js\` + docs) |
| Packed size | 58.9 kB | 29.6 kB |
| Unpacked size | 174.5 kB | 107.6 kB |
| \`bunx @appstrate/cli --help\` | ❌ | ✅ |

End-to-end:
\`\`\`sh
npm pack                             # produces appstrate-cli-0.0.0.tgz
cd /tmp && npm init -y && npm install /path/to/tgz
./node_modules/.bin/appstrate --help # ✅ prints usage
\`\`\`

\`bun run check\` 15/15 green. 252 CLI tests pass.

## Next steps (manual, after merge)

1. \`gh workflow run publish-cli.yml -f version=1.0.0-alpha.53 --ref main\` — publishes a good version with provenance (OIDC via GitHub Actions)
2. \`npm deprecate @appstrate/cli@0.0.0 "Broken tarball — use 1.0.0-alpha.53 or newer"\` — warns anyone who pinned 0.0.0

## Test plan

- [ ] Workflow dispatch publishes successfully with provenance
- [ ] \`bunx @appstrate/cli@<version> --help\` succeeds
- [ ] \`bunx @appstrate/cli@<version> install --tier 0\` reaches at least the tier-selection prompt (validates YAML inlining)
- [ ] Deprecate 0.0.0

## Alternatives considered (+ why not)

- **Commit copies of YAMLs in \`apps/cli/templates/\` + CI parity test** — 17 kB duplication in git, two-step edit flow, DRY violation that will puzzle contributors
- **Move YAMLs to \`apps/cli/templates/\` as source of truth** — touches docs (\`examples/self-hosting/\` path references) and breaks external links to those files
- **\`prepare\` script that copies YAMLs at install / pre-publish** — fragile fresh-clone UX, relies on lifecycle scripts running reliably across bun/npm versions

Bundling is the boring, battle-tested choice and the ecosystem default for npm CLIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)