### PR TITLE
refactor(cli): rename npm package @appstrate/cli → appstrate

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,4 +1,4 @@
-name: Publish @appstrate/cli to npm
+name: Publish appstrate CLI to npm
 
 # The CLI keeps `version: "0.0.0"` in the repo as a dev-build sentinel
 # (see `apps/cli/src/lib/version.ts::DEV_CLI_VERSION`). This workflow
@@ -69,27 +69,28 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp
           mv package.json.tmp package.json
-          echo "Publishing @appstrate/cli@$VERSION"
+          echo "Publishing appstrate@$VERSION"
           jq '.version' package.json
 
       - name: Pre-publish smoke test (pack + install + run locally)
         # Build the tarball with `npm pack` (triggers `prepack` →
         # `bun run build`), install it into a throwaway directory, and
         # invoke the bin. This mirrors exactly what a consumer gets from
-        # `bunx @appstrate/cli`. If the bundle is broken or missing
+        # `bunx appstrate`. If the bundle is broken or missing
         # inlined assets (the #175 regression), we fail BEFORE polluting
         # the npm registry — unlike a post-publish smoke test, this
         # failure mode is recoverable without `npm deprecate`.
         run: |
           npm pack
-          TARBALL="$(ls appstrate-cli-*.tgz | head -1)"
+          TARBALL="$(ls appstrate-*.tgz | head -1)"
           WORK="$(mktemp -d)"
           (cd "$WORK" && npm init -y >/dev/null && npm install "${GITHUB_WORKSPACE}/apps/cli/$TARBALL")
           "$WORK/node_modules/.bin/appstrate" --help
           rm -rf "$WORK" "$TARBALL" dist
 
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        # Unscoped packages are public by default — no `--access public` needed.
+        run: npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
@@ -99,7 +100,7 @@ jobs:
         # npm registry metadata is wrong (bin field dropped, etc).
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          bunx -y "@appstrate/cli@${VERSION}" --help
+          bunx -y "appstrate@${VERSION}" --help
 
       - name: Create GitHub Release
         if: github.event_name == 'push'

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -82,7 +82,9 @@ jobs:
         # failure mode is recoverable without `npm deprecate`.
         run: |
           npm pack
-          TARBALL="$(ls appstrate-*.tgz | head -1)"
+          # `npm pack` names the tarball `<package>-<version>.tgz` deterministically;
+          # constructing the path is safer than globbing (shellcheck SC2012).
+          TARBALL="appstrate-${{ steps.version.outputs.version }}.tgz"
           WORK="$(mktemp -d)"
           (cd "$WORK" && npm init -y >/dev/null && npm install "${GITHUB_WORKSPACE}/apps/cli/$TARBALL")
           "$WORK/node_modules/.bin/appstrate" --help

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -14,7 +14,7 @@ curl -fsSL https://get.appstrate.dev | bash
 
 Detects your OS/arch, downloads the matching binary from [GitHub Releases](https://github.com/appstrate/appstrate/releases/latest), drops it at `/usr/local/bin/appstrate`, and immediately execs `appstrate install`.
 
-Supported: `darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`. **Windows is not a v1 target** — run the one-liner inside WSL2 (which reuses the `linux-x64` binary), or invoke `bunx @appstrate/cli install` natively if you already have Bun on Windows.
+Supported: `darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`. **Windows is not a v1 target** — run the one-liner inside WSL2 (which reuses the `linux-x64` binary), or invoke `bunx appstrate install` natively if you already have Bun on Windows.
 
 ### Alternate install paths
 
@@ -23,7 +23,7 @@ Supported: `darwin-arm64`, `darwin-x64`, `linux-x64`, `linux-arm64`. **Windows i
 curl -fsSL https://get.appstrate.dev/verify.sh | bash
 
 # Bun-native (if you already have Bun)
-bunx @appstrate/cli install
+bunx appstrate install
 ```
 
 See [`examples/self-hosting/README.md`](../../examples/self-hosting/README.md#verifying-the-installer) for signature verification details (minisign + SLSA build provenance).

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@appstrate/cli",
+  "name": "appstrate",
   "version": "0.0.0",
   "description": "Official CLI for Appstrate — install, login, and manage your instance",
   "license": "Apache-2.0",
@@ -8,7 +8,6 @@
     "bun": ">=1.3.9"
   },
   "publishConfig": {
-    "access": "public",
     "provenance": true
   },
   "author": "Appstrate <hello@appstrate.dev>",

--- a/apps/cli/test/bundle.test.ts
+++ b/apps/cli/test/bundle.test.ts
@@ -18,7 +18,7 @@
  * literal.
  *
  * The 0.0.0 release on npm was broken because it shipped raw `src/` and
- * `bunx @appstrate/cli --help` exploded with:
+ * `bunx appstrate --help` exploded with:
  *
  *   Cannot find module '../../../../../examples/self-hosting/docker-compose.tier1.yml'
  *
@@ -29,7 +29,7 @@
  *      templates — if any tier is missing, YAML inlining regressed.
  *   4. Spawns the bundle with `--help` and asserts it prints usage.
  *
- * If this test breaks, `bunx @appstrate/cli` will break for users. Do
+ * If this test breaks, `bunx appstrate` will break for users. Do
  * not skip or delete — fix the underlying cause.
  */
 

--- a/bun.lock
+++ b/bun.lock
@@ -70,10 +70,10 @@
       },
     },
     "apps/cli": {
-      "name": "@appstrate/cli",
+      "name": "appstrate",
       "version": "0.0.0",
       "bin": {
-        "appstrate": "./src/cli.ts",
+        "appstrate": "./dist/cli.js",
       },
       "dependencies": {
         "@clack/prompts": "^1.2.0",
@@ -299,8 +299,6 @@
     "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@14.2.1", "", { "dependencies": { "js-yaml": "^4.1.0" }, "peerDependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg=="],
 
     "@appstrate/api": ["@appstrate/api@workspace:apps/api"],
-
-    "@appstrate/cli": ["@appstrate/cli@workspace:apps/cli"],
 
     "@appstrate/connect": ["@appstrate/connect@workspace:packages/connect"],
 
@@ -1233,6 +1231,8 @@
     "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
+    "appstrate": ["appstrate@workspace:apps/cli"],
 
     "appstrate-pi-runtime": ["appstrate-pi-runtime@workspace:runtime-pi"],
 

--- a/docs/adr/ADR-006-cli-device-flow-monorepo.md
+++ b/docs/adr/ADR-006-cli-device-flow-monorepo.md
@@ -65,9 +65,9 @@ When the CLI **is** in the platform language AND the platform is open-source, th
 
 An official CLI, `appstrate`, distributed as:
 
-- An npm package `@appstrate/cli` (installable via `bunx @appstrate/cli …`).
+- An npm package `appstrate` (installable via `bunx appstrate …`).
 - Standalone single-binary builds for `linux-x64`, `linux-arm64`, `darwin-x64`, and `darwin-arm64`, produced by `bun build --compile --target=<target>` and attached to GitHub Releases. **Windows (`win32-x64`) is deliberately out of scope for v1** — the 2026 dev-tool baseline (Supabase, Railway, Fly, Neon, Wrangler) is WSL2 on Windows, which reuses the `linux-x64` binary. Shipping a native Windows build would double the `install` / `login` manual-test surface (Docker Desktop paths, CRLF line endings, Credential Manager quirks) for a user segment that is already well-served via WSL2. A native Windows binary can be added post-v1 by appending a `windows-latest` row to the release matrix if demand warrants.
-- A refactored `https://get.appstrate.dev` shell one-liner that detects OS/arch, downloads the matching binary to `/usr/local/bin/appstrate`, and chains into `appstrate install`. Windows users run the one-liner inside a WSL2 shell, or invoke `bunx @appstrate/cli install` natively if they already have Bun on Windows.
+- A refactored `https://get.appstrate.dev` shell one-liner that detects OS/arch, downloads the matching binary to `/usr/local/bin/appstrate`, and chains into `appstrate install`. Windows users run the one-liner inside a WSL2 shell, or invoke `bunx appstrate install` natively if they already have Bun on Windows.
 
 Version number tracks the platform release train (lockstep).
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -63,11 +63,11 @@ _appstrate_bootstrap() {
     *)
       # Windows is deliberately not a v1 target — see ADR-006 § Deliverable.
       # The recommended path on Windows is WSL2 (which reuses the linux-x64
-      # binary); `bunx @appstrate/cli install` is the Bun-native escape
+      # binary); `bunx appstrate install` is the Bun-native escape
       # hatch for users who have Bun but no WSL2. We fail loud here instead
       # of hinting at a flow this script doesn't handle.
       echo "Unsupported OS: $OS." >&2
-      echo "On Windows, run this inside WSL2 (recommended), or install natively via: bunx @appstrate/cli install" >&2
+      echo "On Windows, run this inside WSL2 (recommended), or install natively via: bunx appstrate install" >&2
       exit 1
       ;;
   esac


### PR DESCRIPTION
Aligns the CLI with the SOTA naming for Bun/Node CLIs: short unscoped package name that matches the binary.

## Why

`bunx @appstrate/cli` is awkward. Every recently-designed CLI in the ecosystem ships under a short unscoped name matching the bin:

| CLI | Package | Command |
|---|---|---|
| Supabase | `supabase` | `bunx supabase` |
| Vercel | `vercel` | `bunx vercel` |
| Cloudflare | `wrangler` | `bunx wrangler` |
| pnpm | `pnpm` | `bunx pnpm` |
| Turbo | `turbo` | `bunx turbo` |

The scoped `@scope/cli` + different bin pattern (`@angular/cli` → `ng`, `@nestjs/cli` → `nest`) is from 2016-2018 and forces users into `npx -p @scope/cli <bin>` or global installs.

Supabase is the closest structural match to Appstrate — they publish `supabase` (CLI, unscoped) alongside `@supabase/supabase-js` and other `@supabase/*` libs. Clean separation: **scoped for libs, unscoped for the end-user CLI**.

## Changes

- \`apps/cli/package.json\`: \`name\` → \`appstrate\`, drop \`publishConfig.access\` (unscoped packages are public by default)
- \`apps/cli/README.md\`, \`scripts/bootstrap.sh\`, \`docs/adr/ADR-006\`: update user-facing command examples
- \`apps/cli/test/bundle.test.ts\`: doc comments referencing the published name
- \`.github/workflows/publish-cli.yml\`: smoke test package ID + tarball glob, drop \`--access public\`, workflow display name
- \`bun.lock\`: regenerated

**No runtime/source change.** The binary command is still \`appstrate\`, the source layout is unchanged, 255 CLI tests pass unchanged.

## Verification

- \`bun run check\` 15/15 green
- \`bun run test\` in apps/cli — 255 pass (incl. \`bundle.test.ts\` which still validates the bundle)
- \`npm pack --dry-run\` — produces \`appstrate-0.0.0.tgz\`, 5 files, 29.6 kB (identical content to prior tarball)

## Post-merge plan

1. \`gh workflow run publish-cli.yml -f version=1.0.0-alpha.54 --ref main\` — publishes \`appstrate@1.0.0-alpha.54\` with provenance
2. \`npm deprecate @appstrate/cli@1.0.0-alpha.53 "Renamed to 'appstrate'. Use \`bunx appstrate\` instead."\` (needs OTP)
3. Users migrate from \`bunx @appstrate/cli …\` → \`bunx appstrate …\`

Only one version of \`@appstrate/cli\` ever existed (published 15 min ago, no external users yet) — deprecation cost is nil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)