### PR TITLE
chore(core): bump to 2.11.1

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -176,7 +176,7 @@
     },
     "packages/core": {
       "name": "@appstrate/core",
-      "version": "2.11.0",
+      "version": "2.11.1",
       "dependencies": {
         "@afps-spec/schema": "^1.3.1",
         "ajv": "^8.18.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `@appstrate/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.11.0] — Unreleased
+## [2.11.1] — 2026-04-18
 
 ### Changed
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Patch release for `@appstrate/core` shipping the validation-aggregation fix from #153.

## Why now

`core@2.11.0` was tagged on `e9ef75a2` (Apr 16) and is already on npm. The CHANGELOG entry labeled `[2.11.0] — Unreleased` actually describes commit `c202c5fc` (Apr 17, validation error aggregation in `validateManifest`), which landed AFTER the 2.11.0 tag. Renaming to `2.11.1` so the published version reflects what npm will actually receive.

## Changes

- `packages/core/package.json` → `2.11.1`
- `packages/core/CHANGELOG.md` → header renamed `[2.11.0] — Unreleased` → `[2.11.1] — 2026-04-18`
- `bun.lock` regenerated (no actual content change — workspace dep)

## Verification

- `bun run check` — 15/15 ✅
- `bun run generate:schemas` — no diff (only validation.ts logic changed, no exported schema)
- `bun test` — 2695 pass, 0 fail
- `bash scripts/docker-check.sh` — ALL CHECKS PASSED

## Post-merge

1. Tag `core@2.11.1` from `origin/main`
2. `publish-core.yml` → npm
3. Bump `^@appstrate/core` in `cloud/` and `registry/` lockfiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)