### PR TITLE
fix(cli): wire --version to CLI_VERSION instead of hard-coded 0.0.0

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -26,6 +26,7 @@ import { loginCommand } from "./commands/login.ts";
 import { logoutCommand } from "./commands/logout.ts";
 import { whoamiCommand } from "./commands/whoami.ts";
 import { exitWithError } from "./lib/ui.ts";
+import { CLI_VERSION } from "./lib/version.ts";
 
 // Catch stray unhandled rejections + uncaughts before Bun's default
 // stack-trace dump kicks in — commands are async and may throw after
@@ -38,7 +39,7 @@ const program = new Command();
 program
   .name("appstrate")
   .description("Official CLI for the Appstrate platform")
-  .version("0.0.0")
+  .version(CLI_VERSION)
   .option(
     "-p, --profile <name>",
     "Profile to use (overrides APPSTRATE_PROFILE / defaultProfile / 'default').",


### PR DESCRIPTION
## Why

\`apps/cli/src/cli.ts:41\` was passing the literal string \`\"0.0.0\"\` to commander, so \`appstrate --version\` always reported the dev sentinel — even after \`release.yml\`'s \"Stamp release version\" step rewrote \`apps/cli/package.json\` with the actual tag.

The bundled JSON import was correct (verified via \`strings\` on the alpha.54 binary — \`package_default.version === \"1.0.0-alpha.54\"\`), but commander never read it. Routing commander through the same \`CLI_VERSION\` import that the rest of the CLI uses makes the ADR-006 §\"Lockstep versioning\" invariant actually hold end-to-end.

## Why this only surfaced on alpha.54

The smoke-test step in \`release.yml\` (added in #154) caught this on the first release that exercised the \`build-cli\` matrix. #154 itself landed AFTER alpha.53 was tagged, which is why alpha.53 shipped successfully despite carrying the same bug.

Result for alpha.54: 3 Docker images + npm CLI + installer-pages all succeeded; 4 CLI binaries + GitHub Release failed. \`bunx appstrate@1.0.0-alpha.54\` works, \`curl https://get.appstrate.dev | bash\` does not.

## Fix

\`\`\`diff
+ import { CLI_VERSION } from \"./lib/version.ts\";
  ...
-   .version(\"0.0.0\")
+   .version(CLI_VERSION)
\`\`\`

## Verification

- \`bun run check\` 15/15 ✅
- \`bun test\` (apps/cli) — 255 pass
- Local repro: bumped \`package.json\` to \`1.0.0-test\`, ran \`bun build --compile --target=bun-darwin-arm64 src/cli.ts --outfile=/tmp/x\`, \`/tmp/x --version\` → \`1.0.0-test\`

## Post-merge

Tag \`v1.0.0-alpha.55\` + \`cli@1.0.0-alpha.55\` to ship the binaries + GH Release that alpha.54 missed. The 3 Docker images for alpha.54 already on GHCR are still consumable by Coolify; alpha.55 will publish the same set plus the missing artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)