### PR TITLE
fix(release): keyring probe accepts null on macOS + npm smoke retries

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -100,9 +100,24 @@ jobs:
         # Belt-and-suspenders check: pull from the actual registry and
         # run via bunx. Catches cases where the tarball is correct but
         # npm registry metadata is wrong (bin field dropped, etc).
+        #
+        # `npm publish` returns as soon as the registry accepts the
+        # tarball, but the version may take 30-90s to appear in the
+        # public CDN that `bunx` queries — alpha.55 saw a 404 from
+        # bunx ~10s after publish. Retry with backoff so a propagation
+        # delay doesn't fail the workflow.
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          bunx -y "appstrate@${VERSION}" --help
+          for attempt in 1 2 3 4 5 6; do
+            if bunx -y "appstrate@${VERSION}" --help; then
+              echo "Smoke test passed on attempt $attempt"
+              exit 0
+            fi
+            echo "Attempt $attempt failed (registry propagation?), retrying in 20s…"
+            sleep 20
+          done
+          echo "::error::Post-publish smoke test failed after 6 attempts (~120s of backoff)."
+          exit 1
 
       - name: Create GitHub Release
         if: github.event_name == 'push'

--- a/apps/cli/scripts/ci-keyring-probe.ts
+++ b/apps/cli/scripts/ci-keyring-probe.ts
@@ -93,9 +93,22 @@ try {
           SERVICE,
           `nonexistent-${process.pid}-${randomBytes(8).toString("hex")}`,
         );
-        freshEntry.getPassword();
-        // If this call returned *without* throwing, something is very
-        // wrong — we never wrote that entry. Fall through to FAIL.
+        const confirmRead = freshEntry.getPassword();
+        // Per `@napi-rs/keyring`'s typedef, `Entry.getPassword()` returns
+        // `string | null` — the macOS native keychain backend yields
+        // `null` for a missing entry instead of throwing `NoEntry` like
+        // the Linux secret-service backend does. Both outcomes are
+        // equally strong evidence that the native binding loaded and
+        // the backend responded, so accept either as OK. A non-null
+        // string here would mean the keychain returned a value for an
+        // account we never wrote — that's the actual regression we're
+        // guarding against.
+        if (confirmRead === null || confirmRead === undefined) {
+          process.stdout.write(
+            `OK (no backend): native binding loaded, backend unavailable on this runner — ${opErr instanceof Error ? opErr.message : String(opErr)}\n`,
+          );
+          process.exit(0);
+        }
         process.stderr.write(
           "FAIL: confirmation probe returned a value for an entry we never wrote.\n",
         );


### PR DESCRIPTION
Two release flakes from alpha.55 fixed together:

## 1. macOS CLI binaries (`release.yml::build-cli`)

`@napi-rs/keyring`'s `Entry.getPassword()` returns `string | null` per typedef. Linux secret-service throws `NoEntry` for missing entries; **macOS native keychain returns `null`**. The probe assumed every backend throws → both darwin binaries failed alpha.55 with "FAIL: confirmation probe returned a value for an entry we never wrote" even though the binding loaded fine.

Fix: accept `null`/`undefined` from the confirmation `getPassword()` as the same evidence as a NoEntry/no-backend throw. Non-null string still fails — that's the real regression we guard against.

## 2. npm post-publish smoke race (`publish-cli.yml`)

`npm publish` returns when the registry accepts the tarball, but the public CDN that `bunx` queries needs 30-90s to propagate. alpha.55 hit a 404 ~10s post-publish:

```
error: No version matching "1.0.0-alpha.55" found for specifier "appstrate" (but package exists)
```

Fix: 6 attempts × 20s sleep (~120s of backoff). Well beyond typical npm CDN window.

## Verification

- `bun run check` 15/15 ✅
- `bun test` (apps/cli) — 255 pass

## Post-merge

Tag v1.0.0-alpha.56 + cli@1.0.0-alpha.56. Both binaries (macOS + linux) and GH Release should ship clean for the first time since alpha.53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)