### PR TITLE
fix(release): filter download-artifact to skip docker-buildx summary blobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,12 @@ jobs:
       - name: Download CLI binaries
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
+          # `docker/build-push-action` auto-uploads
+          # `<name>~<name>~<id>.dockerbuild` summary artifacts to the
+          # same run; without a pattern filter, download-artifact pulls
+          # them too — and they're large enough to flake the 5-retry
+          # blob download budget. Restrict to the binary asset names.
+          pattern: appstrate-*
           path: cli-binaries
           merge-multiple: false
 
@@ -310,6 +316,9 @@ jobs:
       - name: Download CLI binaries
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
+          # Same filter as the sign job — skip the docker-buildx summary
+          # artifacts that share the run.
+          pattern: appstrate-*
           path: cli-binaries
           # Each artifact is extracted into its own subdir under `path`;
           # flatten by globbing in the release step below.


### PR DESCRIPTION
## Why

`docker/build-push-action` auto-uploads `<image>~<image>~<id>.dockerbuild` build-summary artifacts to the same workflow run as the binary artifacts. The Sign + Release jobs in `release.yml` use `actions/download-artifact` **without a pattern filter**, so they pull every artifact from the run — the 4 binaries we care about + 3 dockerbuild summaries (one per image: appstrate, appstrate-pi, appstrate-sidecar).

The dockerbuild blobs are large enough that one of them flakes the action's 5-retry blob-download budget. alpha.57:

```
##[error]Unable to download artifact(s): Unable to download and extract artifact: Artifact download failed after 5 retries.
```

## Why this surfaces now

alpha.54-alpha.56 each had ≥1 binary fail in the `build-cli` matrix (version-mismatch then keyring-probe), so the Sign job's `needs: build-cli` skipped and never exercised the download. alpha.57 was the first run with all 4 binaries green — which is also the first run that hit this latent flake.

## Fix

`pattern: appstrate-*` on both download-artifact steps (sign + release jobs). The binary asset names use `-` as a separator (`appstrate-darwin-x64`) while the dockerbuild summaries use `~` (`appstrate~appstrate~XXX`), so the glob cleanly partitions the two groups.

## Verification

- `bun run check` 15/15 ✅
- Pre-existing actionlint SC2129 warning is filtered by CI's `-ignore 'SC2129'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)