### PR TITLE
ci: harden release pipeline before GA (concurrency, bun pin, timeouts)

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -24,6 +24,12 @@ jobs:
   publish:
     name: Quality, Tests & Publish
     runs-on: ubuntu-latest
+    # 15m caps the worst case: install + tsc + tests + pack + install
+    # smoke + publish + 6×20s post-publish CDN retry (~120s) + GH
+    # Release. Steady state is ~4-6m. A hang past 15m means npm/CDN
+    # is wedged — fail loud rather than burn the GH Actions minutes
+    # quota until the 6h hard ceiling.
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: apps/cli
@@ -33,7 +39,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: "1.3.9"
+          bun-version: "1.3.11"
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -20,6 +20,16 @@ permissions:
   contents: write
   id-token: write
 
+# Serialize ALL CLI publishes — `npm publish` updates the `latest`
+# dist-tag on every non-prerelease publish. Two tags pushed in rapid
+# succession (cli@1.0.0 then cli@1.0.1) would race: if 1.0.0 finishes
+# last, `latest` points back to the older version. `cancel-in-progress:
+# false` because a cancelled publish mid-flight leaves the registry
+# inconsistent (provenance attestation orphaned, etc).
+concurrency:
+  group: publish-cli
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: Quality, Tests & Publish

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -10,6 +10,12 @@ permissions:
   contents: write
   id-token: write
 
+# Serialize ALL core publishes — see publish-cli.yml for rationale
+# (npm `latest` dist-tag race on rapid-fire tag pushes).
+concurrency:
+  group: publish-core
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: Quality, Tests & Publish

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -14,6 +14,7 @@ jobs:
   publish:
     name: Quality, Tests & Publish
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: packages/core
@@ -23,7 +24,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: "1.3.9"
+          bun-version: "1.3.11"
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/publish-installer.yml
+++ b/.github/workflows/publish-installer.yml
@@ -1,9 +1,16 @@
 name: Publish Installer
 
+# Triggered AFTER `release.yml` succeeds for a `v*` tag — NOT directly
+# on the tag push. This ordering matters: `install.sh` pinned to vX.Y.Z
+# tells `curl get.appstrate.dev | bash` to fetch CLI binaries from the
+# vX.Y.Z GH Release. If the installer publishes before `release.yml`
+# finishes signing & uploading those binaries, users hit a 404 in the
+# 10-15 min window between the two workflows. `workflow_run` chains
+# them so the installer only updates once the release artifacts exist.
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_run:
+    workflows: ["Release Docker Images + CLI Binaries"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       version:
@@ -24,23 +31,45 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Skip when:
+    #   - `release.yml` did not succeed (failure / cancelled / skipped)
+    #     → publishing an installer pointing at a missing release would
+    #       brick `get.appstrate.dev`.
+    #   - `release.yml` was triggered by something other than a v* tag
+    #     push (defensive — the workflow currently only triggers on v*
+    #     tags, but `workflow_run.head_branch` is the cleanest filter
+    #     in case that ever changes).
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+        startsWith(github.event.workflow_run.head_branch, 'v'))
     steps:
-      - name: Checkout source
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
       - name: Resolve version
         id: ver
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             VERSION="${{ inputs.version }}"
           else
-            VERSION="${GITHUB_REF_NAME}"
+            # `workflow_run.head_branch` carries the tag name (e.g.
+            # `v1.0.0-alpha.59`) when the upstream workflow was tag-
+            # triggered — per GitHub webhook payload docs.
+            VERSION="${{ github.event.workflow_run.head_branch }}"
           fi
           if ! echo "$VERSION" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._]+)?$'; then
             echo "Invalid version format: $VERSION (expected vMAJOR.MINOR.PATCH[-prerelease])" >&2
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout source at tag
+        # `workflow_run` runs in the context of the default branch
+        # (so `github.ref` is `refs/heads/main`, NOT the tag). Check
+        # out the resolved tag explicitly so we render `bootstrap.sh`,
+        # `verify.sh`, and `appstrate.pub` from the exact commit that
+        # was released — not whatever happens to be on main right now.
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ steps.ver.outputs.version }}
 
       - name: Render installer with pinned version
         run: |

--- a/.github/workflows/publish-ui.yml
+++ b/.github/workflows/publish-ui.yml
@@ -10,6 +10,12 @@ permissions:
   contents: write
   id-token: write
 
+# Serialize ALL ui publishes — see publish-cli.yml for rationale
+# (npm `latest` dist-tag race on rapid-fire tag pushes).
+concurrency:
+  group: publish-ui
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: Quality & Publish

--- a/.github/workflows/publish-ui.yml
+++ b/.github/workflows/publish-ui.yml
@@ -14,6 +14,7 @@ jobs:
   publish:
     name: Quality & Publish
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: packages/ui
@@ -23,7 +24,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: "1.3.9"
+          bun-version: "1.3.11"
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,16 @@ on:
     tags:
       - "v*"
 
+# Serialize per-tag so two tags pushed in rapid succession can never
+# race on shared release artifacts (npm package overwrite, GH Release
+# creation, GHCR image push). `cancel-in-progress: false` because once
+# a release has started publishing to npm/GHCR, cancelling mid-flight
+# leaves the registries in an inconsistent state — better to let it
+# finish, then run the next tag.
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
 env:
   REGISTRY: ghcr.io
   IMAGE_PREFIX: ghcr.io/${{ github.repository_owner }}/appstrate
@@ -135,7 +145,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: "1.3.11"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,14 +5,19 @@ on:
     tags:
       - "v*"
 
-# Serialize per-tag so two tags pushed in rapid succession can never
-# race on shared release artifacts (npm package overwrite, GH Release
-# creation, GHCR image push). `cancel-in-progress: false` because once
-# a release has started publishing to npm/GHCR, cancelling mid-flight
-# leaves the registries in an inconsistent state — better to let it
-# finish, then run the next tag.
+# Serialize ALL release runs (single global group, NOT per-tag).
+# Two different tags pushed in rapid succession would otherwise race
+# on shared cross-tag state:
+#   - `metadata-action` with `flavor: latest=auto` (line ~82) pushes
+#     the GHCR `:latest` tag based on highest-semver-seen — if v1.0.0
+#     finishes after v1.0.1, `:latest` ends up pointing at v1.0.0.
+#   - GH Release marking (which tag is `latest`) has the same hazard.
+# `cancel-in-progress: false` because once a release has started
+# publishing to GHCR / signing binaries / creating the GH Release,
+# cancelling mid-flight leaves registries inconsistent — better to
+# let it finish, then run the queued tag.
 concurrency:
-  group: release-${{ github.ref_name }}
+  group: release
   cancel-in-progress: false
 
 env:


### PR DESCRIPTION
## Summary

Pre-GA hardening of the release pipeline. 4 fixes from the post-alpha.58 audit, all non-functional changes to GitHub Actions workflows.

### Concurrency
- **`release.yml`**: global `concurrency: { group: release, cancel-in-progress: false }`. `metadata-action` with `flavor: latest=auto` recomputes the GHCR `:latest` tag based on highest-semver-seen — without a global group, two tags racing leaves `:latest` on the older version. `cancel-in-progress: false` because mid-flight cancellation of a GHCR/sign step leaves registries inconsistent.
- **`publish-{cli,core,ui}.yml`**: matching global groups. `npm publish` of a non-prerelease auto-updates the `latest` dist-tag — same race hazard as GHCR.

### Bun version alignment
- All 6 workflows pinned to `1.3.11`. Previously `release.yml` was on `latest` (broken reproducibility — a Bun upstream regression silently changes the compiled CLI binary between identical tags), `publish-*` on `1.3.9`, `test.yml`/`check.yml` already on `1.3.11`. Future Bun upgrades are now a single coordinated bump.

### Timeouts
- `publish-{cli,core,ui}.yml`: explicit `timeout-minutes` (15 / 10 / 10). Without it a wedged `npm publish` would consume runner minutes up to GitHub's 6h default.

### Cross-workflow ordering
- **`publish-installer.yml`** trigger changed from `tags: [v*]` to `workflow_run` after `release.yml` succeeds. Closes a 10-15 min 404 window on `curl get.appstrate.dev | bash`: previously install.sh was published in parallel with release.yml, so it pointed at a version whose CLI binaries hadn't yet been signed and uploaded to the GH Release. Now install.sh only updates after the artifacts it points to actually exist. On release.yml failure the installer is skipped and the previous install.sh keeps serving — no broken state.
- Companion runbook update in `appstrate/docs@13415e2` documents the new sequencing + the global-concurrency operational rules.

## Pre-GA context

Pre-1.0 we ship only prereleases, so neither GHCR `:latest` nor npm `latest` race actually fires today (`flavor: latest=auto` skips prereleases, `npm publish` of a prerelease leaves `latest` alone). And the install.sh race is mitigated by low get.appstrate.dev traffic during alphas. But the moment we ship v1.0.0 GA followed by v1.0.1, all four hazards become real — landing now while we're auditing.

## Test plan

- [x] Local pre-commit gate (typecheck + lint + format + verify-openapi + breaking-detection) passes
- [x] `oven-sh/setup-bun@v2` accepts `1.3.11` (verified — `test.yml` already uses it)
- [ ] Next `v*` tag exercises the new concurrency group + workflow_run chain end-to-end
- [ ] Next `cli@*` / `core@*` / `ui@*` tag confirms the publish workflows still complete inside the new timeout budgets

🤖 Generated with [Claude Code](https://claude.com/claude-code)