### PR TITLE
ci: align download-artifact with upload-artifact (both v7)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Download CLI binaries
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           # `docker/build-push-action` auto-uploads
           # `<name>~<name>~<id>.dockerbuild` summary artifacts to the
@@ -329,7 +329,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download CLI binaries
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           # Same filter as the sign job — skip the docker-buildx summary
           # artifacts that share the run.
@@ -340,7 +340,7 @@ jobs:
           merge-multiple: false
 
       - name: Download signed bundle
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: cli-signed-bundle
           path: cli-signed


### PR DESCRIPTION
## Summary

PR #88 (dependabot) bumped `actions/upload-artifact` to v7.0.1 in `release.yml` + `test.yml` but left `actions/download-artifact` on v4.3.0 in the 3 places `release.yml` uses it. Aligns both to v7.

The artifact storage format change happened v3 → v4 — v4 download CAN read v7 upload in practice — but the docs are explicit about "match major versions", and a release.yml regression is only discoverable by tagging. Aligning eliminates the question before alpha.59.

3 sites in `release.yml`:
- Sign job: download CLI binaries
- Release job: download CLI binaries
- Release job: download signed bundle

SHA pinned (v7.0.0 = `37930b1c`) per repo convention.

## Test plan
- [x] Local pre-commit gate passes
- [ ] Next `v*` tag (alpha.59) exercises the new `actions/download-artifact@v7.0.0` against `actions/upload-artifact@v7.0.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)