### PR TITLE
fix(installer): reopen stdin from /dev/tty before exec'ing CLI (#184)

### DIFF
--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -336,6 +336,16 @@ export async function resolveTier(raw: string | undefined): Promise<Tier> {
     if (parsed === 0 || parsed === 1 || parsed === 2 || parsed === 3) return parsed as Tier;
     throw new Error(`Invalid --tier value "${raw}". Expected 0, 1, 2, or 3.`);
   }
+  // Prompting requires a TTY. If stdin isn't a TTY (CI, `curl | bash`
+  // inside a Dockerfile, cron) clack would crash with no readable
+  // error — surface a clear message pointing at the `--tier` escape
+  // hatch instead. See `scripts/bootstrap.sh` for the matching branch.
+  if (!process.stdin.isTTY) {
+    throw new Error(
+      "Cannot prompt for tier: stdin is not a TTY. " +
+        "Re-run with `--tier N` (0, 1, 2, or 3), e.g. `curl -fsSL https://get.appstrate.dev | bash -s -- --tier 3`.",
+    );
+  }
   const chosen = await clack.select<Tier>({
     message: "Which tier do you want to install?",
     options: [

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -367,6 +367,12 @@ export async function resolveTier(raw: string | undefined): Promise<Tier> {
  * normalize to an absolute path. Exported for unit testing.
  */
 export async function resolveDir(raw: string | undefined): Promise<string> {
+  if (raw === undefined && !process.stdin.isTTY) {
+    throw new Error(
+      "Cannot prompt for install directory: stdin is not a TTY. " +
+        "Re-run with `--dir <path>`, e.g. `curl -fsSL https://get.appstrate.dev | bash -s -- --tier 3 --dir ~/appstrate`.",
+    );
+  }
   const chosen = raw ?? (await askText("Install directory", DEFAULT_INSTALL_DIR));
   // `tier0.ts` passes `dir` as an argv positional to `tar`, `curl`,
   // `git`, etc. without a shell wrapper, so interpolation injection is

--- a/apps/cli/src/lib/ui.ts
+++ b/apps/cli/src/lib/ui.ts
@@ -19,7 +19,26 @@ export function outro(message: string): void {
   clack.outro(message);
 }
 
+/**
+ * Defensive fail-fast for prompts with no matching non-interactive
+ * flag (Bun install confirm, "Start dev server?", upgrade confirm, the
+ * login instance URL askText, etc.). Without this, `@clack/prompts`
+ * reads a closed/missing stdin and either hangs or SIGKILLs with no
+ * readable error — issue #184. Callers that do have a flag (resolveTier,
+ * resolveDir) should guard earlier with a specific message naming it.
+ */
+function requireTTY(message: string): void {
+  if (!process.stdin.isTTY) {
+    throw new Error(
+      `Cannot prompt "${message}": stdin is not a TTY. ` +
+        "Re-run from an interactive terminal, or pass the matching flag " +
+        "so the command doesn't need to prompt (see `appstrate <command> --help`).",
+    );
+  }
+}
+
 export async function askText(message: string, initialValue?: string): Promise<string> {
+  requireTTY(message);
   const value = await clack.text({ message, initialValue });
   if (clack.isCancel(value)) {
     clack.cancel("Cancelled.");
@@ -29,6 +48,7 @@ export async function askText(message: string, initialValue?: string): Promise<s
 }
 
 export async function confirm(message: string, initialValue = true): Promise<boolean> {
+  requireTTY(message);
   const value = await clack.confirm({ message, initialValue });
   if (clack.isCancel(value)) {
     clack.cancel("Cancelled.");

--- a/apps/cli/test/install.test.ts
+++ b/apps/cli/test/install.test.ts
@@ -49,6 +49,17 @@ describe("resolveTier", () => {
     await expect(resolveTier("1.5")).rejects.toThrow(/Invalid --tier/);
     await expect(resolveTier("NaN")).rejects.toThrow(/Invalid --tier/);
   });
+
+  it("throws a clear error when stdin is not a TTY and --tier is missing", async () => {
+    // Regression for issue #184: `curl … | bash` bootstrap inherited a
+    // closed pipe as stdin, so clack's `select` crashed silently. The
+    // CLI now fails fast with an actionable message pointing at --tier.
+    // bun:test runs with stdin.isTTY === false, matching the non-TTY
+    // install path exactly — no mocking needed.
+    expect(process.stdin.isTTY).toBeFalsy();
+    await expect(resolveTier(undefined)).rejects.toThrow(/stdin is not a TTY/);
+    await expect(resolveTier(undefined)).rejects.toThrow(/--tier/);
+  });
 });
 
 describe("resolveDir", () => {

--- a/apps/cli/test/install.test.ts
+++ b/apps/cli/test/install.test.ts
@@ -82,6 +82,15 @@ describe("resolveDir", () => {
   it("rejects paths containing a NUL byte", async () => {
     await expect(resolveDir("/tmp/bad\0path")).rejects.toThrow(/newlines or NUL/);
   });
+
+  it("throws a clear error when stdin is not a TTY and --dir is missing", async () => {
+    // Sibling of the resolveTier non-TTY case: `curl | bash -s -- --tier 3`
+    // clears the tier prompt but would still crash on the askText() for
+    // --dir. Same fail-fast contract — message must name --dir.
+    expect(process.stdin.isTTY).toBeFalsy();
+    await expect(resolveDir(undefined)).rejects.toThrow(/stdin is not a TTY/);
+    await expect(resolveDir(undefined)).rejects.toThrow(/--dir/);
+  });
 });
 
 describe("parsePort", () => {

--- a/apps/cli/test/ui.test.ts
+++ b/apps/cli/test/ui.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `lib/ui.ts` — specifically the non-TTY guard on
+ * `askText` and `confirm`. Issue #184: `curl … | bash` inherits a
+ * closed pipe as stdin, and `@clack/prompts` crashes silently
+ * (SIGKILL, no readable error) when asked to prompt against it. The
+ * guard turns every prompt call into an explicit, actionable throw.
+ *
+ * bun:test runs with `process.stdin.isTTY === false`, so any call to
+ * the guarded helpers in this test file exercises the non-TTY branch.
+ * The happy-path (TTY present) is covered by the e2e install smoke.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { askText, confirm } from "../src/lib/ui.ts";
+
+describe("askText non-TTY guard", () => {
+  it("throws before clack when stdin is not a TTY", async () => {
+    expect(process.stdin.isTTY).toBeFalsy();
+    await expect(askText("Instance URL")).rejects.toThrow(/stdin is not a TTY/);
+  });
+
+  it("names the prompt message so the user can identify the missing flag", async () => {
+    await expect(askText("Install directory")).rejects.toThrow(/Install directory/);
+  });
+});
+
+describe("confirm non-TTY guard", () => {
+  it("throws before clack when stdin is not a TTY", async () => {
+    expect(process.stdin.isTTY).toBeFalsy();
+    await expect(confirm("Start the dev server now?")).rejects.toThrow(/stdin is not a TTY/);
+  });
+
+  it("names the prompt message for identifiability", async () => {
+    await expect(confirm("Install Bun now?")).rejects.toThrow(/Install Bun now\?/);
+  });
+});

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -243,7 +243,25 @@ _appstrate_bootstrap() {
   # stale install in /usr/local/bin shadowed by ~/.local/bin, etc.)
   # would silently shadow the one we just verified — defeating the
   # whole trust chain. `$DEST` is the exact file we wrote + chmod'd.
-  exec "$DEST" install "$@"
+  #
+  # Reopen stdin from the controlling terminal before exec'ing the CLI.
+  # Under `curl … | bash`, bash's stdin is the pipe from curl; once the
+  # download is done the pipe is closed, and `exec` inherits that closed
+  # pipe as stdin. `appstrate install` is interactive (`@clack/prompts`
+  # for tier + directory), so it would die silently (SIGKILL'd by the
+  # shell) with no prompt ever shown. Redirecting stdin to /dev/tty is
+  # the same pattern used by rustup-init, bun, deno, and Homebrew. The
+  # `$@` forwarding is preserved — redirections come before argv.
+  if [ -e /dev/tty ] && [ -r /dev/tty ]; then
+    exec </dev/tty "$DEST" install "$@"
+  else
+    # No controlling terminal (CI, Dockerfile `RUN curl | bash`, cron).
+    # Exec without the redirect and let the CLI surface a clear "stdin
+    # is not a TTY, pass --tier N" error instead of being SIGKILL'd.
+    # The CLI already supports `--tier` as a non-interactive escape
+    # hatch (see `apps/cli/src/commands/install.ts`).
+    exec "$DEST" install "$@"
+  fi
 
 }
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -252,7 +252,15 @@ _appstrate_bootstrap() {
   # shell) with no prompt ever shown. Redirecting stdin to /dev/tty is
   # the same pattern used by rustup-init, bun, deno, and Homebrew. The
   # `$@` forwarding is preserved — redirections come before argv.
-  if [ -e /dev/tty ] && [ -r /dev/tty ]; then
+  #
+  # Detection: `[ -r /dev/tty ]` only checks permission bits (world-
+  # readable on Linux: `crw-rw-rw-`), not whether this process has a
+  # controlling terminal. In CI / command substitutions the permission
+  # check passes but `open("/dev/tty")` still returns ENXIO, which would
+  # make the `exec </dev/tty …` below fail and kill the install. So we
+  # *actually* try to open /dev/tty in a subshell — if that succeeds,
+  # the redirect on the real exec will succeed too.
+  if (exec </dev/tty) >/dev/null 2>&1; then
     exec </dev/tty "$DEST" install "$@"
   else
     # No controlling terminal (CI, Dockerfile `RUN curl | bash`, cron).


### PR DESCRIPTION
## Summary

Fixes #184 — `curl -fsSL https://get.appstrate.dev | bash` crashes right after verification, with `appstrate install` SIGKILL'd before the tier prompt is ever shown.

Root cause: `scripts/bootstrap.sh:246` ends with `exec "$DEST" install "$@"`. Under `curl … | bash`, bash's stdin is the pipe from curl; once the download is done that pipe is closed. `exec` inherits the closed pipe as stdin, and `@clack/prompts` dies silently trying to prompt against it.

- **`scripts/bootstrap.sh`** — reopen stdin from `/dev/tty` before the `exec`, matching the pattern used by rustup-init, bun, deno, and Homebrew. `$@` forwarding is preserved (redirections come before argv). Falls back to the old `exec` when `/dev/tty` is unavailable (CI, Dockerfile `RUN curl | bash`), so the CLI gets a chance to surface a readable error instead of being SIGKILL'd.
- **`apps/cli/src/commands/install.ts`** — `resolveTier()` now fails fast with an actionable message pointing at the `--tier` escape hatch when `process.stdin.isTTY` is false and `--tier` wasn't passed, instead of letting clack crash.
- **`apps/cli/test/install.test.ts`** — unit test for the non-TTY branch (bun:test naturally runs without a TTY, no mocking needed).

## Test plan

- [x] `cd apps/cli && bun test test/install.test.ts` — 39/39 pass, including the new non-TTY case
- [x] `bash -n scripts/bootstrap.sh` — syntax OK
- [x] `bun run check --filter=appstrate` — typecheck passes
- [ ] Smoke: `curl -fsSL https://get.appstrate.dev | bash` on a fresh macOS shell → tier prompt appears (validate after release/deploy)
- [ ] Smoke: `curl -fsSL … | bash -s -- --tier 3` preserves `$@` forwarding through the `</dev/tty` redirect
- [ ] Smoke: `curl -fsSL … | bash` inside a scripted context (no /dev/tty) → CLI exits with the "stdin is not a TTY, pass --tier" error instead of SIGKILL

🤖 Generated with [Claude Code](https://claude.com/claude-code)