### PR TITLE
feat(cli): default install to Tier 3 with Docker-aware fallback (#180)

### DIFF
--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -21,6 +21,7 @@ import {
   DockerMissingError,
   dockerComposeUp,
   findRunningComposeProject as findRunningComposeProjectImport,
+  isDockerAvailable,
   waitForAppstrate,
   writeComposeFile,
   writeEnvFile as writeComposeEnv,
@@ -325,27 +326,61 @@ async function ensurePortFree(
 }
 
 /**
+ * DI seam for `resolveTier()` — production wires `clack` + the real
+ * Docker probe; tests inject deterministic stubs.
+ */
+export interface TierResolverDeps {
+  select?: typeof clack.select;
+  isCancel?: typeof clack.isCancel;
+  note?: typeof clack.note;
+  isDockerAvailable?: () => Promise<boolean>;
+}
+
+/**
  * Parse `--tier` or drop into an interactive select. `clack`'s
  * `select` with 4 options reads better than free-form text and avoids
  * the "what did I type?" typo recovery. Exported so unit tests can
  * lock down the validation contract without invoking the prompt.
+ *
+ * Interactive default: Tier 3 (full production stack) when Docker is
+ * reachable — the happy path for the one-liner installer is
+ * `press Enter → working production-grade Appstrate`. When Docker is
+ * missing we silently downgrade the default to Tier 0 and surface a
+ * friendly note so the user is not pushed into a tier they cannot
+ * actually run; the fatal `DockerMissingError` in `installDockerTier`
+ * remains the safety net for the explicit-pick case.
  */
-export async function resolveTier(raw: string | undefined): Promise<Tier> {
+export async function resolveTier(
+  raw: string | undefined,
+  deps: TierResolverDeps = {},
+): Promise<Tier> {
   if (raw !== undefined) {
     const parsed = Number(raw);
     if (parsed === 0 || parsed === 1 || parsed === 2 || parsed === 3) return parsed as Tier;
     throw new Error(`Invalid --tier value "${raw}". Expected 0, 1, 2, or 3.`);
   }
-  const chosen = await clack.select<Tier>({
+  const select = deps.select ?? clack.select;
+  const isCancel = deps.isCancel ?? clack.isCancel;
+  const note = deps.note ?? clack.note;
+  const probe = deps.isDockerAvailable ?? isDockerAvailable;
+  const dockerOk = await probe();
+  const defaultTier: Tier = dockerOk ? 3 : 0;
+  if (!dockerOk) {
+    note(
+      "Docker not detected — Tier 0 selected by default. Install Docker Desktop and re-run for the production stack (Tier 3).",
+    );
+  }
+  const chosen = await select<Tier>({
     message: "Which tier do you want to install?",
+    initialValue: defaultTier,
     options: [
-      { value: 0, label: "Tier 0 — Hobby (Bun + local files, no Docker)" },
-      { value: 1, label: "Tier 1 — Minimal (PostgreSQL)" },
-      { value: 2, label: "Tier 2 — Standard (PostgreSQL + Redis)" },
-      { value: 3, label: "Tier 3 — Production (PostgreSQL + Redis + MinIO)" },
+      { value: 3, label: "Tier 3 — Production (PostgreSQL + Redis + MinIO) — recommended" },
+      { value: 2, label: "Tier 2 — Standard (PostgreSQL + Redis, no object storage)" },
+      { value: 1, label: "Tier 1 — Minimal (PostgreSQL only, dev/testing)" },
+      { value: 0, label: "Tier 0 — Hobby (no Docker, evaluation only)" },
     ],
   });
-  if (clack.isCancel(chosen)) {
+  if (isCancel(chosen)) {
     clack.cancel("Cancelled.");
     process.exit(130);
   }

--- a/apps/cli/src/lib/install/os.ts
+++ b/apps/cli/src/lib/install/os.ts
@@ -30,6 +30,13 @@ export interface RunCommandOptions {
    * captures into the returned `stdout` / `stderr`.
    */
   stdio?: "inherit" | "ignore" | "pipe";
+  /**
+   * Kill the child after this many ms and resolve with `ok: false`
+   * (exitCode `-1`, stderr `"timeout"`). Intended for probes that must
+   * not block the UI — e.g. `docker info` when the daemon is starting
+   * up can hang for 10–30 s. Undefined = no timeout (legacy behaviour).
+   */
+  timeoutMs?: number;
 }
 
 /** Run `cmd args...` and await its exit. Never throws on non-zero — returns `ok: false` instead. */
@@ -58,6 +65,35 @@ export async function runCommand(
 
     let stdout = "";
     let stderr = "";
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+    const settle = (r: CommandResult) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve(r);
+    };
+    if (opts.timeoutMs !== undefined) {
+      timer = setTimeout(() => {
+        // SIGTERM first, then SIGKILL shortly after in case the child
+        // ignores the term. We don't await — the `close` listener below
+        // is already short-circuited by `settled`.
+        try {
+          child.kill("SIGTERM");
+          setTimeout(() => {
+            try {
+              child.kill("SIGKILL");
+            } catch {
+              // already gone
+            }
+          }, 500).unref();
+        } catch {
+          // already gone
+        }
+        settle({ ok: false, exitCode: -1, stdout, stderr: stderr || "timeout" });
+      }, opts.timeoutMs);
+      timer.unref?.();
+    }
     child.stdout?.on("data", (d) => {
       stdout += d.toString();
     });
@@ -66,11 +102,11 @@ export async function runCommand(
     });
     child.on("error", () => {
       // ENOENT when `cmd` is not on PATH — surface as ok:false.
-      resolve({ ok: false, exitCode: -1, stdout, stderr });
+      settle({ ok: false, exitCode: -1, stdout, stderr });
     });
     child.on("close", (code) => {
       const exitCode = code ?? -1;
-      resolve({ ok: exitCode === 0, exitCode, stdout, stderr });
+      settle({ ok: exitCode === 0, exitCode, stdout, stderr });
     });
   });
 }

--- a/apps/cli/src/lib/install/tier123.ts
+++ b/apps/cli/src/lib/install/tier123.ts
@@ -47,6 +47,16 @@ export async function assertDockerAvailable(): Promise<void> {
   if (!res.ok) throw new DockerMissingError();
 }
 
+/**
+ * Non-throwing sibling of `assertDockerAvailable()`. Used by the tier
+ * prompt to decide which tier to highlight as the default — failure
+ * here is informational, not fatal.
+ */
+export async function isDockerAvailable(): Promise<boolean> {
+  const res = await runCommand("docker", ["info"], { stdio: "ignore" });
+  return res.ok;
+}
+
 /** Copy the embedded YAML for `tier` into `<dir>/docker-compose.yml`. */
 export async function writeComposeFile(dir: string, tier: DockerTier): Promise<void> {
   await mkdir(dir, { recursive: true });

--- a/apps/cli/src/lib/install/tier123.ts
+++ b/apps/cli/src/lib/install/tier123.ts
@@ -51,9 +51,16 @@ export async function assertDockerAvailable(): Promise<void> {
  * Non-throwing sibling of `assertDockerAvailable()`. Used by the tier
  * prompt to decide which tier to highlight as the default — failure
  * here is informational, not fatal.
+ *
+ * Capped at 3 s because `docker info` can hang 10–30 s while Docker
+ * Desktop's daemon is starting up (common on macOS/Windows post-reboot),
+ * and we don't want a first-time user to sit on a frozen prompt. A
+ * timeout → "Docker unavailable" is the right UX: either the user
+ * accepts Tier 0 as the default, or explicitly picks Tier 3 and the
+ * fatal `DockerMissingError` in `installDockerTier` catches the case.
  */
 export async function isDockerAvailable(): Promise<boolean> {
-  const res = await runCommand("docker", ["info"], { stdio: "ignore" });
+  const res = await runCommand("docker", ["info"], { stdio: "ignore", timeoutMs: 3000 });
   return res.ok;
 }
 

--- a/apps/cli/test/install.test.ts
+++ b/apps/cli/test/install.test.ts
@@ -49,6 +49,29 @@ describe("resolveTier", () => {
     await expect(resolveTier("1.5")).rejects.toThrow(/Invalid --tier/);
     await expect(resolveTier("NaN")).rejects.toThrow(/Invalid --tier/);
   });
+
+  it("never invokes the Docker probe when --tier is provided", async () => {
+    // Locks down the contract that the CI one-liner (`--tier 3`) never
+    // spawns `docker info` — a regression here would change the byte-
+    // identical CI install path into something that depends on daemon
+    // availability (or daemon latency, via the probe's 3 s timeout).
+    const probe = async () => {
+      throw new Error("isDockerAvailable must not be called when --tier is provided");
+    };
+    for (const raw of ["0", "1", "2", "3"] as const) {
+      const tier = await resolveTier(raw, {
+        isDockerAvailable: probe,
+        select: (async () => {
+          throw new Error("select must not be called when --tier is provided");
+        }) as unknown as typeof import("@clack/prompts").select,
+        isCancel: (() => false) as unknown as typeof import("@clack/prompts").isCancel,
+        note: () => {
+          throw new Error("note must not be called when --tier is provided");
+        },
+      });
+      expect(tier).toBe(Number(raw) as 0 | 1 | 2 | 3);
+    }
+  });
 });
 
 describe("resolveTier (interactive)", () => {

--- a/apps/cli/test/install.test.ts
+++ b/apps/cli/test/install.test.ts
@@ -17,7 +17,7 @@
  *     in tier0/tier123 gets a stable cwd.
  */
 
-import { describe, it, expect, afterEach } from "bun:test";
+import { describe, it, expect, afterEach, spyOn } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { createServer, type Server } from "node:net";
 import { tmpdir } from "node:os";
@@ -48,6 +48,100 @@ describe("resolveTier", () => {
     await expect(resolveTier("standard")).rejects.toThrow(/Invalid --tier/);
     await expect(resolveTier("1.5")).rejects.toThrow(/Invalid --tier/);
     await expect(resolveTier("NaN")).rejects.toThrow(/Invalid --tier/);
+  });
+});
+
+describe("resolveTier (interactive)", () => {
+  /** Captures whatever options are passed into the fake `select`. */
+  type SelectOpts = {
+    initialValue?: number;
+    options?: Array<{ value: number; label: string }>;
+  };
+
+  it("defaults to Tier 3 when Docker is available", async () => {
+    let captured: SelectOpts | undefined;
+    const select = (async (opts: SelectOpts) => {
+      captured = opts;
+      return opts.initialValue;
+    }) as unknown as typeof import("@clack/prompts").select;
+    const tier = await resolveTier(undefined, {
+      select,
+      isCancel: (() => false) as unknown as typeof import("@clack/prompts").isCancel,
+      note: () => {},
+      isDockerAvailable: async () => true,
+    });
+    expect(tier).toBe(3);
+    expect(captured?.initialValue).toBe(3);
+    expect(captured?.options?.[0]?.value).toBe(3);
+    expect(captured?.options?.[0]?.label).toMatch(/recommended/i);
+  });
+
+  it("falls back to Tier 0 default when Docker is missing and surfaces a note", async () => {
+    let captured: SelectOpts | undefined;
+    let noteCalls = 0;
+    const select = (async (opts: SelectOpts) => {
+      captured = opts;
+      return opts.initialValue;
+    }) as unknown as typeof import("@clack/prompts").select;
+    const tier = await resolveTier(undefined, {
+      select,
+      isCancel: (() => false) as unknown as typeof import("@clack/prompts").isCancel,
+      note: (msg) => {
+        noteCalls += 1;
+        expect(msg).toMatch(/Docker not detected/i);
+      },
+      isDockerAvailable: async () => false,
+    });
+    expect(tier).toBe(0);
+    expect(captured?.initialValue).toBe(0);
+    expect(noteCalls).toBe(1);
+  });
+
+  it("returns whatever the user explicitly selects, regardless of default", async () => {
+    const select = (async () => 2) as unknown as typeof import("@clack/prompts").select;
+    const tier = await resolveTier(undefined, {
+      select,
+      isCancel: (() => false) as unknown as typeof import("@clack/prompts").isCancel,
+      note: () => {},
+      isDockerAvailable: async () => true,
+    });
+    expect(tier).toBe(2);
+  });
+
+  it("orders options Tier 3 → 2 → 1 → 0", async () => {
+    let captured: SelectOpts | undefined;
+    const select = (async (opts: SelectOpts) => {
+      captured = opts;
+      return 3;
+    }) as unknown as typeof import("@clack/prompts").select;
+    await resolveTier(undefined, {
+      select,
+      isCancel: (() => false) as unknown as typeof import("@clack/prompts").isCancel,
+      note: () => {},
+      isDockerAvailable: async () => true,
+    });
+    expect(captured?.options?.map((o) => o.value)).toEqual([3, 2, 1, 0]);
+  });
+
+  it("exits with 130 on cancel", async () => {
+    const select = (async () =>
+      Symbol("cancel-sentinel")) as unknown as typeof import("@clack/prompts").select;
+    const exitSpy = spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`exit:${code}`);
+    }) as never);
+    try {
+      await expect(
+        resolveTier(undefined, {
+          select,
+          isCancel: ((value: unknown) =>
+            typeof value === "symbol") as unknown as typeof import("@clack/prompts").isCancel,
+          note: () => {},
+          isDockerAvailable: async () => true,
+        }),
+      ).rejects.toThrow("exit:130");
+    } finally {
+      exitSpy.mockRestore();
+    }
   });
 });
 

--- a/apps/cli/test/install/os.test.ts
+++ b/apps/cli/test/install/os.test.ts
@@ -77,6 +77,18 @@ describe("runCommand", () => {
     expect(res.ok).toBe(true);
     expect(res.stdout).toBe("hello");
   });
+
+  it("kills the child and returns ok=false when timeoutMs elapses", async () => {
+    if (platform() === "win32") return;
+    const start = Date.now();
+    const res = await runCommand("sleep", ["5"], { stdio: "ignore", timeoutMs: 150 });
+    const elapsed = Date.now() - start;
+    expect(res.ok).toBe(false);
+    expect(res.exitCode).toBe(-1);
+    // Generous upper bound — CI runners can be slow, but we MUST come
+    // back well before `sleep 5` would have exited on its own.
+    expect(elapsed).toBeLessThan(3000);
+  });
 });
 
 describe("commandExists", () => {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import tseslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier";
 
 export default tseslint.config(
-  { ignores: ["**/dist", "**/node_modules", "**/.claude", "apps/web/src/components/ui"] },
+  { ignores: ["**/dist", "**/node_modules", ".claude/", "apps/web/src/components/ui"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/src/**/*.{ts,tsx}", "**/test/**/*.ts"],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,7 +6,7 @@ import tseslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier";
 
 export default tseslint.config(
-  { ignores: ["**/dist", "**/node_modules", "apps/web/src/components/ui"] },
+  { ignores: ["**/dist", "**/node_modules", "**/.claude", "apps/web/src/components/ui"] },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ["**/src/**/*.{ts,tsx}", "**/test/**/*.ts"],

--- a/examples/self-hosting/README.md
+++ b/examples/self-hosting/README.md
@@ -12,12 +12,16 @@ curl -fsSL https://get.appstrate.dev | bash
 ```
 
 This downloads the `appstrate` CLI binary for your OS/arch and hands
-control to `appstrate install`, which prompts for a tier:
+control to `appstrate install`. Just press Enter at the tier prompt to
+land on the recommended Tier 3 production stack:
 
+- **Tier 3** — Postgres + Redis + MinIO (full production, **default — what this README covers**)
+- **Tier 2** — Postgres + Redis (no object storage)
+- **Tier 1** — Postgres only (dev / testing)
 - **Tier 0** — Bun + PGlite + filesystem (no Docker, hobby / evaluation)
-- **Tier 1** — Postgres + filesystem storage
-- **Tier 2** — Postgres + Redis + filesystem storage
-- **Tier 3** — Postgres + Redis + MinIO (full production, what this README covers)
+
+If Docker is not detected on your machine the CLI automatically falls
+back to Tier 0 as the highlighted default.
 
 The CLI generates cryptographic secrets, writes `.env` +
 `docker-compose.yml`, runs `docker compose up -d`, waits for the


### PR DESCRIPTION
## Summary
- Make Tier 3 (Postgres + Redis + MinIO) the highlighted default in `appstrate install` so first-time users land on a production-grade stack by pressing Enter at the tier prompt.
- Reorder options to Tier 3 → 2 → 1 → 0, mark Tier 3 as "recommended" in the label.
- Detect Docker via a new non-throwing `isDockerAvailable()` and downgrade the highlighted default to Tier 0 with a friendly `clack.note` when Docker is unreachable.
- Refactor `resolveTier()` to accept a `TierResolverDeps` injection seam (mirrors the existing `PortResolverDeps` pattern) so the interactive branch is fully unit-tested without touching a real TTY or Docker daemon.
- Update `examples/self-hosting/README.md` to reflect the new default.
- Drive-by chore: add `**/.claude` to the eslint ignore list — local Claude Code worktrees were poisoning `typescript-eslint` tsconfig root resolution and producing 2000+ phantom parse errors locally.

`--tier <N>` non-interactive parsing is unchanged, so the one-liner `curl … | bash -s -- --tier 3` and CI invocations keep working byte-identically.

Closes #180.

## Test plan
- [x] `bun test test/install.test.ts` (apps/cli) — 43 pass, 0 fail (5 new interactive tests + 38 existing)
- [x] `bun test` (apps/cli full suite) — 260 pass, 0 fail
- [x] `bun run typecheck` (apps/cli) — clean
- [x] `bun run lint` (root) — clean (was failing before the eslint ignore fix)
- [ ] Manual smoke (reviewer): `bun run src/index.ts install --dir /tmp/appstrate-smoke` with Docker running → cursor on "Tier 3 — Production … recommended", Enter → Tier 3 install
- [ ] Manual smoke (reviewer): same command with Docker stopped → note explains Docker is missing, default cursor on Tier 0
- [ ] Manual smoke (reviewer): `--tier 4` still fails fast with "Invalid --tier value" (regression check)

## Acceptance-criteria mapping (from #180)
- [x] Press Enter → Tier 3 (when Docker available)
- [x] Tier 3 visually labeled "recommended"
- [x] One-liner lands on working Tier 3 stack
- [x] Docker-missing case helpful (upstream note + existing `DockerMissingError` fatal path preserved)
- [x] `apps/cli/test/install.test.ts` covers the new default
- [x] `examples/self-hosting/README.md` reflects the new default

🤖 Generated with [Claude Code](https://claude.com/claude-code)