### PR TITLE
fix(installer): rootless `~/.local/bin` default + shell PATH setup (closes #186)

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -467,6 +467,19 @@ jobs:
             || { echo "::error::.zshrc missing install marker"; exit 1; }
           grep -q "export PATH=\"$H8/.local/bin:\$PATH\"" "$H8/.zshrc" \
             || { echo "::error::.zshrc missing PATH export"; exit 1; }
+          # .zprofile covers login shells — macOS default for zsh is a login
+          # shell, so missing this would leave PATH broken in Terminal.app
+          # until the first interactive sub-shell.
+          test -f "$H8/.zprofile" \
+            || { echo "::error::.zprofile was not created (login-shell coverage)"; exit 1; }
+          grep -qF "$MARKER" "$H8/.zprofile" \
+            || { echo "::error::.zprofile missing install marker"; exit 1; }
+          # The hint output must list every touched file, not just the last
+          # one — regression guard for the MODIFIED_PROFILE-overwritten bug.
+          echo "$OUT8" | grep -qF ".zshrc" \
+            || { echo "::error::hint output missing .zshrc"; exit 1; }
+          echo "$OUT8" | grep -qF ".zprofile" \
+            || { echo "::error::hint output missing .zprofile"; exit 1; }
           echo "::endgroup::"
           echo "✓ rootless-zsh OK"
 
@@ -537,22 +550,29 @@ jobs:
           echo "::endgroup::"
           echo "✓ no-modify-path opt-out OK"
 
-          # ── Scenario 13: CI=true auto-skips PATH modification ───────
-          echo "::group::CI=true auto-skip"
-          H13="$GITHUB_WORKSPACE/home-13"
-          rm -rf "$H13"; mkdir -p "$H13/.local/bin"
-          env -i \
-            HOME="$H13" \
-            SHELL="/bin/zsh" \
-            CI=true \
-            PATH="/usr/local/bin:/usr/bin:/bin" \
-            bash /tmp/bootstrap.sh >/dev/null 2>&1 || {
-            echo "::error::bootstrap failed with CI=true"; exit 1
-          }
-          test ! -f "$H13/.zshrc" \
-            || { echo "::error::CI=true did not auto-skip PATH modification"; exit 1; }
-          echo "::endgroup::"
-          echo "✓ CI=true auto-skip OK"
+          # ── Scenario 13: CI=<truthy> auto-skips PATH modification ───
+          # Iterate over the accepted truthy values (true / 1 / yes) — not
+          # every CI exports CI=true verbatim (some use 1), so all three
+          # must short-circuit the rc modification path.
+          for _ci_val in true 1 yes; do
+            echo "::group::CI=${_ci_val} auto-skip"
+            H13="$GITHUB_WORKSPACE/home-13-${_ci_val}"
+            rm -rf "$H13"; mkdir -p "$H13/.local/bin"
+            env -i \
+              HOME="$H13" \
+              SHELL="/bin/zsh" \
+              CI="$_ci_val" \
+              PATH="/usr/local/bin:/usr/bin:/bin" \
+              bash /tmp/bootstrap.sh >/dev/null 2>&1 || {
+              echo "::error::bootstrap failed with CI=${_ci_val}"; exit 1
+            }
+            test ! -f "$H13/.zshrc" \
+              || { echo "::error::CI=${_ci_val} did not auto-skip PATH modification"; exit 1; }
+            test ! -f "$H13/.zprofile" \
+              || { echo "::error::CI=${_ci_val} did not auto-skip .zprofile"; exit 1; }
+            echo "::endgroup::"
+            echo "✓ CI=${_ci_val} auto-skip OK"
+          done
 
           # ── Scenario 14: BIN_DIR already in PATH → skip rc ──────────
           echo "::group::BIN_DIR already on PATH"

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -417,3 +417,155 @@ jobs:
           mv "$ROOT/release/checksums.txt.minisig.bak" "$ROOT/release/checksums.txt.minisig"
           echo "::endgroup::"
           echo "✓ empty-manifest path OK"
+
+          # ── PATH-setup scenarios ────────────────────────────────────────
+          # Following scenarios exercise the rootless install + shell-rc
+          # modification introduced for issue #186. Trust chain is
+          # unchanged; these only assert BIN_DIR defaulting and PATH
+          # plumbing. Each runs with an isolated HOME so rc files from
+          # one scenario can't leak into the next.
+          #
+          # PATH-mod only runs when CI is unset (GHA sets CI=true → the
+          # installer auto-skips). We strip it with `env -u CI` for the
+          # scenarios that must exercise the modification path, and
+          # preserve it to assert the auto-skip.
+          MARKER="# added by appstrate installer"
+
+          # Helper: run bootstrap in an isolated HOME with a chosen
+          # $SHELL and return rc + output. Keeps the per-scenario blocks
+          # focused on assertions rather than plumbing.
+          run_bootstrap_isolated() {
+            _scenario="$1"; shift
+            _shell="$1"; shift
+            _home="$GITHUB_WORKSPACE/home-${_scenario}"
+            rm -rf "$_home"
+            mkdir -p "$_home/.local/bin"
+            # `env -i` gives us a clean slate — keep only what bootstrap
+            # actually needs (PATH for curl/grep/etc.) and the caller's
+            # extra vars. This is the only way to reliably strip CI=true
+            # from GHA's injected environment in a child process.
+            env -i \
+              HOME="$_home" \
+              SHELL="$_shell" \
+              PATH="/usr/local/bin:/usr/bin:/bin" \
+              "$@" \
+              bash /tmp/bootstrap.sh 2>&1
+          }
+
+          # ── Scenario 8: rootless default + zsh rc modification ──────
+          echo "::group::rootless default (zsh)"
+          OUT8=$(run_bootstrap_isolated 8 "/bin/zsh") || {
+            echo "$OUT8"; echo "::error::bootstrap failed on rootless zsh path"; exit 1
+          }
+          echo "$OUT8"
+          H8="$GITHUB_WORKSPACE/home-8"
+          test -x "$H8/.local/bin/appstrate" \
+            || { echo "::error::binary not installed to rootless default"; exit 1; }
+          test -f "$H8/.zshrc" \
+            || { echo "::error::.zshrc was not created"; exit 1; }
+          grep -qF "$MARKER" "$H8/.zshrc" \
+            || { echo "::error::.zshrc missing install marker"; exit 1; }
+          grep -q "export PATH=\"$H8/.local/bin:\$PATH\"" "$H8/.zshrc" \
+            || { echo "::error::.zshrc missing PATH export"; exit 1; }
+          echo "::endgroup::"
+          echo "✓ rootless-zsh OK"
+
+          # ── Scenario 9: idempotent re-run (no duplicate lines) ─────
+          echo "::group::idempotent re-run"
+          # Re-use the scenario-8 HOME so the marker is already present.
+          BEFORE=$(wc -l <"$H8/.zshrc")
+          env -i \
+            HOME="$H8" \
+            SHELL="/bin/zsh" \
+            PATH="/usr/local/bin:/usr/bin:/bin" \
+            bash /tmp/bootstrap.sh >/dev/null 2>&1 || {
+            echo "::error::second bootstrap run failed"; exit 1
+          }
+          AFTER=$(wc -l <"$H8/.zshrc")
+          test "$BEFORE" -eq "$AFTER" \
+            || { echo "::error::.zshrc grew on re-run ($BEFORE → $AFTER lines)"; exit 1; }
+          # And only one marker, not two.
+          COUNT=$(grep -cF "$MARKER" "$H8/.zshrc")
+          test "$COUNT" -eq 1 \
+            || { echo "::error::marker appeared $COUNT times, expected 1"; exit 1; }
+          echo "::endgroup::"
+          echo "✓ idempotent path OK"
+
+          # ── Scenario 10: bash shotgun ──────────────────────────────
+          echo "::group::bash shotgun"
+          OUT10=$(run_bootstrap_isolated 10 "/bin/bash") || {
+            echo "$OUT10"; echo "::error::bootstrap failed on bash shotgun path"; exit 1
+          }
+          H10="$GITHUB_WORKSPACE/home-10"
+          for f in .profile .bashrc .bash_profile; do
+            test -f "$H10/$f" \
+              || { echo "::error::bash shotgun did not write $f"; exit 1; }
+            grep -qF "$MARKER" "$H10/$f" \
+              || { echo "::error::$f missing install marker"; exit 1; }
+          done
+          echo "::endgroup::"
+          echo "✓ bash-shotgun OK"
+
+          # ── Scenario 11: fish conf.d ───────────────────────────────
+          echo "::group::fish conf.d"
+          OUT11=$(run_bootstrap_isolated 11 "/usr/bin/fish") || {
+            echo "$OUT11"; echo "::error::bootstrap failed on fish path"; exit 1
+          }
+          H11="$GITHUB_WORKSPACE/home-11"
+          FISH_CONF="$H11/.config/fish/conf.d/appstrate.fish"
+          test -f "$FISH_CONF" \
+            || { echo "::error::fish conf.d file was not created"; exit 1; }
+          grep -q "fish_add_path $H11/.local/bin" "$FISH_CONF" \
+            || { echo "::error::fish config missing fish_add_path line"; exit 1; }
+          # No bash/zsh artifacts should exist for fish users.
+          test ! -f "$H11/.zshrc" \
+            || { echo "::error::fish scenario wrote .zshrc"; exit 1; }
+          echo "::endgroup::"
+          echo "✓ fish path OK"
+
+          # ── Scenario 12: APPSTRATE_NO_MODIFY_PATH=1 opt-out ────────
+          echo "::group::no-modify-path opt-out"
+          OUT12=$(run_bootstrap_isolated 12 "/bin/zsh" \
+            APPSTRATE_NO_MODIFY_PATH=1) || {
+            echo "$OUT12"; echo "::error::bootstrap failed with NO_MODIFY_PATH"; exit 1
+          }
+          H12="$GITHUB_WORKSPACE/home-12"
+          test -x "$H12/.local/bin/appstrate" \
+            || { echo "::error::binary not installed with NO_MODIFY_PATH"; exit 1; }
+          test ! -f "$H12/.zshrc" \
+            || { echo "::error::.zshrc was written despite NO_MODIFY_PATH=1"; exit 1; }
+          echo "::endgroup::"
+          echo "✓ no-modify-path opt-out OK"
+
+          # ── Scenario 13: CI=true auto-skips PATH modification ───────
+          echo "::group::CI=true auto-skip"
+          H13="$GITHUB_WORKSPACE/home-13"
+          rm -rf "$H13"; mkdir -p "$H13/.local/bin"
+          env -i \
+            HOME="$H13" \
+            SHELL="/bin/zsh" \
+            CI=true \
+            PATH="/usr/local/bin:/usr/bin:/bin" \
+            bash /tmp/bootstrap.sh >/dev/null 2>&1 || {
+            echo "::error::bootstrap failed with CI=true"; exit 1
+          }
+          test ! -f "$H13/.zshrc" \
+            || { echo "::error::CI=true did not auto-skip PATH modification"; exit 1; }
+          echo "::endgroup::"
+          echo "✓ CI=true auto-skip OK"
+
+          # ── Scenario 14: BIN_DIR already in PATH → skip rc ──────────
+          echo "::group::BIN_DIR already on PATH"
+          H14="$GITHUB_WORKSPACE/home-14"
+          rm -rf "$H14"; mkdir -p "$H14/.local/bin"
+          env -i \
+            HOME="$H14" \
+            SHELL="/bin/zsh" \
+            PATH="$H14/.local/bin:/usr/local/bin:/usr/bin:/bin" \
+            bash /tmp/bootstrap.sh >/dev/null 2>&1 || {
+            echo "::error::bootstrap failed with BIN_DIR pre-on-PATH"; exit 1
+          }
+          test ! -f "$H14/.zshrc" \
+            || { echo "::error::rc modified despite BIN_DIR already on PATH"; exit 1; }
+          echo "::endgroup::"
+          echo "✓ already-on-PATH skip OK"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Deploy Appstrate with a single command. The installer downloads the `appstrate` 
 curl -fsSL https://get.appstrate.dev | bash
 ```
 
+The CLI installs into `~/.local/bin` (no sudo) and adds it to your `PATH`. For a system-wide install, prefix the command with `APPSTRATE_BIN_DIR=/usr/local/bin` (sudo will be requested). To skip the shell profile modification, set `APPSTRATE_NO_MODIFY_PATH=1`.
+
 Once a tier is chosen, the CLI generates cryptographic secrets, writes `.env` + `docker-compose.yml` (Tiers 1/2/3) or clones the source + spawns `bun run dev` (Tier 0), waits for the healthcheck, and opens [http://localhost:3000](http://localhost:3000). Non-interactive: `curl ... | bash -s -- --tier 3 --dir ~/appstrate`.
 
 See [`apps/cli/README.md`](./apps/cli/README.md) for the full CLI reference, and [`examples/self-hosting/`](./examples/self-hosting/) for manual Docker Compose setup.

--- a/docs/adr/ADR-006-cli-device-flow-monorepo.md
+++ b/docs/adr/ADR-006-cli-device-flow-monorepo.md
@@ -67,7 +67,7 @@ An official CLI, `appstrate`, distributed as:
 
 - An npm package `appstrate` (installable via `bunx appstrate …`).
 - Standalone single-binary builds for `linux-x64`, `linux-arm64`, `darwin-x64`, and `darwin-arm64`, produced by `bun build --compile --target=<target>` and attached to GitHub Releases. **Windows (`win32-x64`) is deliberately out of scope for v1** — the 2026 dev-tool baseline (Supabase, Railway, Fly, Neon, Wrangler) is WSL2 on Windows, which reuses the `linux-x64` binary. Shipping a native Windows build would double the `install` / `login` manual-test surface (Docker Desktop paths, CRLF line endings, Credential Manager quirks) for a user segment that is already well-served via WSL2. A native Windows binary can be added post-v1 by appending a `windows-latest` row to the release matrix if demand warrants.
-- A refactored `https://get.appstrate.dev` shell one-liner that detects OS/arch, downloads the matching binary to `/usr/local/bin/appstrate`, and chains into `appstrate install`. Windows users run the one-liner inside a WSL2 shell, or invoke `bunx appstrate install` natively if they already have Bun on Windows.
+- A refactored `https://get.appstrate.dev` shell one-liner that detects OS/arch, downloads the matching binary to `$HOME/.local/bin/appstrate` (rootless XDG default — matches uv / rustup / Bun / Deno; system-wide install via `APPSTRATE_BIN_DIR=/usr/local/bin`), adds that directory to the user's shell `PATH` (opt-out: `APPSTRATE_NO_MODIFY_PATH=1`), and chains into `appstrate install`. Windows users run the one-liner inside a WSL2 shell, or invoke `bunx appstrate install` natively if they already have Bun on Windows.
 
 Version number tracks the platform release train (lockstep).
 

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -29,10 +29,14 @@
 #   curl -fsSL https://get.appstrate.dev | bash -s -- --tier 3
 #
 # Env overrides:
-#   APPSTRATE_VERSION        Pin a release tag (default: pinned or "latest").
-#   APPSTRATE_BIN_DIR        Install location (default: /usr/local/bin).
-#   APPSTRATE_SKIP_VERIFY=1  Skip signature + checksum verification (CI
-#                            debug only — do NOT set on user machines).
+#   APPSTRATE_VERSION             Pin a release tag (default: pinned or "latest").
+#   APPSTRATE_BIN_DIR             Install location (default: $HOME/.local/bin).
+#                                 Set to /usr/local/bin for a system-wide install
+#                                 (sudo will be requested).
+#   APPSTRATE_NO_MODIFY_PATH=1    Do not touch shell rc files to add BIN_DIR to
+#                                 PATH. Equivalent to uv's UV_NO_MODIFY_PATH.
+#   APPSTRATE_SKIP_VERIFY=1       Skip signature + checksum verification (CI
+#                                 debug only — do NOT set on user machines).
 
 set -euo pipefail
 
@@ -81,7 +85,12 @@ _appstrate_bootstrap() {
   _DEFAULT_VERSION="__APPSTRATE_VERSION__"
   if [[ "$_DEFAULT_VERSION" == __* ]]; then _DEFAULT_VERSION="latest"; fi
   VERSION="${APPSTRATE_VERSION:-$_DEFAULT_VERSION}"
-  BIN_DIR="${APPSTRATE_BIN_DIR:-/usr/local/bin}"
+  # Rootless default: install into $HOME/.local/bin (XDG user-space equivalent
+  # of /usr/local/bin). Matches uv, rustup, Bun, Deno, pipx — avoids a sudo
+  # prompt on the happy path, works in containers / CI without privileges, and
+  # contains blast radius if the binary is ever compromised (can't escape $HOME).
+  # Users who want a system-wide install can opt in via APPSTRATE_BIN_DIR.
+  BIN_DIR="${APPSTRATE_BIN_DIR:-$HOME/.local/bin}"
   DEST="${BIN_DIR}/appstrate"
   ASSET="appstrate-${OS}-${ARCH}"
 
@@ -226,9 +235,20 @@ _appstrate_bootstrap() {
 
   # ─── Install ────────────────────────────────────────────────────────────────
 
+  # Create BIN_DIR if it doesn't exist — ~/.local/bin isn't present by
+  # default on macOS vanilla. mkdir -p is a no-op if the dir already exists.
+  # We attempt this unconditionally under the current user; if BIN_DIR lives
+  # under a system path that requires root (explicit APPSTRATE_BIN_DIR
+  # override), the mkdir will silently fail and we'll catch it in the
+  # writability check below.
+  mkdir -p "$BIN_DIR" 2>/dev/null || true
+
   # `sudo` only if the destination isn't user-writable — skips a pointless
-  # auth prompt when /usr/local/bin is already owned by the user (common
-  # on macOS Homebrew setups under /opt/homebrew + symlinked /usr/local/bin).
+  # auth prompt on the rootless default ($HOME/.local/bin), and on
+  # /usr/local/bin setups where the dir is already user-owned (macOS Homebrew
+  # under /opt/homebrew + symlinked /usr/local/bin). Only the explicit
+  # APPSTRATE_BIN_DIR=/usr/local/bin override on a stock Linux/macOS system
+  # will trigger the sudo prompt.
   SUDO=""
   if [ ! -w "$BIN_DIR" ]; then
     SUDO="sudo"
@@ -236,6 +256,91 @@ _appstrate_bootstrap() {
 
   log "Installing to $DEST"
   $SUDO install -m 0755 "$TMPDIR/$ASSET" "$DEST"
+
+  # ─── PATH setup ─────────────────────────────────────────────────────────────
+
+  # Add BIN_DIR to PATH by appending `export PATH="$BIN_DIR:$PATH"` to the
+  # user's shell rc files. Same pattern as uv, rustup, Bun, Deno.
+  #
+  # Skipped when:
+  #   - APPSTRATE_NO_MODIFY_PATH=1 (explicit opt-out, like UV_NO_MODIFY_PATH)
+  #   - CI=true (CIs don't restart shells; they set PATH explicitly)
+  #   - BIN_DIR is already on PATH (common for /usr/local/bin — no-op needed)
+  #
+  # Idempotent: a marker comment (APPSTRATE_PATH_MARKER) is grep'd before
+  # appending, so re-running the installer doesn't duplicate lines.
+  APPSTRATE_PATH_MARKER="# added by appstrate installer"
+  MODIFIED_PROFILE=""
+  if [ "${APPSTRATE_NO_MODIFY_PATH:-0}" = "1" ] || [ "${CI:-}" = "true" ]; then
+    : # explicit opt-out
+  else
+    case ":${PATH}:" in
+      *":${BIN_DIR}:"*) : ;; # already on PATH, nothing to do
+      *)
+        _shell_name=$(basename "${SHELL:-}")
+        # The exact export line written to rc files. Quoted so variable
+        # expansion happens at shell-startup time, not now — keeps the rc
+        # file portable if HOME ever changes (it shouldn't, but).
+        _path_line="export PATH=\"${BIN_DIR}:\$PATH\""
+
+        # Append `$marker` + `$line` to `$file` if the marker isn't already
+        # present. Touches the file if it doesn't exist (uv shotgun pattern).
+        _append_path() {
+          _file="$1"
+          _line="$2"
+          if [ -f "$_file" ] && grep -qF "$APPSTRATE_PATH_MARKER" "$_file" 2>/dev/null; then
+            return 0
+          fi
+          # `>> "$file"` creates the file if absent — matches uv's behavior
+          # of writing .profile/.zshrc even on fresh systems.
+          printf '\n%s\n%s\n' "$APPSTRATE_PATH_MARKER" "$_line" >>"$_file"
+          MODIFIED_PROFILE="$_file"
+        }
+
+        case "$_shell_name" in
+          bash)
+            # Shotgun approach — bash's rc-file loading varies wildly
+            # (interactive vs login, macOS vs Linux, with/without
+            # .bash_profile). Writing to all common candidates covers every
+            # case without needing to introspect the invocation context.
+            # .profile is included for POSIX sh / dash fallback.
+            _append_path "$HOME/.profile" "$_path_line"
+            _append_path "$HOME/.bashrc" "$_path_line"
+            _append_path "$HOME/.bash_profile" "$_path_line"
+            ;;
+          zsh)
+            # zsh only loads .zshrc for interactive shells and .zshenv for
+            # all invocations. .zshrc is the common case; .zshenv is only
+            # touched if it already exists (avoid polluting non-interactive
+            # environments for users who haven't opted in).
+            _append_path "$HOME/.zshrc" "$_path_line"
+            if [ -f "$HOME/.zshenv" ]; then
+              _append_path "$HOME/.zshenv" "$_path_line"
+            fi
+            ;;
+          fish)
+            # fish has its own syntax and a dedicated drop-in directory for
+            # environment config — cleaner than touching config.fish
+            # directly, and removable by deleting a single file.
+            _fish_conf="$HOME/.config/fish/conf.d"
+            mkdir -p "$_fish_conf" 2>/dev/null || true
+            _append_path "$_fish_conf/appstrate.fish" "fish_add_path ${BIN_DIR}"
+            ;;
+          *)
+            # Unknown shell — fall back to .profile (sourced by sh/dash and
+            # some bash login configurations). Better than silently doing
+            # nothing: at least the next login shell will pick it up.
+            _append_path "$HOME/.profile" "$_path_line"
+            ;;
+        esac
+        ;;
+    esac
+  fi
+
+  if [ -n "$MODIFIED_PROFILE" ]; then
+    warn "Added ${BIN_DIR} to PATH in ${MODIFIED_PROFILE}."
+    warn "Restart your shell or run: source ${MODIFIED_PROFILE}"
+  fi
 
   log "Launching \`appstrate install\`"
   # Exec by absolute path, NOT by `appstrate` on PATH. A different

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -264,23 +264,35 @@ _appstrate_bootstrap() {
   #
   # Skipped when:
   #   - APPSTRATE_NO_MODIFY_PATH=1 (explicit opt-out, like UV_NO_MODIFY_PATH)
-  #   - CI=true (CIs don't restart shells; they set PATH explicitly)
+  #   - CI is truthy: 1/true/yes (covers GHA, GitLab, CircleCI, Travis,
+  #     Jenkins and anything else that exports a boolean-ish CI flag —
+  #     CIs don't restart shells; they set PATH explicitly)
   #   - BIN_DIR is already on PATH (common for /usr/local/bin — no-op needed)
   #
   # Idempotent: a marker comment (APPSTRATE_PATH_MARKER) is grep'd before
   # appending, so re-running the installer doesn't duplicate lines.
   APPSTRATE_PATH_MARKER="# added by appstrate installer"
-  MODIFIED_PROFILE=""
-  if [ "${APPSTRATE_NO_MODIFY_PATH:-0}" = "1" ] || [ "${CI:-}" = "true" ]; then
+  # Newline-separated list of rc files we touched. Accumulated (not
+  # overwritten) so the final restart-your-shell hint reports every file,
+  # not just the last one — critical for the bash shotgun case where up
+  # to three files may be modified in a single run.
+  MODIFIED_PROFILES=""
+  _ci_flag="${CI:-}"
+  if [ "${APPSTRATE_NO_MODIFY_PATH:-0}" = "1" ] \
+    || [ "$_ci_flag" = "true" ] || [ "$_ci_flag" = "1" ] || [ "$_ci_flag" = "yes" ]; then
     : # explicit opt-out
   else
     case ":${PATH}:" in
       *":${BIN_DIR}:"*) : ;; # already on PATH, nothing to do
       *)
         _shell_name=$(basename "${SHELL:-}")
-        # The exact export line written to rc files. Quoted so variable
-        # expansion happens at shell-startup time, not now — keeps the rc
-        # file portable if HOME ever changes (it shouldn't, but).
+        # The exact export line written to POSIX rc files. The `$PATH` ref
+        # is escaped (`\$PATH`) so it expands at shell-startup time, not
+        # now — the rc file stays portable if the user ever moves $HOME.
+        # (The fish branch below doesn't use this line; it writes a
+        # fish-native `fish_add_path` invocation instead, which resolves
+        # BIN_DIR eagerly — acceptable because fish re-evaluates conf.d
+        # on every shell start and $HOME rewrites are vanishingly rare.)
         _path_line="export PATH=\"${BIN_DIR}:\$PATH\""
 
         # Append `$marker` + `$line` to `$file` if the marker isn't already
@@ -294,7 +306,8 @@ _appstrate_bootstrap() {
           # `>> "$file"` creates the file if absent — matches uv's behavior
           # of writing .profile/.zshrc even on fresh systems.
           printf '\n%s\n%s\n' "$APPSTRATE_PATH_MARKER" "$_line" >>"$_file"
-          MODIFIED_PROFILE="$_file"
+          MODIFIED_PROFILES="${MODIFIED_PROFILES}${_file}
+"
         }
 
         case "$_shell_name" in
@@ -309,11 +322,15 @@ _appstrate_bootstrap() {
             _append_path "$HOME/.bash_profile" "$_path_line"
             ;;
           zsh)
-            # zsh only loads .zshrc for interactive shells and .zshenv for
-            # all invocations. .zshrc is the common case; .zshenv is only
-            # touched if it already exists (avoid polluting non-interactive
-            # environments for users who haven't opted in).
+            # zsh loads .zshrc (interactive), .zprofile (login), and
+            # .zshenv (all invocations). .zshrc + .zprofile are written
+            # unconditionally — between them they cover every interactive
+            # zsh session on macOS (default login shell) and Linux.
+            # .zshenv is only touched if already present, to avoid
+            # polluting non-interactive environments for users who
+            # haven't opted in.
             _append_path "$HOME/.zshrc" "$_path_line"
+            _append_path "$HOME/.zprofile" "$_path_line"
             if [ -f "$HOME/.zshenv" ]; then
               _append_path "$HOME/.zshenv" "$_path_line"
             fi
@@ -337,9 +354,17 @@ _appstrate_bootstrap() {
     esac
   fi
 
-  if [ -n "$MODIFIED_PROFILE" ]; then
-    warn "Added ${BIN_DIR} to PATH in ${MODIFIED_PROFILE}."
-    warn "Restart your shell or run: source ${MODIFIED_PROFILE}"
+  if [ -n "$MODIFIED_PROFILES" ]; then
+    # Informational output (not a warning — the action succeeded). Uses
+    # `log` rather than `warn` so users don't mistake it for an error,
+    # and lists every touched file so the shotgun bash case doesn't hide
+    # the .profile / .bashrc writes behind the last one.
+    log "Added ${BIN_DIR} to PATH in:"
+    # Trim trailing newline so the loop doesn't emit a blank entry.
+    printf '%s' "$MODIFIED_PROFILES" | while IFS= read -r _profile; do
+      [ -n "$_profile" ] && log "  - ${_profile}"
+    done
+    log "Restart your shell to pick up the new PATH."
   fi
 
   log "Launching \`appstrate install\`"

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -278,8 +278,8 @@ _appstrate_bootstrap() {
   # to three files may be modified in a single run.
   MODIFIED_PROFILES=""
   _ci_flag="${CI:-}"
-  if [ "${APPSTRATE_NO_MODIFY_PATH:-0}" = "1" ] \
-    || [ "$_ci_flag" = "true" ] || [ "$_ci_flag" = "1" ] || [ "$_ci_flag" = "yes" ]; then
+  if [ "${APPSTRATE_NO_MODIFY_PATH:-0}" = "1" ] ||
+    [ "$_ci_flag" = "true" ] || [ "$_ci_flag" = "1" ] || [ "$_ci_flag" = "yes" ]; then
     : # explicit opt-out
   else
     case ":${PATH}:" in


### PR DESCRIPTION
## Summary

- Switch bootstrap installer default from `/usr/local/bin` (sudo) to `$HOME/.local/bin` (XDG, rootless) — aligns with uv, Bun, rustup, Deno, pipx.
- Auto-add `BIN_DIR` to `PATH` via shell rc modification (bash shotgun / zsh / fish / `.profile` fallback). Idempotent via marker comment. Opt-out: `APPSTRATE_NO_MODIFY_PATH=1`. Auto-skip when `CI=true` or `BIN_DIR` already on `$PATH`.
- Minisign + SHA-256 trust chain unchanged — this PR only touches install destination and `PATH` plumbing.

Closes #186.

## Why

`curl -fsSL https://get.appstrate.dev | bash` currently prompts `Password:` on vanilla macOS / Linux because `/usr/local/bin` isn't user-writable. Modern installers have moved away from this pattern — the XDG Base Directory Specification designates `~/.local/bin` as the user-space equivalent of `/usr/local/bin`. Rootless install is also faster (no prompt), more contained (compromised binary can't escape `$HOME`), and works in environments where `sudo` isn't available (rootless containers, CI without privileges, corporate machines).

SOTA validated against [uv](https://docs.astral.sh/uv/getting-started/installation/), [Bun](https://bun.com/docs/installation), [rustup](https://rust-lang.github.io/rustup/installation/index.html), [Deno](https://docs.deno.com/runtime/getting_started/installation/).

## Behavior matrix

| Scenario | BIN_DIR | sudo? | PATH modified? |
|---|---|---|---|
| Default | `$HOME/.local/bin` | no | yes (opt-out via env) |
| `APPSTRATE_BIN_DIR=/usr/local/bin` | `/usr/local/bin` | yes | no (already on PATH) |
| `APPSTRATE_NO_MODIFY_PATH=1` | default | no | no |
| `CI=true` (any CI) | default | no | no (auto-skip) |
| `BIN_DIR` already on `$PATH` | default | no | no (redundant) |

## Shell profile targets

- **bash** — shotgun `~/.profile` + `~/.bashrc` + `~/.bash_profile` (covers interactive vs login, macOS vs Linux rc-loading variance in one pass, matches uv's approach)
- **zsh** — `~/.zshrc` always, `~/.zshenv` only if already present
- **fish** — `~/.config/fish/conf.d/appstrate.fish` with `fish_add_path` (dedicated drop-in, removable by deleting the file)
- **unknown shell** — `~/.profile` fallback

## Test plan

Added 7 scenarios to `bootstrap-verify-dry-run` in `test-install.yml` (reusing the signed fake-release setup already in place), each running with an isolated `HOME` to prevent rc leakage between scenarios:

- [x] 8 — Rootless default (zsh): binary in `~/.local/bin`, `.zshrc` contains marker + `export PATH`
- [x] 9 — Idempotent re-run: line count stable, exactly one marker
- [x] 10 — bash shotgun: all three rc files written with marker
- [x] 11 — fish: `conf.d/appstrate.fish` with `fish_add_path`, no `.zshrc` leak
- [x] 12 — `APPSTRATE_NO_MODIFY_PATH=1`: binary installed, no rc touched
- [x] 13 — `CI=true`: auto-skip, no rc touched
- [x] 14 — `BIN_DIR` already on `$PATH`: skip, no rc touched

All 7 scenarios validated locally against the real `scripts/bootstrap.sh` with a real minisign trust chain.

## Docs

- `README.md` — install snippet annotated with new destination + sudo override + `NO_MODIFY_PATH`
- `docs/adr/ADR-006-cli-device-flow-monorepo.md` — path updated from `/usr/local/bin/appstrate` to `$HOME/.local/bin/appstrate`, XDG rationale added

🤖 Generated with [Claude Code](https://claude.com/claude-code)