### PR TITLE
chore(core): bump to 2.12.0

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to `@appstrate/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.12.0] — 2026-04-19
+
+### Added
+
+- `@appstrate/core/api-errors` — HTTP error layer (`ApiError`, factory
+  helpers `invalidRequest` / `unauthorized` / `forbidden` / `notFound` /
+  `conflict` / `gone` / `internalError` / `systemEntityForbidden`,
+  `parseBody`, `asRecord`). Lets external modules loaded via `MODULES=`
+  build RFC 9457 `problem+json` responses without reaching into
+  `apps/api/src/*`.
+- `@appstrate/core/platform-types` — structural contracts for platform
+  capabilities (`ContainerOrchestrator`, `PubSub`, workload types).
+- `ModuleInitContext.services` — typed `PlatformServices` surface
+  (orchestrator, pubsub, models, packages, runs, realtime, cross-module
+  events, logger) wired by the platform at module init. External modules
+  now depend only on `@appstrate/core` at compile time and receive every
+  runtime capability through the init context.
+
+### Changed
+
+- Internal: `safe-json` helper exported for module use.
+
 ## [2.11.1] — 2026-04-18
 
 ### Changed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump `@appstrate/core` to 2.12.0 (minor)
- Adds `PlatformServices` injection via `ModuleInitContext.services`
- Extracts `api-errors` + `platform-types` as public subpath exports for external modules
- Strictly additive — built-in modules unchanged

All new APIs already landed in #193 (f33e5727). This PR just ships the version bump + changelog so publish-core.yml publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)