### PR TITLE
fix: actionable error + auto-recovery on Docker network pool exhaustion

### DIFF
--- a/apps/api/src/services/docker-errors.ts
+++ b/apps/api/src/services/docker-errors.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Typed Docker errors that warrant specific handling upstream.
+ *
+ * The Docker Engine returns plain text error bodies; callers that need to
+ * react differently per failure mode (retry, user-facing remediation) must
+ * classify by string. Centralising that mapping here keeps `docker.ts` a
+ * thin HTTP wrapper and makes the classifier trivially unit-testable.
+ */
+
+/**
+ * Raised when Docker refuses to create a new bridge network because the
+ * default IPAM address pool is exhausted — Moby's `ErrNoMoreSubnets`
+ * (`daemon/libnetwork/ipamapi/contract.go`). By default the pool splits
+ * `172.17.0.0/12` into `/16` subnets, yielding ~31 networks per host; a
+ * single Appstrate install holds several of them and every run consumes
+ * one more, so busy hosts hit the ceiling well before they run out of
+ * actual address space.
+ *
+ * The thrown message is user-facing: it includes both the quick fix
+ * (`docker network prune`) and the permanent remediation (tune
+ * `default-address-pools` in `daemon.json`).
+ */
+export class DockerAddressPoolExhaustedError extends Error {
+  readonly code = "DOCKER_ADDRESS_POOL_EXHAUSTED" as const;
+
+  constructor(dockerMessage?: string) {
+    super(
+      [
+        "Docker's default address pool is exhausted — cannot create more bridge networks.",
+        "",
+        "Quick fix:   docker network prune",
+        "Permanent:   configure `default-address-pools` in /etc/docker/daemon.json",
+        "             (macOS/Windows: Docker Desktop → Settings → Docker Engine)",
+        "             see examples/self-hosting/README.md#docker-network-pool-tuning",
+      ].join("\n"),
+    );
+    this.name = "DockerAddressPoolExhaustedError";
+    if (dockerMessage) this.cause = dockerMessage;
+  }
+}
+
+/**
+ * Inspect a Docker API network-create failure and return a typed error
+ * when the daemon signalled pool exhaustion, `null` otherwise.
+ *
+ * The match is a substring check against the stable Moby constant
+ * `ErrNoMoreSubnets` — `types.InvalidParameterErrorf` maps to HTTP 400
+ * at the REST layer, so we gate on status too to avoid false positives
+ * in pathological 500 bodies.
+ */
+export function classifyDockerNetworkError(
+  status: number,
+  body: string,
+): DockerAddressPoolExhaustedError | null {
+  if (status === 400 && body.includes("all predefined address pools have been fully subnetted")) {
+    return new DockerAddressPoolExhaustedError(body);
+  }
+  return null;
+}
+
+/**
+ * Create a network with opportunistic recovery on pool exhaustion.
+ *
+ * The flow:
+ *   1. Try to create the network.
+ *   2. On `DockerAddressPoolExhaustedError`, reclaim orphan networks left
+ *      by crashed runs.
+ *   3. If cleanup freed at least one network, retry once. Otherwise the
+ *      pool is genuinely full → re-throw the typed error so the user sees
+ *      the remediation steps instead of a pointless retry.
+ *
+ * Any other error type is propagated unchanged. Dependencies are injected
+ * so this helper is trivially unit-testable without touching the real
+ * Docker socket.
+ */
+export async function createNetworkWithPoolRetry(
+  createNetwork: () => Promise<string>,
+  cleanupOrphanedNetworks: () => Promise<number>,
+  log: { warn: (msg: string, data?: Record<string, unknown>) => void } = {
+    warn: () => {},
+  },
+): Promise<string> {
+  try {
+    return await createNetwork();
+  } catch (err) {
+    if (!(err instanceof DockerAddressPoolExhaustedError)) throw err;
+    log.warn("Docker address pool exhausted, attempting orphan network cleanup");
+    const reclaimed = await cleanupOrphanedNetworks();
+    log.warn("Orphan network cleanup complete", { reclaimed });
+    if (reclaimed === 0) throw err;
+    return await createNetwork();
+  }
+}

--- a/apps/api/src/services/docker.ts
+++ b/apps/api/src/services/docker.ts
@@ -8,6 +8,15 @@ import { classifyDockerNetworkError } from "./docker-errors.ts";
 const DOCKER_SOCKET = getEnv().DOCKER_SOCKET;
 const DOCKER_API_TIMEOUT_MS = 30_000;
 
+/**
+ * Naming prefix for per-run isolation networks. The orchestrator creates
+ * `${EXEC_NETWORK_PREFIX}${runId}` for every run, and the cleanup helpers
+ * match on this prefix to reclaim orphans from crashed runs. Kept in one
+ * place so creator and cleaner can never drift apart — a mismatch would
+ * silently leak networks until the address pool is exhausted.
+ */
+export const EXEC_NETWORK_PREFIX = "appstrate-exec-";
+
 // Support both unix socket (/var/run/docker.sock) and TCP (http://host:port).
 // Bun supports fetch() with unix: option for Unix sockets.
 // Pass timeoutMs=false for long-running calls (streamLogs, waitForExit).
@@ -505,7 +514,7 @@ export async function cleanupOrphanedContainers(): Promise<{
 export async function cleanupOrphanedNetworks(): Promise<number> {
   return removeNetworksMatching(
     (name) =>
-      name.startsWith("appstrate-exec-") ||
+      name.startsWith(EXEC_NETWORK_PREFIX) ||
       name === "appstrate-sidecar-pool" ||
       name === "appstrate-egress",
   );
@@ -520,7 +529,7 @@ export async function cleanupOrphanedNetworks(): Promise<number> {
  * reclaiming even one orphan is often enough to unblock the retry.
  */
 export async function cleanupOrphanedRunNetworks(): Promise<number> {
-  return removeNetworksMatching((name) => name.startsWith("appstrate-exec-"));
+  return removeNetworksMatching((name) => name.startsWith(EXEC_NETWORK_PREFIX));
 }
 
 async function removeNetworksMatching(predicate: (name: string) => boolean): Promise<number> {

--- a/apps/api/src/services/docker.ts
+++ b/apps/api/src/services/docker.ts
@@ -492,27 +492,46 @@ export async function cleanupOrphanedContainers(): Promise<{
 }
 
 /**
- * List all Docker networks matching `appstrate-exec-*` or `appstrate-sidecar-pool` and remove them.
- * This is safe to call at startup because no runs should be running. Exported so the
- * orchestrator can call it opportunistically when network creation hits address-pool
- * exhaustion mid-operation — orphan leaks from crashed runs keep consuming pool slots
- * until reclaimed, and reclaiming them is often enough to unblock the next `createNetwork`.
+ * List all Docker networks matching `appstrate-exec-*` or the shared infra
+ * networks (`appstrate-sidecar-pool`, `appstrate-egress`) and remove them.
+ * Only safe to call at startup because no runs should be running — the infra
+ * networks it targets are actively reused across runs, so tearing them down
+ * mid-operation can strand the sidecar pool or break egress routing.
+ *
+ * For opportunistic recovery during a live operation, use
+ * {@link cleanupOrphanedRunNetworks} instead, which is strictly scoped to
+ * per-run networks.
  */
 export async function cleanupOrphanedNetworks(): Promise<number> {
+  return removeNetworksMatching(
+    (name) =>
+      name.startsWith("appstrate-exec-") ||
+      name === "appstrate-sidecar-pool" ||
+      name === "appstrate-egress",
+  );
+}
+
+/**
+ * Remove orphan per-run networks (`appstrate-exec-*`) without touching the
+ * shared infra networks. Safe to call mid-operation: Docker refuses to delete
+ * networks that still have attached endpoints (live runs), so only truly
+ * abandoned networks from crashed runs get reclaimed. Used as the opportunistic
+ * recovery path when `createNetwork` hits address-pool exhaustion —
+ * reclaiming even one orphan is often enough to unblock the retry.
+ */
+export async function cleanupOrphanedRunNetworks(): Promise<number> {
+  return removeNetworksMatching((name) => name.startsWith("appstrate-exec-"));
+}
+
+async function removeNetworksMatching(predicate: (name: string) => boolean): Promise<number> {
   const res = await dockerFetch("/networks");
   if (!res.ok) return 0;
 
   const networks = (await res.json()) as Array<{ Id: string; Name: string }>;
-  const orphaned = networks.filter(
-    (n) =>
-      n.Name.startsWith("appstrate-exec-") ||
-      n.Name === "appstrate-sidecar-pool" ||
-      n.Name === "appstrate-egress",
-  );
+  const targets = networks.filter((n) => predicate(n.Name));
+  if (targets.length === 0) return 0;
 
-  if (orphaned.length === 0) return 0;
-
-  const results = await Promise.allSettled(orphaned.map((n) => removeNetwork(n.Id)));
+  const results = await Promise.allSettled(targets.map((n) => removeNetwork(n.Id)));
   return results.filter((r) => r.status === "fulfilled").length;
 }
 

--- a/apps/api/src/services/docker.ts
+++ b/apps/api/src/services/docker.ts
@@ -3,6 +3,7 @@
 import { hostname } from "node:os";
 import { logger } from "../lib/logger.ts";
 import { getEnv } from "@appstrate/env";
+import { classifyDockerNetworkError } from "./docker-errors.ts";
 
 const DOCKER_SOCKET = getEnv().DOCKER_SOCKET;
 const DOCKER_API_TIMEOUT_MS = 30_000;
@@ -19,6 +20,13 @@ async function assertDockerOk(
 ): Promise<void> {
   if (res.ok || allowedStatuses.includes(res.status)) return;
   const body = await res.text();
+  // Promote known pool-exhaustion failures on network creation to a typed
+  // error so the orchestrator can trigger opportunistic cleanup + retry
+  // before surfacing the raw Docker body to the user.
+  if (operation.startsWith("create network")) {
+    const typed = classifyDockerNetworkError(res.status, body);
+    if (typed) throw typed;
+  }
   throw new Error(`Docker ${operation} failed: ${res.status} ${body}`);
 }
 
@@ -485,9 +493,12 @@ export async function cleanupOrphanedContainers(): Promise<{
 
 /**
  * List all Docker networks matching `appstrate-exec-*` or `appstrate-sidecar-pool` and remove them.
- * This is safe to call at startup because no runs should be running.
+ * This is safe to call at startup because no runs should be running. Exported so the
+ * orchestrator can call it opportunistically when network creation hits address-pool
+ * exhaustion mid-operation — orphan leaks from crashed runs keep consuming pool slots
+ * until reclaimed, and reclaiming them is often enough to unblock the next `createNetwork`.
  */
-async function cleanupOrphanedNetworks(): Promise<number> {
+export async function cleanupOrphanedNetworks(): Promise<number> {
   const res = await dockerFetch("/networks");
   if (!res.ok) return 0;
 

--- a/apps/api/src/services/orchestrator/docker-orchestrator.ts
+++ b/apps/api/src/services/orchestrator/docker-orchestrator.ts
@@ -11,6 +11,8 @@ import type {
   StopResult,
 } from "./types.ts";
 import * as docker from "../docker.ts";
+import { createNetworkWithPoolRetry } from "../docker-errors.ts";
+import { logger } from "../../lib/logger.ts";
 import * as sidecarPool from "../sidecar-pool.ts";
 import { getSidecarImage, startSidecarAndHealthCheck } from "../sidecar-pool.ts";
 import {
@@ -64,7 +66,11 @@ export class DockerOrchestrator implements ContainerOrchestrator {
 
   async createIsolationBoundary(runId: string): Promise<IsolationBoundary> {
     const name = `appstrate-exec-${runId}`;
-    const id = await docker.createNetwork(name, { internal: true });
+    const id = await createNetworkWithPoolRetry(
+      () => docker.createNetwork(name, { internal: true }),
+      () => docker.cleanupOrphanedNetworks(),
+      logger,
+    );
     return { id, name };
   }
 

--- a/apps/api/src/services/orchestrator/docker-orchestrator.ts
+++ b/apps/api/src/services/orchestrator/docker-orchestrator.ts
@@ -68,7 +68,7 @@ export class DockerOrchestrator implements ContainerOrchestrator {
     const name = `appstrate-exec-${runId}`;
     const id = await createNetworkWithPoolRetry(
       () => docker.createNetwork(name, { internal: true }),
-      () => docker.cleanupOrphanedNetworks(),
+      () => docker.cleanupOrphanedRunNetworks(),
       logger,
     );
     return { id, name };

--- a/apps/api/src/services/orchestrator/docker-orchestrator.ts
+++ b/apps/api/src/services/orchestrator/docker-orchestrator.ts
@@ -65,7 +65,7 @@ export class DockerOrchestrator implements ContainerOrchestrator {
   }
 
   async createIsolationBoundary(runId: string): Promise<IsolationBoundary> {
-    const name = `appstrate-exec-${runId}`;
+    const name = `${docker.EXEC_NETWORK_PREFIX}${runId}`;
     const id = await createNetworkWithPoolRetry(
       () => docker.createNetwork(name, { internal: true }),
       () => docker.cleanupOrphanedRunNetworks(),

--- a/apps/api/test/integration/services/docker-api.test.ts
+++ b/apps/api/test/integration/services/docker-api.test.ts
@@ -15,6 +15,7 @@ import {
   removeNetwork,
   cleanupOrphanedContainers,
   cleanupOrphanedNetworks,
+  cleanupOrphanedRunNetworks,
   getContainerHostPort,
 } from "../../../src/services/docker.ts";
 
@@ -634,6 +635,36 @@ describe("cleanupOrphanedNetworks", () => {
       }
       const stillThere = await fetch(`${DOCKER_URL}/networks/${bystander}`);
       expect(stillThere.status).toBe(200);
+    },
+    TIMEOUT,
+  );
+});
+
+// ─── cleanupOrphanedRunNetworks ──────────────────────────────
+
+describe("cleanupOrphanedRunNetworks", () => {
+  it(
+    "only reclaims appstrate-exec-* — leaves sidecar-pool and egress alone",
+    async () => {
+      await cleanupOrphanedNetworks();
+
+      const execOrphan = await createNetwork(`appstrate-exec-orphan-${uid()}`);
+      // Simulate the shared infra networks the orchestrator stands up at boot.
+      const sidecarPool = await createNetwork("appstrate-sidecar-pool");
+      trackNetwork(sidecarPool);
+      const egress = await createNetwork("appstrate-egress");
+      trackNetwork(egress);
+
+      const reclaimed = await cleanupOrphanedRunNetworks();
+      expect(reclaimed).toBeGreaterThanOrEqual(1);
+
+      const execGone = await fetch(`${DOCKER_URL}/networks/${execOrphan}`);
+      expect(execGone.status).toBe(404);
+
+      const poolStill = await fetch(`${DOCKER_URL}/networks/${sidecarPool}`);
+      expect(poolStill.status).toBe(200);
+      const egressStill = await fetch(`${DOCKER_URL}/networks/${egress}`);
+      expect(egressStill.status).toBe(200);
     },
     TIMEOUT,
   );

--- a/apps/api/test/integration/services/docker-api.test.ts
+++ b/apps/api/test/integration/services/docker-api.test.ts
@@ -14,6 +14,7 @@ import {
   connectContainerToNetwork,
   removeNetwork,
   cleanupOrphanedContainers,
+  cleanupOrphanedNetworks,
   getContainerHostPort,
 } from "../../../src/services/docker.ts";
 
@@ -603,6 +604,36 @@ describe("cleanupOrphanedContainers", () => {
 
       const result = await cleanupOrphanedContainers();
       expect(result.containers).toBe(0);
+    },
+    TIMEOUT,
+  );
+});
+
+// ─── cleanupOrphanedNetworks ─────────────────────────────────
+
+describe("cleanupOrphanedNetworks", () => {
+  it(
+    "reclaims appstrate-exec-* networks without touching unrelated networks",
+    async () => {
+      // Pre-condition: clear any leftovers from earlier tests.
+      await cleanupOrphanedNetworks();
+
+      // Three orphan run networks + one unrelated bystander that must survive.
+      const orphan1 = await createNetwork(`appstrate-exec-orphan-${uid()}`);
+      const orphan2 = await createNetwork(`appstrate-exec-orphan-${uid()}`);
+      const orphan3 = await createNetwork(`appstrate-exec-orphan-${uid()}`);
+      const bystander = await createNetwork(`appstrate-test-keepme-${uid()}`);
+      trackNetwork(bystander);
+
+      const reclaimed = await cleanupOrphanedNetworks();
+      expect(reclaimed).toBeGreaterThanOrEqual(3);
+
+      for (const id of [orphan1, orphan2, orphan3]) {
+        const res = await fetch(`${DOCKER_URL}/networks/${id}`);
+        expect(res.status).toBe(404);
+      }
+      const stillThere = await fetch(`${DOCKER_URL}/networks/${bystander}`);
+      expect(stillThere.status).toBe(200);
     },
     TIMEOUT,
   );

--- a/apps/api/test/unit/docker-errors.test.ts
+++ b/apps/api/test/unit/docker-errors.test.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, mock } from "bun:test";
+import {
+  DockerAddressPoolExhaustedError,
+  classifyDockerNetworkError,
+  createNetworkWithPoolRetry,
+} from "../../src/services/docker-errors.ts";
+
+const POOL_BODY = `{"message":"all predefined address pools have been fully subnetted"}`;
+
+describe("classifyDockerNetworkError", () => {
+  it("returns DockerAddressPoolExhaustedError on the Moby ErrNoMoreSubnets message", () => {
+    const err = classifyDockerNetworkError(400, POOL_BODY);
+    expect(err).toBeInstanceOf(DockerAddressPoolExhaustedError);
+    expect(err?.code).toBe("DOCKER_ADDRESS_POOL_EXHAUSTED");
+    expect(err?.cause).toBe(POOL_BODY);
+  });
+
+  it("returns null when status is not 400 (guard against pathological bodies)", () => {
+    expect(classifyDockerNetworkError(500, POOL_BODY)).toBeNull();
+    expect(classifyDockerNetworkError(409, POOL_BODY)).toBeNull();
+  });
+
+  it("returns null when body does not match the ErrNoMoreSubnets pattern", () => {
+    expect(classifyDockerNetworkError(400, `{"message":"network name already in use"}`)).toBeNull();
+    expect(classifyDockerNetworkError(400, "")).toBeNull();
+  });
+
+  it("surfaces a user-actionable remediation in the error message", () => {
+    const err = new DockerAddressPoolExhaustedError(POOL_BODY);
+    expect(err.message).toContain("docker network prune");
+    expect(err.message).toContain("default-address-pools");
+    expect(err.message).toContain("docker-network-pool-tuning");
+  });
+});
+
+describe("createNetworkWithPoolRetry", () => {
+  it("returns the network id on first-try success without calling cleanup", async () => {
+    const create = mock(() => Promise.resolve("net-ok"));
+    const cleanup = mock(() => Promise.resolve(0));
+    const id = await createNetworkWithPoolRetry(create, cleanup);
+    expect(id).toBe("net-ok");
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+
+  it("propagates non-pool errors unchanged without attempting cleanup", async () => {
+    const create = mock(() => Promise.reject(new Error("docker daemon unreachable")));
+    const cleanup = mock(() => Promise.resolve(0));
+    await expect(createNetworkWithPoolRetry(create, cleanup)).rejects.toThrow(/daemon unreachable/);
+    expect(cleanup).not.toHaveBeenCalled();
+  });
+
+  it("runs cleanup and retries once when cleanup frees networks", async () => {
+    let calls = 0;
+    const create = mock(() => {
+      calls += 1;
+      if (calls === 1) return Promise.reject(new DockerAddressPoolExhaustedError(POOL_BODY));
+      return Promise.resolve("net-after-retry");
+    });
+    const cleanup = mock(() => Promise.resolve(3));
+    const id = await createNetworkWithPoolRetry(create, cleanup);
+    expect(id).toBe("net-after-retry");
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry when cleanup reclaims zero networks (retry guaranteed to fail)", async () => {
+    const create = mock(() => Promise.reject(new DockerAddressPoolExhaustedError(POOL_BODY)));
+    const cleanup = mock(() => Promise.resolve(0));
+    await expect(createNetworkWithPoolRetry(create, cleanup)).rejects.toBeInstanceOf(
+      DockerAddressPoolExhaustedError,
+    );
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-throws the pool error when the second attempt also fails", async () => {
+    const create = mock(() => Promise.reject(new DockerAddressPoolExhaustedError(POOL_BODY)));
+    const cleanup = mock(() => Promise.resolve(5));
+    await expect(createNetworkWithPoolRetry(create, cleanup)).rejects.toBeInstanceOf(
+      DockerAddressPoolExhaustedError,
+    );
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwards warn logs so ops can trace the cleanup path", async () => {
+    const warn = mock(() => {});
+    const create = mock(() => Promise.reject(new DockerAddressPoolExhaustedError(POOL_BODY)));
+    const cleanup = mock(() => Promise.resolve(0));
+    await expect(createNetworkWithPoolRetry(create, cleanup, { warn })).rejects.toBeInstanceOf(
+      DockerAddressPoolExhaustedError,
+    );
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -18,6 +18,7 @@ import { intro, outro, askText, confirm, spinner, exitWithError } from "../lib/u
 import { generateEnvForTier, renderEnvFile, type Tier } from "../lib/install/secrets.ts";
 import {
   assertDockerAvailable,
+  checkDockerNetworkBudget,
   DockerMissingError,
   dockerComposeUp,
   findRunningComposeProject as findRunningComposeProjectImport,
@@ -580,6 +581,26 @@ async function installDockerTier(
     dockerSpinner.stop("Docker not found");
     if (err instanceof DockerMissingError) throw err;
     throw err;
+  }
+
+  // Informational pre-flight: Docker's default address pool (~31 user-defined
+  // networks) is easy to exhaust once Appstrate's stack plus per-run networks
+  // land on top of existing projects. Warn early so the user can prune or tune
+  // `daemon.json` before the first run fails with the opaque `ErrNoMoreSubnets`.
+  const budget = await checkDockerNetworkBudget();
+  if (budget) {
+    clack.note(
+      [
+        `Detected ${budget.used} Docker networks on this host (default ceiling ≈ 31).`,
+        "Appstrate consumes several networks at boot + 1 per agent run, so you may",
+        "run out of subnets shortly after install.",
+        "",
+        "  Quick fix:   docker network prune",
+        "  Permanent:   tune `default-address-pools` in daemon.json — see",
+        "               https://github.com/appstrate/appstrate/blob/main/examples/self-hosting/README.md#docker-network-pool-tuning",
+      ].join("\n"),
+      "Docker network pool near capacity",
+    );
   }
 
   // Upgrade detection already ran in `installCommand` (it's needed

--- a/apps/cli/src/lib/install/tier123.ts
+++ b/apps/cli/src/lib/install/tier123.ts
@@ -64,6 +64,41 @@ export async function isDockerAvailable(): Promise<boolean> {
   return res.ok;
 }
 
+/**
+ * Probe Docker's default address pool headroom by counting user-defined
+ * networks on the host. Returns `null` on healthy hosts or when probing
+ * fails for any reason — this check is strictly informational and must
+ * never block the install.
+ *
+ * Why 25 as the threshold: Docker's out-of-the-box pool
+ * (`172.17.0.0/12` sliced into `/16` subnets) yields ~31 user-defined
+ * networks. We warn at ~80 % so the user still has headroom to complete
+ * the install and run a few agents before hitting
+ * `ErrNoMoreSubnets`. Operators who have already tuned
+ * `default-address-pools` in `daemon.json` may also cross this
+ * threshold, but their ceiling is far higher — the warning is cheap, and
+ * the remediation doc covers their case.
+ */
+export interface DockerNetworkBudget {
+  used: number;
+  threshold: number;
+}
+
+export async function checkDockerNetworkBudget(): Promise<DockerNetworkBudget | null> {
+  const res = await runCommand("docker", ["network", "ls", "--format", "{{.Name}}"], {
+    stdio: "pipe",
+    timeoutMs: 3000,
+  });
+  if (!res.ok) return null;
+  const builtIns = new Set(["bridge", "host", "none", ""]);
+  const userDefined = res.stdout
+    .split("\n")
+    .map((n) => n.trim())
+    .filter((n) => !builtIns.has(n));
+  const threshold = 25;
+  return userDefined.length >= threshold ? { used: userDefined.length, threshold } : null;
+}
+
 /** Copy the embedded YAML for `tier` into `<dir>/docker-compose.yml`. */
 export async function writeComposeFile(dir: string, tier: DockerTier): Promise<void> {
   await mkdir(dir, { recursive: true });

--- a/apps/cli/test/install/tier123.test.ts
+++ b/apps/cli/test/install/tier123.test.ts
@@ -25,6 +25,7 @@ import {
   writeComposeFile,
   writeEnvFile,
   assertDockerAvailable,
+  checkDockerNetworkBudget,
   findRunningComposeProject,
   waitForAppstrate,
   DockerMissingError,
@@ -223,6 +224,57 @@ describe("findRunningComposeProject", () => {
     process.env.PATH = `${shimDir}:${originalPath}`;
     const hit = await findRunningComposeProject("appstrate-dev-11111111");
     expect(hit).toBeNull();
+  });
+});
+
+describe("checkDockerNetworkBudget", () => {
+  // Shim `docker network ls --format {{.Name}}` with controlled stdout so
+  // we can drive the thresholding logic without a real Docker daemon.
+  it("returns null when the host is below the warning threshold", async () => {
+    if (platform() === "win32") return;
+    const shimDir = join(workDir, "shim-low");
+    await mkShim(
+      shimDir,
+      "docker",
+      `#!/usr/bin/env bash\ncat <<'EOF'\nbridge\nhost\nnone\nmy-app_default\ncoolify\nEOF\n`,
+    );
+    process.env.PATH = `${shimDir}:${originalPath}`;
+    const budget = await checkDockerNetworkBudget();
+    expect(budget).toBeNull();
+  });
+
+  it("returns used + threshold when the host crosses the warning line", async () => {
+    if (platform() === "win32") return;
+    const shimDir = join(workDir, "shim-high");
+    const names = ["bridge", "host", "none"];
+    for (let i = 0; i < 30; i++) names.push(`proj-${i}`);
+    await mkShim(shimDir, "docker", `#!/usr/bin/env bash\ncat <<'EOF'\n${names.join("\n")}\nEOF\n`);
+    process.env.PATH = `${shimDir}:${originalPath}`;
+    const budget = await checkDockerNetworkBudget();
+    expect(budget).not.toBeNull();
+    expect(budget?.used).toBe(30);
+    expect(budget?.threshold).toBe(25);
+  });
+
+  it("returns null when docker exits non-zero (daemon down / cli missing)", async () => {
+    if (platform() === "win32") return;
+    const shimDir = join(workDir, "shim-err");
+    await mkShim(shimDir, "docker", `#!/usr/bin/env bash\necho "daemon unreachable" >&2\nexit 1\n`);
+    process.env.PATH = `${shimDir}:${originalPath}`;
+    const budget = await checkDockerNetworkBudget();
+    expect(budget).toBeNull();
+  });
+
+  it("does not count built-in networks (bridge/host/none) toward the budget", async () => {
+    if (platform() === "win32") return;
+    const shimDir = join(workDir, "shim-builtins");
+    // 24 custom networks + 3 built-ins — total 27 lines, but only 24 count.
+    const names = ["bridge", "host", "none"];
+    for (let i = 0; i < 24; i++) names.push(`proj-${i}`);
+    await mkShim(shimDir, "docker", `#!/usr/bin/env bash\ncat <<'EOF'\n${names.join("\n")}\nEOF\n`);
+    process.env.PATH = `${shimDir}:${originalPath}`;
+    const budget = await checkDockerNetworkBudget();
+    expect(budget).toBeNull();
   });
 });
 

--- a/examples/self-hosting/README.md
+++ b/examples/self-hosting/README.md
@@ -103,6 +103,62 @@ The signing keypair for `1EF2FF084226C4FA` is already provisioned. Rotate only i
 - At least 4 GB of available RAM
 - Docker socket accessible at `/var/run/docker.sock` (required for agent runs)
 
+## Docker Network Pool Tuning
+
+Appstrate is network-heavy by design: the stack creates a few long-lived
+networks at boot (`appstrate-data`, `appstrate-public`,
+`appstrate-egress`, `appstrate-sidecar-pool`) and allocates one isolated
+bridge network per agent run (`appstrate-exec-<runId>`). On a host that
+already runs several Docker projects, that pressure is often enough to
+exhaust Docker's **default address pool** and produce:
+
+```
+Docker create network appstrate-exec-… failed: 400
+{"message":"all predefined address pools have been fully subnetted"}
+```
+
+This is a host-side limit, not a bug in Appstrate. Docker's default
+configuration splits `172.17.0.0/12` into `/16` subnets, which caps the
+whole host at ~31 user-defined networks.
+
+**Diagnose**:
+
+```bash
+docker network ls --format '{{.Name}}' | wc -l
+```
+
+**Quick fix** — reclaim unused networks:
+
+```bash
+docker network prune
+```
+
+**Permanent fix** — carve smaller subnets so the host can hold hundreds
+of networks. Edit Docker's daemon configuration:
+
+- **Linux**: `/etc/docker/daemon.json`
+- **macOS / Windows**: Docker Desktop → Settings → Docker Engine
+
+```json
+{
+  "default-address-pools": [
+    { "base": "172.20.0.0/16", "size": 24 },
+    { "base": "10.200.0.0/16", "size": 24 }
+  ]
+}
+```
+
+Then restart the Docker daemon (`sudo systemctl restart docker` on
+Linux; "Apply & Restart" in Docker Desktop). Each `/16` base yields
+~256 networks at `size: 24`, so two pools give ~512 slots — ample
+headroom for a busy Appstrate host. Docker consumes pools sequentially:
+the second pool is only tapped once the first is exhausted.
+
+Appstrate will still try to recover automatically on first failure — if
+the error above appears despite tuning, the platform reclaims orphan
+`appstrate-exec-*` networks from crashed runs and retries once. The
+remediation above is the durable fix.
+
 ## Manual Setup
 
 If you prefer to set up manually (or can't use the one-liner):


### PR DESCRIPTION
Closes #198.

## Summary

- **Runtime**: classify Moby's `ErrNoMoreSubnets` as `DockerAddressPoolExhaustedError` with a user-actionable message (points to `docker network prune` and daemon.json tuning). On first hit in `createIsolationBoundary`, reclaim orphan `appstrate-exec-*` networks and retry once — skip the retry when cleanup freed zero networks so we surface the remediation immediately instead of adding latency for a guaranteed second failure.
- **CLI**: non-blocking preflight in Tier 1/2/3 install that counts user-defined Docker networks and warns at ~80 % of the default pool ceiling (25/31). 3 s capped, returns null on any failure.
- **Docs**: new "Docker Network Pool Tuning" section in `examples/self-hosting/README.md` with diagnosis, quick fix, and permanent `default-address-pools` remediation.

The retry logic lives in `createNetworkWithPoolRetry()` with deps injected as parameters — unit-testable without `mock.module()`.

## Test plan

- [x] `bun test apps/api/test/unit/docker-errors.test.ts` — 10 tests, classifier + retry branches (happy path, non-pool error pass-through, cleanup-frees-some → retry succeeds, cleanup-frees-zero → no retry, retry-also-fails → re-throw, log forwarding)
- [x] `bun test apps/cli/test/install/tier123.test.ts` — 21 tests, new `checkDockerNetworkBudget` cases (below threshold, above threshold, docker failure, builtins excluded)
- [x] `turbo run typecheck` — 8/8 ✓
- [x] `bun run lint` + `bun run format:check` + `bun run verify:openapi` ✓
- [x] Full CLI suite: 339/339 ✓
- [ ] Integration test for `cleanupOrphanedNetworks` (requires DinD from the CI test setup — will run in CI)

## Design notes

- Moby's `ErrNoMoreSubnets` is `types.InvalidParameterErrorf(...)` → HTTP 400. Gating on status + substring avoids false positives on pathological 500 bodies.
- `cleanupOrphanedNetworks` is now exported so the orchestrator can call it independently of container cleanup.
- The classifier is a pure function; retry is a thin wrapper around injected deps. No module-global mocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)