### PR TITLE
chore(skills): add Appstrate Manager skill

### DIFF
--- a/skills/appstrate/SKILL.md
+++ b/skills/appstrate/SKILL.md
@@ -1,0 +1,394 @@
+---
+name: appstrate
+description: Create, deploy, run, and iterate on AI agents on Appstrate, the open-source platform that runs agents as one-shot AI workflows in ephemeral Docker containers. Supports named profiles so a single session can pilot cloud, self-hosted, and dev instances. Use when the user wants to create or edit an agent (manifest.json + prompt.md), deploy or run a .afps package, run an agent inline without import, validate a manifest, monitor runs, manage skills/tools/providers, connect OAuth or API-key services, schedule agents, write prompts, or call the REST API. Also triggers on mentions of AFPS, scoped packages (`@scope/name`), inline runs, sidecar proxy, "on cloud", "on local", "on dev", or appstrate.com.
+---
+
+# Appstrate
+
+Manage AI agents on [appstrate.com](https://app.appstrate.com) via its REST API. Everything is a **package** with a scoped name (`@scope/name`). Four types: `agent`, `skill`, `tool`, `provider`.
+
+- **API docs**: https://app.appstrate.com/api/docs
+- **OpenAPI spec**: `GET https://app.appstrate.com/api/openapi.json`
+- **GitHub (open-source)**: https://github.com/appstrate/appstrate
+
+## Setup
+
+Three env vars required per instance: `APPSTRATE_URL`, `APPSTRATE_API_KEY`, `APPSTRATE_ORG_ID`.
+
+For first-time setup (create API key, get org ID — or self-host your own instance via `curl -fsSL https://get.appstrate.dev | bash`): read `references/setup.md`.
+
+For multi-instance setups (cloud + self-hosted + dev): use named profiles under `~/.config/appstrate/profiles/<name>.env`. Full guide: `references/profiles.md`.
+
+### Find credentials (resolution order)
+
+On every API call, resolve the active instance in this order — first match wins:
+
+```bash
+# 1. APPSTRATE_PROFILE env var → load that profile file
+if [ -n "$APPSTRATE_PROFILE" ] && [ -f ~/.config/appstrate/profiles/"$APPSTRATE_PROFILE".env ]; then
+  set -a; . ~/.config/appstrate/profiles/"$APPSTRATE_PROFILE".env; set +a
+
+# 2. default-profile pointer (used when no explicit profile is set)
+elif [ -f ~/.config/appstrate/default-profile ]; then
+  p=$(cat ~/.config/appstrate/default-profile)
+  [ -f ~/.config/appstrate/profiles/"$p".env ] && { set -a; . ~/.config/appstrate/profiles/"$p".env; set +a; }
+
+# 3. Legacy: APPSTRATE_URL / APPSTRATE_API_KEY / APPSTRATE_ORG_ID already exported
+elif env | grep -q APPSTRATE_URL; then : ;
+
+# 4. Legacy fallback: project .env files
+elif [ -f .env ] && grep -q APPSTRATE .env; then set -a; . ./.env; set +a
+
+# 5. Legacy fallback: coding-agent config dirs
+else
+  for dir in ~/.claude ~/.cursor ~/.windsurf ~/.codeium ~/.zed ~/.continue ~/.aider ~/.config/github-copilot; do
+    [ -f "$dir/.env" ] && grep -q APPSTRATE "$dir/.env" && { set -a; . "$dir/.env"; set +a; break; }
+  done
+fi
+```
+
+**Inferring a profile from the prompt**: when the user says "on cloud" / "en prod" → use `cloud`; "on local" / "sur mon install" → use `local`; "on dev" → use `dev`. If the named profile doesn't exist, list `ls ~/.config/appstrate/profiles/` and ask which to use. See `references/profiles.md` for the full mapping and for cross-instance iteration patterns (e.g., "list agents across all my instances").
+
+If no credentials are found anywhere, ask the user to provide them or follow `references/setup.md` to create them.
+
+### Verify
+
+```bash
+curl -s "$APPSTRATE_URL/api/agents" \
+  -H "Authorization: Bearer $APPSTRATE_API_KEY" \
+  -H "X-Org-Id: $APPSTRATE_ORG_ID" | head -c 200
+```
+
+## API Conventions
+
+**Auth headers** — every request needs both:
+
+```
+Authorization: Bearer $APPSTRATE_API_KEY
+X-Org-Id: $APPSTRATE_ORG_ID
+```
+
+**Scoped routes** — scope MUST include the `@` prefix: `@tractr/my-agent`, NOT `tractr/my-agent`. Without `@`, routes will NOT reach the API.
+
+**RTK proxy** — if RTK (Rust Token Killer) is installed, it intercepts `curl` output and replaces JSON values with type placeholders (e.g., `string`, `int`). This breaks API responses where actual data is needed. Always prefix curl commands with `rtk proxy` to bypass the filter:
+
+```bash
+rtk proxy curl -s "$APPSTRATE_URL/api/agents" \
+  -H "Authorization: Bearer $APPSTRATE_API_KEY" \
+  -H "X-Org-Id: $APPSTRATE_ORG_ID"
+```
+
+All curl examples below omit auth headers and `rtk proxy` prefix for brevity — always include them.
+
+## Quick Reference
+
+| Task                             | Action                                                                                  |
+| -------------------------------- | --------------------------------------------------------------------------------------- |
+| Create an agent                  | Write manifest.json + prompt.md, pack as .afps, import                                  |
+| Run an agent (persisted)         | `POST /api/agents/@scope/name/run`                                                      |
+| Run an agent (inline, no import) | `POST /api/runs/inline` — manifest + prompt in body, returns `202 { runId, packageId }` |
+| Validate a manifest (dry-run)    | `POST /api/runs/inline/validate` — preflight without firing, no credits burned          |
+| Check status                     | `GET /api/runs/{id}` or SSE stream                                                      |
+| View logs                        | `GET /api/runs/{id}/logs`                                                               |
+| List runs globally               | `GET /api/runs?kind=all\|package\|inline&status=...&startDate=...`                      |
+| Update an agent                  | Bump version in manifest.json, re-pack, re-import                                       |
+| Schedule an agent                | `POST /api/agents/@scope/name/schedules` (inline runs are not schedulable)              |
+| List everything                  | `GET /api/agents`, `/api/packages/skills`, `/api/packages/tools`                        |
+| Manage applications              | `GET/POST /api/applications` (headless multi-tenant)                                    |
+| Manage end users                 | `GET/POST /api/end-users` (per-application)                                             |
+| Upload files                     | `POST /api/uploads/request` → upload → `POST /api/uploads/confirm`                      |
+| Configure OAuth clients          | `GET/POST /api/oauth-clients` (OIDC provider)                                           |
+
+For API conventions, gotchas, and rate limits: read `references/api-cheatsheet.md`. For the full endpoint list, fetch the live OpenAPI spec: `GET https://app.appstrate.com/api/openapi.json`.
+
+## Create an Agent
+
+### 0. Discover available resources
+
+Before writing the manifest, check what's available in the org:
+
+```bash
+# System tools (output, set-state, report, log, add-memory)
+curl "$APPSTRATE_URL/api/packages/tools"
+
+# Skills (knowledge packages to attach)
+curl "$APPSTRATE_URL/api/packages/skills"
+
+# Providers (OAuth/API-key services to connect)
+curl "$APPSTRATE_URL/api/providers"
+
+# Existing agents (avoid name collisions)
+curl "$APPSTRATE_URL/api/agents"
+```
+
+Use these results to choose the right `dependencies.tools`, `dependencies.skills`, and `dependencies.providers` for the manifest. For system tools details and decision guide: read `references/system-tools.md`.
+
+### 1. Write manifest.json
+
+Use the template at `assets/agent-manifest.json`. Key fields:
+
+```json
+{
+  "name": "@my-org/my-agent",
+  "version": "1.0.0",
+  "type": "agent",
+  "schemaVersion": "1.0",
+  "displayName": "My Agent",
+  "description": "What it does",
+  "author": "Author",
+  "dependencies": {
+    "providers": { "@appstrate/gmail": "^1.0.0" },
+    "tools": { "@appstrate/output": "^1.0.0" },
+    "skills": {}
+  },
+  "providersConfiguration": {
+    "@appstrate/gmail": {
+      "scopes": ["https://www.googleapis.com/auth/gmail.modify"],
+      "connectionMode": "user"
+    }
+  },
+  "input": { "schema": { "type": "object", "properties": {}, "required": [] } },
+  "output": {
+    "schema": {
+      "type": "object",
+      "properties": { "summary": { "type": "string" } },
+      "required": ["summary"]
+    }
+  },
+  "timeout": 300
+}
+```
+
+Critical rules:
+
+- `name` MUST be `@scope/name` format (lowercase, hyphens OK)
+- `type` is `"agent"`
+- `dependencies.tools` — system tools are NOT auto-enabled. Declare each tool the agent needs (see `references/system-tools.md` for the decision guide)
+- `dependencies.providers` is `Record<string, semverRange>` (NOT an array)
+- `required` is a top-level array (NOT `required: true` on properties)
+- `connectionMode`: `"user"` (each user connects) or `"admin"` (shared creds)
+
+For the full manifest schema: read `references/manifest-schema.md`.
+
+### 2. Write prompt.md
+
+The agent prompt. Plain Markdown, no template syntax. The platform auto-injects: User Input, Configuration, Previous State, Memory, Tools, Skills, Connected Providers, Output Format.
+
+```markdown
+# Objective
+
+One clear sentence.
+
+# Steps
+
+1. **Fetch data** — Use sidecar proxy for authenticated calls:
+   curl -s "$SIDECAR_URL/proxy" \
+    -H "X-Provider: @appstrate/gmail" \
+    -H "X-Target: https://gmail.googleapis.com/gmail/v1/users/me/messages" \
+    -H "Authorization: Bearer {{access_token}}"
+2. **Process** — Transform, filter, summarize
+3. **Return results** as JSON matching the output schema
+```
+
+Key rules:
+
+- Sidecar proxy: `$SIDECAR_URL/proxy` + `X-Provider` + `X-Target` headers
+- Credential placeholders: `{{access_token}}` (OAuth2), `{{apiKey}}` (API key), `{{fieldName}}` (custom)
+- Public APIs: call directly with curl, no sidecar needed
+- Do NOT repeat injected sections (User Input, Config, etc.)
+- If `@appstrate/output` is in dependencies, instruct the agent to call the `output` tool to return structured results
+
+For detailed prompt guidance: read `references/prompt-writing.md`.
+
+### 3. Package as .afps
+
+```bash
+bash scripts/afps-pack.sh /path/to/agent-dir /tmp/my-agent.afps
+```
+
+The .afps is a ZIP with manifest.json at root (not nested). Manual alternative:
+
+```bash
+cd "$AGENT_DIR" && zip -r /tmp/my-agent.afps manifest.json prompt.md
+```
+
+### 4. Import
+
+```bash
+curl -X POST "$APPSTRATE_URL/api/packages/import" \
+  -F "file=@/tmp/my-agent.afps"
+```
+
+If 409 `DRAFT_OVERWRITE`: add `?force=true` to overwrite the draft.
+
+### 5. Configure (optional post-import)
+
+```bash
+# Attach skills
+curl -X PUT "$APPSTRATE_URL/api/agents/@scope/name/skills" \
+  -H "Content-Type: application/json" \
+  -d '{"skillIds": ["@scope/skill1"]}'
+
+# Set config values
+curl -X PUT "$APPSTRATE_URL/api/agents/@scope/name/config" \
+  -H "Content-Type: application/json" \
+  -d '{"language": "fr"}'
+
+# Override LLM model
+curl -X PUT "$APPSTRATE_URL/api/agents/@scope/name/model" \
+  -H "Content-Type: application/json" \
+  -d '{"modelId": "claude-sonnet-4-20250514"}'
+```
+
+## Run an Agent
+
+```bash
+# Basic run
+curl -X POST "$APPSTRATE_URL/api/agents/@scope/name/run" \
+  -H "Content-Type: application/json" \
+  -d '{"input": {"query": "weekly report"}}'
+
+# With file upload (multipart)
+curl -X POST "$APPSTRATE_URL/api/agents/@scope/name/run" \
+  -F 'input={"description": "Process this"}' \
+  -F "file=@/path/to/file.pdf"
+
+# Specific version
+curl -X POST "$APPSTRATE_URL/api/agents/@scope/name/run?version=1.0.0" ...
+```
+
+### Monitor
+
+```bash
+# Status
+curl "$APPSTRATE_URL/api/runs/{id}"
+
+# Logs
+curl "$APPSTRATE_URL/api/runs/{id}/logs"
+
+# Cancel
+curl -X POST "$APPSTRATE_URL/api/runs/{id}/cancel"
+
+# SSE realtime stream
+curl -N "$APPSTRATE_URL/api/realtime/runs/{id}"
+
+# Global run list (cross-agent, supports kind=all|package|inline, status, date filters)
+curl "$APPSTRATE_URL/api/runs?kind=inline&status=success&limit=50"
+```
+
+Status lifecycle: `pending` → `running` → `success` | `failed` | `timeout` | `cancelled`
+
+## Run Inline (No Package Import)
+
+For one-shot agents or rapid iteration, skip the pack/import cycle: `POST /api/runs/inline` accepts a full manifest + prompt in the request body. The platform creates an **ephemeral shadow package** (`@inline/r-<uuid>`, hidden from catalog queries), runs it through the standard pipeline, and compacts the manifest/prompt after `retention_days` (default 30).
+
+```bash
+# Execute — returns 202 { runId, packageId }
+curl -X POST "$APPSTRATE_URL/api/runs/inline" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "manifest": { "name": "@inline/summary", "version": "0.0.0", "type": "agent", "schemaVersion": "1.0", "dependencies": { "tools": { "@appstrate/output": "^1.0.0" } } },
+    "prompt": "Summarize the input in three bullets.",
+    "input": { "text": "..." }
+  }'
+
+# Dry-run validator — same body, no side effects, returns 200 { ok: true } or 400 problem+json
+curl -X POST "$APPSTRATE_URL/api/runs/inline/validate" \
+  -H "Content-Type: application/json" \
+  -d '{ "manifest": {...}, "prompt": "...", "input": {...} }'
+```
+
+Key rules:
+
+- Dependencies (`skills`, `tools`, `providers`) must reference **existing** org/system packages — no new inline definitions
+- Not schedulable (schedules require a persisted package)
+- `/validate` shares the same rate bucket as `/inline` — debounce tight iteration loops
+- After compaction, `inlineManifest` / `inlinePrompt` become `null` (run row + result persist)
+- Every run (classic AND inline) now persists a **config snapshot** on `runs.config` — the Run Info tab renders it, decoupled from the package's current config
+
+Limits via `INLINE_RUN_LIMITS` env var: `rate_per_min=60`, `manifest_bytes=65536`, `prompt_bytes=200000`, `max_skills=20`, `max_tools=20`, `max_authorized_uris=50`, `wildcard_uri_allowed=false`, `retention_days=30`.
+
+For full request/response schemas, gotchas, and when to choose inline vs package import: read `references/inline-runs.md`.
+
+## Update an Agent (Iterate)
+
+1. Edit prompt.md and/or manifest.json
+2. Bump version (e.g., `1.0.0` → `1.1.0`)
+3. Re-pack: `bash scripts/afps-pack.sh $AGENT_DIR /tmp/my-agent.afps`
+4. Re-import: `curl -X POST "$APPSTRATE_URL/api/packages/import" -F "file=@/tmp/my-agent.afps"`
+
+Same version + `?force=true` overwrites the draft (no version history). Always prefer bumping.
+
+## Schedule an Agent
+
+```bash
+curl -X POST "$APPSTRATE_URL/api/agents/@scope/name/schedules" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Daily digest",
+    "cronExpression": "0 9 * * 1-5",
+    "timezone": "America/Montreal",
+    "connectionProfileId": "profile-uuid",
+    "input": {"maxItems": 20}
+  }'
+```
+
+Common cron patterns: `0 9 * * 1-5` (weekdays 9am), `0 */6 * * *` (every 6h), `0 0 * * 1` (weekly Monday).
+
+## Create a Skill or Tool
+
+Skills and tools follow the same import workflow. Pack as .afps with manifest.json at root.
+
+**Skill** (knowledge for the agent):
+
+```
+manifest.json    # type: "skill"
+SKILL.md         # YAML frontmatter + Markdown content
+scripts/         # Optional bundled scripts
+references/      # Optional reference docs
+```
+
+**Tool** (executable TypeScript extension):
+
+```
+manifest.json    # type: "tool", with entrypoint and tool.inputSchema
+index.ts         # Tool implementation using @mariozechner/pi-coding-agent
+```
+
+Templates: `assets/skill-manifest.json`, `assets/tool-manifest.json`.
+
+For tool conventions (execute signature, return format): read `references/manifest-schema.md` > Tool section.
+
+## Data Model: input vs config vs state vs memory vs output
+
+| Mechanism  | Changes each run? | Who sets it? |     Persists?     | Use for                                 |
+| ---------- | :---------------: | :----------: | :---------------: | --------------------------------------- |
+| **input**  |        Yes        |   End user   |        No         | Runtime params: query, date range, file |
+| **config** |      Rarely       |    Admin     |        Yes        | Setup-once: language, max items         |
+| **output** |        Yes        |    Agent     |        No         | Structured results for the user         |
+| **state**  |        Yes        |    Agent     | Yes (overwritten) | Cursor, last sync timestamp             |
+| **memory** |        Yes        |    Agent     |  Yes (appended)   | Learned preferences, patterns           |
+
+## Common Errors
+
+| Error                            | Cause                                            | Fix                                                          |
+| -------------------------------- | ------------------------------------------------ | ------------------------------------------------------------ |
+| `result: {}` on success          | `@appstrate/output` not in `dependencies.tools`  | Add `"@appstrate/output": "^1.0.0"` to manifest dependencies |
+| 409 `DRAFT_OVERWRITE`            | Package has unpublished changes                  | Add `?force=true` to import URL                              |
+| 403 `agents:write required`      | API key missing new scopes after platform update | Create a new API key in the UI                               |
+| HTML response instead of JSON    | Missing `@` in scope                             | Use `@scope/name`, not `scope/name`                          |
+| Agent doesn't call `output` tool | Tool not in available tool list                  | Verify `dependencies.tools` in manifest, re-import           |
+
+## References
+
+| Need                                                 | File                                             |
+| ---------------------------------------------------- | ------------------------------------------------ |
+| Platform concepts (visual overview)                  | `references/concepts.md`                         |
+| Full manifest schema (all 4 types)                   | `references/manifest-schema.md`                  |
+| Writing effective prompts                            | `references/prompt-writing.md`                   |
+| System tools (output, state, report, etc.)           | `references/system-tools.md`                     |
+| API conventions & gotchas                            | `references/api-cheatsheet.md`                   |
+| Inline runs (endpoints, limits, compaction, gotchas) | `references/inline-runs.md`                      |
+| Multi-instance profiles (cloud + local + dev)        | `references/profiles.md`                         |
+| Full endpoint list (live)                            | `GET https://app.appstrate.com/api/openapi.json` |
+| Step-by-step setup guide                             | `references/setup.md`                            |

--- a/skills/appstrate/assets/agent-manifest.json
+++ b/skills/appstrate/assets/agent-manifest.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://afps.appstrate.dev/schema/v1/flow.schema.json",
+  "name": "@SCOPE/CHANGE-ME",
+  "version": "1.0.0",
+  "type": "agent",
+  "schemaVersion": "1.0",
+  "displayName": "Agent Display Name",
+  "description": "One-line description",
+  "author": "author-name",
+  "keywords": [],
+
+  "dependencies": {
+    "providers": {},
+    "skills": {},
+    "tools": {}
+  },
+
+  "providersConfiguration": {},
+
+  "input": {
+    "schema": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "propertyOrder": []
+    }
+  },
+
+  "config": {
+    "schema": {
+      "type": "object",
+      "properties": {},
+      "required": [],
+      "propertyOrder": []
+    }
+  },
+
+  "output": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string",
+          "description": "Execution summary"
+        }
+      },
+      "required": ["summary"]
+    }
+  },
+
+  "timeout": 300,
+  "x-outputRetries": 2
+}

--- a/skills/appstrate/assets/skill-manifest.json
+++ b/skills/appstrate/assets/skill-manifest.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://afps.appstrate.dev/schema/v1/skill.schema.json",
+  "name": "@SCOPE/CHANGE-ME",
+  "version": "1.0.0",
+  "type": "skill",
+  "displayName": "Skill Display Name",
+  "description": "What this skill provides to the agent"
+}

--- a/skills/appstrate/assets/tool-manifest.json
+++ b/skills/appstrate/assets/tool-manifest.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://afps.appstrate.dev/schema/v1/tool.schema.json",
+  "name": "@SCOPE/CHANGE-ME",
+  "version": "1.0.0",
+  "type": "tool",
+  "displayName": "Tool Display Name",
+  "description": "What this tool does",
+  "entrypoint": "index.ts",
+  "tool": {
+    "name": "my_tool",
+    "description": "Description shown to the agent for tool selection",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "param": {
+          "type": "string",
+          "description": "Parameter description"
+        }
+      },
+      "required": ["param"]
+    }
+  }
+}

--- a/skills/appstrate/references/api-cheatsheet.md
+++ b/skills/appstrate/references/api-cheatsheet.md
@@ -1,0 +1,78 @@
+# Appstrate API — Conventions & Gotchas
+
+**For the complete endpoint list, always use the live source:**
+
+- **Swagger UI**: https://app.appstrate.com/api/docs
+- **OpenAPI JSON**: `GET https://app.appstrate.com/api/openapi.json`
+
+This file documents only the conventions, gotchas, and non-obvious behaviors that the Swagger doesn't make obvious.
+
+## Auth
+
+Every org-scoped request needs **both** headers:
+
+```
+Authorization: Bearer ask_...
+X-Org-Id: <org-id>
+```
+
+SSE realtime endpoints accept API key via query param instead: `?token=ask_...`
+
+## Scope prefix: `@` is mandatory
+
+All `{scope}/{name}` paths require the `@` prefix:
+
+- ✅ `@tractr/my-agent`
+- ❌ `tractr/my-agent` → returns HTML instead of JSON (silent failure)
+
+## Run lifecycle
+
+Statuses: `pending` → `running` → `success` | `failed` | `timeout` | `cancelled`
+
+Run body (JSON): `{ input?, modelId?, proxyId? }`
+Run body (multipart): `{ input (JSON string), file }`
+Version param: `?version=1.0.0` or `?version=latest`
+
+## Package import
+
+- `POST /api/packages/import` — upload .afps ZIP
+- 409 `DRAFT_OVERWRITE` → add `?force=true` to overwrite draft
+- Updates require `lockVersion` field (409 on conflict)
+- GitHub import: `POST /api/packages/import-github`
+
+## Schedules
+
+Create body: `{ connectionProfileId*, cronExpression*, name?, timezone?, input? }`
+
+Common cron: `0 9 * * 1-5` (weekdays 9am), `0 */6 * * *` (every 6h), `0 0 * * 1` (weekly Monday).
+
+## Rate Limits
+
+| Endpoint             | Limit  |
+| -------------------- | ------ |
+| Agent run            | 20/min |
+| Package import       | 10/min |
+| Package download     | 50/min |
+| Model/proxy/key test | 5/min  |
+| OpenRouter search    | 10/min |
+
+## Error Format
+
+RFC 7807: `{ type, title, status, detail }`
+
+| Status | Meaning                                           |
+| ------ | ------------------------------------------------- |
+| 400    | Validation error                                  |
+| 401    | Auth missing or invalid                           |
+| 403    | Insufficient permissions (check API key scopes)   |
+| 404    | Not found (or missing `@` prefix — check scope)   |
+| 409    | Conflict: draft overwrite or lockVersion mismatch |
+| 429    | Rate limit exceeded                               |
+
+## Common pitfalls
+
+1. **`result: {}` on success** — `@appstrate/output` not in `dependencies.tools`. Add it to manifest.
+2. **403 after platform update** — API key missing new scopes. Create a fresh key in the UI.
+3. **HTML response** — Missing `@` prefix on scope. Use `@scope/name`.
+4. **Agent doesn't call output tool** — Tool not in manifest `dependencies.tools`. Re-import after fixing.
+5. **SSE doesn't connect with API key** — Use `?token=ask_...` query param, not Authorization header.

--- a/skills/appstrate/references/concepts.md
+++ b/skills/appstrate/references/concepts.md
@@ -1,0 +1,273 @@
+# Appstrate — Concepts
+
+- [What is Appstrate?](#what-is-appstrate)
+- [Organizations & Access](#organizations--access)
+- [Package Types](#package-types)
+- [Agent Anatomy & Dependencies](#agent-anatomy--dependencies)
+- [How a Run Works](#how-a-run-works)
+- [Agent Data Flow](#agent-data-flow)
+- [Dependencies](#dependencies)
+  - [Providers](#providers)
+  - [Tools](#tools)
+  - [Skills](#skills)
+
+## What is Appstrate?
+
+An open-source platform that runs AI agents in ephemeral Docker containers. Each agent gets a prompt, tools, connected services, and runs autonomously to produce structured output.
+
+Agents are powered by the [Pi Coding Agent](https://github.com/nichochar/pi-coding-agent) runtime — an open-source SDK that gives the LLM access to bash, file system, and extensible tools inside the container. Appstrate wraps Pi with orchestration (scheduling, auth, state, memory) and a sidecar proxy for secure external API calls.
+
+## Organizations & Access
+
+```
+    ┌──────────────────────────────────────────────┐
+    │              ORGANIZATION                     │
+    │                                               │
+    │   Members:                                    │
+    │   ├── owner    (full control, billing)        │
+    │   ├── admin    (manage agents, providers)     │
+    │   └── member   (run agents, view results)     │
+    │                                               │
+    │   Access:                                     │
+    │   ├── UI       (app.appstrate.com)            │
+    │   └── API key  (ask_* prefix, scoped)         │
+    │                                               │
+    │   All agents, skills, tools, providers,       │
+    │   connections, and runs are scoped to the org │
+    └──────────────────────────────────────────────┘
+```
+
+Each API request requires both an API key and an org ID. Keys are created in the UI, start with `ask_`, and can be scoped to specific permissions.
+
+## Package Types
+
+```
+                        PACKAGES
+    ┌──────────┬──────────┬──────────┬──────────┐
+    │  Agent   │  Skill   │   Tool   │ Provider │
+    │          │          │          │          │
+    │ prompt   │ knowledge│ code the │ external │
+    │ + logic  │ for the  │ agent    │ service  │
+    │ + schema │ agent    │ can call │ (OAuth,  │
+    │          │          │ at       │  API key)│
+    │          │          │ runtime  │          │
+    └──────────┴──────────┴──────────┴──────────┘
+
+    All share the same scoped name format: @scope/name
+    All packaged as .afps (ZIP with manifest.json at root)
+```
+
+## Agent Anatomy & Dependencies
+
+```
+    ┌──────────────────────────────────────────────────────┐
+    │                 @my-org/my-agent                     │
+    │                                                      │
+    │   manifest.json            prompt.md                 │
+    │   ┌────────────────┐      ┌──────────────────┐      │
+    │   │ name, version  │      │ # Objective      │      │
+    │   │ type: agent    │      │                  │      │
+    │   │ input schema   │      │ # Steps          │      │
+    │   │ output schema  │      │ 1. Fetch (proxy) │      │
+    │   │ timeout        │      │ 2. Process       │      │
+    │   │                │      │ 3. Output        │      │
+    │   │ dependencies ──┼──┐   └──────────────────┘      │
+    │   └────────────────┘  │                              │
+    │                       │                              │
+    └───────────────────────┼──────────────────────────────┘
+                            │
+              ┌─────────────┼─────────────┐
+              │             │             │
+         providers        tools        skills
+              │             │             │
+    ┌─────────┴───┐  ┌─────┴───────┐  ┌──┴──────────────┐
+    │ Providers   │  │ Tools       │  │ Skills          │
+    │             │  │             │  │                 │
+    │ external    │  │ system or   │  │ knowledge       │
+    │ services    │  │ custom code │  │ injected into   │
+    │ (OAuth, API │  │ the agent   │  │ agent prompt    │
+    │  key)       │  │ can call    │  │                 │
+    └─────────────┘  └─────────────┘  └─────────────────┘
+```
+
+## How a Run Works
+
+```
+  YOU            APPSTRATE          CONTAINER         SIDECAR          EXTERNAL
+   │              CLOUD                │                │           (APIs, Web, LLM)
+   │                │                  │                │               │
+   │ POST /run      │                  │                │               │
+   │ { input }      │                  │                │               │
+   │ ────────────>  │                  │                │               │
+   │                │  spin up         │                │               │
+   │                │ ──────────────>  │                │               │
+   │                │                  │                │               │
+   │                │  inject:         │                │               │
+   │                │  ALWAYS:         │                │               │
+   │                │  - prompt.md     │                │               │
+   │                │  - output schema │                │               │
+   │                │  IF DEFINED:     │                │               │
+   │                │  - input         │                │               │
+   │                │  - config        │                │               │
+   │                │  - prev. state   │                │               │
+   │                │  - memories      │                │               │
+   │                │  - tools         │                │               │
+   │                │  - skills        │                │               │
+   │                │  - credentials   │                │               │
+   │                │ ──────────────>  │                │               │
+   │                │                  │                │               │
+   │                │                  │  LLM calls     │  Anthropic,  │
+   │                │                  │ ────────────>  │  OpenAI...   │
+   │                │                  │ <────────────  │ <──────────> │
+   │                │                  │                │               │
+   │                │           agent executes          │               │
+   │                │                  │                │               │
+   │                │                  │  AUTH call     │               │
+   │                │                  │  (sidecar      │  OAuth APIs  │
+   │                │                  │   proxy)       │  (Drive,     │
+   │                │                  │ ────────────>  │   Gmail...)  │
+   │                │                  │ <────────────  │ <──────────> │
+   │                │                  │                │               │
+   │                │                  │  PUBLIC call   │               │
+   │                │                  │  (direct curl) │               │
+   │                │                  │ ───────────────┼────────────> │
+   │                │                  │ <──────────────┼───────────── │
+   │                │                  │                │               │
+   │  SSE: logs     │    output(data)  │                │               │
+   │ <─ ─ ─ ─ ─ ─  │ <─ ─ ─ ─ ─ ─ ─  │                │               │
+   │                │                  │                │               │
+   │                │  destroy         │                │               │
+   │                │ ──────────────>  │                │               │
+   │                │                  │                │               │
+   │ GET /runs/{id} │                  │                │               │
+   │ { result }     │                  │                │               │
+   │ <────────────  │                  │                │               │
+```
+
+## Agent Data Flow
+
+```
+    ┌─────────────────────────────────────────────────────────────┐
+    │                   DIFFERENT EACH RUN                         │
+    │                                                             │
+    │                   │                                         │
+    │   INPUT ──────> AGENT ──────> INTERNAL OUTPUT               │
+    │   (optional)      │          structured JSON, markdown      │
+    │   e.g. query,     │          report — stored in Appstrate   │
+    │   file, date      │                                        │
+    │   range           │ ──────> EXTERNAL OUTPUT                 │
+    │                   │          upload files, send emails,     │
+    │                   │          call APIs via sidecar or curl  │
+    │                   │                                        │
+    └───────────────────┼─────────────────────────────────────────┘
+                        │
+    ┌───────────────────┼─────────────────────────────────────────┐
+    │              SHARED ACROSS RUNS                              │
+    │                   │                                         │
+    │   CONFIG ─────────┤  (set once via API or UI, rarely        │
+    │   e.g. language,  │   changes — injected as                 │
+    │   max items,      │   ## Configuration)                     │
+    │   target audience │                                         │
+    │                   │                                         │
+    │   STATE ──────────┤  (overwritten each run, only latest     │
+    │   e.g. cursor,    │   value kept — injected as              │
+    │   timestamp       │   ## Previous State)                    │
+    │                   │                                         │
+    │   MEMORY ─────────┘  (appended, never overwritten           │
+    │   e.g. learnings,     shared across all users —             │
+    │   patterns            injected as ## Memory)                │
+    │                                                             │
+    └─────────────────────────────────────────────────────────────┘
+```
+
+**Example: `@my-org/generate-social-post`**
+
+| Layer      | Set by | When        | Example values                                                    |
+| ---------- | ------ | ----------- | ----------------------------------------------------------------- |
+| **Config** | Admin  | Once        | `{ "language": "en", "platform": "linkedin", "maxLength": 1500 }` |
+| **Input**  | User   | Each run    | `{ "topic": "AI in agencies" }`                                   |
+| **Output** | Agent  | Each run    | `{ "post": "AI is transforming...", "hashtags": ["#AI"] }`        |
+| **State**  | Agent  | Each run    | `{ "lastTopics": ["AI", "remote", "hiring"] }`                    |
+| **Memory** | Agent  | When useful | `"User prefers bullet-point format over long paragraphs"`         |
+
+Same agent, 3 runs — config stays the same, input changes each time:
+
+```
+Run 1:  input: { topic: "AI" }         → output: { post: "AI is transforming..." }
+Run 2:  input: { topic: "remote" }     → output: { post: "Remote work in..." }
+Run 3:  input: { topic: "hiring" }     → output: { post: "Hiring in 2026..." }
+        config: { language: "en", platform: "linkedin" }  ← same for all 3
+```
+
+## Dependencies
+
+All dependencies must be declared in `dependencies` in the manifest. Nothing is auto-enabled.
+
+### Providers
+
+External services the agent connects to via the sidecar proxy.
+
+```
+    ┌────────────────────────────────────────────────────────┐
+    │  SYSTEM PROVIDERS (provided by Appstrate)              │
+    │                                                        │
+    │  Google Drive, Gmail, Slack, HubSpot, GitHub...        │
+    │  Full list: GET /api/providers                         │
+    ├────────────────────────────────────────────────────────┤
+    │  CUSTOM PROVIDERS (created by org admins)              │
+    │                                                        │
+    │  Any OAuth2, API key, or custom-credentials service    │
+    │  Auth modes: oauth2, oauth1, api_key, basic, custom   │
+    └────────────────────────────────────────────────────────┘
+
+    Auth mode determines how credentials are injected:
+    - OAuth2/OAuth1 → {{access_token}}
+    - API key       → {{apiKey}}
+    - Custom        → {{fieldName}} per credential field
+```
+
+### Tools
+
+Executable code registered as native tools in the agent's tool list (like `bash`, `read`, `edit`). The agent discovers and calls them by name with typed parameters.
+
+Unlike scripts bundled in a skill (which the agent must call manually via `bash`), tools are visible to the LLM, reusable across agents, and return structured output. Custom tools are TypeScript extensions of the [Pi Coding Agent](https://github.com/nichochar/pi-coding-agent) SDK (`@mariozechner/pi-coding-agent`).
+
+```
+    ┌────────────────────────────────────────────────────────┐
+    │  SYSTEM TOOLS (provided by Appstrate)                  │
+    │                                                        │
+    │  @appstrate/output      Return structured JSON result  │
+    │  @appstrate/report      Generate markdown report       │
+    │  @appstrate/set-state   Persist state for next run     │
+    │  @appstrate/add-memory  Save long-term learning        │
+    │  @appstrate/log         Send real-time progress        │
+    ├────────────────────────────────────────────────────────┤
+    │  CUSTOM TOOLS (created by users)                       │
+    │                                                        │
+    │  TypeScript extensions packaged as .afps               │
+    │  e.g. @my-org/web-scraper, @my-org/pdf-parser         │
+    └────────────────────────────────────────────────────────┘
+```
+
+### Skills
+
+Knowledge and scripts injected into the agent's prompt and container. Always created by users or the community — no system skills. Skills follow the [Anthropic Agent Skills](https://docs.anthropic.com/en/docs/claude-code/skills) structure — same SKILL.md format with YAML frontmatter + Markdown body.
+
+```
+    my-skill/
+    ├── manifest.json          # Appstrate metadata (type: "skill")
+    │
+    ├── SKILL.md               # Anthropic-compatible skill file
+    │   ├── --- (YAML)         #   name, description
+    │   └── (Markdown)         #   instructions, workflows
+    │
+    ├── scripts/               # Deterministic code the agent
+    │   └── transform.py       # calls via bash (not reusable
+    │                          # across agents — use a tool for that)
+    │
+    └── references/            # Docs loaded on demand
+        └── api-guide.md       # by the agent when needed
+
+    Packaged as .afps → imported via POST /api/packages/import
+    Extracted into container at .pi/skills/@scope/name/
+```

--- a/skills/appstrate/references/inline-runs.md
+++ b/skills/appstrate/references/inline-runs.md
@@ -1,0 +1,179 @@
+# Inline Runs
+
+- [Execute](#execute)
+- [Dry-run validation](#dry-run-validation)
+- [Ephemeral shadow packages](#ephemeral-shadow-packages)
+- [Daily compaction](#daily-compaction)
+- [Config snapshot (applies to ALL runs, inline + classic)](#config-snapshot-applies-to-all-runs-inline--classic)
+- [Global run list](#global-run-list)
+- [Environment limits: `INLINE_RUN_LIMITS`](#environment-limits-inline_run_limits)
+- [When to use inline vs package import](#when-to-use-inline-vs-package-import)
+- [Gotchas](#gotchas)
+
+Run an agent defined entirely in the request body — no `.afps` import, no package lifecycle, no version history. The platform creates an **ephemeral shadow package** (`ephemeral = true`, scope `@inline/r-<uuid>`), runs it through the standard pipeline, and compacts the manifest/prompt after 24h (configurable). Perfect for one-shot agents, rapid iteration, or integrating Appstrate as an LLM backend.
+
+Two endpoints:
+
+- `POST /api/runs/inline` — execute
+- `POST /api/runs/inline/validate` — dry-run preflight (no shadow row, no pipeline, no credits)
+
+## Execute
+
+```bash
+curl -X POST "$APPSTRATE_URL/api/runs/inline" \
+  -H "Authorization: Bearer $APPSTRATE_API_KEY" \
+  -H "X-Org-Id: $APPSTRATE_ORG_ID" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "manifest": {
+      "$schema": "https://afps.appstrate.dev/schema/v1/agent.schema.json",
+      "name": "@inline/one-shot",
+      "displayName": "One-shot summary",
+      "version": "0.0.0",
+      "type": "agent",
+      "schemaVersion": "1.0",
+      "dependencies": {
+        "tools": { "@appstrate/output": "^1.0.0" }
+      }
+    },
+    "prompt": "Summarize the attached document in three bullet points.",
+    "input": { "docId": "doc_123" }
+  }'
+```
+
+Response `202 Accepted`:
+
+```json
+{ "runId": "run_cm1abc123", "packageId": "@inline/r-abc12345-..." }
+```
+
+Stream progress: `GET /api/realtime/runs/{runId}` (SSE). Or poll `GET /api/runs/{runId}`.
+
+### Request body
+
+| Field              | Type                       | Required | Notes                                                                                                                                        |
+| ------------------ | -------------------------- | :------: | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `manifest`         | object                     |   yes    | Full AFPS agent manifest. Dependencies must reference **existing** org/system skills/tools/providers — registry-only, no inline new packages |
+| `prompt`           | string                     |   yes    | Contents of `prompt.md`                                                                                                                      |
+| `input`            | object                     |    no    | Validated against `manifest.input.schema` (AJV)                                                                                              |
+| `config`           | object                     |    no    | Per-run config overrides validated against `manifest.config.schema` (AJV)                                                                    |
+| `providerProfiles` | `Record<providerId, uuid>` |    no    | Override caller's default connection profile per provider                                                                                    |
+| `modelId`          | string \| null             |    no    | Per-run model override                                                                                                                       |
+| `proxyId`          | string \| null             |    no    | Per-run proxy override, or `"none"` to disable                                                                                               |
+
+### Response codes
+
+| Code | Meaning                                                                               |
+| ---- | ------------------------------------------------------------------------------------- |
+| 202  | Run accepted, `{ runId, packageId }` returned                                         |
+| 400  | Invalid manifest, schema mismatch, oversized payload, or wildcard URI when disallowed |
+| 401  | Auth missing                                                                          |
+| 409  | Idempotency key in progress                                                           |
+| 422  | Idempotency body mismatch                                                             |
+| 429  | Rate limit (see `INLINE_RUN_LIMITS`)                                                  |
+
+## Dry-run validation
+
+Same body, no side effects. Lets you iterate on a manifest without burning runs or leaving phantom rows.
+
+```bash
+curl -X POST "$APPSTRATE_URL/api/runs/inline/validate" \
+  -H "Authorization: Bearer $APPSTRATE_API_KEY" \
+  -H "X-Org-Id: $APPSTRATE_ORG_ID" \
+  -H "Content-Type: application/json" \
+  -d '{ "manifest": {...}, "prompt": "...", "input": {...}, "config": {...} }'
+```
+
+Runs the same preflight as execute (manifest shape → config/input AJV → provider readiness).
+
+| Code | Body                                              |
+| ---- | ------------------------------------------------- |
+| 200  | `{ "ok": true }`                                  |
+| 400  | `application/problem+json` with the first failure |
+
+**Shares the same rate bucket as `/api/runs/inline`** — tight iteration loops can trigger 429.
+
+## Ephemeral shadow packages
+
+Inline runs create a hidden `packages` row:
+
+- `ephemeral = true`
+- `name` in reserved scope `@inline/r-<uuid>`
+- Never appears in catalog queries (`GET /api/agents`, `/api/packages/*`)
+- `runs.agent_scope` / `runs.agent_name` denormalized — survives package compaction
+- Runs surface with `packageEphemeral: true` in the global run list
+
+You can link directly to an inline run detail: `/agents/@inline/r-.../runs/:runId` (the UI detects the shadow scope and skips the agent detail query).
+
+## Daily compaction
+
+A background worker runs daily:
+
+- NULLs `draft_manifest` + `draft_content` on ephemeral packages older than `retention_days` (default 30)
+- Drops associated `run_logs` via the `run_id` join
+- Never hard-deletes the `packages` row (FK cascade would drop the run)
+- Active runs are protected — their logs are preserved
+
+After compaction, the run row keeps status/result/input/output/cost/tokens but `inlineManifest` and `inlinePrompt` are `null`. The UI shows **"Details expired"** in the run detail view.
+
+## Config snapshot (applies to ALL runs, inline + classic)
+
+Every run — classic AND inline — now persists the effective agent config at creation time in `runs.config`. The Run Info tab renders it under a **Configuration** section, so users can always see what settings were active for a given run, decoupled from the package's current config.
+
+This means: editing a package's config after a run never rewrites history. Each run is self-describing.
+
+## Global run list
+
+New endpoint for cross-agent visibility:
+
+```
+GET /api/runs?kind=inline&status=success&startDate=2026-04-01T00:00:00Z
+```
+
+| Query                   | Values                                                  |
+| ----------------------- | ------------------------------------------------------- |
+| `user`                  | `me` (self-view — ignores `kind`/`status`/date filters) |
+| `kind`                  | `all` \| `package` \| `inline`                          |
+| `status`                | any run status                                          |
+| `startDate` / `endDate` | ISO 8601 date-time                                      |
+| `limit`                 | 1-100, default 20                                       |
+| `offset`                | default 0                                               |
+
+Each row includes `packageEphemeral: boolean` so clients can render an inline badge.
+
+## Environment limits: `INLINE_RUN_LIMITS`
+
+Configured as a JSON object in the `INLINE_RUN_LIMITS` env var. Strictly validated at boot — unknown keys fail-fast.
+
+| Key                    | Default | Meaning                                        |
+| ---------------------- | ------- | ---------------------------------------------- |
+| `rate_per_min`         | 60      | Per-user rate bucket (shared with `/validate`) |
+| `manifest_bytes`       | 65536   | Max serialized manifest size                   |
+| `prompt_bytes`         | 200000  | Max UTF-8 prompt size                          |
+| `max_skills`           | 20      | Max skill dependencies                         |
+| `max_tools`            | 20      | Max tool dependencies                          |
+| `max_authorized_uris`  | 50      | Max per-provider `authorizedUris` entries      |
+| `wildcard_uri_allowed` | false   | Whether `*` is allowed in `authorizedUris`     |
+| `retention_days`       | 30      | Days before compaction NULLs manifest/prompt   |
+
+Also governed by the broader `PLATFORM_RUN_LIMITS` (shared with every run path):
+`timeout_ceiling_seconds` (1800), `per_org_global_rate_per_min` (200), `max_concurrent_per_org` (50).
+
+## When to use inline vs package import
+
+| Use inline                                          | Use package import                           |
+| --------------------------------------------------- | -------------------------------------------- |
+| One-shot agent, no reuse                            | Agent needs a stable name / version history  |
+| Rapid iteration during development                  | Scheduled runs (schedules require a package) |
+| Integrating Appstrate as an LLM backend             | End users install via UI                     |
+| Dynamic manifest composed at call site              | Publishing for other orgs/users              |
+| You don't need the agent to appear in `/api/agents` | —                                            |
+
+## Gotchas
+
+1. **Dependencies are registry-only** — Inline manifests can depend on skills/tools/providers by ID, but cannot define new ones inline. If a dep doesn't exist in org/system catalog, preflight fails with 400.
+2. **Not schedulable** — Schedules require a persisted package. Schedule a regular agent instead.
+3. **Validate shares the rate bucket** — Iterative dev loops calling `/validate` every keystroke will hit 429. Debounce.
+4. **`manifest_bytes` is serialized JSON size** — Not the number of dependencies. A manifest with many defaults/descriptions can exceed the limit.
+5. **`@inline/r-...` scope is reserved** — Don't try to publish a package in that scope.
+6. **Compaction is irreversible** — Once `inlineManifest`/`inlinePrompt` are NULLed, there is no recovery. For audit needs, log the manifest client-side before calling.

--- a/skills/appstrate/references/manifest-schema.md
+++ b/skills/appstrate/references/manifest-schema.md
@@ -1,0 +1,184 @@
+# AFPS Manifest Schema Reference
+
+> AFPS (Agent Flow Packaging Standard) v1.0 — https://afps.appstrate.dev/
+
+Every package has a `manifest.json`. Schema validation: `https://afps.appstrate.dev/schema/v1/{type}.schema.json`
+
+## Table of Contents
+
+- [Common Fields](#common-fields)
+- [Dependencies](#dependencies)
+- [Agent Fields](#agent-fields)
+- [Input/Output/Config Schemas](#inputoutputconfig-schemas)
+- [State and Memories](#state-and-memories)
+- [Skill Fields](#skill-fields)
+- [Tool Fields](#tool-fields)
+- [Provider Fields](#provider-fields)
+- [Validation Rules](#validation-rules)
+
+## Common Fields
+
+| Field         | Type     | Required    | Description                              |
+| ------------- | -------- | ----------- | ---------------------------------------- |
+| `$schema`     | string   | No          | Schema URL for editor validation         |
+| `name`        | string   | **Yes**     | Scoped name: `@scope/name`               |
+| `version`     | string   | **Yes**     | Semver: `MAJOR.MINOR.PATCH[-prerelease]` |
+| `type`        | enum     | **Yes**     | `agent`, `skill`, `tool`, `provider`     |
+| `displayName` | string   | Agents: yes | Human-readable name                      |
+| `description` | string   | No          | Short description                        |
+| `keywords`    | string[] | No          | Tags for marketplace                     |
+| `license`     | string   | No          | SPDX identifier                          |
+
+Name regex: `^@[a-z0-9]([a-z0-9-]*[a-z0-9])?/[a-z0-9]([a-z0-9-]*[a-z0-9])?$`
+
+In API paths, scope includes `@`: `@my-org/my-agent` → `/api/agents/@my-org/my-agent`
+
+## Dependencies
+
+```json
+{
+  "dependencies": {
+    "providers": { "@appstrate/gmail": "^1.0.0" },
+    "skills": { "@appstrate/email-writing": "^1.0.0" },
+    "tools": { "@appstrate/web-scraper": "^1.0.0" }
+  }
+}
+```
+
+All three sub-fields optional. Values are semver ranges: `^1.0.0`, `~1.0.0`, `>=1.0.0 <2.0.0`, `*`.
+
+## Agent Fields
+
+| Field             | Type    | Required | Default | Description                              |
+| ----------------- | ------- | -------- | ------- | ---------------------------------------- |
+| `schemaVersion`   | string  | **Yes**  | —       | `"1.0"` (pattern: `^1\.(0\|[1-9]\d*)$`)  |
+| `author`          | string  | **Yes**  | —       | Author name                              |
+| `timeout`         | number  | No       | —       | Max execution time (seconds)             |
+| `x-outputRetries` | integer | No       | 0       | Retry on output validation failure (0-5) |
+
+### Providers Configuration
+
+```json
+{
+  "providersConfiguration": {
+    "@appstrate/gmail": {
+      "scopes": ["https://www.googleapis.com/auth/gmail.modify"],
+      "connectionMode": "user"
+    }
+  }
+}
+```
+
+- `scopes`: OAuth scopes needed
+- `connectionMode`: `"user"` (per-user) or `"admin"` (shared org creds)
+
+## Input/Output/Config Schemas
+
+All use JSON Schema with these types:
+
+| Type        | Notes                                                           |
+| ----------- | --------------------------------------------------------------- |
+| `"string"`  | Supports `enum`, `default`, `minLength`, `maxLength`, `pattern` |
+| `"number"`  | Supports `minimum`, `maximum`. AJV coerces `"50"` -> `50`       |
+| `"boolean"` | Supports `default`                                              |
+| `"array"`   | Requires `items`                                                |
+| `"object"`  | Nested `properties` + `required`                                |
+| `"file"`    | Input only. `accept`, `maxSize` (bytes), `multiple`, `maxFiles` |
+
+Display: `title` (label), `description` (help text), `default`, `propertyOrder` (field order).
+
+**Critical**: `required` is a top-level array, NOT per-property boolean.
+
+```json
+{
+  "input": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "query": { "type": "string", "title": "Search Query" },
+        "limit": { "type": "number", "default": 10 }
+      },
+      "required": ["query"],
+      "propertyOrder": ["query", "limit"]
+    }
+  }
+}
+```
+
+## State and Memories
+
+**State**: Free-form JSON, overwritten each run. Agent returns `result.state`, injected as `## Previous State` next run.
+
+**Memories**: Single list shared across all users of the agent (appended, never overwritten). Injected as `## Memory` in the prompt. Use the `add_memory` tool to save learnings. No manifest config needed.
+
+## Skill Fields
+
+Minimal manifest. Content lives in `SKILL.md` (YAML frontmatter + Markdown).
+
+```json
+{
+  "name": "@my-org/my-skill",
+  "version": "1.0.0",
+  "type": "skill",
+  "displayName": "My Skill",
+  "description": "What this skill provides"
+}
+```
+
+Skills can bundle `scripts/`, `references/`, `assets/` directories. The entire .afps content is extracted into `.pi/skills/{id}/` in the container.
+
+## Tool Fields
+
+| Field              | Type   | Required | Description                                   |
+| ------------------ | ------ | -------- | --------------------------------------------- |
+| `entrypoint`       | string | **Yes**  | Path to TypeScript entry (e.g., `"index.ts"`) |
+| `tool.name`        | string | **Yes**  | Tool identifier (snake_case)                  |
+| `tool.description` | string | **Yes**  | Description for agent tool selection          |
+| `tool.inputSchema` | object | **Yes**  | JSON Schema for parameters                    |
+
+```json
+{
+  "name": "@my-org/my-tool",
+  "version": "1.0.0",
+  "type": "tool",
+  "entrypoint": "index.ts",
+  "tool": {
+    "name": "my_tool",
+    "description": "Does something useful",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "query": { "type": "string", "description": "Search query" }
+      },
+      "required": ["query"]
+    }
+  }
+}
+```
+
+**Execute signature**: `(toolCallId, params, signal)` — params is the **second** argument.
+**Return type**: `{ content: [{ type: "text", text: "..." }] }` — NOT a plain string.
+**Import**: `import { tool } from "@mariozechner/pi-coding-agent"`
+
+## Provider Fields
+
+Key field: `definition` with `authMode`.
+
+| Auth Mode | Use Case              | Key Fields                                                                   |
+| --------- | --------------------- | ---------------------------------------------------------------------------- |
+| `oauth2`  | Google, GitHub, Slack | `authorizationUrl`, `tokenUrl`, `refreshUrl`, `defaultScopes`, `pkceEnabled` |
+| `oauth1`  | Twitter legacy        | `requestTokenUrl`, `authorizationUrl`, `accessTokenUrl`                      |
+| `api_key` | OpenAI, SendGrid      | `credentialHeaderName`, `credentialHeaderPrefix`                             |
+| `basic`   | JIRA basic auth       | (none extra)                                                                 |
+| `custom`  | Multi-field creds     | `credentialSchema` (JSON Schema form)                                        |
+| `proxy`   | HTTP proxy            | Auto-sets `allowAllUris: true`                                               |
+
+Common definition fields: `authorizedUris` (URL patterns with `*` wildcards), `iconUrl`, `categories`, `docsUrl`, `setupGuide`, `availableScopes` (`[{ value, label }]`).
+
+## Validation Rules
+
+- Versions: forward-only, no downgrades
+- `latest` dist-tag: auto-managed on non-prerelease publishes
+- AJV: `coerceTypes: true`, no `additionalProperties: false`
+- Custom fields: use `x-` prefix (e.g., `x-outputRetries`)
+- Updates require `lockVersion` field (optimistic locking, 409 on conflict)

--- a/skills/appstrate/references/profiles.md
+++ b/skills/appstrate/references/profiles.md
@@ -1,0 +1,148 @@
+# Profiles — Managing Multiple Appstrate Instances
+
+- [Layout](#layout)
+- [Resolution Order](#resolution-order)
+- [Selecting a Profile (Per-Call)](#selecting-a-profile-per-call)
+- [When to Infer a Profile From the Prompt](#when-to-infer-a-profile-from-the-prompt)
+- [Managing Profiles](#managing-profiles)
+- [Cross-Profile Operations](#cross-profile-operations)
+- [Gotchas](#gotchas)
+
+For users who pilot multiple Appstrate instances (cloud, self-hosted production, dev, per-project), the skill supports **named profiles** stored in `~/.config/appstrate/profiles/<name>.env`. Each profile is a plain `.env` file containing the three standard vars.
+
+## Layout
+
+```
+~/.config/appstrate/
+├── default-profile              # one line: the profile name to use when no override
+└── profiles/
+    ├── cloud.env                # e.g., app.appstrate.com
+    ├── local.env                # e.g., self-hosted via ~/.appstrate
+    ├── dev.env                  # e.g., appstrate-dev dev instance
+    └── <anything>.env
+```
+
+Each `<name>.env` file contains:
+
+```
+APPSTRATE_URL=...
+APPSTRATE_API_KEY=ask_...
+APPSTRATE_ORG_ID=...
+```
+
+**Permissions**: the `~/.config/appstrate/` directory and every `.env` inside are `chmod 600` / `700`. Never world-readable.
+
+## Resolution Order
+
+When the skill needs credentials, look in this order (first match wins):
+
+1. **`APPSTRATE_PROFILE` env var** — e.g., `APPSTRATE_PROFILE=local bun run agent.ts`
+2. **`~/.config/appstrate/default-profile`** — contents = profile name
+3. **`APPSTRATE_URL` / `APPSTRATE_API_KEY` / `APPSTRATE_ORG_ID` env vars** — legacy single-instance mode
+4. **Project `.env` files** — legacy per-project override
+5. **Other coding-agent config dirs** (`~/.claude/.env`, `~/.cursor/.env`, …) — legacy fallback
+
+Profiles are only consulted via steps 1–2. If no `profiles/` dir exists, the skill falls back to the legacy search from step 3 — full back-compat.
+
+## Selecting a Profile (Per-Call)
+
+**Inline for a single command** (no env persistence):
+
+```bash
+set -a
+source ~/.config/appstrate/profiles/local.env
+set +a
+curl "$APPSTRATE_URL/api/agents" \
+  -H "Authorization: Bearer $APPSTRATE_API_KEY" \
+  -H "X-Org-Id: $APPSTRATE_ORG_ID"
+```
+
+**Subshell so it never pollutes the current env**:
+
+```bash
+( set -a; . ~/.config/appstrate/profiles/local.env; set +a;
+  curl "$APPSTRATE_URL/api/agents" -H "Authorization: Bearer $APPSTRATE_API_KEY" -H "X-Org-Id: $APPSTRATE_ORG_ID" )
+```
+
+**Via `APPSTRATE_PROFILE`** (resolution expands it):
+
+```bash
+export APPSTRATE_PROFILE=local
+# now every skill-driven call uses local until unset
+```
+
+## When to Infer a Profile From the Prompt
+
+When the user mentions an instance by name or context, resolve to a profile:
+
+| User says                                                   | Profile to use        |
+| ----------------------------------------------------------- | --------------------- |
+| "on cloud", "en cloud", "on prod", "production"             | `cloud`               |
+| "on local", "en local", "my self-hosted", "sur mon install" | `local`               |
+| "on dev", "dev instance", "appstrate-dev"                   | `dev`                 |
+| No mention                                                  | `default-profile`     |
+| "on all my instances"                                       | iterate every profile |
+
+If an inferred profile doesn't exist, list the available ones with `ls ~/.config/appstrate/profiles/` and ask which to use.
+
+## Managing Profiles
+
+### List
+
+```bash
+ls ~/.config/appstrate/profiles/
+cat ~/.config/appstrate/default-profile
+```
+
+### Add
+
+```bash
+cat > ~/.config/appstrate/profiles/dev.env <<EOF
+APPSTRATE_URL=http://localhost:3000
+APPSTRATE_API_KEY=ask_...
+APPSTRATE_ORG_ID=...
+EOF
+chmod 600 ~/.config/appstrate/profiles/dev.env
+```
+
+### Change the default
+
+```bash
+echo local > ~/.config/appstrate/default-profile
+```
+
+### Remove
+
+```bash
+rm ~/.config/appstrate/profiles/<name>.env
+```
+
+### Rotate an API key
+
+Regenerate in the UI, then overwrite the `APPSTRATE_API_KEY=` line in the profile's `.env`. Permissions stay `600`.
+
+## Cross-Profile Operations
+
+When the user asks to inspect or act across instances (e.g., "list agents on all my instances"), iterate:
+
+```bash
+for p in ~/.config/appstrate/profiles/*.env; do
+  name=$(basename "$p" .env)
+  echo "--- $name ---"
+  ( set -a; . "$p"; set +a;
+    curl -s "$APPSTRATE_URL/api/agents" \
+      -H "Authorization: Bearer $APPSTRATE_API_KEY" \
+      -H "X-Org-Id: $APPSTRATE_ORG_ID" | head -c 200 )
+  echo
+done
+```
+
+Use a subshell `( ... )` for each so env isolation is preserved between profiles.
+
+## Gotchas
+
+1. **Don't commit profile files** — they contain API keys. Live under `~/.config/`, outside any repo.
+2. **`APPSTRATE_PROFILE` beats `default-profile`** — if you export it in a session for a quick test, remember to `unset APPSTRATE_PROFILE` after, or the override sticks.
+3. **Legacy env vars still work** — if a user hasn't migrated, step 3 in the resolution order catches them. Offer migration (create profiles from existing env) rather than error.
+4. **Org rotation** — if the user rotates their API key or switches orgs, only the affected profile file needs updating.
+5. **Cross-org within one instance** — each profile pins one `APPSTRATE_ORG_ID`. To target a different org on the same URL, add a second profile file (e.g., `cloud-tractr.env`, `cloud-lakaz.env`).

--- a/skills/appstrate/references/prompt-writing.md
+++ b/skills/appstrate/references/prompt-writing.md
@@ -1,0 +1,142 @@
+# Writing Effective prompt.md Files
+
+## Table of Contents
+
+- [Container Environment](#container-environment)
+- [Auto-Injected Sections](#auto-injected-sections)
+- [Sidecar Proxy Protocol](#sidecar-proxy-protocol)
+- [Recommended Structure](#recommended-structure)
+- [Memory](#memory-scopes)
+- [Incremental Processing](#incremental-processing)
+- [Common Mistakes](#common-mistakes)
+
+## Container Environment
+
+- **Runtimes**: Bun (primary) + Python3/pip
+- **Working dir**: `/workspace`
+- **Uploads**: `/workspace/documents/`
+- **Ephemeral**: destroyed after execution. Persist via state, memory, output only.
+- **Network**: direct outbound HTTP/HTTPS for public endpoints. Sidecar only for authenticated provider calls.
+
+## Auto-Injected Sections
+
+The platform prepends these automatically. Do NOT repeat them in prompt.md:
+
+1. `## System` + `### Environment` — identity, container, timeout
+2. `### Persistence` — state + memory
+3. `### Tools` — `workspace_list/read/write/delete/move/mkdir/delete_folder` + attached tools
+4. `### Skills` — references at `.pi/skills/`
+5. `## Authenticated Provider API` — sidecar proxy with `X-Provider`
+6. `## User Input` — input field values
+7. `## Documents` — uploaded file paths
+8. `## Configuration` — config values
+9. `## Previous State` — JSON from last execution
+10. `## Memory` — 3 scoped arrays
+11. `## Execution History` — curl for history via sidecar
+12. `## Output Format` — expected JSON + validation rules
+
+## Sidecar Proxy Protocol
+
+Authenticated API calls MUST go through the sidecar:
+
+```bash
+curl -s "$SIDECAR_URL/proxy" \
+  -H "X-Provider: @appstrate/gmail" \
+  -H "X-Target: https://gmail.googleapis.com/gmail/v1/users/me/messages" \
+  -H "Authorization: Bearer {{access_token}}"
+```
+
+### Headers
+
+| Header              | Required | Description                                  |
+| ------------------- | -------- | -------------------------------------------- |
+| `X-Provider`        | Yes      | Scoped provider ID (`@scope/name`)           |
+| `X-Target`          | Yes      | Full target URL                              |
+| `X-Substitute-Body` | No       | `true` to replace `{{placeholders}}` in body |
+| `X-Proxy`           | No       | Override proxy for this request              |
+
+### Credential Placeholders
+
+| Auth Mode | Placeholder        | Example                                  |
+| --------- | ------------------ | ---------------------------------------- |
+| OAuth2    | `{{access_token}}` | `Authorization: Bearer {{access_token}}` |
+| API Key   | `{{apiKey}}`       | `X-Api-Key: {{apiKey}}`                  |
+| Custom    | `{{fieldName}}`    | Any field from `credentialSchema`        |
+
+### Response Behavior
+
+- Forwarded as-is (status + body + Content-Type)
+- > 50KB truncated (`X-Truncated: true`)
+- Sidecar errors: `{ "error": "..." }` with 4xx/5xx
+
+Public APIs (no auth): call directly, no sidecar needed.
+
+## Recommended Structure
+
+````markdown
+# Objective
+
+One clear sentence.
+
+# Steps
+
+1. **Fetch data**
+   ```bash
+   curl -s "$SIDECAR_URL/proxy" \
+     -H "X-Provider: @appstrate/provider" \
+     -H "X-Target: https://api.example.com/endpoint" \
+     -H "Authorization: Bearer {{access_token}}"
+   ```
+````
+
+2. **Process** — Transform, filter, summarize
+3. **Return results** — JSON matching output schema
+
+# Incremental Processing
+
+How to use Previous State for delta processing.
+
+# Rules
+
+- Constraints and edge cases
+- Error handling
+- Output format
+
+````
+
+## Memory
+
+| Scope | Purpose | Visibility |
+|-------|---------|------------|
+| Memories | API quirks, data patterns, learnings | Shared across all users of the agent |
+
+Include memory instructions only when the agent should learn across runs. Be selective.
+
+## Incremental Processing
+
+For scheduled/recurring agents, use state to track progress:
+
+```markdown
+Check `## Previous State` for `lastSyncTimestamp`.
+
+- **First run**: Process all items from last 7 days.
+- **Subsequent runs**: Only items after `lastSyncTimestamp`.
+
+Always return `state.lastSyncTimestamp` = current timestamp.
+Process all pages before updating timestamp (timeout safety).
+````
+
+## Common Mistakes
+
+| Mistake                                              | Fix                                               |
+| ---------------------------------------------------- | ------------------------------------------------- |
+| Repeating `## User Input` or `## Configuration`      | Platform injects these — just reference values    |
+| `X-Service` instead of `X-Provider`                  | Use `X-Provider: @scope/name`                     |
+| Missing `X-Target` header                            | Always include full URL                           |
+| URL-based routing (`$SIDECAR_URL/proxy/https://...`) | Use header: `X-Target` for URL                    |
+| No credential placeholder                            | Add `Authorization: Bearer {{access_token}}` etc. |
+| Hardcoding URLs from config                          | Put in `config.schema`, reference from config     |
+| `required: true` on properties                       | Use top-level `"required": ["field1"]` array      |
+| No output format specified                           | Include clear JSON example                        |
+| Writing prompt in wrong language                     | Match target audience language                    |
+| JSON output not mandatory                            | Agent must always return valid JSON               |

--- a/skills/appstrate/references/setup.md
+++ b/skills/appstrate/references/setup.md
@@ -1,0 +1,85 @@
+# Appstrate Setup Guide
+
+## Step 0 (optional): Self-host your own instance
+
+Using `app.appstrate.com` (cloud)? Skip to Step 1.
+
+To self-host, run the one-liner installer on any host with Docker 20+ and Compose V2:
+
+```bash
+curl -fsSL https://get.appstrate.dev | bash
+```
+
+The installer generates secrets, downloads images, starts the stack, and waits for health. Re-run to upgrade — existing secrets are preserved. Overrides: `APPSTRATE_VERSION=v1.2.3`, `APPSTRATE_DIR=~/.appstrate`, `APPSTRATE_PORT=8080`.
+
+For supply-chain verification (SLSA provenance via `gh attestation verify` or offline minisign signatures), see `examples/self-hosting/README.md` in the appstrate-oss repo.
+
+After install, your instance is at `http://localhost:3000` (or your `APPSTRATE_PORT`). Sign up in the UI, then continue with Step 1 — set `APPSTRATE_URL` to your deployed URL instead of `https://app.appstrate.com` at Step 3.
+
+## Step 1: Create your API key
+
+1. Go to [app.appstrate.com](https://app.appstrate.com) and sign in
+2. In the left sidebar, scroll to the **Application** section (bottom of sidebar)
+3. Click **Cles API**
+4. Click the blue **Nouvelle cle API** button (top right)
+5. Fill the form:
+   - **Nom**: a label for this key (e.g., `My Coding Agent`)
+   - **Expire dans**: expiration delay (default: 90 days)
+   - **Permissions**: leave `Tous les scopes` for full access
+6. Click **Nouvelle cle API**
+7. **Copy the key immediately** — it starts with `ask_` and is shown only once
+
+## Step 2: Get your Org ID
+
+Once you have your API key, run:
+
+```bash
+curl -s "https://app.appstrate.com/api/orgs" \
+  -H "Authorization: Bearer ask_YOUR_KEY_HERE"
+```
+
+This returns your organizations with their IDs. Copy the `id` of the org you want to use.
+
+## Step 3: Store credentials
+
+Store these 3 variables so your coding agent can access them:
+
+```bash
+APPSTRATE_URL=https://app.appstrate.com
+APPSTRATE_API_KEY=ask_your_key_here
+APPSTRATE_ORG_ID=your-org-id-here
+```
+
+Common approaches:
+
+- **`.env` file** in your project root (most universal — works with any tool)
+- **Environment variables** in your shell profile (`~/.zshrc`, `~/.bashrc`)
+- **Tool-specific secrets** (Cursor settings, IDE env config, etc.)
+
+## Step 4: Verify
+
+```bash
+curl -s "$APPSTRATE_URL/api/agents" \
+  -H "Authorization: Bearer $APPSTRATE_API_KEY" \
+  -H "X-Org-Id: $APPSTRATE_ORG_ID" | head -c 200
+```
+
+If you see a JSON response with agents, you're good to go.
+
+## Multiple instances?
+
+If you pilot more than one instance (cloud + self-hosted + dev), skip exporting env vars and use named profiles instead: one `.env` file per instance under `~/.config/appstrate/profiles/`. See `references/profiles.md` for layout, resolution order, and cross-instance patterns.
+
+Quick migration from single-instance setup:
+
+```bash
+mkdir -p ~/.config/appstrate/profiles
+chmod 700 ~/.config/appstrate ~/.config/appstrate/profiles
+cat > ~/.config/appstrate/profiles/cloud.env <<EOF
+APPSTRATE_URL=$APPSTRATE_URL
+APPSTRATE_API_KEY=$APPSTRATE_API_KEY
+APPSTRATE_ORG_ID=$APPSTRATE_ORG_ID
+EOF
+chmod 600 ~/.config/appstrate/profiles/cloud.env
+echo cloud > ~/.config/appstrate/default-profile
+```

--- a/skills/appstrate/references/system-tools.md
+++ b/skills/appstrate/references/system-tools.md
@@ -1,0 +1,97 @@
+# Appstrate System Tools
+
+System tools are platform-provided tools that agents can use at runtime. They are NOT available by default — each tool must be declared in `dependencies.tools` in the manifest to be activated.
+
+## Discovery
+
+List available tools in the org:
+
+```bash
+curl "$APPSTRATE_URL/api/packages/tools"
+```
+
+Activate tools for an existing agent via API:
+
+```bash
+curl -X PUT "$APPSTRATE_URL/api/agents/@scope/name/tools" \
+  -H "Content-Type: application/json" \
+  -d '{"toolIds": ["@appstrate/output", "@appstrate/set-state"]}'
+```
+
+Or declare in manifest (preferred — activated at import):
+
+```json
+"dependencies": {
+  "tools": {
+    "@appstrate/output": "^1.0.0",
+    "@appstrate/set-state": "^1.0.0"
+  }
+}
+```
+
+## Tool Reference
+
+### `@appstrate/output` — Return structured data
+
+Returns data as the run result. Each call is deep-merged into the final output, validated against the output schema (AJV) after the run completes.
+
+**When to use**: Agent has an `output` schema defined in its manifest and needs to return structured JSON results.
+
+**Without this tool**: Run completes with `result: {}` even on success — the agent has no way to submit structured data.
+
+**In prompt.md**: Instruct the agent to call the `output` tool with a `data` parameter matching the output schema. Multiple calls are merged.
+
+```markdown
+Use the `output` tool to return results:
+output({ "summary": "...", "itemCount": 42 })
+```
+
+### `@appstrate/report` — Generate a markdown report
+
+Produces a markdown report included in the run result alongside structured output.
+
+**When to use**: Agent should produce a human-readable narrative (summary, analysis, formatted results) in addition to or instead of structured data.
+
+**In prompt.md**: Instruct the agent to call `report` with markdown content.
+
+### `@appstrate/set-state` — Persist state between runs
+
+Saves state that is injected as `## Previous State` on the next run. Overwrites previous state entirely.
+
+**When to use**: Recurring/scheduled agents that need to track progress — sync cursors, timestamps, pagination tokens.
+
+**In prompt.md**:
+
+```markdown
+Check `## Previous State` for `lastSyncTimestamp`.
+
+- First run: process all items from last 7 days.
+- Subsequent runs: only items after `lastSyncTimestamp`.
+  Call `set-state` with `{ "lastSyncTimestamp": "<now>" }` before finishing.
+```
+
+### `@appstrate/add-memory` — Long-term learning
+
+Saves a discovery or learning as a long-term memory. Memories are injected into future runs and persist across versions.
+
+**When to use**: Agent should learn patterns, preferences, or API quirks across runs (e.g., "this endpoint returns dates in UTC", "user prefers bullet points").
+
+**In prompt.md**: Instruct the agent to call `add-memory` when it discovers something worth remembering.
+
+### `@appstrate/log` — Real-time progress messages
+
+Sends progress messages visible to the user in real time (via SSE).
+
+**When to use**: Long-running agents where the user benefits from seeing intermediate progress (e.g., "Processing page 3/10...").
+
+**In prompt.md**: Instruct the agent to call `log` at key milestones.
+
+## Decision Guide
+
+| Agent type                          | Recommended tools                                   |
+| ----------------------------------- | --------------------------------------------------- |
+| One-shot with structured output     | `output`                                            |
+| One-shot with report                | `report` (+ `output` if also needs structured data) |
+| Recurring/scheduled (sync, digest)  | `output` + `set-state`                              |
+| Learning agent (improves over time) | `output` + `add-memory`                             |
+| Long-running (> 30s)                | Add `log` to any of the above                       |

--- a/skills/appstrate/scripts/afps-pack.sh
+++ b/skills/appstrate/scripts/afps-pack.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Pack an Appstrate package directory into an .afps file
+# Usage: afps-pack.sh <source-dir> <output.afps>
+#
+# The source directory must contain manifest.json at its root.
+# All files are included in the ZIP at the root level (flat structure).
+
+set -euo pipefail
+
+SRC_DIR="${1:?Usage: afps-pack.sh <source-dir> <output.afps>}"
+OUTPUT="${2:?Usage: afps-pack.sh <source-dir> <output.afps>}"
+
+if [ ! -f "$SRC_DIR/manifest.json" ]; then
+  echo "Error: manifest.json not found in $SRC_DIR" >&2
+  exit 1
+fi
+
+# Resolve absolute path for output
+OUTPUT=$(cd "$(dirname "$OUTPUT")" && pwd)/$(basename "$OUTPUT")
+
+# Pack from within the source directory to keep flat structure
+cd "$SRC_DIR"
+zip -r "$OUTPUT" . -x '.*' -x '__MACOSX/*' -x '*.DS_Store'
+
+echo "Packed: $OUTPUT"
+echo "Files included:"
+unzip -l "$OUTPUT" | tail -n +4 | head -n -2


### PR DESCRIPTION
## What

Adds the Appstrate Manager skill to the monorepo under `skills/appstrate/`.

The skill is an [Anthropic Agent Skill](https://docs.anthropic.com/en/docs/build-with-claude/agent-skills) that teaches Claude Code (and any compatible coding agent) how to drive Appstrate via its REST API. Imported from internal use at Tractr, then audited against the skill-creator best practices.

## What's inside

- `SKILL.md` — entry point, setup, quick reference (~380 lines)
- `references/` — 8 files (~1100 lines): API cheatsheet, concepts, inline runs, manifest schema, profiles, prompt writing, setup, system tools. 5 ship with a TOC for quick navigation.
- `assets/` — 3 manifest templates (agent, skill, tool)
- `scripts/afps-pack.sh` — AFPS package builder

## Why here

Single source of truth, reachable by `appstrate skill install` once that command lands in CLI v0.1. Already documented at `/docs/getting-started/drivers` on the website (v3, in flight).

## Tests

None. Documentation/configuration only, no code paths.