### PR TITLE
fix(oidc): reconcile platform instance client auth method drift

### DIFF
--- a/apps/api/src/modules/oidc/services/oauth-admin.ts
+++ b/apps/api/src/modules/oidc/services/oauth-admin.ts
@@ -571,10 +571,21 @@ function sameStringSet(a: readonly string[], b: readonly string[]): boolean {
  * Auto-provision the instance-level OIDC client for the platform SPA.
  *
  * Idempotent on presence AND reconciles `redirectUris` /
- * `postLogoutRedirectUris` against the current `APP_URL` on every boot.
- * When the operator changes `APP_URL` (domain move, placeholder → real
- * URL on first setup), the existing row is updated in place — same
+ * `postLogoutRedirectUris` against the current `APP_URL` on every boot,
+ * plus the public-client auth shape (`public=true`,
+ * `tokenEndpointAuthMethod="none"`, `clientSecret=null`). When the
+ * operator changes `APP_URL` (domain move, placeholder → real URL on
+ * first setup), the existing row is updated in place — same
  * `client_id`, so outstanding tokens and live sessions remain valid.
+ *
+ * Auth-shape reconciliation is what upgrades pre-#154 installs. Before
+ * that PR the platform SPA was provisioned as a confidential client
+ * (`tokenEndpointAuthMethod="client_secret_basic"` + hashed
+ * `clientSecret`). The create path now provisions it as public + PKCE,
+ * but existing rows were left stuck as confidential — every SPA OIDC
+ * token exchange then failed with `invalid_client: client secret must
+ * be provided`. The existing-row path below converges the stored shape
+ * to the public-client contract.
  *
  * Without this reconciliation the dashboard SPA would loop on
  * `/api/auth/oauth2/authorize` after a URL change and eventually hit
@@ -585,9 +596,9 @@ function sameStringSet(a: readonly string[], b: readonly string[]): boolean {
  *
  * The SELECT+UPDATE is not transactional. Under multi-replica boot, both
  * replicas may detect drift and both issue the UPDATE — benign, since
- * both compute the exact same `expectedRedirectUris` from the same
- * `APP_URL` env var (last-write-wins with identical payloads). No
- * coordination primitive required.
+ * both compute identical expected values from the same `APP_URL` env
+ * var and the same public-client constants (last-write-wins with
+ * identical payloads). No coordination primitive required.
  *
  * ## Cache propagation across replicas
  *
@@ -636,6 +647,9 @@ export async function ensureInstanceClient(appUrl: string): Promise<string> {
       clientId: oauthClient.clientId,
       redirectUris: oauthClient.redirectUris,
       postLogoutRedirectUris: oauthClient.postLogoutRedirectUris,
+      public: oauthClient.public,
+      tokenEndpointAuthMethod: oauthClient.tokenEndpointAuthMethod,
+      clientSecret: oauthClient.clientSecret,
     })
     .from(oauthClient)
     .where(eq(oauthClient.level, "instance"))
@@ -646,17 +660,29 @@ export async function ensureInstanceClient(appUrl: string): Promise<string> {
     const storedPostLogout = existing.postLogoutRedirectUris ?? [];
     const redirectDrift = !sameStringSet(existing.redirectUris, expectedRedirectUris);
     const postLogoutDrift = !sameStringSet(storedPostLogout, expectedPostLogoutRedirectUris);
-    if (redirectDrift || postLogoutDrift) {
+    const authMethodDrift =
+      existing.public !== true ||
+      existing.tokenEndpointAuthMethod !== "none" ||
+      existing.clientSecret !== null;
+
+    if (redirectDrift || postLogoutDrift || authMethodDrift) {
       await db
         .update(oauthClient)
         .set({
           redirectUris: expectedRedirectUris,
           postLogoutRedirectUris: expectedPostLogoutRedirectUris,
+          ...(authMethodDrift
+            ? {
+                public: true,
+                tokenEndpointAuthMethod: "none" as const,
+                clientSecret: null,
+              }
+            : {}),
           updatedAt: new Date(),
         })
         .where(eq(oauthClient.clientId, existing.clientId));
       cacheInvalidate(existing.clientId);
-      logger.warn("OIDC platform client redirect URIs updated to match APP_URL", {
+      logger.warn("OIDC platform client reconciled to match APP_URL and public-client contract", {
         module: "oidc",
         clientId: existing.clientId,
         appUrl: normalizedAppUrl,
@@ -664,6 +690,11 @@ export async function ensureInstanceClient(appUrl: string): Promise<string> {
         redirectUrisTo: expectedRedirectUris,
         postLogoutRedirectUrisFrom: storedPostLogout,
         postLogoutRedirectUrisTo: expectedPostLogoutRedirectUris,
+        publicFrom: existing.public,
+        publicTo: authMethodDrift ? true : existing.public,
+        tokenEndpointAuthMethodFrom: existing.tokenEndpointAuthMethod,
+        tokenEndpointAuthMethodTo: authMethodDrift ? "none" : existing.tokenEndpointAuthMethod,
+        clientSecretCleared: authMethodDrift && existing.clientSecret !== null,
       });
     }
     return existing.clientId;

--- a/apps/api/src/modules/oidc/test/integration/services/instance-client.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/instance-client.test.ts
@@ -194,6 +194,142 @@ describe("ensureInstanceClient", () => {
     expect(after!.redirectUris).toEqual(["https://example.com/auth/callback"]);
   });
 
+  it("reconciles auth method drift from pre-#154 confidential client", async () => {
+    const { ensureInstanceClient, hashSecret } = await import("../../../services/oauth-admin.ts");
+
+    // Seed a pre-#154 row: confidential client with hashed secret.
+    const id = "oac_legacy_test_0000000000000001";
+    const clientId = "oauth_legacy_instance_client";
+    const hashedSecret = await hashSecret("legacy-platform-secret");
+    const now = new Date();
+    await db.insert(oauthClient).values({
+      id,
+      clientId,
+      clientSecret: hashedSecret,
+      name: "Appstrate Platform",
+      redirectUris: ["http://localhost:3000/auth/callback"],
+      postLogoutRedirectUris: ["http://localhost:3000", "http://localhost:3000/login"],
+      scopes: ["openid", "profile", "email", "offline_access"],
+      level: "instance",
+      referencedOrgId: null,
+      referencedApplicationId: null,
+      metadata: JSON.stringify({ level: "instance", clientId }),
+      skipConsent: true,
+      allowSignup: true,
+      signupRole: "member",
+      disabled: false,
+      type: "web",
+      public: false,
+      tokenEndpointAuthMethod: "client_secret_basic",
+      grantTypes: ["authorization_code", "refresh_token"],
+      responseTypes: ["code"],
+      requirePKCE: true,
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const reconciled = await ensureInstanceClient("http://localhost:3000");
+    expect(reconciled).toBe(clientId);
+
+    const [row] = await db
+      .select()
+      .from(oauthClient)
+      .where(eq(oauthClient.clientId, clientId))
+      .limit(1);
+    expect(row).toBeDefined();
+    expect(row!.public).toBe(true);
+    expect(row!.tokenEndpointAuthMethod).toBe("none");
+    expect(row!.clientSecret).toBeNull();
+    // clientId unchanged → outstanding tokens still valid
+    expect(row!.clientId).toBe(clientId);
+    // Redirect URIs unchanged (already correct)
+    expect(row!.redirectUris).toEqual(["http://localhost:3000/auth/callback"]);
+  });
+
+  it("does not touch an already-conforming public client", async () => {
+    const { ensureInstanceClient } = await import("../../../services/oauth-admin.ts");
+    await ensureInstanceClient("http://localhost:3000");
+
+    const [before] = await db
+      .select()
+      .from(oauthClient)
+      .where(eq(oauthClient.level, "instance"))
+      .limit(1);
+    expect(before!.public).toBe(true);
+    expect(before!.tokenEndpointAuthMethod).toBe("none");
+    expect(before!.clientSecret).toBeNull();
+    const originalUpdatedAt = before!.updatedAt!.getTime();
+
+    await ensureInstanceClient("http://localhost:3000");
+
+    const [after] = await db
+      .select()
+      .from(oauthClient)
+      .where(eq(oauthClient.level, "instance"))
+      .limit(1);
+    expect(after!.updatedAt!.getTime()).toBe(originalUpdatedAt);
+    expect(after!.public).toBe(true);
+    expect(after!.tokenEndpointAuthMethod).toBe("none");
+    expect(after!.clientSecret).toBeNull();
+  });
+
+  it("converges redirect drift + auth method drift in a single atomic UPDATE", async () => {
+    const { ensureInstanceClient, hashSecret } = await import("../../../services/oauth-admin.ts");
+
+    // Seed a legacy row with stale redirects AND confidential auth shape.
+    const id = "oac_legacy_test_0000000000000002";
+    const clientId = "oauth_legacy_combined_drift";
+    const hashedSecret = await hashSecret("legacy-combined-secret");
+    const staleDate = new Date(0);
+    await db.insert(oauthClient).values({
+      id,
+      clientId,
+      clientSecret: hashedSecret,
+      name: "Appstrate Platform",
+      redirectUris: ["https://old.example.com/auth/callback"],
+      postLogoutRedirectUris: ["https://old.example.com", "https://old.example.com/login"],
+      scopes: ["openid", "profile", "email", "offline_access"],
+      level: "instance",
+      referencedOrgId: null,
+      referencedApplicationId: null,
+      metadata: JSON.stringify({ level: "instance", clientId }),
+      skipConsent: true,
+      allowSignup: true,
+      signupRole: "member",
+      disabled: false,
+      type: "web",
+      public: false,
+      tokenEndpointAuthMethod: "client_secret_basic",
+      grantTypes: ["authorization_code", "refresh_token"],
+      responseTypes: ["code"],
+      requirePKCE: true,
+      createdAt: staleDate,
+      updatedAt: staleDate,
+    });
+
+    const reconciled = await ensureInstanceClient("https://new.example.com");
+    expect(reconciled).toBe(clientId);
+
+    const [row] = await db
+      .select()
+      .from(oauthClient)
+      .where(eq(oauthClient.clientId, clientId))
+      .limit(1);
+    expect(row).toBeDefined();
+    // Auth shape converged
+    expect(row!.public).toBe(true);
+    expect(row!.tokenEndpointAuthMethod).toBe("none");
+    expect(row!.clientSecret).toBeNull();
+    // Redirect URIs converged
+    expect(row!.redirectUris).toEqual(["https://new.example.com/auth/callback"]);
+    expect(row!.postLogoutRedirectUris).toEqual([
+      "https://new.example.com",
+      "https://new.example.com/login",
+    ]);
+    // Single UPDATE happened (updatedAt advanced past the sentinel)
+    expect(row!.updatedAt!.getTime()).toBeGreaterThan(staleDate.getTime());
+  });
+
   it("rejects APP_URL that would produce an invalid redirect URI", async () => {
     const { ensureInstanceClient, OAuthAdminValidationError } =
       await import("../../../services/oauth-admin.ts");


### PR DESCRIPTION
## Summary

PR #154 switched the platform SPA OAuth client from confidential (`client_secret_basic` + hashed `clientSecret`) to public + PKCE, but the change only ran on the **create** path of `ensureInstanceClient()`. On instances provisioned before #154, the stored row stays confidential forever, and every SPA OIDC token exchange fails with `invalid_client: client secret must be provided`.

This patch extends the existing-row reconciliation branch to also converge the auth shape:

- SELECT now reads `public`, `tokenEndpointAuthMethod`, `clientSecret` so drift is visible.
- New `authMethodDrift` predicate triggers an atomic UPDATE that sets `public=true, tokenEndpointAuthMethod="none", clientSecret=null` alongside any redirect-URI reconciliation.
- Existing `cacheInvalidate()` + `logger.warn()` paths preserved; log now enriched with `publicFrom/To`, `tokenEndpointAuthMethodFrom/To`, and `clientSecretCleared` (boolean — hash is never logged).
- Docstring updated to document the auth-shape reconciliation and the pre-#154 migration path. Idempotency + multi-replica concurrency story unchanged (both replicas compute identical expected values).

`clientId` is never rewritten, so outstanding tokens and live sessions remain valid across the reconciliation.

## Test plan

- [x] `bun test apps/api/src/modules/oidc` — 399 pass, 0 fail
- [x] `bun run check` — all 15 tasks pass
- [x] New integration test: pre-#154 confidential row → converges to `public=true, tokenEndpointAuthMethod="none", clientSecret=null`, same `clientId`
- [x] New integration test: already-conforming row → no UPDATE, `updatedAt` unchanged
- [x] New integration test: combined redirect + auth drift → single atomic UPDATE converges both

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)