### PR TITLE
feat(cli): pin orgId on login + `appstrate org` subcommands

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -37,6 +37,8 @@ See [`examples/self-hosting/README.md`](../../examples/self-hosting/README.md#ve
 | `appstrate logout`  | Revoke the active session server-side and wipe local credentials.              |
 | `appstrate whoami`  | Print the identity attached to the active profile.                             |
 | `appstrate token`   | Print metadata about the stored access + refresh tokens (debug).               |
+| `appstrate org`     | List, switch, or create organizations pinned on the active profile.            |
+| `appstrate api`     | Authenticated HTTP passthrough to the Appstrate API.                           |
 
 All commands accept `--profile <name>` to target a specific profile (see [Profiles](#profiles)).
 
@@ -86,10 +88,21 @@ appstrate login --profile prod --instance https://app.my.io
 
 **Flags**
 
-| Flag              | Values | Description                                                   |
-| ----------------- | ------ | ------------------------------------------------------------- |
-| `--instance`      | URL    | Instance base URL. Skips the interactive prompt.              |
-| `-p`, `--profile` | name   | Profile name to store credentials under (default: `default`). |
+| Flag              | Values         | Description                                                                                                                                   |
+| ----------------- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--instance`      | URL            | Instance base URL. Skips the interactive prompt.                                                                                              |
+| `-p`, `--profile` | name           | Profile name to store credentials under (default: `default`).                                                                                 |
+| `--org`           | `<id-or-slug>` | After the token exchange, pin this organization on the profile non-interactively. Fails if the reference does not match any org.              |
+| `--create-org`    | `<name>`       | Create a new organization with this name and pin it. A default application + hello-world agent are provisioned server-side. Skips the prompt. |
+| `--no-org`        | —              | Skip the post-login org-pinning step entirely. Subsequent calls must carry `-H 'X-Org-Id: …'`, or pin later via `appstrate org switch`.       |
+
+**Org pinning after login** (issue #209): on success, the CLI calls `GET /api/orgs` and branches:
+
+- **Exactly one org** → auto-pin. The success banner names it: `Logged in as … to "Acme" (org_xxx)`.
+- **Zero orgs** (fresh signup, dashboard onboarding skipped) → offer inline creation (`POST /api/orgs`) which also provisions a default application + hello-world agent server-side.
+- **≥2 orgs** → interactive picker.
+
+The pinned org id is written to `config.toml` and automatically sent as `X-Org-Id` on every subsequent `appstrate api` call, so `appstrate api GET /api/me` works immediately after a fresh login with no extra flags.
 
 **Flow** (what happens on the wire):
 
@@ -191,6 +204,33 @@ Status vocabulary:
 No network call — this command inspects local state only. A refresh token revoked server-side still looks `valid` here by design. Use `whoami` for a server-authoritative identity check.
 
 If the JWT `exp` claim and the locally stored `expiresAt` diverge by more than 2 seconds, `token` flags the mismatch — `api.ts`'s proactive-rotation logic keys off the stored value, so a skew between the two is worth surfacing before it causes unexpected 401s.
+
+---
+
+### `appstrate org`
+
+Manage the organization pinned on the active profile. `login` auto-pins an org where possible (see above); `org switch` / `org create` let you change the pin without re-running the device flow. The pinned org id is sent as `X-Org-Id` on every `appstrate api` call and every `/api/*` endpoint that requires org context.
+
+```sh
+appstrate org list            # enumerate orgs the profile has access to; pinned row is marked *
+appstrate org switch          # interactive picker (current org pre-highlighted)
+appstrate org switch acme     # non-interactive — by slug or id
+appstrate org current         # print the pinned orgId (scripts / shell prompts)
+appstrate org create          # interactive (name + optional slug) → auto-pin
+appstrate org create "Acme"   # non-interactive → auto-pin
+appstrate org create "Acme" --slug acme-prod
+```
+
+All four subcommands respect the global `--profile <name>` flag and talk to `GET /api/orgs` / `POST /api/orgs`. Creating an org server-side also provisions a default application + a hello-world agent, so the CLI lands on a fully-working setup with no extra steps.
+
+**Subcommands**
+
+| Subcommand              | Purpose                                                                                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `org list`              | List the orgs the active profile belongs to. The pinned one is marked with `*`.                                                          |
+| `org switch [id\|slug]` | Re-pin the active org on the profile. With no argument, show an interactive picker with the current one highlighted.                     |
+| `org current`           | Print the pinned org id to stdout. Exits 1 with a hint when no org is pinned — designed for `if` / shell prompts.                        |
+| `org create [name]`     | Create a new org and pin it. With no argument, prompt for name + optional slug. Use `--slug <slug>` for an explicit kebab-case override. |
 
 ---
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -30,6 +30,12 @@ import { logoutCommand } from "./commands/logout.ts";
 import { whoamiCommand } from "./commands/whoami.ts";
 import { tokenCommand } from "./commands/token.ts";
 import { apiCommand, isHttpMethod } from "./commands/api.ts";
+import {
+  orgListCommand,
+  orgSwitchCommand,
+  orgCurrentCommand,
+  orgCreateCommand,
+} from "./commands/org.ts";
 import { exitWithError } from "./lib/ui.ts";
 import { CLI_VERSION } from "./lib/version.ts";
 
@@ -149,11 +155,29 @@ program
   .command("login")
   .description("Sign in to an Appstrate instance via the device-flow grant")
   .option("--instance <url>", "Instance URL (skips the interactive prompt).")
+  .option(
+    "--org <id-or-slug>",
+    "Pin this organization on the profile after login (non-interactive). Fails if no match.",
+  )
+  .option(
+    "--create-org <name>",
+    "Create a new organization with this name after login and pin it (non-interactive). A default application and hello-world agent are provisioned server-side.",
+  )
+  .option(
+    "--no-org",
+    "Skip the post-login org-pinning step entirely. Subsequent calls must pass `-H X-Org-Id: …` or pin later via `appstrate org switch`.",
+  )
   .action(async (opts) => {
     const globalOpts = program.opts<{ profile?: string }>();
     await loginCommand({
       profile: globalOpts.profile,
       instance: typeof opts.instance === "string" ? opts.instance : undefined,
+      org: typeof opts.org === "string" ? opts.org : undefined,
+      createOrg: typeof opts.createOrg === "string" ? opts.createOrg : undefined,
+      // Commander maps `--no-org` to `opts.org === false` (verified against
+      // commander 14). `--org <value>` sets it to a string, neither leaves
+      // it undefined — so `opts.org === false` is the unambiguous skip signal.
+      noOrg: opts.org === false,
     });
   });
 
@@ -179,6 +203,59 @@ program
   .action(async () => {
     const globalOpts = program.opts<{ profile?: string }>();
     await tokenCommand({ profile: globalOpts.profile });
+  });
+
+// ─── `appstrate org …` — manage the pinned organization (issue #209) ───
+
+const orgGroup = program
+  .command("org")
+  .description("Manage the pinned organization for the active profile");
+
+orgGroup
+  .command("list")
+  .description("List organizations the active profile has access to")
+  .action(async () => {
+    const globalOpts = program.opts<{ profile?: string }>();
+    await orgListCommand({ profile: globalOpts.profile });
+  });
+
+orgGroup
+  .command("current")
+  .description("Print the pinned organization id, or exit 1 if none is pinned")
+  .action(async () => {
+    const globalOpts = program.opts<{ profile?: string }>();
+    await orgCurrentCommand({ profile: globalOpts.profile });
+  });
+
+orgGroup
+  .command("switch [ref]")
+  .description(
+    "Re-pin the active organization on the profile. With no argument, show an interactive picker.",
+  )
+  .action(async (ref: string | undefined) => {
+    const globalOpts = program.opts<{ profile?: string }>();
+    await orgSwitchCommand({
+      profile: globalOpts.profile,
+      ref: typeof ref === "string" ? ref : undefined,
+    });
+  });
+
+orgGroup
+  .command("create [name]")
+  .description(
+    "Create a new organization (and pin it on the profile). With no argument, prompt interactively.",
+  )
+  .option(
+    "--slug <slug>",
+    "Explicit slug (kebab-case). Defaults to a server-derived slug from the name.",
+  )
+  .action(async (name: string | undefined, opts) => {
+    const globalOpts = program.opts<{ profile?: string }>();
+    await orgCreateCommand({
+      profile: globalOpts.profile,
+      name: typeof name === "string" ? name : undefined,
+      slug: typeof opts.slug === "string" ? opts.slug : undefined,
+    });
   });
 
 program

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -13,21 +13,87 @@
  *      (issue #165); decode `sub` + `email` from the JWT payload
  *      (via `lib/jwt-identity.ts`) to capture userId + email;
  *      persist the profile in config.toml.
+ *   7. Pin an organization on the profile so subsequent `X-Org-Id`-
+ *      requiring routes (`/api/me`, `/api/agents`, …) work out of the
+ *      box. Issue #209. Auto-pin on one org, interactive picker on
+ *      many, offer inline creation on zero. Non-interactive escapes:
+ *      `--org <id-or-slug>`, `--create-org <name>`, `--no-org`.
  */
 
 import open from "open";
-import { intro, outro, askText, spinner, formatUserCode, exitWithError } from "../lib/ui.ts";
+import {
+  intro,
+  outro,
+  askText,
+  select,
+  spinner,
+  formatUserCode,
+  exitWithError,
+} from "../lib/ui.ts";
 import { readConfig, resolveProfileName, setProfile } from "../lib/config.ts";
 import { saveTokens } from "../lib/keyring.ts";
 import { startDeviceFlow, pollDeviceFlow } from "../lib/device-flow.ts";
 import { normalizeInstance } from "../lib/instance-url.ts";
 import { CLI_CLIENT_ID, CLI_SCOPE } from "../lib/cli-client.ts";
 import { decodeAccessTokenIdentity } from "../lib/jwt-identity.ts";
+import { listOrgs, createOrg, resolveOrgRef, type Org } from "../lib/orgs.ts";
 
 export interface LoginOptions {
   profile?: string;
   instance?: string;
+  /** `--org <id-or-slug>` — non-interactive pin, fails if no match. */
+  org?: string;
+  /** `--create-org <name>` — non-interactive inline creation + pin. */
+  createOrg?: string;
+  /** `--no-org` — explicitly skip the whole pin step. */
+  noOrg?: boolean;
+  deps?: LoginDeps;
 }
+
+/**
+ * Dependency-injected prompt helpers so the login command is testable
+ * without mock.module (banned per CLAUDE.md). Production paths bind to
+ * the real `@clack/prompts` helpers in `lib/ui.ts`. Return `null` from
+ * either hook to signal "user opted out / cannot prompt" — the caller
+ * leaves `orgId` unset and prints a follow-up hint.
+ */
+export interface LoginDeps {
+  /** Interactive picker when the user belongs to ≥2 orgs. */
+  pickOrg?: (orgs: Org[]) => Promise<Org | null>;
+  /** Prompt the user for a new org name + optional slug. */
+  promptCreateOrg?: () => Promise<{ name: string; slug?: string } | null>;
+}
+
+const defaultDeps: Required<LoginDeps> = {
+  pickOrg: async (orgs: Org[]): Promise<Org | null> => {
+    if (!process.stdin.isTTY) {
+      process.stdout.write(
+        "Multiple organizations — pass --org <id-or-slug> to pin non-interactively.\n",
+      );
+      return null;
+    }
+    return select<Org>(
+      "Select the organization to pin on this profile",
+      orgs.map((o) => ({
+        value: o,
+        label: `${o.name} — ${o.slug}`,
+        hint: o.id,
+      })),
+    );
+  },
+  promptCreateOrg: async (): Promise<{ name: string; slug?: string } | null> => {
+    if (!process.stdin.isTTY) {
+      process.stdout.write(
+        "No organization yet on this account — run `appstrate org create <name>` to create one.\n",
+      );
+      return null;
+    }
+    const name = await askText("Organization name");
+    const slugRaw = await askText("Slug (optional — leave blank to auto-generate)", "");
+    const slug = slugRaw.trim();
+    return slug.length > 0 ? { name, slug } : { name };
+  },
+};
 
 export async function loginCommand(opts: LoginOptions): Promise<void> {
   const config = await readConfig();
@@ -54,13 +120,13 @@ export async function loginCommand(opts: LoginOptions): Promise<void> {
   }
 
   try {
-    await runLogin(profileName, normalizedInstance);
+    await runLogin(profileName, normalizedInstance, opts);
   } catch (err) {
     exitWithError(err);
   }
 }
 
-async function runLogin(profileName: string, instance: string): Promise<void> {
+async function runLogin(profileName: string, instance: string, opts: LoginOptions): Promise<void> {
   // Step 1 — device code.
   const s = spinner();
   s.start("Requesting device code");
@@ -132,5 +198,98 @@ async function runLogin(profileName: string, instance: string): Promise<void> {
     email: identity.email,
   });
 
-  outro(`Logged in as ${identity.email}`);
+  // Step 7 — pin an organization. Issue #209. Credentials are already
+  // persisted so `listOrgs` / `createOrg` (both authenticated) work.
+  // Any failure here leaves the login valid but unpinned — surfaced as
+  // a hint to the user, never as a hard failure.
+  const pinned = await pinOrgOnProfile(profileName, opts);
+
+  const orgSuffix = pinned ? ` to "${pinned.name}" (${pinned.id})` : "";
+  outro(`Logged in as ${identity.email}${orgSuffix}`);
+
+  if (!pinned) {
+    process.stdout.write(
+      `No org pinned — pass -H "X-Org-Id: …" on each call, or run \`appstrate org switch\` later.\n`,
+    );
+  }
+}
+
+/**
+ * Resolve the org-pin branch of the login flow. Returns the pinned org
+ * on success, `null` when the user opted out or no pin could be made
+ * (e.g. `--no-org`, zero orgs + user cancelled, non-TTY with no flag).
+ *
+ * Writes the pinned `orgId` back onto `config.toml` in place. The caller
+ * has already persisted the rest of the profile via `setProfile()`.
+ */
+async function pinOrgOnProfile(profileName: string, opts: LoginOptions): Promise<Org | null> {
+  const deps = { ...defaultDeps, ...(opts.deps ?? {}) };
+
+  // `--no-org` short-circuits everything, including the network call.
+  if (opts.noOrg) return null;
+
+  // `--create-org <name>` short-circuits the list fetch — the user knows
+  // they want a fresh org. Don't second-guess them with a prompt.
+  if (opts.createOrg !== undefined) {
+    const created = await createOrg(profileName, { name: opts.createOrg });
+    await persistOrgId(profileName, created.id);
+    return created;
+  }
+
+  let orgs: Org[];
+  try {
+    orgs = await listOrgs(profileName);
+  } catch (err) {
+    // Don't fail the login if /api/orgs is temporarily down — tokens
+    // are already persisted and the user can retry with `org switch`.
+    process.stderr.write(
+      `Failed to list organizations: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return null;
+  }
+
+  // `--org <id-or-slug>` — explicit non-interactive selection.
+  if (opts.org !== undefined) {
+    const match = resolveOrgRef(orgs, opts.org);
+    await persistOrgId(profileName, match.id);
+    return match;
+  }
+
+  if (orgs.length === 1) {
+    const only = orgs[0]!;
+    await persistOrgId(profileName, only.id);
+    return only;
+  }
+
+  if (orgs.length === 0) {
+    const input = await deps.promptCreateOrg();
+    if (!input) return null;
+    const created = await createOrg(profileName, input);
+    await persistOrgId(profileName, created.id);
+    return created;
+  }
+
+  // ≥2 orgs — delegate the (possibly non-TTY) decision to the picker.
+  const chosen = await deps.pickOrg(orgs);
+  if (!chosen) return null;
+  await persistOrgId(profileName, chosen.id);
+  return chosen;
+}
+
+/**
+ * Rewrite the profile's `orgId` without disturbing the other fields.
+ * `setProfile` replaces the whole row, so we re-read first to preserve
+ * `userId` / `email` / `instance` that `runLogin` just persisted.
+ */
+async function persistOrgId(profileName: string, orgId: string): Promise<void> {
+  const config = await readConfig();
+  const existing = config.profiles[profileName];
+  if (!existing) {
+    // Should never happen: `runLogin` called `setProfile` before this.
+    // Fail loudly — silent fallback would mask a real regression.
+    throw new Error(
+      `Profile "${profileName}" missing from config when pinning org — internal invariant broken.`,
+    );
+  }
+  await setProfile(profileName, { ...existing, orgId });
 }

--- a/apps/cli/src/commands/org.ts
+++ b/apps/cli/src/commands/org.ts
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `appstrate org` — manage the pinned organization for the active CLI
+ * profile. Counterpart to the `orgId` written at `appstrate login` time
+ * (issue #209): lets users re-pin, create, or inspect their org without
+ * re-running the device flow.
+ *
+ * Subcommands:
+ *   org list          — enumerate orgs the profile has access to
+ *   org switch [ref]  — re-pin (interactive if no arg)
+ *   org current       — print pinned org id (scripts / prompts)
+ *   org create [name] — create + auto-pin
+ */
+
+import { readConfig, resolveProfileName, setProfile, type Profile } from "../lib/config.ts";
+import { listOrgs, createOrg, resolveOrgRef, type Org } from "../lib/orgs.ts";
+import { askText, select, exitWithError } from "../lib/ui.ts";
+
+export interface OrgBaseOptions {
+  profile?: string;
+}
+
+export interface OrgSwitchOptions extends OrgBaseOptions {
+  /** Positional `[id-or-slug]` — when absent, use interactive picker. */
+  ref?: string;
+}
+
+export interface OrgCreateOptions extends OrgBaseOptions {
+  /** Positional `[name]` — when absent, prompt interactively. */
+  name?: string;
+  /** `--slug <slug>` (optional override — server derives from name if unset). */
+  slug?: string;
+}
+
+export interface OrgCommandDeps {
+  /** Return null when the picker cannot run (e.g. non-TTY). */
+  pickOrg?: (orgs: Org[], currentOrgId?: string) => Promise<Org | null>;
+  /** Return null when the prompt cannot run. */
+  promptCreateOrg?: () => Promise<{ name: string; slug?: string } | null>;
+}
+
+const defaultDeps: Required<OrgCommandDeps> = {
+  pickOrg: async (orgs: Org[], currentOrgId?: string): Promise<Org | null> => {
+    if (!process.stdin.isTTY) return null;
+    const current = currentOrgId ? orgs.find((o) => o.id === currentOrgId) : undefined;
+    return select<Org>(
+      "Select an organization",
+      orgs.map((o) => ({
+        value: o,
+        label: `${o.name} — ${o.slug}${o.id === currentOrgId ? " (current)" : ""}`,
+        hint: o.id,
+      })),
+      current,
+    );
+  },
+  promptCreateOrg: async (): Promise<{ name: string; slug?: string } | null> => {
+    if (!process.stdin.isTTY) return null;
+    const name = await askText("Organization name");
+    const slugRaw = await askText("Slug (optional — leave blank to auto-generate)", "");
+    const slug = slugRaw.trim();
+    return slug.length > 0 ? { name, slug } : { name };
+  },
+};
+
+export async function orgListCommand(opts: OrgBaseOptions): Promise<void> {
+  const { profileName, profile } = await resolveActive(opts.profile);
+  requireLoggedIn(profileName, profile);
+
+  try {
+    const orgs = await listOrgs(profileName);
+    if (orgs.length === 0) {
+      process.stdout.write("(no organizations)\n");
+      return;
+    }
+    for (const o of orgs) {
+      const marker = o.id === profile.orgId ? "*" : " ";
+      process.stdout.write(`${marker} ${o.slug.padEnd(24)}  ${o.id}  ${o.name}\n`);
+    }
+  } catch (err) {
+    exitWithError(err);
+  }
+}
+
+export async function orgCurrentCommand(opts: OrgBaseOptions): Promise<void> {
+  const { profile } = await resolveActive(opts.profile);
+  if (!profile) {
+    process.stderr.write("Not logged in. Run: appstrate login\n");
+    process.exit(1);
+  }
+  if (!profile.orgId) {
+    process.stderr.write("No organization pinned. Run: appstrate org switch\n");
+    process.exit(1);
+  }
+  process.stdout.write(`${profile.orgId}\n`);
+}
+
+export async function orgSwitchCommand(
+  opts: OrgSwitchOptions,
+  deps: OrgCommandDeps = {},
+): Promise<void> {
+  const { profileName, profile } = await resolveActive(opts.profile);
+  requireLoggedIn(profileName, profile);
+  const picker = { ...defaultDeps, ...deps };
+
+  try {
+    const orgs = await listOrgs(profileName);
+    if (orgs.length === 0) {
+      process.stderr.write("No organizations — run `appstrate org create <name>` to create one.\n");
+      process.exit(1);
+    }
+
+    let chosen: Org;
+    if (opts.ref !== undefined) {
+      chosen = resolveOrgRef(orgs, opts.ref);
+    } else {
+      const picked = await picker.pickOrg(orgs, profile.orgId);
+      if (!picked) {
+        process.stderr.write(
+          "Cannot prompt in non-TTY — pass an id or slug: `appstrate org switch <id-or-slug>`.\n",
+        );
+        process.exit(1);
+      }
+      chosen = picked;
+    }
+
+    await setProfile(profileName, { ...profile, orgId: chosen.id });
+    process.stdout.write(`Pinned "${chosen.name}" (${chosen.id}) on profile "${profileName}".\n`);
+  } catch (err) {
+    exitWithError(err);
+  }
+}
+
+export async function orgCreateCommand(
+  opts: OrgCreateOptions,
+  deps: OrgCommandDeps = {},
+): Promise<void> {
+  const { profileName, profile } = await resolveActive(opts.profile);
+  requireLoggedIn(profileName, profile);
+  const picker = { ...defaultDeps, ...deps };
+
+  try {
+    let input: { name: string; slug?: string };
+    if (opts.name !== undefined) {
+      input = { name: opts.name };
+      if (opts.slug !== undefined) input.slug = opts.slug;
+    } else {
+      const prompted = await picker.promptCreateOrg();
+      if (!prompted) {
+        process.stderr.write(
+          "Cannot prompt in non-TTY — pass a name: `appstrate org create <name>`.\n",
+        );
+        process.exit(1);
+      }
+      input = prompted;
+    }
+    const created = await createOrg(profileName, input);
+    await setProfile(profileName, { ...profile, orgId: created.id });
+    process.stdout.write(
+      `Created "${created.name}" (${created.id}) and pinned it on profile "${profileName}".\n`,
+    );
+  } catch (err) {
+    exitWithError(err);
+  }
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────
+
+interface Active {
+  profileName: string;
+  profile: Profile | undefined;
+}
+
+async function resolveActive(explicit: string | undefined): Promise<Active> {
+  const config = await readConfig();
+  const profileName = resolveProfileName(explicit, config);
+  return { profileName, profile: config.profiles[profileName] };
+}
+
+function requireLoggedIn(
+  profileName: string,
+  profile: Profile | undefined,
+): asserts profile is Profile {
+  if (!profile) {
+    process.stderr.write(
+      `Profile "${profileName}" not configured. Run: appstrate login --profile ${profileName}\n`,
+    );
+    process.exit(1);
+  }
+}

--- a/apps/cli/src/commands/whoami.ts
+++ b/apps/cli/src/commands/whoami.ts
@@ -18,6 +18,7 @@
 
 import { readConfig, resolveProfileName } from "../lib/config.ts";
 import { apiFetch } from "../lib/api.ts";
+import { listOrgs } from "../lib/orgs.ts";
 import { formatError } from "../lib/ui.ts";
 
 export interface WhoamiOptions {
@@ -52,13 +53,29 @@ export async function whoamiCommand(opts: WhoamiOptions): Promise<void> {
     // server in the same response so whoami always reflects dashboard
     // state, never the stale copy cached in config.toml.
     const nameLine = me.displayName ?? me.name;
+
+    // When an org is pinned, enrich the line with the server-side name.
+    // We swallow errors from this secondary call — a pinned-but-unknown
+    // org (e.g. membership revoked) still prints the id so the user can
+    // at least see what's wrong, rather than failing the whole command.
+    let orgLine: string | null = null;
+    if (profile.orgId) {
+      try {
+        const orgs = await listOrgs(profileName);
+        const match = orgs.find((o) => o.id === profile.orgId);
+        orgLine = match ? `Org:      ${match.name} (${match.id})` : `Org:      ${profile.orgId}`;
+      } catch {
+        orgLine = `Org:      ${profile.orgId}`;
+      }
+    }
+
     process.stdout.write(
       [
         `Profile:  ${profileName}`,
         `Instance: ${profile.instance}`,
         me.email ? `User:     ${me.email}` : null,
         nameLine ? `Name:     ${nameLine}` : null,
-        profile.orgId ? `Org:      ${profile.orgId}` : null,
+        orgLine,
       ]
         .filter(Boolean)
         .join("\n") + "\n",

--- a/apps/cli/src/lib/orgs.ts
+++ b/apps/cli/src/lib/orgs.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Org helpers for the CLI — list, create, and resolve org references.
+ *
+ * These are thin `apiFetch` wrappers. Kept in their own module so both
+ * `login` (pin-on-first-use) and the new `org` subcommands share the
+ * same parsing / validation + test surface.
+ *
+ * Server contract:
+ *   - `GET /api/orgs` and `POST /api/orgs` both run without org context
+ *     (no `X-Org-Id`), so they work right after a fresh login before
+ *     the profile has a pinned org. See `apps/api/src/routes/organizations.ts`.
+ *   - Creating an org server-side also provisions a default application
+ *     + hello-world agent, so the user lands on a fully-working setup.
+ */
+
+import { apiFetch } from "./api.ts";
+
+export interface Org {
+  id: string;
+  name: string;
+  slug: string;
+  role: string;
+  createdAt: string;
+}
+
+interface ListResponse {
+  organizations: Org[];
+}
+
+export async function listOrgs(profileName: string): Promise<Org[]> {
+  const res = await apiFetch<ListResponse>(profileName, "/api/orgs");
+  return Array.isArray(res.organizations) ? res.organizations : [];
+}
+
+export interface CreateOrgInput {
+  name: string;
+  slug?: string;
+}
+
+export async function createOrg(profileName: string, input: CreateOrgInput): Promise<Org> {
+  const body: Record<string, string> = { name: input.name };
+  if (input.slug && input.slug.length > 0) body.slug = input.slug;
+  return apiFetch<Org>(profileName, "/api/orgs", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Resolve a user-supplied org reference (id or slug) against the list
+ * returned by `/api/orgs`. The CLI accepts either so scripts and humans
+ * can write whichever they have on hand. Exact match only — we do NOT
+ * do substring / fuzzy matching because a typo silently picking a
+ * different org than the user meant is a genuine footgun.
+ *
+ * Throws an Error with a listing of the valid options when the ref
+ * doesn't match — surfaces nicely through `formatError` in `ui.ts`.
+ */
+export function resolveOrgRef(orgs: Org[], ref: string): Org {
+  const trimmed = ref.trim();
+  if (trimmed.length === 0) {
+    throw new Error("Org reference is empty.");
+  }
+  const match = orgs.find((o) => o.id === trimmed || o.slug === trimmed);
+  if (match) return match;
+  if (orgs.length === 0) {
+    throw new Error(
+      `No organizations found for this profile. Run \`appstrate org create\` to create one.`,
+    );
+  }
+  const available = orgs.map((o) => `  - ${o.slug} (${o.id})`).join("\n");
+  throw new Error(`No organization matches "${trimmed}". Available:\n${available}`);
+}

--- a/apps/cli/src/lib/ui.ts
+++ b/apps/cli/src/lib/ui.ts
@@ -57,6 +57,44 @@ export async function confirm(message: string, initialValue = true): Promise<boo
   return value;
 }
 
+export interface SelectOption<T> {
+  value: T;
+  label: string;
+  hint?: string;
+}
+
+/**
+ * Single-select picker wrapping `@clack/prompts.select`. Same cancel
+ * semantics as `askText` / `confirm` — Ctrl-C exits 130 with a clean
+ * "Cancelled." message. `initialValue` highlights the currently-active
+ * choice (e.g. the pinned org in `appstrate org switch`) so users don't
+ * accidentally pick the same value they already had.
+ *
+ * Clack's own `Option<Value>` is a conditional type (primitive values
+ * get an optional label, object values get a required one). We expose a
+ * simpler `SelectOption<T>` that always requires a label, and bridge
+ * through `as unknown` because clack's conditional generic confuses the
+ * inferred intersection when Value extends object — our wrapper's stricter
+ * label requirement is always compatible with whichever branch clack picks.
+ */
+export async function select<T>(
+  message: string,
+  options: SelectOption<T>[],
+  initialValue?: T,
+): Promise<T> {
+  requireTTY(message);
+  const value = await clack.select<T>({
+    message,
+    options: options as unknown as Parameters<typeof clack.select<T>>[0]["options"],
+    initialValue,
+  });
+  if (clack.isCancel(value)) {
+    clack.cancel("Cancelled.");
+    process.exit(130);
+  }
+  return value as T;
+}
+
 export function spinner(): { start(msg: string): void; stop(msg?: string): void } {
   return clack.spinner();
 }

--- a/apps/cli/test/login-org.test.ts
+++ b/apps/cli/test/login-org.test.ts
@@ -1,0 +1,456 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for the post-login org-pinning branch introduced by issue #209.
+ *
+ * Scope: only the branch that fires AFTER the device-flow token
+ * exchange. We stub the device-flow endpoints minimally (just enough to
+ * mint a JWT + refresh pair) so the suite can assert that:
+ *   - one org → auto-pin
+ *   - zero orgs → prompt create, POST /api/orgs, pin the result
+ *   - ≥2 orgs → interactive picker result is pinned
+ *   - `--org <id-or-slug>` → non-interactive, matches or fails
+ *   - `--create-org <name>` → skips the list fetch entirely, POSTs
+ *   - `--no-org` → skips the whole block, leaves orgId unset
+ *   - non-TTY + ≥2 orgs → leaves orgId unset, prints hint
+ *   - failure listing orgs does not fail the login
+ *
+ * Follows the same stdout-capture + tmp-XDG + FakeKeyring pattern as
+ * `whoami.test.ts`. We inject the interactive prompts via `LoginDeps`
+ * rather than replacing `@clack/prompts` globally (CLAUDE.md bans
+ * `mock.module`).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  _setKeyringFactoryForTesting,
+  loadTokens,
+  type KeyringHandle,
+} from "../src/lib/keyring.ts";
+import { readConfig } from "../src/lib/config.ts";
+import { loginCommand } from "../src/commands/login.ts";
+import type { Org } from "../src/lib/orgs.ts";
+
+class FakeKeyring implements KeyringHandle {
+  static store = new Map<string, string>();
+  constructor(private profile: string) {}
+  setPassword(v: string): void {
+    FakeKeyring.store.set(this.profile, v);
+  }
+  getPassword(): string | null {
+    return FakeKeyring.store.get(this.profile) ?? null;
+  }
+  deletePassword(): void {
+    FakeKeyring.store.delete(this.profile);
+  }
+}
+
+type FetchCall = { url: string; method: string | undefined; body?: string };
+
+let tmpDir: string;
+let originalXdg: string | undefined;
+const originalFetch = globalThis.fetch;
+const originalExit = process.exit;
+const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+let fetchCalls: FetchCall[];
+let stdoutChunks: string[];
+let stderrChunks: string[];
+
+class ExitError extends Error {
+  constructor(public readonly code: number) {
+    super(`process.exit(${code}) called`);
+  }
+}
+
+function captureIo(): void {
+  stdoutChunks = [];
+  stderrChunks = [];
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    stderrChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+    return true;
+  }) as typeof process.stderr.write;
+  (process as unknown as { exit: (code?: number) => never }).exit = ((code?: number): never => {
+    throw new ExitError(code ?? 0);
+  }) as (code?: number) => never;
+}
+
+/**
+ * Build a JWT with `sub` + `email` claims so `decodeAccessTokenIdentity`
+ * succeeds. We don't sign — the CLI doesn't verify locally.
+ */
+function makeJwt(sub = "u_test", email = "alice@example.com"): string {
+  const header = Buffer.from(JSON.stringify({ alg: "ES256", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify({ sub, email })).toString("base64url");
+  return `${header}.${payload}.sig`;
+}
+
+interface ResponderMap {
+  deviceCode?: () => Response;
+  cliToken?: () => Response;
+  listOrgs?: () => Response;
+  createOrg?: (body: unknown) => Response;
+}
+
+function installDefaultResponders(overrides: ResponderMap = {}): void {
+  const defaults: Required<ResponderMap> = {
+    deviceCode: () =>
+      new Response(
+        JSON.stringify({
+          device_code: "dc-1",
+          user_code: "ABCD-EFGH",
+          verification_uri: "https://app.example.com/device",
+          verification_uri_complete: "https://app.example.com/device?code=ABCDEFGH",
+          expires_in: 60,
+          interval: 0,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    cliToken: () =>
+      new Response(
+        JSON.stringify({
+          access_token: makeJwt(),
+          refresh_token: "rt-xyz",
+          token_type: "Bearer",
+          expires_in: 900,
+          refresh_expires_in: 30 * 24 * 60 * 60,
+          scope: "cli",
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    listOrgs: () =>
+      new Response(JSON.stringify({ organizations: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    createOrg: () =>
+      new Response(
+        JSON.stringify({
+          id: "org_created",
+          name: "Acme",
+          slug: "acme",
+          role: "owner",
+          createdAt: "t",
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      ),
+  };
+  const resolved = { ...defaults, ...overrides };
+
+  const stub = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method;
+    const body = typeof init?.body === "string" ? init.body : undefined;
+    fetchCalls.push({ url, method, body });
+    if (url.endsWith("/api/auth/device/code")) return resolved.deviceCode();
+    if (url.endsWith("/api/auth/cli/token")) return resolved.cliToken();
+    if (url.endsWith("/api/orgs") && method === "POST") {
+      const parsed = body ? JSON.parse(body) : {};
+      return resolved.createOrg(parsed);
+    }
+    if (url.endsWith("/api/orgs")) return resolved.listOrgs();
+    return new Response("not mocked: " + url, { status: 501 });
+  };
+  globalThis.fetch = stub as unknown as typeof fetch;
+}
+
+beforeAll(() => {
+  originalXdg = process.env.XDG_CONFIG_HOME;
+});
+
+afterAll(() => {
+  if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = originalXdg;
+});
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "appstrate-cli-login-org-"));
+  process.env.XDG_CONFIG_HOME = tmpDir;
+  FakeKeyring.store.clear();
+  _setKeyringFactoryForTesting((p) => new FakeKeyring(p));
+  fetchCalls = [];
+  captureIo();
+});
+
+afterEach(async () => {
+  _setKeyringFactoryForTesting(null);
+  globalThis.fetch = originalFetch;
+  process.stdout.write = originalStdoutWrite;
+  process.stderr.write = originalStderrWrite;
+  (process as unknown as { exit: typeof originalExit }).exit = originalExit;
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+async function readPinnedOrgId(profile = "default"): Promise<string | undefined> {
+  const cfg = await readConfig();
+  return cfg.profiles[profile]?.orgId;
+}
+
+describe("login org-pin branch", () => {
+  it("auto-pins the single org when the user belongs to exactly one", async () => {
+    installDefaultResponders({
+      listOrgs: () =>
+        new Response(
+          JSON.stringify({
+            organizations: [
+              { id: "org_only", name: "Solo", slug: "solo", role: "owner", createdAt: "t" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+    });
+
+    expect(await readPinnedOrgId()).toBe("org_only");
+    const out = stdoutChunks.join("");
+    expect(out).toContain('to "Solo"');
+    expect(out).toContain("org_only");
+  });
+
+  it("uses the injected picker and persists the chosen org when ≥2 orgs", async () => {
+    installDefaultResponders({
+      listOrgs: () =>
+        new Response(
+          JSON.stringify({
+            organizations: [
+              { id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" },
+              { id: "org_2", name: "Beta", slug: "beta", role: "member", createdAt: "t" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    const orgsSeen: Org[][] = [];
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+      deps: {
+        pickOrg: async (orgs) => {
+          orgsSeen.push(orgs);
+          return orgs[1]!;
+        },
+      },
+    });
+
+    expect(await readPinnedOrgId()).toBe("org_2");
+    expect(orgsSeen).toHaveLength(1);
+    expect(orgsSeen[0]!.map((o) => o.id)).toEqual(["org_1", "org_2"]);
+  });
+
+  it("inline-creates an org when the user has none and accepts the prompt", async () => {
+    let createBody: unknown;
+    installDefaultResponders({
+      createOrg: (body) => {
+        createBody = body;
+        return new Response(
+          JSON.stringify({
+            id: "org_new",
+            name: "Fresh",
+            slug: "fresh",
+            role: "owner",
+            createdAt: "t",
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        );
+      },
+    });
+
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+      deps: {
+        promptCreateOrg: async () => ({ name: "Fresh", slug: "fresh" }),
+      },
+    });
+
+    expect(createBody).toEqual({ name: "Fresh", slug: "fresh" });
+    expect(await readPinnedOrgId()).toBe("org_new");
+  });
+
+  it("honors --org <slug> and pins the matching org non-interactively", async () => {
+    installDefaultResponders({
+      listOrgs: () =>
+        new Response(
+          JSON.stringify({
+            organizations: [
+              { id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" },
+              { id: "org_2", name: "Beta", slug: "beta", role: "member", createdAt: "t" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+      org: "beta",
+      // Picker should NOT be called when --org is provided.
+      deps: {
+        pickOrg: async () => {
+          throw new Error("picker should not run");
+        },
+      },
+    });
+
+    expect(await readPinnedOrgId()).toBe("org_2");
+  });
+
+  it("honors --org <id> the same way as slug", async () => {
+    installDefaultResponders({
+      listOrgs: () =>
+        new Response(
+          JSON.stringify({
+            organizations: [
+              { id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" },
+              { id: "org_2", name: "Beta", slug: "beta", role: "member", createdAt: "t" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+      org: "org_1",
+    });
+
+    expect(await readPinnedOrgId()).toBe("org_1");
+  });
+
+  it("exits with an actionable error when --org <ref> does not match", async () => {
+    installDefaultResponders({
+      listOrgs: () =>
+        new Response(
+          JSON.stringify({
+            organizations: [
+              { id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    await expect(
+      loginCommand({
+        profile: "default",
+        instance: "https://app.example.com",
+        org: "does-not-exist",
+      }),
+    ).rejects.toBeInstanceOf(ExitError);
+
+    expect(await readPinnedOrgId()).toBeUndefined();
+  });
+
+  it("honors --create-org <name> without listing orgs first", async () => {
+    let createBody: unknown;
+    let listCalled = false;
+    installDefaultResponders({
+      listOrgs: () => {
+        listCalled = true;
+        return new Response(JSON.stringify({ organizations: [] }), { status: 200 });
+      },
+      createOrg: (body) => {
+        createBody = body;
+        return new Response(
+          JSON.stringify({
+            id: "org_forced",
+            name: "Forced",
+            slug: "forced",
+            role: "owner",
+            createdAt: "t",
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        );
+      },
+    });
+
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+      createOrg: "Forced",
+    });
+
+    expect(listCalled).toBe(false);
+    expect(createBody).toEqual({ name: "Forced" });
+    expect(await readPinnedOrgId()).toBe("org_forced");
+  });
+
+  it("with --no-org skips the pin entirely, prints a hint, leaves orgId unset", async () => {
+    let orgsCalled = false;
+    installDefaultResponders({
+      listOrgs: () => {
+        orgsCalled = true;
+        return new Response(JSON.stringify({ organizations: [] }), { status: 200 });
+      },
+    });
+
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+      noOrg: true,
+    });
+
+    expect(orgsCalled).toBe(false);
+    expect(await readPinnedOrgId()).toBeUndefined();
+    expect(stdoutChunks.join("")).toContain("No org pinned");
+  });
+
+  it("tolerates a failing /api/orgs call — login succeeds unpinned", async () => {
+    installDefaultResponders({
+      listOrgs: () => new Response("boom", { status: 500 }),
+    });
+
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+    });
+
+    expect(await readPinnedOrgId()).toBeUndefined();
+    const tokens = await loadTokens("default");
+    expect(tokens?.accessToken).toBeTruthy();
+    expect(stderrChunks.join("")).toContain("Failed to list organizations");
+    expect(stdoutChunks.join("")).toContain("No org pinned");
+  });
+
+  it("writes orgId in addition to the pre-existing profile fields", async () => {
+    installDefaultResponders({
+      listOrgs: () =>
+        new Response(
+          JSON.stringify({
+            organizations: [
+              { id: "org_only", name: "Solo", slug: "solo", role: "owner", createdAt: "t" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+    });
+
+    const cfg = await readConfig();
+    const profile = cfg.profiles.default;
+    expect(profile).toBeDefined();
+    expect(profile!.instance).toBe("https://app.example.com");
+    expect(profile!.email).toBe("alice@example.com");
+    expect(profile!.userId).toBe("u_test");
+    expect(profile!.orgId).toBe("org_only");
+  });
+});

--- a/apps/cli/test/org-command.test.ts
+++ b/apps/cli/test/org-command.test.ts
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the `appstrate org` subcommand family (issue #209):
+ * `list`, `current`, `switch`, `create`. All tests run against a real
+ * logged-in profile (seeded via `setProfile` + FakeKeyring) and a
+ * stubbed `fetch` — we don't go through commander, we call each
+ * subcommand function directly so the injected `deps` (picker / create
+ * prompt) aren't bypassed by non-TTY guards.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  _setKeyringFactoryForTesting,
+  saveTokens,
+  type KeyringHandle,
+} from "../src/lib/keyring.ts";
+import { setProfile, readConfig } from "../src/lib/config.ts";
+import {
+  orgListCommand,
+  orgCurrentCommand,
+  orgSwitchCommand,
+  orgCreateCommand,
+} from "../src/commands/org.ts";
+
+class FakeKeyring implements KeyringHandle {
+  static store = new Map<string, string>();
+  constructor(private profile: string) {}
+  setPassword(v: string): void {
+    FakeKeyring.store.set(this.profile, v);
+  }
+  getPassword(): string | null {
+    return FakeKeyring.store.get(this.profile) ?? null;
+  }
+  deletePassword(): void {
+    FakeKeyring.store.delete(this.profile);
+  }
+}
+
+type FetchCall = { url: string; method: string | undefined; body?: string };
+
+let tmpDir: string;
+let originalXdg: string | undefined;
+const originalFetch = globalThis.fetch;
+const originalExit = process.exit;
+const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+let fetchCalls: FetchCall[];
+let stdoutChunks: string[];
+let stderrChunks: string[];
+
+class ExitError extends Error {
+  constructor(public readonly code: number) {
+    super(`process.exit(${code}) called`);
+  }
+}
+
+function captureIo(): void {
+  stdoutChunks = [];
+  stderrChunks = [];
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    stderrChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+    return true;
+  }) as typeof process.stderr.write;
+  (process as unknown as { exit: (code?: number) => never }).exit = ((code?: number): never => {
+    throw new ExitError(code ?? 0);
+  }) as (code?: number) => never;
+}
+
+interface Responders {
+  listOrgs?: () => Response;
+  createOrg?: (body: unknown) => Response;
+}
+
+function installFetch(responders: Responders): void {
+  const stub = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method;
+    const body = typeof init?.body === "string" ? init.body : undefined;
+    fetchCalls.push({ url, method, body });
+    if (url.endsWith("/api/orgs") && method === "POST") {
+      const parsed = body ? JSON.parse(body) : {};
+      return (
+        responders.createOrg?.(parsed) ?? new Response("missing createOrg stub", { status: 501 })
+      );
+    }
+    if (url.endsWith("/api/orgs")) {
+      return responders.listOrgs?.() ?? new Response("missing listOrgs stub", { status: 501 });
+    }
+    return new Response("not mocked: " + url, { status: 501 });
+  };
+  globalThis.fetch = stub as unknown as typeof fetch;
+}
+
+beforeAll(() => {
+  originalXdg = process.env.XDG_CONFIG_HOME;
+});
+
+afterAll(() => {
+  if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = originalXdg;
+});
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "appstrate-cli-org-cmd-"));
+  process.env.XDG_CONFIG_HOME = tmpDir;
+  FakeKeyring.store.clear();
+  _setKeyringFactoryForTesting((p) => new FakeKeyring(p));
+  fetchCalls = [];
+  captureIo();
+});
+
+afterEach(async () => {
+  _setKeyringFactoryForTesting(null);
+  globalThis.fetch = originalFetch;
+  process.stdout.write = originalStdoutWrite;
+  process.stderr.write = originalStderrWrite;
+  (process as unknown as { exit: typeof originalExit }).exit = originalExit;
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+async function seedLoggedIn(orgId?: string, profile = "default"): Promise<void> {
+  await setProfile(profile, {
+    instance: "https://app.example.com",
+    userId: "u_1",
+    email: "alice@example.com",
+    ...(orgId ? { orgId } : {}),
+  });
+  await saveTokens(profile, {
+    accessToken: "tok-abc",
+    expiresAt: Date.now() + 15 * 60 * 1000,
+    refreshToken: "rt-xyz",
+    refreshExpiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+  });
+}
+
+async function pinnedOrgId(profile = "default"): Promise<string | undefined> {
+  return (await readConfig()).profiles[profile]?.orgId;
+}
+
+const twoOrgs = {
+  organizations: [
+    { id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" },
+    { id: "org_2", name: "Beta", slug: "beta", role: "member", createdAt: "t" },
+  ],
+};
+
+// ── list ─────────────────────────────────────────────────────────────
+
+describe("org list", () => {
+  it("prints each org with a `*` marker on the pinned one", async () => {
+    await seedLoggedIn("org_2");
+    installFetch({
+      listOrgs: () =>
+        new Response(JSON.stringify(twoOrgs), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    await orgListCommand({ profile: "default" });
+
+    const out = stdoutChunks.join("");
+    expect(out).toContain("acme");
+    expect(out).toContain("beta");
+    // The pinned row is prefixed with `*`, the other with a space.
+    // Don't trim — the non-pinned row's leading space is load-bearing.
+    const lines = out.split("\n").filter((l) => l.length > 0);
+    const beta = lines.find((l) => l.includes("beta"));
+    const acme = lines.find((l) => l.includes("acme"));
+    expect(beta).toBeDefined();
+    expect(acme).toBeDefined();
+    expect(beta!.startsWith("*")).toBe(true);
+    expect(acme!.startsWith(" ")).toBe(true);
+  });
+
+  it("prints a friendly message when the profile has no orgs", async () => {
+    await seedLoggedIn();
+    installFetch({
+      listOrgs: () =>
+        new Response(JSON.stringify({ organizations: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    await orgListCommand({ profile: "default" });
+    expect(stdoutChunks.join("")).toContain("(no organizations)");
+  });
+
+  it("errors out when the profile is not logged in", async () => {
+    await expect(orgListCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
+    expect(stderrChunks.join("")).toContain("not configured");
+  });
+});
+
+// ── current ─────────────────────────────────────────────────────────
+
+describe("org current", () => {
+  it("prints the pinned org id to stdout", async () => {
+    await seedLoggedIn("org_42");
+    await orgCurrentCommand({ profile: "default" });
+    expect(stdoutChunks.join("").trim()).toBe("org_42");
+  });
+
+  it("exits 1 with a hint when no org is pinned", async () => {
+    await seedLoggedIn();
+    await expect(orgCurrentCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
+    expect(stderrChunks.join("")).toContain("No organization pinned");
+  });
+
+  it("exits 1 when the profile is unconfigured", async () => {
+    await expect(orgCurrentCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
+    expect(stderrChunks.join("")).toContain("Not logged in");
+  });
+});
+
+// ── switch ───────────────────────────────────────────────────────────
+
+describe("org switch", () => {
+  it("pins the org matching the positional arg (by id)", async () => {
+    await seedLoggedIn("org_1");
+    installFetch({
+      listOrgs: () =>
+        new Response(JSON.stringify(twoOrgs), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    await orgSwitchCommand({ profile: "default", ref: "org_2" });
+
+    expect(await pinnedOrgId()).toBe("org_2");
+    expect(stdoutChunks.join("")).toContain('Pinned "Beta"');
+  });
+
+  it("pins the org matching the positional arg (by slug)", async () => {
+    await seedLoggedIn("org_1");
+    installFetch({
+      listOrgs: () =>
+        new Response(JSON.stringify(twoOrgs), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    await orgSwitchCommand({ profile: "default", ref: "beta" });
+    expect(await pinnedOrgId()).toBe("org_2");
+  });
+
+  it("uses the injected picker when no ref is passed", async () => {
+    await seedLoggedIn("org_1");
+    installFetch({
+      listOrgs: () =>
+        new Response(JSON.stringify(twoOrgs), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    let seenCurrent: string | undefined;
+    await orgSwitchCommand(
+      { profile: "default" },
+      {
+        pickOrg: async (orgs, current) => {
+          seenCurrent = current;
+          return orgs[1]!;
+        },
+      },
+    );
+
+    expect(seenCurrent).toBe("org_1");
+    expect(await pinnedOrgId()).toBe("org_2");
+  });
+
+  it("exits 1 when no orgs exist", async () => {
+    await seedLoggedIn("org_1");
+    installFetch({
+      listOrgs: () =>
+        new Response(JSON.stringify({ organizations: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    await expect(orgSwitchCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
+    expect(stderrChunks.join("")).toContain("No organizations");
+  });
+
+  it("exits with an error when the ref does not match any org", async () => {
+    await seedLoggedIn("org_1");
+    installFetch({
+      listOrgs: () =>
+        new Response(JSON.stringify(twoOrgs), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    await expect(orgSwitchCommand({ profile: "default", ref: "gamma" })).rejects.toBeInstanceOf(
+      ExitError,
+    );
+    expect(await pinnedOrgId()).toBe("org_1"); // unchanged
+  });
+});
+
+// ── create ──────────────────────────────────────────────────────────
+
+describe("org create", () => {
+  it("POSTs with the positional name + auto-pins", async () => {
+    await seedLoggedIn();
+    let createdBody: unknown;
+    installFetch({
+      createOrg: (body) => {
+        createdBody = body;
+        return new Response(
+          JSON.stringify({
+            id: "org_new",
+            name: "Fresh",
+            slug: "fresh",
+            role: "owner",
+            createdAt: "t",
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        );
+      },
+    });
+
+    await orgCreateCommand({ profile: "default", name: "Fresh" });
+
+    expect(createdBody).toEqual({ name: "Fresh" });
+    expect(await pinnedOrgId()).toBe("org_new");
+    expect(stdoutChunks.join("")).toContain('Created "Fresh"');
+  });
+
+  it("forwards --slug through the request body", async () => {
+    await seedLoggedIn();
+    let createdBody: unknown;
+    installFetch({
+      createOrg: (body) => {
+        createdBody = body;
+        return new Response(
+          JSON.stringify({
+            id: "org_new",
+            name: "Fresh",
+            slug: "override",
+            role: "owner",
+            createdAt: "t",
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        );
+      },
+    });
+
+    await orgCreateCommand({ profile: "default", name: "Fresh", slug: "override" });
+    expect(createdBody).toEqual({ name: "Fresh", slug: "override" });
+  });
+
+  it("prompts via the injected creator when no name is passed", async () => {
+    await seedLoggedIn();
+    let createdBody: unknown;
+    installFetch({
+      createOrg: (body) => {
+        createdBody = body;
+        return new Response(
+          JSON.stringify({
+            id: "org_new",
+            name: "Prompted",
+            slug: "prompted",
+            role: "owner",
+            createdAt: "t",
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        );
+      },
+    });
+
+    await orgCreateCommand(
+      { profile: "default" },
+      {
+        promptCreateOrg: async () => ({ name: "Prompted", slug: "prompted" }),
+      },
+    );
+
+    expect(createdBody).toEqual({ name: "Prompted", slug: "prompted" });
+    expect(await pinnedOrgId()).toBe("org_new");
+  });
+
+  it("requires login", async () => {
+    await expect(orgCreateCommand({ profile: "default", name: "X" })).rejects.toBeInstanceOf(
+      ExitError,
+    );
+    expect(stderrChunks.join("")).toContain("not configured");
+  });
+});

--- a/apps/cli/test/orgs.test.ts
+++ b/apps/cli/test/orgs.test.ts
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `src/lib/orgs.ts`. These cover the pure helpers
+ * (`resolveOrgRef`) and the thin HTTP wrappers (`listOrgs`, `createOrg`)
+ * via the same in-memory keyring + fetch-stub pattern used by the other
+ * CLI tests. No real network, no real keyring.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  _setKeyringFactoryForTesting,
+  saveTokens,
+  type KeyringHandle,
+} from "../src/lib/keyring.ts";
+import { setProfile } from "../src/lib/config.ts";
+import { listOrgs, createOrg, resolveOrgRef, type Org } from "../src/lib/orgs.ts";
+
+class FakeKeyring implements KeyringHandle {
+  static store = new Map<string, string>();
+  constructor(private profile: string) {}
+  setPassword(v: string): void {
+    FakeKeyring.store.set(this.profile, v);
+  }
+  getPassword(): string | null {
+    return FakeKeyring.store.get(this.profile) ?? null;
+  }
+  deletePassword(): void {
+    FakeKeyring.store.delete(this.profile);
+  }
+}
+
+type FetchCall = {
+  url: string;
+  method: string | undefined;
+  body?: string;
+  headers: Record<string, string>;
+};
+
+let tmpDir: string;
+let originalXdg: string | undefined;
+const originalFetch = globalThis.fetch;
+let fetchCalls: FetchCall[];
+
+function installFetch(responder: (url: string, init?: RequestInit) => Promise<Response>): void {
+  const stub = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    let body: string | undefined;
+    if (typeof init?.body === "string") body = init.body;
+    fetchCalls.push({ url, method: init?.method, body, headers });
+    return responder(url, init);
+  };
+  globalThis.fetch = stub as unknown as typeof fetch;
+}
+
+beforeAll(() => {
+  originalXdg = process.env.XDG_CONFIG_HOME;
+});
+
+afterAll(() => {
+  if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = originalXdg;
+});
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "appstrate-cli-orgs-"));
+  process.env.XDG_CONFIG_HOME = tmpDir;
+  FakeKeyring.store.clear();
+  _setKeyringFactoryForTesting((p) => new FakeKeyring(p));
+  fetchCalls = [];
+});
+
+afterEach(async () => {
+  _setKeyringFactoryForTesting(null);
+  globalThis.fetch = originalFetch;
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+async function seedAuth(name = "default"): Promise<void> {
+  await setProfile(name, {
+    instance: "https://app.example.com",
+    userId: "u_1",
+    email: "alice@example.com",
+  });
+  await saveTokens(name, {
+    accessToken: "tok-abc",
+    expiresAt: Date.now() + 15 * 60 * 1000,
+    refreshToken: "rt-xyz",
+    refreshExpiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+  });
+}
+
+describe("listOrgs", () => {
+  it("GETs /api/orgs and returns the array", async () => {
+    await seedAuth();
+    installFetch(async (url) => {
+      expect(url).toBe("https://app.example.com/api/orgs");
+      return new Response(
+        JSON.stringify({
+          organizations: [
+            { id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" },
+          ],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const orgs = await listOrgs("default");
+    expect(orgs).toHaveLength(1);
+    expect(orgs[0]!.id).toBe("org_1");
+    expect(fetchCalls[0]!.method ?? "GET").toBe("GET");
+  });
+
+  it("returns an empty array when the server returns no organizations", async () => {
+    await seedAuth();
+    installFetch(
+      async () =>
+        new Response(JSON.stringify({ organizations: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const orgs = await listOrgs("default");
+    expect(orgs).toEqual([]);
+  });
+
+  it("returns an empty array when response shape is degenerate", async () => {
+    await seedAuth();
+    installFetch(
+      async () =>
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const orgs = await listOrgs("default");
+    expect(orgs).toEqual([]);
+  });
+});
+
+describe("createOrg", () => {
+  it("POSTs with only the name when slug is not provided", async () => {
+    await seedAuth();
+    installFetch(async (url, init) => {
+      expect(url).toBe("https://app.example.com/api/orgs");
+      expect(init?.method).toBe("POST");
+      const body = JSON.parse(String(init?.body));
+      expect(body).toEqual({ name: "Acme" });
+      return new Response(
+        JSON.stringify({ id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const org = await createOrg("default", { name: "Acme" });
+    expect(org.id).toBe("org_1");
+  });
+
+  it("POSTs with name + slug when both are provided", async () => {
+    await seedAuth();
+    installFetch(async (_url, init) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body).toEqual({ name: "Acme Corp", slug: "acme-corp" });
+      return new Response(
+        JSON.stringify({
+          id: "org_2",
+          name: "Acme Corp",
+          slug: "acme-corp",
+          role: "owner",
+          createdAt: "t",
+        }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const org = await createOrg("default", { name: "Acme Corp", slug: "acme-corp" });
+    expect(org.slug).toBe("acme-corp");
+  });
+
+  it("omits an empty slug from the request body", async () => {
+    await seedAuth();
+    installFetch(async (_url, init) => {
+      const body = JSON.parse(String(init?.body));
+      expect("slug" in body).toBe(false);
+      return new Response(
+        JSON.stringify({ id: "org_3", name: "X", slug: "x", role: "owner", createdAt: "t" }),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    await createOrg("default", { name: "X", slug: "" });
+  });
+});
+
+describe("resolveOrgRef", () => {
+  const orgs: Org[] = [
+    { id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" },
+    { id: "org_2", name: "Beta", slug: "beta", role: "member", createdAt: "t" },
+  ];
+
+  it("matches by exact id", () => {
+    expect(resolveOrgRef(orgs, "org_2").name).toBe("Beta");
+  });
+
+  it("matches by exact slug", () => {
+    expect(resolveOrgRef(orgs, "acme").name).toBe("Acme");
+  });
+
+  it("ignores surrounding whitespace", () => {
+    expect(resolveOrgRef(orgs, "  acme  ").id).toBe("org_1");
+  });
+
+  it("throws with the available slugs/ids when ref is unknown", () => {
+    expect(() => resolveOrgRef(orgs, "gamma")).toThrow(/No organization matches/);
+  });
+
+  it("rejects empty references", () => {
+    expect(() => resolveOrgRef(orgs, "")).toThrow(/empty/);
+    expect(() => resolveOrgRef(orgs, "   ")).toThrow(/empty/);
+  });
+
+  it("surfaces a dedicated message when the profile has zero orgs", () => {
+    expect(() => resolveOrgRef([], "anything")).toThrow(/No organizations found/);
+  });
+});

--- a/apps/cli/test/whoami.test.ts
+++ b/apps/cli/test/whoami.test.ts
@@ -234,6 +234,69 @@ describe("whoami (happy path)", () => {
     expect(out).toContain("User:     anon@example.com");
   });
 
+  it("enriches the Org line with name + id when the profile has an orgId pinned (issue #209)", async () => {
+    await seedLoggedInProfile("default");
+    // Manually pin orgId — `seedLoggedInProfile` doesn't set one.
+    await setProfile("default", {
+      instance: "https://app.example.com",
+      userId: "u_1",
+      email: "alice@example.com",
+      orgId: "org_42",
+    });
+    installFetch(async (url) => {
+      if (url.endsWith("/api/profile")) {
+        return new Response(
+          JSON.stringify({ id: "u_1", displayName: "A", language: "en", email: "a@example.com" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.endsWith("/api/orgs")) {
+        return new Response(
+          JSON.stringify({
+            organizations: [
+              { id: "org_42", name: "Acme Corp", slug: "acme", role: "owner", createdAt: "t" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      return new Response("unknown", { status: 500 });
+    });
+
+    await whoamiCommand({ profile: "default" });
+
+    const out = stdoutChunks.join("");
+    expect(out).toContain("Org:      Acme Corp (org_42)");
+  });
+
+  it("falls back to the bare orgId when the pinned org is not in the server list (stale pin)", async () => {
+    await seedLoggedInProfile("default");
+    await setProfile("default", {
+      instance: "https://app.example.com",
+      userId: "u_1",
+      email: "alice@example.com",
+      orgId: "org_gone",
+    });
+    installFetch(async (url) => {
+      if (url.endsWith("/api/profile")) {
+        return new Response(
+          JSON.stringify({ id: "u_1", displayName: "A", language: "en", email: "a@example.com" }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.endsWith("/api/orgs")) {
+        return new Response(JSON.stringify({ organizations: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("unknown", { status: 500 });
+    });
+
+    await whoamiCommand({ profile: "default" });
+    expect(stdoutChunks.join("")).toContain("Org:      org_gone");
+  });
+
   it("sends the stored Bearer token on /api/profile (JWT path, not cookies)", async () => {
     await seedLoggedInProfile("default");
     installFetch(


### PR DESCRIPTION
Closes #209.

## Summary

- `appstrate login` now calls `GET /api/orgs` after the device-flow exchange and pins the right org on the profile (auto on 1, interactive picker on ≥2, inline-create on 0). `config.toml::profile.orgId` is the source of truth that `lib/api.ts` already injects as `X-Org-Id` — so `appstrate api GET /api/me` works out of the box after a fresh login, no `-H "X-Org-Id: …"` needed.
- New `appstrate org {list,switch,current,create}` subcommand group for re-pinning / creating orgs without re-running the device flow.
- `whoami` enriches the Org line with the server-side name (e.g. `Org: Acme (org_42)`), falling back to the bare id on stale pin.

## Non-interactive escape hatches (CI / scripted installs)

- `appstrate login --org <id-or-slug>` — pin a named org, fail if no match.
- `appstrate login --create-org <name>` — force inline creation (`POST /api/orgs`).
- `appstrate login --no-org` — skip the whole step.

## Design notes

- Pure `apiFetch` wrappers live in `apps/cli/src/lib/orgs.ts` (`listOrgs`, `createOrg`, `resolveOrgRef`) — shared by both `login` and the `org` subcommands. Zero server changes: both routes (`GET /api/orgs`, `POST /api/orgs`) already run without `X-Org-Id`, and `POST /api/orgs` already provisions a default application + hello-world agent server-side (per `apps/api/src/routes/organizations.ts`).
- Prompts are dependency-injected through `LoginDeps` / `OrgCommandDeps` so tests drive each branch without `mock.module` (banned per CLAUDE.md). Default impls call the real `@clack/prompts` helpers in `lib/ui.ts` and short-circuit to `null` in non-TTY mode so CI scripts see a clean hint instead of a hang.
- Commander's idiomatic `--org <value>` + `--no-org` pair yields `opts.org === false | string | undefined` — verified against commander v14.

## Test plan

- [x] `bun test apps/cli` — 511 pass (39 new, 0 fail)
  - `test/orgs.test.ts` — `listOrgs` / `createOrg` / `resolveOrgRef` (12)
  - `test/login-org.test.ts` — every login branch (10): auto-pin, interactive, inline-create, `--org`, `--create-org`, `--no-org`, `--org`-not-found, `/api/orgs` failure tolerance, profile-field preservation
  - `test/org-command.test.ts` — each subcommand (15)
  - `test/whoami.test.ts` — 2 new tests for the enriched Org line + stale-pin fallback
- [x] `bun run check` — typecheck + lint + prettier + verify-openapi + detect-breaking + build-system-packages all green
- [ ] Manual smoke (left to reviewer or follow-up): fresh `appstrate login` on a one-org account → `appstrate api GET /api/me` returns 200 without `-H`.

## Files

| File | Change |
| --- | --- |
| `apps/cli/src/lib/orgs.ts` | **new** — `listOrgs`, `createOrg`, `resolveOrgRef` |
| `apps/cli/src/lib/ui.ts` | Add `select()` helper (TTY-gated `@clack/prompts.select` wrapper) |
| `apps/cli/src/commands/login.ts` | Step 7: org-pin branch + DI `LoginDeps` |
| `apps/cli/src/commands/org.ts` | **new** — `list / switch / current / create` |
| `apps/cli/src/commands/whoami.ts` | Enrich the Org line with the server-side name |
| `apps/cli/src/cli.ts` | Wire `--org` / `--create-org` / `--no-org` on `login`; register `org` subcommand group |
| `apps/cli/README.md` | New "Organizations" section + updated login flags table |
| `apps/cli/test/*` | +3 new test files; +2 whoami tests |

## Out of scope (per issue)

- Server-side changes (none needed).
- `appstrate app switch` (X-App-Id counterpart). Plumbing is analogous but `POST /api/orgs` doesn't echo `defaultApplicationId` in the response today — adding it cheaply would need a 1-line server tweak, which I'd rather land as a separate follow-up issue to keep this PR focused.
- API-key-scoped runs (already app-scoped server-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)