### PR TITLE
feat(cli): add openapi command for schema exploration

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -39,6 +39,7 @@ See [`examples/self-hosting/README.md`](../../examples/self-hosting/README.md#ve
 | `appstrate token`   | Print metadata about the stored access + refresh tokens (debug).               |
 | `appstrate org`     | List, switch, or create organizations pinned on the active profile.            |
 | `appstrate api`     | Authenticated HTTP passthrough to the Appstrate API.                           |
+| `appstrate openapi` | Explore the active profile's OpenAPI schema without flooding stdout.           |
 
 All commands accept `--profile <name>` to target a specific profile (see [Profiles](#profiles)).
 
@@ -231,6 +232,65 @@ All four subcommands respect the global `--profile <name>` flag and talk to `GET
 | `org switch [id\|slug]` | Re-pin the active org on the profile. With no argument, show an interactive picker with the current one highlighted.                     |
 | `org current`           | Print the pinned org id to stdout. Exits 1 with a hint when no org is pinned — designed for `if` / shell prompts.                        |
 | `org create [name]`     | Create a new org and pin it. With no argument, prompt for name + optional slug. Use `--slug <slug>` for an explicit kebab-case override. |
+
+---
+
+### `appstrate openapi`
+
+Explore the active profile's OpenAPI 3.1 schema without dumping the whole spec to stdout. The platform exposes ~191 endpoints — `list`, `show`, and `export` subcommands make that corpus explorable at human scale (and agent-ingestable with `--json`).
+
+The schema is fetched once per profile and cached under `~/.cache/appstrate/openapi-<profile>.json` (or `$XDG_CACHE_HOME/appstrate/…`). Each cached copy pairs with an ETag sibling — subsequent invocations send `If-None-Match` and short-circuit on a `304` response, so re-running `list` / `show` during exploration costs one conditional round-trip instead of re-downloading the full spec.
+
+```sh
+appstrate openapi list                              # all operations, one per line
+appstrate openapi list --tag runs                   # filter by tag
+appstrate openapi list --method post                # filter by HTTP method
+appstrate openapi list --path '/api/runs/*'         # filter by path glob
+appstrate openapi list --search "create run"        # fuzzy match on id / summary / path
+appstrate openapi list --json                       # machine-readable index
+
+appstrate openapi show createRun                    # by operationId
+appstrate openapi show GET /api/runs                # by METHOD + path
+appstrate openapi show createRun --json             # full dereferenced object (agent input)
+
+appstrate openapi export                            # dump raw schema to stdout
+appstrate openapi export -o schema.json             # dump to file
+```
+
+**Subcommand flags**
+
+| Subcommand | Flag             | Description                                                                      |
+| ---------- | ---------------- | -------------------------------------------------------------------------------- |
+| `list`     | `--tag <t>`      | Filter by OpenAPI tag (case-insensitive exact match).                            |
+| `list`     | `--method <m>`   | Filter by HTTP method (`GET`, `POST`, …).                                        |
+| `list`     | `--path <glob>`  | Filter by path. Supports `*` (single segment) and `**` (any). Exact match else.  |
+| `list`     | `--search <q>`   | Case-insensitive substring across operationId, summary, description, path.       |
+| `list`     | `--json`         | Emit a minimal JSON array (method, path, operationId, summary, tags) for piping. |
+| `show`     | `--json`         | Emit the full dereferenced operation as JSON instead of the text summary.        |
+| `export`   | `-o`, `--output` | Write the schema to a file (default: stdout).                                    |
+
+**Shared flags** (all three subcommands)
+
+| Flag         | Description                                                           |
+| ------------ | --------------------------------------------------------------------- |
+| `--refresh`  | Force a fresh download; still update the on-disk cache on success.    |
+| `--no-cache` | Fully ephemeral — skip both cache read and write for this invocation. |
+
+**`list` output** — one colored line per operation:
+
+```
+GET    /api/runs — List runs [runs]
+POST   /api/runs — Create a run [runs]
+GET    /api/runs/{id} — Get a run [runs]
+DELETE /api/runs/{id} — Cancel a run [runs]
+GET    /api/deprecated — Legacy endpoint [legacy] [deprecated]
+```
+
+Colors are suppressed when stdout is not a TTY, or when `NO_COLOR` is set in the environment (respects [no-color.org](https://no-color.org)).
+
+**`show` output** — a human-readable operation summary. For `--json`, the response uses `@apidevtools/swagger-parser` to dereference every `$ref` in the operation tree, so nested request/response schemas inline fully — ideal for piping into an LLM prompt or a code generator.
+
+**`export` output** — the raw schema JSON. Use `-o schema.json` for file output (mode `0600`) or stdout for shell piping (`appstrate openapi export | jq '.info'`). Equivalent to calling `appstrate api GET /api/openapi.json`, but served from the local cache when possible.
 
 ---
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -44,6 +44,7 @@
     "prepack": "bun run build"
   },
   "dependencies": {
+    "@apidevtools/swagger-parser": "^12.1.0",
     "@clack/prompts": "^1.2.0",
     "@napi-rs/keyring": "^1.2.0",
     "async-mutex": "^0.5.0",

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -36,6 +36,7 @@ import {
   orgCurrentCommand,
   orgCreateCommand,
 } from "./commands/org.ts";
+import { registerOpenapiCommand } from "./commands/openapi.ts";
 import { exitWithError } from "./lib/ui.ts";
 import { CLI_VERSION } from "./lib/version.ts";
 
@@ -476,5 +477,7 @@ program
         typeof opts.maxTime === "number" && !Number.isNaN(opts.maxTime) ? opts.maxTime : undefined,
     });
   });
+
+registerOpenapiCommand(program, () => program.opts<{ profile?: string }>().profile);
 
 program.parseAsync(process.argv).catch((err) => exitWithError(err));

--- a/apps/cli/src/commands/openapi.ts
+++ b/apps/cli/src/commands/openapi.ts
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `appstrate openapi` — explore the active profile's OpenAPI schema
+ * without piping the full spec (~191 endpoints) through stdout.
+ *
+ * Three subcommands:
+ *
+ *   list    compact index, filterable by --tag, --method, --path,
+ *           --search. Default sink is stdout as colored text; --json
+ *           emits a minimal JSON array for agents.
+ *
+ *   show    detailed view of one operation, identified by either
+ *           `operationId` or `METHOD /path`. Uses swagger-parser to
+ *           dereference `$ref`s so response/parameter schemas are
+ *           inlined. --json emits the full dereferenced operation.
+ *
+ *   export  dump the raw schema to stdout or a file (-o). The escape
+ *           hatch — equivalent to `appstrate api GET /api/openapi.json`
+ *           but via the cached copy.
+ *
+ * Shared flags:
+ *   --no-cache  ephemeral fetch, no read + no write
+ *   --refresh   skip read, re-download, update cache
+ *
+ * Error surface:
+ *   - AuthError / network errors bubble up and render via formatError.
+ *   - Unknown subcommand → Commander handles (exit 1).
+ *   - Unmatched filters → stdout message, exit 0 (not an error: users
+ *     iterate).
+ *   - `show` with no match → stderr error + exit 1 (the user asked for
+ *     a specific thing and got nothing).
+ */
+
+import { Command } from "commander";
+import { resolveProfileName, readConfig } from "../lib/config.ts";
+import { formatError } from "../lib/ui.ts";
+import { fetchOpenApi, type OpenApiDocument } from "../lib/openapi-cache.ts";
+import {
+  collectOperations,
+  filterOperations,
+  findOperation,
+  formatList,
+  formatShow,
+  toListJson,
+} from "../lib/openapi-format.ts";
+import { writeFile } from "node:fs/promises";
+import SwaggerParser from "@apidevtools/swagger-parser";
+
+export interface OpenapiCommandBaseOptions {
+  profile?: string;
+  noCache?: boolean;
+  refresh?: boolean;
+}
+
+export interface OpenapiListOptions extends OpenapiCommandBaseOptions {
+  tag?: string;
+  method?: string;
+  path?: string;
+  search?: string;
+  json?: boolean;
+}
+
+export interface OpenapiShowOptions extends OpenapiCommandBaseOptions {
+  json?: boolean;
+}
+
+export interface OpenapiExportOptions extends OpenapiCommandBaseOptions {
+  output?: string;
+}
+
+/**
+ * Shared resolver — returns the fetched schema for the active profile.
+ * Factored out so all three subcommand handlers look identical up to
+ * the profile-name bootstrap, no duplication.
+ */
+async function loadSchema(opts: OpenapiCommandBaseOptions): Promise<OpenApiDocument> {
+  const config = await readConfig();
+  const profileName = resolveProfileName(opts.profile, config);
+  return fetchOpenApi(profileName, {
+    noCache: opts.noCache,
+    refresh: opts.refresh,
+  });
+}
+
+/**
+ * Default color detection: respect `NO_COLOR` (https://no-color.org),
+ * `FORCE_COLOR`, and fall back to TTY. `process.stdout.isTTY` is
+ * `undefined` under Bun test runners, which correctly evaluates to
+ * "not a TTY" — tests see plain output by default.
+ */
+function detectColor(): boolean {
+  if (process.env.NO_COLOR) return false;
+  if (process.env.FORCE_COLOR && process.env.FORCE_COLOR !== "0") return true;
+  return Boolean(process.stdout.isTTY);
+}
+
+export async function openapiListCommand(opts: OpenapiListOptions): Promise<void> {
+  try {
+    const doc = await loadSchema(opts);
+    const entries = collectOperations(doc);
+    const filtered = filterOperations(entries, {
+      tag: opts.tag,
+      method: opts.method,
+      path: opts.path,
+      search: opts.search,
+    });
+    if (opts.json) {
+      process.stdout.write(JSON.stringify(toListJson(filtered), null, 2) + "\n");
+      return;
+    }
+    process.stdout.write(formatList(filtered, detectColor()));
+  } catch (err) {
+    process.stderr.write(formatError(err) + "\n");
+    process.exit(1);
+  }
+}
+
+export async function openapiShowCommand(
+  identifier: string,
+  pathArg: string | undefined,
+  opts: OpenapiShowOptions,
+): Promise<void> {
+  try {
+    const doc = await loadSchema(opts);
+    const entry = findOperation(doc, identifier, pathArg);
+    if (!entry) {
+      const hint = pathArg
+        ? `No operation matches "${identifier} ${pathArg}".`
+        : `No operation matches "${identifier}" (tried operationId, then "METHOD /path").`;
+      process.stderr.write(
+        `${hint}\nTip: run \`appstrate openapi list\` to see available operations.\n`,
+      );
+      process.exit(1);
+      return;
+    }
+    // Dereference $refs so parameter/request/response schemas are
+    // inlined. SwaggerParser mutates a copy; we feed it the doc and
+    // it returns the dereferenced tree. Failures fall back to the raw
+    // operation (the summary renderer handles $ref stubs gracefully).
+    let dereferenced: OpenApiDocument = doc;
+    try {
+      // SwaggerParser.dereference accepts `string | OpenAPI.Document`;
+      // we pass our own narrower OpenApiDocument through `unknown` to
+      // satisfy its openapi-types signature without pulling the
+      // openapi-types package into our type surface.
+      const result = (await SwaggerParser.dereference(
+        doc as unknown as Parameters<typeof SwaggerParser.dereference>[0],
+      )) as unknown;
+      if (result && typeof result === "object") {
+        dereferenced = result as OpenApiDocument;
+      }
+    } catch {
+      // swallow — renderer copes with refs it can't resolve
+    }
+    // Re-resolve the entry against the dereferenced doc so nested
+    // $refs (especially deeply nested response schemas) are expanded.
+    const derefEntry = findOperation(dereferenced, identifier, pathArg) ?? entry;
+
+    if (opts.json) {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            method: derefEntry.method.toUpperCase(),
+            path: derefEntry.path,
+            operation: derefEntry.op,
+          },
+          null,
+          2,
+        ) + "\n",
+      );
+      return;
+    }
+    process.stdout.write(formatShow(derefEntry, detectColor()));
+  } catch (err) {
+    process.stderr.write(formatError(err) + "\n");
+    process.exit(1);
+  }
+}
+
+export async function openapiExportCommand(opts: OpenapiExportOptions): Promise<void> {
+  try {
+    const doc = await loadSchema(opts);
+    const payload = JSON.stringify(doc, null, 2);
+    if (opts.output) {
+      await writeFile(opts.output, payload + "\n", { mode: 0o600 });
+      process.stderr.write(`Wrote ${payload.length} bytes to ${opts.output}\n`);
+      return;
+    }
+    process.stdout.write(payload + "\n");
+  } catch (err) {
+    process.stderr.write(formatError(err) + "\n");
+    process.exit(1);
+  }
+}
+
+/**
+ * Register the `openapi` command on a Commander `program` instance.
+ * Exported for `cli.ts` — avoids making `cli.ts` aware of the three
+ * subcommands individually.
+ */
+export function registerOpenapiCommand(
+  program: Command,
+  globalProfile: () => string | undefined,
+): Command {
+  const openapi = program
+    .command("openapi")
+    .description(
+      "Explore the API's OpenAPI schema for the active profile.\n" +
+        "Subcommands: list (filterable index), show (single operation), export (raw dump).",
+    );
+
+  openapi
+    .command("list")
+    .description("List operations. Filter with --tag, --method, --path (glob), --search.")
+    .option("--tag <tag>", "Filter by OpenAPI tag (case-insensitive).")
+    .option("--method <m>", "Filter by HTTP method (GET/POST/...).")
+    .option(
+      "--path <pattern>",
+      "Filter by path. Supports `*` (single segment) and `**` (any). Exact match otherwise.",
+    )
+    .option(
+      "--search <query>",
+      "Substring match across operationId, summary, description, path, method.",
+    )
+    .option("--json", "Emit a minimal JSON array instead of text.")
+    .option("--no-cache", "Skip the on-disk cache entirely (no read, no write).")
+    .option("--refresh", "Force a fresh fetch; still update the cache on success.")
+    .action(async (opts: Record<string, unknown>) => {
+      await openapiListCommand({
+        profile: globalProfile(),
+        tag: typeof opts.tag === "string" ? opts.tag : undefined,
+        method: typeof opts.method === "string" ? opts.method : undefined,
+        path: typeof opts.path === "string" ? opts.path : undefined,
+        search: typeof opts.search === "string" ? opts.search : undefined,
+        json: opts.json === true,
+        // Commander turns `--no-cache` into `cache: false`. Normalize.
+        noCache: opts.cache === false,
+        refresh: opts.refresh === true,
+      });
+    });
+
+  openapi
+    .command("show <identifier> [path]")
+    .description(
+      "Show one operation by `operationId` OR `METHOD /path`.\n" +
+        "Examples: appstrate openapi show createRun\n" +
+        "          appstrate openapi show GET /api/runs",
+    )
+    .option("--json", "Emit the full dereferenced operation as JSON.")
+    .option("--no-cache", "Skip the on-disk cache entirely (no read, no write).")
+    .option("--refresh", "Force a fresh fetch; still update the cache on success.")
+    .action(
+      async (identifier: string, pathArg: string | undefined, opts: Record<string, unknown>) => {
+        await openapiShowCommand(identifier, pathArg, {
+          profile: globalProfile(),
+          json: opts.json === true,
+          noCache: opts.cache === false,
+          refresh: opts.refresh === true,
+        });
+      },
+    );
+
+  openapi
+    .command("export")
+    .description("Dump the raw OpenAPI schema. Writes to <file> with -o, else stdout.")
+    .option("-o, --output <file>", "Write the schema to this file (default: stdout).")
+    .option("--no-cache", "Skip the on-disk cache entirely (no read, no write).")
+    .option("--refresh", "Force a fresh fetch; still update the cache on success.")
+    .action(async (opts: Record<string, unknown>) => {
+      await openapiExportCommand({
+        profile: globalProfile(),
+        output: typeof opts.output === "string" ? opts.output : undefined,
+        noCache: opts.cache === false,
+        refresh: opts.refresh === true,
+      });
+    });
+
+  return openapi;
+}

--- a/apps/cli/src/commands/openapi.ts
+++ b/apps/cli/src/commands/openapi.ts
@@ -216,6 +216,26 @@ export async function openapiExportCommand(opts: OpenapiExportOptions): Promise<
 }
 
 /**
+ * Attach the cache-control flags shared by every subcommand. Keeps the
+ * flag strings and their descriptions in one place so a rename lands
+ * uniformly across `list` / `show` / `export`.
+ */
+function addCacheFlags(cmd: Command): Command {
+  return cmd
+    .option("--no-cache", "Skip the on-disk cache entirely (no read, no write).")
+    .option("--refresh", "Force a fresh fetch; still update the cache on success.");
+}
+
+/**
+ * Commander turns `--no-cache` into `cache: false` and leaves `--refresh`
+ * either `true` or undefined. Centralized here so the three action
+ * handlers only translate the subcommand-specific flags.
+ */
+function readCacheFlags(opts: Record<string, unknown>): OpenapiCommandBaseOptions {
+  return { noCache: opts.cache === false, refresh: opts.refresh === true };
+}
+
+/**
  * Register the `openapi` command on a Commander `program` instance.
  * Exported for `cli.ts` — avoids making `cli.ts` aware of the three
  * subcommands individually.
@@ -231,71 +251,64 @@ export function registerOpenapiCommand(
         "Subcommands: list (filterable index), show (single operation), export (raw dump).",
     );
 
-  openapi
-    .command("list")
-    .description("List operations. Filter with --tag, --method, --path (glob), --search.")
-    .option("--tag <tag>", "Filter by OpenAPI tag (case-insensitive).")
-    .option("--method <m>", "Filter by HTTP method (GET/POST/...).")
-    .option(
-      "--path <pattern>",
-      "Filter by path. Supports `*` (single segment) and `**` (any). Exact match otherwise.",
-    )
-    .option(
-      "--search <query>",
-      "Substring match across operationId, summary, description, path, method.",
-    )
-    .option("--json", "Emit a minimal JSON array instead of text.")
-    .option("--no-cache", "Skip the on-disk cache entirely (no read, no write).")
-    .option("--refresh", "Force a fresh fetch; still update the cache on success.")
-    .action(async (opts: Record<string, unknown>) => {
-      await openapiListCommand({
+  addCacheFlags(
+    openapi
+      .command("list")
+      .description("List operations. Filter with --tag, --method, --path (glob), --search.")
+      .option("--tag <tag>", "Filter by OpenAPI tag (case-insensitive).")
+      .option("--method <m>", "Filter by HTTP method (GET/POST/...).")
+      .option(
+        "--path <pattern>",
+        "Filter by path. Supports `*` (single segment) and `**` (any). Exact match otherwise.",
+      )
+      .option(
+        "--search <query>",
+        "Substring match across operationId, summary, description, path, method.",
+      )
+      .option("--json", "Emit a minimal JSON array instead of text."),
+  ).action(async (opts: Record<string, unknown>) => {
+    await openapiListCommand({
+      profile: globalProfile(),
+      tag: typeof opts.tag === "string" ? opts.tag : undefined,
+      method: typeof opts.method === "string" ? opts.method : undefined,
+      path: typeof opts.path === "string" ? opts.path : undefined,
+      search: typeof opts.search === "string" ? opts.search : undefined,
+      json: opts.json === true,
+      ...readCacheFlags(opts),
+    });
+  });
+
+  addCacheFlags(
+    openapi
+      .command("show <identifier> [path]")
+      .description(
+        "Show one operation by `operationId` OR `METHOD /path`.\n" +
+          "Examples: appstrate openapi show createRun\n" +
+          "          appstrate openapi show GET /api/runs",
+      )
+      .option("--json", "Emit the full dereferenced operation as JSON."),
+  ).action(
+    async (identifier: string, pathArg: string | undefined, opts: Record<string, unknown>) => {
+      await openapiShowCommand(identifier, pathArg, {
         profile: globalProfile(),
-        tag: typeof opts.tag === "string" ? opts.tag : undefined,
-        method: typeof opts.method === "string" ? opts.method : undefined,
-        path: typeof opts.path === "string" ? opts.path : undefined,
-        search: typeof opts.search === "string" ? opts.search : undefined,
         json: opts.json === true,
-        // Commander turns `--no-cache` into `cache: false`. Normalize.
-        noCache: opts.cache === false,
-        refresh: opts.refresh === true,
+        ...readCacheFlags(opts),
       });
-    });
+    },
+  );
 
-  openapi
-    .command("show <identifier> [path]")
-    .description(
-      "Show one operation by `operationId` OR `METHOD /path`.\n" +
-        "Examples: appstrate openapi show createRun\n" +
-        "          appstrate openapi show GET /api/runs",
-    )
-    .option("--json", "Emit the full dereferenced operation as JSON.")
-    .option("--no-cache", "Skip the on-disk cache entirely (no read, no write).")
-    .option("--refresh", "Force a fresh fetch; still update the cache on success.")
-    .action(
-      async (identifier: string, pathArg: string | undefined, opts: Record<string, unknown>) => {
-        await openapiShowCommand(identifier, pathArg, {
-          profile: globalProfile(),
-          json: opts.json === true,
-          noCache: opts.cache === false,
-          refresh: opts.refresh === true,
-        });
-      },
-    );
-
-  openapi
-    .command("export")
-    .description("Dump the raw OpenAPI schema. Writes to <file> with -o, else stdout.")
-    .option("-o, --output <file>", "Write the schema to this file (default: stdout).")
-    .option("--no-cache", "Skip the on-disk cache entirely (no read, no write).")
-    .option("--refresh", "Force a fresh fetch; still update the cache on success.")
-    .action(async (opts: Record<string, unknown>) => {
-      await openapiExportCommand({
-        profile: globalProfile(),
-        output: typeof opts.output === "string" ? opts.output : undefined,
-        noCache: opts.cache === false,
-        refresh: opts.refresh === true,
-      });
+  addCacheFlags(
+    openapi
+      .command("export")
+      .description("Dump the raw OpenAPI schema. Writes to <file> with -o, else stdout.")
+      .option("-o, --output <file>", "Write the schema to this file (default: stdout)."),
+  ).action(async (opts: Record<string, unknown>) => {
+    await openapiExportCommand({
+      profile: globalProfile(),
+      output: typeof opts.output === "string" ? opts.output : undefined,
+      ...readCacheFlags(opts),
     });
+  });
 
   return openapi;
 }

--- a/apps/cli/src/commands/openapi.ts
+++ b/apps/cli/src/commands/openapi.ts
@@ -135,17 +135,21 @@ export async function openapiShowCommand(
       return;
     }
     // Dereference $refs so parameter/request/response schemas are
-    // inlined. SwaggerParser mutates a copy; we feed it the doc and
-    // it returns the dereferenced tree. Failures fall back to the raw
+    // inlined. SwaggerParser mutates its input in place, which would
+    // corrupt our pristine `doc` (and therefore `entry`) — and for
+    // self-referential schemas, inlining produces real JS cycles that
+    // later break JSON.stringify. Clone first so `entry` stays safe
+    // regardless of what happens below. Failures fall back to the raw
     // operation (the summary renderer handles $ref stubs gracefully).
     let dereferenced: OpenApiDocument = doc;
     try {
+      const clone = JSON.parse(JSON.stringify(doc)) as OpenApiDocument;
       // SwaggerParser.dereference accepts `string | OpenAPI.Document`;
       // we pass our own narrower OpenApiDocument through `unknown` to
       // satisfy its openapi-types signature without pulling the
       // openapi-types package into our type surface.
       const result = (await SwaggerParser.dereference(
-        doc as unknown as Parameters<typeof SwaggerParser.dereference>[0],
+        clone as unknown as Parameters<typeof SwaggerParser.dereference>[0],
       )) as unknown;
       if (result && typeof result === "object") {
         dereferenced = result as OpenApiDocument;
@@ -158,17 +162,34 @@ export async function openapiShowCommand(
     const derefEntry = findOperation(dereferenced, identifier, pathArg) ?? entry;
 
     if (opts.json) {
-      process.stdout.write(
-        JSON.stringify(
+      // Dereferenced operations can contain mutually-recursive $refs
+      // (e.g. a Category schema that contains Category children).
+      // `SwaggerParser.dereference` inlines them into real cycles,
+      // which `JSON.stringify` would throw on. Fall back to the raw
+      // (non-dereferenced) entry so the user still gets a usable JSON
+      // shape rather than a crash.
+      const payload = {
+        method: derefEntry.method.toUpperCase(),
+        path: derefEntry.path,
+        operation: derefEntry.op,
+      };
+      let serialized: string;
+      try {
+        serialized = JSON.stringify(payload, null, 2);
+      } catch {
+        serialized = JSON.stringify(
           {
-            method: derefEntry.method.toUpperCase(),
-            path: derefEntry.path,
-            operation: derefEntry.op,
+            method: entry.method.toUpperCase(),
+            path: entry.path,
+            operation: entry.op,
+            _warning:
+              "Dereferenced schema contained circular references; returning non-dereferenced operation.",
           },
           null,
           2,
-        ) + "\n",
-      );
+        );
+      }
+      process.stdout.write(serialized + "\n");
       return;
     }
     process.stdout.write(formatShow(derefEntry, detectColor()));

--- a/apps/cli/src/lib/openapi-cache.ts
+++ b/apps/cli/src/lib/openapi-cache.ts
@@ -173,16 +173,6 @@ async function writeCache(
 }
 
 /**
- * Remove the cached schema + ETag for a profile, if present. Exposed
- * for tests and for a future `appstrate openapi --clear-cache` flag.
- */
-export async function clearCache(profileName: string): Promise<void> {
-  const { json, etag } = cachePaths(profileName);
-  await unlink(json).catch(() => {});
-  await unlink(etag).catch(() => {});
-}
-
-/**
  * Fetch the OpenAPI schema for `profileName`, honoring the per-profile
  * ETag cache. Authenticated via `apiFetchRaw` so the request reuses
  * the profile's bearer + silent refresh + X-Org-Id wiring — the same
@@ -197,9 +187,7 @@ export async function clearCache(profileName: string): Promise<void> {
  * controlled Response objects so we can cover hit / miss / 304 /
  * no-ETag / corruption / auth error paths without a live server.
  */
-export interface OpenApiFetcher {
-  (profileName: string, path: string, init: RequestInit): Promise<Response>;
-}
+type OpenApiFetcher = (profileName: string, path: string, init: RequestInit) => Promise<Response>;
 
 const defaultFetcher: OpenApiFetcher = (profileName, path, init) =>
   apiFetchRaw(profileName, path, init as Parameters<typeof apiFetchRaw>[2]);

--- a/apps/cli/src/lib/openapi-cache.ts
+++ b/apps/cli/src/lib/openapi-cache.ts
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Per-profile OpenAPI schema cache with ETag/304 revalidation.
+ *
+ * Why cache at all: `GET /api/openapi.json` returns ~191 endpoints
+ * (~several MB of JSON with all component schemas). Users typically
+ * invoke `appstrate openapi list` / `show` many times in quick
+ * succession while exploring. Re-downloading the full schema on every
+ * invocation is wasteful and slow on high-latency connections.
+ *
+ * Strategy: one cache file + one ETag sibling per profile under
+ * `$XDG_CACHE_HOME/appstrate/` (or `~/.cache/appstrate/`). On fetch:
+ *
+ *   1. Read the cached ETag (if any) and send it as `If-None-Match`.
+ *   2. If the server replies 304, use the cached payload as-is.
+ *   3. If the server replies 200, overwrite both cache + etag files.
+ *   4. If the server returns no ETag header, cache the body without
+ *      an ETag — the next invocation re-downloads but still benefits
+ *      from the single round-trip (no extra 304 handshake needed).
+ *
+ * Corruption tolerance: a cache file that fails JSON.parse is treated
+ * as a miss — we refetch unconditionally rather than propagating a
+ * parse error to the user. Same for missing / partial ETag files.
+ *
+ * User-facing knobs:
+ *   --no-cache  → skip cache lookup AND skip cache write (ephemeral)
+ *   --refresh   → skip cache lookup (force a fresh fetch + ETag), but
+ *                 still write the result to cache
+ *
+ * Tests: `apps/cli/test/openapi-cache.test.ts`.
+ */
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { apiFetchRaw, AuthError } from "./api.ts";
+
+/** Minimal OpenAPI 3.1 shape — only the fields we actually read. */
+export interface OpenApiDocument {
+  openapi?: string;
+  info?: { title?: string; version?: string; description?: string };
+  servers?: Array<{ url: string; description?: string }>;
+  tags?: Array<{ name: string; description?: string }>;
+  paths?: Record<string, Record<string, OpenApiOperation>>;
+  components?: {
+    schemas?: Record<string, unknown>;
+    parameters?: Record<string, unknown>;
+    responses?: Record<string, unknown>;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+export interface OpenApiOperation {
+  operationId?: string;
+  summary?: string;
+  description?: string;
+  tags?: string[];
+  deprecated?: boolean;
+  parameters?: unknown[];
+  requestBody?: unknown;
+  responses?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/**
+ * Options controlling cache behavior for a single fetch. `noCache`
+ * disables reads AND writes (ephemeral mode). `refresh` forces a
+ * fresh fetch but still updates the cache on success — useful for
+ * "invalidate and re-warm" without losing cache benefits on the next
+ * invocation.
+ */
+export interface FetchOptions {
+  noCache?: boolean;
+  refresh?: boolean;
+}
+
+/** Where is $XDG_CACHE_HOME? Mirrors `lib/config.ts::getConfigDir`. */
+export function getCacheDir(): string {
+  const xdg = process.env.XDG_CACHE_HOME;
+  if (xdg && xdg.length > 0) return join(xdg, "appstrate");
+  return join(homedir(), ".cache", "appstrate");
+}
+
+/**
+ * Build the two cache file paths for a given profile. They share the
+ * same stem so a single `rm <profile>*` cleans them up in one shot.
+ * The profile name is URL-encoded defensively — profile names with
+ * path separators (`/`, `\`) would otherwise escape the cache
+ * directory.
+ */
+function cachePaths(profileName: string): { json: string; etag: string } {
+  const stem = `openapi-${encodeURIComponent(profileName)}`;
+  const dir = getCacheDir();
+  return { json: join(dir, `${stem}.json`), etag: join(dir, `${stem}.etag`) };
+}
+
+/**
+ * Read the cached schema + ETag. Either file missing or unparseable is
+ * treated as a miss (returns `null`) — the caller re-downloads. We do
+ * NOT surface read errors other than "not found" because a corrupted
+ * cache is never a fatal condition for exploration commands.
+ */
+async function readCache(
+  profileName: string,
+): Promise<{ doc: OpenApiDocument; etag?: string } | null> {
+  const { json, etag } = cachePaths(profileName);
+  let raw: string;
+  try {
+    raw = await readFile(json, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    return null;
+  }
+  let parsed: OpenApiDocument;
+  try {
+    parsed = JSON.parse(raw) as OpenApiDocument;
+  } catch {
+    // Corrupted cache — treat as miss. The next fetch will overwrite it.
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+
+  let etagValue: string | undefined;
+  try {
+    const raw = await readFile(etag, "utf-8");
+    const trimmed = raw.trim();
+    etagValue = trimmed.length > 0 ? trimmed : undefined;
+  } catch {
+    etagValue = undefined;
+  }
+  return { doc: parsed, etag: etagValue };
+}
+
+/**
+ * Atomic write: same tmp+rename pattern as `writeConfig` in config.ts
+ * so a Ctrl-C mid-save never leaves a torn JSON file on disk. The
+ * ETag is written separately — a missing ETag with a present cache
+ * file is handled gracefully above (skip `If-None-Match`).
+ */
+async function writeCache(
+  profileName: string,
+  doc: OpenApiDocument,
+  etag: string | undefined,
+): Promise<void> {
+  const dir = getCacheDir();
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  const { json, etag: etagPath } = cachePaths(profileName);
+  const tmpJson = `${json}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tmpJson, JSON.stringify(doc), { mode: 0o600 });
+  try {
+    await rename(tmpJson, json);
+  } catch (err) {
+    await unlink(tmpJson).catch(() => {});
+    throw err;
+  }
+  if (etag === undefined) {
+    // Server didn't provide an ETag — wipe any stale one so we don't
+    // send a dangling `If-None-Match` next time and get a 304 whose
+    // cached body no longer matches.
+    await unlink(etagPath).catch(() => {});
+    return;
+  }
+  const tmpEtag = `${etagPath}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tmpEtag, etag, { mode: 0o600 });
+  try {
+    await rename(tmpEtag, etagPath);
+  } catch (err) {
+    await unlink(tmpEtag).catch(() => {});
+    throw err;
+  }
+}
+
+/**
+ * Remove the cached schema + ETag for a profile, if present. Exposed
+ * for tests and for a future `appstrate openapi --clear-cache` flag.
+ */
+export async function clearCache(profileName: string): Promise<void> {
+  const { json, etag } = cachePaths(profileName);
+  await unlink(json).catch(() => {});
+  await unlink(etag).catch(() => {});
+}
+
+/**
+ * Fetch the OpenAPI schema for `profileName`, honoring the per-profile
+ * ETag cache. Authenticated via `apiFetchRaw` so the request reuses
+ * the profile's bearer + silent refresh + X-Org-Id wiring — the same
+ * auth surface the rest of the CLI exposes.
+ *
+ * Returns the parsed JSON document. On non-2xx (other than 304) the
+ * underlying response status is wrapped into an `Error` — the caller
+ * funnels it through `formatError` / `exitWithError`.
+ *
+ * The `fetcher` parameter is a test seam: production code uses the
+ * default (real `apiFetchRaw`), tests inject a stub that returns
+ * controlled Response objects so we can cover hit / miss / 304 /
+ * no-ETag / corruption / auth error paths without a live server.
+ */
+export interface OpenApiFetcher {
+  (profileName: string, path: string, init: RequestInit): Promise<Response>;
+}
+
+const defaultFetcher: OpenApiFetcher = (profileName, path, init) =>
+  apiFetchRaw(profileName, path, init as Parameters<typeof apiFetchRaw>[2]);
+
+export async function fetchOpenApi(
+  profileName: string,
+  options: FetchOptions = {},
+  fetcher: OpenApiFetcher = defaultFetcher,
+): Promise<OpenApiDocument> {
+  // `refresh` = skip read but keep write. `noCache` = skip both.
+  const skipRead = options.noCache === true || options.refresh === true;
+  const skipWrite = options.noCache === true;
+
+  const cached = skipRead ? null : await readCache(profileName);
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+  };
+  if (cached?.etag) {
+    headers["If-None-Match"] = cached.etag;
+  }
+
+  const res = await fetcher(profileName, "/api/openapi.json", {
+    method: "GET",
+    headers,
+  });
+
+  if (res.status === 304) {
+    // Revalidation succeeded — cached copy is still fresh. 304 is
+    // impossible without a prior cache hit, but guard anyway so a
+    // misbehaving server can't crash the CLI.
+    if (!cached) {
+      throw new Error(
+        "Server responded 304 Not Modified but no cached schema is available. Re-run with --refresh.",
+      );
+    }
+    return cached.doc;
+  }
+
+  if (res.status === 401) {
+    throw new AuthError(
+      `Unauthorized — your session may have been revoked. Run: appstrate login --profile ${profileName}`,
+    );
+  }
+
+  if (!res.ok) {
+    let body: string;
+    try {
+      body = await res.text();
+    } catch {
+      body = "";
+    }
+    throw new Error(
+      `Failed to fetch OpenAPI schema: HTTP ${res.status} ${res.statusText}${body ? ` — ${body.slice(0, 200)}` : ""}`,
+    );
+  }
+
+  const etag = res.headers.get("etag") ?? undefined;
+  let doc: OpenApiDocument;
+  try {
+    doc = (await res.json()) as OpenApiDocument;
+  } catch (err) {
+    throw new Error(
+      `OpenAPI schema response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!doc || typeof doc !== "object") {
+    throw new Error("OpenAPI schema response was empty or not an object.");
+  }
+
+  if (!skipWrite) {
+    try {
+      await writeCache(profileName, doc, etag);
+    } catch {
+      // Cache write failure is non-fatal — the user still gets their
+      // result, just without the next-invocation speed-up. Silent on
+      // purpose: the CLI's stderr is reserved for actionable errors.
+    }
+  }
+
+  return doc;
+}

--- a/apps/cli/src/lib/openapi-format.ts
+++ b/apps/cli/src/lib/openapi-format.ts
@@ -1,0 +1,433 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Filter + formatter helpers for `appstrate openapi list` / `show`.
+ *
+ * Stays client-side on purpose:
+ *   - the server ships the whole schema in one call (ETag-cached),
+ *   - filtering in-process keeps `list` sub-100ms even on 191 paths,
+ *   - we avoid coupling the CLI release cadence to the API's filter
+ *     query-param surface (issue #206's "server-side filtering"
+ *     option was explicitly rejected for the same reason).
+ *
+ * Exports two layers:
+ *   1. pure filter predicates (`matchesTag`, `matchesMethod`, …) and
+ *      `collectOperations` which flattens paths[…][method] into a
+ *      single indexable array. These are unit-tested in isolation.
+ *   2. formatters (`formatList`, `formatShow`) returning a ready-to-
+ *      write string. No I/O, no process.exit — the command file owns
+ *      stdout/stderr and exit codes.
+ */
+
+import type { OpenApiDocument, OpenApiOperation } from "./openapi-cache.ts";
+
+/** Known HTTP methods we expose as operations — matches the OpenAPI spec. */
+export const HTTP_METHODS = [
+  "get",
+  "post",
+  "put",
+  "patch",
+  "delete",
+  "head",
+  "options",
+  "trace",
+] as const;
+
+export type HttpMethod = (typeof HTTP_METHODS)[number];
+
+/** Flattened (path, method, op) triple — the primary unit `list` operates on. */
+export interface OperationEntry {
+  path: string;
+  method: HttpMethod;
+  op: OpenApiOperation;
+}
+
+/** ANSI colors — small palette, no dependency. Disabled when stdout isn't a TTY. */
+const COLORS = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  dim: "\x1b[2m",
+  red: "\x1b[31m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  blue: "\x1b[34m",
+  magenta: "\x1b[35m",
+  cyan: "\x1b[36m",
+  gray: "\x1b[90m",
+} as const;
+
+/**
+ * Color per HTTP method, curl-ish scheme. Consumers pass `useColor`
+ * explicitly so tests can assert both plain + colored output.
+ */
+function colorForMethod(method: HttpMethod): string {
+  switch (method) {
+    case "get":
+      return COLORS.green;
+    case "post":
+      return COLORS.yellow;
+    case "put":
+    case "patch":
+      return COLORS.blue;
+    case "delete":
+      return COLORS.red;
+    case "head":
+    case "options":
+    case "trace":
+      return COLORS.magenta;
+  }
+}
+
+function paint(text: string, color: string, useColor: boolean): string {
+  return useColor ? `${color}${text}${COLORS.reset}` : text;
+}
+
+/**
+ * Flatten `paths` → `OperationEntry[]` sorted by (path asc, method
+ * order). Skips entries that aren't HTTP methods (OpenAPI allows
+ * `parameters` / `summary` / `description` / `servers` / `$ref` to
+ * sit next to methods under a path — none are operations).
+ */
+export function collectOperations(doc: OpenApiDocument): OperationEntry[] {
+  const out: OperationEntry[] = [];
+  const paths = doc.paths ?? {};
+  for (const [path, pathItem] of Object.entries(paths)) {
+    if (!pathItem || typeof pathItem !== "object") continue;
+    for (const method of HTTP_METHODS) {
+      const op = (pathItem as Record<string, unknown>)[method];
+      if (!op || typeof op !== "object") continue;
+      out.push({ path, method, op: op as OpenApiOperation });
+    }
+  }
+  out.sort((a, b) => {
+    if (a.path !== b.path) return a.path.localeCompare(b.path);
+    return HTTP_METHODS.indexOf(a.method) - HTTP_METHODS.indexOf(b.method);
+  });
+  return out;
+}
+
+/** Case-insensitive tag match. `undefined` filter matches every op. */
+export function matchesTag(entry: OperationEntry, tag: string | undefined): boolean {
+  if (!tag) return true;
+  const needle = tag.toLowerCase();
+  const tags = entry.op.tags ?? [];
+  return tags.some((t) => typeof t === "string" && t.toLowerCase() === needle);
+}
+
+/** Case-insensitive method match. Accepts "get", "GET", etc. */
+export function matchesMethod(entry: OperationEntry, method: string | undefined): boolean {
+  if (!method) return true;
+  return entry.method.toLowerCase() === method.toLowerCase();
+}
+
+/**
+ * Path glob matcher — supports `*` (single segment) and `**` (any
+ * number of segments). No regex characters are exposed beyond that;
+ * the caller can pass plain prefixes (`/api/runs`) or explicit globs
+ * (`/api/runs/*`). A bare path (no glob char) matches only exactly —
+ * this is the principle-of-least-surprise behavior tested by e.g.
+ * `--path /api/runs` not accidentally matching `/api/runs/cancel`.
+ */
+export function matchesPath(entry: OperationEntry, pattern: string | undefined): boolean {
+  if (!pattern) return true;
+  if (!pattern.includes("*")) {
+    return entry.path === pattern;
+  }
+  const regex = globToRegex(pattern);
+  return regex.test(entry.path);
+}
+
+function globToRegex(pattern: string): RegExp {
+  // Escape everything that isn't `*`, then re-expand glob tokens.
+  // Order matters: `**` → `.*` FIRST so we don't double-expand the
+  // inner `*`. `{` / `}` are also escaped (no brace expansion support).
+  let out = "";
+  let i = 0;
+  while (i < pattern.length) {
+    const c = pattern[i]!;
+    if (c === "*") {
+      if (pattern[i + 1] === "*") {
+        out += ".*";
+        i += 2;
+      } else {
+        out += "[^/]*";
+        i += 1;
+      }
+      continue;
+    }
+    if (/[.+?^${}()|[\]\\]/.test(c)) {
+      out += `\\${c}`;
+    } else {
+      out += c;
+    }
+    i += 1;
+  }
+  return new RegExp(`^${out}$`);
+}
+
+/**
+ * Fuzzy search — lowercased substring match across `operationId`,
+ * `summary`, `description`, and `path`. We deliberately do NOT use a
+ * trigram / Levenshtein matcher: every operation lives in a curated
+ * spec, so substring is both sufficient and predictable. Callers who
+ * want strict equality should use `--tag` / `--path` instead.
+ */
+export function matchesSearch(entry: OperationEntry, search: string | undefined): boolean {
+  if (!search) return true;
+  const needle = search.toLowerCase();
+  const haystacks = [
+    entry.op.operationId,
+    entry.op.summary,
+    entry.op.description,
+    entry.path,
+    entry.method,
+  ];
+  return haystacks.some((h) => typeof h === "string" && h.toLowerCase().includes(needle));
+}
+
+/** All filters combined. The command file composes the flags. */
+export interface ListFilters {
+  tag?: string;
+  method?: string;
+  path?: string;
+  search?: string;
+}
+
+export function filterOperations(
+  entries: OperationEntry[],
+  filters: ListFilters,
+): OperationEntry[] {
+  return entries.filter(
+    (e) =>
+      matchesTag(e, filters.tag) &&
+      matchesMethod(e, filters.method) &&
+      matchesPath(e, filters.path) &&
+      matchesSearch(e, filters.search),
+  );
+}
+
+/**
+ * Render the `list` output: one operation per line, method padded to
+ * 6 chars (length of "DELETE"), path next, summary dimmed, tag in
+ * brackets. Deprecated operations get a trailing `[deprecated]` in
+ * bold red.
+ *
+ * Example:
+ *   GET    /api/runs           List runs [runs]
+ *   POST   /api/runs           Create a run [runs]
+ *   DELETE /api/runs/{id}      Cancel a run [runs]
+ */
+export function formatList(entries: OperationEntry[], useColor: boolean): string {
+  if (entries.length === 0) {
+    return "No operations match the given filters.\n";
+  }
+  const lines: string[] = [];
+  for (const entry of entries) {
+    const method = entry.method.toUpperCase().padEnd(6);
+    const coloredMethod = paint(method, colorForMethod(entry.method), useColor);
+    const summary = typeof entry.op.summary === "string" ? entry.op.summary : "";
+    const summaryPart = summary ? ` — ${paint(summary, COLORS.dim, useColor)}` : "";
+    const tags = Array.isArray(entry.op.tags) && entry.op.tags.length > 0 ? entry.op.tags : [];
+    const tagPart =
+      tags.length > 0 ? ` ${paint(`[${tags.join(",")}]`, COLORS.cyan, useColor)}` : "";
+    const deprecatedPart = entry.op.deprecated
+      ? ` ${paint("[deprecated]", COLORS.bold + COLORS.red, useColor)}`
+      : "";
+    lines.push(`${coloredMethod} ${entry.path}${summaryPart}${tagPart}${deprecatedPart}`);
+  }
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * JSON shape for `list --json`: stable, minimal, omits the full
+ * operation object (use `show --json` for that). One JSON array,
+ * each item keyed so downstream tooling (jq, agent prompts) can
+ * project easily.
+ */
+export interface ListJsonEntry {
+  method: string;
+  path: string;
+  operationId?: string;
+  summary?: string;
+  tags?: string[];
+  deprecated?: boolean;
+}
+
+export function toListJson(entries: OperationEntry[]): ListJsonEntry[] {
+  return entries.map((e) => {
+    const out: ListJsonEntry = {
+      method: e.method.toUpperCase(),
+      path: e.path,
+    };
+    if (typeof e.op.operationId === "string") out.operationId = e.op.operationId;
+    if (typeof e.op.summary === "string") out.summary = e.op.summary;
+    if (Array.isArray(e.op.tags) && e.op.tags.length > 0) {
+      out.tags = e.op.tags.filter((t): t is string => typeof t === "string");
+    }
+    if (e.op.deprecated === true) out.deprecated = true;
+    return out;
+  });
+}
+
+/**
+ * Lookup a single operation. Accepts either:
+ *   - an operationId (e.g. `createRun`), or
+ *   - a `METHOD /path` pair (case-insensitive method).
+ *
+ * Returns `null` when nothing matches; ambiguity (two operations
+ * sharing an id — spec violation but possible) picks the first
+ * occurrence by stable order.
+ */
+export function findOperation(
+  doc: OpenApiDocument,
+  identifier: string,
+  pathArg?: string,
+): OperationEntry | null {
+  const entries = collectOperations(doc);
+  if (pathArg !== undefined) {
+    const method = identifier.toLowerCase();
+    return entries.find((e) => e.method.toLowerCase() === method && e.path === pathArg) ?? null;
+  }
+  // Single argument: try as operationId first, then fall back to a
+  // `METHOD /path` parsed from it (space-separated) for callers who
+  // quote the whole thing: `appstrate openapi show "GET /api/runs"`.
+  const byId = entries.find((e) => e.op.operationId === identifier);
+  if (byId) return byId;
+  const split = identifier.trim().split(/\s+/);
+  if (split.length === 2) {
+    const [m, p] = split as [string, string];
+    const method = m.toLowerCase();
+    return entries.find((e) => e.method.toLowerCase() === method && e.path === p) ?? null;
+  }
+  return null;
+}
+
+/**
+ * Render the `show` output: a readable summary of one operation.
+ * Sections:
+ *   - method + path + tag(s)
+ *   - summary + description
+ *   - parameters table (in / name / required / type / description)
+ *   - request body content types
+ *   - response status + content types
+ *
+ * `--json` emits the full dereferenced operation object instead — the
+ * command layer handles that; this function is text-only.
+ */
+export function formatShow(entry: OperationEntry, useColor: boolean): string {
+  const lines: string[] = [];
+  const methodLabel = entry.method.toUpperCase();
+  const methodColor = colorForMethod(entry.method);
+  lines.push(`${paint(methodLabel, methodColor + COLORS.bold, useColor)} ${entry.path}`);
+  if (entry.op.operationId) {
+    lines.push(paint(`operationId: ${entry.op.operationId}`, COLORS.dim, useColor));
+  }
+  const tags = Array.isArray(entry.op.tags)
+    ? entry.op.tags.filter((t) => typeof t === "string")
+    : [];
+  if (tags.length > 0) {
+    lines.push(paint(`tags: ${tags.join(", ")}`, COLORS.cyan, useColor));
+  }
+  if (entry.op.deprecated === true) {
+    lines.push(paint("DEPRECATED", COLORS.bold + COLORS.red, useColor));
+  }
+  if (typeof entry.op.summary === "string" && entry.op.summary.length > 0) {
+    lines.push("");
+    lines.push(paint(entry.op.summary, COLORS.bold, useColor));
+  }
+  if (typeof entry.op.description === "string" && entry.op.description.length > 0) {
+    lines.push("");
+    lines.push(entry.op.description.trim());
+  }
+
+  // Parameters
+  const params = Array.isArray(entry.op.parameters) ? entry.op.parameters : [];
+  if (params.length > 0) {
+    lines.push("");
+    lines.push(paint("Parameters:", COLORS.bold, useColor));
+    for (const p of params) {
+      if (!p || typeof p !== "object") continue;
+      const param = p as Record<string, unknown>;
+      const name = typeof param.name === "string" ? param.name : "?";
+      const inLoc = typeof param.in === "string" ? param.in : "?";
+      const required = param.required === true;
+      const schema =
+        param.schema && typeof param.schema === "object"
+          ? (param.schema as Record<string, unknown>)
+          : undefined;
+      const type = schema && typeof schema.type === "string" ? schema.type : "any";
+      const description = typeof param.description === "string" ? param.description : "";
+      const reqMark = required ? paint(" (required)", COLORS.red, useColor) : "";
+      const descPart = description ? ` — ${paint(description, COLORS.dim, useColor)}` : "";
+      lines.push(
+        `  ${paint(inLoc, COLORS.cyan, useColor)}.${paint(name, COLORS.bold, useColor)}: ${type}${reqMark}${descPart}`,
+      );
+    }
+  }
+
+  // Request body
+  const requestBody =
+    entry.op.requestBody && typeof entry.op.requestBody === "object"
+      ? (entry.op.requestBody as Record<string, unknown>)
+      : undefined;
+  if (requestBody) {
+    lines.push("");
+    const required = requestBody.required === true;
+    lines.push(paint(`Request body${required ? " (required)" : ""}:`, COLORS.bold, useColor));
+    const content =
+      requestBody.content && typeof requestBody.content === "object"
+        ? (requestBody.content as Record<string, unknown>)
+        : {};
+    const types = Object.keys(content);
+    if (types.length === 0) {
+      lines.push("  (no content)");
+    } else {
+      for (const t of types) {
+        lines.push(`  ${paint(t, COLORS.cyan, useColor)}`);
+      }
+    }
+  }
+
+  // Responses
+  const responses =
+    entry.op.responses && typeof entry.op.responses === "object" ? entry.op.responses : undefined;
+  if (responses && Object.keys(responses).length > 0) {
+    lines.push("");
+    lines.push(paint("Responses:", COLORS.bold, useColor));
+    const sortedStatuses = Object.keys(responses).sort((a, b) => {
+      // Numeric status codes first in ascending order, `default` last.
+      const an = /^\d+$/.test(a) ? Number(a) : Infinity;
+      const bn = /^\d+$/.test(b) ? Number(b) : Infinity;
+      if (an !== bn) return an - bn;
+      return a.localeCompare(b);
+    });
+    for (const status of sortedStatuses) {
+      const resp = (responses as Record<string, unknown>)[status];
+      if (!resp || typeof resp !== "object") continue;
+      const respObj = resp as Record<string, unknown>;
+      const description = typeof respObj.description === "string" ? respObj.description : "";
+      const statusColor = status.startsWith("2")
+        ? COLORS.green
+        : status.startsWith("3")
+          ? COLORS.blue
+          : status.startsWith("4")
+            ? COLORS.yellow
+            : status.startsWith("5")
+              ? COLORS.red
+              : COLORS.gray;
+      const descPart = description ? ` — ${paint(description, COLORS.dim, useColor)}` : "";
+      lines.push(`  ${paint(status, statusColor + COLORS.bold, useColor)}${descPart}`);
+      const content =
+        respObj.content && typeof respObj.content === "object"
+          ? (respObj.content as Record<string, unknown>)
+          : undefined;
+      if (content) {
+        for (const t of Object.keys(content)) {
+          lines.push(`    ${paint(t, COLORS.cyan, useColor)}`);
+        }
+      }
+    }
+  }
+
+  return lines.join("\n") + "\n";
+}

--- a/apps/cli/src/lib/openapi-format.ts
+++ b/apps/cli/src/lib/openapi-format.ts
@@ -120,49 +120,79 @@ export function matchesMethod(entry: OperationEntry, method: string | undefined)
   return entry.method.toLowerCase() === method.toLowerCase();
 }
 
+/** Hard cap on pattern length — guards against absurdly long CLI input. */
+const GLOB_MAX_LENGTH = 200;
+
 /**
- * Path glob matcher — supports `*` (single segment) and `**` (any
- * number of segments). No regex characters are exposed beyond that;
- * the caller can pass plain prefixes (`/api/runs`) or explicit globs
- * (`/api/runs/*`). A bare path (no glob char) matches only exactly —
- * this is the principle-of-least-surprise behavior tested by e.g.
- * `--path /api/runs` not accidentally matching `/api/runs/cancel`.
+ * Path glob matcher — supports `*` (single segment, no `/`) and `**`
+ * (any number of chars including `/`). No regex compilation: an
+ * iterative two-pointer matcher with a single backtrack anchor runs in
+ * O(pattern · path) and is inherently ReDoS-safe. We previously used
+ * `new RegExp()` built from user input, which CodeQL flagged as
+ * regex-injection even though every metacharacter was escaped —
+ * replaced to remove both the false-positive and any residual concern.
+ *
+ * A bare path (no glob char) matches only exactly — principle of least
+ * surprise so `--path /api/runs` doesn't accidentally pick up
+ * `/api/runs/cancel`.
  */
 export function matchesPath(entry: OperationEntry, pattern: string | undefined): boolean {
   if (!pattern) return true;
   if (!pattern.includes("*")) {
     return entry.path === pattern;
   }
-  const regex = globToRegex(pattern);
-  return regex.test(entry.path);
+  if (pattern.length > GLOB_MAX_LENGTH) return false;
+  return matchGlob(pattern, entry.path);
 }
 
-function globToRegex(pattern: string): RegExp {
-  // Escape everything that isn't `*`, then re-expand glob tokens.
-  // Order matters: `**` → `.*` FIRST so we don't double-expand the
-  // inner `*`. `{` / `}` are also escaped (no brace expansion support).
-  let out = "";
-  let i = 0;
-  while (i < pattern.length) {
-    const c = pattern[i]!;
-    if (c === "*") {
-      if (pattern[i + 1] === "*") {
-        out += ".*";
-        i += 2;
+/**
+ * Iterative glob matcher. Single backtrack anchor (`starPi` / `starSi`)
+ * remembers the last `*` position so a mismatch can extend the star's
+ * consumption by one char and retry. For `**` the matcher allows `/`
+ * to be consumed; for `*` a `/` at the extension boundary aborts the
+ * backtrack. Worst-case O(pattern · path), no recursion, no regex.
+ */
+function matchGlob(pattern: string, path: string): boolean {
+  let pi = 0;
+  let si = 0;
+  let starPi = -1;
+  let starSi = -1;
+  let starIsDouble = false;
+
+  while (si < path.length) {
+    if (pi < pattern.length && pattern[pi] === "*") {
+      if (pattern[pi + 1] === "*") {
+        starIsDouble = true;
+        pi += 2;
       } else {
-        out += "[^/]*";
-        i += 1;
+        starIsDouble = false;
+        pi += 1;
       }
+      starPi = pi;
+      starSi = si;
       continue;
     }
-    if (/[.+?^${}()|[\]\\]/.test(c)) {
-      out += `\\${c}`;
-    } else {
-      out += c;
+    if (pi < pattern.length && pattern[pi] === path[si]) {
+      pi += 1;
+      si += 1;
+      continue;
     }
-    i += 1;
+    if (starPi !== -1) {
+      // Extend the star's consumption by one char. For single `*`, the
+      // consumed char cannot be `/` — segment boundary.
+      if (!starIsDouble && path[starSi] === "/") {
+        return false;
+      }
+      starSi += 1;
+      si = starSi;
+      pi = starPi;
+      continue;
+    }
+    return false;
   }
-  return new RegExp(`^${out}$`);
+  // Trailing stars in the pattern still match the empty suffix.
+  while (pi < pattern.length && pattern[pi] === "*") pi += 1;
+  return pi === pattern.length;
 }
 
 /**

--- a/apps/cli/test/fixtures/openapi-fixture.json
+++ b/apps/cli/test/fixtures/openapi-fixture.json
@@ -1,0 +1,167 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Appstrate Test API",
+    "version": "1.0.0",
+    "description": "Fixture spec for CLI tests."
+  },
+  "servers": [{ "url": "https://api.example.com" }],
+  "tags": [
+    { "name": "runs", "description": "Run lifecycle" },
+    { "name": "agents", "description": "Agent management" },
+    { "name": "legacy", "description": "Deprecated endpoints" }
+  ],
+  "paths": {
+    "/api/runs": {
+      "get": {
+        "operationId": "listRuns",
+        "summary": "List runs",
+        "description": "Return the list of runs for the current org.",
+        "tags": ["runs"],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "integer" },
+            "description": "Max number of runs to return."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RunList" }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        }
+      },
+      "post": {
+        "operationId": "createRun",
+        "summary": "Create a run",
+        "tags": ["runs"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/CreateRunRequest" }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Run" } }
+            }
+          }
+        }
+      }
+    },
+    "/api/runs/{id}": {
+      "get": {
+        "operationId": "getRun",
+        "summary": "Get a run",
+        "tags": ["runs"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Run" } }
+            }
+          },
+          "404": { "description": "Not found" }
+        }
+      },
+      "delete": {
+        "operationId": "cancelRun",
+        "summary": "Cancel a run",
+        "tags": ["runs"],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "204": { "description": "No content" } }
+      }
+    },
+    "/api/agents": {
+      "get": {
+        "operationId": "listAgents",
+        "summary": "List agents",
+        "tags": ["agents"],
+        "responses": {
+          "200": { "description": "OK" }
+        }
+      }
+    },
+    "/api/agents/{id}": {
+      "get": {
+        "operationId": "getAgent",
+        "summary": "Get an agent",
+        "tags": ["agents"],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": { "200": { "description": "OK" } }
+      },
+      "put": {
+        "operationId": "updateAgent",
+        "summary": "Update an agent",
+        "tags": ["agents"],
+        "parameters": [
+          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": { "schema": { "type": "object" } }
+          }
+        },
+        "responses": { "200": { "description": "OK" } }
+      }
+    },
+    "/api/deprecated": {
+      "get": {
+        "operationId": "legacyThing",
+        "summary": "Legacy endpoint",
+        "tags": ["legacy"],
+        "deprecated": true,
+        "responses": { "200": { "description": "OK" } }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Run": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "status": { "type": "string" }
+        }
+      },
+      "RunList": {
+        "type": "object",
+        "properties": {
+          "items": { "type": "array", "items": { "$ref": "#/components/schemas/Run" } }
+        }
+      },
+      "CreateRunRequest": {
+        "type": "object",
+        "required": ["agentId"],
+        "properties": {
+          "agentId": { "type": "string" },
+          "input": { "type": "object" }
+        }
+      }
+    }
+  }
+}

--- a/apps/cli/test/openapi-cache.test.ts
+++ b/apps/cli/test/openapi-cache.test.ts
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `lib/openapi-cache.ts` — covers the ETag dance, cache
+ * corruption recovery, `--no-cache` / `--refresh` flag semantics, and
+ * the auth-error propagation path.
+ *
+ * Strategy: inject a stub fetcher so we never touch the network, then
+ * point `XDG_CACHE_HOME` at a per-test tmpdir so read/write go to disk
+ * without polluting the user's home. The real `apiFetchRaw` is NOT
+ * exercised here — that path is covered by the command integration
+ * test.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm, readFile, stat, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  clearCache,
+  fetchOpenApi,
+  getCacheDir,
+  type OpenApiDocument,
+} from "../src/lib/openapi-cache.ts";
+import { AuthError } from "../src/lib/api.ts";
+
+type StubCall = { headers: Record<string, string>; path: string };
+
+const SAMPLE_DOC: OpenApiDocument = {
+  openapi: "3.1.0",
+  info: { title: "Fixture", version: "1.0.0" },
+  paths: {},
+};
+
+let tmp: string;
+let originalXdg: string | undefined;
+
+function stubFetcher(responder: (call: StubCall) => Response | Promise<Response>): {
+  fetcher: Parameters<typeof fetchOpenApi>[2];
+  calls: StubCall[];
+} {
+  const calls: StubCall[] = [];
+  const fetcher = async (
+    _profileName: string,
+    path: string,
+    init: RequestInit,
+  ): Promise<Response> => {
+    const headers = (init.headers ?? {}) as Record<string, string>;
+    calls.push({ path, headers });
+    return responder({ path, headers });
+  };
+  return { fetcher, calls };
+}
+
+beforeAll(() => {
+  originalXdg = process.env.XDG_CACHE_HOME;
+});
+
+afterAll(() => {
+  if (originalXdg === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = originalXdg;
+});
+
+beforeEach(async () => {
+  tmp = await mkdtemp(join(tmpdir(), "appstrate-cli-openapi-cache-"));
+  process.env.XDG_CACHE_HOME = tmp;
+});
+
+afterEach(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe("getCacheDir", () => {
+  it("honors XDG_CACHE_HOME", () => {
+    expect(getCacheDir()).toBe(join(tmp, "appstrate"));
+  });
+
+  it("falls back to ~/.cache/appstrate when XDG_CACHE_HOME is unset", () => {
+    delete process.env.XDG_CACHE_HOME;
+    const dir = getCacheDir();
+    expect(dir).toMatch(/\.cache\/appstrate$/);
+    // Restore so afterEach cleanup works
+    process.env.XDG_CACHE_HOME = tmp;
+  });
+});
+
+describe("fetchOpenApi — fresh fetch (cache miss)", () => {
+  it("GETs /api/openapi.json with no If-None-Match when cache is empty", async () => {
+    const { fetcher, calls } = stubFetcher(
+      () =>
+        new Response(JSON.stringify(SAMPLE_DOC), {
+          status: 200,
+          headers: { "Content-Type": "application/json", ETag: '"v1"' },
+        }),
+    );
+    const doc = await fetchOpenApi("default", {}, fetcher);
+    expect(doc.openapi).toBe("3.1.0");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.path).toBe("/api/openapi.json");
+    expect(calls[0]!.headers["If-None-Match"]).toBeUndefined();
+    // Cache was written
+    const cached = await readFile(join(getCacheDir(), "openapi-default.json"), "utf-8");
+    expect(JSON.parse(cached)).toEqual(SAMPLE_DOC);
+    const etag = await readFile(join(getCacheDir(), "openapi-default.etag"), "utf-8");
+    expect(etag).toBe('"v1"');
+  });
+
+  it("writes cache without ETag when server doesn't send one", async () => {
+    const { fetcher } = stubFetcher(
+      () =>
+        new Response(JSON.stringify(SAMPLE_DOC), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    await fetchOpenApi("default", {}, fetcher);
+    const etagPath = join(getCacheDir(), "openapi-default.etag");
+    // ETag file should not exist
+    const exists = await stat(etagPath)
+      .then(() => true)
+      .catch(() => false);
+    expect(exists).toBe(false);
+  });
+
+  it("surfaces AuthError on 401", async () => {
+    const { fetcher } = stubFetcher(
+      () =>
+        new Response(JSON.stringify({ error: "unauth" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    await expect(fetchOpenApi("default", {}, fetcher)).rejects.toBeInstanceOf(AuthError);
+  });
+
+  it("throws on non-2xx (other than 304)", async () => {
+    const { fetcher } = stubFetcher(
+      () =>
+        new Response("boom", {
+          status: 502,
+          statusText: "Bad Gateway",
+        }),
+    );
+    await expect(fetchOpenApi("default", {}, fetcher)).rejects.toThrow(/HTTP 502/);
+  });
+
+  it("throws when the body is not valid JSON", async () => {
+    const { fetcher } = stubFetcher(
+      () =>
+        new Response("not json", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    await expect(fetchOpenApi("default", {}, fetcher)).rejects.toThrow(/not valid JSON/);
+  });
+});
+
+describe("fetchOpenApi — cache hit with ETag revalidation", () => {
+  it("sends If-None-Match from cached ETag and returns cache on 304", async () => {
+    // Seed cache
+    let { fetcher, calls } = stubFetcher(
+      () =>
+        new Response(JSON.stringify(SAMPLE_DOC), {
+          status: 200,
+          headers: { ETag: '"v1"' },
+        }),
+    );
+    await fetchOpenApi("default", {}, fetcher);
+    expect(calls).toHaveLength(1);
+
+    // Second call should send If-None-Match and receive 304
+    ({ fetcher, calls } = stubFetcher(({ headers }) => {
+      expect(headers["If-None-Match"]).toBe('"v1"');
+      return new Response(null, { status: 304 });
+    }));
+    const doc = await fetchOpenApi("default", {}, fetcher);
+    expect(doc.openapi).toBe("3.1.0");
+    expect(calls).toHaveLength(1);
+  });
+
+  it("overwrites cache when server returns 200 with a new ETag", async () => {
+    // Seed
+    let { fetcher } = stubFetcher(
+      () =>
+        new Response(JSON.stringify(SAMPLE_DOC), {
+          status: 200,
+          headers: { ETag: '"v1"' },
+        }),
+    );
+    await fetchOpenApi("default", {}, fetcher);
+
+    // Server responds with new doc + new ETag
+    const newDoc: OpenApiDocument = { ...SAMPLE_DOC, info: { title: "Changed", version: "2.0.0" } };
+    ({ fetcher } = stubFetcher(
+      () =>
+        new Response(JSON.stringify(newDoc), {
+          status: 200,
+          headers: { ETag: '"v2"' },
+        }),
+    ));
+    const doc = await fetchOpenApi("default", {}, fetcher);
+    expect(doc.info?.title).toBe("Changed");
+    const cached = JSON.parse(await readFile(join(getCacheDir(), "openapi-default.json"), "utf-8"));
+    expect(cached.info.title).toBe("Changed");
+    const etag = await readFile(join(getCacheDir(), "openapi-default.etag"), "utf-8");
+    expect(etag).toBe('"v2"');
+  });
+
+  it("throws a clear error when the server sends 304 with no cache present", async () => {
+    const { fetcher } = stubFetcher(() => new Response(null, { status: 304 }));
+    await expect(fetchOpenApi("default", {}, fetcher)).rejects.toThrow(
+      /304 Not Modified but no cached/,
+    );
+  });
+});
+
+describe("fetchOpenApi — corruption tolerance", () => {
+  it("treats unparseable cache JSON as a miss (refetches)", async () => {
+    const dir = getCacheDir();
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "openapi-default.json"), "{not valid");
+    await writeFile(join(dir, "openapi-default.etag"), '"v1"');
+
+    const { fetcher, calls } = stubFetcher(
+      () =>
+        new Response(JSON.stringify(SAMPLE_DOC), {
+          status: 200,
+          headers: { ETag: '"v2"' },
+        }),
+    );
+    const doc = await fetchOpenApi("default", {}, fetcher);
+    expect(doc.openapi).toBe("3.1.0");
+    // No If-None-Match sent because read failed entirely
+    expect(calls[0]!.headers["If-None-Match"]).toBeUndefined();
+  });
+
+  it("reads cache even when ETag file is missing (no revalidation, downloads fresh)", async () => {
+    const dir = getCacheDir();
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, "openapi-default.json"), JSON.stringify(SAMPLE_DOC));
+    // No etag file
+
+    const { fetcher, calls } = stubFetcher(
+      () =>
+        new Response(JSON.stringify(SAMPLE_DOC), {
+          status: 200,
+        }),
+    );
+    await fetchOpenApi("default", {}, fetcher);
+    // No If-None-Match since we have no ETag
+    expect(calls[0]!.headers["If-None-Match"]).toBeUndefined();
+  });
+
+  it("wipes stale ETag when re-fetch returns no ETag header", async () => {
+    // Seed with ETag
+    let { fetcher } = stubFetcher(
+      () =>
+        new Response(JSON.stringify(SAMPLE_DOC), {
+          status: 200,
+          headers: { ETag: '"v1"' },
+        }),
+    );
+    await fetchOpenApi("default", {}, fetcher);
+    expect(
+      await stat(join(getCacheDir(), "openapi-default.etag"))
+        .then(() => true)
+        .catch(() => false),
+    ).toBe(true);
+
+    // Refresh: server no longer sends ETag
+    ({ fetcher } = stubFetcher(
+      () =>
+        new Response(JSON.stringify(SAMPLE_DOC), {
+          status: 200,
+        }),
+    ));
+    await fetchOpenApi("default", { refresh: true }, fetcher);
+    const exists = await stat(join(getCacheDir(), "openapi-default.etag"))
+      .then(() => true)
+      .catch(() => false);
+    expect(exists).toBe(false);
+  });
+});
+
+describe("fetchOpenApi — flags (noCache, refresh)", () => {
+  it("--no-cache skips both read and write", async () => {
+    // Seed cache so a read would hit
+    const seed = stubFetcher(
+      () =>
+        new Response(JSON.stringify(SAMPLE_DOC), {
+          status: 200,
+          headers: { ETag: '"v1"' },
+        }),
+    );
+    await fetchOpenApi("default", {}, seed.fetcher);
+    const etagPath = join(getCacheDir(), "openapi-default.etag");
+    const cachePath = join(getCacheDir(), "openapi-default.json");
+    const beforeEtag = await readFile(etagPath, "utf-8");
+
+    // Second call with --no-cache and a different server response —
+    // MUST NOT send If-None-Match, MUST NOT update cache
+    const second = stubFetcher(
+      () =>
+        new Response(JSON.stringify({ ...SAMPLE_DOC, info: { title: "New", version: "2.0.0" } }), {
+          status: 200,
+          headers: { ETag: '"v99"' },
+        }),
+    );
+    const doc = await fetchOpenApi("default", { noCache: true }, second.fetcher);
+    expect(doc.info?.title).toBe("New");
+    expect(second.calls[0]!.headers["If-None-Match"]).toBeUndefined();
+    // Cache unchanged
+    const afterEtag = await readFile(etagPath, "utf-8");
+    expect(afterEtag).toBe(beforeEtag);
+    const cached = JSON.parse(await readFile(cachePath, "utf-8"));
+    expect(cached.info.title).toBe("Fixture");
+  });
+
+  it("--refresh skips read but writes new cache", async () => {
+    // Seed
+    const seed = stubFetcher(
+      () =>
+        new Response(JSON.stringify(SAMPLE_DOC), {
+          status: 200,
+          headers: { ETag: '"v1"' },
+        }),
+    );
+    await fetchOpenApi("default", {}, seed.fetcher);
+
+    // Refresh should skip If-None-Match AND overwrite cache
+    const refresh = stubFetcher(
+      () =>
+        new Response(
+          JSON.stringify({ ...SAMPLE_DOC, info: { title: "Refreshed", version: "3.0.0" } }),
+          {
+            status: 200,
+            headers: { ETag: '"v2"' },
+          },
+        ),
+    );
+    const doc = await fetchOpenApi("default", { refresh: true }, refresh.fetcher);
+    expect(doc.info?.title).toBe("Refreshed");
+    expect(refresh.calls[0]!.headers["If-None-Match"]).toBeUndefined();
+    const etag = await readFile(join(getCacheDir(), "openapi-default.etag"), "utf-8");
+    expect(etag).toBe('"v2"');
+  });
+});
+
+describe("clearCache", () => {
+  it("removes both cache files when they exist", async () => {
+    const { fetcher } = stubFetcher(
+      () =>
+        new Response(JSON.stringify(SAMPLE_DOC), {
+          status: 200,
+          headers: { ETag: '"v1"' },
+        }),
+    );
+    await fetchOpenApi("default", {}, fetcher);
+    await clearCache("default");
+    const cacheExists = await stat(join(getCacheDir(), "openapi-default.json"))
+      .then(() => true)
+      .catch(() => false);
+    expect(cacheExists).toBe(false);
+    const etagExists = await stat(join(getCacheDir(), "openapi-default.etag"))
+      .then(() => true)
+      .catch(() => false);
+    expect(etagExists).toBe(false);
+  });
+
+  it("is a no-op on an empty cache (does not throw)", async () => {
+    await expect(clearCache("nonexistent")).resolves.toBeUndefined();
+  });
+});
+
+describe("fetchOpenApi — profile isolation", () => {
+  it("stores caches under per-profile filenames", async () => {
+    const { fetcher } = stubFetcher(
+      () =>
+        new Response(JSON.stringify(SAMPLE_DOC), {
+          status: 200,
+          headers: { ETag: '"v1"' },
+        }),
+    );
+    await fetchOpenApi("alice", {}, fetcher);
+    await fetchOpenApi("bob", {}, fetcher);
+    const aliceCache = await stat(join(getCacheDir(), "openapi-alice.json"));
+    const bobCache = await stat(join(getCacheDir(), "openapi-bob.json"));
+    expect(aliceCache.size).toBeGreaterThan(0);
+    expect(bobCache.size).toBeGreaterThan(0);
+  });
+
+  it("URL-encodes profile names with path separators", async () => {
+    const { fetcher } = stubFetcher(
+      () =>
+        new Response(JSON.stringify(SAMPLE_DOC), {
+          status: 200,
+        }),
+    );
+    await fetchOpenApi("weird/name", {}, fetcher);
+    const cache = await stat(join(getCacheDir(), "openapi-weird%2Fname.json"));
+    expect(cache.size).toBeGreaterThan(0);
+  });
+});

--- a/apps/cli/test/openapi-cache.test.ts
+++ b/apps/cli/test/openapi-cache.test.ts
@@ -16,12 +16,7 @@ import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from
 import { mkdtemp, rm, readFile, stat, writeFile, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import {
-  clearCache,
-  fetchOpenApi,
-  getCacheDir,
-  type OpenApiDocument,
-} from "../src/lib/openapi-cache.ts";
+import { fetchOpenApi, getCacheDir, type OpenApiDocument } from "../src/lib/openapi-cache.ts";
 import { AuthError } from "../src/lib/api.ts";
 
 type StubCall = { headers: Record<string, string>; path: string };
@@ -344,32 +339,6 @@ describe("fetchOpenApi — flags (noCache, refresh)", () => {
     expect(refresh.calls[0]!.headers["If-None-Match"]).toBeUndefined();
     const etag = await readFile(join(getCacheDir(), "openapi-default.etag"), "utf-8");
     expect(etag).toBe('"v2"');
-  });
-});
-
-describe("clearCache", () => {
-  it("removes both cache files when they exist", async () => {
-    const { fetcher } = stubFetcher(
-      () =>
-        new Response(JSON.stringify(SAMPLE_DOC), {
-          status: 200,
-          headers: { ETag: '"v1"' },
-        }),
-    );
-    await fetchOpenApi("default", {}, fetcher);
-    await clearCache("default");
-    const cacheExists = await stat(join(getCacheDir(), "openapi-default.json"))
-      .then(() => true)
-      .catch(() => false);
-    expect(cacheExists).toBe(false);
-    const etagExists = await stat(join(getCacheDir(), "openapi-default.etag"))
-      .then(() => true)
-      .catch(() => false);
-    expect(etagExists).toBe(false);
-  });
-
-  it("is a no-op on an empty cache (does not throw)", async () => {
-    await expect(clearCache("nonexistent")).resolves.toBeUndefined();
   });
 });
 

--- a/apps/cli/test/openapi-command.test.ts
+++ b/apps/cli/test/openapi-command.test.ts
@@ -1,0 +1,447 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration tests for the `openapi` subcommands — exercise the full
+ * resolve-profile → fetch (via stubbed global fetch) → format → stdout
+ * path. Follows the `whoami.test.ts` harness pattern: fake keyring +
+ * `XDG_*` tmpdirs + process stream / exit hijacking.
+ *
+ * The real `apiFetchRaw` is hit here (no injected fetcher), so this
+ * also covers the profile + auth plumbing end-to-end. We deliberately
+ * do NOT spin up a Bun.serve — the global `fetch` stub is sufficient
+ * for asserting request shape and response behavior without a real
+ * socket, and it matches how every other command test in this suite
+ * is structured.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  _setKeyringFactoryForTesting,
+  saveTokens,
+  type KeyringHandle,
+} from "../src/lib/keyring.ts";
+import { setProfile } from "../src/lib/config.ts";
+import {
+  openapiExportCommand,
+  openapiListCommand,
+  openapiShowCommand,
+} from "../src/commands/openapi.ts";
+
+class FakeKeyring implements KeyringHandle {
+  static store = new Map<string, string>();
+  constructor(private profile: string) {}
+  setPassword(v: string): void {
+    FakeKeyring.store.set(this.profile, v);
+  }
+  getPassword(): string | null {
+    return FakeKeyring.store.get(this.profile) ?? null;
+  }
+  deletePassword(): void {
+    FakeKeyring.store.delete(this.profile);
+  }
+}
+
+class ExitError extends Error {
+  constructor(public readonly code: number) {
+    super(`process.exit(${code}) called`);
+  }
+}
+
+let tmpConfig: string;
+let tmpCache: string;
+let originalXdgConfig: string | undefined;
+let originalXdgCache: string | undefined;
+const originalFetch = globalThis.fetch;
+const originalExit = process.exit;
+const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+let stdoutChunks: string[];
+let stderrChunks: string[];
+let fetchCalls: Array<{ url: string; method: string | undefined; headers: Record<string, string> }>;
+
+function installFetch(responder: (url: string, init?: RequestInit) => Promise<Response>): void {
+  const stub = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    fetchCalls.push({ url, method: init?.method, headers });
+    return responder(url, init);
+  };
+  globalThis.fetch = stub as unknown as typeof fetch;
+}
+
+function captureIo(): void {
+  stdoutChunks = [];
+  stderrChunks = [];
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    stderrChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+    return true;
+  }) as typeof process.stderr.write;
+  (process as unknown as { exit: (code?: number) => never }).exit = ((code?: number): never => {
+    throw new ExitError(code ?? 0);
+  }) as (code?: number) => never;
+}
+
+beforeAll(() => {
+  originalXdgConfig = process.env.XDG_CONFIG_HOME;
+  originalXdgCache = process.env.XDG_CACHE_HOME;
+});
+
+afterAll(() => {
+  if (originalXdgConfig === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = originalXdgConfig;
+  if (originalXdgCache === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = originalXdgCache;
+});
+
+beforeEach(async () => {
+  tmpConfig = await mkdtemp(join(tmpdir(), "appstrate-cli-openapi-cfg-"));
+  tmpCache = await mkdtemp(join(tmpdir(), "appstrate-cli-openapi-cache-"));
+  process.env.XDG_CONFIG_HOME = tmpConfig;
+  process.env.XDG_CACHE_HOME = tmpCache;
+  FakeKeyring.store.clear();
+  _setKeyringFactoryForTesting((p) => new FakeKeyring(p));
+  fetchCalls = [];
+  captureIo();
+});
+
+afterEach(async () => {
+  _setKeyringFactoryForTesting(null);
+  globalThis.fetch = originalFetch;
+  process.stdout.write = originalStdoutWrite;
+  process.stderr.write = originalStderrWrite;
+  (process as unknown as { exit: typeof originalExit }).exit = originalExit;
+  await rm(tmpConfig, { recursive: true, force: true });
+  await rm(tmpCache, { recursive: true, force: true });
+});
+
+async function seedLoggedInProfile(name = "default"): Promise<void> {
+  await setProfile(name, {
+    instance: "https://app.example.com",
+    userId: "u_1",
+    email: "a@example.com",
+  });
+  await saveTokens(name, {
+    accessToken: "tok-abc",
+    expiresAt: Date.now() + 15 * 60 * 1000,
+    refreshToken: "rt-xyz",
+    refreshExpiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+  });
+}
+
+function sampleSchema() {
+  return {
+    openapi: "3.1.0",
+    info: { title: "Appstrate", version: "1.0.0" },
+    paths: {
+      "/api/runs": {
+        get: {
+          operationId: "listRuns",
+          summary: "List runs",
+          tags: ["runs"],
+          responses: { "200": { description: "OK" } },
+        },
+        post: {
+          operationId: "createRun",
+          summary: "Create a run",
+          tags: ["runs"],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": { schema: { $ref: "#/components/schemas/CreateRunRequest" } },
+            },
+          },
+          responses: { "201": { description: "Created" } },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        CreateRunRequest: {
+          type: "object",
+          properties: { agentId: { type: "string" } },
+        },
+      },
+    },
+  };
+}
+
+describe("openapi list", () => {
+  it("prints a compact index for the active profile", async () => {
+    await seedLoggedInProfile();
+    installFetch(
+      async () =>
+        new Response(JSON.stringify(sampleSchema()), {
+          status: 200,
+          headers: { "Content-Type": "application/json", ETag: '"v1"' },
+        }),
+    );
+    await openapiListCommand({ profile: "default" });
+    const out = stdoutChunks.join("");
+    expect(out).toContain("GET");
+    expect(out).toContain("/api/runs");
+    expect(out).toContain("POST");
+    expect(out).toContain("— List runs");
+    expect(out).toContain("[runs]");
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]!.url).toBe("https://app.example.com/api/openapi.json");
+    expect(fetchCalls[0]!.headers.Authorization).toBe("Bearer tok-abc");
+  });
+
+  it("filters by tag (case-insensitive)", async () => {
+    await seedLoggedInProfile();
+    installFetch(
+      async () =>
+        new Response(JSON.stringify(sampleSchema()), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    await openapiListCommand({ profile: "default", tag: "RUNS" });
+    const out = stdoutChunks.join("");
+    expect(out).toContain("/api/runs");
+  });
+
+  it("emits JSON with --json", async () => {
+    await seedLoggedInProfile();
+    installFetch(
+      async () =>
+        new Response(JSON.stringify(sampleSchema()), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    await openapiListCommand({ profile: "default", json: true });
+    const out = stdoutChunks.join("");
+    const parsed = JSON.parse(out);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0]).toHaveProperty("method");
+    expect(parsed[0]).toHaveProperty("path");
+  });
+
+  it("prints a friendly message when filters exclude everything", async () => {
+    await seedLoggedInProfile();
+    installFetch(
+      async () =>
+        new Response(JSON.stringify(sampleSchema()), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    await openapiListCommand({ profile: "default", tag: "nonexistent" });
+    const out = stdoutChunks.join("");
+    expect(out).toMatch(/No operations match/);
+  });
+
+  it("exits 1 with an actionable error when the server returns 401", async () => {
+    await seedLoggedInProfile();
+    // Drop refresh token so the 401 is terminal
+    FakeKeyring.store.clear();
+    await saveTokens("default", {
+      accessToken: "tok-abc",
+      expiresAt: Date.now() + 15 * 60 * 1000,
+    });
+    installFetch(
+      async () =>
+        new Response(JSON.stringify({ error: "unauth" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    let code: number | undefined;
+    try {
+      await openapiListCommand({ profile: "default" });
+    } catch (err) {
+      if (err instanceof ExitError) code = err.code;
+      else throw err;
+    }
+    expect(code).toBe(1);
+    const err = stderrChunks.join("");
+    expect(err).toMatch(/appstrate login --profile default/);
+  });
+});
+
+describe("openapi show", () => {
+  it("renders a single operation by operationId", async () => {
+    await seedLoggedInProfile();
+    installFetch(
+      async () =>
+        new Response(JSON.stringify(sampleSchema()), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    await openapiShowCommand("createRun", undefined, { profile: "default" });
+    const out = stdoutChunks.join("");
+    expect(out).toContain("POST /api/runs");
+    expect(out).toContain("operationId: createRun");
+    expect(out).toContain("Create a run");
+    expect(out).toContain("Request body (required):");
+  });
+
+  it("renders by METHOD + path", async () => {
+    await seedLoggedInProfile();
+    installFetch(
+      async () =>
+        new Response(JSON.stringify(sampleSchema()), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    await openapiShowCommand("GET", "/api/runs", { profile: "default" });
+    const out = stdoutChunks.join("");
+    expect(out).toContain("GET /api/runs");
+    expect(out).toContain("operationId: listRuns");
+  });
+
+  it("emits dereferenced JSON with --json", async () => {
+    await seedLoggedInProfile();
+    installFetch(
+      async () =>
+        new Response(JSON.stringify(sampleSchema()), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    await openapiShowCommand("createRun", undefined, { profile: "default", json: true });
+    const out = stdoutChunks.join("");
+    const parsed = JSON.parse(out);
+    expect(parsed.method).toBe("POST");
+    expect(parsed.path).toBe("/api/runs");
+    // $ref to CreateRunRequest should be dereferenced — the actual
+    // object should appear under content.application/json.schema
+    const schema = parsed.operation.requestBody.content["application/json"].schema;
+    expect(schema).toEqual({
+      type: "object",
+      properties: { agentId: { type: "string" } },
+    });
+  });
+
+  it("exits 1 with an actionable hint when the operation is unknown", async () => {
+    await seedLoggedInProfile();
+    installFetch(
+      async () =>
+        new Response(JSON.stringify(sampleSchema()), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    let code: number | undefined;
+    try {
+      await openapiShowCommand("doesNotExist", undefined, { profile: "default" });
+    } catch (err) {
+      if (err instanceof ExitError) code = err.code;
+      else throw err;
+    }
+    expect(code).toBe(1);
+    expect(stderrChunks.join("")).toMatch(/No operation matches/);
+  });
+});
+
+describe("openapi export", () => {
+  it("dumps the full schema to stdout by default", async () => {
+    await seedLoggedInProfile();
+    const schema = sampleSchema();
+    installFetch(
+      async () =>
+        new Response(JSON.stringify(schema), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    await openapiExportCommand({ profile: "default" });
+    const out = stdoutChunks.join("");
+    const parsed = JSON.parse(out);
+    expect(parsed.openapi).toBe("3.1.0");
+    expect(parsed.paths["/api/runs"].get.operationId).toBe("listRuns");
+  });
+
+  it("writes to file with -o / --output", async () => {
+    await seedLoggedInProfile();
+    const schema = sampleSchema();
+    installFetch(
+      async () =>
+        new Response(JSON.stringify(schema), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const target = join(tmpCache, "schema.json");
+    await openapiExportCommand({ profile: "default", output: target });
+    const written = await readFile(target, "utf-8");
+    const parsed = JSON.parse(written);
+    expect(parsed.openapi).toBe("3.1.0");
+    const err = stderrChunks.join("");
+    expect(err).toMatch(/Wrote \d+ bytes/);
+    // Nothing should leak to stdout when -o is set
+    expect(stdoutChunks.join("")).toBe("");
+  });
+});
+
+describe("openapi — ETag revalidation across commands", () => {
+  it("reuses cache across list → show invocations (304 on second hit)", async () => {
+    await seedLoggedInProfile();
+    const schema = sampleSchema();
+
+    // First call: 200 + ETag, caches on disk
+    installFetch(
+      async () =>
+        new Response(JSON.stringify(schema), {
+          status: 200,
+          headers: { "Content-Type": "application/json", ETag: '"v1"' },
+        }),
+    );
+    await openapiListCommand({ profile: "default" });
+    expect(fetchCalls).toHaveLength(1);
+
+    // Reset buffers and swap in a 304 responder
+    stdoutChunks = [];
+    stderrChunks = [];
+    fetchCalls = [];
+    installFetch(async (_url, init) => {
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      expect(headers["If-None-Match"]).toBe('"v1"');
+      return new Response(null, { status: 304 });
+    });
+    await openapiShowCommand("listRuns", undefined, { profile: "default" });
+    expect(fetchCalls).toHaveLength(1);
+    expect(stdoutChunks.join("")).toContain("GET /api/runs");
+  });
+
+  it("--no-cache bypasses ETag revalidation entirely", async () => {
+    await seedLoggedInProfile();
+    const schema = sampleSchema();
+
+    // Seed cache
+    installFetch(
+      async () =>
+        new Response(JSON.stringify(schema), {
+          status: 200,
+          headers: { "Content-Type": "application/json", ETag: '"v1"' },
+        }),
+    );
+    await openapiListCommand({ profile: "default" });
+
+    // Reset + second invocation with --no-cache; server should NOT
+    // receive an If-None-Match header
+    stdoutChunks = [];
+    fetchCalls = [];
+    installFetch(async (_url, init) => {
+      const headers = (init?.headers ?? {}) as Record<string, string>;
+      expect(headers["If-None-Match"]).toBeUndefined();
+      return new Response(JSON.stringify(schema), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    await openapiListCommand({ profile: "default", noCache: true });
+    expect(fetchCalls).toHaveLength(1);
+  });
+});

--- a/apps/cli/test/openapi-command.test.ts
+++ b/apps/cli/test/openapi-command.test.ts
@@ -324,6 +324,66 @@ describe("openapi show", () => {
     });
   });
 
+  it("falls back to the raw operation when dereference yields circular refs", async () => {
+    // Build a schema where Category → properties.children → items → Category
+    // (self-referential). SwaggerParser.dereference inlines this into a
+    // real JS cycle; JSON.stringify would throw without the fallback.
+    await seedLoggedInProfile();
+    const recursiveSchema = {
+      openapi: "3.1.0",
+      info: { title: "T", version: "1" },
+      paths: {
+        "/api/categories": {
+          get: {
+            operationId: "listCategories",
+            summary: "List categories",
+            tags: ["categories"],
+            responses: {
+              "200": {
+                description: "ok",
+                content: {
+                  "application/json": {
+                    schema: { $ref: "#/components/schemas/Category" },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      components: {
+        schemas: {
+          Category: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              children: {
+                type: "array",
+                items: { $ref: "#/components/schemas/Category" },
+              },
+            },
+          },
+        },
+      },
+    };
+    installFetch(
+      async () =>
+        new Response(JSON.stringify(recursiveSchema), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    await openapiShowCommand("listCategories", undefined, { profile: "default", json: true });
+    const out = stdoutChunks.join("");
+    const parsed = JSON.parse(out);
+    expect(parsed.method).toBe("GET");
+    expect(parsed.path).toBe("/api/categories");
+    // Either the fallback triggered (warning + raw $ref preserved) OR
+    // swagger-parser declined to create a cycle and the $ref is still
+    // printable — both outcomes are acceptable and neither crashes.
+    expect(parsed.operation).toBeDefined();
+  });
+
   it("exits 1 with an actionable hint when the operation is unknown", async () => {
     await seedLoggedInProfile();
     installFetch(

--- a/apps/cli/test/openapi-format.test.ts
+++ b/apps/cli/test/openapi-format.test.ts
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `lib/openapi-format.ts` — pure (no I/O, no process,
+ * no keyring). Exercises every filter predicate against the shared
+ * fixture (`test/fixtures/openapi-fixture.json`) plus the text /
+ * JSON formatters.
+ *
+ * The fixture covers:
+ *   - multiple tags (runs, agents, legacy)
+ *   - every HTTP method we care about
+ *   - nested path params (`/api/runs/{id}`)
+ *   - a deprecated op
+ *   - $ref'd request / response schemas
+ *
+ * Tests are deterministic — we never run against the network. The
+ * cache + command tests own integration coverage.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  collectOperations,
+  filterOperations,
+  findOperation,
+  formatList,
+  formatShow,
+  matchesMethod,
+  matchesPath,
+  matchesSearch,
+  matchesTag,
+  toListJson,
+} from "../src/lib/openapi-format.ts";
+import type { OpenApiDocument } from "../src/lib/openapi-cache.ts";
+
+const FIXTURE: OpenApiDocument = JSON.parse(
+  readFileSync(join(import.meta.dir, "fixtures", "openapi-fixture.json"), "utf-8"),
+) as OpenApiDocument;
+
+describe("collectOperations", () => {
+  it("flattens every path x method into a sorted list", () => {
+    const ops = collectOperations(FIXTURE);
+    const ids = ops.map((o) => `${o.method.toUpperCase()} ${o.path}`);
+    expect(ids).toEqual([
+      "GET /api/agents",
+      "GET /api/agents/{id}",
+      "PUT /api/agents/{id}",
+      "GET /api/deprecated",
+      "GET /api/runs",
+      "POST /api/runs",
+      "GET /api/runs/{id}",
+      "DELETE /api/runs/{id}",
+    ]);
+  });
+
+  it("returns an empty list when paths is missing or empty", () => {
+    expect(collectOperations({} as OpenApiDocument)).toEqual([]);
+    expect(collectOperations({ paths: {} } as OpenApiDocument)).toEqual([]);
+  });
+
+  it("ignores non-method siblings under a path (parameters, summary, servers)", () => {
+    // Deliberately malformed path item: parameters / summary sit next
+    // to a real `get` operation. collectOperations must yield only the
+    // `get` entry.
+    const doc = {
+      paths: {
+        "/x": {
+          parameters: [{ name: "p", in: "query" }],
+          summary: "path-level",
+          get: { operationId: "gx", responses: { "200": { description: "OK" } } },
+        },
+      },
+    } as unknown as OpenApiDocument;
+    const ops = collectOperations(doc);
+    expect(ops).toHaveLength(1);
+    expect(ops[0]!.method).toBe("get");
+  });
+});
+
+describe("matchesTag", () => {
+  const [run] = collectOperations(FIXTURE).filter((o) => o.op.operationId === "listRuns");
+  if (!run) throw new Error("fixture drift: listRuns missing");
+
+  it("matches exactly (case-insensitive)", () => {
+    expect(matchesTag(run, "runs")).toBe(true);
+    expect(matchesTag(run, "RUNS")).toBe(true);
+    expect(matchesTag(run, "Runs")).toBe(true);
+  });
+
+  it("rejects unrelated tags", () => {
+    expect(matchesTag(run, "agents")).toBe(false);
+    expect(matchesTag(run, "")).toBe(true); // empty = no filter
+  });
+
+  it("treats undefined filter as no-op (matches all)", () => {
+    expect(matchesTag(run, undefined)).toBe(true);
+  });
+
+  it("rejects operations without the tag array", () => {
+    const noTags = { ...run, op: { ...run.op, tags: undefined } };
+    expect(matchesTag(noTags, "runs")).toBe(false);
+  });
+});
+
+describe("matchesMethod", () => {
+  const [run] = collectOperations(FIXTURE).filter((o) => o.op.operationId === "listRuns");
+  if (!run) throw new Error("fixture drift: listRuns missing");
+
+  it("case-insensitive", () => {
+    expect(matchesMethod(run, "get")).toBe(true);
+    expect(matchesMethod(run, "GET")).toBe(true);
+  });
+
+  it("rejects non-matching methods", () => {
+    expect(matchesMethod(run, "post")).toBe(false);
+  });
+
+  it("no filter matches all", () => {
+    expect(matchesMethod(run, undefined)).toBe(true);
+  });
+});
+
+describe("matchesPath (glob)", () => {
+  const [listRuns] = collectOperations(FIXTURE).filter((o) => o.op.operationId === "listRuns");
+  const [getRun] = collectOperations(FIXTURE).filter((o) => o.op.operationId === "getRun");
+  if (!listRuns || !getRun) throw new Error("fixture drift");
+
+  it("exact match only when no glob", () => {
+    expect(matchesPath(listRuns, "/api/runs")).toBe(true);
+    expect(matchesPath(getRun, "/api/runs")).toBe(false);
+  });
+
+  it("single-segment * match", () => {
+    // /api/* matches /api/runs but not /api/runs/{id} (two segments deep)
+    expect(matchesPath(listRuns, "/api/*")).toBe(true);
+    expect(matchesPath(getRun, "/api/*")).toBe(false);
+  });
+
+  it("multi-segment ** match", () => {
+    expect(matchesPath(getRun, "/api/**")).toBe(true);
+    expect(matchesPath(listRuns, "/api/**")).toBe(true);
+  });
+
+  it("escapes regex metacharacters in the path", () => {
+    // The `{id}` contains braces — must be treated literally, not as regex
+    expect(matchesPath(getRun, "/api/runs/{id}")).toBe(true);
+    expect(matchesPath(getRun, "/api/runs/*")).toBe(true);
+  });
+
+  it("no filter matches all", () => {
+    expect(matchesPath(listRuns, undefined)).toBe(true);
+  });
+});
+
+describe("matchesSearch", () => {
+  const [listRuns] = collectOperations(FIXTURE).filter((o) => o.op.operationId === "listRuns");
+  if (!listRuns) throw new Error("fixture drift");
+
+  it("matches on operationId, case-insensitive", () => {
+    expect(matchesSearch(listRuns, "listruns")).toBe(true);
+    expect(matchesSearch(listRuns, "LISTRUNS")).toBe(true);
+  });
+
+  it("matches on summary", () => {
+    expect(matchesSearch(listRuns, "list")).toBe(true);
+  });
+
+  it("matches on description", () => {
+    expect(matchesSearch(listRuns, "current org")).toBe(true);
+  });
+
+  it("matches on path", () => {
+    expect(matchesSearch(listRuns, "/api/runs")).toBe(true);
+  });
+
+  it("rejects non-matching queries", () => {
+    expect(matchesSearch(listRuns, "agentx")).toBe(false);
+  });
+
+  it("no filter matches all", () => {
+    expect(matchesSearch(listRuns, undefined)).toBe(true);
+  });
+});
+
+describe("filterOperations", () => {
+  it("composes all filters (AND semantics)", () => {
+    const entries = collectOperations(FIXTURE);
+    const out = filterOperations(entries, { tag: "runs", method: "post" });
+    expect(out).toHaveLength(1);
+    expect(out[0]!.op.operationId).toBe("createRun");
+  });
+
+  it("returns empty list when no filter matches", () => {
+    const entries = collectOperations(FIXTURE);
+    const out = filterOperations(entries, { tag: "nonexistent" });
+    expect(out).toEqual([]);
+  });
+
+  it("returns all entries with no filters", () => {
+    const entries = collectOperations(FIXTURE);
+    const out = filterOperations(entries, {});
+    expect(out.length).toBe(entries.length);
+  });
+
+  it("combines tag + path glob", () => {
+    const entries = collectOperations(FIXTURE);
+    const out = filterOperations(entries, { tag: "runs", path: "/api/runs/*" });
+    expect(out.map((e) => e.op.operationId)).toEqual(["getRun", "cancelRun"]);
+  });
+
+  it("search filter respects case-insensitivity", () => {
+    const entries = collectOperations(FIXTURE);
+    const out = filterOperations(entries, { search: "AGENT" });
+    expect(out.length).toBeGreaterThan(0);
+    expect(out.every((e) => (e.op.tags ?? []).includes("agents"))).toBe(true);
+  });
+});
+
+describe("findOperation", () => {
+  it("finds by operationId", () => {
+    const entry = findOperation(FIXTURE, "createRun");
+    expect(entry?.method).toBe("post");
+    expect(entry?.path).toBe("/api/runs");
+  });
+
+  it("finds by METHOD path", () => {
+    const entry = findOperation(FIXTURE, "GET", "/api/runs");
+    expect(entry?.op.operationId).toBe("listRuns");
+  });
+
+  it("parses 'METHOD /path' from a single arg", () => {
+    const entry = findOperation(FIXTURE, "DELETE /api/runs/{id}");
+    expect(entry?.op.operationId).toBe("cancelRun");
+  });
+
+  it("returns null for unknown operationId", () => {
+    expect(findOperation(FIXTURE, "doesNotExist")).toBeNull();
+  });
+
+  it("returns null when METHOD doesn't match path", () => {
+    expect(findOperation(FIXTURE, "POST", "/api/runs/{id}")).toBeNull();
+  });
+});
+
+describe("formatList", () => {
+  it("emits one line per entry with plain output", () => {
+    const ops = collectOperations(FIXTURE);
+    const out = formatList(ops, false);
+    const lines = out.trimEnd().split("\n");
+    expect(lines).toHaveLength(ops.length);
+    // Method is padded to 6 chars so paths line up — `GET   ` is 6 chars
+    expect(lines[0]).toMatch(/^GET {4}/); // "GET" + 3 spaces + space separator (padEnd(6)) then space
+    expect(lines.some((l) => l.includes("DELETE"))).toBe(true);
+  });
+
+  it("shows [deprecated] for deprecated operations", () => {
+    const ops = collectOperations(FIXTURE);
+    const out = formatList(ops, false);
+    expect(out).toContain("[deprecated]");
+  });
+
+  it("shows tags in brackets", () => {
+    const ops = collectOperations(FIXTURE).filter((o) => o.op.operationId === "createRun");
+    const out = formatList(ops, false);
+    expect(out).toContain("[runs]");
+  });
+
+  it("includes the summary with a dash separator", () => {
+    const ops = collectOperations(FIXTURE).filter((o) => o.op.operationId === "createRun");
+    expect(formatList(ops, false)).toContain("— Create a run");
+  });
+
+  it("friendly message when the filtered list is empty", () => {
+    expect(formatList([], false)).toMatch(/No operations match/);
+  });
+
+  it("includes ANSI color codes when useColor=true", () => {
+    const ops = collectOperations(FIXTURE).filter((o) => o.op.operationId === "createRun");
+    const out = formatList(ops, true);
+    expect(out).toContain("\x1b[");
+  });
+
+  it("omits ANSI color codes when useColor=false", () => {
+    const ops = collectOperations(FIXTURE).filter((o) => o.op.operationId === "createRun");
+    const out = formatList(ops, false);
+    expect(out).not.toContain("\x1b[");
+  });
+});
+
+describe("toListJson", () => {
+  it("emits minimal stable shape", () => {
+    const ops = collectOperations(FIXTURE).filter((o) => o.op.operationId === "createRun");
+    const json = toListJson(ops);
+    expect(json).toEqual([
+      {
+        method: "POST",
+        path: "/api/runs",
+        operationId: "createRun",
+        summary: "Create a run",
+        tags: ["runs"],
+      },
+    ]);
+  });
+
+  it("omits optional fields when absent", () => {
+    const ops = collectOperations(FIXTURE).filter((o) => o.op.operationId === "listAgents");
+    const json = toListJson(ops);
+    expect(json[0]).toEqual({
+      method: "GET",
+      path: "/api/agents",
+      operationId: "listAgents",
+      summary: "List agents",
+      tags: ["agents"],
+    });
+  });
+
+  it("includes deprecated=true when set", () => {
+    const ops = collectOperations(FIXTURE).filter((o) => o.op.operationId === "legacyThing");
+    expect(toListJson(ops)[0]?.deprecated).toBe(true);
+  });
+});
+
+describe("formatShow", () => {
+  it("renders summary / description / parameters / responses", () => {
+    const entry = findOperation(FIXTURE, "listRuns");
+    if (!entry) throw new Error("fixture drift");
+    const out = formatShow(entry, false);
+    expect(out).toContain("GET /api/runs");
+    expect(out).toContain("operationId: listRuns");
+    expect(out).toContain("tags: runs");
+    expect(out).toContain("List runs");
+    expect(out).toContain("Parameters:");
+    expect(out).toContain("query.limit");
+    expect(out).toContain("Responses:");
+    expect(out).toContain("200");
+    expect(out).toContain("401");
+    expect(out).toContain("application/json");
+  });
+
+  it("marks required parameters", () => {
+    const entry = findOperation(FIXTURE, "getRun");
+    if (!entry) throw new Error("fixture drift");
+    const out = formatShow(entry, false);
+    expect(out).toContain("path.id");
+    expect(out).toContain("(required)");
+  });
+
+  it("renders request body section when present", () => {
+    const entry = findOperation(FIXTURE, "createRun");
+    if (!entry) throw new Error("fixture drift");
+    const out = formatShow(entry, false);
+    expect(out).toContain("Request body (required):");
+    expect(out).toContain("application/json");
+  });
+
+  it("marks deprecated operations prominently", () => {
+    const entry = findOperation(FIXTURE, "legacyThing");
+    if (!entry) throw new Error("fixture drift");
+    const out = formatShow(entry, false);
+    expect(out).toContain("DEPRECATED");
+  });
+
+  it("handles operations with no parameters and no request body", () => {
+    const entry = findOperation(FIXTURE, "listAgents");
+    if (!entry) throw new Error("fixture drift");
+    const out = formatShow(entry, false);
+    expect(out).toContain("GET /api/agents");
+    // No parameters section since the op has none
+    expect(out).not.toContain("Parameters:");
+  });
+});

--- a/apps/cli/test/openapi-format.test.ts
+++ b/apps/cli/test/openapi-format.test.ts
@@ -151,6 +151,31 @@ describe("matchesPath (glob)", () => {
   it("no filter matches all", () => {
     expect(matchesPath(listRuns, undefined)).toBe(true);
   });
+
+  it("rejects patterns exceeding the length cap", () => {
+    // Defense against absurdly long CLI input — above 200 chars returns
+    // false without running the matcher at all.
+    const longPattern = "/api/" + "*".repeat(250);
+    expect(matchesPath(listRuns, longPattern)).toBe(false);
+  });
+
+  it("treats regex metacharacters in the pattern as literals", () => {
+    // Confirms the old globToRegex metachar-escaping contract still
+    // holds with the iterative matcher: parens / brackets / dots in
+    // the pattern must match themselves, not act as regex tokens.
+    expect(matchesPath(getRun, "/api/runs/{id}")).toBe(true);
+    expect(matchesPath(listRuns, "/api/runs.*")).toBe(false);
+    expect(matchesPath(listRuns, "/api/run[s]")).toBe(false);
+  });
+
+  it("does not exhibit catastrophic backtracking on pathological input", () => {
+    // Iterative two-pointer matcher is O(pattern · path). Even heavy
+    // alternation-style inputs complete in sub-millisecond.
+    const pathological = "a".repeat(50) + "/*".repeat(20);
+    const start = performance.now();
+    matchesPath(listRuns, pathological);
+    expect(performance.now() - start).toBeLessThan(50);
+  });
 });
 
 describe("matchesSearch", () => {

--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,7 @@
         "appstrate": "./dist/cli.js",
       },
       "dependencies": {
+        "@apidevtools/swagger-parser": "^12.1.0",
         "@clack/prompts": "^1.2.0",
         "@napi-rs/keyring": "^1.2.0",
         "async-mutex": "^0.5.0",
@@ -297,6 +298,12 @@
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.73.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-URURVzhxXGJDGUGFunIOtBlSl7KWvZiAAKY/ttTkZAkXT9bTPqdk2eK0b8qqSxXpikh3QKPnPYpiyX98zf5ebw=="],
 
     "@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@14.2.1", "", { "dependencies": { "js-yaml": "^4.1.0" }, "peerDependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-HmdFw9CDYqM6B25pqGBpNeLCKvGPlIx1EbLrVL0zPvj50CJQUHyBNBw45Muk0kEIkogo1VZvOKHajdMuAzSxRg=="],
+
+    "@apidevtools/openapi-schemas": ["@apidevtools/openapi-schemas@2.1.0", "", {}, "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ=="],
+
+    "@apidevtools/swagger-methods": ["@apidevtools/swagger-methods@3.0.2", "", {}, "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg=="],
+
+    "@apidevtools/swagger-parser": ["@apidevtools/swagger-parser@12.1.0", "", { "dependencies": { "@apidevtools/json-schema-ref-parser": "14.0.1", "@apidevtools/openapi-schemas": "^2.1.0", "@apidevtools/swagger-methods": "^3.0.2", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "call-me-maybe": "^1.0.2" }, "peerDependencies": { "openapi-types": ">=7" } }, "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng=="],
 
     "@appstrate/api": ["@appstrate/api@workspace:apps/api"],
 
@@ -1286,6 +1293,8 @@
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
+    "call-me-maybe": ["call-me-maybe@1.0.2", "", {}, "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ=="],
+
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001782", "", {}, "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw=="],
@@ -2249,6 +2258,8 @@
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@apidevtools/swagger-parser/@apidevtools/json-schema-ref-parser": ["@apidevtools/json-schema-ref-parser@14.0.1", "", { "dependencies": { "@types/json-schema": "^7.0.15", "js-yaml": "^4.1.0" } }, "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw=="],
 
     "@appstrate/web/vite": ["vite@8.0.8", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.15", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw=="],
 


### PR DESCRIPTION
## Summary

Adds `appstrate openapi` with `list`, `show`, and `export` subcommands to explore the API's OpenAPI schema from the CLI without flooding stdout (the full spec is ~237 endpoints today).

Closes #206

## Changes

- **`list`** — compact one-line-per-operation index, filterable by `--tag`, `--method`, `--path` (glob), `--search` (substring across operationId / summary / description / path). Colored by HTTP method when stdout is a TTY; `--json` emits a minimal array for agents / jq.
- **`show <operationId | METHOD /path>`** — detailed view of a single operation with `$ref` dereferencing via `@apidevtools/swagger-parser` (12.x). Text summary (params, request/response content types) by default; `--json` emits the full dereferenced operation object.
- **`export [-o <file>]`** — raw schema dump (escape hatch). Equivalent to `appstrate api GET /api/openapi.json` but served from cache when possible.
- **Per-profile ETag cache** at `~/.cache/appstrate/openapi-<profile>.json` (`+ .etag`). Second and subsequent invocations send `If-None-Match` and short-circuit on 304. `--refresh` forces a fresh fetch + cache update; `--no-cache` is fully ephemeral (no read, no write). Corrupt cache JSON or missing ETag files are tolerated (treated as a miss).
- **Auth errors** route through `formatError` / stderr + exit 1 for consistency with `whoami`, `logout`, etc. Global `--profile` and `--insecure` flags are respected.
- **78 new tests** covering every filter predicate, formatter branch, cache hit/miss/ETag/corruption path, and the three subcommands (auth errors, `--json` mode, `--no-cache` bypass, export to file).
- **README updated** with the new command and subcommand flag tables.

## Design decisions (per plan in issue comment)

- Client-side filtering over server-side query params — keeps the CLI release cadence decoupled from the API surface (plan §4 explicitly rejected server-side filtering).
- ETag cache instead of streaming JSON parsing — simpler, faster after first warm-up, and the schema is small enough that holding it in memory is fine.
- `swagger-parser` for `show` `$ref` resolution — reuses a battle-tested parser rather than rolling our own.
- `detectColor()` respects `NO_COLOR` + `FORCE_COLOR` env vars (no-color.org convention); tests see plain output because Bun's test runner reports `process.stdout.isTTY === undefined`.

## Test plan

- [x] `bun run check` passes (turbo tsc + eslint + prettier + verify:openapi + detect:breaking across all packages)
- [x] `cd apps/cli && bun test` — 550 / 550 pass (78 new)
- [ ] Manual smoke:
  - `appstrate openapi list`
  - `appstrate openapi list --tag runs`
  - `appstrate openapi list --method post --json`
  - `appstrate openapi show createRun`
  - `appstrate openapi show GET /api/runs`
  - `appstrate openapi export -o /tmp/schema.json`
  - `appstrate openapi list --refresh` (verify cache overwrite)
  - `appstrate openapi list --no-cache` (verify no disk write)

🤖 Generated with [Claude Code](https://claude.com/claude-code)