### PR TITLE
fix(test): force non-TTY + no-color + no-open in CLI test preloads

### DIFF
--- a/apps/cli/test/setup/preload.ts
+++ b/apps/cli/test/setup/preload.ts
@@ -3,11 +3,18 @@
 /**
  * Test preload — runs before every `bun test` file.
  *
- * Sets `APPSTRATE_CLI_NO_OPEN=1` so the production `open()` call in
- * `commands/login.ts` is a no-op during tests. Primary defense is
- * dependency injection (`LoginDeps.openUrl`), but any suite that
- * forgets the wrapper would still pop real browser tabs — this env
- * var is the belt-and-suspenders that catches copy-paste misses.
+ * Forces a deterministic non-interactive environment so tests behave
+ * identically whether launched from a TTY shell or CI:
+ *  - `APPSTRATE_CLI_NO_OPEN=1` — `defaultOpenUrl()` in `commands/login.ts`
+ *    is a no-op (no real browser tabs).
+ *  - `NO_COLOR=1` — `detectColor()` in `commands/openapi.ts` returns false,
+ *    so formatters emit plain strings that match the expected snapshots.
+ *  - `process.stdin.isTTY = false` — the `askText` / `confirm` guards in
+ *    `lib/ui.ts` throw immediately instead of blocking on clack.
  */
 
 process.env.APPSTRATE_CLI_NO_OPEN = "1";
+process.env.NO_COLOR = "1";
+Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+Object.defineProperty(process.stderr, "isTTY", { value: false, configurable: true });

--- a/test/setup/preload.ts
+++ b/test/setup/preload.ts
@@ -75,6 +75,19 @@ delete process.env.GOOGLE_CLIENT_SECRET;
 process.env.SIDECAR_POOL_SIZE = "0"; // Disable sidecar pool in tests
 process.env.DOCKER_SOCKET = "http://localhost:2375";
 
+// Belt-and-suspenders: when `bun test` runs from the monorepo root, the
+// CLI's own bunfig preload (which sets these) is ignored in favour of this
+// one. Without them, tests launched from a real terminal (not CI) inherit
+// isTTY=true and diverge: login pops real browser tabs, openapi emits ANSI
+// colors the snapshots don't expect, and the non-TTY prompt guards block
+// waiting for input. Force non-TTY + no-color + no-open so bun:test behaves
+// identically whether launched from a TTY shell or CI.
+process.env.APPSTRATE_CLI_NO_OPEN = "1";
+process.env.NO_COLOR = "1";
+Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
+Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+Object.defineProperty(process.stderr, "isTTY", { value: false, configurable: true });
+
 // ─── MinIO bucket creation ───────────────────────────────────
 // Create the test bucket via mc inside the MinIO container (idempotent).
 const mcAlias = Bun.spawnSync(


### PR DESCRIPTION
## Summary

When `bun test` runs from an interactive terminal (not CI), `process.stdin.isTTY` and `process.stdout.isTTY` are inherited as `true` — which makes the CLI suite non-deterministic:

- **openapi-command tests** expected plain strings like `"— List runs"` but received ANSI-colored output (`detectColor()` in `commands/openapi.ts:92` falls back to `process.stdout.isTTY`) → 4 failures
- **ui non-TTY guard tests** failed their `expect(process.stdin.isTTY).toBeFalsy()` precondition
- **login tests** risked popping real browser tabs via `defaultOpenUrl()` in `commands/login.ts:69`
- **clack prompts** blocked waiting on stdin

## Fix

Force a deterministic non-interactive environment in both test preloads:

- `APPSTRATE_CLI_NO_OPEN=1` — neuters `open()` in login flow
- `NO_COLOR=1` — `detectColor()` returns false, formatters emit plain output
- `process.stdin/stdout/stderr.isTTY = false` via `Object.defineProperty` — `askText` / `confirm` guards throw immediately instead of blocking on clack

Both the root preload (`test/setup/preload.ts`) and the CLI bunfig preload (`apps/cli/test/setup/preload.ts`) are updated — the CLI one alone is insufficient because it is ignored when `bun test` runs from the monorepo root.

## Test plan

- [x] `bun test apps/cli/` → 586/586 pass
- [ ] CI: full suite passes on GitHub Actions
- [ ] Manual: run `bun test apps/cli/` from a real interactive terminal and confirm no regressions / no browser tabs / no blocking prompts