### PR TITLE
chore(core): bump to 2.13.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "2.12.0",
+  "version": "2.13.0",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Bump @appstrate/core to 2.13.0 for v1.0.0-alpha.62 release.

Changes since core@2.12.0:
- feat(core,api): named read services on PlatformServices (#203)
- chore: remove legacy shims + dedupe types and JOINs (#218)