### PR TITLE
fix(cli): auto-pick next free port under --yes + document shell-scoping gotcha

### DIFF
--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -127,6 +127,12 @@ export async function installCommand(opts: InstallOptions): Promise<void> {
     const project =
       tier === 0 ? undefined : await resolveProjectName(dir, installState.existing.hasCompose);
 
+    // Under --yes, soften port conflicts by auto-picking the next free
+    // port instead of failing fast. Rationale: the one-liner installer's
+    // user contract is "paste into terminal, get a working Appstrate"
+    // — and the single most common snag is a stale dev server still
+    // bound to :3000 from an earlier session. A strict --tier N script
+    // keeps the fail-fast semantics so CI/automation surfaces the drift.
     const port = await resolveAppstratePort(
       opts.port,
       nonInteractive,
@@ -134,6 +140,7 @@ export async function installCommand(opts: InstallOptions): Promise<void> {
       installState.existing,
       dir,
       project?.name,
+      { autoPick: autoConfirm },
     );
     const minioConsolePort =
       tier === 3
@@ -144,6 +151,7 @@ export async function installCommand(opts: InstallOptions): Promise<void> {
             installState.existing,
             dir,
             project?.name,
+            { autoPick: autoConfirm },
           )
         : undefined;
 
@@ -169,7 +177,31 @@ const NO_EXISTING_INSTALL: ExistingInstall = { hasEnv: false, hasCompose: false,
 /** DI seam for the cross-check with `docker compose ls` — tests inject a fake, production uses the real helper. */
 export interface PortResolverDeps {
   findRunningComposeProject?: (name: string) => Promise<RunningComposeProject | null>;
+  /**
+   * When the preferred port is busy under non-interactive mode, probe
+   * upward (port+1, port+2, …) and use the first free one instead of
+   * failing fast. Wired to `--yes` by `installCommand` so `curl | bash`
+   * re-runs that hit a stale process on :3000 just pick :3001 — matches
+   * the "it just works" contract of the bootstrap installer. Defaulting
+   * to false keeps explicit `--tier N` scripted installs strict: they
+   * surface the conflict instead of silently drifting the port.
+   *
+   * Bounded scan (`AUTO_PICK_MAX_ATTEMPTS`) so a host with dense port
+   * usage can't take us on an O(65k) walk before failing — we'd rather
+   * error cleanly and let the user pass `--port <n>` explicitly.
+   */
+  autoPick?: boolean;
 }
+
+/**
+ * Upper bound on the auto-pick scan window. 20 is deliberately small:
+ * the goal is to tolerate "a stale dev server is still on :3000",
+ * not to gracefully handle a host where the next 200 ports are busy.
+ * If 20 probes come back busy it's almost always a broader problem
+ * (port-scanning tool, misconfigured firewall, thousands of containers)
+ * that the user should see as an error rather than a silent drift.
+ */
+const AUTO_PICK_MAX_ATTEMPTS = 20;
 
 /**
  * Decide whether the inherited port belongs to OUR running stack. Only
@@ -227,7 +259,14 @@ export async function resolveAppstratePort(
       return inherited;
     }
   }
-  return ensurePortFree(requested, "APPSTRATE_PORT", "--port", "Appstrate", nonInteractive);
+  return ensurePortFree(
+    requested,
+    "APPSTRATE_PORT",
+    "--port",
+    "Appstrate",
+    nonInteractive,
+    deps.autoPick ?? false,
+  );
 }
 
 /** Resolve the MinIO console port (Tier 3); preflight-skip additionally gated on MINIO_ROOT_PASSWORD so a Tier 1/2 → 3 upgrade still probes the net-new port. */
@@ -270,6 +309,7 @@ export async function resolveMinioConsolePort(
     "--minio-console-port",
     "MinIO console",
     nonInteractive,
+    deps.autoPick ?? false,
   );
 }
 
@@ -309,9 +349,31 @@ export function parsePort(
 }
 
 /**
+ * Probe `port` upward (port+1, port+2, …) until a free one is found or
+ * the attempt budget is exhausted. Skips the input `port` itself (the
+ * caller already proved it's busy). Returns `null` when the whole
+ * window is busy or the scan walks past 65535 — the caller decides
+ * whether that's fatal or just a fallback to the strict error.
+ */
+async function findNextFreePort(startExclusive: number): Promise<number | null> {
+  for (let offset = 1; offset <= AUTO_PICK_MAX_ATTEMPTS; offset++) {
+    const candidate = startExclusive + offset;
+    if (candidate > 65535) return null;
+    if (await isPortAvailable(candidate)) return candidate;
+  }
+  return null;
+}
+
+/**
  * Probe the port; on conflict, print a best-effort "who's holding it"
- * hint and either prompt the user for a new one (interactive) or
- * throw a helpful error (non-interactive).
+ * hint and either
+ *   - pick the next free port silently-ish (non-interactive + autoPick,
+ *     i.e. the `curl|bash --yes` path — the user explicitly asked for
+ *     zero prompts, and a stale :3000 is the common failure mode),
+ *   - fail fast with a message naming both flag and env-var escape
+ *     hatches (non-interactive without autoPick — scripted installs
+ *     that want strict semantics), or
+ *   - prompt the user for a new port (interactive).
  */
 async function ensurePortFree(
   port: number,
@@ -319,15 +381,40 @@ async function ensurePortFree(
   flagName: string,
   label: string,
   nonInteractive: boolean,
+  autoPick = false,
 ): Promise<number> {
   if (await isPortAvailable(port)) return port;
 
   const holder = await describeProcessOnPort(port);
   const holderHint = holder ? ` Held by ${holder}.` : "";
 
+  if (nonInteractive && autoPick) {
+    const next = await findNextFreePort(port);
+    if (next !== null) {
+      // log.info (not warn) because this is the designed happy path of
+      // --yes — "just pick a free port". The message still names the
+      // override knobs so a user who does care can redirect on re-run.
+      clack.log.info(
+        `Port ${port} (${label}) in use.${holderHint} Auto-picked ${next} instead — pass ${flagName} <n> or pipe via \`curl … | ${envVar}=<n> bash\` to override.`,
+      );
+      return next;
+    }
+    // Fall through to the strict error below. The scan window was
+    // bounded (AUTO_PICK_MAX_ATTEMPTS), and a host with that many
+    // contiguous busy ports is almost never something the installer
+    // should be papering over silently.
+  }
+
   if (nonInteractive) {
+    // Shell gotcha: `${envVar}=<n> curl -fsSL … | bash` sets the env var
+    // for `curl` only, not for the piped `bash` that exec's this CLI.
+    // We call it out explicitly because `curl | bash` is the documented
+    // one-liner and this mistake is common enough to merit a hint in
+    // the error itself rather than buried in a support thread.
     throw new Error(
-      `Port ${port} is already in use (${label}).${holderHint} Re-run with ${flagName} <n> or set ${envVar}=<n> to pick a free port.`,
+      `Port ${port} is already in use (${label}).${holderHint} ` +
+        `Re-run with ${flagName} <n>, or pipe via \`curl -fsSL https://get.appstrate.dev | ${envVar}=<n> bash\` ` +
+        `(note: \`${envVar}=<n> curl … | bash\` sets the var for curl, not bash — use the syntax above instead).`,
     );
   }
 

--- a/apps/cli/test/install.test.ts
+++ b/apps/cli/test/install.test.ts
@@ -384,11 +384,158 @@ describe("resolveAppstratePort (non-interactive preflight)", () => {
     );
   });
 
+  it("documents the correct `curl | VAR=N bash` syntax in the strict error", async () => {
+    // Regression guard for the shell-scoping gotcha that triggered this
+    // whole change: users reach for `APPSTRATE_PORT=N curl … | bash`,
+    // which sets the var for curl only — the piped bash doesn't see it.
+    // The error message must name the working syntax explicitly, or the
+    // user has no way to discover why their "override" was ignored.
+    const port = await holdEphemeralPort(servers);
+    await expect(resolveAppstratePort(String(port), true)).rejects.toThrow(
+      /curl[^\n]*\|[^\n]*APPSTRATE_PORT=[^\n]*bash/,
+    );
+  });
+
   it("honors APPSTRATE_PORT when --port is absent", async () => {
     const port = await pickEphemeralPort();
     process.env.APPSTRATE_PORT = String(port);
     const out = await resolveAppstratePort(undefined, true);
     expect(out).toBe(port);
+  });
+});
+
+/**
+ * Auto-pick mode (wired from `--yes` by `installCommand`). The one-liner
+ * installer's contract is "paste into a terminal, get a working
+ * Appstrate" — the single most common snag is a stale dev server still
+ * bound to :3000 from an earlier session. Under `--yes` we soften the
+ * port conflict into "use the next free port" instead of failing fast.
+ *
+ * Explicit scripted installs (`--tier N` without `--yes`) keep
+ * the strict semantics so CI/automation still surfaces the drift.
+ */
+describe("resolveAppstratePort auto-pick (--yes path)", () => {
+  const servers: Server[] = [];
+  const originalEnvPort = process.env.APPSTRATE_PORT;
+
+  afterEach(async () => {
+    for (const srv of servers.splice(0)) await new Promise((r) => srv.close(() => r(undefined)));
+    if (originalEnvPort === undefined) delete process.env.APPSTRATE_PORT;
+    else process.env.APPSTRATE_PORT = originalEnvPort;
+  });
+
+  it("picks the next free port when the requested one is held", async () => {
+    const held = await holdEphemeralPort(servers);
+    const out = await resolveAppstratePort(
+      String(held),
+      /* nonInteractive */ true,
+      "fresh",
+      undefined,
+      undefined,
+      undefined,
+      { autoPick: true },
+    );
+    // The concrete picked value depends on kernel port allocation, but
+    // it must be free (not the held port) and above the held port
+    // (scan probes upward only).
+    expect(out).toBeGreaterThan(held);
+    expect(out).toBeLessThanOrEqual(65535);
+  });
+
+  it("returns the requested port unchanged when it is free (no drift)", async () => {
+    // Auto-pick must be a conflict-only fallback, never a silent drift
+    // when the user's chosen port works. A regression here would break
+    // users who pass `--yes --port 4000` with :4000 free.
+    const port = await pickEphemeralPort();
+    const out = await resolveAppstratePort(
+      String(port),
+      true,
+      "fresh",
+      undefined,
+      undefined,
+      undefined,
+      { autoPick: true },
+    );
+    expect(out).toBe(port);
+  });
+
+  it("scans past two contiguous held ports (the common stale-dev-server shape)", async () => {
+    // Locks down the "probe upward in a loop" contract: if port N is
+    // held AND port N+1 is held, the resolver must land on N+2. Catches
+    // a regression where findNextFreePort only checks the very next slot.
+    const first = await holdEphemeralPort(servers);
+    const second = await tryHoldSpecificPort(servers, first + 1);
+    if (second === null) {
+      // Adjacent slot is busy for an unrelated reason — skip rather
+      // than assert on OS-dependent allocation we don't control.
+      return;
+    }
+    const out = await resolveAppstratePort(
+      String(first),
+      true,
+      "fresh",
+      undefined,
+      undefined,
+      undefined,
+      { autoPick: true },
+    );
+    expect(out).toBeGreaterThan(second);
+  });
+
+  it("is off by default — omitting autoPick preserves strict fail-fast (--tier N path)", async () => {
+    const port = await holdEphemeralPort(servers);
+    // No `{ autoPick: … }` in deps → explicit --tier scripted install
+    // keeps the "error loudly" behaviour CI relies on.
+    await expect(resolveAppstratePort(String(port), true)).rejects.toThrow(/already in use/);
+  });
+
+  it("autoPick: false is explicitly treated as disabled (not coerced to truthy)", async () => {
+    const port = await holdEphemeralPort(servers);
+    await expect(
+      resolveAppstratePort(String(port), true, "fresh", undefined, undefined, undefined, {
+        autoPick: false,
+      }),
+    ).rejects.toThrow(/already in use/);
+  });
+
+  it("still honors APPSTRATE_PORT when auto-picking (env var sets the starting point)", async () => {
+    // The env var defines the USER's intent. Auto-pick only kicks in if
+    // THAT port is busy. If the user set APPSTRATE_PORT=<free port>,
+    // they must get that exact port — no drift, no log noise.
+    const port = await pickEphemeralPort();
+    process.env.APPSTRATE_PORT = String(port);
+    const out = await resolveAppstratePort(
+      undefined,
+      true,
+      "fresh",
+      undefined,
+      undefined,
+      undefined,
+      { autoPick: true },
+    );
+    expect(out).toBe(port);
+  });
+
+  it("does not trigger in interactive mode (autoPick is non-interactive only)", async () => {
+    // autoPick is gated on nonInteractive=true INSIDE ensurePortFree —
+    // passing `autoPick: true` under nonInteractive=false must fall
+    // through to the interactive prompt branch, never silently drift
+    // to a different port. Under this test harness stdin is not a TTY,
+    // so the interactive askText rejects — that rejection is our proof
+    // that auto-pick did NOT take over. The key negative assertion is
+    // "did not resolve to held+N"; any rejection satisfies that.
+    const port = await holdEphemeralPort(servers);
+    await expect(
+      resolveAppstratePort(
+        String(port),
+        /* nonInteractive */ false,
+        "fresh",
+        undefined,
+        undefined,
+        undefined,
+        { autoPick: true },
+      ),
+    ).rejects.toThrow();
   });
 });
 
@@ -403,6 +550,30 @@ describe("resolveMinioConsolePort (non-interactive preflight)", () => {
     await expect(resolveMinioConsolePort(String(port), true)).rejects.toThrow(
       /MinIO console.*--minio-console-port|APPSTRATE_MINIO_CONSOLE_PORT/,
     );
+  });
+
+  it("auto-picks the next free port under --yes (parity with resolveAppstratePort)", async () => {
+    // The MinIO console port conflict is rarer than the main :3000
+    // conflict, but the user contract is identical under --yes:
+    // don't fail fast, just pick a free port. Parity test so any
+    // future divergence between the two resolvers is caught here.
+    const held = await holdEphemeralPort(servers);
+    const out = await resolveMinioConsolePort(
+      String(held),
+      true,
+      "fresh",
+      undefined,
+      undefined,
+      undefined,
+      { autoPick: true },
+    );
+    expect(out).toBeGreaterThan(held);
+    expect(out).toBeLessThanOrEqual(65535);
+  });
+
+  it("strict fail-fast remains the default without autoPick (explicit --tier 3)", async () => {
+    const port = await holdEphemeralPort(servers);
+    await expect(resolveMinioConsolePort(String(port), true)).rejects.toThrow(/MinIO console/);
   });
 });
 
@@ -863,4 +1034,35 @@ async function holdEphemeralPort(holders: Server[]): Promise<number> {
   });
   holders.push(srv);
   return port;
+}
+
+/**
+ * Attempt to bind `port` specifically — returns the port on success,
+ * or `null` if something else has claimed it in the tiny window
+ * between our ephemeral pick and this follow-up bind. Used to build
+ * "two contiguous busy ports" scenarios without retrying forever when
+ * the kernel refuses to cooperate on a given slot.
+ */
+async function tryHoldSpecificPort(holders: Server[], port: number): Promise<number | null> {
+  const srv = createServer();
+  srv.unref();
+  return new Promise<number | null>((resolve) => {
+    srv.once("error", () => {
+      try {
+        srv.close();
+      } catch {
+        // already closed
+      }
+      resolve(null);
+    });
+    srv.once("listening", () => {
+      holders.push(srv);
+      resolve(port);
+    });
+    try {
+      srv.listen(port, "0.0.0.0");
+    } catch {
+      resolve(null);
+    }
+  });
 }


### PR DESCRIPTION
## Summary

- Under `--yes` (which the bootstrap always passes), `appstrate install` now probes upward (port+1, port+2, …, up to 20 candidates) on conflict and uses the first free port instead of failing fast. Explicit scripted installs (`--tier N` without `--yes`) keep strict fail-fast semantics so CI surfaces drift.
- Sharpened the strict error message to name both `--port <n>` and the working `curl -fsSL … | APPSTRATE_PORT=N bash` syntax — the `VAR=N curl … | bash` mistake is common enough to document in the error itself.
- Same treatment on `APPSTRATE_MINIO_CONSOLE_PORT` for parity.

## Why

Reported in the field: running the published one-liner on a host with a stale `bun run dev` on :3000 aborted with

> Port 3000 is already in use (Appstrate). Re-run with --port \<n> or set APPSTRATE_PORT=\<n> to pick a free port.

Users then tried `APPSTRATE_PORT=3001 curl … | bash`, which hits the classic shell-scoping gotcha (the env var is scoped to `curl`, not the piped `bash`), so the override appears silently ignored. The one-liner's contract is "paste it, get a working Appstrate" — under `--yes` we should just use :3001.

## Test plan

63 tests in `apps/cli/test/install.test.ts` (10 new), exercising:
- [x] Auto-pick returns a port `>` held when the requested one is busy
- [x] Auto-pick returns the requested port unchanged when it is free (no silent drift)
- [x] Auto-pick scans past two contiguous busy ports
- [x] `autoPick: false` and omitted `autoPick` both preserve strict fail-fast (CI contract)
- [x] `APPSTRATE_PORT=<free>` under `--yes` yields that exact port (no drift, no log)
- [x] `autoPick: true` under interactive mode does not take over (gated on `nonInteractive`)
- [x] Strict error message names `--port` and `curl | APPSTRATE_PORT=N bash`
- [x] MinIO console port has parity behaviour and label

Full quality gate:
- [x] `bun run check` — 15/15 turbo tasks green (tsc, eslint, prettier, OpenAPI validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)