### PR TITLE
feat(cli): pin applicationId on login + `appstrate app` subcommands

### DIFF
--- a/apps/cli/AGENTS.md
+++ b/apps/cli/AGENTS.md
@@ -6,9 +6,10 @@ You are an AI coding agent (Claude Code, Cursor, Codex, Gemini CLI, …) and a h
 
 Appstrate is a platform for running autonomous AI agents in sandboxed containers. Its REST API is the single source of truth — 191 endpoints documented in OpenAPI 3.1. The `appstrate` CLI is a thin, authenticated wrapper around that API:
 
-- **`appstrate api`** — `curl`-compatible HTTP passthrough. Replace `curl https://app/api/x` with `appstrate api /api/x`. The CLI injects `Authorization: Bearer <jwt>` + `X-Org-Id` from the OS keyring; you never see the bearer.
+- **`appstrate api`** — `curl`-compatible HTTP passthrough. Replace `curl https://app/api/x` with `appstrate api /api/x`. The CLI injects `Authorization: Bearer <jwt>` + `X-Org-Id` + `X-App-Id` from the OS keyring; you never see the bearer.
 - **`appstrate openapi`** — schema explorer. `list` + `show` + `export` let you discover the 191 endpoints without dumping the whole spec into your context window.
 - **`appstrate org`** — pin which organization the profile targets (`X-Org-Id`).
+- **`appstrate app`** — pin which application the profile targets (`X-App-Id`). Required for app-scoped routes (agents, runs, schedules, …).
 - **`appstrate login` / `logout` / `whoami` / `token`** — session management.
 
 Everything else the user asks for — creating an agent, triggering a run, uploading a package, managing webhooks — is expressed as `appstrate api <METHOD> <path>` plus a JSON body. The CLI never hides endpoints from you.
@@ -28,6 +29,13 @@ appstrate login --instance https://app.example.com
 
 # 3. Confirm which org is pinned (X-Org-Id sent on every call)
 appstrate org current
+
+# 3b. Confirm which application is pinned (X-App-Id sent on every call).
+#     App-scoped routes (agents, runs, schedules, webhooks, api-keys,
+#     notifications, packages, providers, connections, end-users,
+#     app-profiles) require this. `login` cascades into the default app
+#     automatically, so this usually already prints a value.
+appstrate app current
 
 # 4. Discover the "runs" domain. --json produces compact, greppable output.
 appstrate openapi list --tag runs --json
@@ -60,7 +68,7 @@ appstrate api POST /api/agents/agt_123/run \
 1. **Discover before you POST.** Always run `appstrate openapi show <operationId> --json` before constructing a request body. Schemas change; your training data lies.
 2. **Never hard-code tokens.** If you find yourself writing `Authorization: Bearer …`, you've failed the design. The CLI owns the bearer; you just call `appstrate api`.
 3. **Never print tokens.** `appstrate token` returns metadata only — never the plaintext. Do not try to extract tokens from the keyring.
-4. **Respect the org boundary.** `X-Org-Id` is auto-injected from the pinned profile. To operate on a different org, run `appstrate org switch <slug-or-id>` — do not forge the header.
+4. **Respect the org + app boundaries.** `X-Org-Id` and `X-App-Id` are auto-injected from the pinned profile. To operate on a different org, run `appstrate org switch <slug-or-id>` (the app pin cascades automatically). To operate on a different app within the same org, run `appstrate app switch <id>`. Do not forge either header.
 5. **Fail fast on auth drift.** If `whoami` exits non-zero mid-session, STOP and tell the human to re-run `appstrate login`. Do not retry blindly.
 6. **Use `--profile <name>` for multi-instance.** `--profile dev` / `--profile prod` pick a keyring entry + instance URL pair. Do not hack `~/.config/appstrate/config.toml` by hand.
 
@@ -131,6 +139,8 @@ If you hit any of the following, stop and surface the issue to the human instead
 
 - `401 unauthorized` after `whoami` passed — the refresh token family was revoked; `appstrate login` needed.
 - `403 forbidden` — the pinned org doesn't have permission. Offer `appstrate org switch` or ask which org to use.
+- `400 Application context required` — the profile has no `appId` pinned. Run `appstrate app current` to check, then `appstrate app switch` (or surface the error — the cascade at login should have handled this).
+- `404 Application '<id>' not found in this organization` — stale app pin from a previous org. Run `appstrate app switch` under the current org.
 - `404 not found` on an operationId that `openapi list` shows — the instance version is older than the CLI. Ask the human to upgrade.
 - `This CLI is not registered on the target instance` — version incompatibility; do not patch around it.
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -40,6 +40,7 @@ See [`examples/self-hosting/README.md`](../../examples/self-hosting/README.md#ve
 | `appstrate whoami`  | Print the identity attached to the active profile.                             |
 | `appstrate token`   | Print metadata about the stored access + refresh tokens (debug).               |
 | `appstrate org`     | List, switch, or create organizations pinned on the active profile.            |
+| `appstrate app`     | List, switch, or create applications pinned on the active profile.             |
 | `appstrate api`     | Authenticated HTTP passthrough to the Appstrate API.                           |
 | `appstrate openapi` | Explore the active profile's OpenAPI schema without flooding stdout.           |
 
@@ -98,6 +99,9 @@ appstrate login --profile prod --instance https://app.my.io
 | `--org`           | `<id-or-slug>` | After the token exchange, pin this organization on the profile non-interactively. Fails if the reference does not match any org.              |
 | `--create-org`    | `<name>`       | Create a new organization with this name and pin it. A default application + hello-world agent are provisioned server-side. Skips the prompt. |
 | `--no-org`        | —              | Skip the post-login org-pinning step entirely. Subsequent calls must carry `-H 'X-Org-Id: …'`, or pin later via `appstrate org switch`.       |
+| `--app`           | `<id>`         | After the org pin, pin this application on the profile non-interactively. Fails if the reference does not match any app.                      |
+| `--create-app`    | `<name>`       | Create a new application with this name after login and pin it. Skips the cascade's default-app pick.                                         |
+| `--no-app`        | —              | Skip the post-login app-pinning step entirely. Subsequent calls must carry `-H 'X-App-Id: …'`, or pin later via `appstrate app switch`.       |
 
 **Org pinning after login** (issue #209): on success, the CLI calls `GET /api/orgs` and branches:
 
@@ -106,6 +110,14 @@ appstrate login --profile prod --instance https://app.my.io
 - **≥2 orgs** → interactive picker.
 
 The pinned org id is written to `config.toml` and automatically sent as `X-Org-Id` on every subsequent `appstrate api` call, so `appstrate api GET /api/me` works immediately after a fresh login with no extra flags.
+
+**Application pinning after login** (issue #217): after the org pin succeeds, the CLI cascades into `GET /api/applications` and branches:
+
+- **Exactly one app** → auto-pin.
+- **≥2 apps** → auto-pin the one with `isDefault: true` (the server provisions exactly one default per org). No interactive picker at login — use `appstrate app switch` afterwards for a different app.
+- **No default among ≥2 apps** (defensive — should never happen) → warn on stderr, leave unpinned.
+
+On success, the banner names both: `Logged in as … to "Acme" (org_xxx) / app "Default" (app_xxx)`. The pinned app id is sent as `X-App-Id` on every `appstrate api` call, so app-scoped routes (`/api/agents`, `/api/runs`, `/api/schedules`, …) work with no extra flags.
 
 **Flow** (what happens on the wire):
 
@@ -235,6 +247,34 @@ All four subcommands respect the global `--profile <name>` flag and talk to `GET
 | `org current`           | Print the pinned org id to stdout. Exits 1 with a hint when no org is pinned — designed for `if` / shell prompts.                        |
 | `org create [name]`     | Create a new org and pin it. With no argument, prompt for name + optional slug. Use `--slug <slug>` for an explicit kebab-case override. |
 
+**Cascade — the app pin follows the org pin.** Every `org switch` / `org create` clears the current `appId` and re-pins the new org's default application in the same atomic operation. This keeps `appstrate api GET /api/agents` working immediately after switching — without the cascade the next call would return `404 Application not found in this organization`.
+
+---
+
+### `appstrate app`
+
+Manage the application pinned on the active profile. `login` auto-pins the default application in the pinned org (see above); `app switch` / `app create` let you change the pin without re-running the device flow. The pinned app id is sent as `X-App-Id` on every `appstrate api` call — required for app-scoped routes (agents, runs, schedules, webhooks, api-keys, notifications, packages, providers, connections, end-users, app-profiles).
+
+```sh
+appstrate app list            # enumerate apps in the pinned org; pinned row is marked *, default row tagged [default]
+appstrate app switch          # interactive picker (current app pre-highlighted)
+appstrate app switch app_xxx  # non-interactive — by id
+appstrate app current         # print the pinned appId (scripts / shell prompts)
+appstrate app create          # interactive (name) → auto-pin
+appstrate app create "Staging"   # non-interactive → auto-pin
+```
+
+All four subcommands respect the global `--profile <name>` flag and talk to `GET /api/applications` / `POST /api/applications`. Applications are identified by `id` only (there is no slug column server-side).
+
+**Subcommands**
+
+| Subcommand          | Purpose                                                                                                              |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `app list`          | List the applications in the pinned org. The pinned one is marked with `*`; the org's default is tagged `[default]`. |
+| `app switch [id]`   | Re-pin the active app on the profile. With no argument, show an interactive picker with the current one highlighted. |
+| `app current`       | Print the pinned app id to stdout. Exits 1 with a hint when no app is pinned — designed for `if` / shell prompts.    |
+| `app create [name]` | Create a new app and pin it. With no argument, prompt for a name interactively.                                      |
+
 ---
 
 ### `appstrate openapi`
@@ -298,7 +338,7 @@ Colors are suppressed when stdout is not a TTY, or when `NO_COLOR` is set in the
 
 ### `appstrate api`
 
-Curl-like authenticated HTTP passthrough. Purpose-built so coding agents (Claude Code, Cursor, Aider, …) can call the Appstrate API in a shell-one-liner without ever seeing the raw bearer — the CLI injects `Authorization: Bearer …` + `X-Org-Id` from the keyring-backed profile.
+Curl-like authenticated HTTP passthrough. Purpose-built so coding agents (Claude Code, Cursor, Aider, …) can call the Appstrate API in a shell-one-liner without ever seeing the raw bearer — the CLI injects `Authorization: Bearer …` + `X-Org-Id` + `X-App-Id` from the keyring-backed profile.
 
 ```sh
 appstrate api GET /api/agents
@@ -436,6 +476,7 @@ instance = "https://app.example.com"
 userId = "EWnC2cLyy88EpCGBa3WrIdS7uqI648BB"
 email = "alice@example.com"
 orgId = "org_123abc"
+appId = "app_abc123"
 
 [profile.dev]
 instance = "http://localhost:3000"
@@ -443,12 +484,18 @@ userId = "SVAA9PSXrmqQmg95A3RzyydtlravhhJR"
 email = "dev@example.com"
 ```
 
-`orgId` is optional — when set, every `apiFetch` request sends `X-Org-Id: <orgId>` so the instance scopes requests correctly. Unset means the user's default org applies server-side.
+`orgId` and `appId` are both optional — when set, every `apiFetch` request sends `X-Org-Id: <orgId>` (and `X-App-Id: <appId>`) so the instance scopes requests correctly. Unset `orgId` means the user's default org applies server-side; unset `appId` means app-scoped routes (`/api/agents`, `/api/runs`, …) return `400 Application context required` and the caller must pass `-H X-App-Id: …` manually.
 
 ## Troubleshooting
 
 **`Unauthorized — your session may have been revoked`**
 Session expired or was revoked server-side. Re-run `appstrate login`.
+
+**`Application context required. Provide X-App-Id header or use an API key.`**
+The pinned profile has no `appId`. Either the cascade at login skipped it (`--no-app`, zero apps in the org, or no default found), or a previous `org switch` cleared it and the re-pin fetch flaked. Run `appstrate app switch` to pick one, or pass `-H 'X-App-Id: …'` on the call.
+
+**`Application '<id>' not found in this organization`**
+The pinned `appId` belongs to a different org than the currently pinned `orgId`. Happens when something mutates `config.toml` between an `org switch` and the next API call, or after a manual hand-edit. Run `appstrate app switch` to re-pin a valid app under the current org.
 
 **`This CLI is not registered on the target instance. The platform may be running an incompatible version.`**
 The instance's `appstrate-cli` OAuth client is missing. Boot the platform — `ensureCliClient()` auto-provisions it on startup. If the instance is much older than the CLI (pre-Phase-1 device flow), the CLI binary is incompatible — downgrade via `APPSTRATE_VERSION=<older-tag> curl get.appstrate.dev | bash`.

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -10,6 +10,8 @@
  *   - `appstrate logout`:  revoke the session + wipe local storage.
  *   - `appstrate whoami`:  server-authoritative identity check.
  *   - `appstrate token`:   print access + refresh token metadata (debug).
+ *   - `appstrate org`:     manage the pinned organization (`X-Org-Id`).
+ *   - `appstrate app`:     manage the pinned application (`X-App-Id`).
  *   - `appstrate api`:     authenticated HTTP passthrough for coding agents.
  *
  * Global flags:
@@ -36,6 +38,12 @@ import {
   orgCurrentCommand,
   orgCreateCommand,
 } from "./commands/org.ts";
+import {
+  appListCommand,
+  appSwitchCommand,
+  appCurrentCommand,
+  appCreateCommand,
+} from "./commands/app.ts";
 import { registerOpenapiCommand } from "./commands/openapi.ts";
 import { exitWithError } from "./lib/ui.ts";
 import { CLI_VERSION } from "./lib/version.ts";
@@ -168,6 +176,18 @@ program
     "--no-org",
     "Skip the post-login org-pinning step entirely. Subsequent calls must pass `-H X-Org-Id: …` or pin later via `appstrate org switch`.",
   )
+  .option(
+    "--app <id>",
+    "Pin this application on the profile after login (non-interactive). Fails if no match.",
+  )
+  .option(
+    "--create-app <name>",
+    "Create a new application with this name after login and pin it (non-interactive).",
+  )
+  .option(
+    "--no-app",
+    "Skip the post-login app-pinning step entirely. Subsequent calls must pass `-H X-App-Id: …` or pin later via `appstrate app switch`.",
+  )
   .action(async (opts) => {
     const globalOpts = program.opts<{ profile?: string }>();
     await loginCommand({
@@ -179,6 +199,9 @@ program
       // commander 14). `--org <value>` sets it to a string, neither leaves
       // it undefined — so `opts.org === false` is the unambiguous skip signal.
       noOrg: opts.org === false,
+      app: typeof opts.app === "string" ? opts.app : undefined,
+      createApp: typeof opts.createApp === "string" ? opts.createApp : undefined,
+      noApp: opts.app === false,
     });
   });
 
@@ -259,10 +282,58 @@ orgGroup
     });
   });
 
+// ─── `appstrate app …` — manage the pinned application (issue #217) ────
+
+const appGroup = program
+  .command("app")
+  .description("Manage the pinned application for the active profile");
+
+appGroup
+  .command("list")
+  .description("List applications in the pinned organization")
+  .action(async () => {
+    const globalOpts = program.opts<{ profile?: string }>();
+    await appListCommand({ profile: globalOpts.profile });
+  });
+
+appGroup
+  .command("current")
+  .description("Print the pinned application id, or exit 1 if none is pinned")
+  .action(async () => {
+    const globalOpts = program.opts<{ profile?: string }>();
+    await appCurrentCommand({ profile: globalOpts.profile });
+  });
+
+appGroup
+  .command("switch [ref]")
+  .description(
+    "Re-pin the active application on the profile. With no argument, show an interactive picker.",
+  )
+  .action(async (ref: string | undefined) => {
+    const globalOpts = program.opts<{ profile?: string }>();
+    await appSwitchCommand({
+      profile: globalOpts.profile,
+      ref: typeof ref === "string" ? ref : undefined,
+    });
+  });
+
+appGroup
+  .command("create [name]")
+  .description(
+    "Create a new application (and pin it on the profile). With no argument, prompt interactively.",
+  )
+  .action(async (name: string | undefined) => {
+    const globalOpts = program.opts<{ profile?: string }>();
+    await appCreateCommand({
+      profile: globalOpts.profile,
+      name: typeof name === "string" ? name : undefined,
+    });
+  });
+
 program
   .command("api <target> [extra]")
   .description(
-    "Authenticated HTTP passthrough to the Appstrate API. Injects the active profile's bearer token + X-Org-Id so coding agents (Claude Code, Cursor, Aider, …) can call the API without ever seeing the raw token.\n" +
+    "Authenticated HTTP passthrough to the Appstrate API. Injects the active profile's bearer token + X-Org-Id + X-App-Id so coding agents (Claude Code, Cursor, Aider, …) can call the API without ever seeing the raw token.\n" +
       "\n" +
       "Invocation forms (all curl-compatible):\n" +
       "  appstrate api GET /api/x             # explicit method + path\n" +

--- a/apps/cli/src/commands/api.ts
+++ b/apps/cli/src/commands/api.ts
@@ -237,6 +237,7 @@ export async function apiCommand(
     userHeaders: effectiveOpts.header,
     token: auth.accessToken,
     orgId: auth.orgId,
+    appId: auth.appId,
     userAgent: opts.userAgent,
     referer: opts.referer,
     cookie: opts.cookie,

--- a/apps/cli/src/commands/api/headers.ts
+++ b/apps/cli/src/commands/api/headers.ts
@@ -6,6 +6,7 @@ export function buildHeaders(args: {
   userHeaders: string[];
   token: string;
   orgId?: string;
+  appId?: string;
   userAgent?: string;
   referer?: string;
   cookie?: string;
@@ -19,6 +20,7 @@ export function buildHeaders(args: {
     Authorization: `Bearer ${args.token}`,
   };
   if (args.orgId) out["X-Org-Id"] = args.orgId;
+  if (args.appId) out["X-App-Id"] = args.appId;
   if (args.compressed) out["Accept-Encoding"] = "gzip, deflate, br";
   if (args.range) out["Range"] = `bytes=${args.range}`;
   if (args.referer) out["Referer"] = args.referer;

--- a/apps/cli/src/commands/app.ts
+++ b/apps/cli/src/commands/app.ts
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `appstrate app` — manage the pinned application for the active CLI
+ * profile. Counterpart to the `appId` written at `appstrate login` time
+ * (issue #217): lets users re-pin, create, or inspect their application
+ * without re-running the device flow.
+ *
+ * Mirror of `./org.ts` — the command family, wiring conventions, and
+ * interactive-picker semantics are identical so adding a third layer
+ * (if ever needed) would follow the same rails.
+ *
+ * Subcommands:
+ *   app list          — enumerate apps in the pinned org
+ *   app switch [ref]  — re-pin (interactive if no arg)
+ *   app current       — print pinned app id (scripts / prompts)
+ *   app create [name] — create + auto-pin
+ */
+
+import { resolveActiveProfile, requireLoggedIn, updateProfile } from "../lib/config.ts";
+import {
+  listApplications,
+  createApplication,
+  resolveApplicationRef,
+  type Application,
+} from "../lib/applications.ts";
+import { askText, select, exitWithError } from "../lib/ui.ts";
+
+export interface AppBaseOptions {
+  profile?: string;
+}
+
+export interface AppSwitchOptions extends AppBaseOptions {
+  /** Positional `[id]` — when absent, use interactive picker. */
+  ref?: string;
+}
+
+export interface AppCreateOptions extends AppBaseOptions {
+  /** Positional `[name]` — when absent, prompt interactively. */
+  name?: string;
+}
+
+export interface AppCommandDeps {
+  /** Return null when the picker cannot run (e.g. non-TTY). */
+  pickApp?: (apps: Application[], currentAppId?: string) => Promise<Application | null>;
+  /** Return null when the prompt cannot run. */
+  promptCreateApp?: () => Promise<{ name: string } | null>;
+}
+
+const defaultDeps: Required<AppCommandDeps> = {
+  pickApp: async (apps: Application[], currentAppId?: string): Promise<Application | null> => {
+    if (!process.stdin.isTTY) return null;
+    const current = currentAppId ? apps.find((a) => a.id === currentAppId) : undefined;
+    return select<Application>(
+      "Select an application",
+      apps.map((a) => {
+        const suffixes: string[] = [];
+        if (a.isDefault) suffixes.push("default");
+        if (a.id === currentAppId) suffixes.push("current");
+        const suffix = suffixes.length > 0 ? ` (${suffixes.join(", ")})` : "";
+        return {
+          value: a,
+          label: `${a.name}${suffix}`,
+          hint: a.id,
+        };
+      }),
+      current,
+    );
+  },
+  promptCreateApp: async (): Promise<{ name: string } | null> => {
+    if (!process.stdin.isTTY) return null;
+    const name = await askText("Application name");
+    return { name };
+  },
+};
+
+export async function appListCommand(opts: AppBaseOptions): Promise<void> {
+  const { profileName, profile } = await resolveActiveProfile(opts.profile);
+  requireLoggedIn(profileName, profile);
+
+  try {
+    const apps = await listApplications(profileName);
+    if (apps.length === 0) {
+      process.stdout.write("(no applications)\n");
+      return;
+    }
+    for (const a of apps) {
+      const marker = a.id === profile.appId ? "*" : " ";
+      const def = a.isDefault ? " [default]" : "";
+      process.stdout.write(`${marker} ${a.name.padEnd(24)}  ${a.id}${def}\n`);
+    }
+  } catch (err) {
+    exitWithError(err);
+  }
+}
+
+export async function appCurrentCommand(opts: AppBaseOptions): Promise<void> {
+  const { profile } = await resolveActiveProfile(opts.profile);
+  if (!profile) {
+    process.stderr.write("Not logged in. Run: appstrate login\n");
+    process.exit(1);
+  }
+  if (!profile.appId) {
+    process.stderr.write("No application pinned. Run: appstrate app switch\n");
+    process.exit(1);
+  }
+  process.stdout.write(`${profile.appId}\n`);
+}
+
+export async function appSwitchCommand(
+  opts: AppSwitchOptions,
+  deps: AppCommandDeps = {},
+): Promise<void> {
+  const { profileName, profile } = await resolveActiveProfile(opts.profile);
+  requireLoggedIn(profileName, profile);
+  const picker = { ...defaultDeps, ...deps };
+
+  try {
+    const apps = await listApplications(profileName);
+    if (apps.length === 0) {
+      process.stderr.write("No applications — run `appstrate app create <name>` to create one.\n");
+      process.exit(1);
+    }
+
+    let chosen: Application;
+    if (opts.ref !== undefined) {
+      chosen = resolveApplicationRef(apps, opts.ref);
+    } else {
+      const picked = await picker.pickApp(apps, profile.appId);
+      if (!picked) {
+        process.stderr.write(
+          "Cannot prompt in non-TTY — pass an id: `appstrate app switch <id>`.\n",
+        );
+        process.exit(1);
+      }
+      chosen = picked;
+    }
+
+    await updateProfile(profileName, { appId: chosen.id });
+    process.stdout.write(`Pinned "${chosen.name}" (${chosen.id}) on profile "${profileName}".\n`);
+  } catch (err) {
+    exitWithError(err);
+  }
+}
+
+export async function appCreateCommand(
+  opts: AppCreateOptions,
+  deps: AppCommandDeps = {},
+): Promise<void> {
+  const { profileName, profile } = await resolveActiveProfile(opts.profile);
+  requireLoggedIn(profileName, profile);
+  const picker = { ...defaultDeps, ...deps };
+
+  try {
+    let name: string;
+    if (opts.name !== undefined) {
+      name = opts.name;
+    } else {
+      const prompted = await picker.promptCreateApp();
+      if (!prompted) {
+        process.stderr.write(
+          "Cannot prompt in non-TTY — pass a name: `appstrate app create <name>`.\n",
+        );
+        process.exit(1);
+      }
+      name = prompted.name;
+    }
+    const created = await createApplication(profileName, name);
+    await updateProfile(profileName, { appId: created.id });
+    process.stdout.write(
+      `Created "${created.name}" (${created.id}) and pinned it on profile "${profileName}".\n`,
+    );
+  } catch (err) {
+    exitWithError(err);
+  }
+}

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -18,6 +18,11 @@
  *      box. Issue #209. Auto-pin on one org, interactive picker on
  *      many, offer inline creation on zero. Non-interactive escapes:
  *      `--org <id-or-slug>`, `--create-org <name>`, `--no-org`.
+ *   8. Cascade: pin an application on the profile so subsequent
+ *      `X-App-Id`-requiring routes (`/api/agents`, `/api/runs`, …)
+ *      work out of the box. Issue #217. Auto-pins the default app
+ *      (the server provisions one per org). Non-interactive escapes:
+ *      `--app <id>`, `--create-app <name>`, `--no-app`.
  */
 
 import open from "open";
@@ -30,13 +35,20 @@ import {
   formatUserCode,
   exitWithError,
 } from "../lib/ui.ts";
-import { readConfig, resolveProfileName, setProfile } from "../lib/config.ts";
+import { readConfig, resolveProfileName, setProfile, updateProfile } from "../lib/config.ts";
 import { saveTokens } from "../lib/keyring.ts";
 import { startDeviceFlow, pollDeviceFlow } from "../lib/device-flow.ts";
 import { normalizeInstance } from "../lib/instance-url.ts";
 import { CLI_CLIENT_ID, CLI_SCOPE } from "../lib/cli-client.ts";
 import { decodeAccessTokenIdentity } from "../lib/jwt-identity.ts";
 import { listOrgs, createOrg, resolveOrgRef, type Org } from "../lib/orgs.ts";
+import {
+  listApplications,
+  createApplication,
+  resolveApplicationRef,
+  findDefaultApplication,
+  type Application,
+} from "../lib/applications.ts";
 
 export interface LoginOptions {
   profile?: string;
@@ -47,6 +59,12 @@ export interface LoginOptions {
   createOrg?: string;
   /** `--no-org` — explicitly skip the whole pin step. */
   noOrg?: boolean;
+  /** `--app <id>` — non-interactive app pin, fails if no match. */
+  app?: string;
+  /** `--create-app <name>` — non-interactive inline creation + pin. */
+  createApp?: string;
+  /** `--no-app` — explicitly skip the app-pinning step. */
+  noApp?: boolean;
   deps?: LoginDeps;
 }
 
@@ -200,23 +218,23 @@ async function runLogin(profileName: string, instance: string, opts: LoginOption
     refreshExpiresAt: Date.now() + token.refreshExpiresIn * 1000,
   });
 
-  // Preserve the previous `orgId` when re-logging-in as the SAME user.
-  // Without this, a re-login whose step-7 `/api/orgs` call happens to
-  // flake (network, server blip) would silently drop the pin the user
-  // had carefully set — surprising regression. Only carry it over when
-  // `userId` matches: re-logging-in as a different user on the same
-  // profile must NOT inherit the previous account's org id.
+  // Preserve the previous `orgId` / `appId` when re-logging-in as the
+  // SAME user. Without this, a re-login whose step-7 / step-8 list call
+  // happens to flake (network, server blip) would silently drop the pins
+  // the user had carefully set — surprising regression. Only carry them
+  // over when `userId` matches: re-logging-in as a different user on the
+  // same profile must NOT inherit the previous account's pins.
   const existingProfile = (await readConfig()).profiles[profileName];
-  const preservedOrgId =
-    existingProfile?.userId === identity.userId && existingProfile?.orgId
-      ? existingProfile.orgId
-      : undefined;
+  const sameUser = existingProfile?.userId === identity.userId;
+  const preservedOrgId = sameUser && existingProfile?.orgId ? existingProfile.orgId : undefined;
+  const preservedAppId = sameUser && existingProfile?.appId ? existingProfile.appId : undefined;
 
   await setProfile(profileName, {
     instance,
     userId: identity.userId,
     email: identity.email,
     ...(preservedOrgId ? { orgId: preservedOrgId } : {}),
+    ...(preservedAppId ? { appId: preservedAppId } : {}),
   });
 
   // Step 7 — pin an organization. Issue #209. Credentials are already
@@ -225,12 +243,22 @@ async function runLogin(profileName: string, instance: string, opts: LoginOption
   // a hint to the user, never as a hard failure.
   const pinned = await pinOrgOnProfile(profileName, opts);
 
+  // Step 8 — cascade into application pinning. Issue #217. Requires an
+  // `orgId` in context (listApplications is org-scoped), so we gate on
+  // `pinned` rather than re-fetching from the keyring.
+  const pinnedApp = await pinAppOnProfile(profileName, opts, pinned);
+
   const orgSuffix = pinned ? ` to "${pinned.name}" (${pinned.id})` : "";
-  outro(`Logged in as ${identity.email}${orgSuffix}`);
+  const appSuffix = pinnedApp ? ` / app "${pinnedApp.name}" (${pinnedApp.id})` : "";
+  outro(`Logged in as ${identity.email}${orgSuffix}${appSuffix}`);
 
   if (!pinned) {
     process.stdout.write(
       `No org pinned — pass -H "X-Org-Id: …" on each call, or run \`appstrate org switch\` later.\n`,
+    );
+  } else if (!pinnedApp && !opts.noApp) {
+    process.stdout.write(
+      `No app pinned — pass -H "X-App-Id: …" on each call, or run \`appstrate app switch\` later.\n`,
     );
   }
 }
@@ -253,7 +281,7 @@ async function pinOrgOnProfile(profileName: string, opts: LoginOptions): Promise
   // they want a fresh org. Don't second-guess them with a prompt.
   if (opts.createOrg !== undefined) {
     const created = await createOrg(profileName, { name: opts.createOrg });
-    await persistOrgId(profileName, created.id);
+    await updateProfile(profileName, { orgId: created.id });
     return created;
   }
 
@@ -272,13 +300,13 @@ async function pinOrgOnProfile(profileName: string, opts: LoginOptions): Promise
   // `--org <id-or-slug>` — explicit non-interactive selection.
   if (opts.org !== undefined) {
     const match = resolveOrgRef(orgs, opts.org);
-    await persistOrgId(profileName, match.id);
+    await updateProfile(profileName, { orgId: match.id });
     return match;
   }
 
   if (orgs.length === 1) {
     const only = orgs[0]!;
-    await persistOrgId(profileName, only.id);
+    await updateProfile(profileName, { orgId: only.id });
     return only;
   }
 
@@ -286,31 +314,85 @@ async function pinOrgOnProfile(profileName: string, opts: LoginOptions): Promise
     const input = await deps.promptCreateOrg();
     if (!input) return null;
     const created = await createOrg(profileName, input);
-    await persistOrgId(profileName, created.id);
+    await updateProfile(profileName, { orgId: created.id });
     return created;
   }
 
   // ≥2 orgs — delegate the (possibly non-TTY) decision to the picker.
   const chosen = await deps.pickOrg(orgs);
   if (!chosen) return null;
-  await persistOrgId(profileName, chosen.id);
+  await updateProfile(profileName, { orgId: chosen.id });
   return chosen;
 }
 
 /**
- * Rewrite the profile's `orgId` without disturbing the other fields.
- * `setProfile` replaces the whole row, so we re-read first to preserve
- * `userId` / `email` / `instance` that `runLogin` just persisted.
+ * Resolve the app-pin branch of the login cascade. Issue #217.
+ *
+ * Gated on a successful org pin: `GET /api/applications` needs an
+ * `X-Org-Id` header, so when no org is pinned (user passed `--no-org`,
+ * or the cascade failed) we return null without a network call.
+ *
+ * Unlike `pinOrgOnProfile` this does NOT expose an interactive picker at
+ * login time — the server provisions exactly one default application per
+ * org, so the non-flag path is fully deterministic. Users with ≥2 apps
+ * and no clear default get a stderr hint and pin manually via
+ * `appstrate app switch` afterwards.
  */
-async function persistOrgId(profileName: string, orgId: string): Promise<void> {
-  const config = await readConfig();
-  const existing = config.profiles[profileName];
-  if (!existing) {
-    // Should never happen: `runLogin` called `setProfile` before this.
-    // Fail loudly — silent fallback would mask a real regression.
-    throw new Error(
-      `Profile "${profileName}" missing from config when pinning org — internal invariant broken.`,
-    );
+async function pinAppOnProfile(
+  profileName: string,
+  opts: LoginOptions,
+  orgPinned: Org | null,
+): Promise<Application | null> {
+  if (opts.noApp) return null;
+  if (!orgPinned) return null;
+
+  if (opts.createApp !== undefined) {
+    const created = await createApplication(profileName, opts.createApp);
+    await updateProfile(profileName, { appId: created.id });
+    return created;
   }
-  await setProfile(profileName, { ...existing, orgId });
+
+  let apps: Application[];
+  try {
+    apps = await listApplications(profileName);
+  } catch (err) {
+    process.stderr.write(
+      `Failed to list applications: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return null;
+  }
+
+  // `--app <id>` — explicit non-interactive selection.
+  if (opts.app !== undefined) {
+    const match = resolveApplicationRef(apps, opts.app);
+    await updateProfile(profileName, { appId: match.id });
+    return match;
+  }
+
+  if (apps.length === 0) {
+    // Should be impossible in practice — every org has a server-provisioned
+    // default app. Surface defensively in case of partial state.
+    process.stderr.write(
+      "No applications found on the pinned organization — run `appstrate app create <name>` to create one.\n",
+    );
+    return null;
+  }
+
+  if (apps.length === 1) {
+    const only = apps[0]!;
+    await updateProfile(profileName, { appId: only.id });
+    return only;
+  }
+
+  // ≥2 apps — pin the server-provisioned default. If none is marked,
+  // surface a hint; pinning silently to apps[0] would be too guessy.
+  const def = findDefaultApplication(apps);
+  if (def) {
+    await updateProfile(profileName, { appId: def.id });
+    return def;
+  }
+  process.stderr.write(
+    "Multiple applications but none marked default — run `appstrate app switch` to pin one.\n",
+  );
+  return null;
 }

--- a/apps/cli/src/commands/org.ts
+++ b/apps/cli/src/commands/org.ts
@@ -11,10 +11,17 @@
  *   org switch [ref]  — re-pin (interactive if no arg)
  *   org current       — print pinned org id (scripts / prompts)
  *   org create [name] — create + auto-pin
+ *
+ * Cascade invariant (issue #217): the pinned `appId` is always scoped to
+ * the pinned `orgId`. `org switch` and `org create` therefore clear the
+ * stale app pin and re-pin the new org's default application in the same
+ * atomic operation — otherwise the next `appstrate api` call would 404
+ * with "Application not found in this organization".
  */
 
-import { readConfig, resolveProfileName, setProfile, type Profile } from "../lib/config.ts";
+import { resolveActiveProfile, requireLoggedIn, updateProfile } from "../lib/config.ts";
 import { listOrgs, createOrg, resolveOrgRef, type Org } from "../lib/orgs.ts";
+import { listApplications, findDefaultApplication, type Application } from "../lib/applications.ts";
 import { askText, select, exitWithError } from "../lib/ui.ts";
 
 export interface OrgBaseOptions {
@@ -64,7 +71,7 @@ const defaultDeps: Required<OrgCommandDeps> = {
 };
 
 export async function orgListCommand(opts: OrgBaseOptions): Promise<void> {
-  const { profileName, profile } = await resolveActive(opts.profile);
+  const { profileName, profile } = await resolveActiveProfile(opts.profile);
   requireLoggedIn(profileName, profile);
 
   try {
@@ -83,7 +90,7 @@ export async function orgListCommand(opts: OrgBaseOptions): Promise<void> {
 }
 
 export async function orgCurrentCommand(opts: OrgBaseOptions): Promise<void> {
-  const { profile } = await resolveActive(opts.profile);
+  const { profile } = await resolveActiveProfile(opts.profile);
   if (!profile) {
     process.stderr.write("Not logged in. Run: appstrate login\n");
     process.exit(1);
@@ -99,7 +106,7 @@ export async function orgSwitchCommand(
   opts: OrgSwitchOptions,
   deps: OrgCommandDeps = {},
 ): Promise<void> {
-  const { profileName, profile } = await resolveActive(opts.profile);
+  const { profileName, profile } = await resolveActiveProfile(opts.profile);
   requireLoggedIn(profileName, profile);
   const picker = { ...defaultDeps, ...deps };
 
@@ -124,8 +131,15 @@ export async function orgSwitchCommand(
       chosen = picked;
     }
 
-    await setProfile(profileName, { ...profile, orgId: chosen.id });
-    process.stdout.write(`Pinned "${chosen.name}" (${chosen.id}) on profile "${profileName}".\n`);
+    // Clear the stale app pin first: it belongs to the previous org and
+    // would immediately 404 on the next app-scoped call. Re-pin the new
+    // org's default app in the same commit below.
+    await updateProfile(profileName, { orgId: chosen.id, appId: undefined });
+    const repinned = await repinAppAfterOrgChange(profileName);
+    const appSuffix = repinned ? ` / app "${repinned.name}" (${repinned.id})` : "";
+    process.stdout.write(
+      `Pinned "${chosen.name}" (${chosen.id})${appSuffix} on profile "${profileName}".\n`,
+    );
   } catch (err) {
     exitWithError(err);
   }
@@ -135,7 +149,7 @@ export async function orgCreateCommand(
   opts: OrgCreateOptions,
   deps: OrgCommandDeps = {},
 ): Promise<void> {
-  const { profileName, profile } = await resolveActive(opts.profile);
+  const { profileName, profile } = await resolveActiveProfile(opts.profile);
   requireLoggedIn(profileName, profile);
   const picker = { ...defaultDeps, ...deps };
 
@@ -155,36 +169,38 @@ export async function orgCreateCommand(
       input = prompted;
     }
     const created = await createOrg(profileName, input);
-    await setProfile(profileName, { ...profile, orgId: created.id });
+    // Server auto-provisions a default application on org creation — clear
+    // any stale app pin from the previous org and re-pin the new default.
+    await updateProfile(profileName, { orgId: created.id, appId: undefined });
+    const repinned = await repinAppAfterOrgChange(profileName);
+    const appSuffix = repinned ? ` / app "${repinned.name}" (${repinned.id})` : "";
     process.stdout.write(
-      `Created "${created.name}" (${created.id}) and pinned it on profile "${profileName}".\n`,
+      `Created "${created.name}" (${created.id})${appSuffix} and pinned it on profile "${profileName}".\n`,
     );
   } catch (err) {
     exitWithError(err);
   }
 }
 
-// ─── helpers ──────────────────────────────────────────────────────────
-
-interface Active {
-  profileName: string;
-  profile: Profile | undefined;
-}
-
-async function resolveActive(explicit: string | undefined): Promise<Active> {
-  const config = await readConfig();
-  const profileName = resolveProfileName(explicit, config);
-  return { profileName, profile: config.profiles[profileName] };
-}
-
-function requireLoggedIn(
-  profileName: string,
-  profile: Profile | undefined,
-): asserts profile is Profile {
-  if (!profile) {
-    process.stderr.write(
-      `Profile "${profileName}" not configured. Run: appstrate login --profile ${profileName}\n`,
-    );
-    process.exit(1);
+/**
+ * After the org pin changes, pick the new org's default application
+ * and pin it on the profile. Returns the pinned app, or null when there
+ * is nothing sensible to pin (no apps, or ≥2 without a default) — the
+ * command continues regardless; the user can run `app switch` manually.
+ *
+ * Swallows network errors: the org pin already succeeded and forcing the
+ * user to re-run `org switch` over a transient `/api/applications` blip
+ * would be a worse UX than an unpinned app.
+ */
+async function repinAppAfterOrgChange(profileName: string): Promise<Application | null> {
+  try {
+    const apps = await listApplications(profileName);
+    if (apps.length === 0) return null;
+    const chosen = findDefaultApplication(apps) ?? (apps.length === 1 ? apps[0]! : null);
+    if (!chosen) return null;
+    await updateProfile(profileName, { appId: chosen.id });
+    return chosen;
+  } catch {
+    return null;
   }
 }

--- a/apps/cli/src/lib/api.ts
+++ b/apps/cli/src/lib/api.ts
@@ -12,10 +12,11 @@
  *     BEFORE issuing the request (proactive refresh), OR
  *   - the request returns `401` (reactive refresh + single retry).
  *
- * Inject `X-Org-Id` when the profile is pinned to a specific
- * organization — matches the dashboard SPA's header contract
- * (`apps/web/src/lib/api.ts`) so routes that use `requireOrgMembership`
- * work identically from the CLI.
+ * Inject `X-Org-Id` + `X-App-Id` when the profile is pinned to a
+ * specific organization / application — matches the dashboard SPA's
+ * header contract (`apps/web/src/lib/api.ts`) so routes that use
+ * `requireOrgMembership` + `requireAppContext` work identically from
+ * the CLI.
  */
 
 import { loadTokens, saveTokens, deleteTokens, type Tokens } from "./keyring.ts";
@@ -165,6 +166,7 @@ export interface AuthContext {
   instance: string;
   accessToken: string;
   orgId?: string;
+  appId?: string;
 }
 
 /**
@@ -185,6 +187,7 @@ export async function resolveAuthContext(profileName: string): Promise<AuthConte
     instance: normalizeInstance(profile.instance),
     accessToken: token,
     orgId: profile.orgId,
+    appId: profile.appId,
   };
 }
 
@@ -295,6 +298,7 @@ export async function apiFetchRaw(
       headers["Content-Type"] = "application/json";
     }
     if (profile.orgId) headers["X-Org-Id"] = profile.orgId;
+    if (profile.appId) headers["X-App-Id"] = profile.appId;
     return fetch(`${normalizeInstance(profile.instance)}${path}`, { ...init, headers });
   };
 

--- a/apps/cli/src/lib/applications.ts
+++ b/apps/cli/src/lib/applications.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Application helpers for the CLI — list, create, and resolve application
+ * references.
+ *
+ * Mirror of `./orgs.ts`. Kept separate so both `login` (pin-on-first-use
+ * cascade — org → app) and the new `app` subcommands share the same
+ * parsing / validation + test surface.
+ *
+ * Server contract:
+ *   - `GET /api/applications` runs under org context (`X-Org-Id`) but
+ *     does NOT require app context (`X-App-Id`) — see
+ *     `apps/api/src/index.ts` `CORE_APP_SCOPED_PREFIXES`. That makes it
+ *     safe to call immediately after an org is pinned and before the app
+ *     cascade has chosen a default.
+ *   - `POST /api/orgs` server-side also provisions a default application
+ *     (`isDefault: true`, unique per-org), so `listApplications` on a
+ *     fresh org reliably returns at least one row.
+ *   - `POST /api/applications` requires session auth (rejected for API
+ *     keys server-side) — the CLI uses the device-flow JWT, so this is
+ *     always fine.
+ */
+
+import { apiFetch } from "./api.ts";
+
+export interface Application {
+  id: string;
+  orgId: string;
+  name: string;
+  isDefault: boolean;
+  createdAt: string;
+}
+
+interface ListResponse {
+  data?: Application[];
+}
+
+export async function listApplications(profileName: string): Promise<Application[]> {
+  const res = await apiFetch<ListResponse>(profileName, "/api/applications");
+  return Array.isArray(res.data) ? res.data : [];
+}
+
+export async function createApplication(profileName: string, name: string): Promise<Application> {
+  return apiFetch<Application>(profileName, "/api/applications", {
+    method: "POST",
+    body: JSON.stringify({ name }),
+  });
+}
+
+/**
+ * Resolve a user-supplied application reference against the list returned
+ * by `/api/applications`. Applications are identified by id only — the
+ * server schema has no slug column (unlike orgs). Keep the name `*Ref`
+ * for parallel symmetry with `resolveOrgRef` — the abstraction is the
+ * same, only the matching attribute differs.
+ *
+ * Throws an Error whose `.message` lists the available applications when
+ * the ref doesn't match, including a `[default]` marker so the user sees
+ * which one would be picked automatically at login / org switch.
+ */
+export function resolveApplicationRef(apps: Application[], ref: string): Application {
+  const trimmed = ref.trim();
+  if (trimmed.length === 0) {
+    throw new Error("Application reference is empty.");
+  }
+  const match = apps.find((a) => a.id === trimmed);
+  if (match) return match;
+  if (apps.length === 0) {
+    throw new Error(
+      `No applications found for this profile. Run \`appstrate app create <name>\` to create one.`,
+    );
+  }
+  const available = apps
+    .map((a) => `  - ${a.name} (${a.id})${a.isDefault ? " [default]" : ""}`)
+    .join("\n");
+  throw new Error(`No application matches "${trimmed}". Available:\n${available}`);
+}
+
+/**
+ * Return the `isDefault: true` app, if any. Used by the login org→app
+ * cascade and by `org switch` / `org create` re-pin helpers — the server
+ * guarantees exactly one default per org, so this is a single-step look.
+ */
+export function findDefaultApplication(apps: Application[]): Application | undefined {
+  return apps.find((a) => a.isDefault);
+}

--- a/apps/cli/src/lib/config.ts
+++ b/apps/cli/src/lib/config.ts
@@ -30,6 +30,7 @@ export interface Profile {
   userId: string;
   email: string;
   orgId?: string;
+  appId?: string;
 }
 
 export interface Config {
@@ -108,6 +109,7 @@ export async function readConfig(): Promise<Config> {
       userId: row.userId,
       email: row.email,
       orgId: typeof row.orgId === "string" ? row.orgId : undefined,
+      appId: typeof row.appId === "string" ? row.appId : undefined,
     };
   }
   return { defaultProfile, profiles };
@@ -140,6 +142,63 @@ export async function writeConfig(config: Config): Promise<void> {
 export async function getProfile(name: string): Promise<Profile | null> {
   const config = await readConfig();
   return config.profiles[name] ?? null;
+}
+
+/**
+ * Merge a partial update into an existing profile. Used by the login
+ * org→app cascade and the `org switch` / `app switch` commands to rewrite
+ * a single field (`orgId`, `appId`) without re-reading the whole profile
+ * at each call site.
+ *
+ * `undefined` in the patch means "clear the key" — strip it before write
+ * so the key doesn't round-trip as a bare TOML entry.
+ */
+export async function updateProfile(name: string, patch: Partial<Profile>): Promise<void> {
+  const config = await readConfig();
+  const existing = config.profiles[name];
+  if (!existing) {
+    throw new Error(`Profile "${name}" missing from config — internal invariant broken.`);
+  }
+  const next: Profile = { ...existing, ...patch };
+  for (const [k, v] of Object.entries(patch)) {
+    if (v === undefined) delete (next as unknown as Record<string, unknown>)[k];
+  }
+  config.profiles[name] = next;
+  await writeConfig(config);
+}
+
+/**
+ * Resolve the active profile in one call — wraps the
+ * `resolveProfileName` → `readConfig` → lookup dance every command does
+ * at entry. Returns `profile: undefined` if the resolved name has no
+ * matching section in `config.toml`; pair with `requireLoggedIn` to
+ * hard-exit on that path.
+ */
+export async function resolveActiveProfile(
+  explicit: string | undefined,
+): Promise<{ profileName: string; profile: Profile | undefined }> {
+  const config = await readConfig();
+  const profileName = resolveProfileName(explicit, config);
+  return { profileName, profile: config.profiles[profileName] };
+}
+
+/**
+ * Narrow `profile` from `Profile | undefined` to `Profile`, hard-exiting
+ * with an actionable hint when the resolved profile has no config entry.
+ * Used by every `appstrate org …` / `appstrate app …` subcommand —
+ * centralized so the phrasing stays in sync across the two command
+ * families.
+ */
+export function requireLoggedIn(
+  profileName: string,
+  profile: Profile | undefined,
+): asserts profile is Profile {
+  if (!profile) {
+    process.stderr.write(
+      `Profile "${profileName}" not configured. Run: appstrate login --profile ${profileName}\n`,
+    );
+    process.exit(1);
+  }
 }
 
 export async function setProfile(name: string, profile: Profile): Promise<void> {

--- a/apps/cli/test/api.test.ts
+++ b/apps/cli/test/api.test.ts
@@ -370,6 +370,59 @@ describe("apiFetchRaw — X-Org-Id header injection", () => {
   });
 });
 
+describe("apiFetchRaw — X-App-Id header injection", () => {
+  it("forwards profile.appId as X-App-Id when set", async () => {
+    await setProfile("default", {
+      instance: "https://app.example.com",
+      userId: "u_1",
+      email: "a@example.com",
+      orgId: "org_42",
+      appId: "app_7",
+    });
+    await saveTokens("default", {
+      accessToken: "tok",
+      expiresAt: Date.now() + 5 * 60 * 1000,
+      refreshToken: "r",
+      refreshExpiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    });
+    let capturedApp: string | undefined;
+    let capturedOrg: string | undefined;
+    installFetch(async (_url, init) => {
+      const h = init?.headers as Record<string, string>;
+      capturedApp = h["X-App-Id"];
+      capturedOrg = h["X-Org-Id"];
+      return jsonResponse(200, {});
+    });
+    await apiFetchRaw("default", "/api/data");
+    // Both headers sent when both are pinned — the common agent recipe path.
+    expect(capturedApp).toBe("app_7");
+    expect(capturedOrg).toBe("org_42");
+  });
+
+  it("does NOT send X-App-Id when profile.appId is unset", async () => {
+    await setProfile("default", {
+      instance: "https://app.example.com",
+      userId: "u_1",
+      email: "a@example.com",
+      orgId: "org_42",
+    });
+    await saveTokens("default", {
+      accessToken: "tok",
+      expiresAt: Date.now() + 5 * 60 * 1000,
+      refreshToken: "r",
+      refreshExpiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+    });
+    let sawAppHeader = true;
+    installFetch(async (_url, init) => {
+      const h = init?.headers as Record<string, string>;
+      sawAppHeader = "X-App-Id" in h;
+      return jsonResponse(200, {});
+    });
+    await apiFetchRaw("default", "/api/data");
+    expect(sawAppHeader).toBe(false);
+  });
+});
+
 describe("apiFetchRaw — concurrent refresh dedup (PR #191 review)", () => {
   it("collapses N parallel proactive refreshes into ONE /cli/token call", async () => {
     // Seed with an access token that is past the 30s proactive-refresh

--- a/apps/cli/test/app-command.test.ts
+++ b/apps/cli/test/app-command.test.ts
@@ -1,0 +1,405 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the `appstrate app` subcommand family (issue #217):
+ * `list`, `current`, `switch`, `create`. Mirror of `org-command.test.ts`.
+ * We call each subcommand directly — commander is not in the loop — so
+ * injected `deps` (picker / create prompt) aren't bypassed by non-TTY
+ * guards.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  _setKeyringFactoryForTesting,
+  saveTokens,
+  type KeyringHandle,
+} from "../src/lib/keyring.ts";
+import { setProfile, readConfig } from "../src/lib/config.ts";
+import {
+  appListCommand,
+  appCurrentCommand,
+  appSwitchCommand,
+  appCreateCommand,
+} from "../src/commands/app.ts";
+
+class FakeKeyring implements KeyringHandle {
+  static store = new Map<string, string>();
+  constructor(private profile: string) {}
+  setPassword(v: string): void {
+    FakeKeyring.store.set(this.profile, v);
+  }
+  getPassword(): string | null {
+    return FakeKeyring.store.get(this.profile) ?? null;
+  }
+  deletePassword(): void {
+    FakeKeyring.store.delete(this.profile);
+  }
+}
+
+type FetchCall = { url: string; method: string | undefined; body?: string };
+
+let tmpDir: string;
+let originalXdg: string | undefined;
+const originalFetch = globalThis.fetch;
+const originalExit = process.exit;
+const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+const originalStderrWrite = process.stderr.write.bind(process.stderr);
+
+let fetchCalls: FetchCall[];
+let stdoutChunks: string[];
+let stderrChunks: string[];
+
+class ExitError extends Error {
+  constructor(public readonly code: number) {
+    super(`process.exit(${code}) called`);
+  }
+}
+
+function captureIo(): void {
+  stdoutChunks = [];
+  stderrChunks = [];
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    stdoutChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+    return true;
+  }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    stderrChunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8"));
+    return true;
+  }) as typeof process.stderr.write;
+  (process as unknown as { exit: (code?: number) => never }).exit = ((code?: number): never => {
+    throw new ExitError(code ?? 0);
+  }) as (code?: number) => never;
+}
+
+interface Responders {
+  listApps?: () => Response;
+  createApp?: (body: unknown) => Response;
+}
+
+function installFetch(responders: Responders): void {
+  const stub = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const method = init?.method;
+    const body = typeof init?.body === "string" ? init.body : undefined;
+    fetchCalls.push({ url, method, body });
+    if (url.endsWith("/api/applications") && method === "POST") {
+      const parsed = body ? JSON.parse(body) : {};
+      return (
+        responders.createApp?.(parsed) ?? new Response("missing createApp stub", { status: 501 })
+      );
+    }
+    if (url.endsWith("/api/applications")) {
+      return responders.listApps?.() ?? new Response("missing listApps stub", { status: 501 });
+    }
+    return new Response("not mocked: " + url, { status: 501 });
+  };
+  globalThis.fetch = stub as unknown as typeof fetch;
+}
+
+beforeAll(() => {
+  originalXdg = process.env.XDG_CONFIG_HOME;
+});
+
+afterAll(() => {
+  if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = originalXdg;
+});
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "appstrate-cli-app-cmd-"));
+  process.env.XDG_CONFIG_HOME = tmpDir;
+  FakeKeyring.store.clear();
+  _setKeyringFactoryForTesting((p) => new FakeKeyring(p));
+  fetchCalls = [];
+  captureIo();
+});
+
+afterEach(async () => {
+  _setKeyringFactoryForTesting(null);
+  globalThis.fetch = originalFetch;
+  process.stdout.write = originalStdoutWrite;
+  process.stderr.write = originalStderrWrite;
+  (process as unknown as { exit: typeof originalExit }).exit = originalExit;
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+async function seedLoggedIn(appId?: string, profile = "default", orgId = "org_1"): Promise<void> {
+  await setProfile(profile, {
+    instance: "https://app.example.com",
+    userId: "u_1",
+    email: "alice@example.com",
+    orgId,
+    ...(appId ? { appId } : {}),
+  });
+  await saveTokens(profile, {
+    accessToken: "tok-abc",
+    expiresAt: Date.now() + 15 * 60 * 1000,
+    refreshToken: "rt-xyz",
+    refreshExpiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+  });
+}
+
+async function pinnedAppId(profile = "default"): Promise<string | undefined> {
+  return (await readConfig()).profiles[profile]?.appId;
+}
+
+const twoApps = {
+  object: "list",
+  data: [
+    {
+      id: "app_1",
+      orgId: "org_1",
+      name: "Default",
+      isDefault: true,
+      createdAt: "t",
+    },
+    {
+      id: "app_2",
+      orgId: "org_1",
+      name: "Staging",
+      isDefault: false,
+      createdAt: "t",
+    },
+  ],
+};
+
+// ── list ─────────────────────────────────────────────────────────────
+
+describe("app list", () => {
+  it("prints each app with a `*` marker on the pinned one and [default] tag", async () => {
+    await seedLoggedIn("app_2");
+    installFetch({
+      listApps: () =>
+        new Response(JSON.stringify(twoApps), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    await appListCommand({ profile: "default" });
+
+    const out = stdoutChunks.join("");
+    const lines = out.split("\n").filter((l) => l.length > 0);
+    const defaultLine = lines.find((l) => l.includes("Default"));
+    const stagingLine = lines.find((l) => l.includes("Staging"));
+    expect(defaultLine).toBeDefined();
+    expect(stagingLine).toBeDefined();
+    // app_2 is pinned → starts with `*`; app_1 is not but is the default.
+    expect(stagingLine!.startsWith("*")).toBe(true);
+    expect(defaultLine!.startsWith(" ")).toBe(true);
+    expect(defaultLine!).toContain("[default]");
+    expect(stagingLine!).not.toContain("[default]");
+  });
+
+  it("prints a friendly message when the org has no applications", async () => {
+    await seedLoggedIn();
+    installFetch({
+      listApps: () =>
+        new Response(JSON.stringify({ object: "list", data: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    await appListCommand({ profile: "default" });
+    expect(stdoutChunks.join("")).toContain("(no applications)");
+  });
+
+  it("errors out when the profile is not logged in", async () => {
+    await expect(appListCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
+    expect(stderrChunks.join("")).toContain("not configured");
+  });
+});
+
+// ── current ─────────────────────────────────────────────────────────
+
+describe("app current", () => {
+  it("prints the pinned app id to stdout", async () => {
+    await seedLoggedIn("app_42");
+    await appCurrentCommand({ profile: "default" });
+    expect(stdoutChunks.join("").trim()).toBe("app_42");
+  });
+
+  it("exits 1 with a hint when no app is pinned", async () => {
+    await seedLoggedIn();
+    await expect(appCurrentCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
+    expect(stderrChunks.join("")).toContain("No application pinned");
+  });
+
+  it("exits 1 when the profile is unconfigured", async () => {
+    await expect(appCurrentCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
+    expect(stderrChunks.join("")).toContain("Not logged in");
+  });
+});
+
+// ── switch ───────────────────────────────────────────────────────────
+
+describe("app switch", () => {
+  it("pins the app matching the positional arg (by id)", async () => {
+    await seedLoggedIn("app_1");
+    installFetch({
+      listApps: () =>
+        new Response(JSON.stringify(twoApps), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    await appSwitchCommand({ profile: "default", ref: "app_2" });
+
+    expect(await pinnedAppId()).toBe("app_2");
+    expect(stdoutChunks.join("")).toContain('Pinned "Staging"');
+  });
+
+  it("uses the injected picker when no ref is passed", async () => {
+    await seedLoggedIn("app_1");
+    installFetch({
+      listApps: () =>
+        new Response(JSON.stringify(twoApps), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    let seenCurrent: string | undefined;
+    await appSwitchCommand(
+      { profile: "default" },
+      {
+        pickApp: async (apps, current) => {
+          seenCurrent = current;
+          return apps[1]!;
+        },
+      },
+    );
+
+    expect(seenCurrent).toBe("app_1");
+    expect(await pinnedAppId()).toBe("app_2");
+  });
+
+  it("exits 1 when no apps exist", async () => {
+    await seedLoggedIn("app_1");
+    installFetch({
+      listApps: () =>
+        new Response(JSON.stringify({ object: "list", data: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    await expect(appSwitchCommand({ profile: "default" })).rejects.toBeInstanceOf(ExitError);
+    expect(stderrChunks.join("")).toContain("No applications");
+  });
+
+  it("exits with an error when the ref does not match any app", async () => {
+    await seedLoggedIn("app_1");
+    installFetch({
+      listApps: () =>
+        new Response(JSON.stringify(twoApps), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    await expect(appSwitchCommand({ profile: "default", ref: "nope" })).rejects.toBeInstanceOf(
+      ExitError,
+    );
+    expect(await pinnedAppId()).toBe("app_1"); // unchanged
+  });
+
+  it("exits with a hint when the picker returns null (non-TTY, no ref)", async () => {
+    await seedLoggedIn("app_1");
+    installFetch({
+      listApps: () =>
+        new Response(JSON.stringify(twoApps), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    await expect(
+      appSwitchCommand({ profile: "default" }, { pickApp: async () => null }),
+    ).rejects.toBeInstanceOf(ExitError);
+    expect(stderrChunks.join("")).toContain("non-TTY");
+    expect(await pinnedAppId()).toBe("app_1"); // unchanged
+  });
+});
+
+// ── create ──────────────────────────────────────────────────────────
+
+describe("app create", () => {
+  it("POSTs with the positional name + auto-pins", async () => {
+    await seedLoggedIn();
+    let createdBody: unknown;
+    installFetch({
+      createApp: (body) => {
+        createdBody = body;
+        return new Response(
+          JSON.stringify({
+            id: "app_new",
+            orgId: "org_1",
+            name: "Fresh",
+            isDefault: false,
+            createdAt: "t",
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        );
+      },
+    });
+
+    await appCreateCommand({ profile: "default", name: "Fresh" });
+
+    expect(createdBody).toEqual({ name: "Fresh" });
+    expect(await pinnedAppId()).toBe("app_new");
+    expect(stdoutChunks.join("")).toContain('Created "Fresh"');
+  });
+
+  it("prompts via the injected creator when no name is passed", async () => {
+    await seedLoggedIn();
+    let createdBody: unknown;
+    installFetch({
+      createApp: (body) => {
+        createdBody = body;
+        return new Response(
+          JSON.stringify({
+            id: "app_new",
+            orgId: "org_1",
+            name: "Prompted",
+            isDefault: false,
+            createdAt: "t",
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        );
+      },
+    });
+
+    await appCreateCommand(
+      { profile: "default" },
+      {
+        promptCreateApp: async () => ({ name: "Prompted" }),
+      },
+    );
+
+    expect(createdBody).toEqual({ name: "Prompted" });
+    expect(await pinnedAppId()).toBe("app_new");
+  });
+
+  it("exits with a hint when prompt is unavailable (non-TTY + no name)", async () => {
+    await seedLoggedIn();
+    installFetch({});
+
+    await expect(
+      appCreateCommand({ profile: "default" }, { promptCreateApp: async () => null }),
+    ).rejects.toBeInstanceOf(ExitError);
+    expect(stderrChunks.join("")).toContain("non-TTY");
+  });
+
+  it("requires login", async () => {
+    await expect(appCreateCommand({ profile: "default", name: "X" })).rejects.toBeInstanceOf(
+      ExitError,
+    );
+    expect(stderrChunks.join("")).toContain("not configured");
+  });
+});

--- a/apps/cli/test/applications.test.ts
+++ b/apps/cli/test/applications.test.ts
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `src/lib/applications.ts`. Mirror of `orgs.test.ts`:
+ * the pure helpers (`resolveApplicationRef`, `findDefaultApplication`)
+ * and the thin HTTP wrappers (`listApplications`, `createApplication`)
+ * via the same in-memory keyring + fetch-stub pattern used by the other
+ * CLI tests. No real network, no real keyring.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  _setKeyringFactoryForTesting,
+  saveTokens,
+  type KeyringHandle,
+} from "../src/lib/keyring.ts";
+import { setProfile } from "../src/lib/config.ts";
+import {
+  listApplications,
+  createApplication,
+  resolveApplicationRef,
+  findDefaultApplication,
+  type Application,
+} from "../src/lib/applications.ts";
+
+class FakeKeyring implements KeyringHandle {
+  static store = new Map<string, string>();
+  constructor(private profile: string) {}
+  setPassword(v: string): void {
+    FakeKeyring.store.set(this.profile, v);
+  }
+  getPassword(): string | null {
+    return FakeKeyring.store.get(this.profile) ?? null;
+  }
+  deletePassword(): void {
+    FakeKeyring.store.delete(this.profile);
+  }
+}
+
+type FetchCall = {
+  url: string;
+  method: string | undefined;
+  body?: string;
+  headers: Record<string, string>;
+};
+
+let tmpDir: string;
+let originalXdg: string | undefined;
+const originalFetch = globalThis.fetch;
+let fetchCalls: FetchCall[];
+
+function installFetch(responder: (url: string, init?: RequestInit) => Promise<Response>): void {
+  const stub = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers = (init?.headers ?? {}) as Record<string, string>;
+    let body: string | undefined;
+    if (typeof init?.body === "string") body = init.body;
+    fetchCalls.push({ url, method: init?.method, body, headers });
+    return responder(url, init);
+  };
+  globalThis.fetch = stub as unknown as typeof fetch;
+}
+
+beforeAll(() => {
+  originalXdg = process.env.XDG_CONFIG_HOME;
+});
+
+afterAll(() => {
+  if (originalXdg === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = originalXdg;
+});
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "appstrate-cli-apps-"));
+  process.env.XDG_CONFIG_HOME = tmpDir;
+  FakeKeyring.store.clear();
+  _setKeyringFactoryForTesting((p) => new FakeKeyring(p));
+  fetchCalls = [];
+});
+
+afterEach(async () => {
+  _setKeyringFactoryForTesting(null);
+  globalThis.fetch = originalFetch;
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+async function seedAuth(name = "default"): Promise<void> {
+  await setProfile(name, {
+    instance: "https://app.example.com",
+    userId: "u_1",
+    email: "alice@example.com",
+    orgId: "org_1",
+  });
+  await saveTokens(name, {
+    accessToken: "tok-abc",
+    expiresAt: Date.now() + 15 * 60 * 1000,
+    refreshToken: "rt-xyz",
+    refreshExpiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+  });
+}
+
+function appRow(overrides: Partial<Application> = {}): Application {
+  return {
+    id: "app_1",
+    orgId: "org_1",
+    name: "Default",
+    isDefault: true,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("listApplications", () => {
+  it("GETs /api/applications and returns the `data` array", async () => {
+    await seedAuth();
+    installFetch(async (url) => {
+      expect(url).toBe("https://app.example.com/api/applications");
+      return new Response(
+        JSON.stringify({
+          object: "list",
+          data: [appRow({ id: "app_1", name: "Default", isDefault: true })],
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const apps = await listApplications("default");
+    expect(apps).toHaveLength(1);
+    expect(apps[0]!.id).toBe("app_1");
+    expect(fetchCalls[0]!.method ?? "GET").toBe("GET");
+    // The pinned org is forwarded as X-Org-Id — listApplications is
+    // org-scoped even though it doesn't require X-App-Id.
+    expect(fetchCalls[0]!.headers["X-Org-Id"]).toBe("org_1");
+  });
+
+  it("returns an empty array when the server returns no applications", async () => {
+    await seedAuth();
+    installFetch(
+      async () =>
+        new Response(JSON.stringify({ object: "list", data: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const apps = await listApplications("default");
+    expect(apps).toEqual([]);
+  });
+
+  it("returns an empty array when response shape is degenerate", async () => {
+    await seedAuth();
+    installFetch(
+      async () =>
+        new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const apps = await listApplications("default");
+    expect(apps).toEqual([]);
+  });
+});
+
+describe("createApplication", () => {
+  it("POSTs with the name and returns the created application", async () => {
+    await seedAuth();
+    installFetch(async (url, init) => {
+      expect(url).toBe("https://app.example.com/api/applications");
+      expect(init?.method).toBe("POST");
+      const body = JSON.parse(String(init?.body));
+      expect(body).toEqual({ name: "Staging" });
+      return new Response(
+        JSON.stringify(appRow({ id: "app_2", name: "Staging", isDefault: false })),
+        { status: 201, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    const app = await createApplication("default", "Staging");
+    expect(app.id).toBe("app_2");
+    expect(app.isDefault).toBe(false);
+  });
+});
+
+describe("resolveApplicationRef", () => {
+  const apps: Application[] = [
+    appRow({ id: "app_1", name: "Default", isDefault: true }),
+    appRow({ id: "app_2", name: "Staging", isDefault: false }),
+  ];
+
+  it("matches by exact id", () => {
+    expect(resolveApplicationRef(apps, "app_2").name).toBe("Staging");
+  });
+
+  it("ignores surrounding whitespace", () => {
+    expect(resolveApplicationRef(apps, "  app_1  ").id).toBe("app_1");
+  });
+
+  it("throws with the available apps (marked [default]) when ref is unknown", () => {
+    try {
+      resolveApplicationRef(apps, "app_999");
+      throw new Error("expected resolveApplicationRef to throw");
+    } catch (err) {
+      const msg = (err as Error).message;
+      expect(msg).toContain('No application matches "app_999"');
+      expect(msg).toContain("app_1");
+      expect(msg).toContain("[default]");
+      expect(msg).toContain("app_2");
+    }
+  });
+
+  it("rejects empty references", () => {
+    expect(() => resolveApplicationRef(apps, "")).toThrow(/empty/);
+    expect(() => resolveApplicationRef(apps, "   ")).toThrow(/empty/);
+  });
+
+  it("surfaces a dedicated message when the profile has zero apps", () => {
+    expect(() => resolveApplicationRef([], "anything")).toThrow(/No applications found/);
+  });
+});
+
+describe("findDefaultApplication", () => {
+  it("returns the app marked isDefault", () => {
+    const apps = [
+      appRow({ id: "app_1", isDefault: false }),
+      appRow({ id: "app_2", isDefault: true }),
+    ];
+    expect(findDefaultApplication(apps)?.id).toBe("app_2");
+  });
+
+  it("returns undefined when no app is marked default (defensive path)", () => {
+    const apps = [appRow({ id: "app_1", isDefault: false })];
+    expect(findDefaultApplication(apps)).toBeUndefined();
+  });
+
+  it("returns undefined on an empty list", () => {
+    expect(findDefaultApplication([])).toBeUndefined();
+  });
+});

--- a/apps/cli/test/config.test.ts
+++ b/apps/cli/test/config.test.ts
@@ -15,6 +15,7 @@ import {
   writeConfig,
   getProfile,
   setProfile,
+  updateProfile,
   deleteProfile,
   listProfiles,
   resolveProfileName,
@@ -50,13 +51,43 @@ describe("readConfig", () => {
     const input: Config = {
       defaultProfile: "prod",
       profiles: {
-        prod: { instance: "https://app.example.com", userId: "u1", email: "a@b.c", orgId: "o1" },
+        prod: {
+          instance: "https://app.example.com",
+          userId: "u1",
+          email: "a@b.c",
+          orgId: "o1",
+          appId: "a1",
+        },
         dev: { instance: "http://localhost:3000", userId: "u2", email: "x@y.z" },
       },
     };
     await writeConfig(input);
     const read = await readConfig();
     expect(read).toEqual(input);
+  });
+
+  it("round-trips a profile without appId unchanged (forward-compat)", async () => {
+    // Legacy profiles predating #217 have `orgId` but no `appId`. They
+    // must parse cleanly and write back without materializing a phantom
+    // `appId = ""` entry in the TOML file.
+    const input: Config = {
+      defaultProfile: "legacy",
+      profiles: {
+        legacy: {
+          instance: "https://app.example.com",
+          userId: "u1",
+          email: "a@b.c",
+          orgId: "o1",
+        },
+      },
+    };
+    await writeConfig(input);
+    const read = await readConfig();
+    expect(read).toEqual(input);
+    expect(read.profiles.legacy!.appId).toBeUndefined();
+    const { readFile } = await import("node:fs/promises");
+    const raw = await readFile(join(tmpDir, "appstrate", "config.toml"), "utf-8");
+    expect(raw).not.toContain("appId");
   });
 
   it("skips malformed profile rows without throwing", async () => {
@@ -158,6 +189,78 @@ describe("setProfile + getProfile + deleteProfile", () => {
     const config = await readConfig();
     expect(config.defaultProfile).toBe("default");
     expect(await listProfiles()).toEqual([]);
+  });
+});
+
+describe("updateProfile", () => {
+  it("merges a partial patch into an existing profile", async () => {
+    await setProfile("dev", {
+      instance: "http://localhost:3000",
+      userId: "u",
+      email: "e",
+      orgId: "org_1",
+    });
+    await updateProfile("dev", { appId: "app_1" });
+    const after = await getProfile("dev");
+    expect(after).toEqual({
+      instance: "http://localhost:3000",
+      userId: "u",
+      email: "e",
+      orgId: "org_1",
+      appId: "app_1",
+    });
+  });
+
+  it("treats `undefined` in the patch as 'clear this key'", async () => {
+    await setProfile("dev", {
+      instance: "http://localhost:3000",
+      userId: "u",
+      email: "e",
+      orgId: "org_1",
+      appId: "app_1",
+    });
+    // Clearing appId should drop the key entirely — not leave an explicit
+    // `appId: undefined` that TOML would serialize as `appId = ""`.
+    await updateProfile("dev", { appId: undefined });
+    const after = await getProfile("dev");
+    expect(after!.appId).toBeUndefined();
+    const { readFile } = await import("node:fs/promises");
+    const raw = await readFile(join(tmpDir, "appstrate", "config.toml"), "utf-8");
+    expect(raw).not.toContain("appId");
+  });
+
+  it("rewrites multiple fields atomically — orgId + appId in one call", async () => {
+    await setProfile("dev", {
+      instance: "http://localhost:3000",
+      userId: "u",
+      email: "e",
+      orgId: "org_old",
+      appId: "app_old",
+    });
+    // Simulates `org switch` cascade: swap org and clear app pin in one write.
+    await updateProfile("dev", { orgId: "org_new", appId: undefined });
+    const after = await getProfile("dev");
+    expect(after!.orgId).toBe("org_new");
+    expect(after!.appId).toBeUndefined();
+  });
+
+  it("throws when the profile is missing (invariant: runLogin writes first)", async () => {
+    await expect(updateProfile("ghost", { orgId: "o" })).rejects.toThrow(/missing/);
+  });
+
+  it("preserves unrelated fields", async () => {
+    await setProfile("dev", {
+      instance: "http://localhost:3000",
+      userId: "u",
+      email: "e",
+      orgId: "org_1",
+    });
+    await updateProfile("dev", { appId: "app_1" });
+    const after = await getProfile("dev");
+    expect(after!.instance).toBe("http://localhost:3000");
+    expect(after!.userId).toBe("u");
+    expect(after!.email).toBe("e");
+    expect(after!.orgId).toBe("org_1");
   });
 });
 

--- a/apps/cli/test/login-org.test.ts
+++ b/apps/cli/test/login-org.test.ts
@@ -33,6 +33,7 @@ import {
 import { readConfig } from "../src/lib/config.ts";
 import { loginCommand } from "../src/commands/login.ts";
 import type { Org } from "../src/lib/orgs.ts";
+import type { Application } from "../src/lib/applications.ts";
 
 class FakeKeyring implements KeyringHandle {
   static store = new Map<string, string>();
@@ -98,6 +99,19 @@ interface ResponderMap {
   cliToken?: () => Response;
   listOrgs?: () => Response;
   createOrg?: (body: unknown) => Response;
+  listApplications?: () => Response;
+  createApplication?: (body: unknown) => Response;
+}
+
+function appRow(overrides: Partial<Application> = {}): Application {
+  return {
+    id: "app_default",
+    orgId: "org_created",
+    name: "Default",
+    isDefault: true,
+    createdAt: "t",
+    ...overrides,
+  };
 }
 
 function installDefaultResponders(overrides: ResponderMap = {}): void {
@@ -142,6 +156,21 @@ function installDefaultResponders(overrides: ResponderMap = {}): void {
         }),
         { status: 201, headers: { "Content-Type": "application/json" } },
       ),
+    // By default, the app cascade sees a single default app — mirrors
+    // the real server behavior where `POST /api/orgs` provisions one.
+    // NOTE: the cascade only runs when an org is pinned. Test suites that
+    // need the cascade to fire must either override `listOrgs` to return
+    // a non-empty list, or pass `--create-org <name>`.
+    listApplications: () =>
+      new Response(JSON.stringify({ object: "list", data: [appRow()] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    createApplication: () =>
+      new Response(JSON.stringify(appRow({ id: "app_forced", name: "Forced" })), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      }),
   };
   const resolved = { ...defaults, ...overrides };
 
@@ -157,6 +186,11 @@ function installDefaultResponders(overrides: ResponderMap = {}): void {
       return resolved.createOrg(parsed);
     }
     if (url.endsWith("/api/orgs")) return resolved.listOrgs();
+    if (url.endsWith("/api/applications") && method === "POST") {
+      const parsed = body ? JSON.parse(body) : {};
+      return resolved.createApplication(parsed);
+    }
+    if (url.endsWith("/api/applications")) return resolved.listApplications();
     return new Response("not mocked: " + url, { status: 501 });
   };
   globalThis.fetch = stub as unknown as typeof fetch;
@@ -192,6 +226,11 @@ afterEach(async () => {
 async function readPinnedOrgId(profile = "default"): Promise<string | undefined> {
   const cfg = await readConfig();
   return cfg.profiles[profile]?.orgId;
+}
+
+async function readPinnedAppId(profile = "default"): Promise<string | undefined> {
+  const cfg = await readConfig();
+  return cfg.profiles[profile]?.appId;
 }
 
 describe("login org-pin branch", () => {
@@ -542,5 +581,372 @@ describe("login org-pin branch", () => {
     expect(profile!.email).toBe("alice@example.com");
     expect(profile!.userId).toBe("u_test");
     expect(profile!.orgId).toBe("org_only");
+  });
+});
+
+// ─── App cascade (issue #217) ─────────────────────────────────────────
+//
+// Every org-pin outcome that leaves an `orgId` on the profile triggers
+// a second fetch to `/api/applications` and re-pins the default app.
+// The coverage below pairs with `login org-pin branch` above — it
+// asserts the SAME flows, plus the app-specific escapes.
+
+describe("login app-pin cascade", () => {
+  // Shared: `listOrgs` returning exactly one org so the cascade has an
+  // `orgId` to work with. Every test in this block inherits it unless it
+  // overrides explicitly.
+  const oneOrg = () =>
+    new Response(
+      JSON.stringify({
+        organizations: [{ id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" }],
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+
+  it("auto-pins the default application after org pin (one app)", async () => {
+    installDefaultResponders({
+      listOrgs: oneOrg,
+      listApplications: () =>
+        new Response(
+          JSON.stringify({
+            object: "list",
+            data: [appRow({ id: "app_only", name: "Only", isDefault: true })],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+    });
+
+    expect(await readPinnedAppId()).toBe("app_only");
+    const out = stdoutChunks.join("");
+    expect(out).toContain('/ app "Only"');
+    expect(out).toContain("app_only");
+  });
+
+  it("pins the isDefault app when ≥2 applications exist", async () => {
+    installDefaultResponders({
+      listOrgs: oneOrg,
+      listApplications: () =>
+        new Response(
+          JSON.stringify({
+            object: "list",
+            data: [
+              appRow({ id: "app_staging", name: "Staging", isDefault: false }),
+              appRow({ id: "app_default", name: "Default", isDefault: true }),
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+
+    expect(await readPinnedAppId()).toBe("app_default");
+  });
+
+  it("warns on stderr and leaves appId unset when ≥2 apps but no default", async () => {
+    installDefaultResponders({
+      listOrgs: oneOrg,
+      listApplications: () =>
+        new Response(
+          JSON.stringify({
+            object: "list",
+            data: [
+              appRow({ id: "app_a", name: "A", isDefault: false }),
+              appRow({ id: "app_b", name: "B", isDefault: false }),
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+
+    expect(await readPinnedAppId()).toBeUndefined();
+    expect(stderrChunks.join("")).toContain("none marked default");
+    expect(stdoutChunks.join("")).toContain("No app pinned");
+  });
+
+  it("warns on stderr when the org has zero applications", async () => {
+    installDefaultResponders({
+      listOrgs: () =>
+        new Response(
+          JSON.stringify({
+            organizations: [
+              { id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      listApplications: () =>
+        new Response(JSON.stringify({ object: "list", data: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+
+    expect(await readPinnedAppId()).toBeUndefined();
+    expect(stderrChunks.join("")).toContain("No applications found");
+  });
+
+  it("honors --app <id> for non-interactive pinning", async () => {
+    installDefaultResponders({
+      listOrgs: () =>
+        new Response(
+          JSON.stringify({
+            organizations: [
+              { id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      listApplications: () =>
+        new Response(
+          JSON.stringify({
+            object: "list",
+            data: [
+              appRow({ id: "app_1", name: "One", isDefault: true }),
+              appRow({ id: "app_2", name: "Two", isDefault: false }),
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+      app: "app_2",
+    });
+
+    expect(await readPinnedAppId()).toBe("app_2");
+  });
+
+  it("exits with an actionable error when --app <id> does not match", async () => {
+    installDefaultResponders({
+      listOrgs: () =>
+        new Response(
+          JSON.stringify({
+            organizations: [
+              { id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      listApplications: () =>
+        new Response(
+          JSON.stringify({
+            object: "list",
+            data: [appRow({ id: "app_1", isDefault: true })],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    await expect(
+      loginCommand({
+        profile: "default",
+        instance: "https://app.example.com",
+        app: "app_does_not_exist",
+      }),
+    ).rejects.toBeInstanceOf(ExitError);
+  });
+
+  it("honors --create-app <name> and skips the list fetch", async () => {
+    let createBody: unknown;
+    let listCalled = false;
+    installDefaultResponders({
+      listOrgs: () =>
+        new Response(
+          JSON.stringify({
+            organizations: [
+              { id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      listApplications: () => {
+        listCalled = true;
+        return new Response(JSON.stringify({ object: "list", data: [] }), { status: 200 });
+      },
+      createApplication: (body) => {
+        createBody = body;
+        return new Response(
+          JSON.stringify(appRow({ id: "app_forced", name: "Forced", isDefault: false })),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        );
+      },
+    });
+
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+      createApp: "Forced",
+    });
+
+    expect(listCalled).toBe(false);
+    expect(createBody).toEqual({ name: "Forced" });
+    expect(await readPinnedAppId()).toBe("app_forced");
+  });
+
+  it("with --no-app skips the app cascade entirely (no fetch, no hint)", async () => {
+    let appsCalled = false;
+    installDefaultResponders({
+      listApplications: () => {
+        appsCalled = true;
+        return new Response(JSON.stringify({ object: "list", data: [] }), { status: 200 });
+      },
+    });
+
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+      noApp: true,
+    });
+
+    expect(appsCalled).toBe(false);
+    expect(await readPinnedAppId()).toBeUndefined();
+    // No "No app pinned" hint when the user opted out.
+    expect(stdoutChunks.join("")).not.toContain("No app pinned");
+  });
+
+  it("skips the app cascade when no org was pinned (no X-Org-Id to fetch with)", async () => {
+    let appsCalled = false;
+    installDefaultResponders({
+      listApplications: () => {
+        appsCalled = true;
+        return new Response(JSON.stringify({ object: "list", data: [] }), { status: 200 });
+      },
+    });
+
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+      noOrg: true,
+    });
+
+    expect(appsCalled).toBe(false);
+    expect(await readPinnedAppId()).toBeUndefined();
+    // The "No org pinned" hint fires; the app hint does not (skipped upstream).
+    expect(stdoutChunks.join("")).toContain("No org pinned");
+    expect(stdoutChunks.join("")).not.toContain("No app pinned");
+  });
+
+  it("tolerates a failing /api/applications call — login succeeds org-pinned but app-unpinned", async () => {
+    installDefaultResponders({
+      listOrgs: () =>
+        new Response(
+          JSON.stringify({
+            organizations: [
+              { id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      listApplications: () => new Response("boom", { status: 500 }),
+    });
+
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+    });
+
+    expect(await readPinnedOrgId()).toBe("org_1");
+    expect(await readPinnedAppId()).toBeUndefined();
+    expect(stderrChunks.join("")).toContain("Failed to list applications");
+  });
+
+  it("preserves a prior appId across same-user re-login when /api/applications flakes", async () => {
+    // First login — default-path cascade pins app_default via the
+    // shared responder defaults.
+    installDefaultResponders({
+      listOrgs: () =>
+        new Response(
+          JSON.stringify({
+            organizations: [
+              { id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      listApplications: () =>
+        new Response(
+          JSON.stringify({
+            object: "list",
+            data: [appRow({ id: "app_pinned", name: "Pinned", isDefault: true })],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+    expect(await readPinnedAppId()).toBe("app_pinned");
+
+    // Second login — app fetch flakes. Without preservation we'd drop
+    // the pin silently.
+    installDefaultResponders({
+      listOrgs: () =>
+        new Response(
+          JSON.stringify({
+            organizations: [
+              { id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      listApplications: () => new Response("boom", { status: 500 }),
+    });
+    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+
+    expect(await readPinnedAppId()).toBe("app_pinned");
+  });
+
+  it("does NOT preserve appId when re-logging-in as a different user", async () => {
+    // First login — user A pins.
+    installDefaultResponders({
+      listOrgs: () =>
+        new Response(
+          JSON.stringify({
+            organizations: [{ id: "org_A", name: "A", slug: "a", role: "owner", createdAt: "t" }],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      listApplications: () =>
+        new Response(
+          JSON.stringify({
+            object: "list",
+            data: [appRow({ id: "app_A", isDefault: true })],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+    expect(await readPinnedAppId()).toBe("app_A");
+
+    // Second login — different user, network flakes. Preservation must not kick in.
+    installDefaultResponders({
+      cliToken: () =>
+        new Response(
+          JSON.stringify({
+            access_token: makeJwt("u_OTHER", "bob@example.com"),
+            refresh_token: "rt-xyz",
+            token_type: "Bearer",
+            expires_in: 900,
+            refresh_expires_in: 30 * 24 * 60 * 60,
+            scope: "cli",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      listOrgs: () => new Response("boom", { status: 500 }),
+      listApplications: () => new Response("boom", { status: 500 }),
+    });
+    await loginCommand({ profile: "default", instance: "https://app.example.com" });
+
+    expect(await readPinnedAppId()).toBeUndefined();
   });
 });

--- a/apps/cli/test/org-command.test.ts
+++ b/apps/cli/test/org-command.test.ts
@@ -78,6 +78,7 @@ function captureIo(): void {
 interface Responders {
   listOrgs?: () => Response;
   createOrg?: (body: unknown) => Response;
+  listApplications?: () => Response;
 }
 
 function installFetch(responders: Responders): void {
@@ -94,6 +95,27 @@ function installFetch(responders: Responders): void {
     }
     if (url.endsWith("/api/orgs")) {
       return responders.listOrgs?.() ?? new Response("missing listOrgs stub", { status: 501 });
+    }
+    if (url.endsWith("/api/applications")) {
+      // Default: the new org has exactly one server-provisioned default app.
+      return (
+        responders.listApplications?.() ??
+        new Response(
+          JSON.stringify({
+            object: "list",
+            data: [
+              {
+                id: "app_cascade_default",
+                orgId: "org_2",
+                name: "Default",
+                isDefault: true,
+                createdAt: "t",
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        )
+      );
     }
     return new Response("not mocked: " + url, { status: 501 });
   };
@@ -127,12 +149,13 @@ afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true });
 });
 
-async function seedLoggedIn(orgId?: string, profile = "default"): Promise<void> {
+async function seedLoggedIn(orgId?: string, profile = "default", appId?: string): Promise<void> {
   await setProfile(profile, {
     instance: "https://app.example.com",
     userId: "u_1",
     email: "alice@example.com",
     ...(orgId ? { orgId } : {}),
+    ...(appId ? { appId } : {}),
   });
   await saveTokens(profile, {
     accessToken: "tok-abc",
@@ -144,6 +167,10 @@ async function seedLoggedIn(orgId?: string, profile = "default"): Promise<void> 
 
 async function pinnedOrgId(profile = "default"): Promise<string | undefined> {
   return (await readConfig()).profiles[profile]?.orgId;
+}
+
+async function pinnedAppId(profile = "default"): Promise<string | undefined> {
+  return (await readConfig()).profiles[profile]?.appId;
 }
 
 const twoOrgs = {
@@ -399,5 +426,130 @@ describe("org create", () => {
       ExitError,
     );
     expect(stderrChunks.join("")).toContain("not configured");
+  });
+});
+
+// ─── App cascade on org change (issue #217) ───────────────────────────
+//
+// An `appId` pinned to org A is invalid under org B — the server returns
+// 404 on the next app-scoped call. `org switch` and `org create` must
+// both (a) clear the stale app pin and (b) re-pin the new org's default
+// app so `appstrate api` keeps working without manual intervention.
+
+describe("org switch — cascade: re-pins new org's default app", () => {
+  it("pins the new org AND pins the new org's default app in one call", async () => {
+    // Start pinned to org_1 with an app pin that only exists under org_1.
+    await seedLoggedIn("org_1", "default", "app_stale_from_org_1");
+    installFetch({
+      listOrgs: () =>
+        new Response(JSON.stringify(twoOrgs), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      listApplications: () =>
+        new Response(
+          JSON.stringify({
+            object: "list",
+            data: [
+              {
+                id: "app_for_org_2",
+                orgId: "org_2",
+                name: "Org 2 Default",
+                isDefault: true,
+                createdAt: "t",
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    await orgSwitchCommand({ profile: "default", ref: "org_2" });
+
+    expect(await pinnedOrgId()).toBe("org_2");
+    expect(await pinnedAppId()).toBe("app_for_org_2");
+    const out = stdoutChunks.join("");
+    expect(out).toContain('Pinned "Beta"');
+    expect(out).toContain('/ app "Org 2 Default"');
+  });
+
+  it("clears the stale app pin even when the new org has no default app", async () => {
+    await seedLoggedIn("org_1", "default", "app_stale");
+    installFetch({
+      listOrgs: () =>
+        new Response(JSON.stringify(twoOrgs), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      listApplications: () =>
+        new Response(JSON.stringify({ object: "list", data: [] }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    });
+
+    await orgSwitchCommand({ profile: "default", ref: "org_2" });
+
+    expect(await pinnedOrgId()).toBe("org_2");
+    // Crucially, the stale pin is gone even though no new default was found.
+    expect(await pinnedAppId()).toBeUndefined();
+  });
+
+  it("tolerates a failing /api/applications call — org pin still commits", async () => {
+    await seedLoggedIn("org_1", "default", "app_stale");
+    installFetch({
+      listOrgs: () =>
+        new Response(JSON.stringify(twoOrgs), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      listApplications: () => new Response("boom", { status: 500 }),
+    });
+
+    await orgSwitchCommand({ profile: "default", ref: "org_2" });
+
+    expect(await pinnedOrgId()).toBe("org_2");
+    expect(await pinnedAppId()).toBeUndefined();
+  });
+});
+
+describe("org create — cascade: re-pins new org's default app", () => {
+  it("pins the newly created org AND pins the auto-provisioned default app", async () => {
+    await seedLoggedIn(undefined, "default", "app_stale");
+    installFetch({
+      createOrg: () =>
+        new Response(
+          JSON.stringify({
+            id: "org_new",
+            name: "Fresh",
+            slug: "fresh",
+            role: "owner",
+            createdAt: "t",
+          }),
+          { status: 201, headers: { "Content-Type": "application/json" } },
+        ),
+      listApplications: () =>
+        new Response(
+          JSON.stringify({
+            object: "list",
+            data: [
+              {
+                id: "app_new_default",
+                orgId: "org_new",
+                name: "Default",
+                isDefault: true,
+                createdAt: "t",
+              },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    await orgCreateCommand({ profile: "default", name: "Fresh" });
+
+    expect(await pinnedOrgId()).toBe("org_new");
+    expect(await pinnedAppId()).toBe("app_new_default");
+    expect(stdoutChunks.join("")).toContain('/ app "Default"');
   });
 });


### PR DESCRIPTION
## Summary

Closes #217.

- Persist `appId` on the profile and auto-inject `X-App-Id` alongside `X-Org-Id` on every authenticated request — app-scoped routes (`/api/agents`, `/api/runs`, `/api/schedules`, …) now work out of the box after `appstrate login`, no more `400 Application context required` on the canonical agent recipes shipped in #216.
- Cascade at login: after the orgId pin, auto-pin the org's default application (`isDefault: true`, server-provisioned). New `--app <id>` / `--create-app <name>` / `--no-app` flags.
- New `appstrate app {list,current,switch,create}` command family (mirror of `appstrate org`).
- `org switch` / `org create` clear the stale `appId` and re-pin the new org's default in the same atomic update — prevents `404 Application not found in this organization` on the next call.
- Factor profile rewrites into a single `updateProfile(name, patch)` helper; extract `resolveActiveProfile` + `requireLoggedIn` to `lib/config.ts` so `org.ts` and `app.ts` share the same helpers. Zero duplication between the two command families.

## Test plan

- [x] `bun test` in `apps/cli` — **647 pass / 0 fail / 1277 expect() calls** across 29 files (123 new or extended tests).
- [x] `bun run check` at monorepo root — tsc + eslint + prettier + verify-openapi all green.
- [x] TOML round-trip with `appId`, forward-compat for legacy profiles without it, `updateProfile({ appId: undefined })` clears the key.
- [x] `X-App-Id` header injection (set when pinned, absent when unpinned, coexists with `X-Org-Id`).
- [x] Login cascade: one-app auto-pin, ≥2-apps default pick, no-default warning, zero-apps warning, `--app`/`--create-app`/`--no-app` flags, `--no-org` short-circuits the cascade, `/api/applications` flake tolerated, preservation across same-user re-login, drop on different-user re-login.
- [x] `org switch` / `org create` cascade: new orgId + default app pinned, stale appId cleared even when no new default exists, `/api/applications` flake tolerated.
- [x] `app list` (marker + `[default]` tag), `app current` (stdout / exit 1 hints), `app switch` (id / picker / no-match / non-TTY), `app create` (positional name / prompt / non-TTY).
- [ ] Manual e2e against a local Tier 0 instance (reviewer's call — the existing `login-org` + `org-command` suites exercise the same plumbing with mocked `fetch`, and the new tests layer on top).

🤖 Generated with [Claude Code](https://claude.com/claude-code)