### PR TITLE
fix(api): return 404 problem+json for unknown /api/* paths

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -46,7 +46,7 @@ import {
   getModuleOpenApiTags,
   registerModuleRoutes,
 } from "./lib/modules/module-loader.ts";
-import { ApiError } from "./lib/errors.ts";
+import { ApiError, notFound } from "./lib/errors.ts";
 import { apiVersion } from "./middleware/api-version.ts";
 import { getOrgSettings } from "./services/organizations.ts";
 import { getAppConfig, initAppConfig } from "./lib/app-config.ts";
@@ -251,6 +251,14 @@ app.route("/internal", internalRouter);
 // catch-all below, otherwise the static fallback shadows module paths.
 // No-op when no module exposes `createRouter()`.
 registerModuleRoutes(app);
+
+// Unknown /api/* → 404 problem+json. Without this the SPA fallback below would
+// match every unknown API path and return index.html with a 200, breaking
+// pass-through clients (CLI, curl, SDKs).
+app.all("/api/*", (c) => {
+  const pathname = new URL(c.req.url).pathname;
+  throw notFound(`API endpoint not found: ${c.req.method} ${pathname}`);
+});
 
 // Static files for UI (JS, CSS, images, fonts — skip index.html, served with config below)
 app.use(

--- a/apps/api/test/helpers/app.ts
+++ b/apps/api/test/helpers/app.ts
@@ -32,6 +32,7 @@ import { initSystemProviderKeys } from "../../src/services/model-registry.ts";
 import { initRunLimits } from "../../src/services/run-limits.ts";
 import { applyAuthPipeline, skipAuth } from "../../src/lib/auth-pipeline.ts";
 import { initAppConfig } from "../../src/lib/app-config.ts";
+import { notFound } from "../../src/lib/errors.ts";
 
 // Route imports
 import { createAgentsRouter } from "../../src/routes/agents.ts";
@@ -199,6 +200,12 @@ export function getTestApp(options?: GetTestAppOptions): Hono<AppEnv> {
   app.route("/invite", invitationsRouter);
   app.route("/api", welcomeRouter);
   app.route("/internal", createInternalRouter());
+
+  // Mirrors production: unknown /api/* → 404 problem+json (no SPA fallback in tests).
+  app.all("/api/*", (c) => {
+    const pathname = new URL(c.req.url).pathname;
+    throw notFound(`API endpoint not found: ${c.req.method} ${pathname}`);
+  });
 
   if (!explicit) cachedApp = app;
   return app;

--- a/apps/api/test/integration/routes/error-paths.test.ts
+++ b/apps/api/test/integration/routes/error-paths.test.ts
@@ -126,6 +126,59 @@ describe("404 — non-existent resources", () => {
   });
 });
 
+// ─── 404 — unknown /api/* paths (no SPA fallback) ──────────
+
+describe("404 — unknown /api/* paths", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "testorg" });
+  });
+
+  it("GET /api/me returns 404 problem+json (not SPA HTML)", async () => {
+    const res = await app.request("/api/me", { headers: authHeaders(ctx) });
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Content-Type")).toContain("application/problem+json");
+    const body = (await res.json()) as any;
+    expect(body.status).toBe(404);
+    expect(body.code).toBe("not_found");
+    expect(body.detail).toContain("/api/me");
+  });
+
+  it("POST /api/does-not-exist returns 404 problem+json", async () => {
+    const res = await app.request("/api/does-not-exist", {
+      method: "POST",
+      headers: authHeaders(ctx),
+    });
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Content-Type")).toContain("application/problem+json");
+    const body = (await res.json()) as any;
+    expect(body.code).toBe("not_found");
+  });
+
+  it("GET /api/unknown-nested/path/segment returns 404 problem+json", async () => {
+    const res = await app.request("/api/unknown-nested/path/segment", {
+      headers: authHeaders(ctx),
+    });
+    expect(res.status).toBe(404);
+    expect(res.headers.get("Content-Type")).toContain("application/problem+json");
+  });
+
+  it("unknown /api/* response includes Request-Id header", async () => {
+    const res = await app.request("/api/me", { headers: authHeaders(ctx) });
+    expect(res.headers.get("Request-Id")).toBeTruthy();
+  });
+
+  it("detail message includes the HTTP method and path", async () => {
+    const res = await app.request("/api/typo", { method: "PUT", headers: authHeaders(ctx) });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as any;
+    expect(body.detail).toContain("PUT");
+    expect(body.detail).toContain("/api/typo");
+  });
+});
+
 // ─── 403 — cross-org access ────────────────────────────────
 
 describe("403 — cross-org access prevention", () => {


### PR DESCRIPTION
## Summary

- The SPA catch-all (`app.get("/*", ...)`) was matching unknown `/api/*` paths and returning `index.html` with a `200`, making CLI/SDK pass-through clients parse HTML as JSON and fail downstream.
- Install a `/api/*` catch-all **before** `serveStatic` + the SPA fallback that throws `notFound()`. The existing `errorHandler` then renders RFC 9457 `application/problem+json`.
- Mirror the same handler in `apps/api/test/helpers/app.ts` (tests already skip the SPA fallback) and add coverage in `error-paths.test.ts`.

Closes #215

## Test plan

- [x] `bun test apps/api/test/integration/routes/error-paths.test.ts` — 42 pass, 0 fail (5 new cases)
- [x] `bun test apps/api/test/integration/routes/auth.test.ts` + `health.test.ts` — no regressions
- [x] `bunx tsc --noEmit` inside `apps/api` — clean
- [x] `bun run verify:openapi` — all checks pass
- [ ] Manual repro from the issue: `bun ./apps/cli/dist/cli api -i GET /api/me` should now return `404` + `application/problem+json` instead of `200` + HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)