### PR TITLE
fix(ui): read formContext from registry in FileWidget (RJSF v6)

### DIFF
--- a/packages/ui/src/schema-form/file-widget.tsx
+++ b/packages/ui/src/schema-form/file-widget.tsx
@@ -68,14 +68,14 @@ const DEFAULT_LABELS: Required<FileWidgetLabels> = {
  *   - `{ type: "array", items: { type: "string", format: "uri", … } }` → multi
  *
  * The binary is uploaded directly to storage via the endpoint resolved from
- * `formContext.uploadPath` (POST), and `onChange` writes back an
+ * `registry.formContext.uploadPath` (POST), and `onChange` writes back an
  * `upload://upl_xxx` URI (or array of URIs). RJSF then validates the schema
  * on this URI — the server re-validates when the run is triggered.
  */
 export function FileWidget(props: WidgetProps) {
-  const { id, value, onChange, required, label, schema, disabled, readonly, options, formContext } =
+  const { id, value, onChange, required, label, schema, disabled, readonly, options, registry } =
     props;
-  const ctx = (formContext ?? {}) as SchemaFormContext;
+  const ctx = (registry?.formContext ?? {}) as SchemaFormContext;
   const labels = useMemo<Required<FileWidgetLabels>>(
     () => ({ ...DEFAULT_LABELS, ...(ctx.labels ?? {}) }),
     [ctx.labels],


### PR DESCRIPTION
## Summary

- `FileWidget` destructured `formContext` from `WidgetProps`, but RJSF v6 dropped `formContext` from widget props — it now lives on `registry.formContext` only.
- Result: `ctx.uploadPath` was always `undefined`, so every file upload attempt surfaced **"File uploads are not configured for this form."** before any network request. Breakage is visible on `@saneki/edi-order-transform` and any agent whose input declares a `{ format: "uri", contentMediaType }` field.
- Templates in the same package already use `registry.formContext` (see `templates.tsx:247`) — this aligns the widget with that convention.

## Test plan

- [ ] `bun run check` at the repo root (tsc + eslint + prettier + verify-openapi) — local typecheck on `@appstrate/ui` and `@appstrate/web` passed
- [ ] On app.appstrate.com, open an agent with a file input (e.g. `@saneki/edi-order-transform`) → Run → drop/pick a file → confirm a `POST /api/uploads` fires and the upload flow completes through to the run
- [ ] Portal consumer (`@appstrate/ui@^1.0.1`) unaffected until a 1.0.2 is published + bumped in `portal/` — follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)