### PR TITLE
fix(web): inject org/app headers on file uploads

### DIFF
--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -1,12 +1,58 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import type { UploadFn } from "@appstrate/ui/schema-form";
 import { getCurrentOrgId } from "./hooks/use-org";
 import { getCurrentApplicationId } from "./stores/app-store";
 
 const API_BASE = "/api";
 
-/** Direct-upload endpoint consumed by `<SchemaForm uploadPath={...} />`. */
-export const UPLOADS_PATH = `${API_BASE}/uploads`;
+const UPLOADS_PATH = `${API_BASE}/uploads`;
+
+interface UploadDescriptor {
+  id: string;
+  uri: string;
+  url: string;
+  method: "PUT";
+  headers: Record<string, string>;
+}
+
+/**
+ * Authed uploader for `<SchemaForm upload={...} />`. The default UI-package
+ * uploader uses raw fetch (no org context), which the `/api/uploads` middleware
+ * rejects with "X-Org-Id header is required". This variant injects the same
+ * org/app headers as `apiFetch`.
+ */
+export const uploadClient: UploadFn = async (file, signal) => {
+  const descRes = await fetch(UPLOADS_PATH, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+    body: JSON.stringify({
+      name: file.name,
+      size: file.size,
+      mime: file.type || "application/octet-stream",
+    }),
+    signal,
+  });
+  if (!descRes.ok) {
+    const body = (await descRes.json().catch(() => ({ detail: descRes.statusText }))) as {
+      detail?: string;
+    };
+    throw new Error(body.detail ?? `upload init failed: ${descRes.status}`);
+  }
+  const desc = (await descRes.json()) as UploadDescriptor;
+
+  const putRes = await fetch(desc.url, {
+    method: desc.method,
+    headers: desc.headers,
+    body: file,
+    signal,
+  });
+  if (!putRes.ok) {
+    throw new Error(`upload failed: ${putRes.status} ${putRes.statusText}`);
+  }
+  return desc.uri;
+};
 
 export class ApiError extends Error {
   constructor(

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -6,8 +6,6 @@ import { getCurrentApplicationId } from "./stores/app-store";
 
 const API_BASE = "/api";
 
-const UPLOADS_PATH = `${API_BASE}/uploads`;
-
 interface UploadDescriptor {
   id: string;
   uri: string;
@@ -17,16 +15,14 @@ interface UploadDescriptor {
 }
 
 /**
- * Authed uploader for `<SchemaForm upload={...} />`. The default UI-package
- * uploader uses raw fetch (no org context), which the `/api/uploads` middleware
- * rejects with "X-Org-Id header is required". This variant injects the same
- * org/app headers as `apiFetch`.
+ * Authed uploader for `<SchemaForm upload={...} />`. The UI package's default
+ * uploader uses raw fetch (no org context); this variant goes through `api()`
+ * so `/api/uploads` gets the same `X-Org-Id` / `X-App-Id` headers as every
+ * other call.
  */
 export const uploadClient: UploadFn = async (file, signal) => {
-  const descRes = await fetch(UPLOADS_PATH, {
+  const desc = await api<UploadDescriptor>("/uploads", {
     method: "POST",
-    credentials: "include",
-    headers: { "Content-Type": "application/json", ...getAuthHeaders() },
     body: JSON.stringify({
       name: file.name,
       size: file.size,
@@ -34,13 +30,6 @@ export const uploadClient: UploadFn = async (file, signal) => {
     }),
     signal,
   });
-  if (!descRes.ok) {
-    const body = (await descRes.json().catch(() => ({ detail: descRes.statusText }))) as {
-      detail?: string;
-    };
-    throw new Error(body.detail ?? `upload init failed: ${descRes.status}`);
-  }
-  const desc = (await descRes.json()) as UploadDescriptor;
 
   const putRes = await fetch(desc.url, {
     method: desc.method,

--- a/apps/web/src/components/input-modal.tsx
+++ b/apps/web/src/components/input-modal.tsx
@@ -9,7 +9,7 @@ import { Spinner } from "./spinner";
 import { SchemaForm } from "@appstrate/ui/schema-form";
 import type { SchemaWrapper, JSONSchemaObject } from "@appstrate/core/form";
 import { useSchemaFormLabels } from "../hooks/use-schema-form-labels";
-import { UPLOADS_PATH } from "../api";
+import { uploadClient } from "../api";
 import type { AgentDetail } from "@appstrate/shared-types";
 
 interface InputModalProps {
@@ -82,7 +82,7 @@ function InputModalForm({
         ref={formRef}
         wrapper={wrapper}
         formData={formData}
-        uploadPath={UPLOADS_PATH}
+        upload={uploadClient}
         labels={labels}
         onChange={(e) => setFormData(e.formData as Record<string, unknown>)}
         onSubmit={(e) => onSubmit(e.formData as Record<string, unknown>)}

--- a/apps/web/src/components/package-detail/agent-configuration-tab.tsx
+++ b/apps/web/src/components/package-detail/agent-configuration-tab.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/select";
 import { SchemaForm } from "@appstrate/ui/schema-form";
 import { useSchemaFormLabels } from "../../hooks/use-schema-form-labels";
-import { UPLOADS_PATH } from "../../api";
+import { uploadClient } from "../../api";
 import { PROVIDER_ICONS } from "../icons";
 import { findProviderByApiAndBaseUrl } from "@/lib/model-presets";
 import { useModels, useAgentModel, useSetAgentModel } from "../../hooks/use-models";
@@ -55,7 +55,7 @@ function ConfigSection({
       <SchemaForm
         wrapper={wrapper}
         formData={values}
-        uploadPath={UPLOADS_PATH}
+        upload={uploadClient}
         labels={labels}
         onChange={(e) => setValues(e.formData as Record<string, unknown>)}
       />

--- a/apps/web/src/components/schedule-form.tsx
+++ b/apps/web/src/components/schedule-form.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/ui/select";
 import { SchemaForm } from "@appstrate/ui/schema-form";
 import { useSchemaFormLabels } from "../hooks/use-schema-form-labels";
-import { UPLOADS_PATH } from "../api";
+import { uploadClient } from "../api";
 import type { JSONSchemaObject, SchemaWrapper } from "@appstrate/core/form";
 import { useConnectionProfiles, useAppProfiles } from "../hooks/use-connection-profiles";
 import { CombinedProfileSelect, type ForeignProfile } from "./combined-profile-select";
@@ -311,7 +311,7 @@ export function ScheduleForm({
           <SchemaForm
             wrapper={wrapper}
             formData={inputValues}
-            uploadPath={UPLOADS_PATH}
+            upload={uploadClient}
             labels={labels}
             onChange={(e) => setInputValues(e.formData as Record<string, unknown>)}
           />


### PR DESCRIPTION
## Summary

- File uploads were failing with **"X-Org-Id header is required"** since #239 unblocked the RJSF v6 file widget.
- Root cause: when `schema-form` was extracted into `@appstrate/ui` (#120), the default `createUploader(uploadPath)` was rewritten to a raw `fetch()` without `X-Org-Id` / `X-App-Id` (to stay reusable by Portal's token-scoped endpoint). The web app kept passing `uploadPath` — none of the three consumers switched to the `upload={...}` escape hatch, so `POST /api/uploads` went out un-scoped and the org-context middleware rejected it.
- Bug was dormant until #239 fixed `FileWidget` reading `formContext` from `registry` — before that, uploads errored earlier ("File uploads are not configured for this form.") and never hit the network.

## Fix

- Add a small authed `uploadClient: UploadFn` in `apps/web/src/api.ts` that reuses `getAuthHeaders()` — same org/app headers as every other call.
- Swap `uploadPath={UPLOADS_PATH}` → `upload={uploadClient}` in the three consumers: `input-modal.tsx`, `schedule-form.tsx`, `package-detail/agent-configuration-tab.tsx`.
- `UPLOADS_PATH` is no longer exported (only used internally by `uploadClient`).
- `@appstrate/ui` stays generic — Portal keeps using `uploadPath` for its token-scoped `/share/:token/uploads` endpoint (no org context needed there).

## Test plan

- [x] `bun run check` (turbo check + verify-openapi) — all 15 tasks green
- [ ] On a running platform: open an agent with a file input → pick a file → confirm `POST /api/uploads` succeeds and the run fires
- [ ] Same check in the schedule form and the agent configuration tab (the two other callers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)