### PR TITLE
T2.E: appstrate run accepts .afps-bundle

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -555,7 +555,7 @@ registerOpenapiCommand(program, () => program.opts<{ profile?: string }>().profi
 program
   .command("run")
   .description("Execute an AFPS bundle locally via PiRunner (CLI mode — no platform preamble)")
-  .argument("<bundle>", "Path to the .afps bundle (or .zip)")
+  .argument("<bundle>", "Path to the bundle — .afps (single-package) or .afps-bundle (with deps)")
   .option(
     "--providers <mode>",
     "Provider resolution: remote (default, via Appstrate instance), local (creds file), or none",

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -23,7 +23,7 @@ import {
   prepareBundleForPi,
   buildProviderExtensionFactories,
 } from "@appstrate/runner-pi";
-import { loadBundleFromFile } from "@appstrate/afps-runtime/bundle";
+import { loadAnyBundleFromFile } from "@appstrate/afps-runtime/bundle";
 import { renderPrompt } from "@appstrate/afps-runtime";
 import type { ExecutionContext } from "@appstrate/afps-runtime/types";
 import { resolveActiveProfile } from "../lib/config.ts";
@@ -86,7 +86,12 @@ async function runCommandInner(opts: RunCommandOptions): Promise<void> {
   } catch {
     throw new Error(`Bundle not found: ${bundlePath}`);
   }
-  const bundle = await loadBundleFromFile(bundlePath);
+  // Accept both legacy `.afps` (single-package) and the new multi-package
+  // `.afps-bundle` format. `loadAnyBundleFromFile` peeks at the archive
+  // once, dispatches to the right reader, and projects multi-package
+  // bundles onto the LoadedBundle surface that `prepareBundleForPi` +
+  // the resolvers expect.
+  const bundle = await loadAnyBundleFromFile(bundlePath);
 
   // ─── 5. Parse input + config ───────────────────────────────────────
   const input = await resolveInput(opts);

--- a/packages/afps-runtime/src/bundle/bridge.ts
+++ b/packages/afps-runtime/src/bundle/bridge.ts
@@ -11,10 +11,13 @@
  * other during the transition.
  */
 
+import { readFile } from "node:fs/promises";
+import { unzipSync } from "fflate";
 import { extractRootFromAfps } from "./build.ts";
 import { buildBundleFromCatalog } from "./build.ts";
 import { emptyPackageCatalog } from "./catalog.ts";
-import type { LoadedBundle } from "./loader.ts";
+import { loadBundleFromBuffer, type LoadBundleOptions, type LoadedBundle } from "./loader.ts";
+import { readBundleFromBuffer, type ReadBundleOptions } from "./read.ts";
 import { computeRecordEntries, recordIntegrity, serializeRecord } from "./integrity.ts";
 import { BUNDLE_FORMAT_VERSION, formatPackageIdentity, parsePackageIdentity } from "./types.ts";
 import type { Bundle, BundlePackage, PackageIdentity } from "./types.ts";
@@ -159,4 +162,59 @@ function prefixForType(type: unknown): string | null {
   if (type === "skill") return "skills/";
   if (type === "provider") return "providers/";
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Format-detecting loader (for CLI entrypoints that accept either format)
+// ---------------------------------------------------------------------------
+
+export interface LoadAnyBundleOptions {
+  /** Passed through to the legacy `.afps` loader when that path is taken. */
+  legacy?: LoadBundleOptions;
+  /** Passed through to the new `.afps-bundle` reader when that path is taken. */
+  multi?: ReadBundleOptions;
+}
+
+/**
+ * Accept either the legacy single-package `.afps` format or the new
+ * multi-package `.afps-bundle` format and produce a {@link LoadedBundle}
+ * suitable for `prepareBundleForPi` + resolvers.
+ *
+ * Detection: the presence of `bundle.json` at the archive root is the
+ * canonical discriminant — `.afps-bundle` requires it (spec §4.1),
+ * `.afps` never has it. The check peeks at a single archive decompress
+ * and dispatches; no double-read on either path.
+ */
+export async function loadAnyBundleFromFile(
+  path: string,
+  opts: LoadAnyBundleOptions = {},
+): Promise<LoadedBundle> {
+  const buffer = await readFile(path);
+  return loadAnyBundleFromBuffer(new Uint8Array(buffer), opts);
+}
+
+export function loadAnyBundleFromBuffer(
+  bytes: Uint8Array,
+  opts: LoadAnyBundleOptions = {},
+): LoadedBundle {
+  if (isMultiPackageBundle(bytes)) {
+    const bundle = readBundleFromBuffer(bytes, opts.multi);
+    return bundleToLoadedBundle(bundle);
+  }
+  return loadBundleFromBuffer(bytes, opts.legacy);
+}
+
+/**
+ * Quick format check: decompress the archive (once) and look for
+ * `bundle.json` at the root. Malformed archives fall back to "legacy" so
+ * the subsequent `loadBundleFromBuffer` surfaces its specific error
+ * code (ZIP_INVALID / MISSING_MANIFEST) instead of a generic one here.
+ */
+function isMultiPackageBundle(bytes: Uint8Array): boolean {
+  try {
+    const entries = unzipSync(bytes);
+    return Object.prototype.hasOwnProperty.call(entries, "bundle.json");
+  } catch {
+    return false;
+  }
 }

--- a/packages/afps-runtime/src/bundle/index.ts
+++ b/packages/afps-runtime/src/bundle/index.ts
@@ -58,7 +58,14 @@ export {
   type BundleValidationResult,
   type ValidateBundleV2Options,
 } from "./validate-bundle.ts";
-export { bundleOfOneFromAfps, bundleToLoadedBundle, loadedBundleToBundle } from "./bridge.ts";
+export {
+  bundleOfOneFromAfps,
+  bundleToLoadedBundle,
+  loadAnyBundleFromBuffer,
+  loadAnyBundleFromFile,
+  loadedBundleToBundle,
+  type LoadAnyBundleOptions,
+} from "./bridge.ts";
 
 // ─── Legacy single-package surface (deprecated, kept for migration) ─
 export {

--- a/packages/afps-runtime/test/bundle/bridge.test.ts
+++ b/packages/afps-runtime/test/bundle/bridge.test.ts
@@ -2,8 +2,11 @@
 // Copyright 2026 Appstrate
 
 import { describe, it, expect } from "bun:test";
+import { zipSync } from "fflate";
 import {
   bundleToLoadedBundle,
+  loadAnyBundleFromBuffer,
+  writeBundleToBuffer,
   BUNDLE_FORMAT_VERSION,
   type Bundle,
   type BundlePackage,
@@ -205,6 +208,54 @@ describe("bundleToLoadedBundle", () => {
     );
     const loaded = bundleToLoadedBundle(makeBundle({ root: root.identity, packages: [root] }));
     expect(loaded.prompt).toBe("");
+  });
+
+  it("accepts a multi-package bundle via loadAnyBundleFromBuffer", () => {
+    const root = makePkg(
+      "@me/root@1.0.0" as PackageIdentity,
+      { name: "@me/root", version: "1.0.0", type: "agent" },
+      { "prompt.md": enc("Hello") },
+    );
+    const tool = makePkg(
+      "@vendor/t@1.0.0" as PackageIdentity,
+      { name: "@vendor/t", version: "1.0.0", type: "tool" },
+      { "TOOL.md": enc("tool doc") },
+    );
+    const bundle = makeBundle({ root: root.identity, packages: [root, tool] });
+    const archive = writeBundleToBuffer(bundle);
+
+    const loaded = loadAnyBundleFromBuffer(archive);
+    expect(loaded.prompt).toBe("Hello");
+    expect(dec(loaded.files["tools/@vendor/t/TOOL.md"])).toBe("tool doc");
+  });
+
+  it("accepts a legacy single-package .afps via loadAnyBundleFromBuffer", () => {
+    // A classic AFPS is just a ZIP with manifest.json + prompt.md at root.
+    const archive = zipSync({
+      "manifest.json": enc(
+        JSON.stringify({
+          name: "@me/legacy",
+          version: "1.0.0",
+          type: "agent",
+          schemaVersion: "1.1",
+        }),
+      ),
+      "prompt.md": enc("Legacy prompt"),
+    });
+
+    const loaded = loadAnyBundleFromBuffer(archive);
+    expect(loaded.prompt).toBe("Legacy prompt");
+    expect((loaded.manifest as { name?: string }).name).toBe("@me/legacy");
+    // No dep prefixes since legacy is flat — files stay at top level.
+    expect(Object.keys(loaded.files).every((k) => !k.startsWith("tools/"))).toBe(true);
+  });
+
+  it("surfaces the legacy MISSING_MANIFEST error when a non-bundle ZIP has no manifest.json", () => {
+    // An archive that has neither bundle.json nor manifest.json — detect
+    // as "not multi-package" then let the legacy loader throw the
+    // specific MISSING_MANIFEST error (not a generic one).
+    const archive = zipSync({ "random.txt": enc("hi") });
+    expect(() => loadAnyBundleFromBuffer(archive)).toThrow(/manifest\.json/);
   });
 
   it("throws BUNDLE_JSON_INVALID when the root identity is missing from packages", () => {

--- a/runtime-pi/entrypoint.ts
+++ b/runtime-pi/entrypoint.ts
@@ -32,7 +32,7 @@ import {
   prepareBundleForPi,
   buildProviderExtensionFactories,
 } from "@appstrate/runner-pi";
-import { loadBundleFromFile } from "@appstrate/afps-runtime/bundle";
+import { loadAnyBundleFromFile } from "@appstrate/afps-runtime/bundle";
 import type { EventSink } from "@appstrate/afps-runtime/interfaces";
 import { SidecarProviderResolver, type ProviderResolver } from "@appstrate/afps-runtime/resolvers";
 import type { ExecutionContext, RunEvent } from "@appstrate/afps-runtime/types";
@@ -127,7 +127,7 @@ const hasPackage = await exists(packagePath);
 
 const [, bundle] = await Promise.all([
   initGitWorkspace(),
-  hasPackage ? loadBundleFromFile(packagePath) : Promise.resolve(null),
+  hasPackage ? loadAnyBundleFromFile(packagePath) : Promise.resolve(null),
 ]);
 
 // --- 2b. Phase B: materialise .pi/ layout + dynamic-import tools ---


### PR DESCRIPTION
## Summary

Wires the CLI to accept the new multi-package `.afps-bundle` format. Stacked on #243.

Before: \`appstrate run bundle.afps-bundle\` → \`BundleLoadError: bundle does not contain manifest.json\` (legacy loader expects single-package layout).

After: auto-detects format via presence of \`bundle.json\` at archive root, dispatches to the right reader, projects onto LoadedBundle via \`bundleToLoadedBundle\` (from #243). Downstream (PiRunner, resolvers, \`prepareBundleForPi\`) stays on LoadedBundle so the runtime contract swap (B/C/D) can ship independently.

New surface: \`loadAnyBundleFromFile\` / \`loadAnyBundleFromBuffer\` in \`@appstrate/afps-runtime/bundle\`.

## Verification

Ran against a real \`.afps-bundle\` downloaded from the platform UI:

\`\`\`
bun apps/cli/src/cli.ts run pierre-cabriere-hello-world.afps-bundle \\
  --providers none --model claude-sonnet-4-6 --llm-api-key sk-ant-oat01-...
→ running pierre-cabriere-hello-world.afps-bundle (CLI mode — no platform preamble)
[full markdown agent response]
∑ tokens in=1971 out=514
[run complete]
\`\`\`

## Test plan

- [x] 3 new tests in \`bridge.test.ts\`: multi-package writer/reader round-trip, legacy \`.afps\` passthrough, non-bundle ZIP preserves legacy MISSING_MANIFEST error
- [x] Full afps-runtime suite: 314 / 314 pass
- [x] \`bun run check\`: green
- [x] Real-world smoke test end-to-end (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)