### PR TITLE
T2.C: runtime-pi entrypoint accepts .afps-bundle

### DIFF
--- a/runtime-pi/entrypoint.ts
+++ b/runtime-pi/entrypoint.ts
@@ -32,7 +32,7 @@ import {
   prepareBundleForPi,
   buildProviderExtensionFactories,
 } from "@appstrate/runner-pi";
-import { loadBundleFromFile } from "@appstrate/afps-runtime/bundle";
+import { loadAnyBundleFromFile } from "@appstrate/afps-runtime/bundle";
 import type { EventSink } from "@appstrate/afps-runtime/interfaces";
 import { SidecarProviderResolver, type ProviderResolver } from "@appstrate/afps-runtime/resolvers";
 import type { ExecutionContext, RunEvent } from "@appstrate/afps-runtime/types";
@@ -127,7 +127,7 @@ const hasPackage = await exists(packagePath);
 
 const [, bundle] = await Promise.all([
   initGitWorkspace(),
-  hasPackage ? loadBundleFromFile(packagePath) : Promise.resolve(null),
+  hasPackage ? loadAnyBundleFromFile(packagePath) : Promise.resolve(null),
 ]);
 
 // --- 2b. Phase B: materialise .pi/ layout + dynamic-import tools ---


### PR DESCRIPTION
## Summary

Container counterpart to #244 (T2.E CLI). Swaps `runtime-pi/entrypoint.ts` to the format-detecting `loadAnyBundleFromFile` from T2.A (#243). The injection path `/workspace/agent-package.afps` is unchanged — only the decoder switches.

- Legacy `.afps` → dispatches to `loadBundleFromBuffer` (unchanged)
- New `.afps-bundle` → dispatches to `readBundleFromBuffer` + `bundleToLoadedBundle`

Unblocks **T2.B** (host-side `buildAgentPackage` → multi-package write path), which can now land without coordinating a rollout of the Pi image.

## Stacking

Base: `feat/cli-afps-bundle-run` (#244). Merge order:
1. #241 phase 1 base
2. #243 T2.A adapter
3. #244 T2.E CLI
4. **#245 this PR**
5. T2.B (next — host emits multi-package)

## Test plan

- [x] `bun run check` — 24/24 tasks green
- [x] `cd runtime-pi && bun test` — 155/155 green
- [x] Adapter dispatch covered by `packages/afps-runtime/test/bundle/bridge.test.ts` (11 tests including MISSING_MANIFEST forwarding)
- [x] End-to-end validated via the CLI (same loader) on `pierre-cabriere-hello-world.afps-bundle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)