### PR TITLE
feat(bundle-format): phase 3 — host multi-package + T2.D/T2.F cleanup

### DIFF
--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -21,7 +21,7 @@ import type { AppstrateRunPlan, UploadedFile } from "../services/adapters/types.
 import type { ExecutionContext } from "@appstrate/afps-runtime/types";
 import { AppstrateEventSink } from "../services/adapters/appstrate-event-sink.ts";
 import { AppstrateContainerRunner } from "../services/adapters/appstrate-container-runner.ts";
-import { loadBundleFromBuffer, type LoadedBundle } from "@appstrate/afps-runtime/bundle";
+import { loadAnyBundleFromBuffer, type LoadedBundle } from "@appstrate/afps-runtime/bundle";
 import {
   BundledToolResolver,
   BundledSkillResolver,
@@ -53,19 +53,20 @@ import { runInlinePreflight } from "../services/inline-run-preflight.ts";
 
 /**
  * Build a {@link LoadedBundle} for the Runner contract. When the route
- * already has the packaged ZIP (produced by `buildAgentPackage`), we
- * parse it via the runtime loader so the shape matches what an external
- * consumer would see. Otherwise we synthesise a minimal bundle from the
- * in-memory agent — sufficient for the contract since
- * AppstrateContainerRunner delegates execution to the Pi container,
- * which reads the bundle from `/workspace/agent-package.afps`.
+ * already has the packaged ZIP (produced by `buildAgentPackage`, now
+ * the multi-package `.afps-bundle` format), we parse it via the
+ * format-detecting loader so the shape matches what an external consumer
+ * would see. Otherwise we synthesise a minimal bundle from the in-memory
+ * agent — sufficient for the contract since AppstrateContainerRunner
+ * delegates execution to the Pi container, which reads the bundle from
+ * `/workspace/agent-package.afps`.
  */
 async function buildRunnerBundle(
   agent: LoadedPackage,
   agentPackage: Buffer | null,
 ): Promise<LoadedBundle> {
   if (agentPackage) {
-    return loadBundleFromBuffer(agentPackage);
+    return loadAnyBundleFromBuffer(new Uint8Array(agentPackage));
   }
   const encoder = new TextEncoder();
   const files: Record<string, Uint8Array> = {

--- a/apps/api/src/services/adapters/draft-package-catalog.ts
+++ b/apps/api/src/services/adapters/draft-package-catalog.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * {@link DraftPackageCatalog} — platform-side `PackageCatalog` that
+ * resolves dependencies against the DRAFT state of each package (the
+ * `packages.draftManifest` column + the `package-items` storage
+ * bucket) rather than against published versions.
+ *
+ * This is the catalog used on the run hot path by `buildAgentPackage`,
+ * where runs must see the latest tool/skill/provider edits without a
+ * republish step. The counterpart {@link DbPackageCatalog} resolves
+ * against published versions (signed, version-range-pinned) and is
+ * used by the import/export endpoints, where reproducibility matters
+ * more than edit-loop responsiveness.
+ *
+ * Contract details:
+ *   - `resolve(name, versionSpec)` ignores `versionSpec` — draft deps
+ *     are referenced by id only, and the identity is synthesised from
+ *     the dep's own `draftManifest.version` so the produced Bundle is
+ *     still identity-keyed and walk-cycle-safe.
+ *   - `fetch(identity)` returns a `BundlePackage` whose `integrity` is
+ *     left empty; `buildBundleFromCatalog` recomputes it from the
+ *     RECORD entries (same policy as `DbPackageCatalog`).
+ *   - System packages (`orgId IS NULL`) are visible cross-org — same
+ *     rule as every other platform resolver.
+ */
+
+import { and, eq, isNull, or } from "drizzle-orm";
+import { db } from "@appstrate/db/client";
+import { packages } from "@appstrate/db/schema";
+import {
+  BundleError,
+  formatPackageIdentity,
+  parsePackageIdentity,
+  type BundlePackage,
+  type PackageCatalog,
+  type PackageIdentity,
+  type ResolvedPackage,
+} from "@appstrate/afps-runtime/bundle";
+import { asRecord } from "../../lib/safe-json.ts";
+import { downloadPackageFiles } from "../package-items/storage.ts";
+
+export interface DraftPackageCatalogOptions {
+  /** Org whose draft packages are visible (plus system packages, `orgId IS NULL`). */
+  orgId: string;
+}
+
+type DraftStorageFolder = "skills" | "tools" | "providers";
+
+export class DraftPackageCatalog implements PackageCatalog {
+  private readonly rowCache = new Map<
+    string,
+    { draftManifest: unknown } | null | Promise<{ draftManifest: unknown } | null>
+  >();
+  private readonly fetchCache = new Map<PackageIdentity, BundlePackage>();
+
+  constructor(private readonly opts: DraftPackageCatalogOptions) {}
+
+  async resolve(name: string, _versionSpec: string): Promise<ResolvedPackage | null> {
+    const row = await this.getPackageRow(name);
+    if (!row) return null;
+    const manifest = asRecord(row.draftManifest);
+    const version = typeof manifest.version === "string" ? manifest.version : "0.0.0";
+    return {
+      identity: formatPackageIdentity(name as `@${string}/${string}`, version),
+      integrity: "",
+    };
+  }
+
+  async fetch(identity: PackageIdentity): Promise<BundlePackage> {
+    const cached = this.fetchCache.get(identity);
+    if (cached) return cached;
+
+    const parsed = parsePackageIdentity(identity);
+    if (!parsed) {
+      throw new BundleError(
+        "BUNDLE_JSON_INVALID",
+        `DraftPackageCatalog: invalid identity ${identity}`,
+      );
+    }
+
+    const row = await this.getPackageRow(parsed.packageId);
+    if (!row) {
+      throw new BundleError(
+        "DEPENDENCY_UNRESOLVED",
+        `DraftPackageCatalog: ${parsed.packageId} not visible to org ${this.opts.orgId}`,
+        { identity, orgId: this.opts.orgId },
+      );
+    }
+
+    const manifest = asRecord(row.draftManifest);
+    const folder = typeToFolder(manifest.type);
+    if (!folder) {
+      throw new BundleError(
+        "BUNDLE_JSON_INVALID",
+        `DraftPackageCatalog: ${parsed.packageId} has unsupported type ${String(manifest.type)}`,
+        { identity },
+      );
+    }
+
+    const files = await downloadPackageFiles(folder, this.opts.orgId, parsed.packageId);
+    if (!files) {
+      throw new BundleError(
+        "DEPENDENCY_UNRESOLVED",
+        `DraftPackageCatalog: ${parsed.packageId} has no files in storage`,
+        { identity },
+      );
+    }
+
+    // Ensure manifest.json is present (some upload paths store only content
+    // files). Reconstruct from draftManifest to keep the Bundle self-contained.
+    const fileMap = new Map<string, Uint8Array>();
+    for (const [p, bytes] of Object.entries(files)) fileMap.set(p, bytes);
+    if (!fileMap.has("manifest.json")) {
+      fileMap.set(
+        "manifest.json",
+        new TextEncoder().encode(JSON.stringify(row.draftManifest, null, 2)),
+      );
+    }
+
+    const pkg: BundlePackage = {
+      identity,
+      manifest: asRecord(row.draftManifest),
+      files: fileMap,
+      integrity: "",
+    };
+    this.fetchCache.set(identity, pkg);
+    return pkg;
+  }
+
+  private getPackageRow(packageId: string): Promise<{ draftManifest: unknown } | null> {
+    const cached = this.rowCache.get(packageId);
+    if (cached !== undefined) return Promise.resolve(cached);
+
+    const promise = db
+      .select({ draftManifest: packages.draftManifest })
+      .from(packages)
+      .where(
+        and(
+          eq(packages.id, packageId),
+          or(eq(packages.orgId, this.opts.orgId), isNull(packages.orgId)),
+        ),
+      )
+      .limit(1)
+      .then((rows) => {
+        const row = rows[0] ?? null;
+        this.rowCache.set(packageId, row);
+        return row;
+      });
+    this.rowCache.set(packageId, promise);
+    return promise;
+  }
+}
+
+function typeToFolder(type: unknown): DraftStorageFolder | null {
+  if (type === "skill") return "skills";
+  if (type === "tool") return "tools";
+  if (type === "provider") return "providers";
+  return null;
+}

--- a/apps/api/src/services/package-storage.ts
+++ b/apps/api/src/services/package-storage.ts
@@ -6,11 +6,13 @@ import * as storage from "@appstrate/db/storage";
 import { logger } from "../lib/logger.ts";
 import type { LoadedPackage } from "../types/index.ts";
 import {
-  getPackageDepFiles,
-  SKILL_CONFIG,
-  TOOL_CONFIG,
-  PROVIDER_CONFIG,
-} from "./package-items/index.ts";
+  buildBundleFromCatalog,
+  formatPackageIdentity,
+  parsePackageIdentity,
+  writeBundleToBuffer,
+  type BundlePackage,
+} from "@appstrate/afps-runtime/bundle";
+import { DraftPackageCatalog } from "./adapters/draft-package-catalog.ts";
 import { loadAndVerifyBundle } from "./adapters/bundle-signature-policy.ts";
 
 const BUCKET = "agent-packages";
@@ -104,51 +106,66 @@ interface AgentPackageResult {
   toolDocs: Array<{ id: string; content: string }>;
 }
 
-/** Build an agent package ZIP on-the-fly and extract TOOL.md docs in a single pass. */
+/**
+ * Build a multi-package `.afps-bundle` for the run hot path and
+ * extract TOOL.md docs in a single pass.
+ *
+ * The returned ZIP is the canonical bundle format (bundle.json root +
+ * per-package dirs under `packages/@scope/name/version/`). The
+ * container-side loader (`loadAnyBundleFromFile` in runtime-pi) detects
+ * the format by the presence of `bundle.json` and projects it back onto
+ * a flat LoadedBundle for the PiRunner + resolvers.
+ *
+ * Dependency resolution uses {@link DraftPackageCatalog}, which reads
+ * draft manifests + the `package-items` storage bucket — NOT published
+ * versions. This preserves the legacy "edit tool → next run sees it"
+ * behaviour on the dev loop.
+ */
 export async function buildAgentPackage(
   agent: LoadedPackage,
   orgId: string,
 ): Promise<AgentPackageResult> {
-  const entries: Zippable = {
-    "manifest.json": new TextEncoder().encode(JSON.stringify(agent.manifest, null, 2)),
-    "prompt.md": new TextEncoder().encode(agent.prompt),
+  const manifest = agent.manifest as Record<string, unknown>;
+  const name = typeof manifest.name === "string" ? manifest.name : null;
+  const version = typeof manifest.version === "string" ? manifest.version : null;
+  if (!name || !version || !name.startsWith("@") || !name.includes("/")) {
+    throw new Error(
+      `buildAgentPackage: agent ${agent.id} has no valid scoped name/version in its manifest`,
+    );
+  }
+
+  const rootFiles = new Map<string, Uint8Array>([
+    ["manifest.json", new TextEncoder().encode(JSON.stringify(manifest, null, 2))],
+    ["prompt.md", new TextEncoder().encode(agent.prompt)],
+  ]);
+  const root: BundlePackage = {
+    identity: formatPackageIdentity(name as `@${string}/${string}`, version),
+    manifest,
+    files: rootFiles,
+    integrity: "",
   };
 
-  // Fetch skill, tool, and provider files in parallel
-  const [skillFiles, toolFiles, providerFiles] = await Promise.all([
-    getPackageDepFiles(agent.id, orgId, SKILL_CONFIG),
-    getPackageDepFiles(agent.id, orgId, TOOL_CONFIG),
-    getPackageDepFiles(agent.id, orgId, PROVIDER_CONFIG),
-  ]);
+  const bundle = await buildBundleFromCatalog(root, new DraftPackageCatalog({ orgId }), {
+    onWarn: (message) => {
+      logger.warn("buildAgentPackage: bundle builder warning", { agentId: agent.id, message });
+    },
+  });
 
-  for (const [skillId, files] of skillFiles) {
-    for (const [filePath, content] of Object.entries(files)) {
-      entries[`skills/${skillId}/${filePath}`] = content;
-    }
-  }
+  const zipBuffer = writeBundleToBuffer(bundle);
 
-  for (const [toolId, files] of toolFiles) {
-    for (const [filePath, content] of Object.entries(files)) {
-      entries[`tools/${toolId}/${filePath}`] = content;
-    }
-  }
-
-  for (const [providerId, files] of providerFiles) {
-    for (const [filePath, content] of Object.entries(files)) {
-      entries[`providers/${providerId}/${filePath}`] = content;
-    }
-  }
-
-  // Extract TOOL.md content from tool files (avoids a second S3 fetch)
   const toolDocs: Array<{ id: string; content: string }> = [];
-  for (const [toolId, files] of toolFiles) {
-    const md = files["TOOL.md"];
-    if (md) {
-      toolDocs.push({ id: toolId, content: new TextDecoder().decode(md) });
-    }
+  const decoder = new TextDecoder();
+  for (const [identity, pkg] of bundle.packages) {
+    if (identity === bundle.root) continue;
+    if ((pkg.manifest as { type?: unknown }).type !== "tool") continue;
+    const md = pkg.files.get("TOOL.md");
+    if (!md) continue;
+    const parsed = parsePackageIdentity(identity);
+    if (!parsed) continue;
+    toolDocs.push({ id: parsed.packageId, content: decoder.decode(md) });
   }
 
-  return { zip: Buffer.from(zipArtifact(entries, ZIP_COMPRESSION_LEVEL)), toolDocs };
+  return { zip: Buffer.from(zipBuffer), toolDocs };
 }
 
 /** Build a minimal ZIP with just manifest.json + a content file (default: prompt.md). */

--- a/apps/api/test/integration/services/build-agent-package-bundle.test.ts
+++ b/apps/api/test/integration/services/build-agent-package-bundle.test.ts
@@ -30,6 +30,7 @@ import { seedPackage } from "../../helpers/seed.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
 import { uploadPackageFiles } from "../../../src/services/package-items/storage.ts";
 import { buildAgentPackage } from "../../../src/services/package-storage.ts";
+import type { AgentManifest } from "../../../src/types/index.ts";
 import { bundleToLoadedBundle, readBundleFromBuffer } from "@appstrate/afps-runtime/bundle";
 
 function enc(s: string): Uint8Array {
@@ -128,7 +129,7 @@ describe("buildAgentPackage — multi-package bundle output", () => {
     const result = await buildAgentPackage(
       {
         id: "@bundlehost/root-agent",
-        manifest: agentManifest,
+        manifest: agentManifest as unknown as AgentManifest,
         prompt: "You are the agent.",
         skills: [],
         tools: [],
@@ -186,7 +187,7 @@ describe("buildAgentPackage — multi-package bundle output", () => {
     const a = await buildAgentPackage(
       {
         id: "@bundlehost/solo-agent",
-        manifest,
+        manifest: manifest as unknown as AgentManifest,
         prompt: "Deterministic please.",
         skills: [],
         tools: [],
@@ -197,7 +198,7 @@ describe("buildAgentPackage — multi-package bundle output", () => {
     const b = await buildAgentPackage(
       {
         id: "@bundlehost/solo-agent",
-        manifest,
+        manifest: manifest as unknown as AgentManifest,
         prompt: "Deterministic please.",
         skills: [],
         tools: [],
@@ -230,7 +231,7 @@ describe("buildAgentPackage — multi-package bundle output", () => {
       buildAgentPackage(
         {
           id: "@bundlehost/broken-agent",
-          manifest,
+          manifest: manifest as unknown as AgentManifest,
           prompt: "nope",
           skills: [],
           tools: [],

--- a/apps/api/test/integration/services/build-agent-package-bundle.test.ts
+++ b/apps/api/test/integration/services/build-agent-package-bundle.test.ts
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration test: `buildAgentPackage` now emits the canonical
+ * multi-package `.afps-bundle` format (Phase 3 of the bundle-format
+ * roadmap).
+ *
+ * Seeds an agent with skill + tool + provider draft deps, drops each
+ * dep's file set into the `library-packages` bucket, and asserts:
+ *   - the produced ZIP is a valid multi-package bundle
+ *     (`readBundleFromBuffer` accepts it)
+ *   - the bundle's root is the seeded agent, with `manifest.json` +
+ *     `prompt.md` at the root package
+ *   - each declared dep is resolved and embedded under
+ *     `packages/@scope/name/version/…`
+ *   - `toolDocs` preserves the legacy contract: one entry per
+ *     tool dep that ships a `TOOL.md`
+ *   - when projected back through `bundleToLoadedBundle` (what the
+ *     container does), the flat layout matches what the runtime
+ *     resolvers expect: `tools/<scoped-id>/`, `skills/<scoped-id>/`,
+ *     `providers/<scoped-id>/`.
+ *
+ * This is the round-trip guarantee that lets the host switch to
+ * multi-package without breaking the container resolvers.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { truncateAll } from "../../helpers/db.ts";
+import { seedPackage } from "../../helpers/seed.ts";
+import { createTestContext, type TestContext } from "../../helpers/auth.ts";
+import { uploadPackageFiles } from "../../../src/services/package-items/storage.ts";
+import { buildAgentPackage } from "../../../src/services/package-storage.ts";
+import { bundleToLoadedBundle, readBundleFromBuffer } from "@appstrate/afps-runtime/bundle";
+
+function enc(s: string): Uint8Array {
+  return new TextEncoder().encode(s);
+}
+
+function dec(b: Uint8Array | undefined): string {
+  return b ? new TextDecoder().decode(b) : "";
+}
+
+describe("buildAgentPackage — multi-package bundle output", () => {
+  let ctx: TestContext;
+  let ORG_ID: string;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "bundlehost" });
+    ORG_ID = ctx.org.id;
+  });
+
+  it("emits a valid Bundle with root + skill + tool + provider deps", async () => {
+    // ─── 1. Seed the dep packages and their draft files ──────────────
+    const skillManifest = {
+      name: "@bundlehost/md-skill",
+      version: "1.0.0",
+      type: "skill",
+      description: "Markdown skill",
+    };
+    const toolManifest = {
+      name: "@bundlehost/calc-tool",
+      version: "2.1.0",
+      type: "tool",
+      description: "Calc tool",
+    };
+    const providerManifest = {
+      name: "@bundlehost/svc-provider",
+      version: "0.5.0",
+      type: "provider",
+      description: "Svc provider",
+    };
+
+    await seedPackage({
+      id: "@bundlehost/md-skill",
+      type: "skill",
+      orgId: ORG_ID,
+      draftManifest: skillManifest,
+    });
+    await uploadPackageFiles("skills", ORG_ID, "@bundlehost/md-skill", {
+      "manifest.json": enc(JSON.stringify(skillManifest, null, 2)),
+      "SKILL.md": enc("---\nname: md\n---\nUse markdown."),
+    });
+
+    await seedPackage({
+      id: "@bundlehost/calc-tool",
+      type: "tool",
+      orgId: ORG_ID,
+      draftManifest: toolManifest,
+    });
+    await uploadPackageFiles("tools", ORG_ID, "@bundlehost/calc-tool", {
+      "manifest.json": enc(JSON.stringify(toolManifest, null, 2)),
+      "TOOL.md": enc("Calculator tool documentation"),
+      "index.ts": enc("export default () => ({ name: 'calc' });"),
+    });
+
+    await seedPackage({
+      id: "@bundlehost/svc-provider",
+      type: "provider",
+      orgId: ORG_ID,
+      draftManifest: providerManifest,
+    });
+    await uploadPackageFiles("providers", ORG_ID, "@bundlehost/svc-provider", {
+      "manifest.json": enc(JSON.stringify(providerManifest, null, 2)),
+      "PROVIDER.md": enc("Provider doc"),
+    });
+
+    // ─── 2. Seed the root agent with all three deps ──────────────────
+    const agentManifest = {
+      name: "@bundlehost/root-agent",
+      version: "3.0.0",
+      type: "agent",
+      description: "Root agent",
+      dependencies: {
+        skills: { "@bundlehost/md-skill": "^1" },
+        tools: { "@bundlehost/calc-tool": "^2" },
+        providers: { "@bundlehost/svc-provider": "^0.5" },
+      },
+    };
+    await seedPackage({
+      id: "@bundlehost/root-agent",
+      type: "agent",
+      orgId: ORG_ID,
+      draftManifest: agentManifest,
+    });
+
+    // ─── 3. buildAgentPackage — emits multi-package bundle ───────────
+    const result = await buildAgentPackage(
+      {
+        id: "@bundlehost/root-agent",
+        manifest: agentManifest,
+        prompt: "You are the agent.",
+        skills: [],
+        tools: [],
+        source: "local",
+      },
+      ORG_ID,
+    );
+
+    expect(result.zip.byteLength).toBeGreaterThan(0);
+    expect(result.toolDocs).toEqual([
+      { id: "@bundlehost/calc-tool", content: "Calculator tool documentation" },
+    ]);
+
+    // ─── 4. Read it back as a Bundle ─────────────────────────────────
+    const bundle = readBundleFromBuffer(new Uint8Array(result.zip));
+    expect(bundle.root).toBe("@bundlehost/root-agent@3.0.0");
+    expect(bundle.packages.size).toBe(4); // agent + 3 deps
+
+    const rootPkg = bundle.packages.get(bundle.root)!;
+    expect(dec(rootPkg.files.get("prompt.md"))).toBe("You are the agent.");
+    expect(dec(rootPkg.files.get("manifest.json"))).toContain('"name": "@bundlehost/root-agent"');
+
+    expect(bundle.packages.has("@bundlehost/md-skill@1.0.0")).toBe(true);
+    expect(bundle.packages.has("@bundlehost/calc-tool@2.1.0")).toBe(true);
+    expect(bundle.packages.has("@bundlehost/svc-provider@0.5.0")).toBe(true);
+
+    // ─── 5. Project back through the adapter — the shape the runtime ─
+    //       resolvers + entrypoint expect.
+    const loaded = bundleToLoadedBundle(bundle);
+    expect(loaded.prompt).toBe("You are the agent.");
+    expect(dec(loaded.files["skills/@bundlehost/md-skill/SKILL.md"])).toContain("markdown");
+    expect(dec(loaded.files["tools/@bundlehost/calc-tool/TOOL.md"])).toBe(
+      "Calculator tool documentation",
+    );
+    expect(dec(loaded.files["tools/@bundlehost/calc-tool/index.ts"])).toContain("export default");
+    expect(dec(loaded.files["providers/@bundlehost/svc-provider/PROVIDER.md"])).toBe(
+      "Provider doc",
+    );
+  });
+
+  it("produces a deterministic bundle — two builds yield byte-identical ZIPs", async () => {
+    const manifest = {
+      name: "@bundlehost/solo-agent",
+      version: "1.2.3",
+      type: "agent",
+      description: "Standalone agent",
+    };
+    await seedPackage({
+      id: "@bundlehost/solo-agent",
+      type: "agent",
+      orgId: ORG_ID,
+      draftManifest: manifest,
+    });
+
+    const a = await buildAgentPackage(
+      {
+        id: "@bundlehost/solo-agent",
+        manifest,
+        prompt: "Deterministic please.",
+        skills: [],
+        tools: [],
+        source: "local",
+      },
+      ORG_ID,
+    );
+    const b = await buildAgentPackage(
+      {
+        id: "@bundlehost/solo-agent",
+        manifest,
+        prompt: "Deterministic please.",
+        skills: [],
+        tools: [],
+        source: "local",
+      },
+      ORG_ID,
+    );
+
+    expect(a.zip.equals(b.zip)).toBe(true);
+  });
+
+  it("ignores deps present in manifest but absent from DB/storage via explicit error", async () => {
+    const manifest = {
+      name: "@bundlehost/broken-agent",
+      version: "1.0.0",
+      type: "agent",
+      description: "Declares a ghost dep",
+      dependencies: {
+        tools: { "@bundlehost/ghost": "^1" },
+      },
+    };
+    await seedPackage({
+      id: "@bundlehost/broken-agent",
+      type: "agent",
+      orgId: ORG_ID,
+      draftManifest: manifest,
+    });
+
+    await expect(
+      buildAgentPackage(
+        {
+          id: "@bundlehost/broken-agent",
+          manifest,
+          prompt: "nope",
+          skills: [],
+          tools: [],
+          source: "local",
+        },
+        ORG_ID,
+      ),
+    ).rejects.toThrow(/unresolved dependency|ghost/i);
+  });
+});

--- a/packages/afps-runtime/src/bundle/index.ts
+++ b/packages/afps-runtime/src/bundle/index.ts
@@ -4,13 +4,17 @@
 /**
  * Public surface for `@appstrate/afps-runtime/bundle`.
  *
- * The new multi-package {@link Bundle} contract (spec §4) is the primary
- * API from Phase 1 onwards. The legacy single-package {@link LoadedBundle}
- * surface is kept during the migration — callers should prefer the new
- * API and use {@link loadedBundleToBundle} when bridging.
+ * The multi-package {@link Bundle} contract (spec §4) is the primary
+ * API. {@link LoadedBundle} is a flat path-keyed projection used by
+ * runtime consumers that prefer single-map file access — both are
+ * first-class and stable.
+ *
+ * Interop utilities at the bottom (`bundleToLoadedBundle`,
+ * `loadedBundleToBundle`, `loadAnyBundleFrom*`) let callers move between
+ * the two representations without re-decoding the archive.
  */
 
-// ─── New Bundle contract ────────────────────────────────────────────
+// ─── Core types + errors ────────────────────────────────────────────
 export {
   BUNDLE_FORMAT_VERSION,
   parsePackageIdentity,
@@ -28,6 +32,8 @@ export {
 export { BundleError, type BundleErrorCode } from "./errors.ts";
 export { DEFAULT_BUNDLE_LIMITS, resolveBundleLimits, type BundleLimits } from "./limits.ts";
 export { canonicalJsonStringify } from "./canonical-json.ts";
+
+// ─── Integrity primitives (RECORD + bundle.json merkle) ─────────────
 export {
   bundleIntegrity,
   computeRecordEntries,
@@ -38,6 +44,12 @@ export {
   serializeRecord,
   type RecordEntry,
 } from "./integrity.ts";
+// Byte-level SRI over a whole archive (used by platform storage layer
+// to detect at-rest corruption — orthogonal to the Merkle integrity
+// that ships inside Bundle.integrity).
+export { computeIntegrity, type IntegrityCheckResult } from "./hash.ts";
+
+// ─── Read / write / build ───────────────────────────────────────────
 export { readBundleFromBuffer, readBundleFromFile, type ReadBundleOptions } from "./read.ts";
 export { writeBundleToBuffer, writeBundleToFile } from "./write.ts";
 export {
@@ -52,12 +64,26 @@ export {
   emptyPackageCatalog,
   type InMemoryCatalogOptions,
 } from "./catalog.ts";
+
+// ─── Validation ─────────────────────────────────────────────────────
+// Primary: multi-package Bundle validator.
 export {
-  validateBundle as validateBundleV2,
+  validateBundle,
   type BundleValidationIssue,
   type BundleValidationResult,
-  type ValidateBundleV2Options,
+  type ValidateBundleOptions,
 } from "./validate-bundle.ts";
+// Secondary: AFPS single-package manifest validator — used when you
+// only have a `LoadedBundle` (tooling, CLI inspect/verify paths).
+export {
+  validateAfpsManifest,
+  type AfpsManifestValidationIssue,
+  type AfpsManifestValidationResult,
+  type ValidateAfpsManifestOptions,
+} from "./validator.ts";
+
+// ─── LoadedBundle flat surface + interop adapters ───────────────────
+export { loadBundleFromBuffer, type LoadedBundle } from "./loader.ts";
 export {
   bundleOfOneFromAfps,
   bundleToLoadedBundle,
@@ -67,7 +93,7 @@ export {
   type LoadAnyBundleOptions,
 } from "./bridge.ts";
 
-// ─── Legacy single-package surface (deprecated, kept for migration) ─
+// ─── Prompt rendering ───────────────────────────────────────────────
 export {
   renderPrompt,
   buildPromptView,
@@ -76,20 +102,8 @@ export {
   type PromptViewUpload,
   type RenderPromptOptions,
 } from "./prompt-renderer.ts";
-export { computeIntegrity, verifyIntegrity, type IntegrityCheckResult } from "./hash.ts";
-export {
-  loadBundleFromBuffer,
-  loadBundleFromFile,
-  BundleLoadError,
-  type LoadedBundle,
-  type LoadBundleOptions,
-} from "./loader.ts";
-export {
-  validateBundle,
-  type ValidationResult,
-  type ValidationIssue,
-  type ValidateBundleOptions,
-} from "./validator.ts";
+
+// ─── Signing / trust root ───────────────────────────────────────────
 export {
   canonicalBundleDigest,
   signBundle,

--- a/packages/afps-runtime/src/bundle/validate-bundle.ts
+++ b/packages/afps-runtime/src/bundle/validate-bundle.ts
@@ -52,7 +52,7 @@ export interface BundleValidationResult {
   issues: readonly BundleValidationIssue[];
 }
 
-export interface ValidateBundleV2Options {
+export interface ValidateBundleOptions {
   /** Accepted schemaVersion MAJORs. Default: `[1]`. */
   supportedMajors?: readonly number[];
   /**
@@ -65,7 +65,7 @@ export interface ValidateBundleV2Options {
 
 export function validateBundle(
   bundle: Bundle,
-  opts: ValidateBundleV2Options = {},
+  opts: ValidateBundleOptions = {},
 ): BundleValidationResult {
   const supportedMajors = opts.supportedMajors ?? [1];
   const agentOnlyRoot = opts.agentOnlyRoot ?? true;

--- a/packages/afps-runtime/src/bundle/validator.ts
+++ b/packages/afps-runtime/src/bundle/validator.ts
@@ -5,7 +5,7 @@ import { agentManifestSchema } from "@afps-spec/schema";
 import type { LoadedBundle } from "./loader.ts";
 import { validateTemplate } from "../template/mustache.ts";
 
-export interface ValidationIssue {
+export interface AfpsManifestValidationIssue {
   /**
    * Stable machine-readable code. Consumers may switch on this to
    * render locale-aware UI messages or translate to error types.
@@ -26,13 +26,13 @@ export interface ValidationIssue {
   message: string;
 }
 
-export interface ValidationResult {
+export interface AfpsManifestValidationResult {
   /** `true` iff every issue is non-fatal (currently empty list). */
   valid: boolean;
-  issues: readonly ValidationIssue[];
+  issues: readonly AfpsManifestValidationIssue[];
 }
 
-export interface ValidateBundleOptions {
+export interface ValidateAfpsManifestOptions {
   /**
    * Accept only these schemaVersion majors. Default: `[1]` (AFPS v1 —
    * the only released major). An entry of `1` accepts any `1.x`.
@@ -64,13 +64,18 @@ export interface ValidateBundleOptions {
  * synthetic view is available via
  * {@link import("./prompt-renderer.ts").buildPromptView} if needed.
  */
-export function validateBundle(
+/**
+ * Validates the manifest + prompt of a single AFPS package (the flat
+ * LoadedBundle surface). For validating a multi-package Bundle contract,
+ * use {@link import("./validate-bundle.ts").validateBundle} instead.
+ */
+export function validateAfpsManifest(
   bundle: LoadedBundle,
-  opts: ValidateBundleOptions = {},
-): ValidationResult {
+  opts: ValidateAfpsManifestOptions = {},
+): AfpsManifestValidationResult {
   const supportedMajors = opts.supportedMajors ?? [1];
   const agentOnly = opts.agentOnly ?? true;
-  const issues: ValidationIssue[] = [];
+  const issues: AfpsManifestValidationIssue[] = [];
 
   const rawType = bundle.manifest["type"];
   if (agentOnly && rawType !== "agent") {

--- a/packages/afps-runtime/src/cli/commands/inspect.ts
+++ b/packages/afps-runtime/src/cli/commands/inspect.ts
@@ -3,7 +3,7 @@
 
 import { parseArgs } from "node:util";
 import { readFile } from "node:fs/promises";
-import { loadBundleFromBuffer } from "../../bundle/loader.ts";
+import { loadAnyBundleFromBuffer } from "../../bundle/bridge.ts";
 import { readBundleSignature } from "../../bundle/signing.ts";
 import type { CliIO } from "../index.ts";
 
@@ -48,7 +48,7 @@ export async function run(argv: readonly string[], io: CliIO): Promise<number> {
   }
 
   const bundleBytes = await readFile(bundlePath);
-  const bundle = loadBundleFromBuffer(bundleBytes);
+  const bundle = loadAnyBundleFromBuffer(bundleBytes);
   const signature = readBundleSignature(bundle);
 
   if (parsed.values.json) {

--- a/packages/afps-runtime/src/cli/commands/render.ts
+++ b/packages/afps-runtime/src/cli/commands/render.ts
@@ -3,7 +3,7 @@
 
 import { parseArgs } from "node:util";
 import { readFile } from "node:fs/promises";
-import { loadBundleFromBuffer } from "../../bundle/loader.ts";
+import { loadAnyBundleFromBuffer } from "../../bundle/bridge.ts";
 import { renderPrompt } from "../../bundle/prompt-renderer.ts";
 import type { ExecutionContext } from "../../types/execution-context.ts";
 import type { CliIO } from "../index.ts";
@@ -65,7 +65,7 @@ export async function run(argv: readonly string[], io: CliIO): Promise<number> {
   }
 
   const bundleBytes = await readFile(bundlePath);
-  const bundle = loadBundleFromBuffer(bundleBytes);
+  const bundle = loadAnyBundleFromBuffer(bundleBytes);
 
   let contextFile: RenderContextFile = {};
   if (parsed.values.context) {

--- a/packages/afps-runtime/src/cli/commands/run.ts
+++ b/packages/afps-runtime/src/cli/commands/run.ts
@@ -3,7 +3,7 @@
 
 import { parseArgs } from "node:util";
 import { readFile, writeFile } from "node:fs/promises";
-import { loadBundleFromBuffer } from "../../bundle/loader.ts";
+import { loadAnyBundleFromBuffer } from "../../bundle/bridge.ts";
 import { ConsoleSink } from "../../sinks/console-sink.ts";
 import { FileSink } from "../../sinks/file-sink.ts";
 import { CompositeSink } from "../../sinks/composite-sink.ts";
@@ -76,7 +76,7 @@ export async function run(argv: readonly string[], io: CliIO): Promise<number> {
   // by scripted replay — the sink + reducer contract is independent of
   // the bundle's prompt content.
   const bundleBytes = await readFile(bundlePath);
-  loadBundleFromBuffer(bundleBytes);
+  loadAnyBundleFromBuffer(bundleBytes);
 
   const sink = await buildSink(parsed.values, bundlePath, io);
   if (!sink) return 1;

--- a/packages/afps-runtime/src/cli/commands/sign.ts
+++ b/packages/afps-runtime/src/cli/commands/sign.ts
@@ -4,7 +4,7 @@
 import { parseArgs } from "node:util";
 import { readFile, writeFile } from "node:fs/promises";
 import { zipSync } from "fflate";
-import { loadBundleFromBuffer } from "../../bundle/loader.ts";
+import { loadAnyBundleFromBuffer } from "../../bundle/bridge.ts";
 import { canonicalBundleDigest, signBundle, type TrustChainEntry } from "../../bundle/signing.ts";
 import type { CliIO } from "../index.ts";
 
@@ -91,7 +91,7 @@ export async function run(argv: readonly string[], io: CliIO): Promise<number> {
   }
 
   const bundleBytes = await readFile(bundlePath);
-  const bundle = loadBundleFromBuffer(bundleBytes);
+  const bundle = loadAnyBundleFromBuffer(bundleBytes);
 
   const canonical = canonicalBundleDigest(bundle.files);
   const signature = signBundle(canonical, {

--- a/packages/afps-runtime/src/cli/commands/verify.ts
+++ b/packages/afps-runtime/src/cli/commands/verify.ts
@@ -3,8 +3,8 @@
 
 import { parseArgs } from "node:util";
 import { readFile } from "node:fs/promises";
-import { loadBundleFromBuffer } from "../../bundle/loader.ts";
-import { validateBundle } from "../../bundle/validator.ts";
+import { loadAnyBundleFromBuffer } from "../../bundle/bridge.ts";
+import { validateAfpsManifest } from "../../bundle/validator.ts";
 import {
   canonicalBundleDigest,
   readBundleSignature,
@@ -61,9 +61,9 @@ export async function run(argv: readonly string[], io: CliIO): Promise<number> {
   }
 
   const bundleBytes = await readFile(bundlePath);
-  const bundle = loadBundleFromBuffer(bundleBytes);
+  const bundle = loadAnyBundleFromBuffer(bundleBytes);
 
-  const validation = validateBundle(bundle);
+  const validation = validateAfpsManifest(bundle);
   if (!validation.valid) {
     io.stderr(`afps verify: ${validation.issues.length} validation issue(s):\n`);
     for (const issue of validation.issues) {

--- a/packages/afps-runtime/src/index.ts
+++ b/packages/afps-runtime/src/index.ts
@@ -9,6 +9,11 @@
  * import the narrow surface they need; the top-level re-exports the
  * full public API for convenience.
  *
+ * The multi-package {@link Bundle} contract (spec §4) is the primary
+ * API. {@link LoadedBundle} remains a first-class flat projection for
+ * consumers that prefer path-keyed access — `bundleToLoadedBundle`
+ * bridges the two without re-decoding.
+ *
  * AFPS 1.3 introduces three spec-aligned resolver interfaces
  * (ToolResolver, ProviderResolver, SkillResolver). They live under
  * `@appstrate/afps-runtime/resolvers`.
@@ -22,7 +27,7 @@ export * from "./events/index.ts";
 export * from "./sinks/index.ts";
 export * from "./template/index.ts";
 
-// New multi-package Bundle contract (spec §4)
+// Multi-package Bundle contract (spec §4) — primary API.
 export {
   BUNDLE_FORMAT_VERSION,
   BundleError,
@@ -48,7 +53,7 @@ export {
   recordIntegrity,
   resolveBundleLimits,
   serializeRecord,
-  validateBundleV2,
+  validateBundle,
   writeBundleToBuffer,
   writeBundleToFile,
   type AfpsManifest,
@@ -68,10 +73,28 @@ export {
   type ReadBundleOptions,
   type RecordEntry,
   type ResolvedPackage,
-  type ValidateBundleV2Options,
+  type ValidateBundleOptions,
 } from "./bundle/index.ts";
 
-// Legacy single-package surface (deprecated — prefer the Bundle API above)
+// LoadedBundle flat projection + interop adapters.
+export {
+  bundleToLoadedBundle,
+  loadAnyBundleFromBuffer,
+  loadAnyBundleFromFile,
+  loadBundleFromBuffer,
+  type LoadAnyBundleOptions,
+  type LoadedBundle,
+} from "./bundle/index.ts";
+
+// AFPS single-package manifest validator (flat LoadedBundle input).
+export {
+  validateAfpsManifest,
+  type AfpsManifestValidationIssue,
+  type AfpsManifestValidationResult,
+  type ValidateAfpsManifestOptions,
+} from "./bundle/index.ts";
+
+// Prompt rendering.
 export {
   renderPrompt,
   buildPromptView,
@@ -79,21 +102,12 @@ export {
   type PromptViewProvider,
   type PromptViewUpload,
   type RenderPromptOptions,
-} from "./bundle/prompt-renderer.ts";
-export { computeIntegrity, verifyIntegrity, type IntegrityCheckResult } from "./bundle/hash.ts";
-export {
-  loadBundleFromBuffer,
-  loadBundleFromFile,
-  BundleLoadError,
-  type LoadedBundle,
-  type LoadBundleOptions,
-} from "./bundle/loader.ts";
-export {
-  validateBundle,
-  type ValidationResult,
-  type ValidationIssue,
-  type ValidateBundleOptions,
-} from "./bundle/validator.ts";
+} from "./bundle/index.ts";
+
+// Archive-level SRI integrity helpers (orthogonal to Bundle.integrity).
+export { computeIntegrity, type IntegrityCheckResult } from "./bundle/index.ts";
+
+// Signing + trust root.
 export {
   canonicalBundleDigest,
   signBundle,
@@ -112,7 +126,7 @@ export {
   type SignChildKeyOptions,
   type VerifySignatureResult,
   type VerifySignatureFailureReason,
-} from "./bundle/signing.ts";
+} from "./bundle/index.ts";
 
 export * from "./runner/index.ts";
 export * from "./conformance/index.ts";

--- a/packages/afps-runtime/test/bundle/integration.test.ts
+++ b/packages/afps-runtime/test/bundle/integration.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect } from "bun:test";
 import { zipSync } from "fflate";
 import { loadBundleFromBuffer } from "../../src/bundle/loader.ts";
-import { validateBundle } from "../../src/bundle/validator.ts";
+import { validateAfpsManifest } from "../../src/bundle/validator.ts";
 import { computeIntegrity, verifyIntegrity } from "../../src/bundle/hash.ts";
 import { renderPrompt } from "../../src/bundle/prompt-renderer.ts";
 
@@ -40,7 +40,7 @@ describe("bundle integration — build → load → validate → render", () => 
   it("round-trips through loader + validator with no issues", () => {
     const bundle = loadBundleFromBuffer(zip);
     expect(bundle.manifest.name).toBe("@acme/research");
-    const result = validateBundle(bundle);
+    const result = validateAfpsManifest(bundle);
     expect(result.valid).toBe(true);
     expect(result.issues).toEqual([]);
   });

--- a/packages/afps-runtime/test/bundle/validator.test.ts
+++ b/packages/afps-runtime/test/bundle/validator.test.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 Appstrate
 
 import { describe, it, expect } from "bun:test";
-import { validateBundle } from "../../src/bundle/validator.ts";
+import { validateAfpsManifest } from "../../src/bundle/validator.ts";
 import type { LoadedBundle } from "../../src/bundle/loader.ts";
 
 const VALID_AGENT_MANIFEST = {
@@ -25,9 +25,9 @@ function bundle(overrides: Partial<LoadedBundle> = {}): LoadedBundle {
   };
 }
 
-describe("validateBundle — happy path", () => {
+describe("validateAfpsManifest — happy path", () => {
   it("accepts a well-formed agent bundle", () => {
-    const result = validateBundle(bundle());
+    const result = validateAfpsManifest(bundle());
     expect(result.valid).toBe(true);
     expect(result.issues).toEqual([]);
   });
@@ -36,17 +36,17 @@ describe("validateBundle — happy path", () => {
     const b = bundle({
       prompt: "{{#memories}}- {{content}}\n{{/memories}}{{^memories}}none{{/memories}}",
     });
-    const result = validateBundle(b);
+    const result = validateAfpsManifest(b);
     expect(result.valid).toBe(true);
   });
 });
 
-describe("validateBundle — manifest schema", () => {
+describe("validateAfpsManifest — manifest schema", () => {
   it("rejects a manifest missing required fields (no name)", () => {
     const b = bundle({
       manifest: { ...VALID_AGENT_MANIFEST, name: undefined } as unknown as Record<string, unknown>,
     });
-    const result = validateBundle(b);
+    const result = validateAfpsManifest(b);
     expect(result.valid).toBe(false);
     expect(result.issues.map((i) => i.code)).toContain("MANIFEST_SCHEMA");
   });
@@ -55,7 +55,7 @@ describe("validateBundle — manifest schema", () => {
     const b = bundle({
       manifest: { ...VALID_AGENT_MANIFEST, name: "bad-name" },
     });
-    const result = validateBundle(b);
+    const result = validateAfpsManifest(b);
     expect(result.valid).toBe(false);
     expect(result.issues.some((i) => i.path.includes("name"))).toBe(true);
   });
@@ -64,41 +64,41 @@ describe("validateBundle — manifest schema", () => {
     const b = bundle({
       manifest: { ...VALID_AGENT_MANIFEST, version: "v1" },
     });
-    const result = validateBundle(b);
+    const result = validateAfpsManifest(b);
     expect(result.valid).toBe(false);
     expect(result.issues.some((i) => i.path.includes("version"))).toBe(true);
   });
 });
 
-describe("validateBundle — type filtering", () => {
+describe("validateAfpsManifest — type filtering", () => {
   it("rejects a non-agent bundle when agentOnly (default) is true", () => {
     const b = bundle({ manifest: { ...VALID_AGENT_MANIFEST, type: "skill" } });
-    const result = validateBundle(b);
+    const result = validateAfpsManifest(b);
     expect(result.valid).toBe(false);
     expect(result.issues.some((i) => i.code === "UNSUPPORTED_TYPE")).toBe(true);
   });
 
   it("skipping agentOnly still fails through MANIFEST_SCHEMA for a skill manifest (missing agent fields)", () => {
     const b = bundle({ manifest: { ...VALID_AGENT_MANIFEST, type: "skill" } });
-    const result = validateBundle(b, { agentOnly: false });
+    const result = validateAfpsManifest(b, { agentOnly: false });
     // No UNSUPPORTED_TYPE, but MANIFEST_SCHEMA likely triggers because
     // the agent schema expects type === "agent".
     expect(result.issues.some((i) => i.code === "UNSUPPORTED_TYPE")).toBe(false);
   });
 });
 
-describe("validateBundle — schemaVersion gating", () => {
+describe("validateAfpsManifest — schemaVersion gating", () => {
   it("accepts the default supported major (1.x)", () => {
     for (const v of ["1.0", "1.1", "1.42"]) {
       const b = bundle({ manifest: { ...VALID_AGENT_MANIFEST, schemaVersion: v } });
-      const result = validateBundle(b);
+      const result = validateAfpsManifest(b);
       expect(result.valid).toBe(true);
     }
   });
 
   it("rejects a future major when not in supportedMajors", () => {
     const b = bundle({ manifest: { ...VALID_AGENT_MANIFEST, schemaVersion: "2.0" } });
-    const result = validateBundle(b);
+    const result = validateAfpsManifest(b);
     // 2.x is outside v1 manifest spec — MANIFEST_SCHEMA fires before our guard.
     expect(result.valid).toBe(false);
     expect(
@@ -113,15 +113,15 @@ describe("validateBundle — schemaVersion gating", () => {
     // fails MANIFEST_SCHEMA even with supportedMajors: [2]. This test
     // pins the runtime-side gate specifically.
     const b = bundle({ manifest: { ...VALID_AGENT_MANIFEST } });
-    const result = validateBundle(b, { supportedMajors: [1, 2] });
+    const result = validateAfpsManifest(b, { supportedMajors: [1, 2] });
     expect(result.valid).toBe(true);
   });
 });
 
-describe("validateBundle — template syntax", () => {
+describe("validateAfpsManifest — template syntax", () => {
   it("rejects an unclosed section", () => {
     const b = bundle({ prompt: "{{#memories}}forever" });
-    const result = validateBundle(b);
+    const result = validateAfpsManifest(b);
     expect(result.valid).toBe(false);
     const issue = result.issues.find((i) => i.code === "TEMPLATE_SYNTAX");
     expect(issue).toBeDefined();
@@ -130,19 +130,19 @@ describe("validateBundle — template syntax", () => {
 
   it("rejects a stray closing tag", () => {
     const b = bundle({ prompt: "hello {{/never-opened}}" });
-    const result = validateBundle(b);
+    const result = validateAfpsManifest(b);
     expect(result.valid).toBe(false);
     expect(result.issues.some((i) => i.code === "TEMPLATE_SYNTAX")).toBe(true);
   });
 });
 
-describe("validateBundle — issue accumulation", () => {
+describe("validateAfpsManifest — issue accumulation", () => {
   it("surfaces multiple issues in a single pass (fail fast avoided)", () => {
     const b = bundle({
       manifest: { ...VALID_AGENT_MANIFEST, name: "bad-name" },
       prompt: "{{#unterminated}}",
     });
-    const result = validateBundle(b);
+    const result = validateAfpsManifest(b);
     expect(result.valid).toBe(false);
     expect(result.issues.length).toBeGreaterThanOrEqual(2);
     expect(result.issues.some((i) => i.code === "MANIFEST_SCHEMA")).toBe(true);

--- a/packages/afps-runtime/test/fixtures/reference.test.ts
+++ b/packages/afps-runtime/test/fixtures/reference.test.ts
@@ -16,7 +16,7 @@ import { describe, it, expect } from "bun:test";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { loadBundleFromBuffer } from "../../src/bundle/loader.ts";
-import { validateBundle } from "../../src/bundle/validator.ts";
+import { validateAfpsManifest } from "../../src/bundle/validator.ts";
 import {
   canonicalBundleDigest,
   readBundleSignature,
@@ -50,7 +50,7 @@ describe("fixtures/reference — end-to-end round trip", () => {
   it("loads and validates the signed bundle without issues", async () => {
     const bytes = await readFile(join(FIXTURE, "bundle.afps"));
     const bundle = loadBundleFromBuffer(bytes);
-    const result = validateBundle(bundle);
+    const result = validateAfpsManifest(bundle);
     expect(result.valid).toBe(true);
     expect(result.issues).toEqual([]);
     expect(bundle.manifest["name"]).toBe("@afps/conformance-ref");


### PR DESCRIPTION
## Summary

Phase 3 of the bundle-format roadmap. Bundles T2.B (host emits multi-package), T2.D (inline + scheduled run coverage), and T2.F (surface cleanup) on a single branch stacked on #242.

## T2.B — host emits multi-package `.afps-bundle`

The host-side `buildAgentPackage` (run hot path) now produces the canonical multi-package bundle instead of the ad-hoc flat ZIP. Container-side `loadAnyBundleFromFile` (from #242) detects the new format and projects it back through `bundleToLoadedBundle` to the flat surface PiRunner + resolvers expect.

- New `DraftPackageCatalog` — draft-state `PackageCatalog` that reads `packages.draftManifest` + `library-packages` bucket. Preserves "edit tool → rerun agent → see changes" dev loop. Counterpart to `DbPackageCatalog` (used for published-version resolution on the import/export path).
- `buildAgentPackage` signature unchanged (`(LoadedPackage, orgId) → { zip, toolDocs }`).
- Injection path unchanged (`/workspace/agent-package.afps`).
- `routes/runs.ts::buildRunnerBundle` swapped `loadBundleFromBuffer` → `loadAnyBundleFromBuffer`.
- Unresolved deps now fail fast at build time (was: silent skip → cryptic in-container error).

## T2.D — inline + scheduled runs — coverage via shared pipeline

Both inline and scheduled runs already flow through `prepareAndExecuteRun → buildRunContext → buildAgentPackage`. No additional code needed — Phase 3 automatically applies. 30 inline route tests + 1634 API tests all green.

## T2.F — surface cleanup (no version bump)

Pre-1.0 cleanup of `@appstrate/afps-runtime/bundle`. Package isn't published — `publish-afps-runtime` workflow was dropped in `45a605b7` — so there's no trust-root / signature-invalidation concern.

- All bundle-tooling CLI commands (sign/verify/inspect/render/run) now go through `loadAnyBundleFromBuffer` — accept both legacy `.afps` and new `.afps-bundle` format.
- Validator names unified:
  - `validateBundle` (was flat-manifest validator) → `validateAfpsManifest`
  - `validateBundleV2` (was multi-package Bundle validator) → `validateBundle` (primary)
  - Associated types follow the same rename pattern.
- Bundle `index.ts` docblock refreshed — `LoadedBundle` is explicitly first-class (not "deprecated"), since it stays load-bearing for runtime-pi + resolvers under the path-1 format-only migration.
- Pruned 4 unused re-exports (`BundleLoadError`, `LoadBundleOptions`, `loadBundleFromFile`, `verifyIntegrity`).
- Version remains at 0.0.0 per user directive — 1.0.0 bump is a separate signaling decision.

## What's not here

- **Signature semantics unchanged** — `canonicalBundleDigest` still operates on the flat LoadedBundle projection. A true multi-package canonical digest over `Bundle.integrity` would invalidate existing signed archives and needs ADR-009 v2.
- **Published-version dep resolution for runs** — `DraftPackageCatalog` is the default. Switching runs to `DbPackageCatalog` (semver-pinned published versions) is a user-visible dev-loop change that needs its own PR with editor UX.

## Test plan

- [x] `bun run check` — 24/24 tasks green
- [x] `bun test apps/api/test/` — 1634 tests pass (3 new in `build-agent-package-bundle.test.ts`, 0 regressions)
- [x] `bun test packages/afps-runtime` — 315 tests pass
- [x] `bun test runtime-pi` — 155 tests pass
- [x] Inline-specific tests (30) green

## Stacking

Base: `feat/bundle-export-import` (#242). Merge after #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)