### PR TITLE
fix(api): reconcile orphan sidecars in process orchestrator

### DIFF
--- a/apps/api/src/services/orchestrator/process-orchestrator.ts
+++ b/apps/api/src/services/orchestrator/process-orchestrator.ts
@@ -18,7 +18,7 @@
  * Re-test with `stdout: "pipe"` after upgrading Bun to check if the fix is still needed.
  */
 
-import { mkdir, rm, open as fsOpen } from "node:fs/promises";
+import { mkdir, rm, readdir, open as fsOpen } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { getEnv } from "@appstrate/env";
 import { logger } from "../../lib/logger.ts";
@@ -83,17 +83,19 @@ export class ProcessOrchestrator implements ContainerOrchestrator {
     const handles = [...this.processes.entries()];
     await Promise.all(
       handles.map(async ([_id, handle]) => {
-        if (!handle.proc) return;
-        try {
-          handle.proc.kill("SIGTERM");
-          const exited = await Promise.race([
-            handle.proc.exited.then(() => true),
-            new Promise<false>((r) => setTimeout(() => r(false), 5000)),
-          ]);
-          if (!exited) handle.proc.kill("SIGKILL");
-        } catch {
-          // Already dead
+        if (handle.proc) {
+          try {
+            handle.proc.kill("SIGTERM");
+            const exited = await Promise.race([
+              handle.proc.exited.then(() => true),
+              new Promise<false>((r) => setTimeout(() => r(false), 5000)),
+            ]);
+            if (!exited) handle.proc.kill("SIGKILL");
+          } catch {
+            // Already dead
+          }
         }
+        await this.removePidfile(handle.runId, handle.role);
       }),
     );
     this.processes.clear();
@@ -105,8 +107,60 @@ export class ProcessOrchestrator implements ContainerOrchestrator {
     // No-op — no images needed in process mode
   }
 
+  /**
+   * Reconcile orphans left over from a previous platform process.
+   *
+   * Mode `process` has no Docker label to scan, so every spawn writes a pidfile
+   * inside its boundary directory (`./data/runs/<runId>/<role>.pid`). At boot,
+   * every subdirectory of `DATA_DIR` is by definition orphaned — boot.ts has
+   * already marked any in-progress runs as failed before we run, and the new
+   * platform process holds no in-memory handles yet. We SIGKILL each pid that
+   * is still alive and rm -rf the boundary directory.
+   *
+   * Best-effort throughout: an unreadable pidfile or a permission error never
+   * blocks startup. Idempotent — calling twice in a row returns zeros on the
+   * second call.
+   */
   async cleanupOrphans(): Promise<CleanupReport> {
-    return { workloads: 0, isolationBoundaries: 0 };
+    let workloads = 0;
+    let isolationBoundaries = 0;
+
+    let entries: string[];
+    try {
+      entries = (await readdir(DATA_DIR)) as unknown as string[];
+    } catch {
+      return { workloads: 0, isolationBoundaries: 0 };
+    }
+
+    for (const name of entries) {
+      const dir = join(DATA_DIR, name);
+      const files = ((await readdir(dir).catch(() => [])) as unknown as string[]) ?? [];
+      for (const f of files) {
+        if (!f.endsWith(".pid")) continue;
+        const text = await Bun.file(join(dir, f))
+          .text()
+          .catch(() => "");
+        const pid = Number(text.trim());
+        if (!Number.isFinite(pid) || pid <= 0) continue;
+        try {
+          process.kill(pid, 0);
+        } catch {
+          // Already dead — nothing to kill, but the pidfile still counts as a
+          // recovered orphan boundary (handled by the rm -rf below).
+          continue;
+        }
+        try {
+          process.kill(pid, "SIGKILL");
+          workloads++;
+        } catch {
+          // Race: died between the probe and the kill.
+        }
+      }
+      await rm(dir, { recursive: true, force: true }).catch(() => {});
+      isolationBoundaries++;
+    }
+
+    return { workloads, isolationBoundaries };
   }
 
   async createIsolationBoundary(runId: string): Promise<IsolationBoundary> {
@@ -152,8 +206,24 @@ export class ProcessOrchestrator implements ContainerOrchestrator {
     this.drainStderr(proc, id);
     this.processes.set(id, { proc, role: "sidecar", runId });
     this.sidecarPorts.set(runId, port);
+    await this.writePidfile(runId, "sidecar", proc.pid);
 
-    await this.waitForHealth(`http://localhost:${port}/health`, 5000);
+    try {
+      await this.waitForHealth(`http://localhost:${port}/health`, 5000);
+    } catch (err) {
+      // Health check failed — kill the spawned sidecar and purge state so the
+      // process doesn't outlive the failed createSidecar call. Without this,
+      // pi.ts's finally never sees a sidecarHandle and the leak persists.
+      try {
+        proc.kill("SIGKILL");
+      } catch {
+        // Already dead
+      }
+      this.processes.delete(id);
+      this.sidecarPorts.delete(runId);
+      await this.removePidfile(runId, "sidecar");
+      throw err;
+    }
     logger.info("Sidecar ready", { runId, port, pid: proc.pid });
 
     return { id, runId, role: "sidecar" };
@@ -212,6 +282,7 @@ export class ProcessOrchestrator implements ContainerOrchestrator {
     ph.proc = proc;
     ph.stdoutPath = stdoutPath;
     this.pendingSpecs.delete(handle.id);
+    await this.writePidfile(handle.runId, ph.role, proc.pid);
   }
 
   async stopWorkload(handle: WorkloadHandle, timeoutSeconds = 5): Promise<void> {
@@ -235,6 +306,8 @@ export class ProcessOrchestrator implements ContainerOrchestrator {
       // Already dead
     }
     this.processes.delete(handle.id);
+    if (ph.role === "sidecar") this.sidecarPorts.delete(ph.runId);
+    await this.removePidfile(ph.runId, ph.role);
   }
 
   async waitForExit(handle: WorkloadHandle): Promise<number> {
@@ -303,6 +376,30 @@ export class ProcessOrchestrator implements ContainerOrchestrator {
   // ---------------------------------------------------------------------------
   // Internal helpers
   // ---------------------------------------------------------------------------
+
+  /**
+   * Persist a spawned subprocess's pid in its boundary directory so the next
+   * platform boot can reconcile the orphan if this process is killed before
+   * cleanup runs (SIGKILL, hot-reload crash, machine reboot).
+   *
+   * Best-effort: the pidfile is a recovery aid, not a correctness requirement.
+   * A failed write only loses the boot-time orphan recovery for one process.
+   */
+  private async writePidfile(runId: string, role: string, pid: number): Promise<void> {
+    try {
+      await Bun.write(join(DATA_DIR, runId, `${role}.pid`), String(pid));
+    } catch (err) {
+      logger.warn("Failed to write sidecar/workload pidfile", {
+        runId,
+        role,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  private async removePidfile(runId: string, role: string): Promise<void> {
+    await rm(join(DATA_DIR, runId, `${role}.pid`), { force: true }).catch(() => {});
+  }
 
   private async findAvailablePort(retries = 3): Promise<number> {
     for (let attempt = 0; attempt < retries; attempt++) {

--- a/apps/api/test/unit/process-orchestrator.test.ts
+++ b/apps/api/test/unit/process-orchestrator.test.ts
@@ -1,14 +1,48 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, afterEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { existsSync } from "node:fs";
+import { mkdir, rm, writeFile, readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
 import { ProcessOrchestrator } from "../../src/services/orchestrator/process-orchestrator.ts";
+
+const DATA_DIR = resolve("./data/runs");
 
 let orchestrator: ProcessOrchestrator;
 
 afterEach(async () => {
   await orchestrator?.shutdown();
 });
+
+/** Wipe DATA_DIR so each test starts from a known empty state. */
+async function resetDataDir() {
+  await rm(DATA_DIR, { recursive: true, force: true });
+  await mkdir(DATA_DIR, { recursive: true });
+}
+
+/** Spawn a long-lived child process and return its pid. Caller must kill it. */
+function spawnSleeper(): number {
+  const proc = Bun.spawn(["bun", "-e", "setInterval(()=>{},60000)"], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  if (!proc.pid) throw new Error("Failed to spawn sleeper");
+  return proc.pid;
+}
+
+/** Wait for `process.kill(pid, 0)` to throw ESRCH (i.e. pid is gone). */
+async function waitForExit(pid: number, timeoutMs = 2000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return true;
+    }
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return false;
+}
 
 describe("ProcessOrchestrator", () => {
   describe("createIsolationBoundary / removeIsolationBoundary", () => {
@@ -81,11 +115,129 @@ describe("ProcessOrchestrator", () => {
   });
 
   describe("cleanupOrphans", () => {
-    it("returns zero counts", async () => {
+    beforeEach(async () => {
+      await resetDataDir();
+    });
+
+    it("returns zero counts when DATA_DIR is empty", async () => {
       orchestrator = new ProcessOrchestrator();
       const report = await orchestrator.cleanupOrphans();
       expect(report).toEqual({ workloads: 0, isolationBoundaries: 0 });
     });
+
+    it("removes a boundary directory whose pidfile points at a dead pid", async () => {
+      const dir = join(DATA_DIR, "orphan-dead");
+      await mkdir(dir, { recursive: true });
+      // 99999999 is well above /proc/sys/kernel/pid_max defaults, so it's safe
+      // to assume no live process owns it.
+      await writeFile(join(dir, "sidecar.pid"), "99999999");
+
+      orchestrator = new ProcessOrchestrator();
+      const report = await orchestrator.cleanupOrphans();
+
+      expect(report.isolationBoundaries).toBe(1);
+      expect(report.workloads).toBe(0);
+      expect(existsSync(dir)).toBe(false);
+    });
+
+    it("kills a live orphan process and removes its boundary directory", async () => {
+      const pid = spawnSleeper();
+      const dir = join(DATA_DIR, "orphan-live");
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "sidecar.pid"), String(pid));
+
+      try {
+        orchestrator = new ProcessOrchestrator();
+        const report = await orchestrator.cleanupOrphans();
+
+        expect(report.workloads).toBe(1);
+        expect(report.isolationBoundaries).toBe(1);
+        expect(existsSync(dir)).toBe(false);
+        expect(await waitForExit(pid)).toBe(true);
+      } finally {
+        // Defensive: if the test fails, make sure we don't leak the sleeper.
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {
+          // Already dead
+        }
+      }
+    });
+
+    it("ignores malformed pidfiles but still wipes the boundary", async () => {
+      const dir = join(DATA_DIR, "orphan-garbage");
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "sidecar.pid"), "not-a-pid");
+
+      orchestrator = new ProcessOrchestrator();
+      const report = await orchestrator.cleanupOrphans();
+
+      expect(report.isolationBoundaries).toBe(1);
+      expect(report.workloads).toBe(0);
+      expect(existsSync(dir)).toBe(false);
+    });
+
+    it("is idempotent — second call after a wipe returns zeros", async () => {
+      const dir = join(DATA_DIR, "orphan-twice");
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "sidecar.pid"), "99999999");
+
+      orchestrator = new ProcessOrchestrator();
+      await orchestrator.cleanupOrphans();
+      const second = await orchestrator.cleanupOrphans();
+      expect(second).toEqual({ workloads: 0, isolationBoundaries: 0 });
+    });
+  });
+
+  describe("createSidecar failure path", () => {
+    beforeEach(async () => {
+      await resetDataDir();
+    });
+
+    it("kills the spawned sidecar and removes its pidfile when health check fails", async () => {
+      orchestrator = new ProcessOrchestrator();
+      await orchestrator.initialize();
+      const boundary = await orchestrator.createIsolationBoundary("test-run-health-fail");
+
+      // Force the sidecar binary to a no-op script that never serves /health.
+      // The path lives inside the boundary so it's cleaned up with the run.
+      const fakeSidecar = join(boundary.id, "fake-sidecar.ts");
+      await writeFile(fakeSidecar, "setInterval(()=>{},60000);");
+
+      // Reflectively swap the sidecar entry path. We can't override the module
+      // constant, so we monkey-patch Bun.spawn for this single call.
+      const originalSpawn = Bun.spawn;
+      let capturedPid: number | undefined;
+      const patchedSpawn = ((cmd: string[], opts: Parameters<typeof Bun.spawn>[1]) => {
+        const replaced = cmd[0] === "bun" && cmd[1] === "run" ? ["bun", "run", fakeSidecar] : cmd;
+        const proc = originalSpawn(replaced, opts);
+        capturedPid = proc.pid;
+        return proc;
+      }) as typeof Bun.spawn;
+      (Bun as { spawn: typeof Bun.spawn }).spawn = patchedSpawn;
+
+      try {
+        await expect(
+          orchestrator.createSidecar("test-run-health-fail", boundary, {
+            runToken: "tok",
+            platformApiUrl: "http://localhost:1",
+          }),
+        ).rejects.toThrow(/health check timed out/i);
+      } finally {
+        (Bun as { spawn: typeof Bun.spawn }).spawn = originalSpawn;
+      }
+
+      expect(capturedPid).toBeDefined();
+      // The sidecar process should be dead.
+      expect(await waitForExit(capturedPid!)).toBe(true);
+      // No leftover pidfile under the boundary.
+      const remaining = await readdir(boundary.id).catch(() => [] as string[]);
+      expect(remaining.includes("sidecar.pid")).toBe(false);
+      // stopByRunId should now report not_found — internal map is purged.
+      expect(await orchestrator.stopByRunId("test-run-health-fail")).toBe("not_found");
+
+      await orchestrator.removeIsolationBoundary(boundary);
+    }, 10_000);
   });
 
   describe("stopByRunId", () => {


### PR DESCRIPTION
## Summary

- `ProcessOrchestrator.cleanupOrphans()` now actually reconciles state instead of returning zeros. Every spawned sidecar/workload writes a pidfile in its boundary directory; at boot, every leftover boundary is wiped and any pid still alive is SIGKILL'd.
- `createSidecar` no longer leaks the spawned subprocess when the health check times out — kill, purge in-memory maps + pidfile, then rethrow.
- Boot.ts already calls `cleanupOrphans` at startup; the no-op implementation meant orphans from a previous SIGKILL'd dev server (hot-reload crash, machine reboot) stayed running forever.

Fixes #229.

## Why this matters

Mode `RUN_ADAPTER=process` is the default Tier-0 path (zero-install dev). Before this PR, every cancelled/timed-out run could leak its sidecar — observed in practice: 5 orphan sidecars after a handful of hung runs, plus port pressure on subsequent dev runs. Docker mode was unaffected (label-based reconciliation already worked).

## Approach

Source of truth = pidfiles under `./data/runs/<runId>/<role>.pid`. Single-instance by construction (subprocesses on the same host), so no Redis/lock needed — keeps Tier-0 zero-dependency. Cleanup is destructive but safe: `markOrphanRunsFailed()` already runs first in `boot.ts`, so any boundary on disk at cleanup time is by definition unowned.

Three coordinated changes inside `ProcessOrchestrator` (no public API, no other callers touched):

1. `writePidfile` / `removePidfile` helpers — best-effort, never block spawn.
2. `cleanupOrphans` — reads each `*.pid` under `DATA_DIR`, SIGKILL's live pids, `rm -rf` the boundary dir. Idempotent.
3. `createSidecar` — try/catch around `waitForHealth`: on failure, kill proc, purge state, throw.

`shutdown` and `removeWorkload` also delete pidfiles for symmetry, so a clean exit leaves `DATA_DIR` empty.

Out of scope (intentional): `detached`/`setpgid` (not cleanly exposed by Bun, redundant given pidfile reconciliation); changes to `pi.ts` (its `finally` is correct — the bug was entirely on the orchestrator side); changes to `DockerOrchestrator` (already correct).

## Test plan

- [x] `bun test apps/api/test/unit/process-orchestrator.test.ts` — 12/12 pass (5 new tests covering: empty DATA_DIR, dead pid, live pid, malformed pidfile, idempotency, createSidecar health-check failure)
- [x] `bun test apps/api/test/unit` — 626/626 pass
- [x] `bun run check` — all 17 turbo tasks pass (tsc + eslint + prettier + verify-openapi)
- [ ] Manual repro on `bun run dev`: trigger + cancel a hung run, `pgrep -fl runtime-pi` → empty; SIGKILL dev, restart → boot wipes leftover dirs and kills surviving pids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)