### PR TITLE
refactor(api): split AppstrateEventSink into Persisting + Aggregating

### DIFF
--- a/apps/api/src/services/adapters/appstrate-event-sink.ts
+++ b/apps/api/src/services/adapters/appstrate-event-sink.ts
@@ -1,18 +1,34 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Appstrate-backed {@link EventSink} — composition of the runtime
- * reducer (source of truth for canonical AFPS aggregation) with a
- * platform write-through that persists `run_logs`, snapshots token
- * usage onto the run row, and appends cost to the unified `llm_usage`
- * ledger.
+ * Appstrate-backed {@link EventSink} implementations — composition of
+ * the runtime reducer (source of truth for canonical AFPS aggregation)
+ * with a platform write-through that persists `run_logs`, snapshots
+ * token usage onto the run row, and appends cost to the unified
+ * `llm_usage` ledger.
  *
- * Event routing:
+ * Two flavours, no flags:
  *
- *   AFPS canonical (reserved domains) → reducer snapshot:
+ *   {@link PersistingEventSink} — fan-out only. Used by the ingestion
+ *     hot path: each request rebuilds one sink, calls `handle()`, and
+ *     drops it. No reducer is constructed, no in-memory state is kept.
+ *
+ *   {@link AggregatingEventSink} — long-lived sink for parity tests
+ *     and in-process runners that read back `current` / `result`
+ *     between events. Wraps {@link PersistingEventSink} and feeds the
+ *     same events into a runtime reducer + platform projection.
+ *
+ * Splitting the two eliminates the previous `persistOnly` flag whose
+ * `current` getter threw — every method on every public surface is now
+ * total. Liskov substitution: an `AggregatingEventSink` is a
+ * `PersistingEventSink` with extra read-back capabilities, never less.
+ *
+ * Event routing (identical for both sinks):
+ *
+ *   AFPS canonical (reserved domains) → reducer snapshot (aggregating only):
  *     memory.added / state.set / output.emitted / report.appended / log.written
  *
- *   Platform write-through (always, independent of reducer):
+ *   Platform write-through (always, both sinks):
  *     output.emitted  → run_logs (result/output)
  *     report.appended → run_logs (result/report)
  *     log.written     → run_logs (progress/progress) with level
@@ -24,13 +40,9 @@
  *                         + llm_usage ledger row (source="runner")
  *
  * `runs.cost` is NEVER written here — it is the cached aggregate written
- * exactly once by `finalizeRun`. This sink is the single writer of the
- * `llm_usage` runner rows and the single reader/writer of
+ * exactly once by `finalizeRun`. These sinks are the single writer of
+ * the `llm_usage` runner rows and the single reader/writer of
  * `runs.tokenUsage`.
- *
- * The sink performs NO status update, NO webhook dispatch, and NO
- * post-run metadata collection — those remain the route handler's
- * responsibility.
  */
 
 import { createReducerSink, type ReducerSinkHandle } from "@appstrate/afps-runtime/sinks";
@@ -48,9 +60,10 @@ import type { TokenUsage } from "./types.ts";
 
 /**
  * Platform-facing projection of the runtime {@link RunResult} + the
- * platform-specific accumulators. Shapes match the DB persistence
- * expectations (memories as `string[]`, state/output as plain objects,
- * report as string, never null).
+ * platform-specific accumulators. Only exposed by the
+ * {@link AggregatingEventSink} for in-process consumers that read back
+ * the running snapshot. The ingestion path uses the persisting sink
+ * which has no `current` projection.
  */
 export interface AggregatedRunState {
   /** Latest `output.emitted` object payload (replaces previous). Non-object payloads project to `{}`. */
@@ -69,49 +82,60 @@ export interface AggregatedRunState {
   lastAdapterError: string | null;
 }
 
-export interface AppstrateEventSinkOptions {
+export interface PersistingEventSinkOptions {
   scope: AppScope;
   runId: string;
-  /**
-   * When `true`, skips the in-memory AFPS reducer entirely. The ingestion
-   * route re-instantiates the sink per event and never reads `current` /
-   * `result`, so the reducer is dead work on the hot path. Long-lived
-   * callers (parity tests, in-process runners) leave this unset to keep
-   * reading the canonical snapshot.
-   */
-  persistOnly?: boolean;
   /**
    * When `true`, `appstrate.metric` events write a runner-source row to
    * the `llm_usage` ledger. At most one runner row per run; concurrent
    * writers race via ON CONFLICT DO NOTHING. The ingestion path turns
-   * this on; long-lived in-process runners (parity tests) leave it off.
+   * this on; long-lived in-process runners (parity tests) leave it off
+   * — they go through {@link AggregatingEventSink} which never enables
+   * ledger writes.
    */
   writeLedger?: boolean;
 }
 
-export class AppstrateEventSink implements EventSink {
+export type AggregatingEventSinkOptions = Pick<PersistingEventSinkOptions, "scope" | "runId">;
+
+/**
+ * Persists each {@link RunEvent} to `run_logs` + (for `appstrate.metric`)
+ * to `runs.tokenUsage` + the `llm_usage` ledger.
+ *
+ * Stateless across events: a fresh instance is built per ingested
+ * envelope by the route handler. Calls to this sink are total —
+ * no method ever throws because of an unsupported mode.
+ */
+export class PersistingEventSink implements EventSink {
   readonly runId: string;
-  private readonly scope: AppScope;
-  private readonly reducer: ReducerSinkHandle | null;
-  private readonly usage: TokenUsage = { input_tokens: 0, output_tokens: 0 };
-  private accumulatedCost = 0;
-  private lastAdapterError: string | null = null;
-  private finalResult: RunResult | null = null;
+  protected readonly scope: AppScope;
+  protected lastAdapterError: string | null = null;
   private readonly writeLedger: boolean;
 
-  constructor(opts: AppstrateEventSinkOptions) {
+  constructor(opts: PersistingEventSinkOptions) {
     this.scope = opts.scope;
     this.runId = opts.runId;
-    this.reducer = opts.persistOnly ? null : createReducerSink();
     this.writeLedger = opts.writeLedger ?? false;
   }
 
   async handle(event: RunEvent): Promise<void> {
-    // Delegate canonical events to the runtime reducer (skipped in
-    // persist-only mode — ingestion fan-out doesn't need the snapshot).
-    if (this.reducer) await this.reducer.sink.handle(event);
+    await this.persist(event);
+  }
 
-    // Platform write-through + metrics accumulation.
+  async finalize(_result: RunResult): Promise<void> {
+    // Persistence-only sink — finalize is the route handler's job.
+    // The interface contract requires the method, so we no-op.
+  }
+
+  /**
+   * Last `appstrate.error.message` observed during the lifetime of this
+   * sink instance. Per-instance — short-lived in the ingestion path.
+   */
+  get lastError(): string | null {
+    return this.lastAdapterError;
+  }
+
+  protected async persist(event: RunEvent): Promise<void> {
     switch (event.type) {
       case "output.emitted": {
         await appendRunLog(
@@ -181,14 +205,6 @@ export class AppstrateEventSink implements EventSink {
         const usage = isPlainObject(event.usage) ? (event.usage as TokenUsage) : null;
         const cost = typeof event.cost === "number" ? event.cost : null;
 
-        // In-memory accumulators feed `sink.current` for long-lived sinks
-        // (parity tests, in-process runners). Skip in persistOnly mode
-        // where `sink.current` throws.
-        if (this.reducer) {
-          if (usage) accumulateUsage(this.usage, usage);
-          if (cost !== null) this.accumulatedCost += cost;
-        }
-
         // Token usage is a running-total snapshot on the run row.
         if (usage) {
           await updateRun(this.scope, this.runId, {
@@ -204,27 +220,59 @@ export class AppstrateEventSink implements EventSink {
       }
 
       default:
-        // memory.added / state.set / third-party — reducer-only, no run_logs row.
+        // memory.added / state.set / third-party — no run_logs row.
         break;
     }
   }
+}
 
-  async finalize(result: RunResult): Promise<void> {
-    if (this.reducer) await this.reducer.sink.finalize(result);
+/**
+ * Long-lived sink that wraps {@link PersistingEventSink} with an
+ * additional in-memory reducer + platform projection. Use when a caller
+ * needs to read `current` / `result` between events (parity tests,
+ * in-process runners). The ingestion path does not need this — it
+ * builds a fresh persisting sink per event.
+ */
+export class AggregatingEventSink extends PersistingEventSink {
+  private readonly reducer: ReducerSinkHandle;
+  private readonly usage: TokenUsage = { input_tokens: 0, output_tokens: 0 };
+  private accumulatedCost = 0;
+  private finalResult: RunResult | null = null;
+
+  constructor(opts: AggregatingEventSinkOptions) {
+    // Aggregating sinks never write the ledger — they are never on the
+    // ingestion hot path. Pass `writeLedger: false` explicitly so the
+    // base class's metric handler skips the ledger write.
+    super({ ...opts, writeLedger: false });
+    this.reducer = createReducerSink();
+  }
+
+  override async handle(event: RunEvent): Promise<void> {
+    // 1. Feed the runtime reducer so `current` reflects every event.
+    await this.reducer.sink.handle(event);
+
+    // 2. Accumulate platform-specific running totals from metric events.
+    if (event.type === "appstrate.metric") {
+      const usage = isPlainObject(event.usage) ? (event.usage as TokenUsage) : null;
+      const cost = typeof event.cost === "number" ? event.cost : null;
+      if (usage) accumulateUsage(this.usage, usage);
+      if (cost !== null) this.accumulatedCost += cost;
+    }
+
+    // 3. Run the persistence write-through (delegates to base).
+    await super.handle(event);
+  }
+
+  override async finalize(result: RunResult): Promise<void> {
+    await this.reducer.sink.finalize(result);
     this.finalResult = result;
   }
 
   /**
-   * Platform-facing projection of the runtime snapshot + platform accumulators.
-   * Safe to read at any point during or after a run.
-   *
-   * Throws when the sink was created with `persistOnly: true` — that
-   * mode is reserved for fan-out-only consumers that never read back.
+   * Live snapshot — projects the runtime reducer + platform
+   * accumulators into the platform DTO shape. Total: never throws.
    */
   get current(): Readonly<AggregatedRunState> {
-    if (!this.reducer) {
-      throw new Error("AppstrateEventSink.current is unavailable in persistOnly mode");
-    }
     const snapshot = this.reducer.snapshot();
     return {
       output: isPlainObject(snapshot.output) ? snapshot.output : {},
@@ -233,7 +281,7 @@ export class AppstrateEventSink implements EventSink {
       report: snapshot.report ?? "",
       usage: this.usage,
       cost: this.accumulatedCost,
-      lastAdapterError: this.lastAdapterError,
+      lastAdapterError: this.lastError,
     };
   }
 

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -33,7 +33,7 @@ import { logger } from "../lib/logger.ts";
 import { getCache, getEventBuffer } from "../infra/index.ts";
 import { getEnv } from "@appstrate/env";
 import {
-  AppstrateEventSink,
+  PersistingEventSink,
   hasRunnerLedgerRow,
   writeRunnerLedgerRow,
 } from "./adapters/appstrate-event-sink.ts";
@@ -469,12 +469,9 @@ async function persistEventAndAdvance(
 ): Promise<void> {
   // Dispatch first; advance the counter only on success so a crashing handler
   // lets the same event retry (deduped via replay cache if already acked).
-  const sink = new AppstrateEventSink({
+  const sink = new PersistingEventSink({
     scope: { orgId: run.orgId, applicationId: run.applicationId },
     runId: run.id,
-    // Ingestion never reads `sink.current` / `sink.result` — the reducer
-    // would be built and thrown away for every event. Skip it.
-    persistOnly: true,
     // The metric event handler is one of the two writers of the
     // runner-source ledger row (the other is the finalize fallback).
     writeLedger: true,

--- a/apps/api/test/integration/services/appstrate-event-sink.test.ts
+++ b/apps/api/test/integration/services/appstrate-event-sink.test.ts
@@ -1,9 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * AppstrateEventSink — verifies fan-out to run_logs + the internal
- * aggregator for the AFPS 1.3 canonical events and the `appstrate.*`
- * platform-specific namespace.
+ * Tests for the two split sinks:
+ *
+ *   - {@link AggregatingEventSink} — long-lived, exposes `current` /
+ *     `result` for parity tests + in-process runners. Verifies fan-out
+ *     to run_logs + the in-memory reducer projection.
+ *
+ *   - {@link PersistingEventSink} — stateless persistence used by the
+ *     ingestion hot path. Verifies fan-out to run_logs + ledger writes
+ *     when `writeLedger` is enabled.
  */
 
 import { describe, it, expect, beforeEach } from "bun:test";
@@ -11,14 +17,17 @@ import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
 import { seedAgent, seedRun } from "../../helpers/seed.ts";
 import { installPackage } from "../../../src/services/application-packages.ts";
-import { AppstrateEventSink } from "../../../src/services/adapters/appstrate-event-sink.ts";
+import {
+  AggregatingEventSink,
+  PersistingEventSink,
+} from "../../../src/services/adapters/appstrate-event-sink.ts";
 import type { RunEvent } from "@appstrate/afps-runtime/types";
 import { reduceEvents, emptyRunResult } from "@appstrate/afps-runtime/runner";
 import { db } from "@appstrate/db/client";
 import { runLogs, llmUsage, runs } from "@appstrate/db/schema";
 import { eq, and, asc } from "drizzle-orm";
 
-describe("AppstrateEventSink", () => {
+describe("AggregatingEventSink", () => {
   let ctx: TestContext;
   const agentId = "@testorg/sink-agent";
   let runId: string;
@@ -50,11 +59,15 @@ describe("AppstrateEventSink", () => {
       .orderBy(asc(runLogs.id));
   }
 
-  it("aggregates memory.added events into the memories list", async () => {
-    const sink = new AppstrateEventSink({
+  function newSink() {
+    return new AggregatingEventSink({
       scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
       runId,
     });
+  }
+
+  it("aggregates memory.added events into the memories list", async () => {
+    const sink = newSink();
     await sink.handle(event("memory.added", { content: "first" }));
     await sink.handle(event("memory.added", { content: "second" }));
 
@@ -62,30 +75,21 @@ describe("AppstrateEventSink", () => {
   });
 
   it("stores state.set as-is when payload is an object", async () => {
-    const sink = new AppstrateEventSink({
-      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
-      runId,
-    });
+    const sink = newSink();
     await sink.handle(event("state.set", { state: { counter: 42 } }));
 
     expect(sink.current.state).toEqual({ counter: 42 });
   });
 
   it("projects non-object state.set payloads to null (runtime stores raw, projection drops)", async () => {
-    const sink = new AppstrateEventSink({
-      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
-      runId,
-    });
+    const sink = newSink();
     await sink.handle(event("state.set", { state: "just a string" }));
 
     expect(sink.current.state).toBeNull();
   });
 
   it("replaces output on each emission + writes a run log per call", async () => {
-    const sink = new AppstrateEventSink({
-      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
-      runId,
-    });
+    const sink = newSink();
     await sink.handle(event("output.emitted", { data: { a: 1, b: 2 } }));
     await sink.handle(event("output.emitted", { data: { b: 3, c: 4 } }));
 
@@ -98,22 +102,16 @@ describe("AppstrateEventSink", () => {
     expect(outputLogs[0]!.data).toEqual({ a: 1, b: 2 });
   });
 
-  it("projects non-object output replacement to empty object (runtime stores raw, projection drops)", async () => {
-    const sink = new AppstrateEventSink({
-      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
-      runId,
-    });
+  it("projects non-object output replacement to empty object", async () => {
+    const sink = newSink();
     await sink.handle(event("output.emitted", { data: { a: 1 } }));
     await sink.handle(event("output.emitted", { data: [1, 2, 3] }));
 
     expect(sink.current.output).toEqual({});
   });
 
-  it("concatenates report.appended events with \\n (runtime-canonical) + writes a run log per line", async () => {
-    const sink = new AppstrateEventSink({
-      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
-      runId,
-    });
+  it("concatenates report.appended events with \\n + writes a run log per line", async () => {
+    const sink = newSink();
     await sink.handle(event("report.appended", { content: "line one" }));
     await sink.handle(event("report.appended", { content: "line two" }));
 
@@ -126,10 +124,7 @@ describe("AppstrateEventSink", () => {
   });
 
   it("maps log.written into run_logs with the original level + message", async () => {
-    const sink = new AppstrateEventSink({
-      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
-      runId,
-    });
+    const sink = newSink();
     await sink.handle(event("log.written", { level: "info", message: "booting" }));
     await sink.handle(event("log.written", { level: "warn", message: "retry" }));
 
@@ -140,10 +135,7 @@ describe("AppstrateEventSink", () => {
   });
 
   it("maps appstrate.progress into progress run_logs with message/data/level", async () => {
-    const sink = new AppstrateEventSink({
-      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
-      runId,
-    });
+    const sink = newSink();
     await sink.handle(
       event("appstrate.progress", {
         message: "Tool: read_file",
@@ -161,10 +153,7 @@ describe("AppstrateEventSink", () => {
   });
 
   it("captures appstrate.error into lastAdapterError + writes system row", async () => {
-    const sink = new AppstrateEventSink({
-      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
-      runId,
-    });
+    const sink = newSink();
     await sink.handle(event("appstrate.error", { message: "OOM killed" }));
 
     expect(sink.current.lastAdapterError).toBe("OOM killed");
@@ -177,11 +166,8 @@ describe("AppstrateEventSink", () => {
     expect(systemLogs[0]!.level).toBe("error");
   });
 
-  it("accumulates appstrate.metric usage + cost (in-memory, long-lived sink)", async () => {
-    const sink = new AppstrateEventSink({
-      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
-      runId,
-    });
+  it("accumulates appstrate.metric usage + cost in memory", async () => {
+    const sink = newSink();
     await sink.handle(
       event("appstrate.metric", {
         usage: { input_tokens: 100, output_tokens: 50 },
@@ -199,8 +185,8 @@ describe("AppstrateEventSink", () => {
     expect(sink.current.usage.output_tokens).toBe(125);
     expect(sink.current.cost).toBeCloseTo(0.003, 5);
 
-    // Long-lived sinks (parity tests, in-process runners) do not write
-    // to the ledger — sequence is undefined, so the runner row is skipped.
+    // Aggregating sinks NEVER write the ledger — `writeLedger` is forced
+    // off in the constructor, so the runner row is skipped.
     const ledgerRows = await db
       .select()
       .from(llmUsage)
@@ -208,11 +194,73 @@ describe("AppstrateEventSink", () => {
     expect(ledgerRows).toHaveLength(0);
   });
 
+  it("exposes the RunResult from the runtime reducer on finalize", async () => {
+    const sink = newSink();
+    const events: RunEvent[] = [
+      event("memory.added", { content: "m" }),
+      event("output.emitted", { data: { x: 1 } }),
+    ];
+    for (const ev of events) {
+      await sink.handle(ev);
+    }
+
+    expect(sink.result).toBeNull();
+    const result = reduceEvents(events);
+    await sink.finalize(result);
+
+    expect(sink.result).not.toBeNull();
+    expect(sink.result?.memories).toEqual([{ content: "m" }]);
+    expect(sink.result?.output).toEqual({ x: 1 });
+  });
+
+  it("is compatible with emptyRunResult as a baseline", async () => {
+    const sink = newSink();
+    await sink.finalize(emptyRunResult());
+    expect(sink.result).toEqual(emptyRunResult());
+  });
+
+  it("current never throws — totality across every public method (LSP)", async () => {
+    const sink = newSink();
+    // No events handled yet — current MUST return a valid empty snapshot.
+    expect(() => sink.current).not.toThrow();
+    expect(sink.current.memories).toEqual([]);
+    expect(sink.current.state).toBeNull();
+    expect(sink.current.output).toEqual({});
+    expect(sink.current.report).toBe("");
+    expect(sink.current.usage.input_tokens).toBe(0);
+    expect(sink.current.cost).toBe(0);
+    expect(sink.current.lastAdapterError).toBeNull();
+  });
+});
+
+describe("PersistingEventSink", () => {
+  let ctx: TestContext;
+  const agentId = "@testorg/persist-agent";
+  let runId: string;
+
+  function event(type: string, extra: Record<string, unknown> = {}): RunEvent {
+    return { type, timestamp: Date.now(), runId, ...extra };
+  }
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext();
+    await seedAgent({ id: agentId, orgId: ctx.orgId, createdBy: ctx.user.id });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, agentId);
+    const run = await seedRun({
+      packageId: agentId,
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      dashboardUserId: ctx.user.id,
+      status: "running",
+    });
+    runId = run.id;
+  });
+
   it("appstrate.metric → single runner ledger row + tokenUsage snapshot when writeLedger is on", async () => {
-    const sink = new AppstrateEventSink({
+    const sink = new PersistingEventSink({
       scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
       runId,
-      persistOnly: true,
       writeLedger: true,
     });
     await sink.handle(
@@ -252,10 +300,9 @@ describe("AppstrateEventSink", () => {
     const totals = [0.001, 0.003, 0.006, 0.01, 0.015];
     await Promise.all(
       totals.map((cost) => {
-        const sink = new AppstrateEventSink({
+        const sink = new PersistingEventSink({
           scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
           runId,
-          persistOnly: true,
           writeLedger: true,
         });
         return sink.handle(
@@ -274,8 +321,8 @@ describe("AppstrateEventSink", () => {
     expect(rows).toHaveLength(1);
   });
 
-  it("writeLedger off → metric event accumulates in memory but writes no ledger row", async () => {
-    const sink = new AppstrateEventSink({
+  it("writeLedger off (default) → metric event still writes tokenUsage but no ledger row", async () => {
+    const sink = new PersistingEventSink({
       scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
       runId,
     });
@@ -286,61 +333,29 @@ describe("AppstrateEventSink", () => {
       }),
     );
 
-    expect(sink.current.cost).toBeCloseTo(0.0005, 5);
-
     const rows = await db
       .select()
       .from(llmUsage)
       .where(and(eq(llmUsage.runId, runId), eq(llmUsage.source, "runner")));
     expect(rows).toHaveLength(0);
+
+    // The token snapshot still lands on runs.tokenUsage even without ledger.
+    const [runRow] = await db.select().from(runs).where(eq(runs.id, runId));
+    expect(runRow?.tokenUsage).toMatchObject({ input_tokens: 10, output_tokens: 5 });
   });
 
-  it("exposes the RunResult from the runtime reducer on finalize", async () => {
-    const sink = new AppstrateEventSink({
+  it("writes run_logs fan-out without exposing a current snapshot getter", async () => {
+    const sink = new PersistingEventSink({
       scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
       runId,
-    });
-    const events: RunEvent[] = [
-      event("memory.added", { content: "m" }),
-      event("output.emitted", { data: { x: 1 } }),
-    ];
-    for (const ev of events) {
-      await sink.handle(ev);
-    }
-
-    expect(sink.result).toBeNull();
-    const result = reduceEvents(events);
-    await sink.finalize(result);
-
-    expect(sink.result).not.toBeNull();
-    expect(sink.result?.memories).toEqual([{ content: "m" }]);
-    expect(sink.result?.output).toEqual({ x: 1 });
-  });
-
-  it("is compatible with emptyRunResult as a baseline", async () => {
-    const sink = new AppstrateEventSink({
-      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
-      runId,
-    });
-    await sink.finalize(emptyRunResult());
-    expect(sink.result).toEqual(emptyRunResult());
-  });
-
-  // The ingestion route re-instantiates the sink per event and never
-  // reads the snapshot — `persistOnly` skips the runtime reducer so the
-  // hot path is allocation-free beyond the required write-through. We
-  // assert both that the snapshot is refused (accidental reads would
-  // silently return empty data) AND that fan-out still writes logs.
-  it("persistOnly mode skips the reducer — fan-out still writes, snapshot throws", async () => {
-    const sink = new AppstrateEventSink({
-      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
-      runId,
-      persistOnly: true,
     });
 
     await sink.handle(event("output.emitted", { data: { x: 1 } }));
 
-    expect(() => sink.current).toThrow(/persistOnly/);
+    // The persisting sink intentionally does NOT expose `current` —
+    // accessing it is a TS error and at runtime the property is
+    // undefined. Fan-out to run_logs is still verified.
+    expect((sink as unknown as { current?: unknown }).current).toBeUndefined();
 
     const logs = await db
       .select()
@@ -348,5 +363,22 @@ describe("AppstrateEventSink", () => {
       .where(and(eq(runLogs.runId, runId), eq(runLogs.event, "output")))
       .orderBy(asc(runLogs.createdAt));
     expect(logs.length).toBeGreaterThan(0);
+  });
+
+  it("finalize is a no-op on the persisting sink", async () => {
+    const sink = new PersistingEventSink({
+      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      runId,
+    });
+    await expect(sink.finalize(emptyRunResult())).resolves.toBeUndefined();
+  });
+
+  it("lastError surfaces the most recent appstrate.error message", async () => {
+    const sink = new PersistingEventSink({
+      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      runId,
+    });
+    await sink.handle(event("appstrate.error", { message: "boom" }));
+    expect(sink.lastError).toBe("boom");
   });
 });

--- a/apps/api/test/integration/services/parity-e2e.test.ts
+++ b/apps/api/test/integration/services/parity-e2e.test.ts
@@ -19,7 +19,7 @@ import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
 import { seedAgent, seedRun } from "../../helpers/seed.ts";
 import { installPackage } from "../../../src/services/application-packages.ts";
-import { AppstrateEventSink } from "../../../src/services/adapters/appstrate-event-sink.ts";
+import { AggregatingEventSink } from "../../../src/services/adapters/appstrate-event-sink.ts";
 import type { RunEvent } from "@appstrate/afps-runtime/types";
 import { reduceEvents } from "@appstrate/afps-runtime/runner";
 import { db } from "@appstrate/db/client";
@@ -46,7 +46,7 @@ describe("Parity E2E — full adapter stack", () => {
     runId = run.id;
   });
 
-  it("inline executor loop → AppstrateEventSink produces the same RunResult as reduceEvents", async () => {
+  it("inline executor loop → AggregatingEventSink produces the same RunResult as reduceEvents", async () => {
     const script: RunEvent[] = [
       {
         type: "appstrate.progress",
@@ -67,7 +67,7 @@ describe("Parity E2E — full adapter stack", () => {
       { type: "report.appended", timestamp: Date.now(), runId, content: "work done" },
     ];
 
-    const sink = new AppstrateEventSink({
+    const sink = new AggregatingEventSink({
       scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
       runId,
     });


### PR DESCRIPTION
## Summary
- Eliminates the `persistOnly: boolean` flag and the `current` getter that threw — Liskov substitution violation
- `PersistingEventSink` (stateless fan-out, ingestion hot path) and `AggregatingEventSink` (long-lived sink with reducer + projection) are now distinct types; every public method is total
- All call-sites migrated; tests split into two describe blocks with a totality regression guard

## Test plan
- [x] `bun run check` — 17/17 turbo tasks ✓
- [x] `apps/api/test/integration/services/appstrate-event-sink.test.ts` — 18 tests
- [x] `apps/api/test/integration/services/parity-e2e.test.ts` — 1 test
- [x] `apps/api/test/integration/routes/runs-events-ingestion.test.ts` — 17 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)