### PR TITLE
refactor(afps-runtime): canonical appstrate.metric shape

### DIFF
--- a/packages/afps-runtime/src/sinks/console-sink.ts
+++ b/packages/afps-runtime/src/sinks/console-sink.ts
@@ -69,8 +69,14 @@ export class ConsoleSink implements EventSink {
           return `${seq} → ${canonical.message}`;
         case "appstrate.error":
           return `${seq} ✗ ${canonical.message}`;
-        case "appstrate.metric":
-          return `${seq} ⊘ metric: ${truncate(safeStringify(canonical.data ?? {}), 200)}`;
+        case "appstrate.metric": {
+          const summary = {
+            ...(canonical.usage !== undefined ? { usage: canonical.usage } : {}),
+            ...(canonical.cost !== undefined ? { cost: canonical.cost } : {}),
+            ...(canonical.durationMs !== undefined ? { durationMs: canonical.durationMs } : {}),
+          };
+          return `${seq} ⊘ metric: ${truncate(safeStringify(summary), 200)}`;
+        }
         default: {
           const _exhaustive: never = canonical;
           void _exhaustive;

--- a/packages/afps-runtime/src/types/canonical-events.ts
+++ b/packages/afps-runtime/src/types/canonical-events.ts
@@ -26,6 +26,7 @@
  */
 
 import type { RunEvent } from "@afps-spec/types";
+import type { TokenUsage } from "./run-result.ts";
 
 interface BaseEnvelope {
   timestamp: number;
@@ -83,14 +84,21 @@ export interface AppstrateErrorEvent extends BaseEnvelope {
   data?: Record<string, unknown>;
 }
 
-/** `appstrate.metric` — token usage / cost / duration emitted by the runner at agent_end. */
+/**
+ * `appstrate.metric` — token usage / cost / duration emitted by the runner.
+ *
+ * `usage` is a {@link TokenUsage} object, `cost` is a USD number, both
+ * optional so a runner with no LLM traffic can still emit a metric
+ * carrying just `durationMs`.
+ */
 export interface AppstrateMetricEvent extends BaseEnvelope {
   type: "appstrate.metric";
-  data?: Record<string, unknown>;
-  /** Sometimes inlined alongside `data` for legacy reasons. */
+  /** Token usage counters; mirrors `runs.tokenUsage` JSONB shape. */
+  usage?: TokenUsage;
+  /** Cost in USD attributed to this segment of the run. Non-negative. */
   cost?: number;
-  inputTokens?: number;
-  outputTokens?: number;
+  /** Optional wall-clock duration in milliseconds covered by this metric. */
+  durationMs?: number;
 }
 
 /** Discriminated union over every canonical event the runtime owns. */
@@ -148,8 +156,18 @@ export function isCanonicalRunEvent(event: RunEvent): event is CanonicalRunEvent
     case "appstrate.progress":
     case "appstrate.error":
       return typeof (event as Record<string, unknown>).message === "string";
-    case "appstrate.metric":
+    case "appstrate.metric": {
+      const e = event as Record<string, unknown>;
+      // usage and cost are both optional, but when present must be valid:
+      // usage = plain object, cost = non-negative finite number.
+      if (e.usage !== undefined) {
+        if (e.usage === null || typeof e.usage !== "object" || Array.isArray(e.usage)) return false;
+      }
+      if (e.cost !== undefined) {
+        if (typeof e.cost !== "number" || !Number.isFinite(e.cost) || e.cost < 0) return false;
+      }
       return true;
+    }
     default:
       return false;
   }

--- a/packages/afps-runtime/test/types/canonical-events.test.ts
+++ b/packages/afps-runtime/test/types/canonical-events.test.ts
@@ -22,7 +22,12 @@ describe("isCanonicalRunEvent", () => {
       { ...baseEnvelope, type: "log.written", level: "info", message: "x" },
       { ...baseEnvelope, type: "appstrate.progress", message: "running" },
       { ...baseEnvelope, type: "appstrate.error", message: "boom" },
-      { ...baseEnvelope, type: "appstrate.metric", data: { cost: 0.01 } },
+      {
+        ...baseEnvelope,
+        type: "appstrate.metric",
+        usage: { input_tokens: 10, output_tokens: 5 },
+        cost: 0.01,
+      },
     ];
     for (const e of events) expect(isCanonicalRunEvent(e)).toBe(true);
   });
@@ -68,6 +73,37 @@ describe("isCanonicalRunEvent", () => {
     expect(isCanonicalRunEvent({ ...baseEnvelope, type: "appstrate.progress" } as RunEvent)).toBe(
       false,
     );
+    // appstrate.metric with non-object usage
+    expect(
+      isCanonicalRunEvent({ ...baseEnvelope, type: "appstrate.metric", usage: 42 } as RunEvent),
+    ).toBe(false);
+    // appstrate.metric with negative cost
+    expect(
+      isCanonicalRunEvent({ ...baseEnvelope, type: "appstrate.metric", cost: -1 } as RunEvent),
+    ).toBe(false);
+    // appstrate.metric with non-finite cost
+    expect(
+      isCanonicalRunEvent({
+        ...baseEnvelope,
+        type: "appstrate.metric",
+        cost: Number.POSITIVE_INFINITY,
+      } as RunEvent),
+    ).toBe(false);
+  });
+
+  it("accepts appstrate.metric with no payload (durationMs-only or empty)", () => {
+    // A runner with no LLM traffic still emits a metric event — usage
+    // and cost are both optional.
+    expect(isCanonicalRunEvent({ ...baseEnvelope, type: "appstrate.metric" } as RunEvent)).toBe(
+      true,
+    );
+    expect(
+      isCanonicalRunEvent({
+        ...baseEnvelope,
+        type: "appstrate.metric",
+        durationMs: 1234,
+      } as RunEvent),
+    ).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- `AppstrateMetricEvent` now has a single typed shape: `{ usage?: TokenUsage, cost?: number, durationMs?: number }`
- Drops the catch-all `data?` and the flat `inputTokens`/`outputTokens` — the runner-pi emitter already produces nested usage + cost, the type now matches reality
- `isCanonicalRunEvent` strictly validates: usage = plain object, cost = non-negative finite number, both optional
- `ConsoleSink` and reducer consumers read typed fields; tests cover validator rejections + acceptance of empty/duration-only metrics

## Test plan
- [x] `bun run check` — all green
- [x] `packages/afps-runtime/test/types/canonical-events.test.ts` — 9 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)