### PR TITLE
refactor(api): single runner ledger row per run

### DIFF
--- a/apps/api/src/services/adapters/appstrate-event-sink.ts
+++ b/apps/api/src/services/adapters/appstrate-event-sink.ts
@@ -38,7 +38,7 @@ import type { EventSink } from "@appstrate/afps-runtime/interfaces";
 import type { RunEvent } from "@appstrate/afps-runtime/types";
 import type { RunResult } from "@appstrate/afps-runtime/runner";
 import { isPlainObject } from "@appstrate/core/safe-json";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
 import { llmUsage } from "@appstrate/db/schema";
 import type { AppScope } from "../../lib/scope.ts";
@@ -81,12 +81,12 @@ export interface AppstrateEventSinkOptions {
    */
   persistOnly?: boolean;
   /**
-   * Envelope sequence for the single event this sink instance will handle.
-   * Required only in `persistOnly` mode because the ledger dedup key is
-   * `(run_id, source='runner', sequence)`. Long-lived sinks (parity tests,
-   * in-process runners) never hit the ledger so they omit it.
+   * When `true`, `appstrate.metric` events write a runner-source row to
+   * the `llm_usage` ledger. At most one runner row per run; concurrent
+   * writers race via ON CONFLICT DO NOTHING. The ingestion path turns
+   * this on; long-lived in-process runners (parity tests) leave it off.
    */
-  sequence?: number;
+  writeLedger?: boolean;
 }
 
 export class AppstrateEventSink implements EventSink {
@@ -97,13 +97,13 @@ export class AppstrateEventSink implements EventSink {
   private accumulatedCost = 0;
   private lastAdapterError: string | null = null;
   private finalResult: RunResult | null = null;
-  private readonly sequence: number | undefined;
+  private readonly writeLedger: boolean;
 
   constructor(opts: AppstrateEventSinkOptions) {
     this.scope = opts.scope;
     this.runId = opts.runId;
     this.reducer = opts.persistOnly ? null : createReducerSink();
-    this.sequence = opts.sequence;
+    this.writeLedger = opts.writeLedger ?? false;
   }
 
   async handle(event: RunEvent): Promise<void> {
@@ -189,23 +189,16 @@ export class AppstrateEventSink implements EventSink {
           if (cost !== null) this.accumulatedCost += cost;
         }
 
-        // Persistence — always, regardless of mode. Token usage is a
-        // running-total snapshot on the run row; cost is appended to the
-        // `llm_usage` ledger so finalize can aggregate it. Ledger writes
-        // only happen in the ingestion path (persistOnly sink carries a
-        // sequence); long-lived sinks keep the in-memory accumulators
-        // above and nothing else.
+        // Token usage is a running-total snapshot on the run row.
         if (usage) {
           await updateRun(this.scope, this.runId, {
             tokenUsage: usage as unknown as Record<string, unknown>,
           });
         }
-        if (this.sequence !== undefined) {
-          await appendRunnerLedgerRow(this.scope, this.runId, {
-            sequence: this.sequence,
-            cost,
-            usage,
-          });
+        // Ledger row — only the ingestion path opts in. Concurrent
+        // writers race via ON CONFLICT DO NOTHING.
+        if (this.writeLedger) {
+          await writeRunnerLedgerRow(this.scope, this.runId, { cost, usage });
         }
         break;
       }
@@ -258,41 +251,21 @@ function resolveLogLevel(value: unknown): "debug" | "info" | "warn" | "error" | 
 }
 
 /**
- * Synthetic sequence reserved for the finalize-time ledger write — real
- * `appstrate.metric` events use sequence ≥ 1 (HttpSink's counter starts
- * at 1), so the unique key (run_id, source, sequence) cannot collide.
- * Co-owned by `run-event-ingestion.ts` which falls back to this writer
- * when the metric POST is aborted by `process.exit()`.
- */
-export const SYNTHESISED_RUNNER_LEDGER_SEQUENCE = 0;
-
-/**
- * Append one runner-source row to the `llm_usage` ledger.
+ * Write the runner-source row for a run to the `llm_usage` ledger.
  *
- * Runners emit running totals, not deltas. The per-event delta is derived
- * from `(running_total − previously_persisted_total)` so `SUM(ledger)`
- * stays equal to the final running total regardless of how many metric
- * events a run produces (one today; multi-turn agents tomorrow).
- *
- * Concurrency: the read-then-insert is wrapped in a transaction with a
- * per-run `pg_advisory_xact_lock(hashtext(run_id))` so two concurrent
- * metric events for the same run cannot both read the same prior SUM and
- * over-count the delta. The lock is keyed on the run id alone; concurrent
- * writes for OTHER runs are unaffected. Lock is released automatically
- * when the transaction commits or rolls back.
- *
- * Dedup on `(run_id, sequence)` makes envelope replay a no-op — the
- * ingestion route guarantees the sequence is monotonic per run.
+ * The metric event carries the runner's full LLM cost + token usage for
+ * the run. At most one runner row per run — concurrent writers (the
+ * `appstrate.metric` event handler and the finalize-time fallback)
+ * race via the partial unique index `uq_llm_usage_runner_run_id`;
+ * whichever lands first wins, the other no-ops.
  *
  * Best-effort: metric persistence MUST NOT fail the ingestion path.
- * Errors are logged; correctness is self-healing because the next
- * metric event carries the full running total.
+ * Errors are logged.
  */
-export async function appendRunnerLedgerRow(
+export async function writeRunnerLedgerRow(
   scope: AppScope,
   runId: string,
   row: {
-    sequence: number;
     cost: number | null;
     usage: TokenUsage | null;
   },
@@ -302,62 +275,46 @@ export async function appendRunnerLedgerRow(
   if (row.cost === null && !row.usage) return;
 
   try {
-    await db.transaction(async (tx) => {
-      // Per-run advisory lock — serialises concurrent metric inserts for
-      // THIS run, leaves all other runs unaffected. Auto-released on
-      // commit / rollback.
-      await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtext(${runId}))`);
-
-      const [prior] = await tx
-        .select({ total: sql<string>`COALESCE(SUM(${llmUsage.costUsd}), 0)` })
-        .from(llmUsage)
-        .where(and(eq(llmUsage.runId, runId), eq(llmUsage.source, "runner")));
-      const existing = Number(prior?.total ?? 0);
-      const delta = Math.max(0, (row.cost ?? 0) - existing);
-
-      await tx
-        .insert(llmUsage)
-        .values({
-          source: "runner",
-          orgId: scope.orgId,
-          runId,
-          sequence: row.sequence,
-          inputTokens: row.usage?.input_tokens ?? 0,
-          outputTokens: row.usage?.output_tokens ?? 0,
-          cacheReadTokens: row.usage?.cache_read_input_tokens ?? null,
-          cacheWriteTokens: row.usage?.cache_creation_input_tokens ?? null,
-          costUsd: delta,
-        })
-        .onConflictDoNothing();
-    });
+    await db
+      .insert(llmUsage)
+      .values({
+        source: "runner",
+        orgId: scope.orgId,
+        runId,
+        inputTokens: row.usage?.input_tokens ?? 0,
+        outputTokens: row.usage?.output_tokens ?? 0,
+        cacheReadTokens: row.usage?.cache_read_input_tokens ?? null,
+        cacheWriteTokens: row.usage?.cache_creation_input_tokens ?? null,
+        costUsd: row.cost ?? 0,
+      })
+      .onConflictDoNothing();
   } catch (err) {
-    logger.error("Failed to append runner ledger row", {
+    logger.error("Failed to write runner ledger row", {
       runId,
-      sequence: row.sequence,
       error: err instanceof Error ? err.message : String(err),
     });
   }
 }
 
 /**
- * SUM of runner-source cost_usd persisted so far for this run.
- * Read-only — safe to call without a lock for post-finalize snapshots.
- * Do NOT use to compute deltas in concurrent writers; use the
- * transactional read inside {@link appendRunnerLedgerRow} instead.
+ * Whether a runner-source row has already been persisted for this run.
+ * Used by the finalize-time fallback to decide whether to synthesise the
+ * row or trust the metric event handler that already ran.
  */
-export async function sumRunnerCost(runId: string): Promise<number> {
+export async function hasRunnerLedgerRow(runId: string): Promise<boolean> {
   try {
     const [row] = await db
-      .select({ total: sql<string>`COALESCE(SUM(${llmUsage.costUsd}), 0)` })
+      .select({ id: llmUsage.id })
       .from(llmUsage)
-      .where(and(eq(llmUsage.runId, runId), eq(llmUsage.source, "runner")));
-    return Number(row?.total ?? 0);
+      .where(and(eq(llmUsage.runId, runId), eq(llmUsage.source, "runner")))
+      .limit(1);
+    return row !== undefined;
   } catch (err) {
-    logger.warn("Failed to read prior runner ledger; treating delta as running total", {
+    logger.warn("Failed to read runner ledger; assuming row absent", {
       runId,
       error: err instanceof Error ? err.message : String(err),
     });
-    return 0;
+    return false;
   }
 }
 

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -34,9 +34,8 @@ import { getCache, getEventBuffer } from "../infra/index.ts";
 import { getEnv } from "@appstrate/env";
 import {
   AppstrateEventSink,
-  appendRunnerLedgerRow,
-  sumRunnerCost,
-  SYNTHESISED_RUNNER_LEDGER_SEQUENCE,
+  hasRunnerLedgerRow,
+  writeRunnerLedgerRow,
 } from "./adapters/appstrate-event-sink.ts";
 import { updateRun, appendRunLog } from "./state/runs.ts";
 import { addPackageMemories } from "./state/package-memories.ts";
@@ -269,18 +268,18 @@ export async function finalizeRun(input: FinalizeRunInput): Promise<void> {
   const resultToPersist =
     Object.keys(resultPayload).length > 0 ? (resultPayload as Record<string, unknown>) : null;
 
-  // 4b. Synthesise the runner-source ledger row from `result.cost` when
-  //     the `appstrate.metric` event never landed (e.g. process exited
-  //     before the fire-and-forget POST resolved). Idempotent: if the
-  //     metric did land first, the runner ledger sum is already non-zero
-  //     and we skip — its real row already accounts for the cost. The
-  //     synthetic row uses `SYNTHESISED_RUNNER_LEDGER_SEQUENCE` (= 0) so
-  //     it cannot collide with real metric sequences (≥ 1).
+  // 4b. Write the runner-source ledger row from `result.cost` when the
+  //     `appstrate.metric` event never landed (e.g. process exited
+  //     before the fire-and-forget POST resolved). The metric handler
+  //     and this fallback both target the same partial unique index
+  //     (run_id WHERE source='runner'); whichever lands first owns the
+  //     row, the other is a no-op via ON CONFLICT DO NOTHING. The
+  //     pre-check avoids an insert attempt when we already know the
+  //     row is there.
   if (typeof result.cost === "number" && result.cost > 0) {
-    const existing = await sumRunnerCost(run.id);
-    if (existing === 0) {
-      await appendRunnerLedgerRow({ orgId: run.orgId, applicationId: run.applicationId }, run.id, {
-        sequence: SYNTHESISED_RUNNER_LEDGER_SEQUENCE,
+    const alreadyWritten = await hasRunnerLedgerRow(run.id);
+    if (!alreadyWritten) {
+      await writeRunnerLedgerRow({ orgId: run.orgId, applicationId: run.applicationId }, run.id, {
         cost: result.cost,
         usage: result.usage ?? null,
       });
@@ -476,9 +475,9 @@ async function persistEventAndAdvance(
     // Ingestion never reads `sink.current` / `sink.result` — the reducer
     // would be built and thrown away for every event. Skip it.
     persistOnly: true,
-    // Carry the envelope sequence so runner-source ledger rows can dedup
-    // on `(run_id, sequence)` under envelope replay.
-    sequence,
+    // The metric event handler is one of the two writers of the
+    // runner-source ledger row (the other is the finalize fallback).
+    writeLedger: true,
   });
   await sink.handle(event);
 

--- a/apps/api/test/integration/routes/runs-events-ingestion.test.ts
+++ b/apps/api/test/integration/routes/runs-events-ingestion.test.ts
@@ -483,13 +483,13 @@ describe("POST /api/runs/:runId/events/finalize — complete result persistence"
     });
     expect(res.status).toBe(200);
 
-    // Synthetic row uses sequence=0 (real metric events start at 1).
+    // The finalize fallback writes the single runner row when the
+    // metric event never arrived.
     const ledger = await db
       .select()
       .from(llmUsage)
       .where(and(eq(llmUsage.runId, runId), eq(llmUsage.source, "runner")));
     expect(ledger).toHaveLength(1);
-    expect(ledger[0]!.sequence).toBe(0);
     expect(ledger[0]!.costUsd).toBeCloseTo(0.0042, 5);
     expect(ledger[0]!.inputTokens).toBe(200);
     expect(ledger[0]!.outputTokens).toBe(100);
@@ -502,8 +502,8 @@ describe("POST /api/runs/:runId/events/finalize — complete result persistence"
   it("does NOT duplicate the runner ledger row when a metric event already landed", async () => {
     const runId = await seedRunWithSink(ctx, "@test/final-agent");
 
-    // Metric arrives first — the platform persists a runner-source row
-    // at the metric's envelope sequence (1+).
+    // Metric arrives first — the platform persists the single
+    // runner-source row.
     const ev = buildEnvelope(
       runId,
       "appstrate.metric",
@@ -516,9 +516,9 @@ describe("POST /api/runs/:runId/events/finalize — complete result persistence"
     );
     expect((await postEvent(runId, ev)).status).toBe(200);
 
-    // Finalize ships the same `cost` in the body. It MUST detect the
-    // existing runner row and skip its own synthesis — otherwise we'd
-    // double-bill the run.
+    // Finalize ships the same `cost` in the body. The partial unique
+    // index on `(run_id) WHERE source='runner'` guarantees a single
+    // runner row regardless of which writer raced first.
     const res = await postFinalize(runId, {
       status: "success",
       output: { ok: true },
@@ -533,7 +533,6 @@ describe("POST /api/runs/:runId/events/finalize — complete result persistence"
       .from(llmUsage)
       .where(and(eq(llmUsage.runId, runId), eq(llmUsage.source, "runner")));
     expect(ledger).toHaveLength(1);
-    expect(ledger[0]!.sequence).toBe(1); // the metric event's sequence, not the synth sentinel
     expect(ledger[0]!.costUsd).toBeCloseTo(0.0042, 5);
 
     const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
@@ -566,25 +565,13 @@ describe("POST /api/runs/:runId/events/finalize — complete result persistence"
   // Cost-ledger end-to-end regression: before the llm_usage unification,
   // runs.cost was overwritten with null at finalize for platform runs
   // because aggregateRunCost only summed the proxy tables. Now finalize
-  // reads the unified ledger, which includes runner-source rows written
-  // by the sink on each `appstrate.metric` event.
+  // reads the unified ledger, which includes the single runner-source
+  // row written by the sink on the `appstrate.metric` event.
   it("accumulates runner-source cost into runs.cost at finalize", async () => {
     const runId = await seedRunWithSink(ctx, "@test/final-agent");
 
-    // Emit two running-total metric events: 0.001 → 0.003. The ledger
-    // derives deltas (0.001, then 0.002) so the SUM matches the running
-    // total regardless of how many events flow.
-    const ev1 = buildEnvelope(
-      runId,
-      "appstrate.metric",
-      {
-        usage: { input_tokens: 100, output_tokens: 50 },
-        cost: 0.001,
-        timestamp: Date.now(),
-      },
-      1,
-    );
-    const ev2 = buildEnvelope(
+    // Emit one metric event with the runner's final cost + usage.
+    const ev = buildEnvelope(
       runId,
       "appstrate.metric",
       {
@@ -592,19 +579,17 @@ describe("POST /api/runs/:runId/events/finalize — complete result persistence"
         cost: 0.003,
         timestamp: Date.now(),
       },
-      2,
+      1,
     );
-    expect((await postEvent(runId, ev1)).status).toBe(200);
-    expect((await postEvent(runId, ev2)).status).toBe(200);
+    expect((await postEvent(runId, ev)).status).toBe(200);
 
-    // Two runner-source ledger rows, SUM = final running total.
+    // Single runner-source ledger row.
     const ledger = await db
       .select()
       .from(llmUsage)
       .where(and(eq(llmUsage.runId, runId), eq(llmUsage.source, "runner")));
-    expect(ledger).toHaveLength(2);
-    const ledgerSum = ledger.reduce((acc, r) => acc + (r.costUsd ?? 0), 0);
-    expect(ledgerSum).toBeCloseTo(0.003, 5);
+    expect(ledger).toHaveLength(1);
+    expect(ledger[0]!.costUsd).toBeCloseTo(0.003, 5);
 
     // Finalize caches the aggregate into runs.cost.
     const res = await postFinalize(runId, {

--- a/apps/api/test/integration/services/appstrate-event-sink.test.ts
+++ b/apps/api/test/integration/services/appstrate-event-sink.test.ts
@@ -208,29 +208,14 @@ describe("AppstrateEventSink", () => {
     expect(ledgerRows).toHaveLength(0);
   });
 
-  it("appstrate.metric → ledger row (runner source) + tokenUsage snapshot in persistOnly mode", async () => {
-    // Runners emit running totals. Two events with totals 0.001 → 0.003
-    // must produce two ledger rows whose SUM equals the final total.
-    const sink1 = new AppstrateEventSink({
+  it("appstrate.metric → single runner ledger row + tokenUsage snapshot when writeLedger is on", async () => {
+    const sink = new AppstrateEventSink({
       scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
       runId,
       persistOnly: true,
-      sequence: 1,
+      writeLedger: true,
     });
-    await sink1.handle(
-      event("appstrate.metric", {
-        usage: { input_tokens: 100, output_tokens: 50 },
-        cost: 0.001,
-      }),
-    );
-
-    const sink2 = new AppstrateEventSink({
-      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
-      runId,
-      persistOnly: true,
-      sequence: 2,
-    });
-    await sink2.handle(
+    await sink.handle(
       event("appstrate.metric", {
         usage: { input_tokens: 300, output_tokens: 125 },
         cost: 0.003,
@@ -240,13 +225,11 @@ describe("AppstrateEventSink", () => {
     const ledgerRows = await db
       .select()
       .from(llmUsage)
-      .where(and(eq(llmUsage.runId, runId), eq(llmUsage.source, "runner")))
-      .orderBy(asc(llmUsage.sequence));
-    expect(ledgerRows).toHaveLength(2);
-    expect(ledgerRows[0]!.costUsd).toBeCloseTo(0.001, 5);
-    expect(ledgerRows[1]!.costUsd).toBeCloseTo(0.002, 5);
-    const sum = ledgerRows.reduce((acc, r) => acc + (r.costUsd ?? 0), 0);
-    expect(sum).toBeCloseTo(0.003, 5);
+      .where(and(eq(llmUsage.runId, runId), eq(llmUsage.source, "runner")));
+    expect(ledgerRows).toHaveLength(1);
+    expect(ledgerRows[0]!.costUsd).toBeCloseTo(0.003, 5);
+    expect(ledgerRows[0]!.inputTokens).toBe(300);
+    expect(ledgerRows[0]!.outputTokens).toBe(125);
 
     // runs.tokenUsage is a running-total snapshot (whole-object replace).
     const [runRow] = await db.select().from(runs).where(eq(runs.id, runId));
@@ -259,27 +242,25 @@ describe("AppstrateEventSink", () => {
     expect(runRow?.cost).toBeNull();
   });
 
-  it("concurrent metric inserts for the same run produce SUM == final running total", async () => {
-    // Multi-turn agents emit several appstrate.metric events whose `cost`
-    // is the running total to date. The sink derives a per-row delta as
-    // `(running_total − prior_SUM)`. Without the per-run advisory lock,
-    // concurrent reads of `prior_SUM` would all observe the same stale
-    // value and the deltas would over-count. This test fires the inserts
-    // in parallel and asserts that SUM(ledger) equals the highest
-    // observed running total — invariant of the delta-from-running-total
-    // protocol, regardless of arrival interleaving.
+  it("concurrent metric writes for the same run land at most one runner row", async () => {
+    // The runner row is dedup'd via the partial unique index
+    // `uq_llm_usage_runner_run_id`. Multiple concurrent writers (the
+    // metric event handler and the finalize fallback) both target the
+    // same key — whichever lands first owns the row, the others no-op
+    // via ON CONFLICT DO NOTHING. The total row count is 1 regardless
+    // of how many writers raced.
     const totals = [0.001, 0.003, 0.006, 0.01, 0.015];
     await Promise.all(
-      totals.map((cost, idx) => {
+      totals.map((cost) => {
         const sink = new AppstrateEventSink({
           scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
           runId,
           persistOnly: true,
-          sequence: idx + 1,
+          writeLedger: true,
         });
         return sink.handle(
           event("appstrate.metric", {
-            usage: { input_tokens: (idx + 1) * 100, output_tokens: (idx + 1) * 50 },
+            usage: { input_tokens: 100, output_tokens: 50 },
             cost,
           }),
         );
@@ -290,32 +271,28 @@ describe("AppstrateEventSink", () => {
       .select()
       .from(llmUsage)
       .where(and(eq(llmUsage.runId, runId), eq(llmUsage.source, "runner")));
-    const sum = rows.reduce((acc, r) => acc + (r.costUsd ?? 0), 0);
-    expect(rows).toHaveLength(totals.length);
-    expect(sum).toBeCloseTo(Math.max(...totals), 5);
+    expect(rows).toHaveLength(1);
   });
 
-  it("envelope replay is idempotent on the ledger (unique (run_id, sequence))", async () => {
-    const build = () =>
-      new AppstrateEventSink({
-        scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
-        runId,
-        persistOnly: true,
-        sequence: 7,
-      });
-    const payload = event("appstrate.metric", {
-      usage: { input_tokens: 10, output_tokens: 5 },
-      cost: 0.0005,
+  it("writeLedger off → metric event accumulates in memory but writes no ledger row", async () => {
+    const sink = new AppstrateEventSink({
+      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      runId,
     });
+    await sink.handle(
+      event("appstrate.metric", {
+        usage: { input_tokens: 10, output_tokens: 5 },
+        cost: 0.0005,
+      }),
+    );
 
-    await build().handle(payload);
-    await build().handle(payload);
+    expect(sink.current.cost).toBeCloseTo(0.0005, 5);
 
     const rows = await db
       .select()
       .from(llmUsage)
       .where(and(eq(llmUsage.runId, runId), eq(llmUsage.source, "runner")));
-    expect(rows).toHaveLength(1);
+    expect(rows).toHaveLength(0);
   });
 
   it("exposes the RunResult from the runtime reducer on finalize", async () => {

--- a/packages/db/drizzle/0008_runner_ledger_simple.sql
+++ b/packages/db/drizzle/0008_runner_ledger_simple.sql
@@ -1,0 +1,29 @@
+-- 0008_runner_ledger_simple.sql
+--
+-- Drop the runner-row sequence column + transactional delta scheme.
+--
+-- Pre-change: runner-source rows used `(run_id, sequence)` as their dedup
+-- key, with the per-row `cost_usd` storing a delta against the previously
+-- persisted SUM. The scheme existed to keep `SUM(ledger)` correct under a
+-- hypothetical multi-event running-total stream that never materialised.
+--
+-- Post-change: at most one runner-source row per run, dedup on `(run_id)`
+-- alone. The metric event handler and the finalize-time fallback compete
+-- via ON CONFLICT DO NOTHING — whichever lands first owns the row, the
+-- other is a no-op. The row's `cost_usd` is the canonical runner cost.
+-- Future multi-segment metrics (multi-turn agents, …) are an additive
+-- redesign at that point, not a rollback of this one.
+
+DROP INDEX IF EXISTS "uq_llm_usage_runner_run_sequence";
+
+ALTER TABLE "llm_usage" DROP CONSTRAINT IF EXISTS "llm_usage_runner_has_sequence";
+
+ALTER TABLE "llm_usage" DROP COLUMN IF EXISTS "sequence";
+
+ALTER TABLE "llm_usage"
+  ADD CONSTRAINT "llm_usage_runner_has_run_id"
+  CHECK (source <> 'runner' OR run_id IS NOT NULL);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_llm_usage_runner_run_id"
+  ON "llm_usage" ("run_id")
+  WHERE source = 'runner' AND run_id IS NOT NULL;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1777939200000,
       "tag": "0007_run_heartbeat",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1777939300000,
+      "tag": "0008_runner_ledger_simple",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/runs.ts
+++ b/packages/db/src/schema/runs.ts
@@ -267,11 +267,8 @@ export const llmUsage = pgTable(
     costUsd: doublePrecision("cost_usd").notNull().default(0),
     durationMs: integer("duration_ms"),
     // Proxy dedup key — one per upstream call minted by the proxy route.
-    // `null` on runner-source rows (they dedup on sequence instead).
+    // Null on runner-source rows (they dedup on run_id instead).
     requestId: text("request_id"),
-    // Runner dedup key — monotonic per-run event sequence from the AFPS
-    // sink protocol. `null` on proxy-source rows.
-    sequence: integer("sequence"),
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },
   (table) => [
@@ -281,25 +278,23 @@ export const llmUsage = pgTable(
     index("idx_llm_usage_run_id").on(table.runId),
     index("idx_llm_usage_org_created").on(table.orgId, table.createdAt),
     // Proxy-source dedup: request_id is unique across all proxy rows.
-    // Runner-source rows leave request_id NULL and dedup via sequence.
     uniqueIndex("uq_llm_usage_proxy_request_id")
       .on(table.requestId)
       .where(sql`source = 'proxy' AND request_id IS NOT NULL`),
-    // Runner-source dedup: (run_id, sequence) is unique for runner rows.
-    // Proxy-source rows leave sequence NULL.
-    uniqueIndex("uq_llm_usage_runner_run_sequence")
-      .on(table.runId, table.sequence)
-      .where(sql`source = 'runner' AND run_id IS NOT NULL AND sequence IS NOT NULL`),
+    // Runner-source dedup: at most one runner row per run. The metric
+    // event carries a running total; the row is written once by whichever
+    // path lands first (the metric event handler or the finalize-time
+    // fallback). ON CONFLICT DO NOTHING enforces single-write.
+    uniqueIndex("uq_llm_usage_runner_run_id")
+      .on(table.runId)
+      .where(sql`source = 'runner' AND run_id IS NOT NULL`),
     // INSERT invariant: exactly one principal. After FK cleanup (api_key /
     // user deleted) both may become NULL — the row survives for audit /
     // billing retention, so we don't enforce "exactly one" forever.
     check("llm_usage_principal_single", sql`api_key_id IS NULL OR user_id IS NULL`),
     // Source-consistency invariants.
     check("llm_usage_proxy_has_request_id", sql`source <> 'proxy' OR request_id IS NOT NULL`),
-    check(
-      "llm_usage_runner_has_sequence",
-      sql`source <> 'runner' OR (run_id IS NOT NULL AND sequence IS NOT NULL)`,
-    ),
+    check("llm_usage_runner_has_run_id", sql`source <> 'runner' OR run_id IS NOT NULL`),
   ],
 );
 


### PR DESCRIPTION
## Summary
The transactional delta-from-running-total scheme on `llm_usage` runner rows existed to keep `SUM(ledger)` correct under multi-event runner streams that never materialised. One metric event per run today carrying the full cost.

- Drops `pg_advisory_xact_lock` + transactional read-then-insert
- Drops the `sequence` column on `llm_usage` entirely (proxy rows used `request_id`, runner rows now use `run_id` alone)
- Partial unique index `(run_id) WHERE source='runner'` enforces single-row dedup; concurrent writers (metric event handler + finalize-time fallback) race via `ON CONFLICT DO NOTHING`
- `writeRunnerLedgerRow` replaces `appendRunnerLedgerRow`; `hasRunnerLedgerRow` replaces `sumRunnerCost`
- Sink option `sequence` replaced by explicit `writeLedger: boolean`
- Migration **0008_runner_ledger_simple** drops the old column + index, adds the new partial unique index

## Test plan
- [x] `bun run check` — 17/17 ✓
- [x] `apps/api/test/integration/services/appstrate-event-sink.test.ts` — concurrent writers test asserts single-row dedup
- [x] `apps/api/test/integration/routes/runs-events-ingestion.test.ts` — finalize fallback + metric handler convergence
- [ ] Verify migration applies cleanly on a fresh PGlite + on a staging Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)