### PR TITLE
feat(cli): stamp install source at build time (#249 phase 1)

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -96,6 +96,11 @@ jobs:
         # inlined assets (the #175 regression), we fail BEFORE polluting
         # the npm registry — unlike a post-publish smoke test, this
         # failure mode is recoverable without `npm deprecate`.
+        #
+        # APPSTRATE_INSTALL_SOURCE=bun stamps the bundled CLI as the
+        # npm-channel artefact (see `src/lib/install-source.ts`, issue #249).
+        env:
+          APPSTRATE_INSTALL_SOURCE: bun
         run: |
           npm pack
           # `npm pack` names the tarball `<package>-<version>.tgz` deterministically;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,8 +173,13 @@ jobs:
       - name: Compile CLI binary
         working-directory: apps/cli
         run: |
+          # `--define '__APPSTRATE_INSTALL_SOURCE__="curl"'` stamps the
+          # binary as the curl-channel artefact at build time. See
+          # `src/lib/install-source.ts` and issue #249. Source/dev builds
+          # leave the identifier undefined and resolve to "unknown".
           bun build --compile \
             --target=${{ matrix.target }} \
+            --define '__APPSTRATE_INSTALL_SOURCE__="curl"' \
             src/cli.ts \
             --outfile=${{ matrix.asset }}
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test test/",
-    "build": "bun build --target=bun --packages external --outdir=dist src/cli.ts",
+    "build": "bun scripts/build.ts",
     "prepack": "bun run build"
   },
   "dependencies": {

--- a/apps/cli/scripts/build.ts
+++ b/apps/cli/scripts/build.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env bun
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Build wrapper for the npm channel of the CLI.
+ *
+ * Wraps `bun build --target=bun --packages external --outdir=dist src/cli.ts`
+ * with a `--define` flag that stamps `INSTALL_SOURCE` (see
+ * `src/lib/install-source.ts`). `package.json#scripts.build` calls this
+ * instead of `bun build` directly so the `prepack` hook (run by `npm pack`
+ * during the npm publish workflow) carries the stamp without manual escape
+ * hell in `package.json`.
+ *
+ * Channel selection:
+ *   - `APPSTRATE_INSTALL_SOURCE=bun`  — set by `.github/workflows/publish-cli.yml`
+ *   - `APPSTRATE_INSTALL_SOURCE=curl` — never used here (release.yml stamps directly
+ *     in `bun build --compile`), but accepted for parity / manual smoke tests.
+ *   - unset / `unknown`              — local dev tarball (`bun run build`)
+ *
+ * The release.yml workflow does NOT use this script — it invokes
+ * `bun build --compile` directly with its own `--define` for the curl channel.
+ */
+
+import { spawn } from "bun";
+
+const VALID = new Set(["curl", "bun", "unknown"]);
+const raw = process.env.APPSTRATE_INSTALL_SOURCE?.trim() ?? "unknown";
+const source = VALID.has(raw) ? raw : "unknown";
+
+if (raw !== source) {
+  console.error(
+    `WARN: APPSTRATE_INSTALL_SOURCE="${raw}" is not one of ${[...VALID].join("|")}; falling back to "unknown".`,
+  );
+}
+
+const proc = spawn({
+  cmd: [
+    "bun",
+    "build",
+    "--target=bun",
+    "--packages",
+    "external",
+    "--outdir=dist",
+    `--define=__APPSTRATE_INSTALL_SOURCE__="${source}"`,
+    "src/cli.ts",
+  ],
+  stdout: "inherit",
+  stderr: "inherit",
+});
+
+const code = await proc.exited;
+process.exit(code);

--- a/apps/cli/src/lib/install-source.ts
+++ b/apps/cli/src/lib/install-source.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Build-time stamp identifying which distribution channel produced this CLI.
+ *
+ * Two channels currently ship `appstrate`:
+ *   - `curl`: the signed binary released via `curl -fsSL https://get.appstrate.dev | bash`
+ *     (built by `.github/workflows/release.yml` with `bun build --compile`).
+ *   - `bun`: the npm package consumed via `bun install -g appstrate` / `bunx appstrate`
+ *     (built by `.github/workflows/publish-cli.yml` via `npm pack` → `bun run build`).
+ *
+ * The two artefacts are produced by separate workflows and never copied across
+ * channels, so a build-time stamp is honest by construction. Source checkouts
+ * (`bun run dev`, `bun apps/cli/src/cli.ts`) report `unknown` and let runtime
+ * heuristics (e.g. `process.execPath` in `appstrate doctor`) take over.
+ *
+ * Implementation: `bun build --define '__APPSTRATE_INSTALL_SOURCE__="<channel>"'`
+ * substitutes the identifier with a string literal at bundle time. The `typeof`
+ * guard makes the lookup safe in dev where the identifier is undefined — `typeof`
+ * never throws on missing globals, so we gracefully fall through to `"unknown"`.
+ */
+
+declare const __APPSTRATE_INSTALL_SOURCE__: string;
+
+export type InstallSource = "curl" | "bun" | "unknown";
+
+export const INSTALL_SOURCES: readonly InstallSource[] = ["curl", "bun", "unknown"] as const;
+
+function resolveInstallSource(): InstallSource {
+  // `typeof` on a missing identifier returns "undefined" without throwing,
+  // unlike a bare reference. Required because the identifier is replaced
+  // by `bun build --define` only in workflow builds — dev runs leave it
+  // undefined and a bare reference would ReferenceError at module load.
+  if (typeof __APPSTRATE_INSTALL_SOURCE__ !== "string") {
+    return "unknown";
+  }
+  const stamp = __APPSTRATE_INSTALL_SOURCE__;
+  if (stamp === "curl" || stamp === "bun" || stamp === "unknown") {
+    return stamp;
+  }
+  return "unknown";
+}
+
+/** Channel that produced this binary, or `"unknown"` for source/dev builds. */
+export const INSTALL_SOURCE: InstallSource = resolveInstallSource();
+
+/** Human-readable upgrade hint for the detected channel. */
+export function upgradeHint(source: InstallSource = INSTALL_SOURCE): string {
+  switch (source) {
+    case "curl":
+      return "curl -fsSL https://get.appstrate.dev | bash";
+    case "bun":
+      return "bun update -g appstrate";
+    case "unknown":
+      return "reinstall via curl -fsSL https://get.appstrate.dev | bash, or `bun update -g appstrate`";
+  }
+}

--- a/apps/cli/test/install-source.test.ts
+++ b/apps/cli/test/install-source.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { INSTALL_SOURCE, INSTALL_SOURCES, upgradeHint } from "../src/lib/install-source.ts";
+
+/**
+ * Phase 1 — `__APPSTRATE_INSTALL_SOURCE__` build-time stamp (issue #249).
+ *
+ * Validates three layers:
+ *   1. `INSTALL_SOURCE` resolves to `"unknown"` in source/dev (no `--define`).
+ *   2. `bun build --define='__APPSTRATE_INSTALL_SOURCE__="curl"'` produces a
+ *      bundle whose `INSTALL_SOURCE` is `"curl"` at runtime.
+ *   3. Same for `"bun"`, and bogus values fall back to `"unknown"`.
+ *
+ * The build-time tests `bun build` a tiny probe that imports `INSTALL_SOURCE`
+ * and prints it, then `bun` the output. This is the same wiring used by
+ * `release.yml` (`bun build --compile`) and `apps/cli/scripts/build.ts`
+ * (`bun build` for npm), so a regression in either workflow surfaces here.
+ */
+
+describe("install-source", () => {
+  describe("dev / source build", () => {
+    it("resolves to 'unknown' when the identifier is not defined", () => {
+      // `bun test` runs source files directly without a `--define`, so the
+      // identifier is undefined and the typeof guard kicks in.
+      expect(INSTALL_SOURCE).toBe("unknown");
+    });
+
+    it("exposes the canonical channel list", () => {
+      expect(INSTALL_SOURCES).toEqual(["curl", "bun", "unknown"]);
+    });
+
+    it("returns a stable upgrade hint per channel", () => {
+      expect(upgradeHint("curl")).toContain("get.appstrate.dev");
+      expect(upgradeHint("bun")).toContain("bun update -g appstrate");
+      expect(upgradeHint("unknown")).toContain("appstrate");
+    });
+  });
+
+  describe("build-time substitution", () => {
+    async function buildAndRun(stampValue: string | null): Promise<string> {
+      const dir = await mkdtemp(join(tmpdir(), "appstrate-install-source-"));
+      try {
+        const probeSrc = join(dir, "probe.ts");
+        const probeOut = join(dir, "probe.js");
+        const installSourceSrc = await Bun.file(
+          join(import.meta.dir, "../src/lib/install-source.ts"),
+        ).text();
+        await writeFile(join(dir, "install-source.ts"), installSourceSrc);
+        await writeFile(
+          probeSrc,
+          `import { INSTALL_SOURCE } from "./install-source.ts";\nprocess.stdout.write(INSTALL_SOURCE);`,
+        );
+
+        const buildArgs = ["build", "--target=bun", "--outfile", probeOut, probeSrc];
+        if (stampValue !== null) {
+          buildArgs.push(`--define=__APPSTRATE_INSTALL_SOURCE__="${stampValue}"`);
+        }
+        const buildRes = spawnSync("bun", buildArgs, {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        if (buildRes.status !== 0) {
+          throw new Error(`bun build failed: ${buildRes.stderr}`);
+        }
+
+        const runRes = spawnSync("bun", [probeOut], {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        if (runRes.status !== 0) {
+          throw new Error(`probe failed: ${runRes.stderr}`);
+        }
+        return runRes.stdout;
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+
+    it("stamps 'curl' when --define='__APPSTRATE_INSTALL_SOURCE__=\"curl\"'", async () => {
+      const out = await buildAndRun("curl");
+      expect(out).toBe("curl");
+    });
+
+    it("stamps 'bun' when --define='__APPSTRATE_INSTALL_SOURCE__=\"bun\"'", async () => {
+      const out = await buildAndRun("bun");
+      expect(out).toBe("bun");
+    });
+
+    it("falls back to 'unknown' when no --define is provided", async () => {
+      const out = await buildAndRun(null);
+      expect(out).toBe("unknown");
+    });
+
+    it("falls back to 'unknown' for an unrecognised stamp value", async () => {
+      const out = await buildAndRun("brew");
+      expect(out).toBe("unknown");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of #249. Stamps every CLI binary with the distribution channel that produced it (`"curl"` for the signed release binary, `"bun"` for the npm package, `"unknown"` for source/dev builds).

## Wiring

- `apps/cli/src/lib/install-source.ts` — exports `INSTALL_SOURCE`, `INSTALL_SOURCES`, `upgradeHint(source)`. Resolves via a `typeof` guard on the build-time identifier `__APPSTRATE_INSTALL_SOURCE__`, falling back to `"unknown"` when the bundle was not stamped.
- `apps/cli/scripts/build.ts` — wraps `bun build` with the `--define` so the npm `prepack` chain stays clean. Reads `APPSTRATE_INSTALL_SOURCE` env var with `"unknown"` default.
- `apps/cli/package.json` — `build` now calls `bun scripts/build.ts`.
- `.github/workflows/release.yml` — adds `--define '__APPSTRATE_INSTALL_SOURCE__="curl"'` to the compile step.
- `.github/workflows/publish-cli.yml` — sets `APPSTRATE_INSTALL_SOURCE=bun` before `npm pack`.

## Why now

Unblocks phases 2 (`self-update`) and 3 (`doctor`) of #249 — both need to know which channel produced the running binary. No runtime behavior change in this PR; the constant is exported but no command consumes it yet.

## Test plan
- [x] `bun test apps/cli/test/install-source.test.ts` (7 tests, end-to-end build+run probes)
- [x] `bun test` in `apps/cli` — 717 pass
- [x] `bun run check` (turbo + verify-openapi) — all green
- [x] Manual smoke: `APPSTRATE_INSTALL_SOURCE=bun bun scripts/build.ts` → `dist/cli.js` reports `bun`

🤖 Generated with [Claude Code](https://claude.com/claude-code)