### PR TITLE
feat(oidc): persist device-session metadata on cli_refresh_tokens (#251 phase 1)

### DIFF
--- a/apps/api/src/modules/oidc/auth/cli-plugin.ts
+++ b/apps/api/src/modules/oidc/auth/cli-plugin.ts
@@ -49,7 +49,38 @@ import {
   exchangeDeviceCodeForTokens,
   revokeRefreshToken,
   rotateRefreshToken,
+  type DeviceMetadata,
 } from "../services/cli-tokens.ts";
+import { getClientIpFromRequest } from "../../../lib/client-ip.ts";
+
+/** Header the CLI uses to declare a human-friendly device label
+ *  (mirrors `gh auth login --hostname`). Optional — when absent, the UI
+ *  falls back to a UA-derived label. Capped to a sane length to keep the
+ *  device list scannable; longer values are truncated. */
+const DEVICE_NAME_HEADER = "x-appstrate-device-name";
+const DEVICE_NAME_MAX_LENGTH = 120;
+
+/** Reasonable upper bound on `User-Agent` storage. Real-world UAs sit
+ *  well under 1 KB; we cap to defang a misbehaving client that ships a
+ *  multi-KB blob into a freshly-indexable text column. */
+const USER_AGENT_MAX_LENGTH = 1024;
+
+function clamp(s: string | null | undefined, max: number): string | null {
+  if (!s) return null;
+  const trimmed = s.trim();
+  if (!trimmed) return null;
+  return trimmed.length > max ? trimmed.slice(0, max) : trimmed;
+}
+
+function metadataFromRequest(request: Request | undefined): DeviceMetadata {
+  if (!request) return {};
+  const headers = request.headers;
+  return {
+    deviceName: clamp(headers.get(DEVICE_NAME_HEADER), DEVICE_NAME_MAX_LENGTH),
+    userAgent: clamp(headers.get("user-agent"), USER_AGENT_MAX_LENGTH),
+    ip: getClientIpFromRequest(request),
+  };
+}
 
 // RFC 6749 §5.2 error → HTTP status. Polling errors (authorization_pending,
 // slow_down) are 400 per RFC 8628 §3.5.
@@ -179,6 +210,7 @@ export function cliTokenPlugin() {
               const tokens = await exchangeDeviceCodeForTokens({
                 deviceCodeValue: device_code,
                 clientId: client_id,
+                metadata: metadataFromRequest(ctx.request),
               });
               return ctx.json(
                 {
@@ -202,6 +234,12 @@ export function cliTokenPlugin() {
               const tokens = await rotateRefreshToken({
                 refreshToken: refresh_token,
                 clientId: client_id,
+                // Only the IP is meaningful on rotations — `last_used_at`
+                // is set by the service from `Date.now()`. UA/deviceName
+                // are head-of-family attributes captured at login time;
+                // re-capturing them on every refresh would let a CLI
+                // silently mutate its declared identity.
+                metadata: { ip: getClientIpFromRequest(ctx.request) },
               });
               return ctx.json(
                 {

--- a/apps/api/src/modules/oidc/drizzle/migrations/0006_cli_refresh_tokens_metadata.sql
+++ b/apps/api/src/modules/oidc/drizzle/migrations/0006_cli_refresh_tokens_metadata.sql
@@ -1,0 +1,39 @@
+-- OIDC module: device-session metadata on `cli_refresh_tokens` (issue #251).
+--
+-- Phase 1 of the "authorized devices" workstream deferred by ADR-006. The
+-- columns added below let the platform answer two questions the schema
+-- shipped with #227 cannot:
+--
+--   1. "Which devices are signed in to my account right now?"
+--      → human-readable device label, observed UA, observed IP, last-seen
+--        timestamp/IP. Without these, every refresh-token row is
+--        indistinguishable.
+--
+--   2. "When did this session last actually do something?"
+--      → `last_used_at` + `last_used_ip` updated on each `refresh_token`
+--        rotation. Activity attribution for the session list view.
+--
+-- Storage convention: metadata lives ONLY on the *head of family* — the
+-- row inserted at device-code exchange (`parent_id IS NULL`). Rotation
+-- rows (children) stay light: read paths join by `family_id` to surface
+-- the head row's metadata. This keeps rotation INSERTs minimal and means
+-- a session "rename" or "last_used update" is a single UPDATE on the
+-- head, never a per-row replicate.
+--
+-- IP storage: `text`, not `inet`. Mirrors the `session.ip_address` column
+-- the Better Auth schema uses (`packages/db/src/schema/auth.ts:47`) — keeps
+-- portability across PGlite (Tier-0 dev) and PostgreSQL identical, and
+-- avoids parsing pressure on every write. `unknown` is a legitimate value
+-- when `TRUST_PROXY` is disabled and the request arrives via a non-direct
+-- transport (`getClientIpFromRequest` returns the literal `"unknown"`).
+--
+-- All columns nullable: pre-existing rows from #227 carry no metadata, and
+-- a future `appstrate-cli` invocation that omits the optional
+-- `X-Appstrate-Device-Name` header still has a usable session entry.
+
+ALTER TABLE "cli_refresh_tokens"
+  ADD COLUMN IF NOT EXISTS "device_name" text,
+  ADD COLUMN IF NOT EXISTS "user_agent" text,
+  ADD COLUMN IF NOT EXISTS "created_ip" text,
+  ADD COLUMN IF NOT EXISTS "last_used_ip" text,
+  ADD COLUMN IF NOT EXISTS "last_used_at" timestamp;

--- a/apps/api/src/modules/oidc/schema.ts
+++ b/apps/api/src/modules/oidc/schema.ts
@@ -252,6 +252,17 @@ export const cliRefreshToken = pgTable(
     usedAt: timestamp("used_at"),
     revokedAt: timestamp("revoked_at"),
     revokedReason: text("revoked_reason"),
+    // Device-session metadata, populated on the head of family only
+    // (`parent_id IS NULL`). Rotation rows leave these NULL; read paths
+    // resolve metadata by joining children to the family head. See
+    // migration `0006_cli_refresh_tokens_metadata.sql` for the rationale
+    // (one UPDATE per "rename"/"last_used" event regardless of family
+    // size, no per-rotation duplication).
+    deviceName: text("device_name"),
+    userAgent: text("user_agent"),
+    createdIp: text("created_ip"),
+    lastUsedIp: text("last_used_ip"),
+    lastUsedAt: timestamp("last_used_at"),
   },
   (t) => [
     index("idx_cli_refresh_tokens_family").on(t.familyId),

--- a/apps/api/src/modules/oidc/services/cli-tokens.ts
+++ b/apps/api/src/modules/oidc/services/cli-tokens.ts
@@ -122,6 +122,22 @@ export interface TokenPair {
 }
 
 /**
+ * Device metadata captured at device-code exchange. Persisted on the head
+ * of family for the listing/revocation UI (issue #251). All fields
+ * optional — pre-2.x CLIs that omit `X-Appstrate-Device-Name` and
+ * deployments with `TRUST_PROXY=false` (which yields `"unknown"` from
+ * `getClientIpFromRequest`) will produce rows with partial metadata.
+ */
+export interface DeviceMetadata {
+  /** Optional user-supplied label (`X-Appstrate-Device-Name`). */
+  deviceName?: string | null;
+  /** Raw `User-Agent` header at exchange/rotation time. */
+  userAgent?: string | null;
+  /** Resolved client IP, honors `TRUST_PROXY`. */
+  ip?: string | null;
+}
+
+/**
  * Exchange an approved device code for a JWT + refresh pair. Called by
  * the BA plugin `/cli/token` endpoint after device-flow approval.
  *
@@ -151,8 +167,9 @@ export interface TokenPair {
 export async function exchangeDeviceCodeForTokens(params: {
   deviceCodeValue: string;
   clientId: string;
+  metadata?: DeviceMetadata;
 }): Promise<TokenPair> {
-  const { deviceCodeValue, clientId } = params;
+  const { deviceCodeValue, clientId, metadata } = params;
 
   // Two-phase exchange. Minting the JWT calls Better Auth's `signJWT`
   // plugin which issues its own DB reads via the BA adapter; nesting
@@ -308,9 +325,11 @@ export async function exchangeDeviceCodeForTokens(params: {
       userId: user.id,
       clientId,
       scope,
-      // No parent — head of a fresh family.
+      // No parent — head of a fresh family. Device metadata is persisted
+      // on this head row only; rotation rows leave the columns NULL.
       parentId: null,
       familyId: prefixedId("crf"),
+      metadata,
     });
     // One-shot contract.
     await tx.delete(deviceCode).where(eq(deviceCode.id, rowId));
@@ -361,8 +380,12 @@ type ExchangeOutcome =
 export async function rotateRefreshToken(params: {
   refreshToken: string;
   clientId: string;
+  /** Optional last-used metadata. Updates the head of family in the same
+   *  transaction that marks the presented row used; rotation children stay
+   *  light. */
+  metadata?: DeviceMetadata;
 }): Promise<TokenPair> {
-  const { refreshToken, clientId } = params;
+  const { refreshToken, clientId, metadata } = params;
   const tokenHash = hashRefreshToken(refreshToken);
 
   // Two-phase rotation — same split as `exchangeDeviceCodeForTokens`:
@@ -457,6 +480,20 @@ export async function rotateRefreshToken(params: {
       .update(cliRefreshToken)
       .set({ usedAt: new Date() })
       .where(eq(cliRefreshToken.id, row.id));
+
+    // Bump last-used metadata on the family head (`parent_id IS NULL`).
+    // Activity attribution lives on the head row so the listing UI can
+    // join children to the head by `family_id` and surface a single
+    // "last used" timestamp per device, regardless of how many rotations
+    // have occurred. The UPDATE is scoped by `family_id` AND
+    // `parent_id IS NULL` so we never accidentally write metadata onto a
+    // rotation row even if the head was somehow deleted or revoked.
+    const lastUsedAt = new Date();
+    const lastUsedIp = metadata?.ip ?? null;
+    await tx
+      .update(cliRefreshToken)
+      .set({ lastUsedAt, lastUsedIp })
+      .where(and(eq(cliRefreshToken.familyId, row.familyId), isNull(cliRefreshToken.parentId)));
 
     const [clientRow] = await tx
       .select({ scopes: oauthClient.scopes })
@@ -624,12 +661,16 @@ async function persistRefreshTokenInTx(
     scope: string;
     parentId: string | null;
     familyId: string;
+    /** Only honored on the head of family (`parentId === null`). Rotation
+     *  children always store `null` for the metadata columns. */
+    metadata?: DeviceMetadata;
   },
 ): Promise<{ refreshPlain: string }> {
-  const { userId, clientId, scope, parentId, familyId } = params;
+  const { userId, clientId, scope, parentId, familyId, metadata } = params;
   const refreshPlain = generateRefreshToken();
   const refreshHash = hashRefreshToken(refreshPlain);
   const expiresAt = new Date(Date.now() + REFRESH_TOKEN_TTL_SECONDS * 1000);
+  const isHead = parentId === null;
   await tx.insert(cliRefreshToken).values({
     id: prefixedId("crf"),
     tokenHash: refreshHash,
@@ -643,6 +684,11 @@ async function persistRefreshTokenInTx(
     usedAt: null,
     revokedAt: null,
     revokedReason: null,
+    deviceName: isHead ? (metadata?.deviceName ?? null) : null,
+    userAgent: isHead ? (metadata?.userAgent ?? null) : null,
+    createdIp: isHead ? (metadata?.ip ?? null) : null,
+    lastUsedIp: null,
+    lastUsedAt: null,
   });
   return { refreshPlain };
 }

--- a/apps/api/src/modules/oidc/test/integration/services/cli-token-flow.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/cli-token-flow.test.ts
@@ -820,3 +820,182 @@ describe("POST /api/auth/cli/revoke", () => {
     expect(row?.revokedAt).toBeNull();
   });
 });
+
+describe("device-session metadata (issue #251)", () => {
+  beforeEach(async () => {
+    await truncateAll();
+    await flushRedis();
+    resetOidcGuardsLimiters();
+    overrideJwksResolver(null);
+    await createTestContext({ orgSlug: "climeta" });
+    await ensureCliClient();
+  });
+
+  // `TRUST_PROXY` defaults to `false` in the test env, so
+  // `getClientIpFromRequest` returns the literal string `"unknown"`
+  // when reading from a test request. Tests that need a real IP must
+  // either set up `TRUST_PROXY=1` + `X-Forwarded-For` or accept the
+  // sentinel. The current suite uses the XFF route — see
+  // `lib/client-ip.ts` for the resolution rules.
+
+  async function loginWithMetadata(headers: Record<string, string>): Promise<{
+    refreshToken: string;
+    familyId: string;
+    headRowId: string;
+  }> {
+    const { cookie } = await signUpPlatformUser();
+    const { deviceCodeValue } = await runDeviceFlow(cookie);
+    const res = await app.request("/api/auth/cli/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...headers },
+      body: JSON.stringify({
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        device_code: deviceCodeValue,
+        client_id: "appstrate-cli",
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { refresh_token: string };
+    const [row] = await db
+      .select()
+      .from(cliRefreshToken)
+      .where(eq(cliRefreshToken.tokenHash, _hashRefreshTokenForTesting(body.refresh_token)))
+      .limit(1);
+    expect(row).toBeDefined();
+    return {
+      refreshToken: body.refresh_token,
+      familyId: row!.familyId,
+      headRowId: row!.id,
+    };
+  }
+
+  it("captures user_agent + device_name + created_ip on the head row at device-code exchange", async () => {
+    const { headRowId } = await loginWithMetadata({
+      "User-Agent": "appstrate-cli/2.4.0 (darwin arm64; node 20.11.1)",
+      "X-Appstrate-Device-Name": "pierre's macbook",
+      "X-Forwarded-For": "203.0.113.7",
+    });
+
+    const [row] = await db
+      .select()
+      .from(cliRefreshToken)
+      .where(eq(cliRefreshToken.id, headRowId))
+      .limit(1);
+    expect(row).toBeDefined();
+    expect(row!.parentId).toBeNull(); // confirm this is the head
+    expect(row!.userAgent).toBe("appstrate-cli/2.4.0 (darwin arm64; node 20.11.1)");
+    expect(row!.deviceName).toBe("pierre's macbook");
+    // `TRUST_PROXY=false` (test default) → XFF ignored, ip recorded as "unknown".
+    // The point of the assertion is that the column is populated (non-null),
+    // and that `last_used_*` is left blank until the first rotation.
+    expect(typeof row!.createdIp).toBe("string");
+    expect(row!.lastUsedAt).toBeNull();
+    expect(row!.lastUsedIp).toBeNull();
+  });
+
+  it("clamps device_name to 120 chars and trims whitespace", async () => {
+    const longName = "a".repeat(500);
+    const { headRowId } = await loginWithMetadata({
+      "X-Appstrate-Device-Name": `   ${longName}   `,
+    });
+    const [row] = await db
+      .select()
+      .from(cliRefreshToken)
+      .where(eq(cliRefreshToken.id, headRowId))
+      .limit(1);
+    expect(row?.deviceName?.length).toBe(120);
+    expect(row?.deviceName).toMatch(/^a+$/);
+  });
+
+  it("treats empty/whitespace device_name as null", async () => {
+    const { headRowId } = await loginWithMetadata({
+      "X-Appstrate-Device-Name": "   ",
+    });
+    const [row] = await db
+      .select()
+      .from(cliRefreshToken)
+      .where(eq(cliRefreshToken.id, headRowId))
+      .limit(1);
+    expect(row?.deviceName).toBeNull();
+  });
+
+  it("updates last_used_at + last_used_ip on the head row when a child rotates", async () => {
+    const { refreshToken, familyId, headRowId } = await loginWithMetadata({
+      "User-Agent": "appstrate-cli/2.4.0",
+    });
+
+    const before = Date.now();
+    const rotateRes = await app.request("/api/auth/cli/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: "appstrate-cli",
+      }),
+    });
+    expect(rotateRes.status).toBe(200);
+    const after = Date.now();
+    const body = (await rotateRes.json()) as { refresh_token: string };
+
+    // Head row: last_used_* updated
+    const [head] = await db
+      .select()
+      .from(cliRefreshToken)
+      .where(eq(cliRefreshToken.id, headRowId))
+      .limit(1);
+    expect(head?.lastUsedAt).not.toBeNull();
+    const ts = new Date(head!.lastUsedAt!).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+
+    // Child row: NULL metadata (rotation rows stay light)
+    const [child] = await db
+      .select()
+      .from(cliRefreshToken)
+      .where(eq(cliRefreshToken.tokenHash, _hashRefreshTokenForTesting(body.refresh_token)))
+      .limit(1);
+    expect(child).toBeDefined();
+    expect(child!.parentId).toBe(headRowId);
+    expect(child!.familyId).toBe(familyId);
+    expect(child!.deviceName).toBeNull();
+    expect(child!.userAgent).toBeNull();
+    expect(child!.createdIp).toBeNull();
+    expect(child!.lastUsedAt).toBeNull();
+    expect(child!.lastUsedIp).toBeNull();
+  });
+
+  it("does not overwrite head user_agent or device_name on rotation (head-only-on-login contract)", async () => {
+    const { refreshToken, headRowId } = await loginWithMetadata({
+      "User-Agent": "appstrate-cli/2.4.0",
+      "X-Appstrate-Device-Name": "original-name",
+    });
+
+    // Rotate with a *different* UA + a different (would-be) device-name header.
+    // Per the contract these MUST NOT be re-captured — only `last_used_*` may
+    // change on the head, otherwise a CLI could silently mutate its
+    // declared identity through a refresh.
+    const rotateRes = await app.request("/api/auth/cli/token", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": "evil-cli/9.9.9",
+        "X-Appstrate-Device-Name": "attacker-relabel",
+      },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+        client_id: "appstrate-cli",
+      }),
+    });
+    expect(rotateRes.status).toBe(200);
+
+    const [head] = await db
+      .select()
+      .from(cliRefreshToken)
+      .where(eq(cliRefreshToken.id, headRowId))
+      .limit(1);
+    expect(head?.userAgent).toBe("appstrate-cli/2.4.0");
+    expect(head?.deviceName).toBe("original-name");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1/3 of #251 — adds the schema foundation for the "authorized devices" UI deferred by ADR-006.

- Migration `0006_cli_refresh_tokens_metadata.sql` adds 5 nullable columns to `cli_refresh_tokens`: `device_name`, `user_agent`, `created_ip`, `last_used_ip`, `last_used_at`. Metadata lives only on the head of family (`parent_id IS NULL`); rotation children stay light.
- `exchangeDeviceCodeForTokens()` captures UA + IP + optional `X-Appstrate-Device-Name` on the head row at device-code exchange.
- `rotateRefreshToken()` bumps `last_used_at` + `last_used_ip` on the family head. UA / device_name are intentionally not re-captured on refresh — a CLI silently mutating its declared identity through a refresh would defeat the point of the audit columns.
- IP resolution honors `TRUST_PROXY` via `getClientIpFromRequest()`. Header-derived strings are trimmed and clamped (device_name ≤ 120, user_agent ≤ 1024) before persistence.

No new endpoints, no breaking changes — the new fields are nullable and optional everywhere. The existing `/cli/token` and `/cli/revoke` continue to work unchanged for clients that omit the new header.

## Stack

This is the first of three stacked PRs:
1. **#251 phase 1 (this PR)** — schema + metadata capture
2. #251 phase 2 — user-facing `GET/DELETE /api/auth/cli/sessions` + dashboard UI + `appstrate logout --all` server primitive
3. #251 phase 3 — admin org-scoped oversight

Phases 2 and 3 depend on this migration landing first.

## Test plan

- [x] `bun test apps/api/src/modules/oidc/test` — 413/413 pass (incl. 5 new metadata cases + 19 existing CLI-token cases as regression)
- [x] `bun run check` — turbo typecheck + lint + format:check + verify:openapi + detect:breaking all green
- [ ] Manual verify: `appstrate login` → check `cli_refresh_tokens` row carries UA/IP; second `appstrate <cmd>` triggers refresh → `last_used_at` bumped on head row only

Refs #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)