### PR TITLE
feat(cli): add `appstrate self-update` (#249 phase 2)

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -96,6 +96,11 @@ jobs:
         # inlined assets (the #175 regression), we fail BEFORE polluting
         # the npm registry — unlike a post-publish smoke test, this
         # failure mode is recoverable without `npm deprecate`.
+        #
+        # APPSTRATE_INSTALL_SOURCE=bun stamps the bundled CLI as the
+        # npm-channel artefact (see `src/lib/install-source.ts`, issue #249).
+        env:
+          APPSTRATE_INSTALL_SOURCE: bun
         run: |
           npm pack
           # `npm pack` names the tarball `<package>-<version>.tgz` deterministically;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,8 +173,13 @@ jobs:
       - name: Compile CLI binary
         working-directory: apps/cli
         run: |
+          # `--define '__APPSTRATE_INSTALL_SOURCE__="curl"'` stamps the
+          # binary as the curl-channel artefact at build time. See
+          # `src/lib/install-source.ts` and issue #249. Source/dev builds
+          # leave the identifier undefined and resolve to "unknown".
           bun build --compile \
             --target=${{ matrix.target }} \
+            --define '__APPSTRATE_INSTALL_SOURCE__="curl"' \
             src/cli.ts \
             --outfile=${{ matrix.asset }}
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "test": "bun test test/",
-    "build": "bun build --target=bun --packages external --outdir=dist src/cli.ts",
+    "build": "bun scripts/build.ts",
     "prepack": "bun run build"
   },
   "dependencies": {

--- a/apps/cli/scripts/build.ts
+++ b/apps/cli/scripts/build.ts
@@ -1,0 +1,52 @@
+#!/usr/bin/env bun
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Build wrapper for the npm channel of the CLI.
+ *
+ * Wraps `bun build --target=bun --packages external --outdir=dist src/cli.ts`
+ * with a `--define` flag that stamps `INSTALL_SOURCE` (see
+ * `src/lib/install-source.ts`). `package.json#scripts.build` calls this
+ * instead of `bun build` directly so the `prepack` hook (run by `npm pack`
+ * during the npm publish workflow) carries the stamp without manual escape
+ * hell in `package.json`.
+ *
+ * Channel selection:
+ *   - `APPSTRATE_INSTALL_SOURCE=bun`  — set by `.github/workflows/publish-cli.yml`
+ *   - `APPSTRATE_INSTALL_SOURCE=curl` — never used here (release.yml stamps directly
+ *     in `bun build --compile`), but accepted for parity / manual smoke tests.
+ *   - unset / `unknown`              — local dev tarball (`bun run build`)
+ *
+ * The release.yml workflow does NOT use this script — it invokes
+ * `bun build --compile` directly with its own `--define` for the curl channel.
+ */
+
+import { spawn } from "bun";
+
+const VALID = new Set(["curl", "bun", "unknown"]);
+const raw = process.env.APPSTRATE_INSTALL_SOURCE?.trim() ?? "unknown";
+const source = VALID.has(raw) ? raw : "unknown";
+
+if (raw !== source) {
+  console.error(
+    `WARN: APPSTRATE_INSTALL_SOURCE="${raw}" is not one of ${[...VALID].join("|")}; falling back to "unknown".`,
+  );
+}
+
+const proc = spawn({
+  cmd: [
+    "bun",
+    "build",
+    "--target=bun",
+    "--packages",
+    "external",
+    "--outdir=dist",
+    `--define=__APPSTRATE_INSTALL_SOURCE__="${source}"`,
+    "src/cli.ts",
+  ],
+  stdout: "inherit",
+  stderr: "inherit",
+});
+
+const code = await proc.exited;
+process.exit(code);

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -47,6 +47,7 @@ import {
 import { modelsListCommand } from "./commands/models.ts";
 import { registerOpenapiCommand } from "./commands/openapi.ts";
 import { runCommand } from "./commands/run.ts";
+import { selfUpdateCommand } from "./commands/self-update.ts";
 import { exitWithError } from "./lib/ui.ts";
 import { CLI_VERSION } from "./lib/version.ts";
 
@@ -574,6 +575,21 @@ program
   });
 
 registerOpenapiCommand(program, () => program.opts<{ profile?: string }>().profile);
+
+program
+  .command("self-update")
+  .description("Upgrade the running appstrate binary in place (curl channel only — issue #249).")
+  .option(
+    "--release <version>",
+    "Pin a specific release version (default: latest from GitHub Releases).",
+  )
+  .option("-f, --force", "Reinstall even if the current version equals the target.")
+  .action(async (opts) => {
+    await selfUpdateCommand({
+      version: typeof opts.release === "string" ? opts.release : undefined,
+      force: opts.force === true,
+    });
+  });
 
 program
   .command("run")

--- a/apps/cli/src/commands/self-update.ts
+++ b/apps/cli/src/commands/self-update.ts
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `appstrate self-update` — bring the running CLI to a newer release.
+ *
+ * Channel dispatch follows the build-time stamp from `INSTALL_SOURCE`
+ * (issue #249, phase 1). Only the curl channel can self-update; other
+ * channels exit non-zero with a hint so the user invokes the right
+ * package manager. See `docs/cli/upgrades.md` for the full matrix.
+ */
+
+import * as clack from "@clack/prompts";
+import { INSTALL_SOURCE, upgradeHint, type InstallSource } from "../lib/install-source.ts";
+import { CLI_VERSION } from "../lib/version.ts";
+import {
+  detectPlatform,
+  performCurlUpdate,
+  resolveTargetVersion,
+  defaultSelfUpdateDeps,
+  type PerformCurlUpdateResult,
+  type PlatformInfo,
+  type SelfUpdateDeps,
+  type ResolveTargetVersionDeps,
+} from "../lib/self-update.ts";
+
+export interface SelfUpdateOptions {
+  /** Specific version to install. Default: latest published release. */
+  version?: string;
+  /** Reinstall even if the current version equals the target. */
+  force?: boolean;
+  /** Override the build-time stamp for tests. */
+  source?: InstallSource;
+  /** Override the deps for tests (network, fs, exec). */
+  deps?: SelfUpdateDeps;
+  /** Override the running CLI version for tests. Defaults to bundled `CLI_VERSION`. */
+  currentVersion?: string;
+  /** Override platform detection for tests. Production reads `process.platform/arch`. */
+  platform?: PlatformInfo;
+  /** Logger override for tests; production uses `console.error`. */
+  log?: (line: string) => void;
+}
+
+/** Exit-code constants used by `runSelfUpdate` so the CLI top-level can map to `process.exit`. */
+export const SELF_UPDATE_EXIT = {
+  OK: 0,
+  WRONG_CHANNEL: 1,
+  UNKNOWN_SOURCE: 1,
+  UPDATE_FAILED: 1,
+} as const;
+
+export interface SelfUpdateRunResult {
+  exitCode: number;
+  message: string;
+  detail?: PerformCurlUpdateResult;
+}
+
+/**
+ * Pure entry point — returns an exit code + message instead of mutating
+ * `process.exit` directly so the test surface stays simple. The thin wrapper
+ * `selfUpdateCommand` (registered in `cli.ts`) does the I/O and exits.
+ */
+export async function runSelfUpdate(opts: SelfUpdateOptions = {}): Promise<SelfUpdateRunResult> {
+  const source = opts.source ?? INSTALL_SOURCE;
+
+  if (source === "bun") {
+    return {
+      exitCode: SELF_UPDATE_EXIT.WRONG_CHANNEL,
+      message: [
+        `This appstrate CLI was installed via the npm channel.`,
+        `\`self-update\` only manages the curl-channel binary — running it`,
+        `here would desync the npm package metadata from the binary on disk.`,
+        ``,
+        `Upgrade with:`,
+        `  ${upgradeHint("bun")}`,
+      ].join("\n"),
+    };
+  }
+
+  if (source === "unknown") {
+    const execPath = (opts.deps ?? defaultSelfUpdateDeps).execPath();
+    return {
+      exitCode: SELF_UPDATE_EXIT.UNKNOWN_SOURCE,
+      message: [
+        `Cannot self-update: this binary has no install-source stamp.`,
+        `It was either built from source (\`bun run dev\`, \`bun apps/cli/src/cli.ts\`)`,
+        `or copied from one channel to another, which we cannot reason about safely.`,
+        ``,
+        `Diagnostic:`,
+        `  Running binary: ${execPath}`,
+        `  CLI version:    ${CLI_VERSION}`,
+        ``,
+        `Reinstall via the curl channel to enable self-update:`,
+        `  ${upgradeHint("unknown")}`,
+      ].join("\n"),
+    };
+  }
+
+  // source === "curl"
+  const deps = opts.deps ?? defaultSelfUpdateDeps;
+  const resolveDeps: ResolveTargetVersionDeps = { fetchText: deps.fetchText.bind(deps) };
+  let target: string;
+  try {
+    target = await resolveTargetVersion(opts.version, resolveDeps);
+  } catch (err) {
+    return {
+      exitCode: SELF_UPDATE_EXIT.UPDATE_FAILED,
+      message: `Could not resolve target version: ${(err as Error).message}`,
+    };
+  }
+
+  const platform = opts.platform ?? detectPlatform();
+  let result: PerformCurlUpdateResult;
+  try {
+    result = await performCurlUpdate({
+      targetVersion: target,
+      platform,
+      force: opts.force === true,
+      deps,
+      currentVersion: opts.currentVersion,
+      log: opts.log,
+    });
+  } catch (err) {
+    return {
+      exitCode: SELF_UPDATE_EXIT.UPDATE_FAILED,
+      message: `Update failed: ${(err as Error).message}`,
+    };
+  }
+
+  if (result.status === "already-up-to-date") {
+    return {
+      exitCode: SELF_UPDATE_EXIT.OK,
+      message: `Already on appstrate ${result.version}. Pass --force to reinstall.`,
+      detail: result,
+    };
+  }
+  return {
+    exitCode: SELF_UPDATE_EXIT.OK,
+    message: `Updated appstrate to ${result.version} (${result.destination})`,
+    detail: result,
+  };
+}
+
+/**
+ * Commander entry point — does the I/O. Wraps `runSelfUpdate` so a successful
+ * call exits 0 and a failure exits with the chosen non-zero code.
+ */
+export async function selfUpdateCommand(opts: SelfUpdateOptions = {}): Promise<never> {
+  clack.intro(`Appstrate self-update`);
+  const result = await runSelfUpdate(opts);
+  if (result.exitCode === SELF_UPDATE_EXIT.OK) {
+    clack.outro(result.message);
+  } else {
+    clack.cancel(result.message);
+  }
+  process.exit(result.exitCode);
+}

--- a/apps/cli/src/lib/install-source.ts
+++ b/apps/cli/src/lib/install-source.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Build-time stamp identifying which distribution channel produced this CLI.
+ *
+ * Two channels currently ship `appstrate`:
+ *   - `curl`: the signed binary released via `curl -fsSL https://get.appstrate.dev | bash`
+ *     (built by `.github/workflows/release.yml` with `bun build --compile`).
+ *   - `bun`: the npm package consumed via `bun install -g appstrate` / `bunx appstrate`
+ *     (built by `.github/workflows/publish-cli.yml` via `npm pack` → `bun run build`).
+ *
+ * The two artefacts are produced by separate workflows and never copied across
+ * channels, so a build-time stamp is honest by construction. Source checkouts
+ * (`bun run dev`, `bun apps/cli/src/cli.ts`) report `unknown` and let runtime
+ * heuristics (e.g. `process.execPath` in `appstrate doctor`) take over.
+ *
+ * Implementation: `bun build --define '__APPSTRATE_INSTALL_SOURCE__="<channel>"'`
+ * substitutes the identifier with a string literal at bundle time. The `typeof`
+ * guard makes the lookup safe in dev where the identifier is undefined — `typeof`
+ * never throws on missing globals, so we gracefully fall through to `"unknown"`.
+ */
+
+declare const __APPSTRATE_INSTALL_SOURCE__: string;
+
+export type InstallSource = "curl" | "bun" | "unknown";
+
+export const INSTALL_SOURCES: readonly InstallSource[] = ["curl", "bun", "unknown"] as const;
+
+function resolveInstallSource(): InstallSource {
+  // `typeof` on a missing identifier returns "undefined" without throwing,
+  // unlike a bare reference. Required because the identifier is replaced
+  // by `bun build --define` only in workflow builds — dev runs leave it
+  // undefined and a bare reference would ReferenceError at module load.
+  if (typeof __APPSTRATE_INSTALL_SOURCE__ !== "string") {
+    return "unknown";
+  }
+  const stamp = __APPSTRATE_INSTALL_SOURCE__;
+  if (stamp === "curl" || stamp === "bun" || stamp === "unknown") {
+    return stamp;
+  }
+  return "unknown";
+}
+
+/** Channel that produced this binary, or `"unknown"` for source/dev builds. */
+export const INSTALL_SOURCE: InstallSource = resolveInstallSource();
+
+/** Human-readable upgrade hint for the detected channel. */
+export function upgradeHint(source: InstallSource = INSTALL_SOURCE): string {
+  switch (source) {
+    case "curl":
+      return "curl -fsSL https://get.appstrate.dev | bash";
+    case "bun":
+      return "bun update -g appstrate";
+    case "unknown":
+      return "reinstall via curl -fsSL https://get.appstrate.dev | bash, or `bun update -g appstrate`";
+  }
+}

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -1,0 +1,424 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Pure helpers + injectable I/O for `appstrate self-update`.
+ *
+ * Split from `commands/self-update.ts` so tests can exercise the parsing,
+ * resolution, and verification logic without touching the network or the
+ * real filesystem. The command file wires `defaultSelfUpdateDeps` and
+ * formats user-facing prompts; this module owns the algorithm.
+ *
+ * Channel handling (issue #249, phase 2):
+ *   - `curl`: download release asset + signed checksums + minisign sig,
+ *     verify, atomic-rename over `process.execPath`.
+ *   - `bun`: refuse with `bun update -g appstrate` hint (npm owns the
+ *     binary, our atomic-replace would desync npm metadata).
+ *   - `unknown`: refuse with a diagnostic — we cannot prove what produced
+ *     this binary, so we cannot prove the update target matches.
+ */
+
+import { mkdtemp, rename, rm, stat, writeFile, chmod, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { runCommand, type CommandResult } from "./install/os.ts";
+import { CLI_USER_AGENT, CLI_VERSION, DEV_CLI_VERSION } from "./version.ts";
+
+/** Pubkey baked into the curl bootstrap (`scripts/bootstrap.sh`). Same key signs every release. */
+export const APPSTRATE_MINISIGN_PUBKEY = "RWT6xCZCCP/yHolAgDuDqBssxUflw7gInlZlaXEfQ4cFi5XN0KCtKr0e";
+
+const RELEASE_URL_BASE = "https://github.com/appstrate/appstrate/releases";
+const LATEST_API_URL = "https://api.github.com/repos/appstrate/appstrate/releases/latest";
+
+export type Platform = "darwin" | "linux";
+export type Architecture = "x64" | "arm64";
+
+export interface PlatformInfo {
+  platform: Platform;
+  arch: Architecture;
+}
+
+/**
+ * Map Node `process.platform` / `process.arch` to the `appstrate-<os>-<arch>`
+ * asset name format used by the release matrix in `.github/workflows/release.yml`.
+ *
+ * Throws on unsupported combinations — we only ship 4 binaries
+ * (darwin/x64, darwin/arm64, linux/x64, linux/arm64). Anything else
+ * (Windows, freebsd, mips, …) means `self-update` cannot help and the
+ * user has to follow whichever ad-hoc install path got them here.
+ */
+export function detectPlatform(
+  raw: { platform: NodeJS.Platform; arch: string } = {
+    platform: process.platform,
+    arch: process.arch,
+  },
+): PlatformInfo {
+  let platform: Platform;
+  if (raw.platform === "darwin") platform = "darwin";
+  else if (raw.platform === "linux") platform = "linux";
+  else {
+    throw new Error(
+      `self-update is only supported on macOS and Linux (detected: ${raw.platform}).`,
+    );
+  }
+
+  let arch: Architecture;
+  if (raw.arch === "x64") arch = "x64";
+  else if (raw.arch === "arm64") arch = "arm64";
+  else {
+    throw new Error(`self-update is only supported on x64 and arm64 (detected: ${raw.arch}).`);
+  }
+
+  return { platform, arch };
+}
+
+export function assetName(info: PlatformInfo): string {
+  return `appstrate-${info.platform}-${info.arch}`;
+}
+
+export interface ReleaseUrls {
+  binary: string;
+  checksums: string;
+  checksumsSig: string;
+}
+
+/**
+ * Resolve the three URLs needed to install a given version of the CLI.
+ * Mirrors `scripts/bootstrap.sh` — keep them in lockstep so the install
+ * UX is identical whether the user is bootstrapping or self-updating.
+ */
+export function releaseUrls(version: string, info: PlatformInfo): ReleaseUrls {
+  const base =
+    version === "latest"
+      ? `${RELEASE_URL_BASE}/latest/download`
+      : `${RELEASE_URL_BASE}/download/v${version.replace(/^v/, "")}`;
+  const asset = assetName(info);
+  return {
+    binary: `${base}/${asset}`,
+    checksums: `${base}/checksums.txt`,
+    checksumsSig: `${base}/checksums.txt.minisig`,
+  };
+}
+
+/**
+ * Parse a `checksums.txt` line for the given asset and return its hex SHA-256.
+ *
+ * Same defensive validation as bootstrap.sh: the asset MUST be listed exactly
+ * once. Missing → tampering or broken release. Duplicated → could mask a
+ * mismatch. Hash format must be 64 hex chars (SHA-256). Anything else is rejected.
+ */
+export function parseChecksumLine(content: string, asset: string): string {
+  const lines = content
+    .split(/\r?\n/)
+    .map((l) => l.trim())
+    .filter(Boolean);
+  // Each line is `<hex>  <filename>` (sha256sum format) or `<hex> *<filename>` (binary mode).
+  const matches = lines.filter((line) => {
+    const parts = line.split(/\s+/);
+    if (parts.length !== 2) return false;
+    const file = (parts[1] ?? "").replace(/^\*/, "");
+    return file === asset;
+  });
+  if (matches.length === 0) {
+    throw new Error(
+      `Asset ${asset} is not listed in the signed checksums manifest. ` +
+        `This is either a broken release or tampering — refusing to install. ` +
+        `Report at https://github.com/appstrate/appstrate/issues`,
+    );
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Expected exactly one line for ${asset} in checksums.txt, got ${matches.length}. ` +
+        `Duplicate or malformed entries — refusing to install.`,
+    );
+  }
+  const firstLine = matches[0]!;
+  const hash = firstLine.split(/\s+/)[0] ?? "";
+  if (!/^[0-9a-f]{64}$/.test(hash)) {
+    throw new Error(
+      `Invalid SHA-256 in checksums.txt for ${asset}: "${hash}" is not 64 hex characters.`,
+    );
+  }
+  return hash;
+}
+
+/**
+ * Compare two semver-ish strings. Pure prefix-of-numeric-segments compare —
+ * good enough for the "current vs target" check in `self-update`, which only
+ * needs to know if they are equal. Pre-release suffixes (`1.0.0-alpha.5`)
+ * compare lexicographically after the numeric prefix, matching npm.
+ *
+ * Returns -1 if `a < b`, 0 if equal, 1 if `a > b`.
+ */
+export function compareSemver(a: string, b: string): number {
+  const split = (v: string): { numeric: [number, number, number]; pre: string } => {
+    const trimmed = v.replace(/^v/, "");
+    const [core, ...preParts] = trimmed.split("-");
+    const segments = (core ?? "").split(".").map((s) => Number.parseInt(s, 10) || 0);
+    return {
+      numeric: [segments[0] ?? 0, segments[1] ?? 0, segments[2] ?? 0],
+      pre: preParts.join("-"),
+    };
+  };
+  const A = split(a);
+  const B = split(b);
+  for (let i = 0; i < 3; i++) {
+    const ai = A.numeric[i]!;
+    const bi = B.numeric[i]!;
+    if (ai < bi) return -1;
+    if (ai > bi) return 1;
+  }
+  // Numeric-prefix tie. A pre-release is LOWER than a release (npm semver §11).
+  if (A.pre === "" && B.pre === "") return 0;
+  if (A.pre === "" && B.pre !== "") return 1;
+  if (A.pre !== "" && B.pre === "") return -1;
+  if (A.pre < B.pre) return -1;
+  if (A.pre > B.pre) return 1;
+  return 0;
+}
+
+/** Strip a leading `v` from a tag name. GitHub tags are `vX.Y.Z`; the CLI carries `X.Y.Z`. */
+export function normalizeVersion(raw: string): string {
+  return raw.replace(/^v/, "").trim();
+}
+
+export interface SelfUpdateDeps {
+  /** GET a URL and return the body as bytes. Throws on HTTP error. */
+  fetchBinary(url: string): Promise<Uint8Array>;
+  /** GET a URL and return the body as text. */
+  fetchText(url: string): Promise<string>;
+  /** Compute hex SHA-256 of bytes. */
+  sha256Hex(data: Uint8Array): Promise<string>;
+  /** Run a subprocess; same shape as `runCommand`. */
+  runCommand(cmd: string, args: string[]): Promise<CommandResult>;
+  /** `process.execPath` — the running binary path that gets atomic-renamed over. */
+  execPath(): string;
+  /**
+   * Atomically install `bytes` at `dest`. The default impl writes to a same-
+   * directory temp file, chmods +x, and `rename(2)`s on top of `dest`. Tests
+   * stub this entirely to avoid touching the real binary.
+   */
+  atomicReplace(bytes: Uint8Array, dest: string): Promise<void>;
+  /** Working directory for downloaded artefacts (binary + checksums + sig). */
+  makeWorkDir(): Promise<string>;
+  /** Cleanup helper. */
+  removeDir(path: string): Promise<void>;
+  /** Write a file (used in the work dir for minisign input). */
+  writeFile(path: string, data: Uint8Array | string): Promise<void>;
+}
+
+export const defaultSelfUpdateDeps: SelfUpdateDeps = {
+  async fetchBinary(url) {
+    const res = await fetch(url, {
+      headers: { "User-Agent": CLI_USER_AGENT },
+      redirect: "follow",
+    });
+    if (!res.ok) throw new Error(`GET ${url} → ${res.status} ${res.statusText}`);
+    return new Uint8Array(await res.arrayBuffer());
+  },
+  async fetchText(url) {
+    const res = await fetch(url, {
+      headers: { "User-Agent": CLI_USER_AGENT },
+      redirect: "follow",
+    });
+    if (!res.ok) throw new Error(`GET ${url} → ${res.status} ${res.statusText}`);
+    return res.text();
+  },
+  async sha256Hex(data) {
+    // Bun.CryptoHasher is available in the bundled binary (Bun runtime baked in).
+    const hasher = new Bun.CryptoHasher("sha256");
+    hasher.update(data);
+    return hasher.digest("hex");
+  },
+  runCommand,
+  execPath: () => process.execPath,
+  async atomicReplace(bytes, dest) {
+    // POSIX rename(2) on the same filesystem is atomic and works on the
+    // running binary: the kernel detaches the inode but keeps the open fd
+    // in this process valid. The temp file MUST live in the same dir as
+    // dest (same fs by construction).
+    const dir = dirname(dest);
+    await mkdir(dir, { recursive: true });
+    const stagedDir = await mkdtemp(`${dest}.staging.`);
+    try {
+      const staged = join(stagedDir, "appstrate.new");
+      await writeFile(staged, bytes);
+      await chmod(staged, 0o755);
+      await rename(staged, dest);
+    } finally {
+      // Best-effort cleanup. If rename succeeded the staging dir is empty;
+      // if it failed we still want the (possibly large) staged file gone.
+      await rm(stagedDir, { recursive: true, force: true }).catch(() => {});
+    }
+  },
+  makeWorkDir() {
+    return mkdtemp(join(tmpdir(), "appstrate-self-update-"));
+  },
+  removeDir(path) {
+    return rm(path, { recursive: true, force: true });
+  },
+  writeFile(path, data) {
+    return writeFile(path, data);
+  },
+};
+
+// Re-exported only for test introspection — production callers shouldn't need it.
+export const _internals = { stat };
+
+export interface ResolveTargetVersionDeps {
+  fetchText(url: string): Promise<string>;
+}
+
+/**
+ * Resolve the tag name to install. Defaults to `latest` (queries the GitHub
+ * Releases API), but accepts an explicit version (`1.2.3` or `v1.2.3`).
+ *
+ * The API call is cheap (one GET) and avoids the GitHub-issued redirect chain
+ * on `releases/latest/download/<asset>` which otherwise costs three round-trips
+ * per file (binary + checksums + sig = 9 redirects).
+ */
+export async function resolveTargetVersion(
+  requested: string | undefined,
+  deps: ResolveTargetVersionDeps,
+): Promise<string> {
+  if (requested) {
+    const v = normalizeVersion(requested);
+    if (!/^\d+\.\d+\.\d+/.test(v)) {
+      throw new Error(`Invalid version: "${requested}". Expected semver like 1.2.3 or v1.2.3.`);
+    }
+    return v;
+  }
+  const body = await deps.fetchText(LATEST_API_URL);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    throw new Error(`GitHub Releases API returned non-JSON; cannot determine latest version.`);
+  }
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    typeof (parsed as { tag_name?: unknown }).tag_name !== "string"
+  ) {
+    throw new Error(`GitHub Releases API response missing tag_name.`);
+  }
+  return normalizeVersion((parsed as { tag_name: string }).tag_name);
+}
+
+export interface PerformCurlUpdateOptions {
+  /** Resolved tag name without the `v` prefix, e.g. `1.2.3`. */
+  targetVersion: string;
+  /** Detected platform (also used for the asset name). */
+  platform: PlatformInfo;
+  /** When true, skip the equality check that returns "already up to date". */
+  force: boolean;
+  /** Current CLI version (defaults to bundled `CLI_VERSION`). */
+  currentVersion?: string;
+  /** Override deps for tests. */
+  deps?: SelfUpdateDeps;
+  /** Logger sink — defaults to `console.error` so tests can collect output. */
+  log?: (line: string) => void;
+}
+
+export interface PerformCurlUpdateResult {
+  /** `"updated"` when a binary was written; `"already-up-to-date"` when no-op. */
+  status: "updated" | "already-up-to-date";
+  /** Final installed version. */
+  version: string;
+  /** Destination path that was atomic-replaced (only when status === "updated"). */
+  destination?: string;
+}
+
+/**
+ * Curl-channel update implementation. Throws on any verification failure —
+ * the binary is never written unless minisign + SHA-256 both pass.
+ */
+export async function performCurlUpdate(
+  opts: PerformCurlUpdateOptions,
+): Promise<PerformCurlUpdateResult> {
+  const deps = opts.deps ?? defaultSelfUpdateDeps;
+  const log = opts.log ?? ((l) => console.error(l));
+  const current = opts.currentVersion ?? CLI_VERSION;
+  const target = opts.targetVersion;
+
+  if (current === DEV_CLI_VERSION) {
+    throw new Error(
+      `Cannot self-update a dev build (CLI_VERSION="${DEV_CLI_VERSION}"). ` +
+        `This binary was built from source, not from a release artefact. ` +
+        `Reinstall via curl -fsSL https://get.appstrate.dev | bash to switch to a release.`,
+    );
+  }
+
+  if (!opts.force && compareSemver(current, target) === 0) {
+    return { status: "already-up-to-date", version: current };
+  }
+
+  // Require minisign on PATH. Same UX as bootstrap.sh — fail closed; a
+  // signed-checksum check we can't perform is no check at all. The user
+  // already has a working `appstrate` binary; nothing breaks if we don't
+  // upgrade today.
+  const minisignProbe = await deps.runCommand("minisign", ["-v"]);
+  if (!minisignProbe.ok && minisignProbe.exitCode === -1) {
+    // `runCommand` returns exitCode -1 for ENOENT (cmd not found).
+    throw new Error(
+      [
+        "minisign is required to verify the Appstrate CLI update.",
+        "  → macOS:   brew install minisign",
+        "  → Debian:  sudo apt install minisign",
+        "  → Alpine:  apk add minisign",
+        "  → Other:   https://jedisct1.github.io/minisign/",
+      ].join("\n"),
+    );
+  }
+
+  const dest = deps.execPath();
+  const workDir = await deps.makeWorkDir();
+  try {
+    const urls = releaseUrls(target, opts.platform);
+    const asset = assetName(opts.platform);
+
+    log(`→ Downloading Appstrate CLI ${target} (${asset})`);
+    const [binary, checksumsTxt, checksumsSig] = await Promise.all([
+      deps.fetchBinary(urls.binary),
+      deps.fetchText(urls.checksums),
+      deps.fetchBinary(urls.checksumsSig),
+    ]);
+
+    const sumsPath = join(workDir, "checksums.txt");
+    const sigPath = join(workDir, "checksums.txt.minisig");
+    await deps.writeFile(sumsPath, checksumsTxt);
+    await deps.writeFile(sigPath, checksumsSig);
+
+    log(`→ Verifying signature against Appstrate release key`);
+    const sigCheck = await deps.runCommand("minisign", [
+      "-Vm",
+      sumsPath,
+      "-P",
+      APPSTRATE_MINISIGN_PUBKEY,
+    ]);
+    if (!sigCheck.ok) {
+      throw new Error(
+        `Signature verification FAILED. ` +
+          `The checksums manifest was NOT signed by the Appstrate key. ` +
+          `Refusing to install. Report at https://github.com/appstrate/appstrate/issues`,
+      );
+    }
+
+    log(`→ Verifying binary integrity (SHA-256)`);
+    const expected = parseChecksumLine(checksumsTxt, asset);
+    const actual = await deps.sha256Hex(binary);
+    if (actual !== expected) {
+      throw new Error(
+        `SHA-256 mismatch for ${asset}: expected ${expected}, got ${actual}. ` +
+          `The downloaded binary does NOT match the signed manifest. ` +
+          `This strongly suggests tampering — refusing to install.`,
+      );
+    }
+
+    log(`→ Installing ${asset} → ${dest}`);
+    await deps.atomicReplace(binary, dest);
+
+    return { status: "updated", version: target, destination: dest };
+  } finally {
+    await deps.removeDir(workDir).catch(() => {});
+  }
+}

--- a/apps/cli/test/install-source.test.ts
+++ b/apps/cli/test/install-source.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { INSTALL_SOURCE, INSTALL_SOURCES, upgradeHint } from "../src/lib/install-source.ts";
+
+/**
+ * Phase 1 — `__APPSTRATE_INSTALL_SOURCE__` build-time stamp (issue #249).
+ *
+ * Validates three layers:
+ *   1. `INSTALL_SOURCE` resolves to `"unknown"` in source/dev (no `--define`).
+ *   2. `bun build --define='__APPSTRATE_INSTALL_SOURCE__="curl"'` produces a
+ *      bundle whose `INSTALL_SOURCE` is `"curl"` at runtime.
+ *   3. Same for `"bun"`, and bogus values fall back to `"unknown"`.
+ *
+ * The build-time tests `bun build` a tiny probe that imports `INSTALL_SOURCE`
+ * and prints it, then `bun` the output. This is the same wiring used by
+ * `release.yml` (`bun build --compile`) and `apps/cli/scripts/build.ts`
+ * (`bun build` for npm), so a regression in either workflow surfaces here.
+ */
+
+describe("install-source", () => {
+  describe("dev / source build", () => {
+    it("resolves to 'unknown' when the identifier is not defined", () => {
+      // `bun test` runs source files directly without a `--define`, so the
+      // identifier is undefined and the typeof guard kicks in.
+      expect(INSTALL_SOURCE).toBe("unknown");
+    });
+
+    it("exposes the canonical channel list", () => {
+      expect(INSTALL_SOURCES).toEqual(["curl", "bun", "unknown"]);
+    });
+
+    it("returns a stable upgrade hint per channel", () => {
+      expect(upgradeHint("curl")).toContain("get.appstrate.dev");
+      expect(upgradeHint("bun")).toContain("bun update -g appstrate");
+      expect(upgradeHint("unknown")).toContain("appstrate");
+    });
+  });
+
+  describe("build-time substitution", () => {
+    async function buildAndRun(stampValue: string | null): Promise<string> {
+      const dir = await mkdtemp(join(tmpdir(), "appstrate-install-source-"));
+      try {
+        const probeSrc = join(dir, "probe.ts");
+        const probeOut = join(dir, "probe.js");
+        const installSourceSrc = await Bun.file(
+          join(import.meta.dir, "../src/lib/install-source.ts"),
+        ).text();
+        await writeFile(join(dir, "install-source.ts"), installSourceSrc);
+        await writeFile(
+          probeSrc,
+          `import { INSTALL_SOURCE } from "./install-source.ts";\nprocess.stdout.write(INSTALL_SOURCE);`,
+        );
+
+        const buildArgs = ["build", "--target=bun", "--outfile", probeOut, probeSrc];
+        if (stampValue !== null) {
+          buildArgs.push(`--define=__APPSTRATE_INSTALL_SOURCE__="${stampValue}"`);
+        }
+        const buildRes = spawnSync("bun", buildArgs, {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        if (buildRes.status !== 0) {
+          throw new Error(`bun build failed: ${buildRes.stderr}`);
+        }
+
+        const runRes = spawnSync("bun", [probeOut], {
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        if (runRes.status !== 0) {
+          throw new Error(`probe failed: ${runRes.stderr}`);
+        }
+        return runRes.stdout;
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    }
+
+    it("stamps 'curl' when --define='__APPSTRATE_INSTALL_SOURCE__=\"curl\"'", async () => {
+      const out = await buildAndRun("curl");
+      expect(out).toBe("curl");
+    });
+
+    it("stamps 'bun' when --define='__APPSTRATE_INSTALL_SOURCE__=\"bun\"'", async () => {
+      const out = await buildAndRun("bun");
+      expect(out).toBe("bun");
+    });
+
+    it("falls back to 'unknown' when no --define is provided", async () => {
+      const out = await buildAndRun(null);
+      expect(out).toBe("unknown");
+    });
+
+    it("falls back to 'unknown' for an unrecognised stamp value", async () => {
+      const out = await buildAndRun("brew");
+      expect(out).toBe("unknown");
+    });
+  });
+});

--- a/apps/cli/test/self-update.test.ts
+++ b/apps/cli/test/self-update.test.ts
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "bun:test";
+
+import {
+  assetName,
+  compareSemver,
+  detectPlatform,
+  normalizeVersion,
+  parseChecksumLine,
+  releaseUrls,
+  resolveTargetVersion,
+  type SelfUpdateDeps,
+} from "../src/lib/self-update.ts";
+import { runSelfUpdate, SELF_UPDATE_EXIT } from "../src/commands/self-update.ts";
+
+/**
+ * Phase 2 — `appstrate self-update` (issue #249).
+ *
+ * Pure helpers (parsing, asset/url derivation, semver compare) get exhaustive
+ * unit coverage. The full update flow is tested with a fake `SelfUpdateDeps`
+ * that records every call — no network, no minisign, no real binary touched.
+ */
+
+describe("detectPlatform", () => {
+  it("maps darwin/arm64 → { darwin, arm64 }", () => {
+    expect(detectPlatform({ platform: "darwin", arch: "arm64" })).toEqual({
+      platform: "darwin",
+      arch: "arm64",
+    });
+  });
+
+  it("maps linux/x64 → { linux, x64 }", () => {
+    expect(detectPlatform({ platform: "linux", arch: "x64" })).toEqual({
+      platform: "linux",
+      arch: "x64",
+    });
+  });
+
+  it("rejects win32", () => {
+    expect(() => detectPlatform({ platform: "win32", arch: "x64" })).toThrow(
+      /only supported on macOS and Linux/,
+    );
+  });
+
+  it("rejects unsupported arch", () => {
+    expect(() => detectPlatform({ platform: "linux", arch: "ia32" })).toThrow(
+      /only supported on x64 and arm64/,
+    );
+  });
+});
+
+describe("assetName + releaseUrls", () => {
+  it("builds the canonical asset name", () => {
+    expect(assetName({ platform: "linux", arch: "arm64" })).toBe("appstrate-linux-arm64");
+    expect(assetName({ platform: "darwin", arch: "x64" })).toBe("appstrate-darwin-x64");
+  });
+
+  it("builds /latest/download URLs when target is 'latest'", () => {
+    const urls = releaseUrls("latest", { platform: "linux", arch: "x64" });
+    expect(urls.binary).toBe(
+      "https://github.com/appstrate/appstrate/releases/latest/download/appstrate-linux-x64",
+    );
+    expect(urls.checksums).toBe(
+      "https://github.com/appstrate/appstrate/releases/latest/download/checksums.txt",
+    );
+    expect(urls.checksumsSig).toBe(
+      "https://github.com/appstrate/appstrate/releases/latest/download/checksums.txt.minisig",
+    );
+  });
+
+  it("builds /download/v<version>/ URLs for a pinned version", () => {
+    const urls = releaseUrls("1.2.3", { platform: "darwin", arch: "arm64" });
+    expect(urls.binary).toBe(
+      "https://github.com/appstrate/appstrate/releases/download/v1.2.3/appstrate-darwin-arm64",
+    );
+  });
+
+  it("does not double-prefix the v if the caller already passed v1.2.3", () => {
+    const urls = releaseUrls("v1.2.3", { platform: "darwin", arch: "arm64" });
+    expect(urls.binary).toBe(
+      "https://github.com/appstrate/appstrate/releases/download/v1.2.3/appstrate-darwin-arm64",
+    );
+  });
+});
+
+describe("parseChecksumLine", () => {
+  const goodHash = "a".repeat(64);
+  const otherHash = "b".repeat(64);
+
+  it("returns the hash for the matching asset", () => {
+    const txt = `${goodHash}  appstrate-linux-x64\n${otherHash}  appstrate-darwin-arm64\n`;
+    expect(parseChecksumLine(txt, "appstrate-linux-x64")).toBe(goodHash);
+  });
+
+  it("accepts the BSD `*<asset>` (binary mode) format", () => {
+    const txt = `${goodHash}  *appstrate-linux-x64\n`;
+    expect(parseChecksumLine(txt, "appstrate-linux-x64")).toBe(goodHash);
+  });
+
+  it("throws when the asset is missing", () => {
+    expect(() =>
+      parseChecksumLine(`${goodHash}  appstrate-darwin-x64\n`, "appstrate-linux-x64"),
+    ).toThrow(/not listed in the signed checksums manifest/);
+  });
+
+  it("throws when the asset appears more than once", () => {
+    const txt = `${goodHash}  appstrate-linux-x64\n${otherHash}  appstrate-linux-x64\n`;
+    expect(() => parseChecksumLine(txt, "appstrate-linux-x64")).toThrow(
+      /Expected exactly one line/,
+    );
+  });
+
+  it("throws when the hash is not 64 hex chars", () => {
+    const txt = `notahash  appstrate-linux-x64\n`;
+    expect(() => parseChecksumLine(txt, "appstrate-linux-x64")).toThrow(/not 64 hex characters/);
+  });
+});
+
+describe("compareSemver", () => {
+  it("orders 1.2.3 < 1.2.4", () => {
+    expect(compareSemver("1.2.3", "1.2.4")).toBe(-1);
+  });
+
+  it("orders 1.10.0 > 1.9.0 (numeric, not lexical)", () => {
+    expect(compareSemver("1.10.0", "1.9.0")).toBe(1);
+  });
+
+  it("treats v-prefixed and bare versions as equal", () => {
+    expect(compareSemver("v1.2.3", "1.2.3")).toBe(0);
+  });
+
+  it("orders pre-releases as lower than the same release", () => {
+    expect(compareSemver("1.0.0-alpha.5", "1.0.0")).toBe(-1);
+    expect(compareSemver("1.0.0", "1.0.0-alpha.5")).toBe(1);
+  });
+
+  it("orders alpha.5 < alpha.6 (lexical within numeric tie)", () => {
+    expect(compareSemver("1.0.0-alpha.5", "1.0.0-alpha.6")).toBe(-1);
+  });
+});
+
+describe("normalizeVersion", () => {
+  it("strips leading v", () => {
+    expect(normalizeVersion("v1.2.3")).toBe("1.2.3");
+  });
+  it("trims whitespace", () => {
+    expect(normalizeVersion("  1.2.3 \n")).toBe("1.2.3");
+  });
+});
+
+describe("resolveTargetVersion", () => {
+  it("returns the requested version stripped of v", async () => {
+    const out = await resolveTargetVersion("v1.4.0", {
+      fetchText: async () => "should not be called",
+    });
+    expect(out).toBe("1.4.0");
+  });
+
+  it("rejects a non-semver requested version", async () => {
+    await expect(
+      resolveTargetVersion("not-a-version", { fetchText: async () => "" }),
+    ).rejects.toThrow(/Invalid version/);
+  });
+
+  it("queries GitHub when no version is requested", async () => {
+    const calls: string[] = [];
+    const out = await resolveTargetVersion(undefined, {
+      fetchText: async (url) => {
+        calls.push(url);
+        return JSON.stringify({ tag_name: "v2.5.0" });
+      },
+    });
+    expect(out).toBe("2.5.0");
+    expect(calls).toEqual(["https://api.github.com/repos/appstrate/appstrate/releases/latest"]);
+  });
+
+  it("throws on malformed GitHub response", async () => {
+    await expect(
+      resolveTargetVersion(undefined, { fetchText: async () => "not json" }),
+    ).rejects.toThrow(/non-JSON/);
+    await expect(resolveTargetVersion(undefined, { fetchText: async () => "{}" })).rejects.toThrow(
+      /missing tag_name/,
+    );
+  });
+});
+
+// ─── runSelfUpdate (channel dispatch + curl flow) ──────────────────────────
+
+interface FakeDepsState {
+  binary: Uint8Array;
+  checksumsTxt: string;
+  checksumsSig: Uint8Array;
+  /** Hash returned by the fake sha256Hex — must match parseChecksumLine output for happy path. */
+  hashOverride?: string;
+  minisignAvailable: boolean;
+  minisignOk: boolean;
+  execPath: string;
+  /** Side effects collected for assertions. */
+  written: Array<{ path: string; bytes: number }>;
+  replaced: Array<{ dest: string; bytes: number }>;
+  fetched: string[];
+  commands: Array<{ cmd: string; args: string[] }>;
+}
+
+function makeFakeDeps(state: FakeDepsState): SelfUpdateDeps {
+  return {
+    async fetchBinary(url) {
+      state.fetched.push(url);
+      if (url.endsWith(".minisig")) return state.checksumsSig;
+      return state.binary;
+    },
+    async fetchText(url) {
+      state.fetched.push(url);
+      return state.checksumsTxt;
+    },
+    async sha256Hex(data) {
+      // Either return the override (used to simulate mismatch) or produce a deterministic hash.
+      if (state.hashOverride) return state.hashOverride;
+      // Sum bytes for a stable, content-dependent fake hash. Tests inject the
+      // matching value into checksumsTxt so the round-trip succeeds.
+      let n = 0;
+      for (const b of data) n = (n + b) | 0;
+      return `${"f".repeat(60)}${(n & 0xffff).toString(16).padStart(4, "0")}`;
+    },
+    async runCommand(cmd, args) {
+      state.commands.push({ cmd, args });
+      if (cmd === "minisign") {
+        if (!state.minisignAvailable) {
+          return { ok: false, exitCode: -1, stdout: "", stderr: "ENOENT" };
+        }
+        return state.minisignOk
+          ? { ok: true, exitCode: 0, stdout: "Signature OK", stderr: "" }
+          : { ok: false, exitCode: 1, stdout: "", stderr: "BAD SIG" };
+      }
+      return { ok: true, exitCode: 0, stdout: "", stderr: "" };
+    },
+    execPath: () => state.execPath,
+    async atomicReplace(bytes, dest) {
+      state.replaced.push({ dest, bytes: bytes.byteLength });
+    },
+    async makeWorkDir() {
+      return "/tmp/fake-work";
+    },
+    async removeDir() {
+      // no-op
+    },
+    async writeFile(path, data) {
+      state.written.push({
+        path,
+        bytes: typeof data === "string" ? data.length : data.byteLength,
+      });
+    },
+  };
+}
+
+describe("runSelfUpdate — channel dispatch", () => {
+  it("rejects bun source with an actionable npm hint", async () => {
+    const out = await runSelfUpdate({ source: "bun" });
+    expect(out.exitCode).toBe(SELF_UPDATE_EXIT.WRONG_CHANNEL);
+    expect(out.message).toContain("npm channel");
+    expect(out.message).toContain("bun update -g appstrate");
+  });
+
+  it("rejects unknown source with a diagnostic", async () => {
+    const out = await runSelfUpdate({
+      source: "unknown",
+      deps: makeFakeDeps({
+        binary: new Uint8Array(),
+        checksumsTxt: "",
+        checksumsSig: new Uint8Array(),
+        minisignAvailable: true,
+        minisignOk: true,
+        execPath: "/usr/local/bin/appstrate",
+        written: [],
+        replaced: [],
+        fetched: [],
+        commands: [],
+      }),
+    });
+    expect(out.exitCode).toBe(SELF_UPDATE_EXIT.UNKNOWN_SOURCE);
+    expect(out.message).toContain("install-source stamp");
+    expect(out.message).toContain("/usr/local/bin/appstrate");
+  });
+});
+
+describe("runSelfUpdate — curl flow", () => {
+  function freshState(overrides: Partial<FakeDepsState> = {}): FakeDepsState {
+    const binary = new Uint8Array([1, 2, 3, 4, 5]);
+    // Match the fake sha256 algorithm: sum bytes mod 0xffff.
+    const sum = binary.reduce((a, b) => (a + b) | 0, 0) & 0xffff;
+    const fakeHash = `${"f".repeat(60)}${sum.toString(16).padStart(4, "0")}`;
+    return {
+      binary,
+      checksumsTxt: `${fakeHash}  appstrate-linux-x64\n`,
+      checksumsSig: new Uint8Array([0xde, 0xad]),
+      minisignAvailable: true,
+      minisignOk: true,
+      execPath: "/home/user/.local/bin/appstrate",
+      written: [],
+      replaced: [],
+      fetched: [],
+      commands: [],
+      ...overrides,
+    };
+  }
+
+  it("downloads, verifies and atomic-replaces on a real version", async () => {
+    const state = freshState();
+    const out = await runSelfUpdate({
+      source: "curl",
+      platform: { platform: "linux", arch: "x64" },
+      log: () => {},
+      version: "1.2.3",
+      currentVersion: "1.0.0",
+      deps: makeFakeDeps(state),
+    });
+
+    expect(out.exitCode).toBe(SELF_UPDATE_EXIT.OK);
+    expect(out.message).toContain("Updated appstrate to 1.2.3");
+    expect(state.fetched).toEqual([
+      "https://github.com/appstrate/appstrate/releases/download/v1.2.3/appstrate-linux-x64",
+      "https://github.com/appstrate/appstrate/releases/download/v1.2.3/checksums.txt",
+      "https://github.com/appstrate/appstrate/releases/download/v1.2.3/checksums.txt.minisig",
+    ]);
+    expect(state.commands.find((c) => c.cmd === "minisign" && c.args[0] === "-Vm")).toBeTruthy();
+    expect(state.replaced).toEqual([{ dest: "/home/user/.local/bin/appstrate", bytes: 5 }]);
+  });
+
+  it("reports already-up-to-date and skips replace when versions match", async () => {
+    const state = freshState();
+    const out = await runSelfUpdate({
+      source: "curl",
+      platform: { platform: "linux", arch: "x64" },
+      log: () => {},
+      version: "1.2.3",
+      currentVersion: "1.2.3",
+      deps: makeFakeDeps(state),
+    });
+    expect(out.exitCode).toBe(SELF_UPDATE_EXIT.OK);
+    expect(out.message).toMatch(/Already on appstrate 1\.2\.3/);
+    expect(state.replaced).toEqual([]);
+  });
+
+  it("--force reinstalls even when versions match", async () => {
+    const state = freshState();
+    const out = await runSelfUpdate({
+      source: "curl",
+      platform: { platform: "linux", arch: "x64" },
+      log: () => {},
+      version: "1.2.3",
+      currentVersion: "1.2.3",
+      force: true,
+      deps: makeFakeDeps(state),
+    });
+    expect(out.exitCode).toBe(SELF_UPDATE_EXIT.OK);
+    expect(out.message).toContain("Updated appstrate to 1.2.3");
+    expect(state.replaced).toHaveLength(1);
+  });
+
+  it("fails closed when minisign is missing", async () => {
+    const state = freshState({ minisignAvailable: false });
+    const out = await runSelfUpdate({
+      source: "curl",
+      platform: { platform: "linux", arch: "x64" },
+      log: () => {},
+      version: "1.2.3",
+      currentVersion: "1.0.0",
+      deps: makeFakeDeps(state),
+    });
+    expect(out.exitCode).toBe(SELF_UPDATE_EXIT.UPDATE_FAILED);
+    expect(out.message).toContain("minisign is required");
+    expect(state.replaced).toEqual([]);
+  });
+
+  it("fails closed when minisign reports a bad signature", async () => {
+    const state = freshState({ minisignOk: false });
+    const out = await runSelfUpdate({
+      source: "curl",
+      platform: { platform: "linux", arch: "x64" },
+      log: () => {},
+      version: "1.2.3",
+      currentVersion: "1.0.0",
+      deps: makeFakeDeps(state),
+    });
+    expect(out.exitCode).toBe(SELF_UPDATE_EXIT.UPDATE_FAILED);
+    expect(out.message).toContain("Signature verification FAILED");
+    expect(state.replaced).toEqual([]);
+  });
+
+  it("fails closed when SHA-256 does not match", async () => {
+    const state = freshState({ hashOverride: "0".repeat(64) });
+    const out = await runSelfUpdate({
+      source: "curl",
+      platform: { platform: "linux", arch: "x64" },
+      log: () => {},
+      version: "1.2.3",
+      currentVersion: "1.0.0",
+      deps: makeFakeDeps(state),
+    });
+    expect(out.exitCode).toBe(SELF_UPDATE_EXIT.UPDATE_FAILED);
+    expect(out.message).toContain("SHA-256 mismatch");
+    expect(state.replaced).toEqual([]);
+  });
+
+  it("blocks self-update on a dev build (CLI_VERSION === 0.0.0)", async () => {
+    const state = freshState();
+    const out = await runSelfUpdate({
+      source: "curl",
+      platform: { platform: "linux", arch: "x64" },
+      log: () => {},
+      version: "1.2.3",
+      currentVersion: "0.0.0",
+      deps: makeFakeDeps(state),
+    });
+    expect(out.exitCode).toBe(SELF_UPDATE_EXIT.UPDATE_FAILED);
+    expect(out.message).toContain("dev build");
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 of #249. Adds `appstrate self-update` with channel-aware dispatch on the build-time `INSTALL_SOURCE` stamp from #258 (phase 1).

## Channel behavior

| Source | Action |
|---|---|
| `curl` | Download release asset + signed checksums + minisign sig, verify, atomic-rename over `process.execPath`. |
| `bun` | Exit 1 with `bun update -g appstrate` hint — npm owns the binary. |
| `unknown` | Exit 1 with diagnostic (`process.execPath`, `CLI_VERSION`) and reinstall hint. |

The curl path mirrors `scripts/bootstrap.sh` exactly: same minisign pubkey, same checksum line parsing, same fail-closed posture (no minisign on PATH → refuse). All verification happens before any file is touched at the destination.

## Files

- `apps/cli/src/lib/self-update.ts` — pure helpers (`detectPlatform`, `assetName`, `releaseUrls`, `parseChecksumLine`, `compareSemver`, `resolveTargetVersion`) + injectable I/O via `SelfUpdateDeps` + `performCurlUpdate`.
- `apps/cli/src/commands/self-update.ts` — channel dispatch + `runSelfUpdate` entry (returns exit code + message; no `process.exit` so tests can assert).
- `apps/cli/src/cli.ts` — register `self-update` with `--release <version>` and `-f, --force`.
- `apps/cli/test/self-update.test.ts` — 33 tests, no network, no minisign, no real binary touched.

## Notes for review

- Renamed the option `--release` instead of `--version` to avoid colliding visually with the global `--version` flag.
- Atomic replace stages a temp file in the same directory as `process.execPath` and `rename(2)`s on top — POSIX guarantees atomicity on the same filesystem and the running text segment stays paged from the original inode.
- Built on top of #258 — that PR must merge first.

## Test plan
- [x] `bun test apps/cli/test/self-update.test.ts` — 33 pass
- [x] `bun test` (apps/cli) — 750 pass total (33 new)
- [x] `bun run check` — all green
- [x] `bun src/cli.ts self-update --help` — option list renders
- [x] `bun src/cli.ts self-update --release 1.0.0` from source → exits with the unknown-source diagnostic

🤖 Generated with [Claude Code](https://claude.com/claude-code)