### PR TITLE
feat(sidecar): raise default response cap to 256 KB + document binary contract

### DIFF
--- a/runtime-pi/sidecar/README.md
+++ b/runtime-pi/sidecar/README.md
@@ -1,0 +1,48 @@
+# Sidecar — credential-isolating HTTP proxy
+
+A small Hono server that runs in its own Docker container alongside every Appstrate agent run. The agent container talks to the sidecar over the run's private bridge network; the sidecar holds the credentials, talks to upstream provider APIs, and returns the response bytes back to the agent.
+
+The agent container has no platform credentials, no access to `host.docker.internal`, and no `SIDECAR_URL` env var after bootstrap (Phase 2e). All sidecar-backed capabilities are exposed to the agent LLM as typed Pi tools — never as a bare URL.
+
+## Endpoints
+
+- `GET /health` — Readiness check. Returns 200 when the forward proxy is ready, 503 (`{ status: "degraded" }`) otherwise.
+- `POST /configure` — One-time runtime configuration for pool-pre-warmed sidecars (`runToken`, `platformApiUrl`, `proxyUrl`, optional `llm`). Authenticated via `Bearer ${CONFIG_SECRET}` and locked after first use. Permanently locked when the sidecar was started fresh with `RUN_TOKEN` already in the environment.
+- `ALL /proxy` — The credential-injecting transparent proxy. Routes via `X-Provider` + `X-Target` headers, validates the resolved URL against the provider's `authorizedUris`, applies SSRF blocklist, injects the credential header server-side, and forwards bytes both ways.
+- `ALL /llm/*` — LLM reverse proxy for the agent's model calls. Replaces the SDK's placeholder API key with the real key, streams the response zero-copy.
+- `GET /run-history` — Thin pass-through to the platform's `/internal/run-history` (authorized via `RUN_TOKEN`).
+
+## Binary safety
+
+`/proxy` reads the request body as `c.req.arrayBuffer()` and returns the upstream body via `targetRes.arrayBuffer()`. Both directions are byte-exact — no `.text()` decode, no UTF-8 round-trip, no implicit Content-Type rewriting. This was originally regressed in #149 and re-fixed in #151; the binary roundtrip suite in `test/app.test.ts` (`describe("binary roundtrip via /proxy")`) pins the contract end-to-end.
+
+The only path that decodes the request body to UTF-8 is the optional `X-Substitute-Body: true` header, which performs `{{variable}}` placeholder substitution. Without that header, the body is forwarded as raw bytes.
+
+## Size limits
+
+| Constant                     | Value  | Header override       | Purpose                                                          |
+| ---------------------------- | ------ | --------------------- | ---------------------------------------------------------------- |
+| `MAX_RESPONSE_SIZE`          | 256 KB | `X-Max-Response-Size` | Default cap on upstream response bytes returned to the agent.    |
+| `ABSOLUTE_MAX_RESPONSE_SIZE` | 1 MB   | (hard cap)            | Ceiling on `X-Max-Response-Size` regardless of header value.     |
+| `MAX_SUBSTITUTE_BODY_SIZE`   | 5 MB   | —                     | Maximum request body size accepted by `/proxy` (413 above).      |
+| `OUTBOUND_TIMEOUT_MS`        | 30 s   | —                     | Upstream `/proxy` request timeout.                               |
+| `LLM_PROXY_TIMEOUT_MS`       | 5 min  | —                     | `/llm/*` request timeout (long enough for streamed completions). |
+
+When the upstream response exceeds the effective cap, the sidecar returns the prefix and sets `X-Truncated: true`. Agents that legitimately need larger payloads should opt in via `responseMode.toFile` on the AFPS provider tool — the runtime resolver then sends a higher `X-Max-Response-Size` (capped at 1 MB) and spills the bytes to the workspace instead of inlining them into the model context.
+
+## The `body.fromFile` contract
+
+The AFPS provider tool exposes `body.fromFile` so agents can upload workspace files without ever having to base64-encode them into a JSON tool argument. **The sidecar has no workspace mount and no knowledge of `fromFile`** — that contract is purely runtime-side:
+
+1. The agent calls the provider tool with `{ body: { fromFile: "report.pdf" } }`.
+2. The AFPS resolver in `packages/afps-runtime/src/resolvers/provider-tool.ts` reads the workspace bytes locally.
+3. The resolver POSTs the raw bytes to `/proxy` as the request body, with the appropriate `Content-Type` and `X-Provider` / `X-Target` headers.
+4. The sidecar sees only bytes — by design.
+
+The download counterpart (`responseMode.toFile`) is the same in reverse: the resolver requests a higher `X-Max-Response-Size`, reads the response bytes, and writes them to the workspace before handing a `{ savedTo, byteLength }` summary back to the agent.
+
+## What lives outside this README
+
+- The resolver-side contract — file resolution, `responseMode` logic, `byteLength` thresholds — is documented next to the code in [`packages/afps-runtime/src/resolvers/provider-tool.ts`](../../packages/afps-runtime/src/resolvers/provider-tool.ts).
+- Sidecar pool lifecycle, network isolation, parallel container startup, and credential reporting paths are documented in the platform-level [`CLAUDE.md`](../../CLAUDE.md) under "Sidecar Protocol".
+- Provider auth modes (`oauth2` / `oauth1` / `api_key` / `basic` / `custom`) and the `credentialHeaderName` / `credentialHeaderPrefix` injection contract live in `@appstrate/connect`.

--- a/runtime-pi/sidecar/helpers.ts
+++ b/runtime-pi/sidecar/helpers.ts
@@ -14,8 +14,15 @@ export { isBlockedHost, isBlockedUrl } from "./ssrf.ts";
 // Accepts both simple IDs (gmail) and scoped IDs (@appstrate/gmail)
 export const PROVIDER_ID_RE = /^(@[a-z0-9][a-z0-9-]*\/)?[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
 
-export const MAX_RESPONSE_SIZE = 50_000;
-export const ABSOLUTE_MAX_RESPONSE_SIZE = 1_000_000; // 1MB
+// Default cap on upstream response bytes returned through `/proxy`. Set
+// generously enough that typical provider responses (Drive metadata
+// listings, Gmail thread snippets, paginated payloads) round-trip
+// untruncated. Agents that legitimately need to pull larger blobs opt
+// in via `responseMode.toFile` on the AFPS provider tool, which causes
+// the runtime to spill bytes to the workspace and request a higher
+// `X-Max-Response-Size` (capped at `ABSOLUTE_MAX_RESPONSE_SIZE`).
+export const MAX_RESPONSE_SIZE = 256 * 1024; // 256 KB
+export const ABSOLUTE_MAX_RESPONSE_SIZE = 1_000_000; // 1MB — hard cap, even when X-Max-Response-Size is larger
 export const OUTBOUND_TIMEOUT_MS = 30_000;
 export const MAX_SUBSTITUTE_BODY_SIZE = 5 * 1024 * 1024; // 5MB
 export const LLM_PROXY_TIMEOUT_MS = 300_000; // 5 minutes

--- a/runtime-pi/sidecar/test/app.test.ts
+++ b/runtime-pi/sidecar/test/app.test.ts
@@ -528,7 +528,7 @@ describe("ALL /proxy — forwarding", () => {
   });
 
   it("truncates response over MAX_RESPONSE_SIZE", async () => {
-    const largeBody = "x".repeat(60_000);
+    const largeBody = "x".repeat(300_000); // > 256 KB default
     const fetchFn = mock(
       async () =>
         new Response(largeBody, {
@@ -547,11 +547,11 @@ describe("ALL /proxy — forwarding", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("X-Truncated")).toBe("true");
     const text = await res.text();
-    expect(text.length).toBe(50_000);
+    expect(text.length).toBe(256 * 1024);
   });
 
   it("X-Max-Response-Size increases the truncation limit", async () => {
-    const largeBody = "x".repeat(100_000);
+    const largeBody = "x".repeat(300_000); // > 256 KB default, < 400_000 cap
     const fetchFn = mock(
       async () =>
         new Response(largeBody, {
@@ -565,13 +565,13 @@ describe("ALL /proxy — forwarding", () => {
       headers: {
         "X-Provider": "gmail",
         "X-Target": "https://api.example.com/v1/large",
-        "X-Max-Response-Size": "200000",
+        "X-Max-Response-Size": "400000",
       },
     });
     expect(res.status).toBe(200);
     expect(res.headers.get("X-Truncated")).toBeNull();
     const text = await res.text();
-    expect(text.length).toBe(100_000);
+    expect(text.length).toBe(300_000);
   });
 
   it("X-Max-Response-Size is capped at ABSOLUTE_MAX_RESPONSE_SIZE", async () => {
@@ -598,8 +598,34 @@ describe("ALL /proxy — forwarding", () => {
     expect(text.length).toBe(1_000_000);
   });
 
+  it("X-Max-Response-Size = ABSOLUTE_MAX_RESPONSE_SIZE returns 600 KB payload untruncated", async () => {
+    // Round-trip a 600 KB payload with the explicit cap exactly at the
+    // sidecar's absolute ceiling: under cap → full body, no X-Truncated.
+    const largeBody = "x".repeat(600_000);
+    const fetchFn = mock(
+      async () =>
+        new Response(largeBody, {
+          status: 200,
+          headers: { "Content-Type": "text/plain" },
+        }),
+    );
+    const app = createApp(makeDeps({ fetchFn }));
+    const res = await app.request("/proxy", {
+      method: "GET",
+      headers: {
+        "X-Provider": "gmail",
+        "X-Target": "https://api.example.com/v1/large",
+        "X-Max-Response-Size": "1000000",
+      },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Truncated")).toBeNull();
+    const text = await res.text();
+    expect(text.length).toBe(600_000);
+  });
+
   it("invalid X-Max-Response-Size falls back to default", async () => {
-    const largeBody = "x".repeat(60_000);
+    const largeBody = "x".repeat(300_000); // > 256 KB default
     const fetchFn = mock(
       async () =>
         new Response(largeBody, {
@@ -619,7 +645,7 @@ describe("ALL /proxy — forwarding", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("X-Truncated")).toBe("true");
     const text = await res.text();
-    expect(text.length).toBe(50_000);
+    expect(text.length).toBe(256 * 1024);
   });
 
   it("stores Set-Cookie headers in cookie jar", async () => {
@@ -1090,8 +1116,10 @@ describe("ALL /proxy — binary body integrity", () => {
   });
 
   it("does not corrupt binary response even when truncation is triggered", async () => {
-    // 60KB binary payload beyond MAX_RESPONSE_SIZE; first 50KB must survive byte-for-byte.
-    const total = 60_000;
+    // 300 KB binary payload beyond the 256 KB default; the first 256 KB
+    // must survive byte-for-byte.
+    const total = 300_000;
+    const cap = 256 * 1024;
     const payload = new Uint8Array(total);
     for (let i = 0; i < total; i++) {
       payload[i] = i % 256; // includes all byte values 0x00–0xff
@@ -1116,10 +1144,10 @@ describe("ALL /proxy — binary body integrity", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("X-Truncated")).toBe("true");
     const received = new Uint8Array(await res.arrayBuffer());
-    expect(received.byteLength).toBe(50_000);
+    expect(received.byteLength).toBe(cap);
     expect(received[0]).toBe(0x00);
     expect(received[0xff]).toBe(0xff);
-    expect(received[49_999]).toBe(49_999 % 256);
+    expect(received[cap - 1]).toBe((cap - 1) % 256);
   });
 });
 

--- a/runtime-pi/sidecar/test/app.test.ts
+++ b/runtime-pi/sidecar/test/app.test.ts
@@ -1151,6 +1151,192 @@ describe("ALL /proxy — binary body integrity", () => {
   });
 });
 
+// --- binary roundtrip via /proxy ---
+//
+// End-to-end coverage of the `/proxy` byte path: the sidecar must
+// preserve request and response bytes byte-for-byte (no UTF-8 decode,
+// no `.text()` round-trip), respect the default 256 KB response cap,
+// and honour `X-Max-Response-Size` up to ABSOLUTE_MAX_RESPONSE_SIZE.
+// These tests pin the contract that the AFPS resolver in
+// `packages/afps-runtime/src/resolvers/provider-tool.ts` depends on
+// for binary upload/download (issues #149, #151, PR #260).
+
+/** Deterministic pseudo-random byte stream — mulberry32 seeded PRNG. */
+function makePseudoRandomBytes(size: number, seed = 0xc0_fe_ba_be): Uint8Array {
+  const buf = new Uint8Array(size);
+  let s = seed >>> 0;
+  for (let i = 0; i < size; i++) {
+    // mulberry32
+    s = (s + 0x6d_2b_79_f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    buf[i] = ((t ^ (t >>> 14)) >>> 0) & 0xff;
+  }
+  return buf;
+}
+
+function sha256Hex(bytes: Uint8Array | ArrayBuffer): string {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(bytes);
+  return hasher.digest("hex");
+}
+
+describe("binary roundtrip via /proxy", () => {
+  it("upload: request body reaches upstream byte-for-byte", async () => {
+    const payload = makePseudoRandomBytes(60_000, 0xa1_b2_c3_d4);
+    const expectedHash = sha256Hex(payload);
+
+    let capturedHash: string | null = null;
+    let capturedLength = 0;
+    const fetchFn = mock(async (_url: string, init: RequestInit) => {
+      const body = init.body;
+      // The proxy passes ArrayBuffer through buildBody() unchanged.
+      if (body instanceof ArrayBuffer) {
+        capturedLength = body.byteLength;
+        capturedHash = sha256Hex(body);
+      } else if (body instanceof Uint8Array) {
+        capturedLength = body.byteLength;
+        capturedHash = sha256Hex(body);
+      } else {
+        throw new Error(`unexpected body type: ${typeof body}`);
+      }
+      return new Response("ok", { status: 200, headers: { "Content-Type": "text/plain" } });
+    });
+
+    const app = createApp(makeDeps({ fetchFn }));
+    const res = await app.request("/proxy", {
+      method: "POST",
+      headers: {
+        "X-Provider": "gmail",
+        "X-Target": "https://api.example.com/v1/upload",
+        "Content-Type": "application/octet-stream",
+      },
+      body: payload,
+    });
+
+    expect(res.status).toBe(200);
+    expect(capturedLength).toBe(payload.byteLength);
+    expect(capturedHash).toBe(expectedHash);
+  });
+
+  it("download: response body returned byte-for-byte under default cap", async () => {
+    const payload = makePseudoRandomBytes(60_000, 0xde_ad_be_ef);
+    const expectedHash = sha256Hex(payload);
+
+    const fetchFn = mock(
+      async () =>
+        new Response(payload, {
+          status: 200,
+          headers: { "Content-Type": "application/octet-stream" },
+        }),
+    );
+
+    const app = createApp(makeDeps({ fetchFn }));
+    const res = await app.request("/proxy", {
+      method: "GET",
+      headers: {
+        "X-Provider": "gmail",
+        "X-Target": "https://api.example.com/v1/download",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Truncated")).toBeNull();
+    const received = new Uint8Array(await res.arrayBuffer());
+    expect(received.byteLength).toBe(payload.byteLength);
+    expect(sha256Hex(received)).toBe(expectedHash);
+  });
+
+  it("download: 400 KB upstream truncated to 256 KB default with X-Truncated", async () => {
+    const cap = 256 * 1024;
+    const payload = makePseudoRandomBytes(400_000, 0x12_34_56_78);
+    const expectedPrefixHash = sha256Hex(payload.subarray(0, cap));
+
+    const fetchFn = mock(
+      async () =>
+        new Response(payload, {
+          status: 200,
+          headers: { "Content-Type": "application/octet-stream" },
+        }),
+    );
+
+    const app = createApp(makeDeps({ fetchFn }));
+    const res = await app.request("/proxy", {
+      method: "GET",
+      headers: {
+        "X-Provider": "gmail",
+        "X-Target": "https://api.example.com/v1/large",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Truncated")).toBe("true");
+    const received = new Uint8Array(await res.arrayBuffer());
+    expect(received.byteLength).toBe(cap);
+    expect(sha256Hex(received)).toBe(expectedPrefixHash);
+  });
+
+  it("download: X-Max-Response-Size=1_000_000 returns 600 KB untruncated", async () => {
+    const payload = makePseudoRandomBytes(600_000, 0x9a_bc_de_f0);
+    const expectedHash = sha256Hex(payload);
+
+    const fetchFn = mock(
+      async () =>
+        new Response(payload, {
+          status: 200,
+          headers: { "Content-Type": "application/octet-stream" },
+        }),
+    );
+
+    const app = createApp(makeDeps({ fetchFn }));
+    const res = await app.request("/proxy", {
+      method: "GET",
+      headers: {
+        "X-Provider": "gmail",
+        "X-Target": "https://api.example.com/v1/largebin",
+        "X-Max-Response-Size": "1000000",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Truncated")).toBeNull();
+    const received = new Uint8Array(await res.arrayBuffer());
+    expect(received.byteLength).toBe(payload.byteLength);
+    expect(sha256Hex(received)).toBe(expectedHash);
+  });
+
+  it("download: X-Max-Response-Size=5_000_000 caps at 1 MB with truncation", async () => {
+    const absoluteCap = 1_000_000;
+    const payload = makePseudoRandomBytes(1_500_000, 0x55_aa_55_aa);
+    const expectedPrefixHash = sha256Hex(payload.subarray(0, absoluteCap));
+
+    const fetchFn = mock(
+      async () =>
+        new Response(payload, {
+          status: 200,
+          headers: { "Content-Type": "application/octet-stream" },
+        }),
+    );
+
+    const app = createApp(makeDeps({ fetchFn }));
+    const res = await app.request("/proxy", {
+      method: "GET",
+      headers: {
+        "X-Provider": "gmail",
+        "X-Target": "https://api.example.com/v1/huge",
+        "X-Max-Response-Size": "5000000",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Truncated")).toBe("true");
+    const received = new Uint8Array(await res.arrayBuffer());
+    expect(received.byteLength).toBe(absoluteCap);
+    expect(sha256Hex(received)).toBe(expectedPrefixHash);
+  });
+});
+
 // --- ALL /llm/* — LLM reverse proxy ---
 
 const LLM_CONFIG: LlmProxyConfig = {

--- a/runtime-pi/sidecar/test/helpers.test.ts
+++ b/runtime-pi/sidecar/test/helpers.test.ts
@@ -16,8 +16,8 @@ import {
 // --- Constants ---
 
 describe("constants", () => {
-  it("MAX_RESPONSE_SIZE is 50_000", () => {
-    expect(MAX_RESPONSE_SIZE).toBe(50_000);
+  it("MAX_RESPONSE_SIZE is 256 KB", () => {
+    expect(MAX_RESPONSE_SIZE).toBe(256 * 1024);
   });
 
   it("ABSOLUTE_MAX_RESPONSE_SIZE is 1_000_000", () => {


### PR DESCRIPTION
## Summary

- Bump sidecar `MAX_RESPONSE_SIZE` from 50 KB to **256 KB** in `runtime-pi/sidecar/helpers.ts`. Keep `ABSOLUTE_MAX_RESPONSE_SIZE = 1 MB` and `MAX_SUBSTITUTE_BODY_SIZE = 5 MB` unchanged.
- Pin the binary `/proxy` byte-level contract with a new `describe("binary roundtrip via /proxy")` block (5 tests: upload sha256 match, download sha256 match, default-cap truncation, explicit cap under absolute, explicit cap above absolute capped at 1 MB).
- Add a focused `runtime-pi/sidecar/README.md` documenting endpoints, the binary safety contract (no `.text()`, byte-exact both ways), the size-limits table, the runtime-side `body.fromFile` contract, and pointers to the resolver-side documentation.
- Realign the existing truncation tests in `app.test.ts` and `helpers.test.ts` with the new default (payloads bumped above 256 KB so the same code paths still fire).

## Why

The 50 KB default was set when the sidecar was the agent's only sink for upstream bytes. Once PR #260 (still open) introduced `responseMode.toFile` and auto-spill semantics in the AFPS resolver (`packages/afps-runtime/src/resolvers/`), the practical effect of the 50 KB default became "many provider responses get truncated for no good reason" — Drive metadata listings, Gmail thread snippets, paginated payloads. 256 KB is generous enough that typical responses round-trip untruncated; agents that legitimately need larger blobs continue to opt in via `responseMode.toFile`, which raises `X-Max-Response-Size` up to the absolute 1 MB cap.

The body-handling logic itself (use `arrayBuffer()` both ways) is unchanged — that fix landed in #149 / #151 and the new binary roundtrip suite pins it end-to-end.

## Series

This is **PR-2 of a 4-PR series** restoring binary upload/download parity:

- **PR-1 (#260, open)**: AFPS resolver — `responseMode.toFile` + auto-spill on the runtime side.
- **PR-2 (this)**: Sidecar default cap + contract tests + README.
- **PR-3**: System prompt updates exposing the new response-mode options to the agent + web viewer affordances.
- **PR-4**: Streaming response support.

PR-2 is independent of PR-1's branch — based on `main` (HEAD `ec9c02cb`) — and ships in `runtime-pi/sidecar/` only.

## Test plan

- [x] `bun test runtime-pi/sidecar` — 158 pass, 0 fail (5 new tests in the binary roundtrip block, 4 existing tests realigned).
- [x] `bun run check` from repo root — all 17 tasks succeed (typecheck, lint, prettier, OpenAPI verification, system-package validation).
- [ ] Manual: drive a real Gmail thread listing through `/proxy` against a development sidecar and confirm responses ≤ 256 KB are no longer truncated.
- [ ] Manual: drive a `responseMode.toFile` provider call with a 600 KB upstream payload and confirm `X-Truncated` is not set and the workspace file matches the upstream sha256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)