### PR TITLE
feat(installer): dual-install pre-check in bootstrap.sh (#249 phase 4)

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -463,6 +463,82 @@ jobs:
           echo "::endgroup::"
           echo "✓ empty-manifest path OK"
 
+          # ── Scenario 8a: dual-install pre-check (issue #249) ─────────
+          # When `appstrate` already exists on PATH at a different path
+          # than $DEST, bootstrap MUST refuse non-interactively (CI=true).
+          # APPSTRATE_FORCE_DUAL=1 must override.
+          echo "::group::dual-install pre-check"
+          mkdir -p "$GITHUB_WORKSPACE/bin-existing"
+          # Plant a fake existing appstrate in a directory that will appear
+          # on PATH BEFORE the install destination, so command -v finds it.
+          cat > "$GITHUB_WORKSPACE/bin-existing/appstrate" <<'EXISTING'
+          #!/usr/bin/env bash
+          echo "EXISTING_APPSTRATE 0.9.0"
+          exit 0
+          EXISTING
+          chmod +x "$GITHUB_WORKSPACE/bin-existing/appstrate"
+
+          # 8a.1: CI=true + dual-install detected → must abort.
+          set +e
+          DUAL_CI_OUT=$(APPSTRATE_BIN_DIR="$GITHUB_WORKSPACE/bin-dual-ci" \
+            CI=true \
+            PATH="$GITHUB_WORKSPACE/bin-existing:$GITHUB_WORKSPACE/bin-dual-ci:$PATH" \
+            bash /tmp/bootstrap.sh 2>&1)
+          rc=$?
+          set -e
+          echo "$DUAL_CI_OUT"
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::bootstrap proceeded despite dual-install detection in CI"; exit 1
+          fi
+          echo "$DUAL_CI_OUT" | grep -q "Another \`appstrate\` is already on PATH" \
+            || { echo "::error::bootstrap did not emit the dual-install warning"; exit 1; }
+          echo "$DUAL_CI_OUT" | grep -q "CI detected" \
+            || { echo "::error::bootstrap did not emit the CI-non-interactive guard"; exit 1; }
+          echo "$DUAL_CI_OUT" | grep -q "FAKE_CLI_RAN" \
+            && { echo "::error::bootstrap exec'd the binary despite refusing dual-install"; exit 1; }
+          test ! -e "$GITHUB_WORKSPACE/bin-dual-ci/appstrate" \
+            || { echo "::error::bootstrap wrote the binary despite aborting"; exit 1; }
+          echo "✓ 8a.1 dual-install + CI → refused"
+
+          # 8a.2: CI=true + APPSTRATE_FORCE_DUAL=1 → must succeed.
+          set +e
+          DUAL_FORCE_OUT=$(APPSTRATE_BIN_DIR="$GITHUB_WORKSPACE/bin-dual-force" \
+            APPSTRATE_FORCE_DUAL=1 \
+            CI=true \
+            PATH="$GITHUB_WORKSPACE/bin-existing:$GITHUB_WORKSPACE/bin-dual-force:$PATH" \
+            bash /tmp/bootstrap.sh 2>&1)
+          rc=$?
+          set -e
+          echo "$DUAL_FORCE_OUT"
+          test "$rc" -eq 0 \
+            || { echo "::error::bootstrap failed with APPSTRATE_FORCE_DUAL=1"; exit 1; }
+          echo "$DUAL_FORCE_OUT" | grep -q "APPSTRATE_FORCE_DUAL=1 set" \
+            || { echo "::error::bootstrap did not emit the FORCE_DUAL acknowledgment"; exit 1; }
+          test -x "$GITHUB_WORKSPACE/bin-dual-force/appstrate" \
+            || { echo "::error::bootstrap did not write the binary under FORCE_DUAL"; exit 1; }
+          echo "✓ 8a.2 dual-install + APPSTRATE_FORCE_DUAL=1 → installed"
+
+          # 8a.3: existing == DEST (re-install over self) → silent no-op.
+          # We need a `command -v appstrate` that resolves to the same path
+          # bootstrap is about to write to. Stage by copying into the dest
+          # FIRST, then re-running bootstrap (which should not warn).
+          set +e
+          DUAL_SAME_OUT=$(APPSTRATE_BIN_DIR="$GITHUB_WORKSPACE/bin-dual-force" \
+            CI=true \
+            PATH="$GITHUB_WORKSPACE/bin-dual-force:$PATH" \
+            bash /tmp/bootstrap.sh 2>&1)
+          rc=$?
+          set -e
+          echo "$DUAL_SAME_OUT"
+          test "$rc" -eq 0 \
+            || { echo "::error::bootstrap failed on re-install over self"; exit 1; }
+          echo "$DUAL_SAME_OUT" | grep -q "Another \`appstrate\` is already on PATH" \
+            && { echo "::error::bootstrap nagged on re-install over self"; exit 1; }
+          echo "✓ 8a.3 re-install over self → no nag"
+
+          echo "::endgroup::"
+          echo "✓ dual-install pre-check path OK"
+
           # ── PATH-setup scenarios ────────────────────────────────────────
           # Following scenarios exercise the rootless install + shell-rc
           # modification introduced for issue #186. Trust chain is

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -123,6 +123,125 @@ _appstrate_bootstrap() {
   have_shasum() { command -v shasum >/dev/null 2>&1; }
   have_minisign() { command -v minisign >/dev/null 2>&1; }
 
+  # ─── Dual-install pre-check (issue #249, phase 4) ───────────────────────────
+  #
+  # If the user already has `appstrate` on PATH at a DIFFERENT location than
+  # the one we're about to write, the two binaries will silently shadow each
+  # other after the install — the order on $PATH decides which one runs, and
+  # `appstrate self-update` will only ever update one of them. uv, deno, bun,
+  # rustup all surface this case at runtime; nobody surfaces it at install
+  # time. We do, because we have $DEST in hand before we touch the disk.
+  #
+  # Behavior:
+  #   - Same path (re-install over self) → silent no-op, proceed.
+  #   - Different path + interactive TTY → prompt [y/N], abort by default.
+  #   - Different path + CI / non-TTY  → abort with a hint to set
+  #                                       APPSTRATE_FORCE_DUAL=1.
+  #   - APPSTRATE_FORCE_DUAL=1         → bypass the check entirely.
+  #
+  # We do this BEFORE downloading the binary so a user who chose the wrong
+  # install method doesn't burn bandwidth + minisign cycles on something
+  # they're going to abort 10 seconds later.
+  resolve_path() {
+    # POSIX-portable path resolver tolerant of non-existent leaf files.
+    #
+    # Why split dir + basename: BSD `realpath` (macOS default) and GNU
+    # `readlink -f` both fail on a non-existent path, but DEST = the file
+    # we're about to write doesn't exist yet on a fresh install. Resolving
+    # only the parent dir handles every scenario where one or both paths
+    # are missing while still canonicalising symlinks at the directory
+    # level (the common case — e.g. /usr/local/bin → /opt/homebrew/bin
+    # on macOS Homebrew). Symlinks AT the leaf are not resolved, but a
+    # symlink at the binary itself is uncommon and a false-positive
+    # warning on that edge case beats a false-negative dual-install miss.
+    _input="$1"
+    _dir="$(dirname -- "$_input")"
+    _base="$(basename -- "$_input")"
+    if command -v realpath >/dev/null 2>&1; then
+      _real_dir="$(realpath "$_dir" 2>/dev/null || printf '%s' "$_dir")"
+    elif command -v readlink >/dev/null 2>&1 && readlink -f / >/dev/null 2>&1; then
+      _real_dir="$(readlink -f "$_dir" 2>/dev/null || printf '%s' "$_dir")"
+    else
+      _real_dir="$_dir"
+    fi
+    printf '%s/%s' "$_real_dir" "$_base"
+  }
+
+  EXISTING_APPSTRATE="$(command -v appstrate 2>/dev/null || true)"
+  if [ -n "$EXISTING_APPSTRATE" ] && [ "${APPSTRATE_FORCE_DUAL:-0}" != "1" ]; then
+    EXISTING_REAL="$(resolve_path "$EXISTING_APPSTRATE")"
+    DEST_REAL="$(resolve_path "$DEST")"
+    # Only act on a TRUE dual-install. Re-running the bootstrap on a machine
+    # that already has the curl-channel binary at $DEST is a normal re-install
+    # — we don't want to nag.
+    if [ "$EXISTING_REAL" != "$DEST_REAL" ]; then
+      EXISTING_VERSION="$("$EXISTING_APPSTRATE" --version 2>/dev/null | head -n 1 || echo "?")"
+      err "Another \`appstrate\` is already on PATH at:"
+      err "    $EXISTING_APPSTRATE  (version: $EXISTING_VERSION)"
+      err ""
+      err "Installing to:"
+      err "    $DEST"
+      err ""
+      err "Two binaries on PATH will silently shadow each other and \`appstrate"
+      err "self-update\` only manages the curl-channel one. Pick a single channel:"
+      err "  • Stay on the existing install: abort this bootstrap and run"
+      err "    its native upgrade command (\`bun update -g appstrate\`, etc)."
+      err "  • Switch to curl: remove the existing binary, then re-run."
+      err "  • Force-install both anyway: APPSTRATE_FORCE_DUAL=1 (not recommended)."
+      err ""
+      err "See https://github.com/appstrate/appstrate/issues/249"
+
+      # Determine interactive vs. non-interactive. `[ -t 0 ]` checks stdin;
+      # when piped from `curl | bash`, stdin is the pipe (NOT a TTY) so we
+      # also try to open /dev/tty for the prompt — same trick rustup uses.
+      _ci_flag="${CI:-}"
+      _is_ci=0
+      case "$_ci_flag" in true | 1 | yes) _is_ci=1 ;; esac
+
+      if [ "$_is_ci" = "1" ]; then
+        err ""
+        err "CI detected — refusing to prompt. Re-run with APPSTRATE_FORCE_DUAL=1"
+        err "if you really want both binaries on this runner."
+        exit 1
+      fi
+
+      _tty=""
+      if [ -t 0 ]; then
+        _tty="stdin"
+      elif [ -r /dev/tty ]; then
+        _tty="/dev/tty"
+      fi
+
+      if [ -z "$_tty" ]; then
+        err ""
+        err "Non-interactive shell detected — refusing to prompt."
+        err "Re-run with APPSTRATE_FORCE_DUAL=1 if intentional."
+        exit 1
+      fi
+
+      printf '\n'
+      printf 'Continue and install the curl-channel binary alongside the existing one? [y/N] '
+      ANSWER=""
+      if [ "$_tty" = "/dev/tty" ]; then
+        IFS= read -r ANSWER </dev/tty || ANSWER=""
+      else
+        IFS= read -r ANSWER || ANSWER=""
+      fi
+      case "$ANSWER" in
+        y | Y | yes | YES) : ;; # proceed
+        *)
+          err ""
+          err "Aborted — no files were written."
+          exit 1
+          ;;
+      esac
+      warn "Proceeding with dual-install at user request."
+    fi
+  elif [ "${APPSTRATE_FORCE_DUAL:-0}" = "1" ] && [ -n "$EXISTING_APPSTRATE" ]; then
+    # User explicitly opted in. Surface the warning so they don't forget.
+    warn "APPSTRATE_FORCE_DUAL=1 set — installing alongside existing $EXISTING_APPSTRATE"
+  fi
+
   # ─── Download + verify ──────────────────────────────────────────────────────
 
   log "Downloading Appstrate CLI ($OS/$ARCH, $VERSION)"


### PR DESCRIPTION
## Summary

Phase 4 of #249. Before downloading anything, `scripts/bootstrap.sh` now scans `\$PATH` for an existing `appstrate` binary at a different location than `\$DEST`. The flow is:

| State | Action |
|---|---|
| No existing `appstrate` on PATH | Continue (current behavior). |
| Existing at same resolved path as `\$DEST` (re-install over self) | Continue silently. |
| Existing at a different path, interactive TTY | Prompt `[y/N]`, abort by default. |
| Existing at a different path, CI or non-TTY | Abort with hint to set `APPSTRATE_FORCE_DUAL=1`. |
| `APPSTRATE_FORCE_DUAL=1` | Bypass + emit a banner. |

## Implementation notes

- The pre-check runs BEFORE `curl` for the binary, so a user who chose the wrong install method doesn't burn bandwidth + minisign cycles before aborting.
- `resolve_path` canonicalises **directory** symlinks but tolerates a non-existent leaf (the leaf is `\$DEST`, which doesn't exist on a fresh install). Handles macOS Homebrew `/usr/local/bin → /opt/homebrew/bin` correctly.
- BSD `realpath` (macOS default) and GNU `readlink -f` both fail on missing paths — splitting `dirname` + `basename` and only resolving the dir avoids this without a portable shell hack like `realpath -m` (Linux-only).
- The interactive prompt reads from `/dev/tty` when stdin is the curl pipe — same trick rustup uses.

## Tests

Three new scenarios in `.github/workflows/test-install.yml` (job `bootstrap-verify-dry-run`):
- 8a.1: CI=true + dual-install detected → must abort with the dual-install banner + CI guard.
- 8a.2: CI=true + `APPSTRATE_FORCE_DUAL=1` → must succeed and emit the override banner.
- 8a.3: existing == DEST (re-install over self) → must succeed without nagging.

Validated locally with a stripped harness against all three scenarios + the BSD-realpath edge case on macOS.

## Test plan
- [x] `shellcheck scripts/bootstrap.sh` — clean
- [x] `shfmt -d -i 2 -ci scripts/bootstrap.sh` — clean
- [x] Local harness: all three branches behave correctly
- [x] `bun run check` — repo-wide quality gate passes
- [x] CI `Test Installer` workflow exercises the new scenarios on every push

🤖 Generated with [Claude Code](https://claude.com/claude-code)