### PR TITLE
fix(api): mistral model test hits /v1/models (closes #148)

### DIFF
--- a/apps/api/src/services/org-models.ts
+++ b/apps/api/src/services/org-models.ts
@@ -310,25 +310,14 @@ export async function loadModel(orgId: string, modelDbId: string): Promise<Resol
 
 // --- Connection test ---
 
-/** Test a model config directly (no DB lookup). */
-export async function testModelConfig(config: {
-  api: string;
-  baseUrl: string;
-  modelId: string;
-  apiKey: string;
-}): Promise<TestResult> {
-  if (isBlockedUrl(config.baseUrl)) {
-    return {
-      ok: false,
-      latency: 0,
-      error: "BLOCKED_URL",
-      message: "URL targets a blocked network",
-    };
-  }
-
+/** Build the discovery URL + headers used to probe a model provider. Pure for unit testing. */
+export function buildModelTestRequest(config: { api: string; baseUrl: string; apiKey: string }): {
+  url: string;
+  headers: Record<string, string>;
+} {
   const base = config.baseUrl.replace(/\/+$/, "");
-  let url: string;
   const headers: Record<string, string> = {};
+  let url: string;
 
   switch (config.api) {
     case "anthropic-messages":
@@ -340,6 +329,10 @@ export async function testModelConfig(config: {
         headers["x-api-key"] = config.apiKey;
       }
       headers["anthropic-version"] = "2023-06-01";
+      break;
+    case "mistral-conversations":
+      url = `${base}/v1/models`;
+      headers["Authorization"] = `Bearer ${config.apiKey}`;
       break;
     case "google-generative-ai":
       url = `${base}/models?key=${encodeURIComponent(config.apiKey)}`;
@@ -360,6 +353,27 @@ export async function testModelConfig(config: {
       headers["Authorization"] = `Bearer ${config.apiKey}`;
       break;
   }
+
+  return { url, headers };
+}
+
+/** Test a model config directly (no DB lookup). */
+export async function testModelConfig(config: {
+  api: string;
+  baseUrl: string;
+  modelId: string;
+  apiKey: string;
+}): Promise<TestResult> {
+  if (isBlockedUrl(config.baseUrl)) {
+    return {
+      ok: false,
+      latency: 0,
+      error: "BLOCKED_URL",
+      message: "URL targets a blocked network",
+    };
+  }
+
+  const { url, headers } = buildModelTestRequest(config);
 
   const start = performance.now();
   try {

--- a/apps/api/test/unit/build-model-test-request.test.ts
+++ b/apps/api/test/unit/build-model-test-request.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "bun:test";
+import { buildModelTestRequest } from "../../src/services/org-models.ts";
+
+describe("buildModelTestRequest", () => {
+  it("anthropic-messages: appends /v1/models, x-api-key for sk-ant- keys", () => {
+    const { url, headers } = buildModelTestRequest({
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com",
+      apiKey: "sk-ant-key",
+    });
+    expect(url).toBe("https://api.anthropic.com/v1/models");
+    expect(headers["x-api-key"]).toBe("sk-ant-key");
+    expect(headers["anthropic-version"]).toBe("2023-06-01");
+    expect(headers["Authorization"]).toBeUndefined();
+    expect(headers["anthropic-beta"]).toBeUndefined();
+  });
+
+  it("anthropic-messages: uses Bearer + oauth beta for sk-ant-oat keys", () => {
+    const { headers } = buildModelTestRequest({
+      api: "anthropic-messages",
+      baseUrl: "https://api.anthropic.com",
+      apiKey: "sk-ant-oat-token",
+    });
+    expect(headers["Authorization"]).toBe("Bearer sk-ant-oat-token");
+    expect(headers["anthropic-beta"]).toBe("oauth-2025-04-20");
+    expect(headers["anthropic-version"]).toBe("2023-06-01");
+    expect(headers["x-api-key"]).toBeUndefined();
+  });
+
+  // Regression: https://github.com/appstrate/appstrate/issues/148
+  it("mistral-conversations: appends /v1/models with Bearer auth", () => {
+    const { url, headers } = buildModelTestRequest({
+      api: "mistral-conversations",
+      baseUrl: "https://api.mistral.ai",
+      apiKey: "mistral-key",
+    });
+    expect(url).toBe("https://api.mistral.ai/v1/models");
+    expect(headers["Authorization"]).toBe("Bearer mistral-key");
+  });
+
+  it("google-generative-ai: passes key as query param, no auth header", () => {
+    const { url, headers } = buildModelTestRequest({
+      api: "google-generative-ai",
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+      apiKey: "google key/with+special",
+    });
+    expect(url).toBe(
+      "https://generativelanguage.googleapis.com/v1beta/models?key=google%20key%2Fwith%2Bspecial",
+    );
+    expect(headers).toEqual({});
+  });
+
+  it("google-vertex: appends /models with Bearer auth", () => {
+    const { url, headers } = buildModelTestRequest({
+      api: "google-vertex",
+      baseUrl: "https://vertex.example.com/v1",
+      apiKey: "vertex-token",
+    });
+    expect(url).toBe("https://vertex.example.com/v1/models");
+    expect(headers["Authorization"]).toBe("Bearer vertex-token");
+  });
+
+  it("azure-openai-responses: appends /models with api-key header", () => {
+    const { url, headers } = buildModelTestRequest({
+      api: "azure-openai-responses",
+      baseUrl: "https://acme.openai.azure.com/openai",
+      apiKey: "azure-key",
+    });
+    expect(url).toBe("https://acme.openai.azure.com/openai/models");
+    expect(headers["api-key"]).toBe("azure-key");
+    expect(headers["Authorization"]).toBeUndefined();
+  });
+
+  it("openai-completions: appends /models with Bearer auth", () => {
+    const { url, headers } = buildModelTestRequest({
+      api: "openai-completions",
+      baseUrl: "https://api.groq.com/openai/v1",
+      apiKey: "groq-key",
+    });
+    expect(url).toBe("https://api.groq.com/openai/v1/models");
+    expect(headers["Authorization"]).toBe("Bearer groq-key");
+  });
+
+  it("openai-responses: appends /models with Bearer auth", () => {
+    const { url, headers } = buildModelTestRequest({
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+      apiKey: "openai-key",
+    });
+    expect(url).toBe("https://api.openai.com/v1/models");
+    expect(headers["Authorization"]).toBe("Bearer openai-key");
+  });
+
+  it("bedrock-converse-stream: appends /models with Bearer auth", () => {
+    const { url, headers } = buildModelTestRequest({
+      api: "bedrock-converse-stream",
+      baseUrl: "https://bedrock.example.com",
+      apiKey: "bedrock-key",
+    });
+    expect(url).toBe("https://bedrock.example.com/models");
+    expect(headers["Authorization"]).toBe("Bearer bedrock-key");
+  });
+
+  it("unknown api: falls back to default branch (/models + Bearer)", () => {
+    const { url, headers } = buildModelTestRequest({
+      api: "some-future-api",
+      baseUrl: "https://example.com/v9",
+      apiKey: "k",
+    });
+    expect(url).toBe("https://example.com/v9/models");
+    expect(headers["Authorization"]).toBe("Bearer k");
+  });
+
+  it("strips trailing slashes from baseUrl", () => {
+    const { url } = buildModelTestRequest({
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1///",
+      apiKey: "k",
+    });
+    expect(url).toBe("https://api.openai.com/v1/models");
+  });
+});


### PR DESCRIPTION
## Summary

- The "Tester" button on Mistral models returned `Provider returned 404` because `testModelConfig` had no `case "mistral-conversations"`. The default branch built `https://api.mistral.ai/models`, but Mistral's real discovery endpoint is `/v1/models`.
- Extracted URL/headers construction into a pure `buildModelTestRequest()` helper and added the Mistral case.
- New unit test `apps/api/test/unit/build-model-test-request.test.ts` covers every `api` value (including a regression case for #148).

Closes #148

## Test plan

- [x] `bun test apps/api/test/unit/build-model-test-request.test.ts` — 11/11 pass
- [x] `bunx tsc -p apps/api/tsconfig.json --noEmit` — clean
- [ ] Manual: Settings → Models → Mistral preset, valid key → "Tester" returns OK
- [ ] Manual: same with invalid key → returns `AUTH_FAILED` (not `PROVIDER_ERROR`), confirms we hit the real endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)