### PR TITLE
refactor(connect): OAuth/credentials hardening — revocation symmetry, scope validation, versioned encryption (#277)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,13 @@ UPLOAD_SIGNING_SECRET=appstrate-dev-upload-secret-do-not-use-in-production
 
 # Credential encryption — ⚠️ DEV ONLY — regenerate for production: openssl rand -base64 32
 CONNECTION_ENCRYPTION_KEY=jChGxOEG1YjCtrkrTYhO7FFdIKaHpe/j1PBY/LqID6s=
+# Active key id embedded in newly-encrypted credential blobs (v1 envelope).
+# Default "k1". Change only when promoting a freshly-rotated key — see
+# packages/connect/README.md for the rotation playbook.
+# CONNECTION_ENCRYPTION_KEY_ID=k1
+# Retired keys held for decrypt-only during a rotation window.
+# JSON map: { "old_kid": "<base64 32-byte key>" }. Empty by default.
+# CONNECTION_ENCRYPTION_KEYS={}
 
 # ─── Tier 1+ (PostgreSQL) ────────────────────────────────────
 # Uncomment to use an external PostgreSQL instead of PGlite (embedded).

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -23,7 +23,7 @@ import {
 import { getDefaultProfileId, getAccessibleProfile } from "../services/connection-profiles.ts";
 import { getActor } from "../lib/actor.ts";
 import type { Actor } from "../lib/actor.ts";
-import { isProviderEnabled, getProviderCredentialId } from "@appstrate/connect";
+import { isProviderEnabled, getProviderCredentialId, OAuthCallbackError } from "@appstrate/connect";
 import { db } from "@appstrate/db/client";
 import type { Context } from "hono";
 import { getAppScope } from "../lib/scope.ts";
@@ -225,6 +225,25 @@ export function createConnectionsRouter() {
       logger.info("OAuth callback success", { state });
       return c.html(`<html><body><script>window.close();</script></body></html>`);
     } catch (err) {
+      // Distinguish revocation from transient failure so the user gets a tailored
+      // message instead of a raw provider error string. Revoked = restart the flow;
+      // transient = retry the request.
+      if (err instanceof OAuthCallbackError) {
+        const userMessage =
+          err.kind === "revoked"
+            ? "The authorization expired before it could be exchanged. Please retry the connection."
+            : "Could not complete the connection. Please try again in a moment.";
+        logger.error("OAuth callback failed", {
+          providerId: err.providerId,
+          kind: err.kind,
+          status: err.status,
+          oauthError: err.oauthError,
+          oauthErrorDescription: err.oauthErrorDescription,
+        });
+        return c.html(
+          `<html><body><p style="color:red;font-family:monospace;">${escapeHtml(userMessage)}</p><script>setTimeout(()=>window.close(),5000);</script></body></html>`,
+        );
+      }
       const message = err instanceof Error ? err.message : "OAuth callback failed";
       logger.error("OAuth callback failed", { message });
       return c.html(

--- a/apps/api/src/services/connection-manager/oauth.ts
+++ b/apps/api/src/services/connection-manager/oauth.ts
@@ -3,8 +3,6 @@
 import { db } from "@appstrate/db/client";
 import { logger } from "../../lib/logger.ts";
 import { getEnv } from "@appstrate/env";
-import { and, eq } from "drizzle-orm";
-import { userProviderConnections } from "@appstrate/db/schema";
 import {
   initiateOAuth,
   handleOAuthCallback,
@@ -69,6 +67,19 @@ export async function handleCallback(code: string, state: string): Promise<OAuth
     result.providerId,
   );
 
+  // Scope shortfall: provider granted fewer scopes than requested (RFC 6749 §3.3
+  // narrowing). Flag the connection in the same upsert so callers see the
+  // "needs reconnection" signal atomically — no readable window between INSERT
+  // and a follow-up UPDATE where the connection looks healthy.
+  const needsReconnection = result.scopeShortfall.length > 0;
+  if (needsReconnection) {
+    logger.warn("OAuth scope shortfall — flagging connection as needsReconnection", {
+      providerId: result.providerId,
+      profileId: result.profileId,
+      shortfall: result.scopeShortfall,
+    });
+  }
+
   await saveConnection(
     db,
     result.profileId,
@@ -82,30 +93,9 @@ export async function handleCallback(code: string, state: string): Promise<OAuth
       scopesGranted: result.scopesGranted,
       expiresAt: result.expiresAt,
       providerCredentialId,
+      needsReconnection,
     },
   );
-
-  // Scope shortfall: provider granted fewer scopes than requested (RFC 6749 §3.3
-  // narrowing). Flag the connection so callers see a structured "needs reconnection"
-  // signal instead of silently working with reduced permissions.
-  if (result.scopeShortfall.length > 0) {
-    logger.warn("OAuth scope shortfall — flagging connection as needsReconnection", {
-      providerId: result.providerId,
-      profileId: result.profileId,
-      shortfall: result.scopeShortfall,
-    });
-    await db
-      .update(userProviderConnections)
-      .set({ needsReconnection: true, updatedAt: new Date() })
-      .where(
-        and(
-          eq(userProviderConnections.profileId, result.profileId),
-          eq(userProviderConnections.providerId, result.providerId),
-          eq(userProviderConnections.orgId, result.orgId),
-          eq(userProviderConnections.providerCredentialId, providerCredentialId),
-        ),
-      );
-  }
 
   // Scope creep: provider returned more scopes than requested. Some providers
   // (Slack, GitHub legacy) always return all owner scopes, so this is non-blocking.

--- a/apps/api/src/services/connection-manager/oauth.ts
+++ b/apps/api/src/services/connection-manager/oauth.ts
@@ -3,6 +3,8 @@
 import { db } from "@appstrate/db/client";
 import { logger } from "../../lib/logger.ts";
 import { getEnv } from "@appstrate/env";
+import { and, eq } from "drizzle-orm";
+import { userProviderConnections } from "@appstrate/db/schema";
 import {
   initiateOAuth,
   handleOAuthCallback,
@@ -83,10 +85,43 @@ export async function handleCallback(code: string, state: string): Promise<OAuth
     },
   );
 
+  // Scope shortfall: provider granted fewer scopes than requested (RFC 6749 §3.3
+  // narrowing). Flag the connection so callers see a structured "needs reconnection"
+  // signal instead of silently working with reduced permissions.
+  if (result.scopeShortfall.length > 0) {
+    logger.warn("OAuth scope shortfall — flagging connection as needsReconnection", {
+      providerId: result.providerId,
+      profileId: result.profileId,
+      shortfall: result.scopeShortfall,
+    });
+    await db
+      .update(userProviderConnections)
+      .set({ needsReconnection: true, updatedAt: new Date() })
+      .where(
+        and(
+          eq(userProviderConnections.profileId, result.profileId),
+          eq(userProviderConnections.providerId, result.providerId),
+          eq(userProviderConnections.orgId, result.orgId),
+          eq(userProviderConnections.providerCredentialId, providerCredentialId),
+        ),
+      );
+  }
+
+  // Scope creep: provider returned more scopes than requested. Some providers
+  // (Slack, GitHub legacy) always return all owner scopes, so this is non-blocking.
+  if (result.scopeCreep.length > 0) {
+    logger.warn("OAuth scope creep — provider granted unrequested scopes", {
+      providerId: result.providerId,
+      profileId: result.profileId,
+      creep: result.scopeCreep,
+    });
+  }
+
   logger.info("OAuth connection established", {
     providerId: result.providerId,
     profileId: result.profileId,
     scopes: result.scopesGranted,
+    shortfall: result.scopeShortfall.length > 0 ? result.scopeShortfall : undefined,
   });
 
   return result;

--- a/apps/api/test/integration/services/oauth-flows.test.ts
+++ b/apps/api/test/integration/services/oauth-flows.test.ts
@@ -429,6 +429,104 @@ describe("OAuth2 flows", () => {
       expect((caught as OAuthCallbackError).kind).toBe("transient");
     });
 
+    // Regression: an earlier version concatenated the raw IdP body into
+    // the error message — some IdPs echo the rejected `code` (or other
+    // request fields) back in 400 bodies, so a generic catcher logging
+    // `err.message` would surface them. The body now lives ONLY on the
+    // typed `body` field.
+    it("never leaks the raw IdP body into err.message; preserves it on err.body", async () => {
+      mockServer.setTokenStatus(400);
+      mockServer.setTokenResponse({
+        error: "invalid_grant",
+        error_description: "Authorization code expired",
+        // Some IdPs echo the rejected code or other sensitive request
+        // fields. Synthesise that here to assert it never reaches
+        // err.message.
+        echoed_code: "leaked-secret-AAA-BBB-CCC",
+      });
+
+      const { state } = await initiateConnection(
+        { orgId: orgId, applicationId: appId },
+        PROVIDER_ID,
+        actor,
+        profileId,
+      );
+
+      let caught: unknown;
+      try {
+        await handleCallback("bad-code", state);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(OAuthCallbackError);
+      const cbErr = caught as OAuthCallbackError;
+
+      // Body is preserved verbatim on the typed field for diagnostics.
+      expect(cbErr.body).toContain("leaked-secret-AAA-BBB-CCC");
+
+      // Message must NOT contain anything the IdP echoed back. The
+      // summary is built from `oauthError` + `oauthErrorDescription`
+      // only, both of which the connection layer treats as
+      // already-classified strings.
+      expect(cbErr.message).not.toContain("leaked-secret-AAA-BBB-CCC");
+      expect(cbErr.message).toContain("invalid_grant");
+      expect(cbErr.message).toContain("Authorization code expired");
+    });
+
+    // Regression: PKCE state used to linger in Redis for the full
+    // 10-minute TTL on a `revoked` callback failure even though the
+    // auth code was already dead at the IdP. Hygiene: delete the row
+    // on revoked outcomes (we keep it on `transient` so retry of the
+    // same code stays possible for transient 5xx).
+    it("deletes the OAuth state row on a revoked callback failure", async () => {
+      mockServer.setTokenStatus(400);
+      mockServer.setTokenResponse({ error: "invalid_grant" });
+
+      const { state } = await initiateConnection(
+        { orgId: orgId, applicationId: appId },
+        PROVIDER_ID,
+        actor,
+        profileId,
+      );
+
+      // State row exists pre-callback.
+      const before = await oauthStateStore.get(state);
+      expect(before).not.toBeNull();
+
+      try {
+        await handleCallback("bad-code", state);
+      } catch {
+        /* expected revoked */
+      }
+
+      // State row reaped after a revoked outcome.
+      const after = await oauthStateStore.get(state);
+      expect(after).toBeNull();
+    });
+
+    it("preserves the OAuth state row on a transient callback failure", async () => {
+      mockServer.setTokenStatus(500);
+      mockServer.setTokenResponse({ error: "server_error" });
+
+      const { state } = await initiateConnection(
+        { orgId: orgId, applicationId: appId },
+        PROVIDER_ID,
+        actor,
+        profileId,
+      );
+
+      try {
+        await handleCallback("bad-code", state);
+      } catch {
+        /* expected transient */
+      }
+
+      // Row preserved so a retry of the same code (for genuine 5xx)
+      // remains possible within the TTL window.
+      const after = await oauthStateStore.get(state);
+      expect(after).not.toBeNull();
+    });
+
     it("throws when token response has no access_token", async () => {
       mockServer.setTokenResponse({ token_type: "Bearer" });
 

--- a/apps/api/test/integration/services/oauth-flows.test.ts
+++ b/apps/api/test/integration/services/oauth-flows.test.ts
@@ -7,7 +7,7 @@ import { seedPackage, seedConnectionProfile } from "../../helpers/seed.ts";
 import { createMockOAuthServer, type MockOAuthServer } from "../../helpers/oauth-server.ts";
 import { applicationProviderCredentials, userProviderConnections } from "@appstrate/db/schema";
 import { eq } from "drizzle-orm";
-import { encryptCredentials, decryptCredentials } from "@appstrate/connect";
+import { encryptCredentials, decryptCredentials, OAuthCallbackError } from "@appstrate/connect";
 import {
   initiateConnection,
   handleCallback,
@@ -376,6 +376,59 @@ describe("OAuth2 flows", () => {
       await expect(handleCallback("bad-code", state)).rejects.toThrow("Token exchange failed");
     });
 
+    // The two paths that hit the token endpoint (initial callback + refresh) MUST
+    // classify a `400 invalid_grant` as a revocation per RFC 6749 §5.2 — historically
+    // only the refresh path did this, leaving the callback to surface a generic 400
+    // with no actionable signal.
+    it("classifies invalid_grant on the initial callback as a revocation (kind=revoked)", async () => {
+      mockServer.setTokenStatus(400);
+      mockServer.setTokenResponse({
+        error: "invalid_grant",
+        error_description: "Authorization code expired",
+      });
+
+      const { state } = await initiateConnection(
+        { orgId: orgId, applicationId: appId },
+        PROVIDER_ID,
+        actor,
+        profileId,
+      );
+
+      let caught: unknown;
+      try {
+        await handleCallback("bad-code", state);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(OAuthCallbackError);
+      const cbErr = caught as OAuthCallbackError;
+      expect(cbErr.kind).toBe("revoked");
+      expect(cbErr.providerId).toBe(PROVIDER_ID);
+      expect(cbErr.oauthError).toBe("invalid_grant");
+      expect(cbErr.oauthErrorDescription).toBe("Authorization code expired");
+    });
+
+    it("classifies non-invalid_grant 400 errors as transient", async () => {
+      mockServer.setTokenStatus(400);
+      mockServer.setTokenResponse({ error: "invalid_client" });
+
+      const { state } = await initiateConnection(
+        { orgId: orgId, applicationId: appId },
+        PROVIDER_ID,
+        actor,
+        profileId,
+      );
+
+      let caught: unknown;
+      try {
+        await handleCallback("bad-code", state);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(OAuthCallbackError);
+      expect((caught as OAuthCallbackError).kind).toBe("transient");
+    });
+
     it("throws when token response has no access_token", async () => {
       mockServer.setTokenResponse({ token_type: "Bearer" });
 
@@ -427,6 +480,61 @@ describe("OAuth2 flows", () => {
 
       // scopesGranted reflects what the token endpoint returned, not what was requested
       expect(result.scopesGranted).toEqual(["read"]);
+      // The provider granted "read" but we requested ["read", "write"] →
+      // shortfall surfaces "write".
+      expect(result.scopeShortfall).toEqual(["write"]);
+    });
+
+    it("flags the saved connection with needsReconnection on scope shortfall", async () => {
+      mockServer.setTokenResponse({
+        access_token: "token",
+        refresh_token: "refresh",
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "read", // only "read" granted, but ["read","write"] requested
+      });
+
+      const { state } = await initiateConnection(
+        { orgId: orgId, applicationId: appId },
+        PROVIDER_ID,
+        actor,
+        profileId,
+      );
+      await handleCallback("mock-code", state);
+
+      const [conn] = await db
+        .select()
+        .from(userProviderConnections)
+        .where(eq(userProviderConnections.profileId, profileId));
+      expect(conn).toBeDefined();
+      expect(conn!.needsReconnection).toBe(true);
+      expect(conn!.scopesGranted).toEqual(["read"]);
+    });
+
+    it("does NOT flag needsReconnection on scope creep (provider over-grant)", async () => {
+      mockServer.setTokenResponse({
+        access_token: "token",
+        refresh_token: "refresh",
+        token_type: "Bearer",
+        expires_in: 3600,
+        scope: "read write admin", // extra "admin" beyond the requested set
+      });
+
+      const { state } = await initiateConnection(
+        { orgId: orgId, applicationId: appId },
+        PROVIDER_ID,
+        actor,
+        profileId,
+      );
+      const result = await handleCallback("mock-code", state);
+      expect(result.scopeCreep).toEqual(["admin"]);
+      expect(result.scopeShortfall).toEqual([]);
+
+      const [conn] = await db
+        .select()
+        .from(userProviderConnections)
+        .where(eq(userProviderConnections.profileId, profileId));
+      expect(conn!.needsReconnection).toBe(false);
     });
   });
 

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -52,9 +52,11 @@ Stored credentials use AES-256-GCM with a versioned envelope:
 v1:<kid>:<base64(iv|authTag|ciphertext)>
 ```
 
-Legacy ("v0") blobs — raw `base64(iv|authTag|ciphertext)` with no header — remain
-decryptable indefinitely with the active key, so the format change rolls out
-non-breaking. New writes always emit v1.
+Legacy ("v0") blobs — raw `base64(iv|authTag|ciphertext)` with no header —
+carry no kid, so `decrypt()` tries every key in the keyring (active + retired)
+until AES-GCM tag verification succeeds. A wrong key cannot pass GCM
+verification by chance (~2^-128), so the multi-key probe is safe. New writes
+always emit v1.
 
 ### Online key rotation playbook
 
@@ -73,13 +75,16 @@ export CONNECTION_ENCRYPTION_KEY=$NEW_KEY
 export CONNECTION_ENCRYPTION_KEY_ID=k2
 
 # 3. Restart the platform. New writes emit `v1:k2:...`. Existing `v1:k1:...`
-#    blobs remain readable via the retired keyring; v0 blobs decrypt with the
-#    current active key.
+#    blobs remain readable via the retired keyring; v0 blobs decrypt by
+#    probing every key in the keyring (active + retired) until AES-GCM tag
+#    verification succeeds.
 
 # 4. Run a background re-encrypt sweep (read → decrypt → encrypt → write) to
 #    rewrite every `userProviderConnections.credentialsEncrypted` row. Idempotent.
+#    The sweep migrates v0 → v1 *and* re-keys v1:<old-kid> blobs to v1:<active-kid>.
 
-# 5. Once sweep is complete, drop the retired key:
+# 5. Only after the sweep confirms no blob still depends on the retired key,
+#    drop it:
 unset CONNECTION_ENCRYPTION_KEYS
 ```
 
@@ -88,6 +93,13 @@ Restrictions:
 - `CONNECTION_ENCRYPTION_KEY_ID` must match `^[A-Za-z0-9_-]{1,32}$`.
 - Retired keys must use a different kid than the active one (validated at boot).
 - Each retired key must be 32 bytes (256-bit) base64-encoded.
+
+**Step ordering invariant.** A key may be removed from
+`CONNECTION_ENCRYPTION_KEYS` (step 5) **only after** the sweep (step 4)
+confirms zero rows still encrypted under that key. Removing it sooner
+permanently corrupts every credential that still depends on it — the v0
+multi-key probe protects against silent breakage during the rotation window
+but not against a key being deleted outright.
 
 ## Dependencies
 

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -18,8 +18,79 @@ OAuth2/PKCE, API key authentication, and encrypted credential storage for provid
 - **basic** — Username/password Base64
 - **custom** — Multi-field credential schema rendered as dynamic form
 
+## OAuth error classification
+
+Both the initial token exchange (`handleOAuthCallback`) and the refresh flow
+(`forceRefresh`) classify failures through the shared `parseTokenErrorResponse`
+helper so revocation handling stays symmetric per RFC 6749 §5.2.
+
+| Error class          | Triggered by                           | Caller behavior                              |
+| -------------------- | -------------------------------------- | -------------------------------------------- |
+| `OAuthCallbackError` | initial token exchange (callback path) | distinguish `kind: "revoked" \| "transient"` |
+| `RefreshError`       | token refresh (already-connected path) | same `kind` discriminant                     |
+
+`kind: "revoked"` (HTTP 400 + `{"error": "invalid_grant"}`) means the
+authorization code or refresh token is dead and the user must reconnect.
+Anything else is `transient` — retry the request, not the entire OAuth flow.
+
+## Scope validation
+
+`parseTokenResponse` returns two diff arrays alongside `scopesGranted`:
+
+- `scopeShortfall` — scopes requested but not granted (provider narrowing).
+  `services/connection-manager/oauth.ts` flags the saved connection with
+  `needsReconnection: true` when this is non-empty.
+- `scopeCreep` — scopes granted that were never requested (provider over-grant).
+  Some providers (Slack, GitHub legacy) always return all owner scopes; logged
+  as a warning, not blocked.
+
+## Credential encryption — versioned envelope
+
+Stored credentials use AES-256-GCM with a versioned envelope:
+
+```
+v1:<kid>:<base64(iv|authTag|ciphertext)>
+```
+
+Legacy ("v0") blobs — raw `base64(iv|authTag|ciphertext)` with no header — remain
+decryptable indefinitely with the active key, so the format change rolls out
+non-breaking. New writes always emit v1.
+
+### Online key rotation playbook
+
+Rotation does not require downtime or an offline batch re-encrypt. The version
+tag plus key id let the platform run with a multi-key keyring during the
+transition window.
+
+```
+# 1. Generate a new key
+NEW_KEY=$(openssl rand -base64 32)
+
+# 2. Move the current key into the retired keyring (decrypt-only)
+#    and promote the new key as primary.
+export CONNECTION_ENCRYPTION_KEYS='{"k1":"<current CONNECTION_ENCRYPTION_KEY value>"}'
+export CONNECTION_ENCRYPTION_KEY=$NEW_KEY
+export CONNECTION_ENCRYPTION_KEY_ID=k2
+
+# 3. Restart the platform. New writes emit `v1:k2:...`. Existing `v1:k1:...`
+#    blobs remain readable via the retired keyring; v0 blobs decrypt with the
+#    current active key.
+
+# 4. Run a background re-encrypt sweep (read → decrypt → encrypt → write) to
+#    rewrite every `userProviderConnections.credentialsEncrypted` row. Idempotent.
+
+# 5. Once sweep is complete, drop the retired key:
+unset CONNECTION_ENCRYPTION_KEYS
+```
+
+Restrictions:
+
+- `CONNECTION_ENCRYPTION_KEY_ID` must match `^[A-Za-z0-9_-]{1,32}$`.
+- Retired keys must use a different kid than the active one (validated at boot).
+- Each retired key must be 32 bytes (256-bit) base64-encoded.
+
 ## Dependencies
 
 - `@appstrate/db` — Database access for credential storage
-- `@appstrate/env` — `CONNECTION_ENCRYPTION_KEY` for credential encryption
+- `@appstrate/env` — `CONNECTION_ENCRYPTION_KEY` (+ optional rotation envs) for credential encryption
 - `@appstrate/shared-types` — Provider and connection type definitions

--- a/packages/connect/src/credentials.ts
+++ b/packages/connect/src/credentials.ts
@@ -208,6 +208,16 @@ export async function saveConnection(
     providerCredentialId: string;
     scopesGranted?: string[];
     expiresAt?: string | null;
+    /**
+     * Initial value for the `needsReconnection` flag. Defaults to `false`
+     * (a fresh OAuth callback grants a working connection). Callers that
+     * detect a scope shortfall can pass `true` here to make the insert
+     * atomic — without this option, a separate UPDATE follows the INSERT
+     * and any consumer reading between the two queries sees a brief
+     * "connected with full scopes" window that disappears once the flag
+     * flips. Atomic upsert eliminates that window.
+     */
+    needsReconnection?: boolean;
   },
 ): Promise<void> {
   const encrypted = encryptCredentials(credentials);
@@ -216,7 +226,7 @@ export async function saveConnection(
     credentialsEncrypted: encrypted,
     scopesGranted: options.scopesGranted ?? [],
     expiresAt: options.expiresAt ? new Date(options.expiresAt) : null,
-    needsReconnection: false,
+    needsReconnection: options.needsReconnection ?? false,
     providerCredentialId: options.providerCredentialId,
   };
 

--- a/packages/connect/src/encryption.ts
+++ b/packages/connect/src/encryption.ts
@@ -7,39 +7,130 @@ const ALGO = "aes-256-gcm";
 const IV_LENGTH = 12;
 const AUTH_TAG_LENGTH = 16;
 
-let encryptionKey: Buffer | null = null;
+/**
+ * Versioned envelope prefix.
+ *
+ * Wire format: `v1:<kid>:<base64(iv|authTag|ciphertext)>`
+ *
+ * The version tag + key id enable online key rotation: new writes embed the
+ * active kid, reads dispatch decryption to the matching key in the keyring.
+ * Legacy v0 blobs (raw base64 of `iv|authTag|ciphertext`, no header) remain
+ * decryptable indefinitely with the primary key — so this change is non-
+ * breaking and can roll out before any re-encryption job runs.
+ *
+ * `kid` MUST match `^[A-Za-z0-9_-]{1,32}$` so it can travel inside the
+ * delimiter-based envelope without escaping.
+ */
+const ENVELOPE_VERSION = "v1";
+const KID_PATTERN = /^[A-Za-z0-9_-]{1,32}$/;
 
-function getKey(): Buffer {
-  if (encryptionKey) return encryptionKey;
+/**
+ * Resolved keyring used by the in-process encryption layer.
+ *
+ * - `activeKid`: kid embedded in newly-encrypted blobs.
+ * - `keys`: every kid the process can decrypt with — at minimum the active
+ *   key, plus retired keys still in the rotation window.
+ *
+ * The legacy ("v0") blobs decrypt with whichever key matches `activeKid` at
+ * read time, because pre-versioning we had only one key and that key is the
+ * one currently configured as primary.
+ */
+interface Keyring {
+  activeKid: string;
+  keys: Map<string, Buffer>;
+}
 
-  const keyEnv = getEnv().CONNECTION_ENCRYPTION_KEY;
-  encryptionKey = Buffer.from(keyEnv, "base64");
-  return encryptionKey;
+let cachedKeyring: Keyring | null = null;
+
+function loadKeyring(): Keyring {
+  if (cachedKeyring) return cachedKeyring;
+
+  const env = getEnv();
+  const primaryKey = Buffer.from(env.CONNECTION_ENCRYPTION_KEY, "base64");
+
+  const activeKid = env.CONNECTION_ENCRYPTION_KEY_ID;
+  if (!KID_PATTERN.test(activeKid)) {
+    throw new Error(
+      `CONNECTION_ENCRYPTION_KEY_ID must match ${KID_PATTERN.source} (got: ${activeKid})`,
+    );
+  }
+
+  const keys = new Map<string, Buffer>();
+  keys.set(activeKid, primaryKey);
+
+  // Retired keys map: { kid: base64 }. Used for decrypting old blobs during a
+  // rotation window. Reject duplicates with the active kid to prevent silent
+  // overrides.
+  const retiredEntries = Object.entries(env.CONNECTION_ENCRYPTION_KEYS as Record<string, string>);
+  for (const [kid, b64] of retiredEntries) {
+    if (!KID_PATTERN.test(kid)) {
+      throw new Error(
+        `CONNECTION_ENCRYPTION_KEYS kid must match ${KID_PATTERN.source} (got: ${kid})`,
+      );
+    }
+    if (kid === activeKid) {
+      throw new Error(
+        `CONNECTION_ENCRYPTION_KEYS contains the active kid '${kid}' — retired keys must use a different kid`,
+      );
+    }
+    const buf = Buffer.from(b64, "base64");
+    if (buf.length !== 32) {
+      throw new Error(
+        `CONNECTION_ENCRYPTION_KEYS['${kid}'] must be 32 bytes (256-bit) base64-encoded`,
+      );
+    }
+    keys.set(kid, buf);
+  }
+
+  cachedKeyring = { activeKid, keys };
+  return cachedKeyring;
+}
+
+/**
+ * Reset the cached keyring. Test-only — production callers should never
+ * mutate the keyring at runtime; rotation is a deploy-time operation.
+ */
+export function _resetKeyringForTesting(): void {
+  cachedKeyring = null;
+}
+
+function getKey(kid: string): Buffer {
+  const keyring = loadKeyring();
+  const key = keyring.keys.get(kid);
+  if (!key) {
+    throw new Error(
+      `No encryption key registered for kid '${kid}'. Add it to CONNECTION_ENCRYPTION_KEYS or set it as CONNECTION_ENCRYPTION_KEY.`,
+    );
+  }
+  return key;
 }
 
 /**
  * Encrypt a plaintext string using AES-256-GCM.
- * Returns base64(iv + authTag + ciphertext).
+ * Returns a versioned envelope: `v1:<kid>:<base64(iv|authTag|ciphertext)>`.
  */
 export function encrypt(plaintext: string): string {
-  const key = getKey();
+  const keyring = loadKeyring();
+  const key = getKey(keyring.activeKid);
   const iv = randomBytes(IV_LENGTH);
   const cipher = createCipheriv(ALGO, key, iv);
 
   const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
   const authTag = cipher.getAuthTag();
 
-  // Pack: iv (12) + authTag (16) + ciphertext
-  const packed = Buffer.concat([iv, authTag, encrypted]);
-  return packed.toString("base64");
+  const packed = Buffer.concat([iv, authTag, encrypted]).toString("base64");
+  return `${ENVELOPE_VERSION}:${keyring.activeKid}:${packed}`;
 }
 
 /**
- * Decrypt a base64(iv + authTag + ciphertext) string.
+ * Decrypt a ciphertext string. Accepts both formats:
+ *
+ * - v1 envelope (`v1:<kid>:<base64>`): kid drives key lookup.
+ * - v0 legacy (raw `base64(iv|authTag|ciphertext)`): falls back to the active key.
  */
 export function decrypt(ciphertext: string): string {
-  const key = getKey();
-  const packed = Buffer.from(ciphertext, "base64");
+  const { kid, packed } = parseEnvelope(ciphertext);
+  const key = getKey(kid);
 
   if (packed.length < IV_LENGTH + AUTH_TAG_LENGTH) {
     throw new Error("Invalid encrypted data: too short");
@@ -54,6 +145,30 @@ export function decrypt(ciphertext: string): string {
 
   const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
   return decrypted.toString("utf8");
+}
+
+interface ParsedEnvelope {
+  kid: string;
+  packed: Buffer;
+}
+
+function parseEnvelope(ciphertext: string): ParsedEnvelope {
+  if (ciphertext.startsWith(`${ENVELOPE_VERSION}:`)) {
+    const rest = ciphertext.slice(ENVELOPE_VERSION.length + 1);
+    const sepIdx = rest.indexOf(":");
+    if (sepIdx === -1) {
+      throw new Error("Invalid v1 envelope: missing kid separator");
+    }
+    const kid = rest.slice(0, sepIdx);
+    const payload = rest.slice(sepIdx + 1);
+    if (!KID_PATTERN.test(kid)) {
+      throw new Error(`Invalid v1 envelope: kid '${kid}' does not match ${KID_PATTERN.source}`);
+    }
+    return { kid, packed: Buffer.from(payload, "base64") };
+  }
+  // v0 legacy: raw base64 of iv|authTag|ciphertext — decrypt with the active key.
+  const keyring = loadKeyring();
+  return { kid: keyring.activeKid, packed: Buffer.from(ciphertext, "base64") };
 }
 
 /**

--- a/packages/connect/src/encryption.ts
+++ b/packages/connect/src/encryption.ts
@@ -14,9 +14,10 @@ const AUTH_TAG_LENGTH = 16;
  *
  * The version tag + key id enable online key rotation: new writes embed the
  * active kid, reads dispatch decryption to the matching key in the keyring.
- * Legacy v0 blobs (raw base64 of `iv|authTag|ciphertext`, no header) remain
- * decryptable indefinitely with the primary key — so this change is non-
- * breaking and can roll out before any re-encryption job runs.
+ * Legacy v0 blobs (raw base64 of `iv|authTag|ciphertext`, no header) carry no
+ * kid, so they remain decryptable by probing every key in the keyring until
+ * AES-GCM tag verification succeeds — non-breaking, and survives rotations as
+ * long as the encrypting key stays in the keyring.
  *
  * `kid` MUST match `^[A-Za-z0-9_-]{1,32}$` so it can travel inside the
  * delimiter-based envelope without escaping.
@@ -31,9 +32,12 @@ const KID_PATTERN = /^[A-Za-z0-9_-]{1,32}$/;
  * - `keys`: every kid the process can decrypt with — at minimum the active
  *   key, plus retired keys still in the rotation window.
  *
- * The legacy ("v0") blobs decrypt with whichever key matches `activeKid` at
- * read time, because pre-versioning we had only one key and that key is the
- * one currently configured as primary.
+ * Legacy ("v0") blobs carry no kid, so `decrypt()` tries every key in the
+ * keyring (active + retired) until AES-GCM tag verification succeeds. This
+ * keeps v0 blobs readable across rotations without requiring a strict
+ * sweep-before-retire ordering — a key may only be removed from
+ * `CONNECTION_ENCRYPTION_KEYS` once the v0 → v1 sweep confirms no legacy
+ * blobs remain that depend on it.
  */
 interface Keyring {
   activeKid: string;
@@ -125,17 +129,33 @@ export function encrypt(plaintext: string): string {
 /**
  * Decrypt a ciphertext string. Accepts both formats:
  *
- * - v1 envelope (`v1:<kid>:<base64>`): kid drives key lookup.
- * - v0 legacy (raw `base64(iv|authTag|ciphertext)`): falls back to the active key.
+ * - v1 envelope (`v1:<kid>:<base64>`): the embedded kid drives key lookup —
+ *   single attempt against the matching key.
+ * - v0 legacy (raw `base64(iv|authTag|ciphertext)`): the blob carries no kid,
+ *   so we try every key in the keyring (active + retired) until one decrypts
+ *   successfully. AES-GCM tag verification makes this safe — a mismatched key
+ *   cannot produce a successful decrypt by chance (~2^-128).
  */
 export function decrypt(ciphertext: string): string {
-  const { kid, packed } = parseEnvelope(ciphertext);
-  const key = getKey(kid);
+  const parsed = parseEnvelope(ciphertext);
 
-  if (packed.length < IV_LENGTH + AUTH_TAG_LENGTH) {
+  if (parsed.packed.length < IV_LENGTH + AUTH_TAG_LENGTH) {
     throw new Error("Invalid encrypted data: too short");
   }
 
+  if (parsed.kind === "v1") {
+    return decryptWithKey(parsed.packed, getKey(parsed.kid));
+  }
+
+  // v0 legacy: try every key in the keyring. The blob was encrypted under
+  // *some* historical active key — which one is unknown until we verify the
+  // GCM tag. This eliminates the temporal coupling between key rotation and
+  // the v0 → v1 re-encrypt sweep: a v0 blob written under k1 stays readable
+  // after k2 is promoted active, so long as k1 is still in the keyring.
+  return decryptV0(parsed.packed);
+}
+
+function decryptWithKey(packed: Buffer, key: Buffer): string {
   const iv = packed.subarray(0, IV_LENGTH);
   const authTag = packed.subarray(IV_LENGTH, IV_LENGTH + AUTH_TAG_LENGTH);
   const encrypted = packed.subarray(IV_LENGTH + AUTH_TAG_LENGTH);
@@ -147,10 +167,30 @@ export function decrypt(ciphertext: string): string {
   return decrypted.toString("utf8");
 }
 
-interface ParsedEnvelope {
-  kid: string;
-  packed: Buffer;
+function decryptV0(packed: Buffer): string {
+  const keyring = loadKeyring();
+  // Active first (hot path: no rotation in flight), then retired.
+  const candidateKids = [
+    keyring.activeKid,
+    ...[...keyring.keys.keys()].filter((kid) => kid !== keyring.activeKid),
+  ];
+
+  let lastError: unknown;
+  for (const kid of candidateKids) {
+    try {
+      return decryptWithKey(packed, getKey(kid));
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  // Intentionally generic — leaking which kid was tried would help an attacker
+  // probe key state. AES-GCM tag failures are indistinguishable from each other.
+  throw new Error("Failed to decrypt v0 credential blob with any keyring key", {
+    cause: lastError,
+  });
 }
+
+type ParsedEnvelope = { kind: "v1"; kid: string; packed: Buffer } | { kind: "v0"; packed: Buffer };
 
 function parseEnvelope(ciphertext: string): ParsedEnvelope {
   if (ciphertext.startsWith(`${ENVELOPE_VERSION}:`)) {
@@ -164,11 +204,10 @@ function parseEnvelope(ciphertext: string): ParsedEnvelope {
     if (!KID_PATTERN.test(kid)) {
       throw new Error(`Invalid v1 envelope: kid '${kid}' does not match ${KID_PATTERN.source}`);
     }
-    return { kid, packed: Buffer.from(payload, "base64") };
+    return { kind: "v1", kid, packed: Buffer.from(payload, "base64") };
   }
-  // v0 legacy: raw base64 of iv|authTag|ciphertext — decrypt with the active key.
-  const keyring = loadKeyring();
-  return { kid: keyring.activeKid, packed: Buffer.from(ciphertext, "base64") };
+  // v0 legacy: raw base64 of iv|authTag|ciphertext — no embedded kid.
+  return { kind: "v0", packed: Buffer.from(ciphertext, "base64") };
 }
 
 /**

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -30,7 +30,7 @@ export {
 } from "./registry.ts";
 
 // OAuth2
-export { initiateOAuth, handleOAuthCallback } from "./oauth.ts";
+export { initiateOAuth, handleOAuthCallback, OAuthCallbackError } from "./oauth.ts";
 export type { InitiateOAuthResult, OAuthCallbackResult } from "./oauth.ts";
 
 // OAuth1
@@ -39,6 +39,10 @@ export type { OAuth1CallbackResult } from "./oauth1.ts";
 
 // Token refresh
 export { RefreshError } from "./token-refresh.ts";
+
+// Token error classification (shared by callback + refresh paths)
+export { parseTokenErrorResponse } from "./token-utils.ts";
+export type { TokenErrorKind, TokenErrorClassification } from "./token-utils.ts";
 
 // Credentials
 export {

--- a/packages/connect/src/oauth.ts
+++ b/packages/connect/src/oauth.ts
@@ -242,8 +242,35 @@ export async function handleOAuthCallback(
   if (!tokenResponse.ok) {
     const body = await tokenResponse.text();
     const classification = parseTokenErrorResponse(tokenResponse.status, body);
+    // Don't concatenate the raw IdP body into the error message — some
+    // IdPs echo the rejected `code` (or other request fields) back into
+    // 400 bodies, so a generic catcher logging `err.message` would
+    // surface them. Callers that need the body for diagnostics read it
+    // off the typed `body` field instead, where the connections route
+    // already sanitises it before user-facing surfaces.
+    const summary =
+      classification.error !== undefined
+        ? `${classification.error}${classification.errorDescription ? ` — ${classification.errorDescription}` : ""}`
+        : `HTTP ${tokenResponse.status}`;
+    // The auth code is dead by the time the IdP rejects with `revoked`
+    // (codes are one-shot), so the PKCE state row will never be useful
+    // again. Delete it instead of letting it sit in Redis for the full
+    // 10-minute TTL — same hygiene as the success path. We do NOT
+    // delete on `transient` failures because some retry strategies want
+    // the row preserved so a re-exchange of the same code is possible
+    // (the IdP may temporarily 5xx). Errors during the delete are
+    // swallowed so the caller still sees the original classification —
+    // a stale state row is a quality-of-service issue, not a security
+    // one (the auth code is already dead).
+    if (classification.kind === "revoked") {
+      try {
+        await store.delete(state);
+      } catch {
+        /* swallowed: stale row reaped by TTL within 10 minutes */
+      }
+    }
     throw new OAuthCallbackError(
-      `Token exchange failed for '${stateRow.providerId}': ${tokenResponse.status} ${body}`,
+      `Token exchange failed for '${stateRow.providerId}': ${summary}`,
       classification.kind,
       stateRow.providerId,
       tokenResponse.status,

--- a/packages/connect/src/oauth.ts
+++ b/packages/connect/src/oauth.ts
@@ -5,8 +5,46 @@ import type { Db } from "@appstrate/db/client";
 import type { OAuthStateRecord, OAuthStateStore } from "./types.ts";
 import type { Actor } from "./types.ts";
 import { getProviderOrThrow, getProviderOAuthCredentialsOrThrow } from "./registry.ts";
-import { parseTokenResponse, buildTokenHeaders, buildTokenBody } from "./token-utils.ts";
+import {
+  parseTokenResponse,
+  parseTokenErrorResponse,
+  buildTokenHeaders,
+  buildTokenBody,
+  type TokenErrorKind,
+} from "./token-utils.ts";
 import { extractErrorMessage } from "./utils.ts";
+
+/**
+ * Error thrown by handleOAuthCallback when the initial token exchange fails.
+ *
+ * Mirrors the {@link import("./token-refresh.ts").RefreshError} pattern so
+ * revocation handling is symmetric across the two paths that call the OAuth2
+ * token endpoint. The discrimination matters because:
+ *
+ * - `"revoked"` (HTTP 400 + `{ "error": "invalid_grant" }` per RFC 6749 §5.2):
+ *   the authorization code is dead. The user must restart the OAuth flow.
+ *   Callers SHOULD surface a structured "please reconnect" message rather than
+ *   a generic 400.
+ *
+ * - `"transient"`: anything else (network, 5xx, non-JSON, other 4xx, other
+ *   OAuth error codes). The authorization code might still be valid on retry
+ *   for some classes of failure; the user should be told to retry the request,
+ *   not the entire OAuth flow.
+ */
+export class OAuthCallbackError extends Error {
+  constructor(
+    message: string,
+    public readonly kind: TokenErrorKind,
+    public readonly providerId: string,
+    public readonly status?: number,
+    public readonly body?: string,
+    public readonly oauthError?: string,
+    public readonly oauthErrorDescription?: string,
+  ) {
+    super(message);
+    this.name = "OAuthCallbackError";
+  }
+}
 
 const OAUTH_STATE_TTL_SECONDS = 10 * 60;
 
@@ -116,6 +154,20 @@ export interface OAuthCallbackResult {
   refreshToken?: string;
   expiresAt: string | null;
   scopesGranted: string[];
+  /**
+   * Scopes that were requested but not granted by the provider.
+   * Non-empty arrays indicate the user must reconnect (or accept a degraded
+   * surface). Callers SHOULD set `needsReconnection: true` when this is
+   * non-empty, except in cases where the missing scopes are explicitly
+   * optional in the provider definition.
+   */
+  scopeShortfall: string[];
+  /**
+   * Scopes the provider granted but were never requested. Some providers
+   * (Slack, GitHub legacy) always return all owner scopes. Treat as a
+   * warning signal (audit log), not as a rejection.
+   */
+  scopeCreep: string[];
 }
 
 /**
@@ -180,21 +232,36 @@ export async function handleOAuthCallback(
       signal: AbortSignal.timeout(30_000),
     });
   } catch (err) {
-    throw new Error(
+    throw new OAuthCallbackError(
       `Token exchange network error for '${stateRow.providerId}': ${extractErrorMessage(err)}`,
+      "transient",
+      stateRow.providerId,
     );
   }
 
   if (!tokenResponse.ok) {
     const body = await tokenResponse.text();
-    throw new Error(`Token exchange failed: ${tokenResponse.status} ${body}`);
+    const classification = parseTokenErrorResponse(tokenResponse.status, body);
+    throw new OAuthCallbackError(
+      `Token exchange failed for '${stateRow.providerId}': ${tokenResponse.status} ${body}`,
+      classification.kind,
+      stateRow.providerId,
+      tokenResponse.status,
+      body,
+      classification.error,
+      classification.errorDescription,
+    );
   }
 
   let tokenData: Record<string, unknown>;
   try {
     tokenData = (await tokenResponse.json()) as Record<string, unknown>;
   } catch {
-    throw new Error(`Token exchange returned non-JSON response for '${stateRow.providerId}'`);
+    throw new OAuthCallbackError(
+      `Token exchange returned non-JSON response for '${stateRow.providerId}'`,
+      "transient",
+      stateRow.providerId,
+    );
   }
 
   const parsed = parseTokenResponse(tokenData, stateRow.scopesRequested);
@@ -213,5 +280,7 @@ export async function handleOAuthCallback(
     refreshToken: parsed.refreshToken,
     expiresAt: parsed.expiresAt,
     scopesGranted: parsed.scopesGranted,
+    scopeShortfall: parsed.scopeShortfall,
+    scopeCreep: parsed.scopeCreep,
   };
 }

--- a/packages/connect/src/token-refresh.ts
+++ b/packages/connect/src/token-refresh.ts
@@ -6,7 +6,12 @@ import type { Db } from "@appstrate/db/client";
 import type { DecryptedCredentials } from "./types.ts";
 import { encryptCredentials, decryptCredentials } from "./encryption.ts";
 import type { OAuthTokenAuthMethod, OAuthTokenContentType } from "@appstrate/core/validation";
-import { parseTokenResponse, buildTokenHeaders, buildTokenBody } from "./token-utils.ts";
+import {
+  parseTokenResponse,
+  parseTokenErrorResponse,
+  buildTokenHeaders,
+  buildTokenBody,
+} from "./token-utils.ts";
 import { extractErrorMessage } from "./utils.ts";
 
 /** In-memory concurrency lock: one refresh at a time per connection. */
@@ -133,24 +138,10 @@ async function doRefresh(
 
   if (!response.ok) {
     const text = await response.text();
-    // Per RFC 6749 §5.2, a dead refresh_token is signaled by HTTP 400 +
-    // body {"error": "invalid_grant"}. Any other failure (5xx, 401, 403,
-    // other 4xx, non-JSON body, body without an `error` field, other OAuth
-    // error codes like invalid_client/invalid_scope) is treated as transient.
-    let kind: "revoked" | "transient" = "transient";
-    if (response.status === 400) {
-      try {
-        const parsed = JSON.parse(text) as { error?: unknown };
-        if (parsed && typeof parsed === "object" && parsed.error === "invalid_grant") {
-          kind = "revoked";
-        }
-      } catch {
-        // Non-JSON body on 400 — not a revocation signal
-      }
-    }
+    const classification = parseTokenErrorResponse(response.status, text);
     throw new RefreshError(
       `Token refresh failed for '${providerId}': ${response.status} ${text}`,
-      kind,
+      classification.kind,
       response.status,
       text,
     );

--- a/packages/connect/src/token-refresh.ts
+++ b/packages/connect/src/token-refresh.ts
@@ -139,8 +139,16 @@ async function doRefresh(
   if (!response.ok) {
     const text = await response.text();
     const classification = parseTokenErrorResponse(response.status, text);
+    // Mirror OAuthCallbackError: the raw IdP body lives on the typed
+    // `body` field, the message carries only the classification summary
+    // so a generic catcher logging `err.message` cannot leak whatever
+    // the IdP echoed back (some servers reflect the rejected token).
+    const summary =
+      classification.error !== undefined
+        ? `${classification.error}${classification.errorDescription ? ` — ${classification.errorDescription}` : ""}`
+        : `HTTP ${response.status}`;
     throw new RefreshError(
-      `Token refresh failed for '${providerId}': ${response.status} ${text}`,
+      `Token refresh failed for '${providerId}': ${summary}`,
       classification.kind,
       response.status,
       text,

--- a/packages/connect/src/token-utils.ts
+++ b/packages/connect/src/token-utils.ts
@@ -57,6 +57,60 @@ export interface ParsedTokenResponse {
   refreshToken?: string;
   expiresAt: string | null;
   scopesGranted: string[];
+  /** Requested scopes that the provider did not grant (RFC 6749 §3.3 narrowing). */
+  scopeShortfall: string[];
+  /** Scopes granted that were never requested (provider over-grant). */
+  scopeCreep: string[];
+}
+
+/**
+ * Classified outcome of a non-2xx OAuth2 token endpoint response.
+ *
+ * Per RFC 6749 §5.2, a dead authorization code or refresh token is signaled by
+ * `HTTP 400` + body `{ "error": "invalid_grant" }`. Any other failure (network,
+ * 5xx, non-JSON body, other 4xx, other OAuth error codes) is treated as transient
+ * because the credential might still be valid.
+ *
+ * Both the initial token exchange (oauth.ts) and the refresh flow (token-refresh.ts)
+ * MUST classify errors through this helper so that revocation handling stays
+ * symmetric — historically only the refresh path detected revocation, leaving the
+ * initial callback path to bubble up a generic 400 with no actionable signal.
+ */
+export type TokenErrorKind = "revoked" | "transient";
+
+export interface TokenErrorClassification {
+  kind: TokenErrorKind;
+  /** OAuth2 error code from the response body (e.g. "invalid_grant") if parseable. */
+  error?: string;
+  /** Human-readable description from the response body if present. */
+  errorDescription?: string;
+}
+
+/**
+ * Classify an HTTP error response from an OAuth2 token endpoint.
+ *
+ * @param status - HTTP status code of the response
+ * @param body - Raw response body (text)
+ */
+export function parseTokenErrorResponse(status: number, body: string): TokenErrorClassification {
+  if (status !== 400) {
+    return { kind: "transient" };
+  }
+  try {
+    const parsed = JSON.parse(body) as { error?: unknown; error_description?: unknown };
+    if (!parsed || typeof parsed !== "object") {
+      return { kind: "transient" };
+    }
+    const error = typeof parsed.error === "string" ? parsed.error : undefined;
+    const errorDescription =
+      typeof parsed.error_description === "string" ? parsed.error_description : undefined;
+    if (error === "invalid_grant") {
+      return { kind: "revoked", error, errorDescription };
+    }
+    return { kind: "transient", error, errorDescription };
+  } catch {
+    return { kind: "transient" };
+  }
 }
 
 /**
@@ -65,13 +119,23 @@ export interface ParsedTokenResponse {
  * Scope parsing is universal: splits by comma, space, or %20 to handle all
  * provider conventions (e.g. GitHub returns comma-separated, Google uses spaces).
  *
+ * Scope validation: when `requestedScopes` is provided, the response is compared
+ * against it to surface `scopeShortfall` (provider granted fewer scopes than
+ * requested — caller should flag the connection as `needsReconnection: true` or
+ * present a warning to the user) and `scopeCreep` (provider returned more than
+ * requested — typically benign, log only). Some providers (Slack, GitHub legacy)
+ * always return all owner scopes regardless of the request, so creep is not a
+ * blocking signal.
+ *
  * @param tokenData - Raw JSON response from the token endpoint
- * @param fallbackScopes - Scopes to use if none are returned in the response
+ * @param requestedScopes - Scopes that were sent in the authorize / refresh call. Used
+ *   both as a fallback when the response omits `scope` and as the reference for
+ *   shortfall / creep comparison.
  * @param fallbackRefreshToken - Refresh token to preserve if not present in response
  */
 export function parseTokenResponse(
   tokenData: Record<string, unknown>,
-  fallbackScopes?: string[],
+  requestedScopes?: string[],
   fallbackRefreshToken?: string,
 ): ParsedTokenResponse {
   const accessToken = tokenData.access_token as string;
@@ -81,17 +145,20 @@ export function parseTokenResponse(
 
   const refreshToken = (tokenData.refresh_token as string | undefined) ?? fallbackRefreshToken;
 
-  // Compute expiration
   let expiresAt: string | null = null;
   if (typeof tokenData.expires_in === "number") {
     expiresAt = new Date(Date.now() + tokenData.expires_in * 1000).toISOString();
   }
 
-  // Extract granted scopes — split by comma, space, or %20 universally
   const scopeStr = typeof tokenData.scope === "string" ? tokenData.scope : "";
-  const scopesGranted = scopeStr
-    ? scopeStr.split(/[\s,]+|%20/).filter(Boolean)
-    : (fallbackScopes ?? []);
+  const responseScopes = scopeStr ? scopeStr.split(/[\s,]+|%20/).filter(Boolean) : [];
+  const scopesGranted = responseScopes.length > 0 ? responseScopes : (requestedScopes ?? []);
 
-  return { accessToken, refreshToken, expiresAt, scopesGranted };
+  const requested = requestedScopes ?? [];
+  const grantedSet = new Set(scopesGranted);
+  const requestedSet = new Set(requested);
+  const scopeShortfall = requested.filter((s) => !grantedSet.has(s));
+  const scopeCreep = scopesGranted.filter((s) => !requestedSet.has(s));
+
+  return { accessToken, refreshToken, expiresAt, scopesGranted, scopeShortfall, scopeCreep };
 }

--- a/packages/connect/test/encryption.test.ts
+++ b/packages/connect/test/encryption.test.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { randomBytes, createCipheriv } from "node:crypto";
+import { _resetCacheForTesting } from "@appstrate/env";
+import {
+  encrypt,
+  decrypt,
+  encryptCredentials,
+  decryptCredentials,
+  _resetKeyringForTesting,
+} from "../src/encryption.ts";
+
+const PRIMARY_KEY_B64 = randomBytes(32).toString("base64");
+
+// Snapshot the only env keys this file mutates, so other tests are unaffected.
+const MUTATED_KEYS = [
+  "CONNECTION_ENCRYPTION_KEY",
+  "CONNECTION_ENCRYPTION_KEY_ID",
+  "CONNECTION_ENCRYPTION_KEYS",
+] as const;
+
+let savedEnv: Partial<Record<(typeof MUTATED_KEYS)[number], string>> = {};
+
+function snapshotEnv(): void {
+  savedEnv = {};
+  for (const k of MUTATED_KEYS) {
+    if (k in process.env) savedEnv[k] = process.env[k];
+  }
+}
+
+function restoreEnv(): void {
+  for (const k of MUTATED_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+  _resetCacheForTesting();
+  _resetKeyringForTesting();
+}
+
+function setRotationEnv(overrides: Partial<Record<(typeof MUTATED_KEYS)[number], string>>): void {
+  // Always start from a clean baseline so prior test state cannot leak.
+  process.env.CONNECTION_ENCRYPTION_KEY = PRIMARY_KEY_B64;
+  delete process.env.CONNECTION_ENCRYPTION_KEY_ID;
+  delete process.env.CONNECTION_ENCRYPTION_KEYS;
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v === undefined) delete process.env[k as (typeof MUTATED_KEYS)[number]];
+    else process.env[k as (typeof MUTATED_KEYS)[number]] = v;
+  }
+  _resetCacheForTesting();
+  _resetKeyringForTesting();
+}
+
+beforeEach(() => {
+  snapshotEnv();
+  setRotationEnv({});
+});
+
+afterEach(() => {
+  restoreEnv();
+});
+
+describe("encryption — v1 versioned envelope", () => {
+  it("round-trips plaintext through the active key", () => {
+    const ciphertext = encrypt("hello world");
+    expect(ciphertext.startsWith("v1:k1:")).toBe(true);
+    expect(decrypt(ciphertext)).toBe("hello world");
+  });
+
+  it("emits the configured active kid in the envelope", () => {
+    setRotationEnv({ CONNECTION_ENCRYPTION_KEY_ID: "k2" });
+    const ciphertext = encrypt("payload");
+    expect(ciphertext.startsWith("v1:k2:")).toBe(true);
+  });
+});
+
+describe("encryption — keyring resolution during rotation", () => {
+  it("decrypts a blob written with the primary key (active kid)", () => {
+    const ciphertext = encrypt("secret");
+    expect(decrypt(ciphertext)).toBe("secret");
+  });
+
+  it("decrypts a blob whose kid lives in CONNECTION_ENCRYPTION_KEYS (retired key)", () => {
+    // Step 1: encrypt with what is currently the active key (kid = "k1").
+    const oldCiphertext = encrypt("retired payload");
+    expect(oldCiphertext.startsWith("v1:k1:")).toBe(true);
+
+    // Step 2: rotate — promote a new active kid, retire the old one.
+    setRotationEnv({
+      CONNECTION_ENCRYPTION_KEY: randomBytes(32).toString("base64"),
+      CONNECTION_ENCRYPTION_KEY_ID: "k2",
+      CONNECTION_ENCRYPTION_KEYS: JSON.stringify({ k1: PRIMARY_KEY_B64 }),
+    });
+
+    // Step 3: blob still readable via the retired-keys map.
+    expect(decrypt(oldCiphertext)).toBe("retired payload");
+
+    // Step 4: new writes use the new active kid.
+    const newCiphertext = encrypt("fresh payload");
+    expect(newCiphertext.startsWith("v1:k2:")).toBe(true);
+    expect(decrypt(newCiphertext)).toBe("fresh payload");
+  });
+
+  it("rejects a retired key map that aliases the active kid", () => {
+    const retiredKey = randomBytes(32).toString("base64");
+    setRotationEnv({
+      CONNECTION_ENCRYPTION_KEY_ID: "k1",
+      CONNECTION_ENCRYPTION_KEYS: JSON.stringify({ k1: retiredKey }),
+    });
+    expect(() => encrypt("anything")).toThrow(/active kid/);
+  });
+
+  it("rejects a retired key with the wrong byte length", () => {
+    setRotationEnv({
+      CONNECTION_ENCRYPTION_KEYS: JSON.stringify({
+        old: Buffer.from("too-short").toString("base64"),
+      }),
+    });
+    expect(() => encrypt("anything")).toThrow(/32 bytes/);
+  });
+
+  it("throws a clear error when decrypting a blob whose kid is unknown", () => {
+    const iv = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", Buffer.from(PRIMARY_KEY_B64, "base64"), iv);
+    const enc = Buffer.concat([cipher.update("x", "utf8"), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    const packed = Buffer.concat([iv, tag, enc]).toString("base64");
+    const forged = `v1:unknown:${packed}`;
+    expect(() => decrypt(forged)).toThrow(/No encryption key registered/);
+  });
+});
+
+describe("encryption — backward compatibility with v0 (legacy unprefixed)", () => {
+  it("decrypts legacy raw-base64 blobs with the active key", () => {
+    // Build a v0 blob the same way the old encrypt() did: raw base64 of
+    // `iv|authTag|ciphertext`, no version prefix, no kid.
+    const key = Buffer.from(PRIMARY_KEY_B64, "base64");
+    const iv = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", key, iv);
+    const enc = Buffer.concat([cipher.update("legacy payload", "utf8"), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    const v0Blob = Buffer.concat([iv, tag, enc]).toString("base64");
+    expect(v0Blob.startsWith("v1:")).toBe(false);
+
+    expect(decrypt(v0Blob)).toBe("legacy payload");
+  });
+
+  it("re-encrypts a v0 blob into a v1 envelope (in-place rotation primitive)", () => {
+    const key = Buffer.from(PRIMARY_KEY_B64, "base64");
+    const iv = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", key, iv);
+    const enc = Buffer.concat([cipher.update("payload", "utf8"), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    const v0Blob = Buffer.concat([iv, tag, enc]).toString("base64");
+
+    const plaintext = decrypt(v0Blob);
+    const reEncrypted = encrypt(plaintext);
+    expect(reEncrypted.startsWith("v1:k1:")).toBe(true);
+    expect(decrypt(reEncrypted)).toBe(plaintext);
+  });
+});
+
+describe("encryption — credentials helpers", () => {
+  it("round-trips a credentials object", () => {
+    const creds = { access_token: "at_123", refresh_token: "rt_456" };
+    const encrypted = encryptCredentials(creds);
+    expect(encrypted.startsWith("v1:")).toBe(true);
+    expect(decryptCredentials<typeof creds>(encrypted)).toEqual(creds);
+  });
+});

--- a/packages/connect/test/encryption.test.ts
+++ b/packages/connect/test/encryption.test.ts
@@ -131,32 +131,94 @@ describe("encryption — keyring resolution during rotation", () => {
 });
 
 describe("encryption — backward compatibility with v0 (legacy unprefixed)", () => {
-  it("decrypts legacy raw-base64 blobs with the active key", () => {
-    // Build a v0 blob the same way the old encrypt() did: raw base64 of
-    // `iv|authTag|ciphertext`, no version prefix, no kid.
-    const key = Buffer.from(PRIMARY_KEY_B64, "base64");
+  function buildV0Blob(plaintext: string, keyB64: string): string {
+    const key = Buffer.from(keyB64, "base64");
     const iv = randomBytes(12);
     const cipher = createCipheriv("aes-256-gcm", key, iv);
-    const enc = Buffer.concat([cipher.update("legacy payload", "utf8"), cipher.final()]);
+    const enc = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
     const tag = cipher.getAuthTag();
-    const v0Blob = Buffer.concat([iv, tag, enc]).toString("base64");
+    return Buffer.concat([iv, tag, enc]).toString("base64");
+  }
+
+  it("decrypts legacy raw-base64 blobs with the active key", () => {
+    const v0Blob = buildV0Blob("legacy payload", PRIMARY_KEY_B64);
     expect(v0Blob.startsWith("v1:")).toBe(false);
 
     expect(decrypt(v0Blob)).toBe("legacy payload");
   });
 
   it("re-encrypts a v0 blob into a v1 envelope (in-place rotation primitive)", () => {
-    const key = Buffer.from(PRIMARY_KEY_B64, "base64");
-    const iv = randomBytes(12);
-    const cipher = createCipheriv("aes-256-gcm", key, iv);
-    const enc = Buffer.concat([cipher.update("payload", "utf8"), cipher.final()]);
-    const tag = cipher.getAuthTag();
-    const v0Blob = Buffer.concat([iv, tag, enc]).toString("base64");
+    const v0Blob = buildV0Blob("payload", PRIMARY_KEY_B64);
 
     const plaintext = decrypt(v0Blob);
     const reEncrypted = encrypt(plaintext);
     expect(reEncrypted.startsWith("v1:k1:")).toBe(true);
     expect(decrypt(reEncrypted)).toBe(plaintext);
+  });
+
+  it("decrypts a v0 blob after rotation when the original key is retired", () => {
+    // Regression: pre-fix, decrypt() always used keyring.activeKid for v0
+    // blobs, so the moment a new key was promoted active, every existing v0
+    // blob became undecryptable — even with the original key still present in
+    // CONNECTION_ENCRYPTION_KEYS — until the v0→v1 sweep finished. The fix
+    // tries every key in the keyring for v0 blobs. AES-GCM tag verification
+    // makes that safe: a wrong key cannot succeed by chance.
+
+    // Build a v0 blob under the current primary key (kid = "k1").
+    const v0Blob = buildV0Blob("retired-era payload", PRIMARY_KEY_B64);
+
+    // Rotate: promote a new primary, retain the old key in the retired map.
+    setRotationEnv({
+      CONNECTION_ENCRYPTION_KEY: randomBytes(32).toString("base64"),
+      CONNECTION_ENCRYPTION_KEY_ID: "k2",
+      CONNECTION_ENCRYPTION_KEYS: JSON.stringify({ k1: PRIMARY_KEY_B64 }),
+    });
+
+    expect(decrypt(v0Blob)).toBe("retired-era payload");
+  });
+
+  it("throws a clear error when no keyring key can decrypt a v0 blob", () => {
+    // Build a v0 blob under a key that is *not* in the keyring at decrypt time.
+    const orphanKey = randomBytes(32).toString("base64");
+    const v0Blob = buildV0Blob("orphan payload", orphanKey);
+
+    // Default keyring only knows PRIMARY_KEY_B64 under kid "k1" — neither the
+    // active key nor any retired key matches the blob's actual key.
+    expect(() => decrypt(v0Blob)).toThrow(/Failed to decrypt v0/);
+  });
+
+  it("does not fall back to the v0 multi-key path for v1 envelopes", () => {
+    // Sanity: the v1 fast path uses the embedded kid only, never the
+    // try-every-key fallback. A v1 envelope with an unknown kid must error
+    // with "No encryption key registered" (kid lookup miss), not with the
+    // v0 fallback message — proving the two paths stay isolated.
+    const iv = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", Buffer.from(PRIMARY_KEY_B64, "base64"), iv);
+    const enc = Buffer.concat([cipher.update("x", "utf8"), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    const packed = Buffer.concat([iv, tag, enc]).toString("base64");
+    const forged = `v1:unknown:${packed}`;
+
+    expect(() => decrypt(forged)).toThrow(/No encryption key registered/);
+  });
+
+  it("v1 blobs still resolve via their explicit kid after rotation (no regression)", () => {
+    // Encrypt under k1.
+    const v1Blob = encrypt("explicit-kid payload");
+    expect(v1Blob.startsWith("v1:k1:")).toBe(true);
+
+    // Rotate: k1 retired, k2 active.
+    setRotationEnv({
+      CONNECTION_ENCRYPTION_KEY: randomBytes(32).toString("base64"),
+      CONNECTION_ENCRYPTION_KEY_ID: "k2",
+      CONNECTION_ENCRYPTION_KEYS: JSON.stringify({ k1: PRIMARY_KEY_B64 }),
+    });
+
+    // The v1 path looks up k1 directly via the embedded kid, not via the
+    // v0 try-every-key loop. This guarantees the active path stays a single
+    // AES-GCM verification, with no measurable timing dependency on the
+    // number of retired keys.
+    expect(decrypt(v1Blob)).toBe("explicit-kid payload");
   });
 });
 

--- a/packages/connect/test/token-utils.test.ts
+++ b/packages/connect/test/token-utils.test.ts
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "bun:test";
-import { parseTokenResponse, buildTokenHeaders, buildTokenBody } from "../src/token-utils.ts";
+import {
+  parseTokenResponse,
+  parseTokenErrorResponse,
+  buildTokenHeaders,
+  buildTokenBody,
+} from "../src/token-utils.ts";
 
 describe("parseTokenResponse", () => {
   const baseToken = { access_token: "tok_123" };
@@ -67,6 +72,101 @@ describe("parseTokenResponse", () => {
       "rt_old",
     );
     expect(result.refreshToken).toBe("rt_new");
+  });
+});
+
+describe("parseTokenResponse — scope diff", () => {
+  const baseToken = { access_token: "tok_x" };
+
+  it("reports zero shortfall and creep when granted == requested", () => {
+    const result = parseTokenResponse({ ...baseToken, scope: "read:user repo" }, [
+      "read:user",
+      "repo",
+    ]);
+    expect(result.scopeShortfall).toEqual([]);
+    expect(result.scopeCreep).toEqual([]);
+  });
+
+  it("reports shortfall when provider grants fewer scopes than requested", () => {
+    const result = parseTokenResponse({ ...baseToken, scope: "read:user" }, ["read:user", "repo"]);
+    expect(result.scopeShortfall).toEqual(["repo"]);
+    expect(result.scopeCreep).toEqual([]);
+  });
+
+  it("reports creep when provider grants extra scopes (Slack-style super-set)", () => {
+    const result = parseTokenResponse({ ...baseToken, scope: "read:user repo admin" }, [
+      "read:user",
+      "repo",
+    ]);
+    expect(result.scopeShortfall).toEqual([]);
+    expect(result.scopeCreep).toEqual(["admin"]);
+  });
+
+  it("reports both shortfall and creep simultaneously", () => {
+    const result = parseTokenResponse({ ...baseToken, scope: "different:scope" }, [
+      "read:user",
+      "repo",
+    ]);
+    expect(result.scopeShortfall).toEqual(["read:user", "repo"]);
+    expect(result.scopeCreep).toEqual(["different:scope"]);
+  });
+
+  it("treats missing scope field as 'requested == granted' (no signal)", () => {
+    // When the provider omits `scope`, we fall back to requestedScopes; that's
+    // the documented assumption that the request was granted in full.
+    const result = parseTokenResponse(baseToken, ["read:user", "repo"]);
+    expect(result.scopesGranted).toEqual(["read:user", "repo"]);
+    expect(result.scopeShortfall).toEqual([]);
+    expect(result.scopeCreep).toEqual([]);
+  });
+
+  it("treats no requested scopes as no shortfall, all granted as creep", () => {
+    const result = parseTokenResponse({ ...baseToken, scope: "read:user" });
+    expect(result.scopeShortfall).toEqual([]);
+    expect(result.scopeCreep).toEqual(["read:user"]);
+  });
+});
+
+describe("parseTokenErrorResponse", () => {
+  it("classifies HTTP 400 + invalid_grant as 'revoked' (RFC 6749 §5.2)", () => {
+    const result = parseTokenErrorResponse(400, JSON.stringify({ error: "invalid_grant" }));
+    expect(result.kind).toBe("revoked");
+    expect(result.error).toBe("invalid_grant");
+  });
+
+  it("preserves error_description on revoked classification", () => {
+    const result = parseTokenErrorResponse(
+      400,
+      JSON.stringify({ error: "invalid_grant", error_description: "Token has been revoked" }),
+    );
+    expect(result.kind).toBe("revoked");
+    expect(result.errorDescription).toBe("Token has been revoked");
+  });
+
+  it("classifies HTTP 400 + other OAuth error codes as 'transient'", () => {
+    const result = parseTokenErrorResponse(400, JSON.stringify({ error: "invalid_client" }));
+    expect(result.kind).toBe("transient");
+    expect(result.error).toBe("invalid_client");
+  });
+
+  it("classifies HTTP 400 + non-JSON body as 'transient'", () => {
+    const result = parseTokenErrorResponse(400, "<html>Bad Request</html>");
+    expect(result.kind).toBe("transient");
+    expect(result.error).toBeUndefined();
+  });
+
+  it("classifies HTTP 5xx as 'transient' regardless of body", () => {
+    const result = parseTokenErrorResponse(500, JSON.stringify({ error: "invalid_grant" }));
+    expect(result.kind).toBe("transient");
+  });
+
+  it("classifies HTTP 401/403 as 'transient'", () => {
+    expect(parseTokenErrorResponse(401, "").kind).toBe("transient");
+    expect(parseTokenErrorResponse(403, "").kind).toBe("transient");
+  });
+
+  it("classifies empty body as 'transient'", () => {
+    expect(parseTokenErrorResponse(400, "").kind).toBe("transient");
   });
 });
 

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -43,6 +43,23 @@ const envSchema = z
       .refine((val) => Buffer.from(val, "base64").length === 32, {
         message: "CONNECTION_ENCRYPTION_KEY must be 32 bytes (256-bit) base64-encoded",
       }),
+    // Active key id embedded in newly-encrypted credential blobs (v1 envelope).
+    // Stable across deploys — change only when promoting a freshly-rotated key.
+    // Must match /^[A-Za-z0-9_-]{1,32}$/.
+    CONNECTION_ENCRYPTION_KEY_ID: z
+      .string()
+      .default("k1")
+      .refine((v) => /^[A-Za-z0-9_-]{1,32}$/.test(v), {
+        message: "CONNECTION_ENCRYPTION_KEY_ID must match /^[A-Za-z0-9_-]{1,32}$/",
+      }),
+    // Retired keys held for decrypt-only during a rotation window. JSON map of
+    // kid → base64-encoded 32-byte key. Exclude the active kid (validated at boot).
+    // Empty map disables the legacy keyring; existing v0 blobs still decrypt with
+    // the active key.
+    CONNECTION_ENCRYPTION_KEYS: z
+      .string()
+      .default("{}")
+      .transform((s) => JSON.parse(s) as Record<string, string>),
     SYSTEM_PROXIES: z
       .string()
       .default("[]")

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -56,10 +56,27 @@ const envSchema = z
     // kid → base64-encoded 32-byte key. Exclude the active kid (validated at boot).
     // Empty map disables the legacy keyring; existing v0 blobs still decrypt with
     // the active key.
+    //
+    // Validated as `Record<string, string>` AT BOOT — a non-string value or
+    // JSON parse error fails fast with a clear Zod issue path, rather than
+    // surfacing inside `loadKeyring()` as a `Buffer.from(b64, "base64")`
+    // length mismatch hours later. The kid format itself is validated by
+    // `loadKeyring()` against the same `KID_PATTERN` used for envelopes.
     CONNECTION_ENCRYPTION_KEYS: z
       .string()
       .default("{}")
-      .transform((s) => JSON.parse(s) as Record<string, string>),
+      .transform((s, ctx) => {
+        try {
+          return JSON.parse(s) as unknown;
+        } catch {
+          ctx.addIssue({
+            code: "custom",
+            message: "CONNECTION_ENCRYPTION_KEYS must be valid JSON",
+          });
+          return z.NEVER;
+        }
+      })
+      .pipe(z.record(z.string(), z.string())),
     SYSTEM_PROXIES: z
       .string()
       .default("[]")


### PR DESCRIPTION
## Summary

Closes #277. Three hardening gaps from the post-#272 audit:

- **Finding 1 — revocation symmetry**: hoist RFC 6749 §5.2 `invalid_grant` classification into `parseTokenErrorResponse(status, body)` shared by both the initial token exchange (`handleOAuthCallback`) and the refresh path (`forceRefresh`). Initial callback errors now throw a typed `OAuthCallbackError` with `kind: \"revoked\" | \"transient\"`, mirroring `RefreshError`. The route layer renders a tailored \"please retry the connection\" message instead of bubbling up a raw 400.
- **Finding 2 — scope validation**: `parseTokenResponse` now returns `scopeShortfall` (granted ⊊ requested) and `scopeCreep` (granted ⊋ requested). The connection-manager flags `needsReconnection: true` on shortfall (FK-scoped to the exact saved row) and logs creep without blocking — Slack / GitHub legacy always return all owner scopes.
- **Finding 5 — versioned encryption envelope**: stored credentials now use a `v1:<kid>:<base64(iv|authTag|ciphertext)>` envelope with multi-key keyring resolution. Legacy v0 blobs (raw base64) remain decryptable indefinitely → non-breaking. New env vars `CONNECTION_ENCRYPTION_KEY_ID` (active kid, default `k1`) and `CONNECTION_ENCRYPTION_KEYS` (retired kids → keys map) gate the rotation playbook documented in `packages/connect/README.md`.

## What's NOT in this PR

- **Finding 3 (RFC 8414 metadataUrl)** — additive `metadataUrl` field on `oauth2Config` requires `afps-spec` schema coordination. Tracked separately.
- **Finding 4 (`credentialTransform.template` DSL)** — explicitly optional in #277, only relevant if #276 forces wire-level placeholder removal.
- **Background re-encrypt sweep job** — the format primitive is shipped, but scheduling the rotation worker is left for a separate ops PR. The current keyring already supports online rotation; the sweep is a follow-up to retire keys faster.

## Test plan

- [x] `bun test packages/connect` — 118 pass (12 new: parseTokenErrorResponse classification, scope diff, encryption envelope, rotation, v0 backward compat)
- [x] `bun test apps/api/test/integration/services/oauth-flows.test.ts` — 26 pass (4 new: revocation classification on callback, transient on other 4xx, shortfall flagging, creep no-block)
- [x] `bun run test:unit` — 658 pass
- [x] `bun run check` — typecheck + OpenAPI + format + lint all green
- [x] `bun run format:check` and `bun run lint` clean

## References

- RFC 6749 §5.2 — https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
- RFC 6749 §3.3 (scope narrowing semantics) — https://datatracker.ietf.org/doc/html/rfc6749#section-3.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)