### PR TITLE
fix(openapi): close coverage holes + add code-vs-spec audit (#284)

### DIFF
--- a/apps/api/src/openapi/index.ts
+++ b/apps/api/src/openapi/index.ts
@@ -46,6 +46,7 @@ import { endUsersPaths } from "./paths/end-users.ts";
 import { uploadsPaths } from "./paths/uploads.ts";
 import { credentialProxyPaths } from "./paths/credential-proxy.ts";
 import { llmProxyPaths } from "./paths/llm-proxy.ts";
+import { libraryPaths } from "./paths/library.ts";
 
 const corePaths = {
   ...healthPaths,
@@ -76,6 +77,7 @@ const corePaths = {
   ...uploadsPaths,
   ...credentialProxyPaths,
   ...llmProxyPaths,
+  ...libraryPaths,
 };
 
 const components = {

--- a/apps/api/src/openapi/info.ts
+++ b/apps/api/src/openapi/info.ts
@@ -35,6 +35,11 @@ export const openApiInfo = {
     { name: "Providers", description: "Provider configuration (OAuth2, API key, etc.)" },
     { name: "API Keys", description: "API key management for programmatic access" },
     { name: "Packages", description: "Organization skills, tools, and package management" },
+    {
+      name: "Library",
+      description:
+        "Consolidated package catalog across an organization's applications (UI-oriented).",
+    },
     { name: "Notifications", description: "Run notification management" },
     { name: "Organizations", description: "Organization and member management" },
     { name: "Profile", description: "User profile management" },

--- a/apps/api/src/openapi/paths/credential-proxy.ts
+++ b/apps/api/src/openapi/paths/credential-proxy.ts
@@ -7,137 +7,189 @@
  * bearer auth: API keys (headless / GitHub Action) or OIDC-issued JWTs
  * (interactive CLI device-flow, dashboard second-party apps). Cookie
  * sessions are rejected.
+ *
+ * The handler is registered as `router.all("/proxy", …)` because upstream
+ * provider semantics are method-defined (Gmail, ClickUp, etc. all rely on
+ * GET/POST/PUT/PATCH/DELETE). A POST-only route would silently 404 every
+ * non-POST tool call, which agents paraphrase as "the API is unavailable".
+ * Each accepted verb is documented below with the same operation shape.
  */
+
+const proxySharedDescription =
+  "High-value endpoint. Accepts an upstream HTTP request and forwards it to the " +
+  "provider after injecting the stored credentials server-side. Credentials never " +
+  "leave Appstrate.\n\n" +
+  "Authentication: bearer only — either an API key with the `credential-proxy:call` " +
+  "scope (NOT granted by default) or an OIDC-issued JWT (device-flow access token " +
+  "for the interactive CLI, dashboard access token for second-party apps). Cookie " +
+  "sessions are rejected. Session binding pins the `X-Session-Id` to the first " +
+  "principal (API key or JWT user) that used it.\n\n" +
+  "Optional `Appstrate-User` header scopes the call to an end-user's connection " +
+  "profile (API-key auth only).\n\n" +
+  "URL and headers can contain `{{credential_field}}` placeholders substituted " +
+  "against the provider's credential schema. Set `X-Substitute-Body: true` to run " +
+  "the same substitution on the request body (verbs that carry one).";
+
+const proxyParameters = [
+  {
+    name: "X-App-Id",
+    in: "header",
+    required: true,
+    description: "Application id (app_…) the API key is scoped to.",
+    schema: { type: "string" },
+  },
+  {
+    name: "X-Provider",
+    in: "header",
+    required: true,
+    description: "Scoped provider name (e.g. `@afps/gmail`).",
+    schema: { type: "string" },
+  },
+  {
+    name: "X-Target",
+    in: "header",
+    required: true,
+    description:
+      "Absolute URL of the upstream endpoint. Must match the provider manifest's " +
+      "`authorizedUris` unless `allowAllUris: true`.",
+    schema: { type: "string", format: "uri" },
+  },
+  {
+    name: "X-Session-Id",
+    in: "header",
+    required: true,
+    description:
+      "Caller-chosen session id; scopes the cookie jar. Fresh UUID per CLI invocation " +
+      "is typical.",
+    schema: { type: "string" },
+  },
+  {
+    name: "X-Substitute-Body",
+    in: "header",
+    required: false,
+    description:
+      "When `true`, the request body is decoded as UTF-8 and `{{field}}` placeholders " +
+      "are substituted. Ignored on verbs that do not carry a body (GET, DELETE).",
+    schema: { type: "string", enum: ["true", "false"] },
+  },
+  {
+    name: "Appstrate-User",
+    in: "header",
+    required: false,
+    description: "Impersonation header — scopes the call to this end-user's connection profile.",
+    schema: { type: "string", pattern: "^eu_" },
+  },
+  {
+    name: "X-Stream-Request",
+    in: "header",
+    required: false,
+    description:
+      "When `1`, forward the request body as a stream instead of buffering. Required for " +
+      "uploads larger than the buffered body cap; the upstream content length is still " +
+      "validated against `CREDENTIAL_PROXY_LIMITS.max_request_bytes`. Ignored on verbs " +
+      "that do not carry a body (GET, DELETE).",
+    schema: { type: "string", enum: ["0", "1"] },
+  },
+  {
+    name: "X-Run-Id",
+    in: "header",
+    required: false,
+    description:
+      "Optional run id (`exec_…`) used for per-run attribution in `credential_proxy_usage`. " +
+      "Not validated against the principal — a mismatched runId is a reporting oddity, not " +
+      "a security boundary.",
+    schema: { type: "string" },
+  },
+] as const;
+
+const proxyResponses = {
+  "200": {
+    description:
+      "Upstream response (status code, headers, body forwarded verbatim). Buffered " +
+      "responses include `X-Truncated`/`X-Truncated-Size` when the body exceeded the " +
+      "platform truncation cap; streamed responses (when the upstream sends " +
+      "`Transfer-Encoding: chunked` or a `Content-Length` over `max_streamed_body_size`) " +
+      "do not carry these headers.",
+    headers: {
+      "X-Truncated": {
+        description:
+          "Set to `true` when the buffered upstream body was truncated to " +
+          "`CREDENTIAL_PROXY_LIMITS.max_response_bytes`. Absent on streamed responses.",
+        schema: { type: "string", enum: ["true"] },
+      },
+      "X-Truncated-Size": {
+        description:
+          "Original upstream `Content-Length` (in bytes) when `X-Truncated: true` is set, " +
+          "so the caller can decide whether to retry with `X-Stream-Request: 1` or accept " +
+          "the truncated body.",
+        schema: { type: "string" },
+      },
+    },
+    content: { "*/*": {} },
+  },
+  "400": { $ref: "#/components/responses/ValidationError" },
+  "401": { $ref: "#/components/responses/Unauthorized" },
+  "403": {
+    description:
+      "Forbidden — principal lacks `credential-proxy:call`, target not in " +
+      "`authorizedUris`, session bound to a different principal, or cookie session used.",
+  },
+  "404": {
+    description: "No credentials or connection profile for the requested provider.",
+  },
+  "429": { $ref: "#/components/responses/RateLimited" },
+} as const;
+
+const proxyRequestBody = {
+  required: false,
+  description:
+    "Forwarded as-is to the upstream. Optional placeholder substitution via `X-Substitute-Body`.",
+  content: { "*/*": {} },
+} as const;
+
+type ProxyVerb = "get" | "post" | "put" | "patch" | "delete";
+
+function makeProxyOperation(verb: ProxyVerb) {
+  const summaries: Record<ProxyVerb, string> = {
+    get: "Proxy a GET request to a provider with server-side credential injection",
+    post: "Proxy a POST request to a provider with server-side credential injection",
+    put: "Proxy a PUT request to a provider with server-side credential injection",
+    patch: "Proxy a PATCH request to a provider with server-side credential injection",
+    delete: "Proxy a DELETE request to a provider with server-side credential injection",
+  };
+  const operationIds: Record<ProxyVerb, string> = {
+    get: "credentialProxyGet",
+    post: "credentialProxyPost",
+    put: "credentialProxyPut",
+    patch: "credentialProxyPatch",
+    delete: "credentialProxyDelete",
+  };
+
+  const op: Record<string, unknown> = {
+    operationId: operationIds[verb],
+    tags: ["Credential Proxy"],
+    summary: summaries[verb],
+    description: proxySharedDescription,
+    security: [{ bearerApiKey: [] }, { bearerJwt: [] }],
+    parameters: proxyParameters,
+    responses: proxyResponses,
+  };
+
+  // GET and DELETE conventionally carry no body — skip requestBody to keep the
+  // OpenAPI lint clean and reflect HTTP semantics.
+  if (verb === "post" || verb === "put" || verb === "patch") {
+    op.requestBody = proxyRequestBody;
+  }
+
+  return op;
+}
 
 export const credentialProxyPaths = {
   "/api/credential-proxy/proxy": {
-    post: {
-      operationId: "credentialProxy",
-      tags: ["Credential Proxy"],
-      summary: "Proxy a request to a provider with server-side credential injection",
-      description:
-        "High-value endpoint. Accepts an upstream HTTP request and forwards it to the " +
-        "provider after injecting the stored credentials server-side. Credentials never " +
-        "leave Appstrate.\n\n" +
-        "Authentication: bearer only — either an API key with the `credential-proxy:call` " +
-        "scope (NOT granted by default) or an OIDC-issued JWT (device-flow access token " +
-        "for the interactive CLI, dashboard access token for second-party apps). Cookie " +
-        "sessions are rejected. Session binding pins the `X-Session-Id` to the first " +
-        "principal (API key or JWT user) that used it.\n\n" +
-        "Optional `Appstrate-User` header scopes the call to an end-user's connection " +
-        "profile (API-key auth only).\n\n" +
-        "The request method + body are forwarded as-is. URL and headers can contain " +
-        "`{{credential_field}}` placeholders substituted against the provider's credential " +
-        "schema. Set `X-Substitute-Body: true` to run the same substitution on the body.",
-      security: [{ bearerApiKey: [] }, { bearerJwt: [] }],
-      parameters: [
-        {
-          name: "X-App-Id",
-          in: "header",
-          required: true,
-          description: "Application id (app_…) the API key is scoped to.",
-          schema: { type: "string" },
-        },
-        {
-          name: "X-Provider",
-          in: "header",
-          required: true,
-          description: "Scoped provider name (e.g. `@afps/gmail`).",
-          schema: { type: "string" },
-        },
-        {
-          name: "X-Target",
-          in: "header",
-          required: true,
-          description:
-            "Absolute URL of the upstream endpoint. Must match the provider manifest's " +
-            "`authorizedUris` unless `allowAllUris: true`.",
-          schema: { type: "string", format: "uri" },
-        },
-        {
-          name: "X-Session-Id",
-          in: "header",
-          required: true,
-          description:
-            "Caller-chosen session id; scopes the cookie jar. Fresh UUID per CLI invocation " +
-            "is typical.",
-          schema: { type: "string" },
-        },
-        {
-          name: "X-Substitute-Body",
-          in: "header",
-          required: false,
-          description:
-            "When `true`, the request body is decoded as UTF-8 and `{{field}}` placeholders " +
-            "are substituted.",
-          schema: { type: "string", enum: ["true", "false"] },
-        },
-        {
-          name: "Appstrate-User",
-          in: "header",
-          required: false,
-          description:
-            "Impersonation header — scopes the call to this end-user's connection profile.",
-          schema: { type: "string", pattern: "^eu_" },
-        },
-        {
-          name: "X-Stream-Request",
-          in: "header",
-          required: false,
-          description:
-            "When `1`, forward the request body as a stream instead of buffering. Required for " +
-            "uploads larger than the buffered body cap; the upstream content length is still " +
-            "validated against `CREDENTIAL_PROXY_LIMITS.max_request_bytes`.",
-          schema: { type: "string", enum: ["0", "1"] },
-        },
-        {
-          name: "X-Run-Id",
-          in: "header",
-          required: false,
-          description:
-            "Optional run id (`exec_…`) used for per-run attribution in `credential_proxy_usage`. " +
-            "Not validated against the principal — a mismatched runId is a reporting oddity, not " +
-            "a security boundary.",
-          schema: { type: "string" },
-        },
-      ],
-      responses: {
-        "200": {
-          description:
-            "Upstream response (status code, headers, body forwarded verbatim). Buffered " +
-            "responses include `X-Truncated`/`X-Truncated-Size` when the body exceeded the " +
-            "platform truncation cap; streamed responses (when the upstream sends " +
-            "`Transfer-Encoding: chunked` or a `Content-Length` over `max_streamed_body_size`) " +
-            "do not carry these headers.",
-          headers: {
-            "X-Truncated": {
-              description:
-                "Set to `true` when the buffered upstream body was truncated to " +
-                "`CREDENTIAL_PROXY_LIMITS.max_response_bytes`. Absent on streamed responses.",
-              schema: { type: "string", enum: ["true"] },
-            },
-            "X-Truncated-Size": {
-              description:
-                "Original upstream `Content-Length` (in bytes) when `X-Truncated: true` is set, " +
-                "so the caller can decide whether to retry with `X-Stream-Request: 1` or accept " +
-                "the truncated body.",
-              schema: { type: "string" },
-            },
-          },
-          content: { "*/*": {} },
-        },
-        "400": { $ref: "#/components/responses/ValidationError" },
-        "401": { $ref: "#/components/responses/Unauthorized" },
-        "403": {
-          description:
-            "Forbidden — principal lacks `credential-proxy:call`, target not in " +
-            "`authorizedUris`, session bound to a different principal, or cookie session used.",
-        },
-        "404": {
-          description: "No credentials or connection profile for the requested provider.",
-        },
-        "429": { $ref: "#/components/responses/RateLimited" },
-      },
-    },
+    get: makeProxyOperation("get"),
+    post: makeProxyOperation("post"),
+    put: makeProxyOperation("put"),
+    patch: makeProxyOperation("patch"),
+    delete: makeProxyOperation("delete"),
   },
 } as const;

--- a/apps/api/src/openapi/paths/library.ts
+++ b/apps/api/src/openapi/paths/library.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Library — consolidated package list across the org's applications.
+ *
+ * Single endpoint that powers the dashboard library view: returns every
+ * package visible to the org (org-owned + system) grouped by type, with
+ * a per-package `installedIn` array indicating which of the caller's
+ * applications already have the package installed.
+ */
+
+export const libraryPaths = {
+  "/api/library": {
+    get: {
+      operationId: "getLibrary",
+      tags: ["Library"],
+      summary: "List all packages visible to the org with per-app install state",
+      description:
+        "Returns every package available to the caller's organization (org-owned + system) " +
+        "grouped by type (`agent`, `skill`, `tool`, `provider`). Each package carries an " +
+        "`installedIn` array of application ids — the applications belonging to the caller's " +
+        "org where the package is currently installed. Ephemeral packages are excluded.\n\n" +
+        "The response also includes the org's applications (id, name, isDefault) so the UI " +
+        "can render a single grid keyed by app without an additional `/api/applications` call.",
+      parameters: [
+        { $ref: "#/components/parameters/XOrgId" },
+        { $ref: "#/components/parameters/XAppId" },
+      ],
+      responses: {
+        "200": {
+          description: "Library snapshot.",
+          headers: {
+            "Request-Id": { $ref: "#/components/headers/RequestId" },
+            "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
+          },
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["object", "applications", "packages"],
+                properties: {
+                  object: { type: "string", enum: ["library"] },
+                  applications: {
+                    type: "array",
+                    description:
+                      "Applications belonging to the caller's organization. The default " +
+                      "application (if any) is listed first.",
+                    items: {
+                      type: "object",
+                      required: ["id", "name", "isDefault"],
+                      properties: {
+                        id: { type: "string", description: "Application id (`app_…`)." },
+                        name: { type: "string" },
+                        isDefault: { type: "boolean" },
+                      },
+                    },
+                  },
+                  packages: {
+                    type: "object",
+                    description:
+                      "Packages grouped by type. Every group is always present (possibly empty).",
+                    required: ["agent", "skill", "tool", "provider"],
+                    properties: {
+                      agent: { $ref: "#/components/schemas/LibraryPackageList" },
+                      skill: { $ref: "#/components/schemas/LibraryPackageList" },
+                      tool: { $ref: "#/components/schemas/LibraryPackageList" },
+                      provider: { $ref: "#/components/schemas/LibraryPackageList" },
+                    },
+                  },
+                },
+              },
+              example: {
+                object: "library",
+                applications: [
+                  { id: "app_default", name: "Default", isDefault: true },
+                  { id: "app_staging", name: "Staging", isDefault: false },
+                ],
+                packages: {
+                  agent: [
+                    {
+                      id: "pkg_inbox_triage",
+                      type: "agent",
+                      source: "org",
+                      name: "Inbox Triage",
+                      description: "Sorts incoming Gmail threads into priority buckets.",
+                      installedIn: ["app_default"],
+                    },
+                  ],
+                  skill: [],
+                  tool: [],
+                  provider: [
+                    {
+                      id: "pkg_gmail",
+                      type: "provider",
+                      source: "system",
+                      name: "Gmail",
+                      description: "Google Mail OAuth provider.",
+                      installedIn: ["app_default", "app_staging"],
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        "401": { $ref: "#/components/responses/Unauthorized" },
+        "403": { $ref: "#/components/responses/Forbidden" },
+      },
+    },
+  },
+} as const;

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -1059,4 +1059,40 @@ export const schemas = {
       },
     },
   },
+  LibraryPackageList: {
+    type: "array",
+    description:
+      "Packages of a single type visible to the org. Each entry carries an " +
+      "`installedIn` array listing the caller-org applications where the package " +
+      "is currently installed (empty array = not installed in any of the caller's apps).",
+    items: {
+      type: "object",
+      required: ["id", "type", "source", "name", "description", "installedIn"],
+      properties: {
+        id: { type: "string", description: "Package id (`pkg_…`)." },
+        type: { type: "string", enum: ["agent", "skill", "tool", "provider"] },
+        source: {
+          type: "string",
+          description:
+            "Package origin (e.g. `org` for org-owned packages, `system` for built-in system packages).",
+        },
+        name: {
+          type: "string",
+          description:
+            "Display name from the package draft manifest (`displayName`); falls back to the package id.",
+        },
+        description: {
+          type: "string",
+          description:
+            "Description from the package draft manifest; empty string when not provided.",
+        },
+        installedIn: {
+          type: "array",
+          description:
+            "Application ids (`app_…`) belonging to the caller's org where this package is installed.",
+          items: { type: "string" },
+        },
+      },
+    },
+  },
 } as const;

--- a/scripts/verify-openapi.ts
+++ b/scripts/verify-openapi.ts
@@ -9,12 +9,19 @@
  * 3. Best practices lint — @redocly/openapi-core (recommended ruleset)
  * 4. Zod ↔ OpenAPI schema comparison — compares Zod-derived JSON Schemas (pre-converted
  *    in the registry via z.toJSONSchema()) against hand-written OpenAPI requestBody schemas
+ * 5. Code subset Spec — statically enumerates router.METHOD() and app.METHOD() calls across
+ *    apps/api/src/routes (per-domain route files) plus apps/api/src/modules (built-in modules)
+ *    plus apps/api/src/index.ts, composes the mount prefix from app.route(prefix, factory) calls,
+ *    normalises Hono path syntax, and asserts every code-registered endpoint is documented in
+ *    the OpenAPI spec or in the explicit allowlist.
  *
  * Module-owned paths and schemas are loaded dynamically from built-in modules.
  * The set of modules validated matches `MODULES` (default: all built-in).
  *
  * Usage: bun scripts/verify-openapi.ts
  */
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
 import { validate as validateOpenAPI } from "@readme/openapi-parser";
 import { lintFromString, createConfig } from "@redocly/openapi-core";
 import { buildOpenApiSpec } from "../apps/api/src/openapi/index.ts";
@@ -331,12 +338,20 @@ const expectedEndpoints = [
   "POST /api/uploads",
   "PUT /api/uploads/_content",
 
-  // Credential proxy (AFPS 1.3 BYOI)
+  // Credential proxy (AFPS 1.3 BYOI) — registered as router.all() in code,
+  // every verb is documented because upstream provider semantics are method-defined.
+  "GET /api/credential-proxy/proxy",
   "POST /api/credential-proxy/proxy",
+  "PUT /api/credential-proxy/proxy",
+  "PATCH /api/credential-proxy/proxy",
+  "DELETE /api/credential-proxy/proxy",
 
   // LLM proxy (Remote CLI execution — Phase 3)
   "POST /api/llm-proxy/openai-completions/v1/chat/completions",
   "POST /api/llm-proxy/anthropic-messages/v1/messages",
+
+  // Library (consolidated package catalog across an org's applications)
+  "GET /api/library",
 ];
 
 // Module-contributed endpoints are sourced directly from each module's
@@ -757,6 +772,302 @@ if (discrepancies.length === 0) {
     }
     console.log();
   }
+}
+
+// ═══════════════════════════════════════════════════
+// 5. Code ⊆ Spec
+// ═══════════════════════════════════════════════════
+//
+// Static analysis of `router.METHOD(...)` / `app.METHOD(...)` registrations
+// across `apps/api/src/routes/*.ts`, `apps/api/src/modules/*/routes.ts` and
+// `apps/api/src/index.ts`. The mount prefix for each route file is composed
+// from `app.route(prefix, factory)` calls in `index.ts`. Every code-registered
+// endpoint that is neither in the spec nor in the explicit allowlist below is
+// reported as orphan and fails the run.
+//
+// Files registered via runtime config (e.g. `routes/llm-proxy.ts` registers
+// routes inside a config-driven `for` loop) and Better Auth's catchall
+// (`/api/auth/*`, plugin-registered) are skipped and the corresponding
+// endpoints are left to coverage check #1 to keep in sync.
+
+console.log(`\n  5. Code ⊆ Spec`);
+console.log(`  ----------------`);
+
+interface RouteRegistration {
+  verb: string;
+  path: string;
+}
+
+const ROUTE_VERBS = ["get", "post", "put", "patch", "delete", "all", "head", "options"] as const;
+const ROUTE_VERB_PATTERN = ROUTE_VERBS.join("|");
+
+/**
+ * Find the body of a top-level `function`/`export function` declaration by
+ * locating its opening `{` after `name(...)` and brace-counting forward.
+ * Returns the source slice between the matching braces (exclusive), or null
+ * if the function isn't found.
+ */
+function extractFunctionBody(src: string, fnName: string): string | null {
+  const sigPattern = new RegExp(`(?:export\\s+)?function\\s+${fnName}\\s*\\(`, "g");
+  const sig = sigPattern.exec(src);
+  if (!sig) return null;
+  const openIdx = src.indexOf("{", sig.index + sig[0].length);
+  if (openIdx === -1) return null;
+  let depth = 1;
+  let i = openIdx + 1;
+  while (i < src.length && depth > 0) {
+    const ch = src[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+    i++;
+  }
+  return depth === 0 ? src.slice(openIdx + 1, i - 1) : null;
+}
+
+/**
+ * Extract all `router.METHOD("path", …)` registrations from a slice of source.
+ */
+function extractRouterRegistrations(slice: string): RouteRegistration[] {
+  const out: RouteRegistration[] = [];
+  const re = new RegExp(`router\\.(${ROUTE_VERB_PATTERN})\\s*\\(\\s*["'\`]([^"'\`]*)["'\`]`, "g");
+  for (const m of slice.matchAll(re)) {
+    out.push({ verb: m[1]!, path: m[2]! });
+  }
+  return out;
+}
+
+/**
+ * Normalise a Hono path to the OpenAPI equivalent.
+ *  - `:id`              → `{id}`
+ *  - `:scope{@[^/]+}`   → `{scope}`  (regex-constrained param)
+ */
+function normaliseHonoPath(path: string): string {
+  return path.replace(/:(\w+)\{[^}]+\}/g, "{$1}").replace(/:(\w+)/g, "{$1}");
+}
+
+/**
+ * Compose a mount prefix and a sub-path safely (handles trailing slashes
+ * and the empty / `/` sub-path).
+ */
+function joinMountPath(prefix: string, sub: string): string {
+  const trimmedPrefix = prefix.replace(/\/+$/, "");
+  if (!sub || sub === "/") return trimmedPrefix || "/";
+  const trimmedSub = sub.startsWith("/") ? sub : "/" + sub;
+  return trimmedPrefix + trimmedSub || "/";
+}
+
+/**
+ * Expand a registration into one or more `"VERB PATH"` entries (handles
+ * `router.all(...)` and `app.all(...)`).
+ */
+function expandRegistration(verb: string, fullPath: string): string[] {
+  if (verb === "all") {
+    return ["GET", "POST", "PUT", "PATCH", "DELETE"].map((v) => `${v} ${fullPath}`);
+  }
+  return [`${verb.toUpperCase()} ${fullPath}`];
+}
+
+const REPO_ROOT = new URL("..", import.meta.url).pathname;
+const indexPath = join(REPO_ROOT, "apps/api/src/index.ts");
+const indexSrc = readFileSync(indexPath, "utf8");
+
+// 1. Build the import map for `./routes/<file>` imports in index.ts
+//    - Named: `import { createXRouter } from "./routes/x.ts"`
+//    - Default: `import xRouter from "./routes/x.ts"`
+const importToFile = new Map<string, string>(); // identifier → relative file path
+for (const m of indexSrc.matchAll(
+  /import\s+\{([^}]+)\}\s+from\s+["']\.\/(routes\/[^"']+?)(?:\.ts)?["']/g,
+)) {
+  const file = m[2]!;
+  for (const raw of m[1]!.split(",")) {
+    const name = raw
+      .trim()
+      .split(/\s+as\s+/)[0]!
+      .trim();
+    if (name) importToFile.set(name, file);
+  }
+}
+for (const m of indexSrc.matchAll(
+  /import\s+(\w+)\s+from\s+["']\.\/(routes\/[^"']+?)(?:\.ts)?["']/g,
+)) {
+  importToFile.set(m[1]!, m[2]!);
+}
+
+// 2. Track `const x = createXRouter()` aliasing so `app.route(prefix, x)` resolves
+const varToFactory = new Map<string, string>();
+for (const m of indexSrc.matchAll(/(?:const|let)\s+(\w+)\s*=\s*(\w+)\s*\(\s*\)/g)) {
+  varToFactory.set(m[1]!, m[2]!);
+}
+
+// 3. Parse `app.route("PREFIX", expr)` calls — expr is one of:
+//    - `createFooRouter()`           → factory call
+//    - `createFooRouter`             → factory reference (rare)
+//    - `fooRouter`                   → variable bound to either `createFooRouter()` or default import
+type Mount = { prefix: string; file: string; factory: string | "__default__" };
+const mounts: Mount[] = [];
+// Matches both `app.route("/p", fooRouter)` and `app.route("/p", createFooRouter())`.
+// The expression group accepts an identifier optionally followed by `()` — this is
+// narrow enough to capture the trailing `)` of the factory call as part of the
+// expression rather than as the closing paren of `app.route(...)`.
+for (const m of indexSrc.matchAll(
+  /app\.route\(\s*["']([^"']+)["']\s*,\s*(\w+(?:\(\s*\))?)\s*\)/g,
+)) {
+  const prefix = m[1]!;
+  const exprRaw = m[2]!.trim();
+  const isCall = /\(\s*\)$/.test(exprRaw);
+  const ident = exprRaw.replace(/\(\s*\)$/, "").trim();
+
+  // Resolve identifier
+  let factory: string | "__default__" = ident;
+  let file: string | undefined;
+
+  if (isCall) {
+    // direct factory call: ident must be a named import
+    file = importToFile.get(ident);
+    factory = ident;
+  } else {
+    // variable: either an alias of a factory or a default import
+    const aliasedFactory = varToFactory.get(ident);
+    if (aliasedFactory) {
+      file = importToFile.get(aliasedFactory);
+      factory = aliasedFactory;
+    } else {
+      file = importToFile.get(ident);
+      factory = "__default__";
+    }
+  }
+
+  if (file) mounts.push({ prefix, file, factory });
+}
+
+// 4. Discovered code endpoints
+const codeEndpoints = new Set<string>();
+
+// 4a. Direct `app.METHOD("path", ...)` calls in index.ts
+for (const m of indexSrc.matchAll(
+  new RegExp(`app\\.(${ROUTE_VERB_PATTERN})\\s*\\(\\s*["']([^"']+)["']`, "g"),
+)) {
+  const verb = m[1]!;
+  const path = normaliseHonoPath(m[2]!);
+  for (const ep of expandRegistration(verb, path)) codeEndpoints.add(ep);
+}
+
+// 4b. Route files referenced by mounts — parse each factory body or default body
+//     and combine with the mount prefix.
+const SKIP_FILES = new Set<string>([
+  // Routes registered via runtime config (config-driven `for` loop). The
+  // emitted endpoints are already covered by check #1; static analysis can't
+  // see them.
+  "routes/llm-proxy",
+  // packages.ts iterates ROUTE_CONFIGS with template-literal paths
+  // (router.get(`/${path}/...`, …) where `path` ∈ {skills, tools, agents,
+  // providers}). All concrete paths are already enumerated in
+  // expectedEndpoints, so check #1 catches drift on this file.
+  "routes/packages",
+]);
+
+const routeFileCache = new Map<string, string>();
+function readRouteFile(relPath: string): string {
+  const cached = routeFileCache.get(relPath);
+  if (cached !== undefined) return cached;
+  const full = join(REPO_ROOT, "apps/api/src", relPath + ".ts");
+  const src = existsSync(full) ? readFileSync(full, "utf8") : "";
+  routeFileCache.set(relPath, src);
+  return src;
+}
+
+for (const mount of mounts) {
+  if (SKIP_FILES.has(mount.file)) continue;
+  const src = readRouteFile(mount.file);
+  if (!src) continue;
+
+  let scope: string;
+  if (mount.factory === "__default__") {
+    scope = src;
+  } else {
+    const body = extractFunctionBody(src, mount.factory);
+    if (body == null) continue;
+    scope = body;
+  }
+
+  for (const reg of extractRouterRegistrations(scope)) {
+    const fullPath = normaliseHonoPath(joinMountPath(mount.prefix, reg.path));
+    for (const ep of expandRegistration(reg.verb, fullPath)) codeEndpoints.add(ep);
+  }
+}
+
+// 4c. Built-in module routes — files at `apps/api/src/modules/<name>/routes.ts`
+//     mounted at `/` (paths are absolute in module routes).
+const modulesDir = join(REPO_ROOT, "apps/api/src/modules");
+if (existsSync(modulesDir)) {
+  for (const name of readdirSync(modulesDir, { withFileTypes: true })) {
+    if (!name.isDirectory()) continue;
+    const routesPath = join(modulesDir, name.name, "routes.ts");
+    if (!existsSync(routesPath)) continue;
+    const src = readFileSync(routesPath, "utf8");
+    for (const reg of extractRouterRegistrations(src)) {
+      const fullPath = normaliseHonoPath(reg.path);
+      for (const ep of expandRegistration(reg.verb, fullPath)) codeEndpoints.add(ep);
+    }
+  }
+}
+
+// 5. Allowlist — endpoints that exist in code by design but are intentionally
+//    NOT documented in the OpenAPI spec.
+const CODE_TO_SPEC_ALLOWLIST = new Set<string>([
+  // OIDC HTML pages — server-rendered CSRF-hardened forms (Post-Redirect-Get),
+  // not API endpoints. Convention across all OIDC implementations.
+  "GET /api/oauth/login",
+  "POST /api/oauth/login",
+  "GET /api/oauth/register",
+  "POST /api/oauth/register",
+  "GET /api/oauth/consent",
+  "POST /api/oauth/consent",
+  "GET /api/oauth/forgot-password",
+  "POST /api/oauth/forgot-password",
+  "GET /api/oauth/reset-password",
+  "POST /api/oauth/reset-password",
+  "GET /api/oauth/magic-link",
+  "POST /api/oauth/magic-link",
+  "GET /api/oauth/magic-link/confirm",
+  "POST /api/oauth/magic-link/confirm",
+  "GET /api/oauth/logout",
+  "POST /api/oauth/logout",
+  "GET /api/oauth/assets/social-sign-in.js",
+  // OIDC device-flow activation pages — server-rendered HTML.
+  "GET /activate",
+  "POST /activate",
+  "POST /activate/approve",
+  "POST /activate/deny",
+  // SPA fallback + unknown-API guard registered directly in index.ts.
+  "GET /api/*",
+  "POST /api/*",
+  "PUT /api/*",
+  "PATCH /api/*",
+  "DELETE /api/*",
+  "GET /*",
+  // Dev-time docs page served as plain text, not part of the JSON API.
+  "GET /llms.txt",
+]);
+
+const orphans = [...codeEndpoints]
+  .filter((ep) => !specEndpoints.has(ep) && !CODE_TO_SPEC_ALLOWLIST.has(ep))
+  .sort();
+
+console.log(
+  `  Code-registered endpoints: ${codeEndpoints.size}  (allowlist: ${CODE_TO_SPEC_ALLOWLIST.size})`,
+);
+
+if (orphans.length === 0) {
+  console.log(`  OK — every code-registered endpoint is documented in the spec.`);
+} else {
+  exitCode = 1;
+  console.log(`\n  Endpoints registered in code but missing from the spec (${orphans.length}):`);
+  for (const ep of orphans) console.log(`    - ${ep}`);
+  console.log(
+    `\n  Either document the endpoint in apps/api/src/openapi/paths/ + add it to ` +
+      `expectedEndpoints, or add a justified entry to CODE_TO_SPEC_ALLOWLIST in this file.`,
+  );
 }
 
 // ═══════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Closes #284 by restoring ADR-004 ("OpenAPI = source of truth") on three findings the existing `verify:openapi` was structurally unable to catch:

- **Document `GET /api/library`** — implemented in `routes/library.ts` and consumed by the dashboard, but absent from `apps/api/src/openapi/` and `expectedEndpoints`.
- **Document every verb on `/api/credential-proxy/proxy`** — the route uses `router.all()` (intentional: upstream provider semantics span GET/POST/PUT/PATCH/DELETE; a POST-only contract makes agents paraphrase 404s as "API unavailable"). The spec previously documented only POST, leaving 4 verbs without contract.
- **Add Check #5 (Code ⊆ Spec)** to `scripts/verify-openapi.ts` — the static analyzer that would have caught finding #1 had it existed.

## Implementation

### 1. `GET /api/library` documented
- New `apps/api/src/openapi/paths/library.ts` describing the consolidated package catalog (`{ object, applications[], packages: { agent, skill, tool, provider } }` with `installedIn[]` per package).
- New `Library` tag in `info.ts`, new `LibraryPackageList` reusable schema in `schemas.ts`.
- Wired into `corePaths` in `openapi/index.ts`, added to `expectedEndpoints` in `verify-openapi.ts`.

### 2. `/api/credential-proxy/proxy` — option (a) from the ticket
Refactored `paths/credential-proxy.ts` to share parameters / responses across **all five verbs** (GET/POST/PUT/PATCH/DELETE), each with its own `operationId`. `requestBody` is omitted on GET/DELETE to reflect HTTP semantics and keep the lint clean. Added the four new entries to `expectedEndpoints`.

### 3. Check #5 — Code ⊆ Spec
Static analyzer at the bottom of `scripts/verify-openapi.ts`:
- Parses `apps/api/src/index.ts` to build the import map (named + default), the `var → factory` alias map (for `const x = createXRouter()`), and the list of `app.route(prefix, expr)` mounts.
- For each mount, locates the corresponding factory body in the route file (brace-counting after `export function name(...)`) and extracts every `router.METHOD("path", …)` call. Default-imported routers fall back to scanning the file body.
- Also enumerates direct `app.METHOD("path", …)` calls in `index.ts` and walks `apps/api/src/modules/<name>/routes.ts` (mounted at `/`, paths absolute).
- Normalises Hono syntax (`:id` → `{id}`, strips `:scope{regex}` constraints) and expands `router.all()` / `app.all()` into the five concrete verbs.
- Files using runtime-config registration loops (`routes/llm-proxy.ts`, `routes/packages.ts`) are in `SKIP_FILES`; their endpoints stay covered by Check #1.
- Allowlist (`CODE_TO_SPEC_ALLOWLIST`) covers OIDC HTML pages (server-rendered Post-Redirect-Get forms), `/activate*`, the `/api/*` 404 fallback, the `/*` SPA fallback, and `/llms.txt`.

### Verification

The analyzer was validated by temporarily reverting fix #1 — Check #5 reported `GET /api/library` as orphan with the documented remediation hint, then went green again once the spec entry was restored.

```
1. Endpoint Coverage:           Spec: 256  Expected: 256  OK
2. Structural Validation:       OK — valid OpenAPI 3.1.0
3. Best Practices Lint:         OK — no lint issues
4. Zod ↔ OpenAPI Body:          54/54 matches
5. Code ⊆ Spec:                 199 code endpoints (28 allowlisted) — OK
```

Full quality gate (`bun run check` = turbo typecheck + lint + format + verify:openapi + detect:breaking + system-packages:check) is green. `detect:breaking` reports 0 breaking changes (only the new endpoints added by this PR + previously-merged work).

## Test plan
- [x] `bun run check` — 18/18 turbo tasks pass
- [x] `bun run verify:openapi` — all 5 checks pass
- [x] `bun test apps/api/test/unit` — 691 unit tests pass
- [x] Regression: removing the new `library` spec entry causes Check #5 to fail with `GET /api/library` listed as orphan
- [ ] CI: integration suite (Docker + Postgres + Redis + MinIO)