### PR TITLE
chore: drop pre-prod legacy (encryption v0, CLI #167, RunResult mirror, hash redirects, draft repair)

### DIFF
--- a/apps/api/src/openapi/paths/runs.ts
+++ b/apps/api/src/openapi/paths/runs.ts
@@ -819,10 +819,10 @@ export const runsPaths = {
             schema: {
               type: "object",
               description:
-                "AFPS runtime `RunResult` — `memories`, `checkpoint`, `output`, `report`, `logs` plus optional terminal `status`/`error`/`durationMs`.",
+                "AFPS runtime `RunResult` — `memories`, `pinned`, `output`, `report`, `logs` plus optional terminal `status`/`error`/`durationMs`.",
               properties: {
                 memories: { type: "array" },
-                checkpoint: {},
+                pinned: { type: "object" },
                 output: {},
                 report: { type: ["string", "null"] },
                 logs: { type: "array" },

--- a/apps/api/src/routes/runs-events.ts
+++ b/apps/api/src/routes/runs-events.ts
@@ -63,8 +63,6 @@ const RunResultSchema = z
       .array(z.object({ content: z.string(), scope: z.enum(["actor", "shared"]).optional() }))
       .optional()
       .default([]),
-    checkpoint: z.unknown().nullable().optional(),
-    checkpointScope: z.enum(["actor", "shared"]).optional(),
     pinned: z
       .record(
         z.string(),
@@ -177,8 +175,6 @@ export function createRunsEventsRouter() {
     const d = parsed.data;
     const result: RunResult = {
       memories: d.memories,
-      checkpoint: d.checkpoint ?? null,
-      ...(d.checkpointScope !== undefined ? { checkpointScope: d.checkpointScope } : {}),
       ...(d.pinned !== undefined ? { pinned: d.pinned } : {}),
       output: d.output ?? null,
       report: d.report ?? null,

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -328,7 +328,11 @@ export async function finalizeRun(input: FinalizeRunInput): Promise<void> {
   // 6. CAS close — single gate for all subsequent side effects. Concurrent
   //    finalize retries (platform synthesis vs container POST) hit the same
   //    row; the CAS lets exactly one proceed.
-  const checkpointToPersist = isPlainRecord(result.checkpoint) ? result.checkpoint : null;
+  const checkpointSlot = result.pinned?.[CHECKPOINT_KEY];
+  const checkpointToPersist =
+    checkpointSlot !== undefined && isPlainRecord(checkpointSlot.content)
+      ? checkpointSlot.content
+      : null;
 
   const rowsAffected = await db
     .update(runs)
@@ -424,29 +428,13 @@ export async function finalizeRun(input: FinalizeRunInput): Promise<void> {
     }
   }
 
-  // Unified-persistence pinned-slot write — the single store for the
-  // carry-over checkpoint AND any other named pinned slot the agent
-  // wrote via `pin({ key, content })`. Honors the AFPS 1.4 scope when
-  // the runtime stamped one onto each slot; falls back to the run's
-  // actor scope.
-  if (checkpointToPersist !== null) {
-    const checkpointScope =
-      result.checkpointScope === "shared" ? { type: "shared" as const } : persistenceScope;
-    await upsertPinned(
-      run.packageId,
-      run.applicationId,
-      run.orgId,
-      checkpointScope,
-      CHECKPOINT_KEY,
-      checkpointToPersist,
-      run.id,
-    );
-  }
+  // Unified-persistence pinned-slot write — the single store for every
+  // named pinned slot the agent wrote via `pin({ key, content })`,
+  // including the carry-over `"checkpoint"` slot. Honors the AFPS 1.4
+  // scope when the runtime stamped one onto each slot; falls back to
+  // the run's actor scope.
   if (result.pinned) {
     for (const [key, slot] of Object.entries(result.pinned)) {
-      // The "checkpoint" slot is mirrored into `result.checkpoint` and
-      // already persisted above — skip the duplicate write.
-      if (key === CHECKPOINT_KEY) continue;
       const slotScope = slot.scope === "shared" ? { type: "shared" as const } : persistenceScope;
       await upsertPinned(
         run.packageId,

--- a/apps/api/test/integration/services/appstrate-event-sink.test.ts
+++ b/apps/api/test/integration/services/appstrate-event-sink.test.ts
@@ -79,14 +79,14 @@ describe("AggregatingEventSink", () => {
     const sink = newSink();
     await sink.handle(event("pinned.set", { key: "checkpoint", content: { counter: 42 } }));
 
-    expect(sink.snapshot().checkpoint).toEqual({ counter: 42 });
+    expect(sink.snapshot().pinned!.checkpoint).toEqual({ content: { counter: 42 } });
   });
 
   it("stores pinned.set with key='checkpoint' raw values verbatim (no projection — runtime keeps the payload)", async () => {
     const sink = newSink();
     await sink.handle(event("pinned.set", { key: "checkpoint", content: "just a string" }));
 
-    expect(sink.snapshot().checkpoint).toBe("just a string");
+    expect(sink.snapshot().pinned!.checkpoint).toEqual({ content: "just a string" });
   });
 
   it("replaces output on each emission + writes a run log per call", async () => {
@@ -225,7 +225,7 @@ describe("AggregatingEventSink", () => {
     // No events handled yet — every read MUST return a valid empty value.
     expect(() => sink.snapshot()).not.toThrow();
     expect(sink.snapshot().memories).toEqual([]);
-    expect(sink.snapshot().checkpoint).toBeNull();
+    expect(sink.snapshot().pinned).toBeUndefined();
     expect(sink.snapshot().output).toBeNull();
     expect(sink.snapshot().report).toBeNull();
     expect(sink.usage.input_tokens).toBe(0);

--- a/apps/api/test/integration/services/parity-e2e.test.ts
+++ b/apps/api/test/integration/services/parity-e2e.test.ts
@@ -96,7 +96,7 @@ describe("Parity E2E — full adapter stack", () => {
     // no platform projection.
     const snap = sink.snapshot();
     expect(snap.output).toEqual({ deliverable: "shipped" });
-    expect(snap.checkpoint).toEqual({ counter: 7 });
+    expect(snap.pinned!.checkpoint).toEqual({ content: { counter: 7 } });
     expect(snap.memories).toEqual([{ content: "learned A" }, { content: "learned B" }]);
     expect(snap.report).toBe("work done");
 

--- a/apps/api/test/integration/services/platform-container-sink.test.ts
+++ b/apps/api/test/integration/services/platform-container-sink.test.ts
@@ -418,7 +418,6 @@ describe("executeAgentInBackground — server-side finalize synthesis", () => {
       run: sinkRun!,
       result: {
         memories: [],
-        checkpoint: null,
         output: null,
         report: null,
         logs: [],

--- a/apps/api/test/unit/local-queue-cron.test.ts
+++ b/apps/api/test/unit/local-queue-cron.test.ts
@@ -9,7 +9,6 @@ import { describe, it, expect } from "bun:test";
 import { LocalQueue } from "../../src/infra/queue/local-queue.ts";
 import type { QueueJob } from "../../src/infra/queue/interface.ts";
 
- 
 function createQueue(): any {
   return new LocalQueue<{ v: string }>("test-cron");
 }

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -53,12 +53,7 @@ import {
   type InstallMode,
 } from "../lib/install/upgrade.ts";
 import type { EnvVars } from "../lib/install/secrets.ts";
-import {
-  LEGACY_PROJECT_NAME,
-  deriveProjectName,
-  readProjectFile,
-  writeProjectFile,
-} from "../lib/install/project.ts";
+import { deriveProjectName, readProjectFile, writeProjectFile } from "../lib/install/project.ts";
 import { CLI_VERSION } from "../lib/version.ts";
 
 export interface InstallOptions {
@@ -155,8 +150,7 @@ export async function installCommand(opts: InstallOptions): Promise<void> {
     // resolution so the resolver can cross-check with `docker compose ls`:
     // a port bound by OUR running stack is safe to skip-preflight, a
     // port bound by anyone else is not. Tier 0 has no compose project.
-    const project =
-      tier === 0 ? undefined : await resolveProjectName(dir, installState.existing.hasCompose);
+    const project = tier === 0 ? undefined : await resolveProjectName(dir);
 
     // Under --yes, soften port conflicts by auto-picking the next free
     // port instead of failing fast. Rationale: the one-liner installer's
@@ -752,14 +746,10 @@ async function installTier0(
 /**
  * Resolve the Compose project name for this install directory.
  *
- * Three cases:
+ * Two cases:
  *   1. `.appstrate/project.json` exists → use the recorded name
  *      (authoritative; never re-derive, never drift).
- *   2. No sidecar but a compose file is already present → legacy
- *      pre-#167 install. Use the fixed `appstrate` name so the upgrade
- *      targets the same containers the user's stack is currently
- *      running under.
- *   3. Fresh install → derive from the absolute dir path (stable +
+ *   2. Fresh install → derive from the absolute dir path (stable +
  *      unique + readable). The caller writes the sidecar on success
  *      so subsequent runs hit case (1).
  *
@@ -767,11 +757,9 @@ async function installTier0(
  */
 export async function resolveProjectName(
   dir: string,
-  hasLegacyCompose: boolean,
-): Promise<{ name: string; origin: "sidecar" | "legacy" | "derived" }> {
+): Promise<{ name: string; origin: "sidecar" | "derived" }> {
   const recorded = await readProjectFile(dir);
   if (recorded) return { name: recorded.projectName, origin: "sidecar" };
-  if (hasLegacyCompose) return { name: LEGACY_PROJECT_NAME, origin: "legacy" };
   return { name: deriveProjectName(dir), origin: "derived" };
 }
 
@@ -827,7 +815,7 @@ async function installDockerTier(
     force: boolean;
     mode: InstallMode;
     existing: ExistingInstall;
-    project: { name: string; origin: "sidecar" | "legacy" | "derived" };
+    project: { name: string; origin: "sidecar" | "derived" };
     autoConfirm: boolean;
     bootstrap: BootstrapOverrides;
   },
@@ -889,9 +877,9 @@ async function installDockerTier(
   }
 
   // Preflight: does another install already claim this project name?
-  // Only meaningful on the derived / legacy paths — a sidecar-recorded
-  // name IS the running project by definition, so the collision check
-  // would just reject the user's own running stack.
+  // Only meaningful on the derived path — a sidecar-recorded name IS
+  // the running project by definition, so the collision check would
+  // just reject the user's own running stack.
   await preflightProjectCollision(dir, project.name, opts.force);
 
   // Backup BEFORE writing so a rollback is possible all the way back

--- a/apps/cli/src/lib/install/project.ts
+++ b/apps/cli/src/lib/install/project.ts
@@ -3,39 +3,22 @@
 /**
  * Compose project-name management for `appstrate install`.
  *
- * Background: the first cut of the CLI hard-coded `name: appstrate` into
- * every compose template, so two installs under different directories
- * shared a single Compose project namespace. Running `appstrate install`
- * a second time silently adopted the first install's running containers,
- * then "recreated" them against a fresh `.env` — in the best case the
- * migrate service failed against the wrong `POSTGRES_PASSWORD`, in the
- * worst case it clobbered production state (#167).
+ * The CLI passes `--project-name <name>` explicitly on every `docker
+ * compose` invocation so the project namespace is under our control:
  *
- * Fix — three pieces:
- *
- *   1. The compose templates no longer carry a top-level `name:`. The
- *      CLI passes `--project-name <name>` explicitly on every `docker
- *      compose` invocation so the project namespace is under our control.
- *
- *   2. `deriveProjectName(dir)` turns the install directory into a
+ *   1. `deriveProjectName(dir)` turns the install directory into a
  *      stable, Compose-legal project name (`appstrate-<slug>-<hash>`).
  *      The hash disambiguates installs that land in sibling directories
  *      with the same basename; the slug keeps the name readable when a
  *      user lists projects with `docker compose ls`.
  *
- *   3. `<dir>/.appstrate/project.json` is written at install time so
+ *   2. `<dir>/.appstrate/project.json` is written at install time so
  *      subsequent runs (`appstrate install` as an upgrade,
  *      uninstall/upgrade helpers we may add later) read the exact name
  *      this dir is bound to — never re-derive, never drift. A user who
  *      renames the install dir will get a fresh project name on the
  *      next upgrade, but that's the right behavior: Compose would have
  *      produced different default-named containers anyway.
- *
- * Backward compat with pre-fix installs: when `<dir>/.appstrate/project.json`
- * is absent but the dir already contains a compose file, the caller
- * treats the project as legacy and falls back to the literal `appstrate`
- * name so `docker compose up` targets the same containers the user's
- * stack was running under. See `resolveProjectName` for the contract.
  */
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
@@ -102,9 +85,7 @@ export function projectFilePath(dir: string): string {
 
 /**
  * Read `<dir>/.appstrate/project.json` if present, returning the parsed
- * record. Returns `null` when the file is missing — callers distinguish
- * "first install" (null + no compose file) from "legacy pre-#167 install"
- * (null + compose file present) at a higher layer.
+ * record. Returns `null` when the file is missing.
  *
  * Malformed files (bad JSON, wrong shape, unknown `version`) are treated
  * as missing. That's safer than throwing — the install flow would then
@@ -146,12 +127,3 @@ export async function writeProjectFile(dir: string, projectName: string): Promis
   await writeFile(projectFilePath(dir), `${JSON.stringify(record, null, 2)}\n`);
   return record;
 }
-
-/**
- * Legacy project name — what every pre-#167 install used. Installed
- * stacks that predate the sidecar file still answer to this exact name
- * via `docker compose ls --filter name=appstrate`, so upgrades must
- * keep targeting it. Exported so tests and callers share the constant
- * instead of sprinkling string literals.
- */
-export const LEGACY_PROJECT_NAME = "appstrate";

--- a/apps/cli/test/install/project.test.ts
+++ b/apps/cli/test/install/project.test.ts
@@ -14,7 +14,6 @@ import { mkdtemp, readFile, rm, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
-  LEGACY_PROJECT_NAME,
   PROJECT_FILE_RELPATH,
   deriveProjectName,
   projectFilePath,
@@ -120,16 +119,5 @@ describe("readProjectFile / writeProjectFile", () => {
     );
     const read = await readProjectFile(workDir);
     expect(read).toBeNull();
-  });
-});
-
-describe("LEGACY_PROJECT_NAME", () => {
-  it("matches the literal string pre-#167 installs used", () => {
-    // The constant gates backward compatibility: pre-fix installs had
-    // `name: appstrate` baked into their compose file, so upgrades on
-    // those dirs MUST continue to target containers under that exact
-    // project name. If this literal ever changes, the upgrade path
-    // for legacy installs breaks.
-    expect(LEGACY_PROJECT_NAME).toBe("appstrate");
   });
 });

--- a/apps/cli/test/install/resolve-project-name.test.ts
+++ b/apps/cli/test/install/resolve-project-name.test.ts
@@ -3,11 +3,10 @@
 /**
  * Unit tests for `installCommand.resolveProjectName`.
  *
- * The three-way origin dispatch (`sidecar` / `legacy` / `derived`) is
- * what keeps pre-#167 installs unbroken: a dir with a compose file but
- * no sidecar MUST answer to the literal `appstrate` project name, so
- * an upgrade targets the user's currently-running containers rather
- * than spinning up a disjoint new stack with fresh secrets.
+ * The two-way origin dispatch (`sidecar` / `derived`) keeps Compose
+ * project namespaces under our control: an install with a recorded
+ * sidecar always answers to that exact name; a fresh dir gets a
+ * deterministic derived one.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
@@ -15,7 +14,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { resolveProjectName } from "../../src/commands/install.ts";
-import { writeProjectFile, LEGACY_PROJECT_NAME } from "../../src/lib/install/project.ts";
+import { writeProjectFile } from "../../src/lib/install/project.ts";
 
 let workDir: string;
 
@@ -30,21 +29,13 @@ afterEach(async () => {
 describe("resolveProjectName", () => {
   it("returns the sidecar-recorded name when `.appstrate/project.json` is present (authoritative)", async () => {
     await writeProjectFile(workDir, "appstrate-recorded-deadbeef");
-    // `hasLegacyCompose` would normally be true for an install that
-    // has been running, but the sidecar must take precedence.
-    const resolved = await resolveProjectName(workDir, true);
+    const resolved = await resolveProjectName(workDir);
     expect(resolved.name).toBe("appstrate-recorded-deadbeef");
     expect(resolved.origin).toBe("sidecar");
   });
 
-  it("falls back to the legacy `appstrate` name when a pre-#167 compose file exists without a sidecar", async () => {
-    const resolved = await resolveProjectName(workDir, true);
-    expect(resolved.name).toBe(LEGACY_PROJECT_NAME);
-    expect(resolved.origin).toBe("legacy");
-  });
-
-  it("derives a fresh name for a truly empty dir (no sidecar, no compose)", async () => {
-    const resolved = await resolveProjectName(workDir, false);
+  it("derives a fresh name for a dir without a sidecar file", async () => {
+    const resolved = await resolveProjectName(workDir);
     expect(resolved.origin).toBe("derived");
     // `appstrate-<slug>-<8 hex>` shape — the slug is the basename of
     // the temp dir, which `mkdtemp` suffixes with random hex.

--- a/apps/cli/test/run-sink.test.ts
+++ b/apps/cli/test/run-sink.test.ts
@@ -56,7 +56,6 @@ function progressEvent(message: string, data?: unknown): RunEvent {
 function emptyResult(): RunResult {
   return {
     memories: [],
-    checkpoint: null,
     output: null,
     report: "",
     logs: [],

--- a/apps/web/src/components/provider-editor/provider-editor-inner.tsx
+++ b/apps/web/src/components/provider-editor/provider-editor-inner.tsx
@@ -105,44 +105,19 @@ function makeDefaultCredentialFields(mode: CredentialMode): SchemaField[] {
 }
 
 /**
- * Normalize the initial editor state: extract credential fields from the manifest,
- * and seed defaults in-place if the manifest declares a credential authMode but
- * lacks a schema (repairs legacy drafts so they pass AFPS validation on save).
+ * Extract credential fields from the manifest's existing credentials schema.
+ * Returns an empty array when the manifest is in an OAuth mode (no creds
+ * needed) or when the credential schema is missing — in the latter case
+ * the user fills in fields via the form and the manifest is patched on
+ * save.
  */
-function normalizeProviderInitialState(initial: ProviderEditorState): {
-  state: ProviderEditorState;
-  credentialFields: SchemaField[];
-} {
-  const def = getDef(initial.manifest);
+function extractCredentialFields(manifest: Record<string, unknown>): SchemaField[] {
+  const def = getDef(manifest);
   const authMode = (def.authMode as string) || "oauth2";
+  if (!isCredentialMode(authMode)) return [];
   const creds = def.credentials as { schema?: JSONSchemaObject } | undefined;
-
-  if (!isCredentialMode(authMode)) {
-    return { state: initial, credentialFields: [] };
-  }
-
-  if (creds?.schema) {
-    return {
-      state: initial,
-      credentialFields: schemaToFields(creds.schema, "credentials"),
-    };
-  }
-
-  const seeded = makeDefaultCredentialFields(authMode);
-  if (seeded.length === 0) {
-    return { state: initial, credentialFields: [] };
-  }
-
-  return {
-    state: {
-      ...initial,
-      manifest: {
-        ...initial.manifest,
-        definition: writeCredentialsToDef(def, seeded),
-      },
-    },
-    credentialFields: seeded,
-  };
+  if (!creds?.schema) return [];
+  return schemaToFields(creds.schema, "credentials");
 }
 
 // ─── Component ─────────────────────────────────────────────
@@ -160,13 +135,12 @@ export function ProviderEditorInner({ initialState, isEdit, packageId }: Provide
   const createPkg = useCreatePackage("provider");
   const updatePkg = useUpdatePackage("provider", packageId || "");
 
-  // Normalize once at mount: extract credential fields, repair legacy drafts
-  // that declare a credential authMode without a schema. The normalized state
-  // becomes the baseline for both `state` and `isDirty` comparisons.
-  const [initialNormalized] = useState(() => normalizeProviderInitialState(initialState));
-  const [state, setState] = useState(initialNormalized.state);
-  const [credentialFields, setCredentialFields] = useState<SchemaField[]>(
-    initialNormalized.credentialFields,
+  // Snapshot the initial state once so `isDirty` compares against the
+  // exact bytes the editor mounted with.
+  const [initialSnapshot] = useState(initialState);
+  const [state, setState] = useState(initialState);
+  const [credentialFields, setCredentialFields] = useState<SchemaField[]>(() =>
+    extractCredentialFields(initialState.manifest),
   );
   const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<ProviderEditorTab>("general");
@@ -191,8 +165,8 @@ export function ProviderEditorInner({ initialState, isEdit, packageId }: Provide
 
   // --- Unsaved changes detection ---
   const isDirty = useMemo(
-    () => JSON.stringify(initialNormalized.state) !== JSON.stringify(state),
-    [initialNormalized, state],
+    () => JSON.stringify(initialSnapshot) !== JSON.stringify(state),
+    [initialSnapshot, state],
   );
   const { blocker, allowNavigation } = useUnsavedChanges(isDirty);
 

--- a/apps/web/src/components/settings-layout.tsx
+++ b/apps/web/src/components/settings-layout.tsx
@@ -40,20 +40,9 @@ interface SettingsLayoutProps {
   title: string;
   emoji?: string;
   breadcrumbs?: BreadcrumbEntry[];
-  /**
-   * Map of legacy hash values (without `#`) to destination pathnames.
-   * When the current URL has a matching hash, we redirect to the pathname.
-   */
-  legacyHashRedirects?: Record<string, string>;
 }
 
-export function SettingsLayout({
-  sections,
-  title,
-  emoji,
-  breadcrumbs,
-  legacyHashRedirects,
-}: SettingsLayoutProps) {
+export function SettingsLayout({ sections, title, emoji, breadcrumbs }: SettingsLayoutProps) {
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -67,17 +56,6 @@ export function SettingsLayout({
       useSidebarStore.getState().setOpenTransient(prev);
     };
   }, []);
-
-  // Backwards-compat: redirect old hash URLs (e.g. /preferences#security) to /preferences/security
-  useEffect(() => {
-    if (!legacyHashRedirects) return;
-    const hash = location.hash.replace(/^#/, "");
-    if (!hash) return;
-    const target = legacyHashRedirects[hash];
-    if (target && target !== location.pathname) {
-      navigate(target, { replace: true });
-    }
-  }, [location.hash, location.pathname, legacyHashRedirects, navigate]);
 
   const visibleSections = sections
     .map((s) => ({ ...s, items: s.items.filter((i) => i.show !== false) }))

--- a/apps/web/src/pages/org-settings/layout.tsx
+++ b/apps/web/src/pages/org-settings/layout.tsx
@@ -142,15 +142,6 @@ export function OrgSettingsLayout() {
       title={t("orgSettings.pageTitle")}
       emoji="⚙️"
       breadcrumbs={breadcrumbs}
-      legacyHashRedirects={{
-        general: "/org-settings/general",
-        members: "/org-settings/members",
-        models: "/org-settings/models",
-        proxies: "/org-settings/proxies",
-        oauth: "/org-settings/oauth",
-        billing: "/org-settings/billing",
-        "cli-sessions": "/org-settings/cli-sessions",
-      }}
       sections={sections}
     />
   );

--- a/apps/web/src/pages/preferences/layout.tsx
+++ b/apps/web/src/pages/preferences/layout.tsx
@@ -15,14 +15,6 @@ export function PreferencesLayout() {
         { label: t("nav.orgSection", { ns: "common" }), href: "/" },
         { label: t("preferences.title") },
       ]}
-      legacyHashRedirects={{
-        general: "/preferences/general",
-        appearance: "/preferences/appearance",
-        security: "/preferences/security",
-        connectors: "/preferences/connectors",
-        profiles: "/preferences/profiles",
-        devices: "/preferences/devices",
-      }}
       sections={[
         {
           items: [

--- a/apps/web/src/pages/run-detail.tsx
+++ b/apps/web/src/pages/run-detail.tsx
@@ -121,15 +121,6 @@ export function RunDetailPage() {
     defaultTab,
   );
 
-  // Legacy hash redirect: #checkpoint and #memories (split tabs pre-ADR-013)
-  // both fold into the unified #memory tab.
-  useEffect(() => {
-    const hash = window.location.hash.replace(/^#/, "");
-    if (hash === "checkpoint" || hash === "memories") {
-      setActiveTab("memory");
-    }
-  }, [setActiveTab]);
-
   // Sub-tab state: report by default if available, otherwise data.
   // Auto-default is derived; user override is tracked separately.
   const autoSubTab = finalReport ? "report" : hasOutput ? "data" : null;

--- a/apps/web/src/pages/unified-package-detail.tsx
+++ b/apps/web/src/pages/unified-package-detail.tsx
@@ -261,15 +261,6 @@ export function UnifiedPackageDetailPage({ type }: { type: PackageType }) {
     if (tab === "diff" && (!hasArchivableChanges || isVersionView)) setTab(defaultTab);
     if (tab === "versions" && source === "system") setTab(defaultTab);
   }, [tab, hasArchivableChanges, isVersionView, source, defaultTab, setTab]);
-  // Legacy hash redirect: #memories and #checkpoints (split tabs pre-ADR-013)
-  // both fold into the unified #memory tab.
-  useEffect(() => {
-    const hash = window.location.hash.replace(/^#/, "");
-    if (type === "agent" && (hash === "memories" || hash === "checkpoints")) {
-      setTab("memory");
-    }
-  }, [type, setTab]);
-
   const [createVersionOpen, setCreateVersionOpen] = useState(false);
 
   // ── Loading / Error ──

--- a/packages/afps-runtime/src/conformance/cases.ts
+++ b/packages/afps-runtime/src/conformance/cases.ts
@@ -457,8 +457,9 @@ const L4_REDUCER_SEMANTICS: ConformanceCase = {
     if (r.memories[0]!.content !== "first" || r.memories[1]!.content !== "second") {
       return fail("memory order / content mismatch");
     }
-    if (!r.checkpoint || (r.checkpoint as { counter: number }).counter !== 2) {
-      return fail(`checkpoint should be last-write-wins, got ${JSON.stringify(r.checkpoint)}`);
+    const checkpoint = r.pinned?.checkpoint?.content as { counter?: number } | undefined;
+    if (!checkpoint || checkpoint.counter !== 2) {
+      return fail(`checkpoint should be last-write-wins, got ${JSON.stringify(checkpoint)}`);
     }
     const out = r.output as { answer?: number; partial?: boolean; extra?: string } | null;
     if (!out || out.answer !== 42 || out.partial !== false || out.extra !== "done") {
@@ -491,7 +492,7 @@ const L4_EMPTY_SCRIPT: ConformanceCase = {
     if (
       r.memories.length !== 0 ||
       r.logs.length !== 0 ||
-      r.checkpoint !== null ||
+      r.pinned !== undefined ||
       r.output !== null ||
       r.report !== null
     ) {

--- a/packages/afps-runtime/src/runner/reducer.ts
+++ b/packages/afps-runtime/src/runner/reducer.ts
@@ -27,7 +27,6 @@ export interface ReduceOptions {
 export function emptyRunResult(): RunResult {
   return {
     memories: [],
-    checkpoint: null,
     output: null,
     report: null,
     logs: [],
@@ -63,13 +62,6 @@ export function foldEvent(result: RunResult, event: RunEvent): void {
       };
       if (canonical.scope !== undefined) slot.scope = canonical.scope;
       result.pinned[canonical.key] = slot;
-      // Mirror into the legacy top-level `checkpoint` field so existing
-      // consumers (run row, prompt builder, ingestion finalize) keep
-      // working without branching on `pinned["checkpoint"]`.
-      if (canonical.key === "checkpoint") {
-        result.checkpoint = canonical.content ?? null;
-        if (canonical.scope !== undefined) result.checkpointScope = canonical.scope;
-      }
       return;
     }
     case "output.emitted":

--- a/packages/afps-runtime/src/sinks/console-sink.ts
+++ b/packages/afps-runtime/src/sinks/console-sink.ts
@@ -45,7 +45,7 @@ export class ConsoleSink implements EventSink {
       `▶ run complete — memories=${result.memories.length} logs=${result.logs.length}` +
       (result.output !== null ? " output=set" : "") +
       (result.report !== null ? " report=set" : "") +
-      (result.checkpoint !== null ? " checkpoint=set" : "") +
+      (result.pinned?.checkpoint !== undefined ? " checkpoint=set" : "") +
       (result.error ? ` ERROR=${result.error.message}` : "");
     this.out.write(summary + "\n");
   }

--- a/packages/afps-runtime/src/types/run-result.ts
+++ b/packages/afps-runtime/src/types/run-result.ts
@@ -15,8 +15,7 @@ export type LogLevel = "info" | "warn" | "error";
  * against the canonical AFPS 1.3 semantics:
  *
  * - `memory.added` events append to `memories`
- * - `pinned.set` events upsert by `key` into `pinned` (last-write-wins per key);
- *   `key === "checkpoint"` additionally mirrors into the legacy `checkpoint` field
+ * - `pinned.set` events upsert by `key` into `pinned` (last-write-wins per key)
  * - `output.emitted` events deep-merge into `output` (JSON merge-patch)
  * - `report.appended` events concatenate into `report` with `\n` separators
  * - `log.written` events append to `logs`
@@ -26,25 +25,11 @@ export type LogLevel = "info" | "warn" | "error";
 export interface RunResult {
   memories: Memory[];
   /**
-   * Aggregated checkpoint payload — the last `pinned.set` value with
-   * `key === "checkpoint"`. Kept as a top-level shorthand because the
-   * checkpoint slot is the most common pinned slot and most ingestion
-   * paths read it directly.
-   */
-  checkpoint: unknown | null;
-  /**
-   * AFPS 1.4+ scope of the most recent checkpoint emit. Absent when no
-   * `pinned.set` event with `key === "checkpoint"` was emitted or when
-   * the emitter omitted the field — consumers default to `"actor"`.
-   */
-  checkpointScope?: "actor" | "shared";
-  /**
-   * AFPS 1.5+ named pinned slots — last-write-wins per `key`. The
-   * `checkpoint` key is mirrored into the top-level `checkpoint` field
-   * for backward compatibility, but `pinned["checkpoint"]` is the same
-   * value. Other keys (e.g. `"persona"`, `"goals"`) are persisted as
-   * named pinned rows in `package_persistence` and rendered into the
-   * system prompt on the next run.
+   * Named pinned slots — last-write-wins per `key`. The reserved
+   * `"checkpoint"` key is the carry-over slot read by ingestion +
+   * prompt builder; other keys (`"persona"`, `"goals"`, …) are
+   * persisted as named pinned rows in `package_persistence` and
+   * rendered into the system prompt on the next run.
    */
   pinned?: Record<string, PinnedSlot>;
   output: unknown | null;

--- a/packages/afps-runtime/test/fixtures/reference.test.ts
+++ b/packages/afps-runtime/test/fixtures/reference.test.ts
@@ -117,7 +117,7 @@ describe("fixtures/reference — end-to-end round trip", () => {
 
     expect(emitted).toHaveLength(events.length);
     expect(result.memories).toHaveLength(1);
-    expect(result.checkpoint).toEqual({ iteration: 1 });
+    expect(result.pinned!.checkpoint).toEqual({ content: { iteration: 1 } });
     expect(result.output).toEqual({ summary: "AFPS ships a portable runtime.", partial: false });
     expect(result.report).toBe("All checks executed.");
     expect(finalized).toBeDefined();

--- a/packages/afps-runtime/test/resolvers/platform-tools.test.ts
+++ b/packages/afps-runtime/test/resolvers/platform-tools.test.ts
@@ -109,7 +109,7 @@ describe("platform tools — open envelope emission", () => {
 });
 
 describe("pinned.set fold semantics", () => {
-  it("reducer folds pinned.set with key='checkpoint' into result.checkpoint with scope captured", () => {
+  it("reducer folds pinned.set with key='checkpoint' into result.pinned with scope captured", () => {
     const events: RunEvent[] = [
       {
         type: "pinned.set",
@@ -121,8 +121,6 @@ describe("pinned.set fold semantics", () => {
       },
     ];
     const result = reduceEvents(events);
-    expect(result.checkpoint).toEqual({ cursor: "abc" });
-    expect(result.checkpointScope).toBe("shared");
     expect(result.pinned).toEqual({
       checkpoint: { content: { cursor: "abc" }, scope: "shared" },
     });
@@ -147,8 +145,6 @@ describe("pinned.set fold semantics", () => {
       },
     ];
     const result = reduceEvents(events);
-    expect(result.checkpoint).toEqual({ v: 2 });
-    expect(result.checkpointScope).toBe("actor");
     expect(result.pinned!.checkpoint).toEqual({ content: { v: 2 }, scope: "actor" });
   });
 
@@ -171,7 +167,6 @@ describe("pinned.set fold semantics", () => {
       },
     ];
     const result = reduceEvents(events);
-    expect(result.checkpoint).toBeNull();
     expect(result.pinned).toEqual({
       persona: { content: "agent persona" },
       goals: { content: ["g1", "g2"], scope: "shared" },
@@ -206,7 +201,7 @@ describe("reduceEvents", () => {
     ];
     const result = reduceEvents(events);
     expect(result.memories).toEqual([{ content: "a" }, { content: "b" }]);
-    expect(result.checkpoint).toEqual({ x: 1 });
+    expect(result.pinned!.checkpoint).toEqual({ content: { x: 1 } });
     expect(result.output).toEqual({ b: 2 });
     expect(result.report).toBe("line 1\nline 2");
     expect(result.logs).toHaveLength(1);

--- a/packages/afps-runtime/test/sinks/composite-sink.test.ts
+++ b/packages/afps-runtime/test/sinks/composite-sink.test.ts
@@ -25,7 +25,6 @@ class RecordingSink implements EventSink {
 
 const emptyResult: RunResult = {
   memories: [],
-  checkpoint: null,
   output: null,
   report: null,
   logs: [],

--- a/packages/afps-runtime/test/sinks/console-sink.test.ts
+++ b/packages/afps-runtime/test/sinks/console-sink.test.ts
@@ -73,7 +73,7 @@ describe("ConsoleSink", () => {
   it("writes a summary on finalize", async () => {
     await sink.finalize({
       memories: [{ content: "a" }, { content: "b" }],
-      checkpoint: { foo: 1 },
+      pinned: { checkpoint: { content: { foo: 1 } } },
       output: { done: true },
       report: "# Done",
       logs: [{ level: "info", message: "ok", timestamp: 0 }],
@@ -88,7 +88,6 @@ describe("ConsoleSink", () => {
   it("surfaces errors in the summary", async () => {
     await sink.finalize({
       memories: [],
-      checkpoint: null,
       output: null,
       report: null,
       logs: [],

--- a/packages/afps-runtime/test/sinks/file-sink.test.ts
+++ b/packages/afps-runtime/test/sinks/file-sink.test.ts
@@ -47,7 +47,7 @@ describe("FileSink", () => {
 
     await sink.finalize({
       memories: [{ content: "hi" }],
-      checkpoint: { n: 1 },
+      pinned: { checkpoint: { content: { n: 1 } } },
       output: null,
       report: null,
       logs: [],
@@ -56,7 +56,7 @@ describe("FileSink", () => {
     const text = await readFile(`${path}.result.json`, "utf8");
     const parsed = JSON.parse(text);
     expect(parsed.memories).toEqual([{ content: "hi" }]);
-    expect(parsed.checkpoint).toEqual({ n: 1 });
+    expect(parsed.pinned).toEqual({ checkpoint: { content: { n: 1 } } });
   });
 
   it("creates parent directories when missing", async () => {

--- a/packages/afps-runtime/test/sinks/http-sink.test.ts
+++ b/packages/afps-runtime/test/sinks/http-sink.test.ts
@@ -69,7 +69,6 @@ const SAMPLE_EVENT: RunEvent = {
 };
 const SAMPLE_RESULT: RunResult = {
   memories: [{ content: "sent via http sink" }],
-  checkpoint: null,
   output: null,
   report: null,
   logs: [],

--- a/packages/afps-runtime/test/sinks/reducer-sink.test.ts
+++ b/packages/afps-runtime/test/sinks/reducer-sink.test.ts
@@ -29,7 +29,7 @@ describe("createReducerSink", () => {
     const { sink, snapshot } = createReducerSink();
     await sink.handle(event("pinned.set", { key: "checkpoint", content: { a: 1 } }));
     await sink.handle(event("pinned.set", { key: "checkpoint", content: { b: 2 } }));
-    expect(snapshot().checkpoint).toEqual({ b: 2 });
+    expect(snapshot().pinned!.checkpoint).toEqual({ content: { b: 2 } });
   });
 
   it("replaces output on each output.emitted event", async () => {

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -75,13 +75,11 @@ export CONNECTION_ENCRYPTION_KEY=$NEW_KEY
 export CONNECTION_ENCRYPTION_KEY_ID=k2
 
 # 3. Restart the platform. New writes emit `v1:k2:...`. Existing `v1:k1:...`
-#    blobs remain readable via the retired keyring; v0 blobs decrypt by
-#    probing every key in the keyring (active + retired) until AES-GCM tag
-#    verification succeeds.
+#    blobs remain readable via the retired keyring.
 
 # 4. Run a background re-encrypt sweep (read → decrypt → encrypt → write) to
 #    rewrite every `userProviderConnections.credentialsEncrypted` row. Idempotent.
-#    The sweep migrates v0 → v1 *and* re-keys v1:<old-kid> blobs to v1:<active-kid>.
+#    The sweep re-keys v1:<old-kid> blobs to v1:<active-kid>.
 
 # 5. Only after the sweep confirms no blob still depends on the retired key,
 #    drop it:

--- a/packages/connect/src/encryption.ts
+++ b/packages/connect/src/encryption.ts
@@ -14,10 +14,6 @@ const AUTH_TAG_LENGTH = 16;
  *
  * The version tag + key id enable online key rotation: new writes embed the
  * active kid, reads dispatch decryption to the matching key in the keyring.
- * Legacy v0 blobs (raw base64 of `iv|authTag|ciphertext`, no header) carry no
- * kid, so they remain decryptable by probing every key in the keyring until
- * AES-GCM tag verification succeeds — non-breaking, and survives rotations as
- * long as the encrypting key stays in the keyring.
  *
  * `kid` MUST match `^[A-Za-z0-9_-]{1,32}$` so it can travel inside the
  * delimiter-based envelope without escaping.
@@ -31,13 +27,6 @@ const KID_PATTERN = /^[A-Za-z0-9_-]{1,32}$/;
  * - `activeKid`: kid embedded in newly-encrypted blobs.
  * - `keys`: every kid the process can decrypt with — at minimum the active
  *   key, plus retired keys still in the rotation window.
- *
- * Legacy ("v0") blobs carry no kid, so `decrypt()` tries every key in the
- * keyring (active + retired) until AES-GCM tag verification succeeds. This
- * keeps v0 blobs readable across rotations without requiring a strict
- * sweep-before-retire ordering — a key may only be removed from
- * `CONNECTION_ENCRYPTION_KEYS` once the v0 → v1 sweep confirms no legacy
- * blobs remain that depend on it.
  */
 interface Keyring {
   activeKid: string;
@@ -127,14 +116,8 @@ export function encrypt(plaintext: string): string {
 }
 
 /**
- * Decrypt a ciphertext string. Accepts both formats:
- *
- * - v1 envelope (`v1:<kid>:<base64>`): the embedded kid drives key lookup —
- *   single attempt against the matching key.
- * - v0 legacy (raw `base64(iv|authTag|ciphertext)`): the blob carries no kid,
- *   so we try every key in the keyring (active + retired) until one decrypts
- *   successfully. AES-GCM tag verification makes this safe — a mismatched key
- *   cannot produce a successful decrypt by chance (~2^-128).
+ * Decrypt a v1 envelope (`v1:<kid>:<base64>`). The embedded kid drives key
+ * lookup against the keyring (active + retired).
  */
 export function decrypt(ciphertext: string): string {
   const parsed = parseEnvelope(ciphertext);
@@ -143,16 +126,7 @@ export function decrypt(ciphertext: string): string {
     throw new Error("Invalid encrypted data: too short");
   }
 
-  if (parsed.kind === "v1") {
-    return decryptWithKey(parsed.packed, getKey(parsed.kid));
-  }
-
-  // v0 legacy: try every key in the keyring. The blob was encrypted under
-  // *some* historical active key — which one is unknown until we verify the
-  // GCM tag. This eliminates the temporal coupling between key rotation and
-  // the v0 → v1 re-encrypt sweep: a v0 blob written under k1 stays readable
-  // after k2 is promoted active, so long as k1 is still in the keyring.
-  return decryptV0(parsed.packed);
+  return decryptWithKey(parsed.packed, getKey(parsed.kid));
 }
 
 function decryptWithKey(packed: Buffer, key: Buffer): string {
@@ -167,47 +141,26 @@ function decryptWithKey(packed: Buffer, key: Buffer): string {
   return decrypted.toString("utf8");
 }
 
-function decryptV0(packed: Buffer): string {
-  const keyring = loadKeyring();
-  // Active first (hot path: no rotation in flight), then retired.
-  const candidateKids = [
-    keyring.activeKid,
-    ...[...keyring.keys.keys()].filter((kid) => kid !== keyring.activeKid),
-  ];
-
-  let lastError: unknown;
-  for (const kid of candidateKids) {
-    try {
-      return decryptWithKey(packed, getKey(kid));
-    } catch (err) {
-      lastError = err;
-    }
-  }
-  // Intentionally generic — leaking which kid was tried would help an attacker
-  // probe key state. AES-GCM tag failures are indistinguishable from each other.
-  throw new Error("Failed to decrypt v0 credential blob with any keyring key", {
-    cause: lastError,
-  });
+interface ParsedEnvelope {
+  kid: string;
+  packed: Buffer;
 }
 
-type ParsedEnvelope = { kind: "v1"; kid: string; packed: Buffer } | { kind: "v0"; packed: Buffer };
-
 function parseEnvelope(ciphertext: string): ParsedEnvelope {
-  if (ciphertext.startsWith(`${ENVELOPE_VERSION}:`)) {
-    const rest = ciphertext.slice(ENVELOPE_VERSION.length + 1);
-    const sepIdx = rest.indexOf(":");
-    if (sepIdx === -1) {
-      throw new Error("Invalid v1 envelope: missing kid separator");
-    }
-    const kid = rest.slice(0, sepIdx);
-    const payload = rest.slice(sepIdx + 1);
-    if (!KID_PATTERN.test(kid)) {
-      throw new Error(`Invalid v1 envelope: kid '${kid}' does not match ${KID_PATTERN.source}`);
-    }
-    return { kind: "v1", kid, packed: Buffer.from(payload, "base64") };
+  if (!ciphertext.startsWith(`${ENVELOPE_VERSION}:`)) {
+    throw new Error(`Invalid envelope: expected '${ENVELOPE_VERSION}:' prefix`);
   }
-  // v0 legacy: raw base64 of iv|authTag|ciphertext — no embedded kid.
-  return { kind: "v0", packed: Buffer.from(ciphertext, "base64") };
+  const rest = ciphertext.slice(ENVELOPE_VERSION.length + 1);
+  const sepIdx = rest.indexOf(":");
+  if (sepIdx === -1) {
+    throw new Error("Invalid v1 envelope: missing kid separator");
+  }
+  const kid = rest.slice(0, sepIdx);
+  const payload = rest.slice(sepIdx + 1);
+  if (!KID_PATTERN.test(kid)) {
+    throw new Error(`Invalid v1 envelope: kid '${kid}' does not match ${KID_PATTERN.source}`);
+  }
+  return { kid, packed: Buffer.from(payload, "base64") };
 }
 
 /**

--- a/packages/connect/test/encryption.test.ts
+++ b/packages/connect/test/encryption.test.ts
@@ -130,76 +130,14 @@ describe("encryption — keyring resolution during rotation", () => {
   });
 });
 
-describe("encryption — backward compatibility with v0 (legacy unprefixed)", () => {
-  function buildV0Blob(plaintext: string, keyB64: string): string {
-    const key = Buffer.from(keyB64, "base64");
-    const iv = randomBytes(12);
-    const cipher = createCipheriv("aes-256-gcm", key, iv);
-    const enc = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
-    const tag = cipher.getAuthTag();
-    return Buffer.concat([iv, tag, enc]).toString("base64");
-  }
-
-  it("decrypts legacy raw-base64 blobs with the active key", () => {
-    const v0Blob = buildV0Blob("legacy payload", PRIMARY_KEY_B64);
-    expect(v0Blob.startsWith("v1:")).toBe(false);
-
-    expect(decrypt(v0Blob)).toBe("legacy payload");
+describe("encryption — envelope format guard", () => {
+  it("rejects a non-v1 ciphertext", () => {
+    const rawBase64 = randomBytes(32).toString("base64");
+    expect(() => decrypt(rawBase64)).toThrow(/expected 'v1:' prefix/);
   });
 
-  it("re-encrypts a v0 blob into a v1 envelope (in-place rotation primitive)", () => {
-    const v0Blob = buildV0Blob("payload", PRIMARY_KEY_B64);
-
-    const plaintext = decrypt(v0Blob);
-    const reEncrypted = encrypt(plaintext);
-    expect(reEncrypted.startsWith("v1:k1:")).toBe(true);
-    expect(decrypt(reEncrypted)).toBe(plaintext);
-  });
-
-  it("decrypts a v0 blob after rotation when the original key is retired", () => {
-    // Regression: pre-fix, decrypt() always used keyring.activeKid for v0
-    // blobs, so the moment a new key was promoted active, every existing v0
-    // blob became undecryptable — even with the original key still present in
-    // CONNECTION_ENCRYPTION_KEYS — until the v0→v1 sweep finished. The fix
-    // tries every key in the keyring for v0 blobs. AES-GCM tag verification
-    // makes that safe: a wrong key cannot succeed by chance.
-
-    // Build a v0 blob under the current primary key (kid = "k1").
-    const v0Blob = buildV0Blob("retired-era payload", PRIMARY_KEY_B64);
-
-    // Rotate: promote a new primary, retain the old key in the retired map.
-    setRotationEnv({
-      CONNECTION_ENCRYPTION_KEY: randomBytes(32).toString("base64"),
-      CONNECTION_ENCRYPTION_KEY_ID: "k2",
-      CONNECTION_ENCRYPTION_KEYS: JSON.stringify({ k1: PRIMARY_KEY_B64 }),
-    });
-
-    expect(decrypt(v0Blob)).toBe("retired-era payload");
-  });
-
-  it("throws a clear error when no keyring key can decrypt a v0 blob", () => {
-    // Build a v0 blob under a key that is *not* in the keyring at decrypt time.
-    const orphanKey = randomBytes(32).toString("base64");
-    const v0Blob = buildV0Blob("orphan payload", orphanKey);
-
-    // Default keyring only knows PRIMARY_KEY_B64 under kid "k1" — neither the
-    // active key nor any retired key matches the blob's actual key.
-    expect(() => decrypt(v0Blob)).toThrow(/Failed to decrypt v0/);
-  });
-
-  it("does not fall back to the v0 multi-key path for v1 envelopes", () => {
-    // Sanity: the v1 fast path uses the embedded kid only, never the
-    // try-every-key fallback. A v1 envelope with an unknown kid must error
-    // with "No encryption key registered" (kid lookup miss), not with the
-    // v0 fallback message — proving the two paths stay isolated.
-    const iv = randomBytes(12);
-    const cipher = createCipheriv("aes-256-gcm", Buffer.from(PRIMARY_KEY_B64, "base64"), iv);
-    const enc = Buffer.concat([cipher.update("x", "utf8"), cipher.final()]);
-    const tag = cipher.getAuthTag();
-    const packed = Buffer.concat([iv, tag, enc]).toString("base64");
-    const forged = `v1:unknown:${packed}`;
-
-    expect(() => decrypt(forged)).toThrow(/No encryption key registered/);
+  it("rejects a v1 envelope with no kid separator", () => {
+    expect(() => decrypt("v1:abcdef")).toThrow(/missing kid separator/);
   });
 
   it("v1 blobs still resolve via their explicit kid after rotation (no regression)", () => {
@@ -214,10 +152,7 @@ describe("encryption — backward compatibility with v0 (legacy unprefixed)", ()
       CONNECTION_ENCRYPTION_KEYS: JSON.stringify({ k1: PRIMARY_KEY_B64 }),
     });
 
-    // The v1 path looks up k1 directly via the embedded kid, not via the
-    // v0 try-every-key loop. This guarantees the active path stays a single
-    // AES-GCM verification, with no measurable timing dependency on the
-    // number of retired keys.
+    // The v1 path looks up k1 directly via the embedded kid.
     expect(decrypt(v1Blob)).toBe("explicit-kid payload");
   });
 });

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -54,8 +54,7 @@ const envSchema = z
       }),
     // Retired keys held for decrypt-only during a rotation window. JSON map of
     // kid → base64-encoded 32-byte key. Exclude the active kid (validated at boot).
-    // Empty map disables the legacy keyring; existing v0 blobs still decrypt with
-    // the active key.
+    // Empty map disables the retired keyring.
     //
     // Validated as `Record<string, string>` AT BOOT — a non-string value or
     // JSON parse error fails fast with a clear Zod issue path, rather than

--- a/runtime-pi/entrypoint.ts
+++ b/runtime-pi/entrypoint.ts
@@ -144,7 +144,7 @@ const sink = new HttpSink({
 // tools still emit canonical events via `process.stdout.write`; we
 // intercept those lines, fold them into an aggregator together with
 // PiRunner's session events, and merge the aggregate into the finalize
-// POST so `result.report` / `result.output` / `result.checkpoint` /
+// POST so `result.report` / `result.output` / `result.pinned` /
 // `result.memories` are complete when the platform ingests the run.
 const tee = attachTeeSink({ sink, runId: AGENT_RUN_ID });
 const teeSink = tee.sink;

--- a/runtime-pi/tee-sink.ts
+++ b/runtime-pi/tee-sink.ts
@@ -25,7 +25,7 @@
  *   - On `finalize(result)`, merges PiRunner's terminal metadata
  *     (`status` / `error` / `durationMs`) with the tee's aggregate so
  *     the single finalize POST carries the complete shape. Without the
- *     merge, `result.report` / `result.output` / `result.checkpoint` /
+ *     merge, `result.report` / `result.output` / `result.pinned` /
  *     `result.memories` would be empty — PiRunner's internal reducer
  *     only sees session events, not tool-stdout events.
  *
@@ -76,15 +76,12 @@ export function looksLikeRunEvent(value: unknown): value is RunEvent {
  * case) keeps its values when the aggregate is untouched.
  */
 export function mergeTerminalResult(aggregate: RunResult, runnerResult: RunResult): RunResult {
-  const checkpointScope = aggregate.checkpointScope ?? runnerResult.checkpointScope;
   const pinned =
     aggregate.pinned !== undefined && Object.keys(aggregate.pinned).length > 0
       ? aggregate.pinned
       : runnerResult.pinned;
   return {
     memories: aggregate.memories.length > 0 ? aggregate.memories : runnerResult.memories,
-    checkpoint: aggregate.checkpoint ?? runnerResult.checkpoint,
-    ...(checkpointScope !== undefined ? { checkpointScope } : {}),
     ...(pinned !== undefined ? { pinned } : {}),
     output: aggregate.output ?? runnerResult.output,
     report: aggregate.report ?? runnerResult.report,

--- a/runtime-pi/test/tee-sink.test.ts
+++ b/runtime-pi/test/tee-sink.test.ts
@@ -79,14 +79,14 @@ describe("mergeTerminalResult", () => {
   it("prefers aggregate values when present, falls back to runner values", () => {
     const aggregate: RunResult = {
       memories: [{ content: "hello" }],
-      checkpoint: { step: 2 },
+      pinned: { checkpoint: { content: { step: 2 } } },
       output: { foo: "bar" },
       report: "# Report\nline",
       logs: [{ level: "info", message: "x", timestamp: 100 }],
     };
     const runner: RunResult = {
       memories: [{ content: "old" }],
-      checkpoint: { step: 1 },
+      pinned: { checkpoint: { content: { step: 1 } } },
       output: { foo: "baz" },
       report: "fallback",
       logs: [{ level: "info", message: "y", timestamp: 50 }],
@@ -95,7 +95,7 @@ describe("mergeTerminalResult", () => {
     };
     const merged = mergeTerminalResult(aggregate, runner);
     expect(merged.memories).toEqual([{ content: "hello" }]);
-    expect(merged.checkpoint).toEqual({ step: 2 });
+    expect(merged.pinned!.checkpoint).toEqual({ content: { step: 2 } });
     expect(merged.output).toEqual({ foo: "bar" });
     expect(merged.report).toBe("# Report\nline");
     expect(merged.logs).toEqual([{ level: "info", message: "x", timestamp: 100 }]);
@@ -108,7 +108,7 @@ describe("mergeTerminalResult", () => {
     const aggregate = emptyRunResult();
     const runner: RunResult = {
       memories: [{ content: "r" }],
-      checkpoint: { ok: true },
+      pinned: { checkpoint: { content: { ok: true } } },
       output: { answer: 42 },
       report: "runner-report",
       logs: [{ level: "warn", message: "w", timestamp: 1 }],
@@ -117,7 +117,7 @@ describe("mergeTerminalResult", () => {
     };
     const merged = mergeTerminalResult(aggregate, runner);
     expect(merged.memories).toEqual([{ content: "r" }]);
-    expect(merged.checkpoint).toEqual({ ok: true });
+    expect(merged.pinned!.checkpoint).toEqual({ content: { ok: true } });
     expect(merged.output).toEqual({ answer: 42 });
     expect(merged.report).toBe("runner-report");
     expect(merged.logs).toHaveLength(1);
@@ -311,7 +311,7 @@ describe("attachTeeSink — aggregation via finalize", () => {
     const final = underlying.finalized!;
     expect(final.report).toBe("## Header\nbody");
     expect(final.output).toEqual({ answer: 42 });
-    expect(final.checkpoint).toEqual({ step: 1 });
+    expect(final.pinned!.checkpoint).toEqual({ content: { step: 1 } });
     expect(final.status).toBe("success");
     expect(final.durationMs).toBe(500);
     tee.restore();
@@ -354,7 +354,7 @@ describe("attachTeeSink — aggregation via finalize", () => {
     tee.restore();
   });
 
-  it("aggregates pinned.set with key='checkpoint' (AFPS 1.5) into result.checkpoint with scope captured", async () => {
+  it("aggregates pinned.set with key='checkpoint' (AFPS 1.5) into result.pinned with scope captured", async () => {
     const underlying = recordingSink();
     const stdout = makeFakeStdout();
     const tee = attachTeeSink({ sink: underlying, runId: "r", stdout });
@@ -369,8 +369,7 @@ describe("attachTeeSink — aggregation via finalize", () => {
     await tee.sink.finalize({ ...emptyRunResult(), status: "success" });
 
     const final = underlying.finalized!;
-    expect(final.checkpoint).toEqual({ cursor: "abc" });
-    expect(final.checkpointScope).toBe("shared");
+    expect(final.pinned!.checkpoint).toEqual({ content: { cursor: "abc" }, scope: "shared" });
     tee.restore();
   });
 
@@ -390,7 +389,7 @@ describe("attachTeeSink — aggregation via finalize", () => {
 
     const final = underlying.finalized!;
     expect(final.pinned).toEqual({ persona: { content: "agent persona" } });
-    expect(final.checkpoint).toBeNull();
+    expect(final.pinned!.checkpoint).toBeUndefined();
     tee.restore();
   });
 });


### PR DESCRIPTION
## Summary

Five surgical removals of legacy / backward-compat code, enabled by the fact that there is no production data. Net **-312 lines** across **36 files**.

| # | What | Files | Net lines |
|---|------|-------|-----------|
| 1 | Drop v0 encryption envelope (raw base64) | `packages/connect/src/encryption.ts`, `packages/connect/test/encryption.test.ts`, `packages/env/src/index.ts`, `packages/connect/README.md` | ~-120 |
| 2 | Drop CLI `LEGACY_PROJECT_NAME` (#167 pre-fix install fallback) | `apps/cli/src/lib/install/project.ts`, `apps/cli/src/commands/install.ts`, related tests | ~-50 |
| 3 | Drop `RunResult.checkpoint` / `checkpointScope` top-level mirror | `packages/afps-runtime/*`, `apps/api/src/routes/runs-events.ts`, `apps/api/src/services/run-event-ingestion.ts`, `runtime-pi/*`, 11 test files | ~-90 |
| 4 | Drop `legacyHashRedirects` prop + its 4 consumers | `apps/web/src/components/settings-layout.tsx`, `pages/preferences/layout.tsx`, `pages/org-settings/layout.tsx`, `pages/run-detail.tsx`, `pages/unified-package-detail.tsx` | ~-40 |
| 5 | Drop `normalizeProviderInitialState` legacy draft repair | `apps/web/src/components/provider-editor/provider-editor-inner.tsx` | ~-25 |

## Detail per change

### 1. v0 encryption envelope

`decrypt()` previously accepted both `v1:<kid>:<base64>` envelopes and raw v0 base64 blobs (no header), trying every key in the keyring until AES-GCM tag verification succeeded. Pre-prod = no v0 blobs anywhere.

- `decryptV0()` removed.
- `ParsedEnvelope` collapsed from `{kind: "v1"; kid; packed} | {kind: "v0"; packed}` to a single `{kid; packed}` shape.
- 5 v0-specific tests removed; 2 envelope-format guard tests added.
- v1→v1 retired-keyring rotation (the legitimate use case) is preserved.
- README rotation playbook trimmed.

### 2. CLI compose project-name fallback

`resolveProjectName(dir, hasLegacyCompose)` had a 3-way return `{origin: "sidecar" | "legacy" | "derived"}` to keep pre-#167 installs (`name: appstrate` baked into the compose file) re-usable on upgrade. None of those installs exist.

- Function signature: `resolveProjectName(dir)` returning `{origin: "sidecar" | "derived"}`.
- `LEGACY_PROJECT_NAME` constant + its dedicated test removed.
- `hasLegacyCompose` parameter dropped from caller chain.

### 3. `RunResult.checkpoint` top-level mirror

The previous PR (`feat/unify-checkpoint-memory`) generalised the carry-over checkpoint into a Letta-style `pinned[key]` map but kept `RunResult.checkpoint` + `RunResult.checkpointScope` as top-level mirrors "for backward compat". Two writers, two readers, divergence risk.

- `RunResult.checkpoint` and `RunResult.checkpointScope` removed from the type.
- The mirror block in `reducer.ts` (`if (canonical.key === "checkpoint") result.checkpoint = …`) deleted.
- `run-event-ingestion.ts` reads `result.pinned?.[CHECKPOINT_KEY]` directly. The special-case `if (checkpointToPersist !== null)` block + the `if (key === CHECKPOINT_KEY) continue` skip are gone — the unified `for (const [key, slot] of Object.entries(result.pinned))` loop handles every named slot, checkpoint included.
- `RunResultSchema` (the wire format) drops `checkpoint` + `checkpointScope`. `.passthrough()` means external runners that still send them are gracefully ignored.
- OpenAPI request body schema updated to expose `pinned: { type: "object" }` instead of `checkpoint: {}`.
- 11 test files migrated from `result.checkpoint` to `result.pinned!.checkpoint?.content`.
- **The `runs.checkpoint` DB column is preserved** — it stores the per-run snapshot read by the `run_history` MCP tool, which is a distinct concern from the per-actor latest pinned slot in `package_persistence`.

### 4. Legacy URL hash redirects

`SettingsLayout` exposed a `legacyHashRedirects?: Record<string, string>` prop used to redirect `/preferences#security` → `/preferences/security` etc. after multiple settings splits. Plus two more hash-redirect `useEffect`s in `unified-package-detail.tsx` and `run-detail.tsx` for the recent `#checkpoint`/`#memories` → `#memory` migration.

Pre-prod = no bookmarks to preserve.

- Prop + its `useEffect` removed from `SettingsLayout`.
- 4 consumer sites updated.

### 5. Provider editor draft repair

`normalizeProviderInitialState` ran at mount and silently patched malformed provider drafts (declaring a credential authMode without a `credentials.schema`) with seeded defaults. Pre-prod = no malformed drafts in any DB.

- Replaced with a pure `extractCredentialFields(manifest)` reader. Save-time AFPS validation now catches malformed manifests instead of the editor silently fixing them.
- `initialNormalized.state` baseline replaced by the actual `initialState` for `isDirty` comparisons.

## Breaking changes (intentional, pre-prod)

- **Wire**: API now ignores `result.checkpoint` and `result.checkpointScope` in `POST /api/runs/:id/events/finalize`. Runners must emit `pinned[checkpoint]`. The current monorepo runtime (`runtime-pi`, `runtime-pi/sidecar`, AFPS-runtime) already does — no internal runner is broken. External runners (older github-action releases, third-party AFPS runners) need a re-release if they were emitting top-level `checkpoint`. OpenAPI breaking-change detector classified the change as **non-breaking** because the field was optional + `.passthrough()` makes the schema accept the old form silently.
- **Encryption**: `decrypt()` rejects raw base64 input with `Invalid envelope: expected 'v1:' prefix`. Any environment carrying real v0 blobs would refuse to decrypt them — explicitly out of scope per the pre-prod assumption.
- **CLI**: `appstrate install` no longer recognises pre-#167 installs. A user re-running install on such a dir gets a fresh derived project name; their old containers stay on `name: appstrate` until they `docker compose down` manually. Acceptable in pre-prod.

## Quality gate

- `bun run check` — 18/18 turbo tasks green (typecheck + lint + format + verify-openapi + breaking-detector).
- 1425 pure tests + 694 API unit tests pass.
- OpenAPI breaking-change detector: 0 breaking, 1 non-breaking (`pinned` field added — the field was already passing through, now formalised).

## Test plan

- [ ] CI green
- [ ] Spot-check `appstrate install` on a fresh dir (Tier 0) end-to-end
- [ ] Spot-check provider editor: create a new credential-mode provider, save, reload, verify fields persist
- [ ] Optional: replay a recent run's events through `reduceEvents` and confirm `result.pinned.checkpoint.content` matches what the run row's `checkpoint` JSONB column stored before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)