### PR TITLE
refactor(api): collapse three architectural redundancies

### DIFF
--- a/apps/api/src/routes/agent-detail-handler.ts
+++ b/apps/api/src/routes/agent-detail-handler.ts
@@ -6,7 +6,7 @@ import { eq, and, inArray } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
 import { packages, applicationProviderCredentials } from "@appstrate/db/schema";
 import { getPackageWithAccess } from "../services/agent-service.ts";
-import { getOrgItem, AGENT_CONFIG } from "../services/package-items/index.ts";
+import { getOrgItem, CONFIG_BY_TYPE } from "../services/package-items/index.ts";
 import {
   getVersionCount,
   getLatestVersionCreatedAt,
@@ -39,7 +39,7 @@ export async function agentDetailHandler(c: Context<AppEnv>) {
 
   const [agent, rawItem, versionCount, latestVersionDate] = await Promise.all([
     getPackageWithAccess(itemId, orgId, applicationId),
-    getOrgItem(orgId, itemId, AGENT_CONFIG),
+    getOrgItem(orgId, itemId, CONFIG_BY_TYPE.agent),
     getVersionCount(itemId),
     getLatestVersionCreatedAt(itemId),
   ]);

--- a/apps/api/src/routes/llm-proxy.ts
+++ b/apps/api/src/routes/llm-proxy.ts
@@ -153,7 +153,7 @@ async function handleProxy(
 
   const started = Date.now();
   try {
-    const { response } = await proxyLlmCall({
+    const response = await proxyLlmCall({
       adapter,
       principal,
       runId,

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -30,10 +30,7 @@ import {
   deleteOrgItem,
   uploadPackageFiles,
   downloadPackageFiles,
-  SKILL_CONFIG,
-  TOOL_CONFIG,
-  AGENT_CONFIG,
-  PROVIDER_CONFIG,
+  CONFIG_BY_TYPE,
   PackageAlreadyExistsError,
   type PackageTypeConfig,
 } from "../services/package-items/index.ts";
@@ -339,7 +336,7 @@ interface PackageRouteConfig {
 
 const ROUTE_CONFIGS: Record<PackageType, PackageRouteConfig> = {
   skill: {
-    cfg: SKILL_CONFIG,
+    cfg: CONFIG_BY_TYPE.skill,
     path: "skills",
     parseOpts: { requiredFile: "SKILL.md", contentFileExt: null },
     responseKey: "skill",
@@ -348,7 +345,7 @@ const ROUTE_CONFIGS: Record<PackageType, PackageRouteConfig> = {
     requireContent: true,
   },
   tool: {
-    cfg: TOOL_CONFIG,
+    cfg: CONFIG_BY_TYPE.tool,
     path: "tools",
     parseOpts: { requiredFile: null, contentFileExt: ".ts" },
     responseKey: "tool",
@@ -358,7 +355,7 @@ const ROUTE_CONFIGS: Record<PackageType, PackageRouteConfig> = {
     jsonBodyCreate: true,
   },
   agent: {
-    cfg: AGENT_CONFIG,
+    cfg: CONFIG_BY_TYPE.agent,
     path: "agents",
     parseOpts: { requiredFile: null, contentFileExt: null },
     responseKey: "agent",
@@ -369,7 +366,7 @@ const ROUTE_CONFIGS: Record<PackageType, PackageRouteConfig> = {
     getHandler: agentDetailHandler,
   },
   provider: {
-    cfg: PROVIDER_CONFIG,
+    cfg: CONFIG_BY_TYPE.provider,
     path: "providers",
     parseOpts: { requiredFile: null, contentFileExt: null },
     responseKey: "provider",

--- a/apps/api/src/services/default-agent.ts
+++ b/apps/api/src/services/default-agent.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createOrgItem } from "./package-items/crud.ts";
-import { AGENT_CONFIG } from "./package-items/config.ts";
+import { CONFIG_BY_TYPE } from "./package-items/config.ts";
 import { installPackage } from "./application-packages.ts";
 import { logger } from "../lib/logger.ts";
 
@@ -62,7 +62,7 @@ export async function provisionDefaultAgentForOrg(
         content: HELLO_WORLD_PROMPT,
         createdBy,
       },
-      AGENT_CONFIG,
+      CONFIG_BY_TYPE.agent,
       manifest,
     );
 

--- a/apps/api/src/services/llm-proxy/core.ts
+++ b/apps/api/src/services/llm-proxy/core.ts
@@ -49,11 +49,6 @@ export interface ProxyCallInputs {
   maxRequestBytes?: number;
 }
 
-export interface ProxyCallResult {
-  /** Upstream response forwarded to the caller, body intact. */
-  response: Response;
-}
-
 export class LlmProxyUnsupportedModelError extends Error {
   constructor(presetId: string) {
     super(`Model preset "${presetId}" is not enabled for this organization.`);
@@ -74,7 +69,7 @@ export class LlmProxyModelApiMismatchError extends Error {
   }
 }
 
-export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<ProxyCallResult> {
+export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
   const fetchImpl = inputs.fetchImpl ?? fetch;
   const maxBytes = inputs.maxRequestBytes ?? DEFAULT_MAX_REQUEST_BYTES;
   if (inputs.rawBody.byteLength > maxBytes) {
@@ -119,9 +114,7 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<ProxyCallRe
   if (!upstream.ok) {
     const errorBody = await upstream.text();
     const headers = cloneResponseHeaders(upstream.headers);
-    return {
-      response: new Response(errorBody, { status: upstream.status, headers }),
-    };
+    return new Response(errorBody, { status: upstream.status, headers });
   }
 
   if (isSse && upstream.body) {
@@ -136,12 +129,10 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<ProxyCallRe
       }),
     );
     const headers = cloneResponseHeaders(upstream.headers);
-    return {
-      response: new Response(clientStream, {
-        status: upstream.status,
-        headers,
-      }),
-    };
+    return new Response(clientStream, {
+      status: upstream.status,
+      headers,
+    });
   }
 
   // Non-streaming JSON. Read once, parse for usage, forward an identical
@@ -155,9 +146,7 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<ProxyCallRe
     // Upstream advertised a non-JSON content-type but still returned a
     // non-SSE body — forward without metering.
     const headers = cloneResponseHeaders(upstream.headers);
-    return {
-      response: new Response(bodyText, { status: upstream.status, headers }),
-    };
+    return new Response(bodyText, { status: upstream.status, headers });
   }
 
   const usage = inputs.adapter.parseJsonUsage(parsed);
@@ -172,9 +161,7 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<ProxyCallRe
   }
 
   const headers = cloneResponseHeaders(upstream.headers);
-  return {
-    response: new Response(bodyText, { status: upstream.status, headers }),
-  };
+  return new Response(bodyText, { status: upstream.status, headers });
 }
 
 function extractPresetId(rawBody: Uint8Array): string {

--- a/apps/api/src/services/package-fork.ts
+++ b/apps/api/src/services/package-fork.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { parseScopedName, isOwnedByOrg } from "@appstrate/core/naming";
+import type { PackageType } from "@appstrate/core/validation";
 
 import { zipArtifact } from "@appstrate/core/zip";
 import {
@@ -9,10 +10,7 @@ import {
   createOrgItem,
   uploadPackageFiles,
   type PackageTypeConfig,
-  AGENT_CONFIG,
-  SKILL_CONFIG,
-  TOOL_CONFIG,
-  PROVIDER_CONFIG,
+  CONFIG_BY_TYPE,
 } from "./package-items/index.ts";
 
 import { getLatestVersionId, createVersionAndUpload } from "./package-versions.ts";
@@ -21,13 +19,6 @@ import { db } from "@appstrate/db/client";
 import { packageVersions } from "@appstrate/db/schema";
 import { eq } from "drizzle-orm";
 import { asRecord } from "../lib/safe-json.ts";
-
-const TYPE_TO_CONFIG: Record<string, PackageTypeConfig> = {
-  agent: AGENT_CONFIG,
-  skill: SKILL_CONFIG,
-  tool: TOOL_CONFIG,
-  provider: PROVIDER_CONFIG,
-};
 
 export interface ForkResult {
   packageId: string;
@@ -56,12 +47,13 @@ export async function forkPackage(
   const parsed = parseScopedName(sourcePackageId);
   if (!parsed) return { code: "NOT_FOUND" };
 
-  const cfg = TYPE_TO_CONFIG[await getPackageType(orgId, sourcePackageId)];
+  const detectedType = await getPackageType(orgId, sourcePackageId);
+  const cfg = detectedType ? CONFIG_BY_TYPE[detectedType] : undefined;
   if (!cfg) {
     // Try to find the package to get its type
     const raw = await getPackageById(sourcePackageId);
     if (!raw) return { code: "NOT_FOUND" };
-    const typeCfg = TYPE_TO_CONFIG[raw.type];
+    const typeCfg = CONFIG_BY_TYPE[raw.type as PackageType];
     if (!typeCfg) return { code: "UNKNOWN_TYPE", type: raw.type };
     return forkWithConfig(
       orgId,
@@ -76,13 +68,13 @@ export async function forkPackage(
   return forkWithConfig(orgId, orgSlug, sourcePackageId, customName ?? parsed.name, cfg, userId);
 }
 
-async function getPackageType(orgId: string, packageId: string): Promise<string> {
+async function getPackageType(orgId: string, packageId: string): Promise<PackageType | null> {
   // Try each config type to find the package in the org context
-  for (const [type, cfg] of Object.entries(TYPE_TO_CONFIG)) {
+  for (const [type, cfg] of Object.entries(CONFIG_BY_TYPE)) {
     const item = await getOrgItem(orgId, packageId, cfg);
-    if (item) return type;
+    if (item) return type as PackageType;
   }
-  return "";
+  return null;
 }
 
 async function forkWithConfig(

--- a/apps/api/src/services/package-items/config.ts
+++ b/apps/api/src/services/package-items/config.ts
@@ -12,40 +12,12 @@ export interface PackageTypeConfig {
   label: string;
 }
 
-export const SKILL_CONFIG: PackageTypeConfig = {
-  type: "skill",
-  storageFolder: "skills",
-  label: "Skills",
+export const CONFIG_BY_TYPE: Record<PackageType, PackageTypeConfig> = {
+  agent: { type: "agent", storageFolder: "agents", label: "Agents" },
+  skill: { type: "skill", storageFolder: "skills", label: "Skills" },
+  tool: { type: "tool", storageFolder: "tools", label: "Tools" },
+  provider: { type: "provider", storageFolder: "providers", label: "Providers" },
 };
-
-export const TOOL_CONFIG: PackageTypeConfig = {
-  type: "tool",
-  storageFolder: "tools",
-  label: "Tools",
-};
-
-export const AGENT_CONFIG: PackageTypeConfig = {
-  type: "agent",
-  storageFolder: "agents",
-  label: "Agents",
-};
-
-export const PROVIDER_CONFIG: PackageTypeConfig = {
-  type: "provider",
-  storageFolder: "providers",
-  label: "Providers",
-};
-
-// ─────────────────────────────────────────────
-// Type → config lookup
-// ─────────────────────────────────────────────
-
-const ALL_CONFIGS: PackageTypeConfig[] = [AGENT_CONFIG, SKILL_CONFIG, TOOL_CONFIG, PROVIDER_CONFIG];
-
-const CONFIG_BY_TYPE = Object.fromEntries(ALL_CONFIGS.map((c) => [c.type, c])) as Record<
-  PackageType,
-  PackageTypeConfig
->;
 
 /** Resolve the S3 storage folder for a package type (e.g. "tool" → "tools"). */
 export function storageFolderForType(type: PackageType): PackageTypeConfig["storageFolder"] {

--- a/apps/api/src/services/post-install-package.ts
+++ b/apps/api/src/services/post-install-package.ts
@@ -8,8 +8,7 @@ import {
   updateOrgItem,
   getOrgItem,
   uploadPackageFiles,
-  SKILL_CONFIG,
-  TOOL_CONFIG,
+  CONFIG_BY_TYPE,
   type PackageTypeConfig,
   type CreateItemInput,
 } from "./package-items/index.ts";
@@ -67,7 +66,7 @@ export async function postInstallPackage(params: {
   const version: string = rawVersion;
 
   if (packageType === "skill" || packageType === "tool") {
-    const cfg = packageType === "skill" ? SKILL_CONFIG : TOOL_CONFIG;
+    const cfg = CONFIG_BY_TYPE[packageType];
     const item: CreateItemInput = { id: packageId, content, createdBy: userId };
     await upsertItem(orgId, packageId, item, cfg, manifest);
     await uploadPackageFiles(cfg.storageFolder, orgId, packageId, files);

--- a/apps/api/src/services/scheduler.ts
+++ b/apps/api/src/services/scheduler.ts
@@ -6,7 +6,6 @@ import { eq, asc, inArray } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
 import { schedules, connectionProfiles as connectionProfilesTable } from "@appstrate/db/schema";
 import { batchLoadUserNames } from "../lib/user-helpers.ts";
-import { user as userTable } from "@appstrate/db/schema";
 import { logger } from "../lib/logger.ts";
 import type { Schedule, EnrichedSchedule, ScheduleReadiness } from "@appstrate/shared-types";
 import { createFailedRun } from "./state/index.ts";
@@ -400,46 +399,8 @@ export async function getSchedule(id: string, scope?: AppScope): Promise<Enriche
     .limit(1);
   if (!rows[0]) return null;
   const schedule = toSchedule(rows[0]);
-  return enrichOneSchedule(schedule, schedule.orgId);
-}
-
-/**
- * Enrich a single schedule with profile info and readiness status.
- * Direct single-row lookups (no batching overhead) — mirrors the shape
- * produced by enrichSchedules() for one row.
- */
-async function enrichOneSchedule(schedule: Schedule, orgId: string): Promise<EnrichedSchedule> {
-  // Load profile + agent in parallel (2 independent queries)
-  const [profileRows, agent] = await Promise.all([
-    db
-      .select()
-      .from(connectionProfilesTable)
-      .where(eq(connectionProfilesTable.id, schedule.connectionProfileId))
-      .limit(1),
-    getPackage(schedule.packageId, orgId),
-  ]);
-
-  const profile = profileRows[0] ?? null;
-
-  let profileName: string | null = null;
-  let profileType: "user" | "app" | null = null;
-  let profileOwnerName: string | null = null;
-  if (profile) {
-    profileName = profile.name;
-    profileType = profile.applicationId ? "app" : "user";
-    if (profile.userId) {
-      const ownerRows = await db
-        .select({ name: userTable.name })
-        .from(userTable)
-        .where(eq(userTable.id, profile.userId))
-        .limit(1);
-      profileOwnerName = ownerRows[0]?.name ?? null;
-    }
-  }
-
-  const readiness = await computeScheduleReadiness(schedule, profile, agent ?? null, orgId);
-
-  return { ...schedule, profileName, profileType, profileOwnerName, readiness };
+  const [enriched] = await enrichSchedules([schedule], schedule.orgId);
+  return enriched ?? null;
 }
 
 /** Compute readiness status for a single schedule based on its profile and agent. */

--- a/apps/api/test/integration/services/dependencies.test.ts
+++ b/apps/api/test/integration/services/dependencies.test.ts
@@ -9,9 +9,11 @@ import {
   listOrgItems,
   getOrgItem,
   deleteOrgItem,
-  SKILL_CONFIG,
-  TOOL_CONFIG,
+  CONFIG_BY_TYPE,
 } from "../../../src/services/package-items/index.ts";
+
+const SKILL_CONFIG = CONFIG_BY_TYPE.skill;
+const TOOL_CONFIG = CONFIG_BY_TYPE.tool;
 import {
   buildDependencies,
   collectAllDepIds,


### PR DESCRIPTION
## Summary

Architectural cleanup across three independent redundancies surfaced by codebase audit. **Net -90 lines, 10 files, zero behaviour change.**

### 1. Scheduler — single enrichment path
`apps/api/src/services/scheduler.ts`

Removed `enrichOneSchedule()` (43 lines). `getSchedule()` now calls `enrichSchedules([schedule])` and returns `[0]`. Eliminates two parallel implementations of the same logic (profile lookup, type, owner name, readiness) that had diverged on loading strategy (`Promise.all` vs `Map` batching).

### 2. LLM proxy — drop wrapper indirection
`apps/api/src/services/llm-proxy/core.ts`, `apps/api/src/routes/llm-proxy.ts`

`proxyLlmCall()` now returns `Response` directly. The `ProxyCallResult = { response: Response }` interface was pure indirection — every caller immediately destructured `{ response }`. It also collided in name with `credential-proxy`'s unrelated `ProxyCallResult` (which has `{status, headers, body, truncated?, authRefreshed?}`), creating two homonymous types with incompatible contracts.

### 3. Package items — single config source
`apps/api/src/services/package-items/config.ts` and 6 consumers

Removed the four standalone `SKILL_CONFIG`/`TOOL_CONFIG`/`AGENT_CONFIG`/`PROVIDER_CONFIG` constants and the duplicate `TYPE_TO_CONFIG` map in `package-fork.ts`. `CONFIG_BY_TYPE` is now the single source of truth — consumers read `CONFIG_BY_TYPE.skill` etc.

## Test plan

- [x] `bun run check` passes (turbo check across all packages + OpenAPI 258 endpoints)
- [x] `bun run test:unit` passes (694 tests)
- [ ] Smoke-test schedules list/detail endpoint in dev
- [ ] Smoke-test LLM proxy SSE + non-streaming paths
- [ ] Smoke-test package install/fork flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)