### PR TITLE
chore: modernization-audit cleanup (5 findings)

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -61,6 +61,16 @@ jobs:
             exit 1
           fi
 
+      - name: Check consumer-repo lockstep
+        working-directory: .
+        env:
+          GITHUB_TOKEN: ${{ secrets.CONSUMER_LOCKSTEP_TOKEN || secrets.GITHUB_TOKEN }}
+          # `fail` blocks publish if any consumer is >= 2 minors behind.
+          # Set to `warn` for an emergency hotfix that intentionally outpaces
+          # consumers, or `off` to bypass entirely.
+          CONSUMER_DRIFT_POLICY: ${{ vars.CONSUMER_DRIFT_POLICY || 'fail' }}
+        run: bun scripts/check-consumer-versions.ts
+
       - name: Publish to npm
         run: npm publish --access public --provenance
         env:

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -11,6 +11,7 @@ import { requireAppContext } from "./middleware/app-context.ts";
 import { requestId } from "./middleware/request-id.ts";
 import { clientIp } from "./middleware/client-ip.ts";
 import { errorHandler } from "./middleware/error-handler.ts";
+import { bodyLimit } from "./middleware/body-limit.ts";
 import { createAgentsRouter } from "./routes/agents.ts";
 import { createRunsRouter } from "./routes/runs.ts";
 import { createRunsRemoteRouter } from "./routes/runs-remote.ts";
@@ -80,6 +81,15 @@ app.use("*", clientIp());
 const trustedOrigins = env.TRUSTED_ORIGINS;
 
 app.use("*", cors({ origin: trustedOrigins, credentials: true }));
+
+// Global body-size cap. Skipped for the public FS upload sink — that route
+// authenticates via a signed token whose payload encodes its own size limit
+// and uses streaming I/O up to 100 MB by design.
+const globalBodyLimit = bodyLimit(env.API_BODY_LIMIT_BYTES);
+app.use("*", async (c, next) => {
+  if (c.req.path === "/api/uploads/_content") return next();
+  return globalBodyLimit(c, next);
+});
 
 // Health check — before auth middleware (no auth required)
 app.route("/", healthRouter);

--- a/apps/api/src/lib/auth-secrets.ts
+++ b/apps/api/src/lib/auth-secrets.ts
@@ -1,0 +1,94 @@
+/**
+ * Versioned auth secrets — the foundation for online rotation of every
+ * cookie/HMAC the platform itself signs.
+ *
+ * Two env vars drive the model:
+ *   - `BETTER_AUTH_ACTIVE_KID` — the kid used when signing new tokens.
+ *   - `BETTER_AUTH_SECRETS`     — JSON `{ kid: secret }` map of every
+ *                                  secret a verifier should accept.
+ *
+ * Backward compat: if `BETTER_AUTH_SECRETS` is empty (the default), we
+ * derive `{ [BETTER_AUTH_ACTIVE_KID]: BETTER_AUTH_SECRET }` so existing
+ * deployments keep working unchanged.
+ *
+ * Signature wire format used by `signAuthHmac` / `verifyAuthHmac`:
+ *
+ *     <kid>$<base64url-hmac>
+ *
+ * Verifiers also accept the legacy un-prefixed `<base64url-hmac>` form
+ * (computed against the active secret only) so a deployment can roll the
+ * helper in without invalidating in-flight cookies.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { getEnv } from "@appstrate/env";
+
+let _cache: { active: string; map: Record<string, string> } | null = null;
+
+function loadSecrets(): { active: string; map: Record<string, string> } {
+  if (_cache) return _cache;
+  const env = getEnv();
+  const map: Record<string, string> = { ...env.BETTER_AUTH_SECRETS };
+  const activeKid = env.BETTER_AUTH_ACTIVE_KID;
+  if (!map[activeKid]) {
+    map[activeKid] = env.BETTER_AUTH_SECRET;
+  }
+  _cache = { active: activeKid, map };
+  return _cache;
+}
+
+/** Returns the secret matching `BETTER_AUTH_ACTIVE_KID` — pass to Better Auth. */
+export function getActiveAuthSecret(): string {
+  const { active, map } = loadSecrets();
+  const secret = map[active];
+  if (!secret) {
+    throw new Error(`No secret configured for active kid '${active}'`);
+  }
+  return secret;
+}
+
+function hmacBase64Url(secret: string, payload: string): string {
+  return createHmac("sha256", secret)
+    .update(payload)
+    .digest("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/** Signs `payload` with the active secret. Returns `<kid>$<sig>`. */
+export function signAuthHmac(payload: string): string {
+  const { active } = loadSecrets();
+  const sig = hmacBase64Url(getActiveAuthSecret(), payload);
+  return `${active}$${sig}`;
+}
+
+/**
+ * Verifies a signature against any known secret. Accepts the prefixed
+ * `<kid>$<sig>` form (preferred) and the legacy un-prefixed `<sig>` form
+ * (verified against the active secret only) for rollout compatibility.
+ */
+export function verifyAuthHmac(payload: string, signature: string): boolean {
+  const { map } = loadSecrets();
+
+  if (signature.includes("$")) {
+    const sep = signature.indexOf("$");
+    const kid = signature.slice(0, sep);
+    const sig = signature.slice(sep + 1);
+    const secret = map[kid];
+    if (!secret) return false;
+    return constantTimeEquals(hmacBase64Url(secret, payload), sig);
+  }
+
+  return constantTimeEquals(hmacBase64Url(getActiveAuthSecret(), payload), signature);
+}
+
+function constantTimeEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a, "utf8"), Buffer.from(b, "utf8"));
+}
+
+/** Test-only: clear the memoised secret map (used by env-overriding tests). */
+export function _resetAuthSecretsCache(): void {
+  _cache = null;
+}

--- a/apps/api/src/lib/jsonb-schemas.ts
+++ b/apps/api/src/lib/jsonb-schemas.ts
@@ -1,0 +1,55 @@
+/**
+ * Zod validators for the JSONB columns that previously accepted any
+ * `Record<string, unknown>` from internal callers. The columns store data
+ * produced by trusted services (run finalize, hooks, sinks), but lack of
+ * structural enforcement at the write boundary means a single rogue caller
+ * can poison the column with `Date` objects, functions, or oversized blobs
+ * — all undetectable until a downstream read explodes.
+ *
+ * Each schema asserts JSON-safety + a soft byte cap on the JSON-stringified
+ * payload. Callers `.parse()` to throw on invalid input (good for the create
+ * / update boundaries) or `.safeParse()` to log-and-skip on the high-volume
+ * log path.
+ */
+
+import { z } from "zod";
+
+const KB = 1024;
+
+const jsonValueSchema: z.ZodType<unknown> = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number().finite(),
+    z.boolean(),
+    z.null(),
+    z.array(jsonValueSchema),
+    z.record(z.string(), jsonValueSchema),
+  ]),
+);
+
+function withByteCap(maxBytes: number) {
+  return (value: Record<string, unknown>, ctx: z.RefinementCtx) => {
+    const size = Buffer.byteLength(JSON.stringify(value), "utf8");
+    if (size > maxBytes) {
+      ctx.addIssue({
+        code: "custom",
+        message: `JSON payload is ${size} bytes; max is ${maxBytes}`,
+      });
+    }
+  };
+}
+
+/** `runs.metadata` — opaque payload returned by the `afterRun` hook. */
+export const runMetadataSchema = z
+  .record(z.string(), jsonValueSchema)
+  .superRefine(withByteCap(8 * KB));
+
+/** `runs.config` — snapshot of the effective agent config at run creation. */
+export const runConfigSchema = z
+  .record(z.string(), jsonValueSchema)
+  .superRefine(withByteCap(16 * KB));
+
+/** `run_logs.data` — per-event payload (progress, result, system events). */
+export const runLogDataSchema = z
+  .record(z.string(), jsonValueSchema)
+  .superRefine(withByteCap(32 * KB));

--- a/apps/api/src/middleware/body-limit.ts
+++ b/apps/api/src/middleware/body-limit.ts
@@ -1,0 +1,16 @@
+import { bodyLimit as honoBodyLimit } from "hono/body-limit";
+import type { MiddlewareHandler } from "hono";
+import { payloadTooLarge } from "../lib/errors.ts";
+
+/**
+ * Global body-size cap. Throws an `ApiError` so the response goes through the
+ * RFC 9457 problem+json error handler (instead of Hono's default plaintext 413).
+ */
+export function bodyLimit(maxSize: number): MiddlewareHandler {
+  return honoBodyLimit({
+    maxSize,
+    onError: () => {
+      throw payloadTooLarge(`Request body exceeds the ${maxSize}-byte limit`);
+    },
+  });
+}

--- a/apps/api/src/modules/oidc/services/pending-client-cookie.ts
+++ b/apps/api/src/modules/oidc/services/pending-client-cookie.ts
@@ -31,11 +31,11 @@
  * both.
  */
 
-import { createHmac, timingSafeEqual } from "node:crypto";
 import { setCookie, getCookie, deleteCookie } from "hono/cookie";
 import type { Context } from "hono";
 import { getEnv } from "@appstrate/env";
 import { logger } from "../../../lib/logger.ts";
+import { signAuthHmac, verifyAuthHmac } from "../../../lib/auth-secrets.ts";
 import type { AppEnv } from "../../../types/index.ts";
 
 let insecureCookieWarned = false;
@@ -51,7 +51,7 @@ const COOKIE_MAX_AGE = 10 * 60; // 10 minutes
 export function issuePendingClientCookie(c: Context<AppEnv>, clientId: string): void {
   const exp = Math.floor(Date.now() / 1000) + COOKIE_MAX_AGE;
   const payload = `${clientId}.${exp}`;
-  const sig = signPayload(payload);
+  const sig = signAuthHmac(payload);
   const value = `${payload}.${sig}`;
   const env = getEnv();
   const secure = env.APP_URL.startsWith("https://");
@@ -107,29 +107,15 @@ export function clearPendingClientCookie(c: Context<AppEnv>): void {
 
 // ─── Internals ────────────────────────────────────────────────────────────────
 
-function signPayload(payload: string): string {
-  const env = getEnv();
-  return createHmac("sha256", env.BETTER_AUTH_SECRET)
-    .update(payload)
-    .digest("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
-}
-
 function parseAndVerify(raw: string): string | null {
   // Format: `<clientId>.<exp>.<sig>`. `clientId` never contains a dot (it
-  // starts with `oauth_` and is base64url), so splitting on `.` gives
-  // exactly 3 parts.
+  // starts with `oauth_` and is base64url) and `sig` is now `<kid>$<hmac>`
+  // — neither contains a dot — so splitting on `.` still yields exactly 3
+  // parts. Legacy un-prefixed signatures are accepted by `verifyAuthHmac`.
   const parts = raw.split(".");
   if (parts.length !== 3) return null;
   const [clientId, expStr, sig] = parts as [string, string, string];
-  const expected = signPayload(`${clientId}.${expStr}`);
-  if (expected.length !== sig.length) return null;
-  // Timing-safe compare — the signature is not secret but we might as well.
-  const a = Buffer.from(expected, "utf8");
-  const b = Buffer.from(sig, "utf8");
-  if (!timingSafeEqual(a, b)) return null;
+  if (!verifyAuthHmac(`${clientId}.${expStr}`, sig)) return null;
   const exp = Number.parseInt(expStr, 10);
   if (!Number.isFinite(exp) || exp < Math.floor(Date.now() / 1000)) return null;
   return clientId;

--- a/apps/api/src/routes/api-keys.ts
+++ b/apps/api/src/routes/api-keys.ts
@@ -16,6 +16,7 @@ import {
   revokeApiKey,
 } from "../services/api-keys.ts";
 import { getAppScope, getOrgScope } from "../lib/scope.ts";
+import { recordAuditFromContext } from "../services/audit.ts";
 
 export const createApiKeySchema = z.object({
   name: z.string().min(1, "name is required").max(100, "name must be 100 characters or less"),
@@ -76,6 +77,13 @@ export function createApiKeysRouter() {
         scopes: validatedScopes,
       });
 
+      await recordAuditFromContext(c, {
+        action: "api_key.created",
+        resourceType: "api_key",
+        resourceId: id,
+        after: { name, keyPrefix, scopes: validatedScopes, expiresAt },
+      });
+
       return c.json({ id, key: rawKey, keyPrefix, scopes: validatedScopes }, 201);
     } catch (err) {
       logger.error("API key creation failed", {
@@ -99,6 +107,11 @@ export function createApiKeysRouter() {
       if (!revoked) {
         throw notFound("API key not found or already revoked");
       }
+      await recordAuditFromContext(c, {
+        action: "api_key.revoked",
+        resourceType: "api_key",
+        resourceId: keyId,
+      });
       return c.body(null, 204);
     } catch (err) {
       if (err instanceof ApiError) throw err;

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -27,6 +27,7 @@ import { isProviderEnabled, getProviderCredentialId, OAuthCallbackError } from "
 import { db } from "@appstrate/db/client";
 import type { Context } from "hono";
 import { getAppScope } from "../lib/scope.ts";
+import { recordAuditFromContext } from "../services/audit.ts";
 
 export const connectOAuthSchema = z.object({
   scopes: z.array(z.string()).optional(),
@@ -133,6 +134,12 @@ export function createConnectionsRouter() {
         }
 
         await saveApiKeyConnection(scope, provider, data.apiKey.trim(), profileId);
+        await recordAuditFromContext(c, {
+          action: "connection.created",
+          resourceType: "connection",
+          resourceId: provider,
+          after: { provider, profileId, mode: "api_key" },
+        });
         return c.json({ success: true });
       } catch (err: unknown) {
         if (err instanceof ApiError) throw err;
@@ -171,6 +178,12 @@ export function createConnectionsRouter() {
         }
 
         await saveCredentialsConnection(scope, provider, mode, data.credentials, profileId);
+        await recordAuditFromContext(c, {
+          action: "connection.created",
+          resourceType: "connection",
+          resourceId: provider,
+          after: { provider, profileId, mode },
+        });
         return c.json({ success: true });
       } catch (err: unknown) {
         if (err instanceof ApiError) throw err;
@@ -298,6 +311,12 @@ export function createConnectionsRouter() {
           }
           await disconnectProvider(scope, provider, profileId, credentialId);
         }
+        await recordAuditFromContext(c, {
+          action: "connection.deleted",
+          resourceType: "connection",
+          resourceId: provider,
+          before: { provider, connectionId: connectionId ?? null },
+        });
         return c.json({ success: true });
       } catch (err) {
         if (err instanceof ApiError) throw err;

--- a/apps/api/src/services/audit.ts
+++ b/apps/api/src/services/audit.ts
@@ -1,0 +1,107 @@
+/**
+ * Audit trail — durable record of state-changing operations.
+ *
+ * Best-effort by design: a failed insert is logged and swallowed so the
+ * caller's mutation never depends on audit health. The trade-off is that
+ * an audit row is not a guarantee of state change (the mutation could
+ * have committed and the insert could have lost), but a state change is
+ * never blocked by audit logging.
+ *
+ * Callers pass a typed `RecordAuditInput`. Most fields are optional so
+ * the helper can be added to existing routes without restructuring
+ * argument plumbing.
+ */
+
+import type { Context } from "hono";
+import { db } from "@appstrate/db/client";
+import { auditEvents } from "@appstrate/db/schema";
+import { logger } from "../lib/logger.ts";
+import type { AppEnv } from "../types/index.ts";
+
+export type AuditActorType = "member" | "end_user" | "api_key" | "system" | (string & {});
+
+export interface RecordAuditInput {
+  orgId: string;
+  applicationId?: string | null;
+  actorType: AuditActorType;
+  actorId?: string | null;
+  /** Verb scoped by resource — `connection.created`, `api_key.revoked`, … */
+  action: string;
+  resourceType: string;
+  resourceId?: string | null;
+  before?: Record<string, unknown> | null;
+  after?: Record<string, unknown> | null;
+  ip?: string | null;
+  userAgent?: string | null;
+  requestId?: string | null;
+}
+
+export async function recordAudit(input: RecordAuditInput): Promise<void> {
+  try {
+    await db.insert(auditEvents).values({
+      orgId: input.orgId,
+      applicationId: input.applicationId ?? null,
+      actorType: input.actorType,
+      actorId: input.actorId ?? null,
+      action: input.action,
+      resourceType: input.resourceType,
+      resourceId: input.resourceId ?? null,
+      before: input.before ?? null,
+      after: input.after ?? null,
+      ip: input.ip ?? null,
+      userAgent: input.userAgent ?? null,
+      requestId: input.requestId ?? null,
+    });
+  } catch (err) {
+    logger.error("recordAudit failed (state change is unaffected)", {
+      action: input.action,
+      resourceType: input.resourceType,
+      resourceId: input.resourceId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Convenience wrapper: derive `actorType`, `actorId`, `ip`, `userAgent`,
+ * `requestId`, and `applicationId` from the Hono context. Routes still
+ * pass the audit-specific fields (`action`, `resourceType`, …).
+ */
+export async function recordAuditFromContext(
+  c: Context<AppEnv>,
+  input: Omit<
+    RecordAuditInput,
+    "orgId" | "applicationId" | "actorType" | "actorId" | "ip" | "userAgent" | "requestId"
+  >,
+): Promise<void> {
+  const orgId = c.get("orgId");
+  if (!orgId) return;
+
+  const user = c.get("user");
+  const apiKeyId = c.get("apiKeyId");
+  const endUser = c.get("endUser");
+
+  let actorType: AuditActorType = "system";
+  let actorId: string | null = null;
+  if (apiKeyId) {
+    actorType = "api_key";
+    actorId = apiKeyId;
+  } else if (endUser) {
+    actorType = "end_user";
+    actorId = endUser.id;
+  } else if (user) {
+    actorType = "member";
+    actorId = user.id;
+  }
+
+  await recordAudit({
+    ...input,
+    orgId,
+    applicationId: c.get("applicationId") ?? null,
+    actorType,
+    actorId,
+    ip: c.req.header("x-forwarded-for") ?? null,
+    userAgent: c.req.header("user-agent") ?? null,
+    requestId: c.get("requestId") ?? null,
+  });
+}

--- a/apps/api/src/services/state/runs.ts
+++ b/apps/api/src/services/state/runs.ts
@@ -28,10 +28,50 @@ import type { RunProviderSnapshot } from "@appstrate/shared-types";
 import { logger } from "../../lib/logger.ts";
 import { scopedWhere } from "../../lib/db-helpers.ts";
 import { type Actor, actorFilter } from "../../lib/actor.ts";
+import { runMetadataSchema, runConfigSchema, runLogDataSchema } from "../../lib/jsonb-schemas.ts";
+import { invalidRequest } from "../../lib/errors.ts";
 import type { AppScope, OrgScope } from "../../lib/scope.ts";
 
 export const RUN_HISTORY_FIELDS = ["checkpoint", "result"] as const;
 export type RunHistoryField = (typeof RUN_HISTORY_FIELDS)[number];
+
+function parseRunConfig(value: Record<string, unknown> | null | undefined) {
+  if (value == null) return null;
+  const result = runConfigSchema.safeParse(value);
+  if (!result.success) {
+    throw invalidRequest(
+      `Invalid run config: ${result.error.issues[0]?.message ?? "validation failed"}`,
+    );
+  }
+  return result.data;
+}
+
+function parseRunMetadata(value: Record<string, unknown>) {
+  const result = runMetadataSchema.safeParse(value);
+  if (!result.success) {
+    throw invalidRequest(
+      `Invalid run metadata: ${result.error.issues[0]?.message ?? "validation failed"}`,
+    );
+  }
+  return result.data;
+}
+
+/**
+ * Run-log writes are high-volume and best-effort — a malformed `data`
+ * payload should not fail the surrounding event ingestion. Drop the
+ * `data` field on validation failure and log the reason.
+ */
+function safeRunLogData(value: Record<string, unknown> | null) {
+  if (value == null) return null;
+  const result = runLogDataSchema.safeParse(value);
+  if (!result.success) {
+    logger.warn("Dropped invalid run_logs.data payload", {
+      reason: result.error.issues[0]?.message,
+    });
+    return null;
+  }
+  return result.data;
+}
 
 import { asRecordOrNull } from "../../lib/safe-json.ts";
 import { toISO } from "../../lib/date-helpers.ts";
@@ -169,7 +209,7 @@ export async function createRun(scope: AppScope, params: CreateRunParams): Promi
     runNumber,
     agentScope: params.agentScope ?? null,
     agentName: params.agentName ?? null,
-    config: params.config ?? null,
+    config: parseRunConfig(params.config),
     runOrigin: params.runOrigin ?? "platform",
     ...(params.sinkSecretEncrypted !== undefined
       ? { sinkSecretEncrypted: params.sinkSecretEncrypted }
@@ -247,7 +287,7 @@ export async function updateRun(
   if (updates.checkpoint !== undefined) set.checkpoint = updates.checkpoint;
   if (updates.tokenUsage !== undefined) set.tokenUsage = updates.tokenUsage;
   if (updates.notifiedAt !== undefined) set.notifiedAt = new Date(updates.notifiedAt);
-  if (updates.metadata !== undefined) set.metadata = updates.metadata;
+  if (updates.metadata !== undefined) set.metadata = parseRunMetadata(updates.metadata);
   if (updates.sinkClosedAt !== undefined) set.sinkClosedAt = new Date(updates.sinkClosedAt);
 
   try {
@@ -405,7 +445,7 @@ export async function appendRunLog(
         type,
         event,
         message,
-        data,
+        data: safeRunLogData(data),
         level,
       })
       .returning({ id: runLogs.id });

--- a/apps/api/test/unit/auth-secrets.test.ts
+++ b/apps/api/test/unit/auth-secrets.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+  signAuthHmac,
+  verifyAuthHmac,
+  getActiveAuthSecret,
+  _resetAuthSecretsCache,
+} from "../../src/lib/auth-secrets.ts";
+import { _resetCacheForTesting as resetEnvCache } from "@appstrate/env";
+
+function resetCaches(): void {
+  resetEnvCache();
+  _resetAuthSecretsCache();
+}
+
+const ENV_KEYS = ["BETTER_AUTH_SECRET", "BETTER_AUTH_ACTIVE_KID", "BETTER_AUTH_SECRETS"] as const;
+
+function snapshotEnv(): Record<(typeof ENV_KEYS)[number], string | undefined> {
+  return Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]])) as Record<
+    (typeof ENV_KEYS)[number],
+    string | undefined
+  >;
+}
+
+function restoreEnv(snap: ReturnType<typeof snapshotEnv>): void {
+  for (const k of ENV_KEYS) {
+    if (snap[k] === undefined) delete process.env[k];
+    else process.env[k] = snap[k];
+  }
+}
+
+describe("auth-secrets", () => {
+  let snap: ReturnType<typeof snapshotEnv>;
+
+  beforeEach(() => {
+    snap = snapshotEnv();
+  });
+
+  afterEach(() => {
+    restoreEnv(snap);
+    resetCaches();
+  });
+
+  describe("backward-compat: single BETTER_AUTH_SECRET", () => {
+    beforeEach(() => {
+      process.env.BETTER_AUTH_SECRET = "legacy-single-secret-32-chars-long";
+      delete process.env.BETTER_AUTH_SECRETS;
+      delete process.env.BETTER_AUTH_ACTIVE_KID;
+      resetCaches();
+    });
+
+    it("uses BETTER_AUTH_SECRET as the active secret", () => {
+      expect(getActiveAuthSecret()).toBe("legacy-single-secret-32-chars-long");
+    });
+
+    it("signs with prefixed kid format", () => {
+      const sig = signAuthHmac("payload");
+      expect(sig.startsWith("k1$")).toBe(true);
+    });
+
+    it("verifies its own prefixed signature", () => {
+      const sig = signAuthHmac("payload");
+      expect(verifyAuthHmac("payload", sig)).toBe(true);
+    });
+
+    it("verifies a legacy un-prefixed signature against the active secret", () => {
+      const sig = signAuthHmac("payload");
+      const legacy = sig.split("$")[1]!;
+      expect(verifyAuthHmac("payload", legacy)).toBe(true);
+    });
+  });
+
+  describe("rotation: active kid + secrets map", () => {
+    beforeEach(() => {
+      process.env.BETTER_AUTH_SECRET = "fallback-not-used-32-chars-long";
+      process.env.BETTER_AUTH_ACTIVE_KID = "k2";
+      process.env.BETTER_AUTH_SECRETS = JSON.stringify({
+        k1: "old-secret-32-chars-long-for-hmac",
+        k2: "new-secret-32-chars-long-for-hmac",
+      });
+      resetCaches();
+    });
+
+    it("returns the active secret", () => {
+      expect(getActiveAuthSecret()).toBe("new-secret-32-chars-long-for-hmac");
+    });
+
+    it("signs with the active kid", () => {
+      const sig = signAuthHmac("payload");
+      expect(sig.startsWith("k2$")).toBe(true);
+    });
+
+    it("verifies signatures from a previous kid", async () => {
+      // Simulate a cookie signed before rotation by k1.
+      const { createHmac } = await import("node:crypto");
+      const hmac = createHmac("sha256", "old-secret-32-chars-long-for-hmac")
+        .update("payload")
+        .digest("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+      expect(verifyAuthHmac("payload", `k1$${hmac}`)).toBe(true);
+    });
+
+    it("rejects an unknown kid", () => {
+      expect(verifyAuthHmac("payload", "k99$ZZZ")).toBe(false);
+    });
+
+    it("rejects a tampered signature under a known kid", () => {
+      expect(verifyAuthHmac("payload", "k1$AAAA")).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/api-errors.ts
+++ b/packages/core/src/api-errors.ts
@@ -183,6 +183,15 @@ export function gone(code: string, detail: string): ApiError {
   });
 }
 
+export function payloadTooLarge(detail: string): ApiError {
+  return new ApiError({
+    status: 413,
+    code: "payload_too_large",
+    title: "Payload Too Large",
+    detail,
+  });
+}
+
 export function internalError(): ApiError {
   return new ApiError({
     status: 500,

--- a/packages/db/drizzle/0012_audit_events.sql
+++ b/packages/db/drizzle/0012_audit_events.sql
@@ -1,0 +1,34 @@
+-- 0012_audit_events.sql
+--
+-- Append-only audit log for state-changing operations. Inserted via the
+-- best-effort `recordAudit()` helper in apps/api/src/services/audit.ts.
+-- See docs/architecture/AUDIT_TRAIL.md for the schema rationale.
+
+CREATE TABLE IF NOT EXISTS "audit_events" (
+  "id"             BIGSERIAL PRIMARY KEY,
+  "org_id"         UUID NOT NULL REFERENCES "organizations"("id") ON DELETE CASCADE,
+  "application_id" TEXT REFERENCES "applications"("id") ON DELETE SET NULL,
+  "actor_type"     TEXT NOT NULL,
+  "actor_id"       TEXT,
+  "action"         TEXT NOT NULL,
+  "resource_type"  TEXT NOT NULL,
+  "resource_id"    TEXT,
+  "before"         JSONB,
+  "after"          JSONB,
+  "ip"             TEXT,
+  "user_agent"     TEXT,
+  "request_id"     TEXT,
+  "created_at"     TIMESTAMP NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_audit_events_org_created"
+  ON "audit_events" ("org_id", "created_at");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_audit_events_resource"
+  ON "audit_events" ("resource_type", "resource_id");
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS "idx_audit_events_actor"
+  ON "audit_events" ("actor_type", "actor_id");

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1778025800000,
       "tag": "0011_persistence_unify",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1782345600000,
+      "tag": "0012_audit_events",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -550,7 +550,10 @@ function buildAuth(
 
     baseURL: env.APP_URL,
     basePath: "/api/auth",
-    secret: env.BETTER_AUTH_SECRET,
+    // Resolve the secret through the kid map so a deployment that has
+    // already populated `BETTER_AUTH_SECRETS` for cookie rotation feeds
+    // Better Auth the active secret (not the legacy single-value var).
+    secret: env.BETTER_AUTH_SECRETS[env.BETTER_AUTH_ACTIVE_KID] ?? env.BETTER_AUTH_SECRET,
 
     plugins: [...basePlugins, ...extraPlugins],
 

--- a/packages/db/src/schema/audit.ts
+++ b/packages/db/src/schema/audit.ts
@@ -1,0 +1,43 @@
+import { pgTable, text, timestamp, bigserial, jsonb, uuid, index } from "drizzle-orm/pg-core";
+import { organizations } from "./organizations.ts";
+import { applications } from "./applications.ts";
+
+/**
+ * Append-only audit log for state-changing operations. Insert via
+ * `recordAudit()` from `apps/api/src/services/audit.ts` — the helper is
+ * best-effort (never throws) so it can be added to any mutation path
+ * without changing its failure modes.
+ *
+ * `actor_type` is open-ended on purpose: today's vocabulary is
+ * `member` / `end_user` / `api_key` / `system`, but module-owned mutations
+ * (oidc client provisioning, …) may add their own kinds without a schema
+ * migration.
+ */
+export const auditEvents = pgTable(
+  "audit_events",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    orgId: uuid("org_id")
+      .notNull()
+      .references(() => organizations.id, { onDelete: "cascade" }),
+    applicationId: text("application_id").references(() => applications.id, {
+      onDelete: "set null",
+    }),
+    actorType: text("actor_type").notNull(),
+    actorId: text("actor_id"),
+    action: text("action").notNull(),
+    resourceType: text("resource_type").notNull(),
+    resourceId: text("resource_id"),
+    before: jsonb("before").$type<Record<string, unknown>>(),
+    after: jsonb("after").$type<Record<string, unknown>>(),
+    ip: text("ip"),
+    userAgent: text("user_agent"),
+    requestId: text("request_id"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_audit_events_org_created").on(table.orgId, table.createdAt),
+    index("idx_audit_events_resource").on(table.resourceType, table.resourceId),
+    index("idx_audit_events_actor").on(table.actorType, table.actorId),
+  ],
+);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -9,4 +9,5 @@ export * from "./packages.ts";
 export * from "./runs.ts";
 export * from "./connections.ts";
 export * from "./uploads.ts";
+export * from "./audit.ts";
 export * from "./types.ts";

--- a/packages/db/src/schema/runs.ts
+++ b/packages/db/src/schema/runs.ts
@@ -199,7 +199,7 @@ export const runLogs = pgTable(
     level: text("level").notNull().default("debug"),
     event: text("event"),
     message: text("message"),
-    data: jsonb("data"),
+    data: jsonb("data").$type<Record<string, unknown>>(),
     createdAt: timestamp("created_at").defaultNow().notNull(),
   },
   (table) => [

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -21,6 +21,47 @@ const envSchema = z
     // PGlite data directory (used when DATABASE_URL is absent)
     PGLITE_DATA_DIR: z.string().default("./data/pglite"),
     BETTER_AUTH_SECRET: z.string().min(1, "BETTER_AUTH_SECRET is required"),
+    /**
+     * Active key id for the auth-secret map. Cookies and HMACs WE sign
+     * (e.g. `pending-client-cookie.ts`) include this kid so verifiers can
+     * pick the right secret from `BETTER_AUTH_SECRETS` during rotation.
+     */
+    BETTER_AUTH_ACTIVE_KID: z
+      .string()
+      .default("k1")
+      .refine((v) => /^[A-Za-z0-9_-]{1,32}$/.test(v), {
+        message: "BETTER_AUTH_ACTIVE_KID must match /^[A-Za-z0-9_-]{1,32}$/",
+      }),
+    /**
+     * JSON map of `{ kid: secret }` enumerating every secret a verifier
+     * should accept. Empty object (default) means "use BETTER_AUTH_SECRET
+     * under BETTER_AUTH_ACTIVE_KID" — fully backward compatible.
+     *
+     * Rotation pattern (online, no forced sign-out for cookies WE sign):
+     *   1. Add the new secret to BETTER_AUTH_SECRETS under a fresh kid.
+     *   2. Flip BETTER_AUTH_ACTIVE_KID to the fresh kid + restart.
+     *   3. Wait out the longest cookie TTL (10 min for pending-client).
+     *   4. Drop the old kid from BETTER_AUTH_SECRETS + restart.
+     *
+     * The Better Auth session cookie is signed with the active secret only;
+     * Better Auth itself does not (yet) accept a verification list, so
+     * rotating the session cookie still requires re-login.
+     */
+    BETTER_AUTH_SECRETS: z
+      .string()
+      .default("{}")
+      .transform((s, ctx) => {
+        try {
+          return JSON.parse(s) as unknown;
+        } catch {
+          ctx.addIssue({
+            code: "custom",
+            message: "BETTER_AUTH_SECRETS must be valid JSON",
+          });
+          return z.NEVER;
+        }
+      })
+      .pipe(z.record(z.string(), z.string())),
     // Dedicated HMAC secret for FS upload-sink tokens. Separate from
     // BETTER_AUTH_SECRET so the two can be rotated independently and a
     // compromise of one does not affect the other.

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -169,6 +169,13 @@ const envSchema = z
           .filter(Boolean),
       ),
     PORT: z.coerce.number().int().positive().default(3000),
+    // Global request body size cap enforced by the Hono `bodyLimit` middleware.
+    // Per-route caps (LLM proxy, signed-token upload sink) still apply on top.
+    API_BODY_LIMIT_BYTES: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(10 * 1024 * 1024),
     COOKIE_DOMAIN: z.string().optional(),
     DOCKER_SOCKET: z.string().default("/var/run/docker.sock"),
     // Empty string → undefined so downstream `??` fallbacks (and the sidecar

--- a/scripts/check-consumer-versions.ts
+++ b/scripts/check-consumer-versions.ts
@@ -1,0 +1,159 @@
+/**
+ * Verify that every known `@appstrate/core` consumer is in lockstep with
+ * the version about to be published. Run by `.github/workflows/publish-core.yml`
+ * before npm publish — failing here forces a consumer bump pass before a new
+ * core version goes out.
+ *
+ * Drift policy:
+ *   - >= 2 minors behind  → fail (block publish).
+ *   - 1 minor behind      → warn.
+ *   - in sync             → OK.
+ *
+ * Override via env: `CONSUMER_DRIFT_POLICY=warn|fail|off`.
+ */
+
+interface Consumer {
+  /** GitHub repo in `owner/repo` form. */
+  repo: string;
+  /** package.json paths within the repo. */
+  paths: string[];
+}
+
+const CONSUMERS: Consumer[] = [
+  {
+    repo: "appstrate/registry",
+    paths: ["package.json", "apps/api/package.json", "apps/web/package.json"],
+  },
+  { repo: "appstrate/cloud", paths: ["package.json"] },
+  { repo: "appstrate/portal", paths: ["package.json"] },
+];
+
+const DEPENDENCY_NAME = "@appstrate/core";
+const POLICY = (process.env.CONSUMER_DRIFT_POLICY ?? "fail") as "warn" | "fail" | "off";
+
+function parseSemver(v: string): [number, number, number] | null {
+  const cleaned = v.replace(/^[\^~>=<\s]+/, "").trim();
+  const m = /^(\d+)\.(\d+)\.(\d+)/.exec(cleaned);
+  if (!m) return null;
+  return [Number(m[1]), Number(m[2]), Number(m[3])];
+}
+
+function compare(a: [number, number, number], b: [number, number, number]): number {
+  for (let i = 0; i < 3; i++) {
+    if (a[i] !== b[i]) return (a[i] ?? 0) - (b[i] ?? 0);
+  }
+  return 0;
+}
+
+async function fetchPackageJson(
+  repo: string,
+  path: string,
+): Promise<Record<string, unknown> | null> {
+  const url = `https://api.github.com/repos/${repo}/contents/${path}`;
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github.raw+json",
+    "User-Agent": "appstrate-consumer-version-check",
+  };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const res = await fetch(url, { headers });
+  if (res.status === 404) return null;
+  if (!res.ok) {
+    throw new Error(`GET ${url} → ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as Record<string, unknown>;
+}
+
+async function main(): Promise<void> {
+  if (POLICY === "off") {
+    console.log("CONSUMER_DRIFT_POLICY=off — skipping check.");
+    return;
+  }
+
+  const localPkg = await Bun.file("packages/core/package.json").json();
+  const localVersion = parseSemver(String(localPkg.version));
+  if (!localVersion) {
+    console.error(`Cannot parse local @appstrate/core version: ${localPkg.version}`);
+    process.exit(1);
+  }
+  const [lMaj, lMin] = localVersion;
+  console.log(`Publishing @appstrate/core@${lMaj}.${lMin}.${localVersion[2]}`);
+  console.log("");
+
+  let warnings = 0;
+  let failures = 0;
+
+  for (const consumer of CONSUMERS) {
+    for (const path of consumer.paths) {
+      let pkg: Record<string, unknown> | null;
+      try {
+        pkg = await fetchPackageJson(consumer.repo, path);
+      } catch (err) {
+        console.warn(
+          `  ! ${consumer.repo}/${path} — fetch failed (${err instanceof Error ? err.message : String(err)})`,
+        );
+        continue;
+      }
+      if (!pkg) {
+        console.log(`  - ${consumer.repo}/${path} — not present, skipping`);
+        continue;
+      }
+
+      const deps = {
+        ...(pkg.dependencies as Record<string, string> | undefined),
+        ...(pkg.devDependencies as Record<string, string> | undefined),
+      };
+      const range = deps[DEPENDENCY_NAME];
+      if (!range) {
+        console.log(`  - ${consumer.repo}/${path} — does not depend on ${DEPENDENCY_NAME}`);
+        continue;
+      }
+
+      const consumerVersion = parseSemver(range);
+      if (!consumerVersion) {
+        console.warn(`  ? ${consumer.repo}/${path} — unparsable range "${range}"`);
+        continue;
+      }
+
+      const [cMaj, cMin] = consumerVersion;
+      if (cMaj !== lMaj) {
+        const msg = `${consumer.repo}/${path} pins ${range} but local is ${localPkg.version} (major mismatch)`;
+        console.error(`  ✗ ${msg}`);
+        failures++;
+        continue;
+      }
+
+      const minorDelta = lMin - cMin;
+      if (minorDelta >= 2) {
+        console.error(
+          `  ✗ ${consumer.repo}/${path} pins ${range} — ${minorDelta} minors behind ${localPkg.version}`,
+        );
+        failures++;
+      } else if (minorDelta === 1) {
+        console.warn(
+          `  ! ${consumer.repo}/${path} pins ${range} — 1 minor behind ${localPkg.version}`,
+        );
+        warnings++;
+      } else if (compare(consumerVersion, localVersion) < 0) {
+        console.log(`  ✓ ${consumer.repo}/${path} pins ${range} — patch-behind, OK`);
+      } else {
+        console.log(`  ✓ ${consumer.repo}/${path} pins ${range} — in sync`);
+      }
+    }
+  }
+
+  console.log("");
+  console.log(`Summary: ${failures} failure(s), ${warnings} warning(s)`);
+
+  if (failures > 0 && POLICY === "fail") {
+    console.error("");
+    console.error("Bump the failing consumers to match before publishing core.");
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.stack : String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Closes the top 5 findings from the 2026-04-25 modernization audit
(`claudedocs/modernization-audit-2026-04-25.md`). Each commit is atomic
and self-contained — review per commit.

| # | Finding | Severity | Commit |
|---|---|---|---|
| 9 | Global request body size cap (RFC 9457 413) | 🟡 | `924de2b4` |
| 6 | Zod-validate JSONB write boundaries on runs + run_logs | 🟡 | `e2b6dbd0` |
| 3 | Durable `audit_events` table + `recordAudit` helper | 🔴 | `481cf96f` |
| 1 | Consumer-lockstep CI gate before `@appstrate/core` publish | 🔴 | `e32b8e75` |
| 2 | Versioned BETTER_AUTH secrets with online rotation window | 🔴 | `3c585bb2` |

Theme: **audit-readiness & operational rotation** — the SOC2-shaped
gaps (audit trail, secret rotation, body limits, JSONB validation) plus
the consumer-version drift that blocks any other cross-repo work.

## What ships

### #9 — Global body limit
- New env var `API_BODY_LIMIT_BYTES` (default 10 MB).
- New `payloadTooLarge()` helper in `@appstrate/core/api-errors` so
  413s flow through the central problem+json error handler.
- New `apps/api/src/middleware/body-limit.ts` Hono middleware applied
  globally; skipped for `/api/uploads/_content` (signed-token PUT).

### #6 — JSONB Zod schemas
- `runMetadataSchema` (8 KB) / `runConfigSchema` (16 KB) / `runLogDataSchema` (32 KB).
- Strict reject on `runs.metadata` and `runs.config` writes (400).
- Best-effort drop on `run_logs.data` (high-volume path; logs and
  drops the field, the surrounding event still ingests).
- `$type<Record<string, unknown>>` on `run_logs.data` for read-side
  type safety.

### #3 — `audit_events` table
- New schema + migration `0012_audit_events.sql`.
- `recordAudit()` (best-effort, never throws) + `recordAuditFromContext()`
  (derives actor/IP/UA/request-id from Hono context).
- Wired from API keys (create + revoke) and connections (create +
  delete) — the two highest-stakes mutation surfaces. Other paths can
  be added later without API churn.

### #1 — Core consumer lockstep
- `scripts/check-consumer-versions.ts` — fetches `package.json` from
  every known consumer (registry, cloud, portal) via the GitHub API
  and compares the pinned `^X.Y.Z` range to the version about to be
  published.
- Drift policy: ≥ 2 minors behind → fail (block publish), 1 minor →
  warn, in sync → OK.
- Wired into `publish-core.yml` after the tag-vs-package.json check,
  before npm publish.
- Override via `CONSUMER_DRIFT_POLICY=warn|off` repo variable for
  emergency hotfixes.

### #2 — Versioned auth secrets
- New env vars `BETTER_AUTH_SECRETS` (`{ kid: secret }` JSON map) and
  `BETTER_AUTH_ACTIVE_KID` (defaults to `k1`).
- New `apps/api/src/lib/auth-secrets.ts`: `getActiveAuthSecret()`,
  `signAuthHmac()`, `verifyAuthHmac()`.
- `pending-client-cookie.ts` migrated as the first consumer.
- Backward compat: when `BETTER_AUTH_SECRETS` is empty (default), the
  helper derives `{ [active]: BETTER_AUTH_SECRET }` so existing
  deployments keep working unchanged.
- The legacy un-prefixed signature format is still accepted for
  rolling out the helper without invalidating in-flight cookies.

**Known limit**: Better Auth itself does not yet accept a verification
list, so rotating the session cookie still requires re-login. The env
wiring is now in place for any future plugin-side dual-key support, and
every HMAC the platform owns can rotate online.

## Test plan
- [x] `bun run check` (turbo typecheck + lint + format + verify-openapi + detect-breaking)
- [x] `bun test apps/api/test/unit/` (703 pass, 0 fail)
- [x] New `auth-secrets.test.ts` (9 tests covering legacy + rotation paths)
- [x] OIDC `signup-guard.test.ts` continues to pass (legacy un-prefixed cookie format)
- [ ] CI: full integration suite + e2e

## Out of scope (deferred, not blocked by this PR)
- Wiring `recordAudit()` into agents / schedules / webhooks / applications
  (additive, no API churn).
- Better Auth plugin for session-cookie multi-secret verification
  (requires upstream cooperation).
- Audit-events admin endpoint (`GET /api/audit-events`).
- Bumping `@appstrate/core` ranges in registry/cloud/portal (those repo
  PRs are out of `appstrate/`'s scope per audit guardrails — but the
  CI gate this PR adds will require them at the next core publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)