### PR TITLE
chore: modernization-audit batch (14 findings)

### DIFF
--- a/apps/api/src/lib/jsonb-schemas.ts
+++ b/apps/api/src/lib/jsonb-schemas.ts
@@ -28,7 +28,7 @@ const jsonValueSchema: z.ZodType<unknown> = z.lazy(() =>
 );
 
 function withByteCap(maxBytes: number) {
-  return (value: Record<string, unknown>, ctx: z.RefinementCtx) => {
+  return (value: unknown, ctx: z.RefinementCtx): void => {
     const size = Buffer.byteLength(JSON.stringify(value), "utf8");
     if (size > maxBytes) {
       ctx.addIssue({
@@ -62,18 +62,4 @@ export const runLogDataSchema = z
  * enough for rich agent state, small enough that a runaway writer
  * cannot single-handedly poison a workspace.
  */
-const jsonValueByteCap =
-  (maxBytes: number) =>
-  (value: unknown, ctx: z.RefinementCtx): void => {
-    const size = Buffer.byteLength(JSON.stringify(value), "utf8");
-    if (size > maxBytes) {
-      ctx.addIssue({
-        code: "custom",
-        message: `JSON payload is ${size} bytes; max is ${maxBytes}`,
-      });
-    }
-  };
-
-export const packagePersistenceContentSchema = jsonValueSchema.superRefine(
-  jsonValueByteCap(64 * KB),
-);
+export const packagePersistenceContentSchema = jsonValueSchema.superRefine(withByteCap(64 * KB));

--- a/apps/api/src/lib/jsonb-schemas.ts
+++ b/apps/api/src/lib/jsonb-schemas.ts
@@ -53,3 +53,27 @@ export const runConfigSchema = z
 export const runLogDataSchema = z
   .record(z.string(), jsonValueSchema)
   .superRefine(withByteCap(32 * KB));
+
+/**
+ * `package_persistence.content` — checkpoint / pinned-slot / memory
+ * payload. Memories may be a plain string (the AFPS `note` tool path);
+ * checkpoints + pinned slots are typically structured objects / arrays.
+ * Validated as any JSON-safe value capped at 64 KB per row — large
+ * enough for rich agent state, small enough that a runaway writer
+ * cannot single-handedly poison a workspace.
+ */
+const jsonValueByteCap =
+  (maxBytes: number) =>
+  (value: unknown, ctx: z.RefinementCtx): void => {
+    const size = Buffer.byteLength(JSON.stringify(value), "utf8");
+    if (size > maxBytes) {
+      ctx.addIssue({
+        code: "custom",
+        message: `JSON payload is ${size} bytes; max is ${maxBytes}`,
+      });
+    }
+  };
+
+export const packagePersistenceContentSchema = jsonValueSchema.superRefine(
+  jsonValueByteCap(64 * KB),
+);

--- a/apps/api/src/lib/pagination-link.ts
+++ b/apps/api/src/lib/pagination-link.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * RFC 5988 `Link` header helpers for paginated list endpoints.
+ *
+ * Generic SDK pagers traditionally walk the body shape (`hasMore`,
+ * `total`, …) which couples them to per-resource envelopes. RFC 5988
+ * is the hypermedia escape hatch: emit `Link: <next>; rel="next"` and
+ * the consumer follows the URL until the header disappears, no matter
+ * what the body shape is.
+ *
+ * Two flavours covered here:
+ *   - `cursorLinkHeader`  — Stripe-style `startingAfter` / `endingBefore`
+ *                            (e.g. `/api/end-users`)
+ *   - `offsetLinkHeader`  — `limit` + `offset`
+ *                            (e.g. `/api/runs`, `/api/notifications`)
+ *
+ * The helpers write directly into the response via `c.header(...)`
+ * and silently no-op when there is no next/prev — RFC 5988 allows a
+ * partial set of relations.
+ */
+
+import type { Context } from "hono";
+
+interface CursorLinkArgs {
+  /** Hono context — the request URL is read from `c.req.url`. */
+  c: Context;
+  /** True when the current page is followed by another. */
+  hasMore: boolean;
+  /** ID of the last row on this page; required when `hasMore`. */
+  lastId?: string | undefined;
+  /** ID of the first row on this page; required when `hasPrev`. */
+  firstId?: string | undefined;
+  /** Whether a `prev` page exists (caller knows because it received an `endingBefore` query). */
+  hasPrev?: boolean;
+}
+
+function buildUrl(c: Context, mutate: (params: URLSearchParams) => void): string {
+  // `c.req.url` is the full URL — preserve scheme + host + path so the
+  // Link href is dereferenceable directly by clients (curl, fetch).
+  const url = new URL(c.req.url);
+  // Strip cursor query params before adding the new one — `next` and
+  // `prev` are mutually exclusive in cursor pagination, and stale
+  // values from the inbound URL would break the next round-trip.
+  url.searchParams.delete("startingAfter");
+  url.searchParams.delete("endingBefore");
+  mutate(url.searchParams);
+  return url.toString();
+}
+
+/**
+ * Set RFC 5988 `Link` header for cursor-paginated responses. Mirrors
+ * Stripe's pager: `next` → `?startingAfter=<lastId>`, `prev` →
+ * `?endingBefore=<firstId>`.
+ */
+export function setCursorLinkHeader({
+  c,
+  hasMore,
+  lastId,
+  firstId,
+  hasPrev = false,
+}: CursorLinkArgs): void {
+  const links: string[] = [];
+  if (hasMore && lastId) {
+    const next = buildUrl(c, (p) => p.set("startingAfter", lastId));
+    links.push(`<${next}>; rel="next"`);
+  }
+  if (hasPrev && firstId) {
+    const prev = buildUrl(c, (p) => p.set("endingBefore", firstId));
+    links.push(`<${prev}>; rel="prev"`);
+  }
+  if (links.length > 0) {
+    c.header("Link", links.join(", "));
+  }
+}
+
+interface OffsetLinkArgs {
+  c: Context;
+  /** Current page limit. */
+  limit: number;
+  /** Current page offset (defaults to 0). */
+  offset: number;
+  /** Total row count, when known. Drives `last` + `prev` clamping. */
+  total?: number;
+  /** True when another page follows (used when `total` is unknown). */
+  hasMore?: boolean;
+}
+
+function buildOffsetUrl(c: Context, limit: number, offset: number): string {
+  const url = new URL(c.req.url);
+  url.searchParams.set("limit", String(limit));
+  if (offset > 0) {
+    url.searchParams.set("offset", String(offset));
+  } else {
+    url.searchParams.delete("offset");
+  }
+  return url.toString();
+}
+
+/**
+ * Set RFC 5988 `Link` header for offset-paginated responses. Emits
+ * `next` + `prev` (and `first` + `last` when `total` is known).
+ */
+export function setOffsetLinkHeader({ c, limit, offset, total, hasMore }: OffsetLinkArgs): void {
+  const links: string[] = [];
+  const moreAvailable = hasMore ?? (total !== undefined ? offset + limit < total : false);
+  if (moreAvailable) {
+    links.push(`<${buildOffsetUrl(c, limit, offset + limit)}>; rel="next"`);
+  }
+  if (offset > 0) {
+    links.push(`<${buildOffsetUrl(c, limit, Math.max(0, offset - limit))}>; rel="prev"`);
+    links.push(`<${buildOffsetUrl(c, limit, 0)}>; rel="first"`);
+  }
+  if (total !== undefined && total > 0) {
+    const lastOffset = Math.max(0, Math.floor((total - 1) / limit) * limit);
+    if (lastOffset !== offset) {
+      links.push(`<${buildOffsetUrl(c, limit, lastOffset)}>; rel="last"`);
+    }
+  }
+  if (links.length > 0) {
+    c.header("Link", links.join(", "));
+  }
+}

--- a/apps/api/src/lib/run-signature.ts
+++ b/apps/api/src/lib/run-signature.ts
@@ -16,6 +16,7 @@
 
 import { decrypt } from "@appstrate/connect";
 import { verify } from "@appstrate/afps-runtime/events";
+import { getEnv } from "@appstrate/env";
 import { ApiError, gone } from "@appstrate/core/api-errors";
 import type { RunSinkContext } from "../types/run-sink.ts";
 
@@ -85,6 +86,7 @@ export function verifyRunSignatureHeaders(input: {
     timestampSec,
     body: input.body,
     secret,
+    toleranceSec: getEnv().WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS,
   });
 
   if (!result.ok) {

--- a/apps/api/src/middleware/request-id.ts
+++ b/apps/api/src/middleware/request-id.ts
@@ -15,6 +15,7 @@
 
 import type { Context, Next } from "hono";
 import { parseTraceparent } from "@appstrate/afps-runtime/transport";
+import { runWithTraceContext } from "@appstrate/core/logger";
 import type { AppEnv } from "../types/index.ts";
 
 /**
@@ -35,7 +36,22 @@ export function requestId() {
       c.set("traceId", trace.traceId);
     }
 
-    await next();
+    // Bind the trace context on the async chain so every pino log line
+    // emitted while serving this request carries `trace_id` / `span_id`
+    // / `trace_flags` per OTel log-correlation conventions. Outside the
+    // trace scope (no inbound traceparent), the mixin is a no-op.
+    if (trace) {
+      await runWithTraceContext(
+        {
+          traceId: trace.traceId,
+          spanId: trace.spanId,
+          traceFlags: trace.flags,
+        },
+        () => next(),
+      );
+    } else {
+      await next();
+    }
 
     c.header("Request-Id", id);
     if (trace && inbound) {

--- a/apps/api/src/modules/webhooks/routes.ts
+++ b/apps/api/src/modules/webhooks/routes.ts
@@ -20,6 +20,7 @@ import { applications } from "@appstrate/db/schema";
 import type { AppEnv } from "../../types/index.ts";
 import { rateLimit } from "../../middleware/rate-limit.ts";
 import { idempotency } from "../../middleware/idempotency.ts";
+import { recordAuditFromContext } from "../../services/audit.ts";
 import {
   createWebhook,
   listWebhooks,
@@ -146,6 +147,12 @@ export function createWebhooksRouter() {
               enabled: data.enabled,
             },
       );
+      await recordAuditFromContext(c, {
+        action: "webhook.created",
+        resourceType: "webhook",
+        resourceId: result.id,
+        after: { url: data.url, events: data.events, level: data.level },
+      });
       return c.json(result, 201);
     },
   );
@@ -199,6 +206,12 @@ export function createWebhooksRouter() {
       const data = parseBody(updateWebhookSchema, body);
 
       const result = await updateWebhook(webhookScope(c), c.req.param("id")!, data);
+      await recordAuditFromContext(c, {
+        action: "webhook.updated",
+        resourceType: "webhook",
+        resourceId: c.req.param("id")!,
+        after: data as unknown as Record<string, unknown>,
+      });
       return c.json(result);
     },
   );
@@ -209,7 +222,13 @@ export function createWebhooksRouter() {
     rateLimit(10),
     requireModulePermission("webhooks", "delete"),
     async (c) => {
-      await deleteWebhook(webhookScope(c), c.req.param("id")!);
+      const id = c.req.param("id")!;
+      await deleteWebhook(webhookScope(c), id);
+      await recordAuditFromContext(c, {
+        action: "webhook.deleted",
+        resourceType: "webhook",
+        resourceId: id,
+      });
       return c.body(null, 204);
     },
   );
@@ -240,7 +259,13 @@ export function createWebhooksRouter() {
     rateLimit(5),
     requireModulePermission("webhooks", "write"),
     async (c) => {
-      const result = await rotateSecret(webhookScope(c), c.req.param("id")!);
+      const id = c.req.param("id")!;
+      const result = await rotateSecret(webhookScope(c), id);
+      await recordAuditFromContext(c, {
+        action: "webhook.secret_rotated",
+        resourceType: "webhook",
+        resourceId: id,
+      });
       return c.json(result);
     },
   );

--- a/apps/api/src/openapi/baseline.json
+++ b/apps/api/src/openapi/baseline.json
@@ -467,17 +467,27 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "agents": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/AgentListItem"
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 },
                 "example": {
-                  "agents": [
+                  "object": "list",
+                  "hasMore": false,
+                  "data": [
                     {
                       "id": "@acme/email-sorter",
                       "displayName": "Email Sorter",
@@ -1958,7 +1968,11 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "runs": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/Run"
@@ -1966,9 +1980,12 @@
                     },
                     "total": {
                       "type": "integer"
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   },
-                  "required": ["runs", "total"]
+                  "required": ["object", "data", "total", "hasMore"]
                 }
               }
             }
@@ -2405,9 +2422,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["runs", "total"],
+                  "required": ["object", "data", "total", "hasMore"],
                   "properties": {
-                    "runs": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/Run"
@@ -2415,6 +2436,9 @@
                     },
                     "total": {
                       "type": "integer"
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 }
@@ -2987,12 +3011,14 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "description": "AFPS runtime `RunResult` — `memories`, `checkpoint`, `output`, `report`, `logs` plus optional terminal `status`/`error`/`durationMs`.",
+                "description": "AFPS runtime `RunResult` — `memories`, `pinned`, `output`, `report`, `logs` plus optional terminal `status`/`error`/`durationMs`.",
                 "properties": {
                   "memories": {
                     "type": "array"
                   },
-                  "checkpoint": {},
+                  "pinned": {
+                    "type": "object"
+                  },
                   "output": {},
                   "report": {
                     "type": ["string", "null"]
@@ -3809,7 +3835,11 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "runs": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/Run"
@@ -3817,9 +3847,12 @@
                     },
                     "total": {
                       "type": "integer"
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   },
-                  "required": ["runs", "total"]
+                  "required": ["object", "data", "total", "hasMore"]
                 }
               }
             }
@@ -6956,8 +6989,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "agents": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -6970,6 +7008,9 @@
                           }
                         }
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 }
@@ -8870,17 +8911,27 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "runs": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "type": "object"
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 },
                 "example": {
-                  "runs": [
+                  "object": "list",
+                  "hasMore": false,
+                  "data": [
                     {
                       "id": "run_cm9abc123",
                       "status": "success",
@@ -10056,17 +10107,27 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "skills": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/OrgPackageItem"
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 },
                 "example": {
-                  "skills": [
+                  "object": "list",
+                  "hasMore": false,
+                  "data": [
                     {
                       "id": "@acme/summarize",
                       "name": "Summarize",
@@ -10836,12 +10897,20 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "tools": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/OrgPackageItem"
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 }
@@ -11598,12 +11667,20 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "agents": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/OrgPackageItem"
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 }
@@ -12455,12 +12532,20 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "providers": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/OrgPackageItem"
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 }

--- a/apps/api/src/openapi/paths/agents.ts
+++ b/apps/api/src/openapi/paths/agents.ts
@@ -27,15 +27,20 @@ export const agentsPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  agents: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/AgentListItem" },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
               example: {
-                agents: [
+                object: "list",
+                hasMore: false,
+                data: [
                   {
                     id: "@acme/email-sorter",
                     displayName: "Email Sorter",

--- a/apps/api/src/openapi/paths/app-profiles.ts
+++ b/apps/api/src/openapi/paths/app-profiles.ts
@@ -382,8 +382,10 @@ export const appProfilesPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  agents: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: {
                       type: "object",
@@ -393,6 +395,7 @@ export const appProfilesPaths = {
                       },
                     },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
             },

--- a/apps/api/src/openapi/paths/internal.ts
+++ b/apps/api/src/openapi/paths/internal.ts
@@ -30,12 +30,17 @@ export const internalPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  runs: { type: "array", items: { type: "object" } },
+                  object: { type: "string", enum: ["list"] },
+                  data: { type: "array", items: { type: "object" } },
+                  hasMore: { type: "boolean" },
                 },
               },
               example: {
-                runs: [
+                object: "list",
+                hasMore: false,
+                data: [
                   {
                     id: "run_cm9abc123",
                     status: "success",

--- a/apps/api/src/openapi/paths/packages.ts
+++ b/apps/api/src/openapi/paths/packages.ts
@@ -414,15 +414,20 @@ export const packagesPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  skills: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/OrgPackageItem" },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
               example: {
-                skills: [
+                object: "list",
+                hasMore: false,
+                data: [
                   {
                     id: "@acme/summarize",
                     name: "Summarize",
@@ -928,11 +933,14 @@ export const packagesPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  tools: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/OrgPackageItem" },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
             },
@@ -1416,11 +1424,14 @@ export const packagesPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  agents: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/OrgPackageItem" },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
             },
@@ -1976,11 +1987,14 @@ export const packagesPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  providers: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/OrgPackageItem" },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
             },

--- a/apps/api/src/openapi/paths/runs.ts
+++ b/apps/api/src/openapi/paths/runs.ts
@@ -143,13 +143,15 @@ export const runsPaths = {
               schema: {
                 type: "object",
                 properties: {
-                  runs: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/Run" },
                   },
                   total: { type: "integer" },
+                  hasMore: { type: "boolean" },
                 },
-                required: ["runs", "total"],
+                required: ["object", "data", "total", "hasMore"],
               },
             },
           },
@@ -430,13 +432,15 @@ export const runsPaths = {
             "application/json": {
               schema: {
                 type: "object",
-                required: ["runs", "total"],
+                required: ["object", "data", "total", "hasMore"],
                 properties: {
-                  runs: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/Run" },
                   },
                   total: { type: "integer" },
+                  hasMore: { type: "boolean" },
                 },
               },
             },

--- a/apps/api/src/openapi/paths/schedules.ts
+++ b/apps/api/src/openapi/paths/schedules.ts
@@ -309,13 +309,15 @@ export const schedulesPaths = {
               schema: {
                 type: "object",
                 properties: {
-                  runs: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/Run" },
                   },
                   total: { type: "integer" },
+                  hasMore: { type: "boolean" },
                 },
-                required: ["runs", "total"],
+                required: ["object", "data", "total", "hasMore"],
               },
             },
           },

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -105,13 +105,7 @@ export function createAgentsRouter() {
       };
     });
 
-    // Emit both the legacy `agents` key (existing dashboard + SDK
-    // consumers) and the canonical Stripe-style envelope (`object` +
-    // `data` + `hasMore`) so generic SDK pagers can stop special-casing
-    // per-resource shapes. The duplication is intentional during the
-    // additive-then-deprecate window — drop `agents` at the next MAJOR.
     return c.json({
-      agents: agentList,
       object: "list" as const,
       data: agentList,
       hasMore: false,

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -105,7 +105,17 @@ export function createAgentsRouter() {
       };
     });
 
-    return c.json({ agents: agentList });
+    // Emit both the legacy `agents` key (existing dashboard + SDK
+    // consumers) and the canonical Stripe-style envelope (`object` +
+    // `data` + `hasMore`) so generic SDK pagers can stop special-casing
+    // per-resource shapes. The duplication is intentional during the
+    // additive-then-deprecate window — drop `agents` at the next MAJOR.
+    return c.json({
+      agents: agentList,
+      object: "list" as const,
+      data: agentList,
+      hasMore: false,
+    });
   });
 
   // PUT /api/agents/:scope/:name/config — save agent configuration (admin-only)

--- a/apps/api/src/routes/app-profiles.ts
+++ b/apps/api/src/routes/app-profiles.ts
@@ -144,7 +144,7 @@ export function createAppProfilesRouter() {
       .innerJoin(packages, eq(packages.id, applicationPackages.packageId))
       .where(eq(applicationPackages.appProfileId, profileId));
 
-    return c.json({ agents: rows });
+    return c.json({ object: "list" as const, data: rows, hasMore: false });
   });
 
   // GET /api/app-profiles/:id/bindings — list provider bindings for an app profile

--- a/apps/api/src/routes/applications.ts
+++ b/apps/api/src/routes/applications.ts
@@ -37,6 +37,7 @@ import { applicationProviderCredentials, packages } from "@appstrate/db/schema";
 import { encryptCredentials } from "@appstrate/connect";
 import { hasActualCredentials } from "../lib/provider-config.ts";
 import { orgOrSystemFilter } from "../lib/package-helpers.ts";
+import { recordAuditFromContext } from "../services/audit.ts";
 
 export const createApplicationSchema = z.object({
   name: z.string().min(1, "name is required").max(100, "name must be 100 characters or less"),
@@ -107,6 +108,12 @@ export function createApplicationsRouter() {
 
     try {
       const app = await createApplication(orgId, data, user.id);
+      await recordAuditFromContext(c, {
+        action: "application.created",
+        resourceType: "application",
+        resourceId: app.id,
+        after: { name: app.name },
+      });
       return c.json({ object: "application", ...app }, 201);
     } catch (err) {
       if (err instanceof ApiError) throw err;
@@ -149,6 +156,12 @@ export function createApplicationsRouter() {
 
     try {
       const app = await updateApplication(orgId, appId, data);
+      await recordAuditFromContext(c, {
+        action: "application.updated",
+        resourceType: "application",
+        resourceId: app.id,
+        after: data as unknown as Record<string, unknown>,
+      });
       return c.json({ object: "application", ...app });
     } catch (err) {
       if (err instanceof ApiError) throw err;
@@ -167,6 +180,11 @@ export function createApplicationsRouter() {
 
     try {
       await deleteApplication(orgId, appId);
+      await recordAuditFromContext(c, {
+        action: "application.deleted",
+        resourceType: "application",
+        resourceId: appId,
+      });
       return c.body(null, 204);
     } catch (err) {
       if (err instanceof ApiError) throw err;

--- a/apps/api/src/routes/end-users.ts
+++ b/apps/api/src/routes/end-users.ts
@@ -17,6 +17,8 @@ import {
   deleteEndUser,
 } from "../services/end-users.ts";
 import { invalidRequest, parseBody } from "../lib/errors.ts";
+import { setCursorLinkHeader } from "../lib/pagination-link.ts";
+import { recordAuditFromContext } from "../services/audit.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
 import { getAppScope } from "../lib/scope.ts";
 
@@ -66,6 +68,15 @@ export function createEndUsersRouter() {
         externalId: data.externalId ?? undefined,
         metadata: data.metadata,
       });
+      await recordAuditFromContext(c, {
+        action: "end_user.created",
+        resourceType: "end_user",
+        resourceId: created.id,
+        after: {
+          externalId: created.externalId,
+          email: created.email,
+        },
+      });
       return c.json(created, 201);
     },
   );
@@ -89,6 +100,14 @@ export function createEndUsersRouter() {
       limit,
       startingAfter: startingAfter ?? undefined,
       endingBefore: endingBefore ?? undefined,
+    });
+
+    setCursorLinkHeader({
+      c,
+      hasMore: result.hasMore,
+      lastId: result.data[result.data.length - 1]?.id,
+      firstId: result.data[0]?.id,
+      hasPrev: Boolean(endingBefore || startingAfter),
     });
 
     return c.json(result);
@@ -115,6 +134,12 @@ export function createEndUsersRouter() {
       externalId: data.externalId ?? undefined,
       metadata: data.metadata,
     });
+    await recordAuditFromContext(c, {
+      action: "end_user.updated",
+      resourceType: "end_user",
+      resourceId: endUserId,
+      after: data as unknown as Record<string, unknown>,
+    });
     return c.json(result);
   });
 
@@ -124,6 +149,11 @@ export function createEndUsersRouter() {
     const endUserId = c.req.param("id")!;
 
     await deleteEndUser(scope, endUserId);
+    await recordAuditFromContext(c, {
+      action: "end_user.deleted",
+      resourceType: "end_user",
+      resourceId: endUserId,
+    });
     return c.body(null, 204);
   });
 

--- a/apps/api/src/routes/internal.ts
+++ b/apps/api/src/routes/internal.ts
@@ -193,7 +193,7 @@ export function createInternalRouter() {
         },
       );
 
-      return c.json({ runs: recentRuns });
+      return c.json({ object: "list" as const, data: recentRuns, hasMore: false });
     } catch (err) {
       logger.error("Failed to fetch run history", {
         runId,

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -15,6 +15,7 @@ import {
 } from "../services/state/index.ts";
 import { invalidRequest } from "../lib/errors.ts";
 import { getAppScope } from "../lib/scope.ts";
+import { setOffsetLinkHeader } from "../lib/pagination-link.ts";
 
 export function createNotificationsRouter() {
   const router = new Hono<AppEnv>();
@@ -76,7 +77,9 @@ export function createNotificationsRouter() {
 
     // End-users always see only their own runs — same semantic as before.
     if (userFilter === "me" || endUser) {
-      return c.json(await listUserRuns(scope, actor.id, { limit, offset }));
+      const result = await listUserRuns(scope, actor.id, { limit, offset });
+      setOffsetLinkHeader({ c, limit, offset, total: result.total });
+      return c.json(result);
     }
 
     const rawKind = c.req.query("kind");
@@ -96,16 +99,16 @@ export function createNotificationsRouter() {
       throw invalidRequest("endDate is not a valid ISO date", "endDate");
     }
 
-    return c.json(
-      await listGlobalRuns(scope, {
-        limit,
-        offset,
-        kind,
-        status,
-        startDate,
-        endDate,
-      }),
-    );
+    const result = await listGlobalRuns(scope, {
+      limit,
+      offset,
+      kind,
+      status,
+      startDate,
+      endDate,
+    });
+    setOffsetLinkHeader({ c, limit, offset, total: result.total });
+    return c.json(result);
   });
 
   return router;

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -396,7 +396,7 @@ function makeListHandler(rcfg: PackageRouteConfig) {
     const applicationId = c.get("applicationId");
     const items = await listOrgItems(orgId, rcfg.cfg, applicationId);
     const enriched = await enrichWithCreatorNames(items);
-    return c.json({ [rcfg.cfg.storageFolder]: enriched });
+    return c.json({ object: "list" as const, data: enriched, hasMore: false });
   };
 }
 

--- a/apps/api/src/routes/providers.ts
+++ b/apps/api/src/routes/providers.ts
@@ -20,6 +20,7 @@ import {
   systemEntityForbidden,
 } from "../lib/errors.ts";
 import {
+  authModeEnum,
   getDefaultAdminCredentialSchema,
   validateProviderCredentialKeys,
 } from "@appstrate/core/validation";
@@ -120,7 +121,7 @@ const baseProviderSchema = z.object({
   version: z.string().optional(),
   description: z.string().optional(),
   author: z.string().optional(),
-  authMode: z.enum(["oauth2", "oauth1", "api_key", "basic", "custom"]),
+  authMode: authModeEnum,
   clientId: z.string().optional(),
   clientSecret: z.string().optional(),
   authorizationUrl: z.string().optional(),

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -393,14 +393,7 @@ export function createRunsRouter() {
       endUserId: endUser?.id,
     });
     setOffsetLinkHeader({ c, limit, offset, total: result.total });
-    // Stripe-style envelope alongside the legacy `runs` / `total` keys.
-    // Drop the legacy keys at the next MAJOR.
-    return c.json({
-      ...result,
-      object: "list" as const,
-      data: result.runs,
-      hasMore: offset + result.runs.length < result.total,
-    });
+    return c.json(result);
   });
 
   // GET /api/runs — served by the notifications router (registered first

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -28,6 +28,7 @@ import { trackRun, untrackRun, abortRun } from "../services/run-tracker.ts";
 import { rateLimit } from "../middleware/rate-limit.ts";
 import { idempotency } from "../middleware/idempotency.ts";
 import { ApiError, notFound, conflict } from "../lib/errors.ts";
+import { setOffsetLinkHeader } from "../lib/pagination-link.ts";
 import { requireAgent } from "../middleware/guards.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
 import { getOrchestrator } from "../services/orchestrator/index.ts";
@@ -391,7 +392,15 @@ export function createRunsRouter() {
       offset,
       endUserId: endUser?.id,
     });
-    return c.json(result);
+    setOffsetLinkHeader({ c, limit, offset, total: result.total });
+    // Stripe-style envelope alongside the legacy `runs` / `total` keys.
+    // Drop the legacy keys at the next MAJOR.
+    return c.json({
+      ...result,
+      object: "list" as const,
+      data: result.runs,
+      hasMore: offset + result.runs.length < result.total,
+    });
   });
 
   // GET /api/runs — served by the notifications router (registered first

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -23,6 +23,7 @@ import { getAppScope } from "../lib/scope.ts";
 import { asJSONSchemaObject } from "@appstrate/core/form";
 import { listScheduleRuns } from "../services/state/index.ts";
 import { recordAuditFromContext } from "../services/audit.ts";
+import { setOffsetLinkHeader } from "../lib/pagination-link.ts";
 
 export const createScheduleSchema = z.object({
   name: z.string().optional(),
@@ -210,6 +211,7 @@ export function createSchedulesRouter() {
       limit,
       offset,
     });
+    setOffsetLinkHeader({ c, limit, offset, total: result.total });
     return c.json(result);
   });
 

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -22,13 +22,14 @@ import { getActor } from "../lib/actor.ts";
 import { getAppScope } from "../lib/scope.ts";
 import { asJSONSchemaObject } from "@appstrate/core/form";
 import { listScheduleRuns } from "../services/state/index.ts";
+import { recordAuditFromContext } from "../services/audit.ts";
 
 export const createScheduleSchema = z.object({
   name: z.string().optional(),
   connectionProfileId: z.uuid(),
   cronExpression: z.string().min(1, "cronExpression is required"),
-  timezone: z.string().optional(),
-  input: z.record(z.string(), z.unknown()).optional(),
+  timezone: z.string().default("UTC"),
+  input: z.record(z.string(), z.unknown()).default({}),
 });
 
 export const updateScheduleSchema = z.object({
@@ -108,6 +109,16 @@ export function createSchedulesRouter() {
 
       const scope = getAppScope(c);
       const schedule = await createSchedule(scope, agent.id, data.connectionProfileId, data);
+      await recordAuditFromContext(c, {
+        action: "schedule.created",
+        resourceType: "schedule",
+        resourceId: schedule.id,
+        after: {
+          packageId: agent.id,
+          cronExpression: data.cronExpression,
+          timezone: data.timezone,
+        },
+      });
       return c.json(schedule, 201);
     },
   );
@@ -152,6 +163,12 @@ export function createSchedulesRouter() {
     }
 
     const schedule = await updateSchedule(scope, id, data);
+    await recordAuditFromContext(c, {
+      action: "schedule.updated",
+      resourceType: "schedule",
+      resourceId: id,
+      after: data as unknown as Record<string, unknown>,
+    });
     return c.json(schedule);
   });
 
@@ -164,6 +181,11 @@ export function createSchedulesRouter() {
       throw notFound(`Schedule '${id}' not found`);
     }
     await deleteSchedule(scope, id);
+    await recordAuditFromContext(c, {
+      action: "schedule.deleted",
+      resourceType: "schedule",
+      resourceId: id,
+    });
     return c.json({ ok: true });
   });
 

--- a/apps/api/src/services/state/package-persistence.ts
+++ b/apps/api/src/services/state/package-persistence.ts
@@ -25,6 +25,22 @@ import { and, asc, count, desc, eq, ilike, isNull, or, sql } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
 import { packagePersistence } from "@appstrate/db/schema";
 import type { Actor } from "../../lib/actor.ts";
+import { packagePersistenceContentSchema } from "../../lib/jsonb-schemas.ts";
+
+/**
+ * Validate any JSON value bound for `package_persistence.content` against
+ * the shared Zod schema (JSON-safe + soft 64 KB cap). Throws on failure
+ * with a path-prefixed message so callers (sidecar tool handlers, route
+ * handlers) bubble a clear `invalidRequest` to the agent. Strings are
+ * passed through unchanged — the AFPS `note` tool stores plain text.
+ */
+function assertValidContent(value: unknown, label: string): void {
+  const parsed = packagePersistenceContentSchema.safeParse(value);
+  if (!parsed.success) {
+    const issue = parsed.error.issues[0];
+    throw new Error(`Invalid ${label} content: ${issue?.message ?? "JSON validation failed"}`);
+  }
+}
 
 // Per-entry char cap and per-scope row cap (archive memories only;
 // pinned/checkpoint paths cap differently because they are bounded by
@@ -205,6 +221,8 @@ export async function upsertPinned(
       `Invalid pinned slot key "${key}" — must match ${PINNED_KEY_PATTERN} and be ≤${MAX_PINNED_KEY_LENGTH} chars`,
     );
   }
+
+  assertValidContent(content, key === CHECKPOINT_KEY ? "checkpoint" : "pinned slot");
 
   const { actorType, actorId } = storageActor(scope);
   const contentJson = sql`${JSON.stringify(content ?? null)}::jsonb`;
@@ -472,20 +490,24 @@ export async function addMemories(
   const available = Math.max(0, MAX_MEMORIES_PER_SCOPE - existing);
   if (available === 0) return 0;
 
-  const toInsert = contents.slice(0, available).map((c) => ({
-    packageId,
-    applicationId,
-    orgId,
-    key: null,
-    pinned,
-    actorType,
-    actorId,
-    content:
+  const toInsert = contents.slice(0, available).map((c) => {
+    const trimmed =
       typeof c === "string"
         ? (c.slice(0, MAX_MEMORY_CONTENT) as unknown as Record<string, unknown>)
-        : (c as Record<string, unknown>),
-    runId,
-  }));
+        : (c as Record<string, unknown>);
+    assertValidContent(trimmed, "memory");
+    return {
+      packageId,
+      applicationId,
+      orgId,
+      key: null,
+      pinned,
+      actorType,
+      actorId,
+      content: trimmed,
+      runId,
+    };
+  });
 
   if (toInsert.length === 0) return 0;
 

--- a/apps/api/src/services/state/runs.ts
+++ b/apps/api/src/services/state/runs.ts
@@ -23,6 +23,8 @@ import {
   endUsers,
   apiKeys,
   schedules,
+  runStatusValues,
+  type RunStatus,
 } from "@appstrate/db/schema";
 import type { RunProviderSnapshot } from "@appstrate/shared-types";
 import { logger } from "../../lib/logger.ts";
@@ -616,17 +618,8 @@ export async function listPackageRuns(
  */
 export type GlobalRunKind = "all" | "package" | "inline";
 
-type RunStatus = "pending" | "running" | "success" | "failed" | "timeout" | "cancelled";
-const KNOWN_RUN_STATUSES: readonly RunStatus[] = [
-  "pending",
-  "running",
-  "success",
-  "failed",
-  "timeout",
-  "cancelled",
-];
 function isRunStatus(value: string): value is RunStatus {
-  return (KNOWN_RUN_STATUSES as readonly string[]).includes(value);
+  return (runStatusValues as readonly string[]).includes(value);
 }
 
 export interface ListGlobalRunsOptions {

--- a/apps/api/src/services/state/runs.ts
+++ b/apps/api/src/services/state/runs.ts
@@ -563,11 +563,18 @@ export async function deletePackageRuns(scope: AppScope, packageId: string): Pro
   return deleted.length;
 }
 
+export interface RunListPage {
+  object: "list";
+  data: Record<string, unknown>[];
+  total: number;
+  hasMore: boolean;
+}
+
 export async function listRunsWithFilter(
   filter: SQL,
   limit: number,
   offset = 0,
-): Promise<{ runs: Record<string, unknown>[]; total: number }> {
+): Promise<RunListPage> {
   const [countRow] = await db.select({ count: count() }).from(runs).where(filter);
 
   const rows = await db
@@ -583,9 +590,13 @@ export async function listRunsWithFilter(
     .limit(limit)
     .offset(offset);
 
+  const data = rows.map(mapEnrichedRun) as unknown as Record<string, unknown>[];
+  const total = countRow?.count ?? 0;
   return {
-    runs: rows.map(mapEnrichedRun) as unknown as Record<string, unknown>[],
-    total: countRow?.count ?? 0,
+    object: "list",
+    data,
+    total,
+    hasMore: offset + data.length < total,
   };
 }
 
@@ -635,10 +646,7 @@ export interface ListGlobalRunsOptions {
 export async function listGlobalRuns(
   scope: AppScope,
   options: ListGlobalRunsOptions = {},
-): Promise<{
-  runs: Record<string, unknown>[];
-  total: number;
-}> {
+): Promise<RunListPage> {
   const { limit = 50, offset = 0, kind, status, startDate, endDate, endUserId } = options;
 
   const conditions = [eq(runs.orgId, scope.orgId), eq(runs.applicationId, scope.applicationId)];
@@ -672,9 +680,13 @@ export async function listGlobalRuns(
     .limit(limit)
     .offset(offset);
 
+  const data = rows.map(mapEnrichedRun) as unknown as Record<string, unknown>[];
+  const total = countRow?.count ?? 0;
   return {
-    runs: rows.map(mapEnrichedRun) as unknown as Record<string, unknown>[],
-    total: countRow?.count ?? 0,
+    object: "list",
+    data,
+    total,
+    hasMore: offset + data.length < total,
   };
 }
 

--- a/apps/api/test/integration/multi-tenancy.test.ts
+++ b/apps/api/test/integration/multi-tenancy.test.ts
@@ -89,10 +89,10 @@ describe("Multi-tenancy isolation", () => {
 
       expect(resA.status).toBe(200);
       expect(resB.status).toBe(200);
-      const bodyA = (await resA.json()) as { agents: { id: string }[] };
-      const bodyB = (await resB.json()) as { agents: { id: string }[] };
-      const idsA = bodyA.agents.map((i) => i.id);
-      const idsB = bodyB.agents.map((i) => i.id);
+      const bodyA = (await resA.json()) as { object: "list"; data: { id: string }[] };
+      const bodyB = (await resB.json()) as { object: "list"; data: { id: string }[] };
+      const idsA = bodyA.data.map((i) => i.id);
+      const idsB = bodyB.data.map((i) => i.id);
       expect(idsA).toContain("@org-a/agent-1");
       expect(idsA).not.toContain("@org-b/agent-1");
       expect(idsB).toContain("@org-b/agent-1");
@@ -170,8 +170,8 @@ describe("Multi-tenancy isolation", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { runs: unknown[] };
-      expect(body.runs).toHaveLength(0);
+      const body = (await res.json()) as { object: "list"; data: unknown[] };
+      expect(body.data).toHaveLength(0);
     });
   });
 

--- a/apps/api/test/integration/routes/agents.test.ts
+++ b/apps/api/test/integration/routes/agents.test.ts
@@ -37,8 +37,8 @@ describe("Agents API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.agents).toBeArray();
-      expect(body.agents).toHaveLength(0);
+      expect(body.data).toBeArray();
+      expect(body.data).toHaveLength(0);
     });
 
     it("returns agents installed in the current app", async () => {
@@ -55,8 +55,8 @@ describe("Agents API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.agents.length).toBeGreaterThanOrEqual(1);
-      const agent = body.agents.find((f: { id: string }) => f.id === "@myorg/test-agent");
+      expect(body.data.length).toBeGreaterThanOrEqual(1);
+      const agent = body.data.find((f: { id: string }) => f.id === "@myorg/test-agent");
       expect(agent).toBeDefined();
       expect(agent.source).toBe("local");
     });
@@ -71,7 +71,7 @@ describe("Agents API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      const leaked = body.agents.find((f: { id: string }) => f.id === "@otherorg/secret-agent");
+      const leaked = body.data.find((f: { id: string }) => f.id === "@otherorg/secret-agent");
       expect(leaked).toBeUndefined();
     });
 
@@ -259,7 +259,7 @@ describe("Agents API", () => {
       });
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      const agent = body.agents.find((f: { id: string }) => f.id === "@myorg/counted-agent");
+      const agent = body.data.find((f: { id: string }) => f.id === "@myorg/counted-agent");
       expect(agent).toBeDefined();
       expect(agent.runningRuns).toBe(1);
     });

--- a/apps/api/test/integration/routes/connection-profiles.test.ts
+++ b/apps/api/test/integration/routes/connection-profiles.test.ts
@@ -301,10 +301,10 @@ describe("Connection Profiles API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.agents).toBeArray();
-      expect(body.agents).toHaveLength(1);
-      expect(body.agents[0].id).toBe("@testorg/linked-agent");
-      expect(body.agents[0].displayName).toBe("Linked Agent");
+      expect(body.data).toBeArray();
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].id).toBe("@testorg/linked-agent");
+      expect(body.data[0].displayName).toBe("Linked Agent");
     });
 
     it("returns empty array when no agents use the profile", async () => {
@@ -319,7 +319,7 @@ describe("Connection Profiles API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.agents).toHaveLength(0);
+      expect(body.data).toHaveLength(0);
     });
 
     it("returns 404 for non-existent profile", async () => {

--- a/apps/api/test/integration/routes/ephemeral-filter.test.ts
+++ b/apps/api/test/integration/routes/ephemeral-filter.test.ts
@@ -58,8 +58,8 @@ describe("ephemeral filter — catalog endpoints hide inline shadows", () => {
   it("GET /api/agents does not include inline shadows", async () => {
     const res = await app.request("/api/agents", { headers: authHeaders(ctx) });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { agents: { id: string }[] };
-    const ids = body.agents.map((a) => a.id);
+    const body = (await res.json()) as { data: { id: string }[] };
+    const ids = body.data.map((a) => a.id);
     expect(ids).toContain("@ephemfilter/real-agent");
     for (const id of ids) {
       expect(id.startsWith("@inline/")).toBe(false);

--- a/apps/api/test/integration/routes/internal.test.ts
+++ b/apps/api/test/integration/routes/internal.test.ts
@@ -94,9 +94,9 @@ describe("Internal API", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { runs: unknown[] };
-      expect(body.runs).toBeArray();
-      expect(body.runs).toHaveLength(0);
+      const body = (await res.json()) as { data: unknown[] };
+      expect(body.data).toBeArray();
+      expect(body.data).toHaveLength(0);
     });
 
     it("returns recent runs for the same agent and user", async () => {
@@ -123,9 +123,9 @@ describe("Internal API", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { runs: Record<string, unknown>[] };
-      expect(body.runs).toBeArray();
-      expect(body.runs.length).toBe(2);
+      const body = (await res.json()) as { data: Record<string, unknown>[] };
+      expect(body.data).toBeArray();
+      expect(body.data.length).toBe(2);
     });
 
     it("respects the limit query parameter", async () => {
@@ -146,8 +146,8 @@ describe("Internal API", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { runs: unknown[] };
-      expect(body.runs).toHaveLength(2);
+      const body = (await res.json()) as { data: unknown[] };
+      expect(body.data).toHaveLength(2);
     });
 
     it("clamps limit to valid range (min 1, max 50)", async () => {
@@ -171,8 +171,8 @@ describe("Internal API", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { runs: { id: string }[] };
-      const ids = body.runs.map((e) => e.id);
+      const body = (await res.json()) as { data: { id: string }[] };
+      const ids = body.data.map((e) => e.id);
       expect(ids).not.toContain(runningRunId);
     });
 
@@ -198,8 +198,8 @@ describe("Internal API", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { runs: unknown[] };
-      expect(body.runs).toHaveLength(0);
+      const body = (await res.json()) as { data: unknown[] };
+      expect(body.data).toHaveLength(0);
     });
 
     it("accepts fields=checkpoint,result and returns the canonical `checkpoint` key", async () => {
@@ -218,9 +218,9 @@ describe("Internal API", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { runs: Record<string, unknown>[] };
-      expect(body.runs).toHaveLength(1);
-      const entry = body.runs[0]!;
+      const body = (await res.json()) as { data: Record<string, unknown>[] };
+      expect(body.data).toHaveLength(1);
+      const entry = body.data[0]!;
       expect(entry.checkpoint).toEqual({ key: "value" });
       expect(entry.result).toEqual({ output: "done" });
       // Legacy key never leaks back out — response speaks the new vocabulary.
@@ -269,11 +269,11 @@ describe("Internal API", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { runs: Record<string, unknown>[] };
-      expect(body.runs).toHaveLength(1);
-      expect(body.runs[0]!.checkpoint).toEqual({ key: "v" });
+      const body = (await res.json()) as { data: Record<string, unknown>[] };
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0]!.checkpoint).toEqual({ key: "v" });
       // No `result` because we defaulted to `checkpoint` only.
-      expect(body.runs[0]!.result).toBeUndefined();
+      expect(body.data[0]!.result).toBeUndefined();
     });
 
     it("does not return checkpoints from a different end-user (actor isolation)", async () => {
@@ -302,10 +302,10 @@ describe("Internal API", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { runs: Record<string, unknown>[] };
+      const body = (await res.json()) as { data: Record<string, unknown>[] };
       // No `secret` checkpoint may leak through — the end-user run is
       // a different actor than the running run's dashboard-user actor.
-      for (const r of body.runs) {
+      for (const r of body.data) {
         const cp = r.checkpoint as Record<string, unknown> | null;
         if (cp) expect(cp.secret).toBeUndefined();
       }

--- a/apps/api/test/integration/routes/notifications.test.ts
+++ b/apps/api/test/integration/routes/notifications.test.ts
@@ -262,11 +262,11 @@ describe("Notifications API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
-        runs: unknown[];
+        data: unknown[];
         total: number;
       };
-      expect(body.runs).toBeArray();
-      expect(body.runs).toHaveLength(0);
+      expect(body.data).toBeArray();
+      expect(body.data).toHaveLength(0);
       expect(body.total).toBe(0);
     });
 
@@ -297,11 +297,11 @@ describe("Notifications API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
-        runs: { id: string; status: string }[];
+        data: { id: string; status: string }[];
         total: number;
       };
-      expect(body.runs).toBeArray();
-      expect(body.runs).toHaveLength(2);
+      expect(body.data).toBeArray();
+      expect(body.data).toHaveLength(2);
       expect(body.total).toBe(2);
     });
 
@@ -335,10 +335,10 @@ describe("Notifications API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
-        runs: unknown[];
+        data: unknown[];
         total: number;
       };
-      expect(body.runs).toHaveLength(2);
+      expect(body.data).toHaveLength(2);
       expect(body.total).toBe(2);
     });
 
@@ -372,12 +372,12 @@ describe("Notifications API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
-        runs: { dashboardUserId: string }[];
+        data: { dashboardUserId: string }[];
         total: number;
       };
-      expect(body.runs).toHaveLength(1);
+      expect(body.data).toHaveLength(1);
       expect(body.total).toBe(1);
-      expect(body.runs[0]!.dashboardUserId).toBe(ctx.user.id);
+      expect(body.data[0]!.dashboardUserId).toBe(ctx.user.id);
     });
 
     it("respects limit parameter", async () => {
@@ -402,10 +402,10 @@ describe("Notifications API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
-        runs: unknown[];
+        data: unknown[];
         total: number;
       };
-      expect(body.runs).toHaveLength(2);
+      expect(body.data).toHaveLength(2);
       expect(body.total).toBe(5);
     });
 
@@ -431,10 +431,10 @@ describe("Notifications API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
-        runs: unknown[];
+        data: unknown[];
         total: number;
       };
-      expect(body.runs).toHaveLength(2);
+      expect(body.data).toHaveLength(2);
       expect(body.total).toBe(5);
     });
 
@@ -460,10 +460,10 @@ describe("Notifications API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
-        runs: unknown[];
+        data: unknown[];
         total: number;
       };
-      expect(body.runs).toHaveLength(0);
+      expect(body.data).toHaveLength(0);
       expect(body.total).toBe(0);
     });
 

--- a/apps/api/test/integration/routes/openapi-response-validation.test.ts
+++ b/apps/api/test/integration/routes/openapi-response-validation.test.ts
@@ -82,9 +82,9 @@ describe("OpenAPI response validation", () => {
       }
 
       expect(result.valid).toBe(true);
-      // Verify the shape matches what we expect structurally
-      expect(body).toHaveProperty("agents");
-      expect((body as any).agents).toBeArray();
+      expect(body).toHaveProperty("object", "list");
+      expect(body).toHaveProperty("data");
+      expect((body as any).data).toBeArray();
     });
   });
 

--- a/apps/api/test/integration/routes/packages.test.ts
+++ b/apps/api/test/integration/routes/packages.test.ts
@@ -33,8 +33,8 @@ describe("Packages API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.agents).toBeArray();
-      expect(body.agents).toHaveLength(0);
+      expect(body.data).toBeArray();
+      expect(body.data).toHaveLength(0);
     });
 
     it("returns agents owned by the org", async () => {
@@ -54,7 +54,7 @@ describe("Packages API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      const agent = body.agents.find((f: { id: string }) => f.id === "@pkgorg/list-agent");
+      const agent = body.data.find((f: { id: string }) => f.id === "@pkgorg/list-agent");
       expect(agent).toBeDefined();
     });
 
@@ -72,7 +72,7 @@ describe("Packages API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      const leaked = body.agents.find((f: { id: string }) => f.id === "@otherorg/secret-agent");
+      const leaked = body.data.find((f: { id: string }) => f.id === "@otherorg/secret-agent");
       expect(leaked).toBeUndefined();
     });
 

--- a/apps/api/test/integration/routes/packages.test.ts
+++ b/apps/api/test/integration/routes/packages.test.ts
@@ -94,7 +94,8 @@ describe("Packages API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.skills).toBeArray();
+      expect(body.object).toBe("list");
+      expect(body.data).toBeArray();
     });
 
     it("returns seeded skill", async () => {
@@ -122,7 +123,7 @@ describe("Packages API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      const skill = body.skills.find((s: { id: string }) => s.id === "@pkgorg/my-skill");
+      const skill = body.data.find((s: { id: string }) => s.id === "@pkgorg/my-skill");
       expect(skill).toBeDefined();
     });
 
@@ -864,8 +865,8 @@ describe("Packages API", () => {
       });
       expect(res1.status).toBe(200);
       const body1 = (await res1.json()) as any;
-      const myAgent = body1.agents.find((f: { id: string }) => f.id === "@pkgorg/my-agent");
-      const theirAgent = body1.agents.find(
+      const myAgent = body1.data.find((f: { id: string }) => f.id === "@pkgorg/my-agent");
+      const theirAgent = body1.data.find(
         (f: { id: string }) => f.id === "@isolatedorg/their-agent",
       );
       expect(myAgent).toBeDefined();
@@ -877,10 +878,10 @@ describe("Packages API", () => {
       });
       expect(res2.status).toBe(200);
       const body2 = (await res2.json()) as any;
-      const theirAgent2 = body2.agents.find(
+      const theirAgent2 = body2.data.find(
         (f: { id: string }) => f.id === "@isolatedorg/their-agent",
       );
-      const myAgent2 = body2.agents.find((f: { id: string }) => f.id === "@pkgorg/my-agent");
+      const myAgent2 = body2.data.find((f: { id: string }) => f.id === "@pkgorg/my-agent");
       expect(theirAgent2).toBeDefined();
       expect(myAgent2).toBeUndefined();
     });

--- a/apps/api/test/integration/routes/runs.test.ts
+++ b/apps/api/test/integration/routes/runs.test.ts
@@ -126,8 +126,8 @@ describe("Runs API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.runs).toBeArray();
-      expect(body.runs).toHaveLength(0);
+      expect(body.data).toBeArray();
+      expect(body.data).toHaveLength(0);
       expect(body.total).toBe(0);
     });
 
@@ -151,8 +151,8 @@ describe("Runs API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.runs.length).toBeGreaterThanOrEqual(1);
-      const found = body.runs.find((e: { id: string }) => e.id === run.id);
+      expect(body.data.length).toBeGreaterThanOrEqual(1);
+      const found = body.data.find((e: { id: string }) => e.id === run.id);
       expect(found).toBeDefined();
     });
 
@@ -680,12 +680,12 @@ describe("Runs API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.runs).toHaveLength(1);
-      expect(body.runs[0].dashboardUserName).toBeString();
-      expect(body.runs[0].dashboardUserName).toBeTruthy();
-      expect(body.runs[0].endUserName).toBeNull();
-      expect(body.runs[0].apiKeyName).toBeNull();
-      expect(body.runs[0].scheduleName).toBeNull();
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].dashboardUserName).toBeString();
+      expect(body.data[0].dashboardUserName).toBeTruthy();
+      expect(body.data[0].endUserName).toBeNull();
+      expect(body.data[0].apiKeyName).toBeNull();
+      expect(body.data[0].scheduleName).toBeNull();
     });
   });
 });

--- a/apps/api/test/integration/routes/runs.test.ts
+++ b/apps/api/test/integration/routes/runs.test.ts
@@ -523,7 +523,7 @@ describe("Runs API", () => {
       });
       expect(listRes.status).toBe(200);
       const listBody = (await listRes.json()) as any;
-      const runIds = listBody.runs.map((r: any) => r.id);
+      const runIds = listBody.data.map((r: any) => r.id);
       expect(runIds).toContain(appBRun.id);
     });
   });

--- a/apps/api/test/integration/routes/schedules.test.ts
+++ b/apps/api/test/integration/routes/schedules.test.ts
@@ -327,9 +327,9 @@ describe("Schedules API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.runs).toBeArray();
-      expect(body.runs.length).toBeGreaterThanOrEqual(1);
-      expect(body.runs[0].scheduleId).toBe(schedule.id);
+      expect(body.data).toBeArray();
+      expect(body.data.length).toBeGreaterThanOrEqual(1);
+      expect(body.data[0].scheduleId).toBe(schedule.id);
       expect(body.total).toBeGreaterThanOrEqual(1);
     });
 
@@ -350,8 +350,8 @@ describe("Schedules API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.runs).toBeArray();
-      expect(body.runs).toHaveLength(0);
+      expect(body.data).toBeArray();
+      expect(body.data).toHaveLength(0);
       expect(body.total).toBe(0);
     });
   });

--- a/apps/api/test/integration/services/list-global-runs.test.ts
+++ b/apps/api/test/integration/services/list-global-runs.test.ts
@@ -67,7 +67,7 @@ describe("listGlobalRuns", () => {
 
   it("returns empty list when no runs exist", async () => {
     const result = await listGlobalRuns({ orgId: ctx.orgId, applicationId: ctx.defaultAppId });
-    expect(result.runs).toEqual([]);
+    expect(result.data).toEqual([]);
     expect(result.total).toBe(0);
   });
 
@@ -78,7 +78,7 @@ describe("listGlobalRuns", () => {
     const result = await listGlobalRuns({ orgId: ctx.orgId, applicationId: ctx.defaultAppId });
     expect(result.total).toBe(2);
 
-    const byId = Object.fromEntries(result.runs.map((r) => [r.id, r]));
+    const byId = Object.fromEntries(result.data.map((r) => [r.id, r]));
     expect(byId[inline.id]?.packageEphemeral).toBe(true);
     expect(byId[pkg.id]?.packageEphemeral).toBe(false);
   });
@@ -93,7 +93,7 @@ describe("listGlobalRuns", () => {
       { kind: "inline" },
     );
     expect(result.total).toBe(2);
-    for (const run of result.runs) {
+    for (const run of result.data) {
       expect(run.packageEphemeral).toBe(true);
     }
   });
@@ -108,7 +108,7 @@ describe("listGlobalRuns", () => {
       { kind: "package" },
     );
     expect(result.total).toBe(2);
-    for (const run of result.runs) {
+    for (const run of result.data) {
       expect(run.packageEphemeral).toBe(false);
     }
   });
@@ -133,7 +133,7 @@ describe("listGlobalRuns", () => {
       { status: "failed" },
     );
     expect(result.total).toBe(1);
-    expect(result.runs[0]?.status).toBe("failed");
+    expect(result.data[0]?.status).toBe("failed");
   });
 
   it("filters by startDate / endDate", async () => {
@@ -155,13 +155,13 @@ describe("listGlobalRuns", () => {
       { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
       { startDate: new Date("2024-01-01") },
     );
-    expect(since2024.runs.map((r) => r.id)).toEqual([recent.id]);
+    expect(since2024.data.map((r) => r.id)).toEqual([recent.id]);
 
     const until2023 = await listGlobalRuns(
       { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
       { endDate: new Date("2023-01-01") },
     );
-    expect(until2023.runs.map((r) => r.id)).toEqual([old.id]);
+    expect(until2023.data.map((r) => r.id)).toEqual([old.id]);
   });
 
   it("respects the applicationId filter (cross-app isolation)", async () => {
@@ -189,14 +189,14 @@ describe("listGlobalRuns", () => {
       { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
       { limit: 2, offset: 0 },
     );
-    expect(page1.runs).toHaveLength(2);
+    expect(page1.data).toHaveLength(2);
     expect(page1.total).toBe(5);
 
     const page2 = await listGlobalRuns(
       { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
       { limit: 2, offset: 2 },
     );
-    expect(page2.runs).toHaveLength(2);
-    expect(page2.runs[0]?.id).not.toBe(page1.runs[0]?.id);
+    expect(page2.data).toHaveLength(2);
+    expect(page2.data[0]?.id).not.toBe(page1.data[0]?.id);
   });
 });

--- a/apps/web/src/components/notification-bell.tsx
+++ b/apps/web/src/components/notification-bell.tsx
@@ -124,7 +124,7 @@ export function NotificationBell() {
     for (const f of agents) agentNameMap.set(f.id, f.displayName);
   }
 
-  const unreadRuns = runsData?.runs.filter((e) => e.notifiedAt != null && e.readAt == null) ?? [];
+  const unreadRuns = runsData?.data.filter((e) => e.notifiedAt != null && e.readAt == null) ?? [];
 
   const handleClick = (runId: string) => {
     markRead.mutate(runId);

--- a/apps/web/src/components/run-list.tsx
+++ b/apps/web/src/components/run-list.tsx
@@ -55,7 +55,7 @@ export function RunList({
     offset: page * pageSize,
   });
 
-  const runs = (data?.runs ?? []) as EnrichedRun[];
+  const runs = (data?.data ?? []) as EnrichedRun[];
   const total = data?.total ?? 0;
   const totalPages = Math.ceil(total / pageSize);
 

--- a/apps/web/src/hooks/use-connection-profiles.ts
+++ b/apps/web/src/hooks/use-connection-profiles.ts
@@ -208,9 +208,9 @@ export function useAppProfileAgents(profileId: string | undefined) {
   return useQuery({
     queryKey: ["app-profile-agents", orgId, appId, profileId],
     queryFn: () =>
-      api<{ agents: { id: string; displayName: string }[] }>(
+      api<{ object: "list"; data: { id: string; displayName: string }[]; hasMore: boolean }>(
         `/app-profiles/${profileId}/agents`,
-      ).then((r) => r.agents),
+      ).then((r) => r.data),
     enabled: !!profileId,
     staleTime: 30_000,
   });

--- a/apps/web/src/hooks/use-packages.ts
+++ b/apps/web/src/hooks/use-packages.ts
@@ -22,10 +22,10 @@ import type {
 // --- Packages — config-driven factory ---
 
 const PACKAGE_CONFIG = {
-  agent: { path: "agents", listKey: "agents", detailKey: "agent" },
-  skill: { path: "skills", listKey: "skills", detailKey: "skill" },
-  tool: { path: "tools", listKey: "tools", detailKey: "tool" },
-  provider: { path: "providers", listKey: "providers", detailKey: "provider" },
+  agent: { path: "agents", detailKey: "agent" },
+  skill: { path: "skills", detailKey: "skill" },
+  tool: { path: "tools", detailKey: "tool" },
+  provider: { path: "providers", detailKey: "provider" },
 } as const;
 
 type PackageDetailMap = {
@@ -42,8 +42,10 @@ function usePackageList(type: PackageType) {
   return useQuery({
     queryKey: ["packages", cfg.path, orgId, appId],
     queryFn: async () => {
-      const data = await api<Record<string, OrgPackageItem[]>>(`/packages/${cfg.path}`);
-      return data[cfg.listKey] as OrgPackageItem[];
+      const result = await api<{ object: "list"; data: OrgPackageItem[]; hasMore: boolean }>(
+        `/packages/${cfg.path}`,
+      );
+      return result.data;
     },
     enabled: !!orgId && !!appId,
   });
@@ -120,8 +122,10 @@ export function useAgents() {
   return useQuery({
     queryKey: ["agents", orgId, appId],
     queryFn: async () => {
-      const data = await api<{ agents: AgentListItem[] }>("/agents");
-      return data.agents;
+      const result = await api<{ object: "list"; data: AgentListItem[]; hasMore: boolean }>(
+        "/agents",
+      );
+      return result.data;
     },
     enabled: !!orgId && !!appId,
   });

--- a/apps/web/src/hooks/use-paginated-runs.ts
+++ b/apps/web/src/hooks/use-paginated-runs.ts
@@ -7,8 +7,10 @@ import { useCurrentApplicationId } from "./use-current-application";
 import type { Run } from "@appstrate/shared-types";
 
 interface PaginatedResult {
-  runs: Run[];
+  object: "list";
+  data: Run[];
   total: number;
+  hasMore: boolean;
 }
 
 export type RunKindFilter = "all" | "package" | "inline";

--- a/apps/web/src/hooks/use-runs.ts
+++ b/apps/web/src/hooks/use-runs.ts
@@ -12,8 +12,10 @@ export function useRuns(packageId: string | undefined) {
   return useQuery({
     queryKey: ["runs", orgId, appId, packageId],
     queryFn: async () => {
-      const result = await api<{ runs: Run[]; total: number }>(`/agents/${packageId}/runs`);
-      return result.runs;
+      const result = await api<{ object: "list"; data: Run[]; total: number; hasMore: boolean }>(
+        `/agents/${packageId}/runs`,
+      );
+      return result.data;
     },
     enabled: !!packageId && !!appId,
   });
@@ -38,7 +40,9 @@ export function useAllRuns(page: number, limit = 20) {
   return useQuery({
     queryKey: ["all-runs", orgId, appId, page, limit],
     queryFn: async () => {
-      return api<{ runs: Run[]; total: number }>(`/runs?limit=${limit}&offset=${offset}`);
+      return api<{ object: "list"; data: Run[]; total: number; hasMore: boolean }>(
+        `/runs?limit=${limit}&offset=${offset}`,
+      );
     },
     enabled: !!orgId && !!appId,
   });

--- a/apps/web/src/hooks/use-schedules.ts
+++ b/apps/web/src/hooks/use-schedules.ts
@@ -13,8 +13,10 @@ export function useScheduleRuns(scheduleId: string | undefined) {
   return useQuery({
     queryKey: ["schedule-runs", orgId, appId, scheduleId],
     queryFn: async () => {
-      const result = await api<{ runs: Run[]; total: number }>(`/schedules/${scheduleId}/runs`);
-      return result.runs;
+      const result = await api<{ object: "list"; data: Run[]; total: number; hasMore: boolean }>(
+        `/schedules/${scheduleId}/runs`,
+      );
+      return result.data;
     },
     enabled: !!scheduleId && !!appId,
   });

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -33,7 +33,7 @@ export function DashboardPage() {
   if (isLoading) return <LoadingState />;
   if (error) return <ErrorState message={error.message} />;
 
-  const runs = runsData?.runs ?? [];
+  const runs = runsData?.data ?? [];
 
   // No runs → redirect to agents page
   if (runs.length === 0) {

--- a/apps/web/src/pages/schedule-detail.tsx
+++ b/apps/web/src/pages/schedule-detail.tsx
@@ -335,7 +335,7 @@ function ScheduleHistory({
     limit: 20,
     offset: 0,
   });
-  const firstExec = data?.runs?.[0];
+  const firstExec = data?.data?.[0];
 
   // Show the fake "next run" row only if the last run started > 30s ago.
   const lastStartedAt = firstExec?.startedAt;

--- a/bun.lock
+++ b/bun.lock
@@ -253,6 +253,7 @@
         "drizzle-orm": "^0.45.2",
         "nodemailer": "^8.0.5",
         "postgres": "^3.4.9",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@types/nodemailer": "^8.0.0",

--- a/packages/core/scripts/generate-schemas.ts
+++ b/packages/core/scripts/generate-schemas.ts
@@ -10,8 +10,6 @@
  */
 
 import { toJSONSchema } from "zod/v4/core";
-import { resolve, dirname } from "node:path";
-import { writeFile, mkdir, rm } from "node:fs/promises";
 import {
   agentManifestSchema,
   skillManifestSchema,
@@ -20,7 +18,8 @@ import {
   afpsJsonSchemaOverride,
 } from "@afps-spec/schema";
 
-const OUTPUT_DIR = resolve(dirname(import.meta.filename!), "../schema");
+// Bun-native pathing — `import.meta.dir` is the directory of this script.
+const OUTPUT_DIR = `${import.meta.dir}/../schema`;
 
 // ─────────────────────────────────────────────
 // Extend AFPS schemas with Appstrate-specific fields
@@ -58,8 +57,11 @@ const appstrateSchemas = [
 // Generate
 // ─────────────────────────────────────────────
 
-await rm(OUTPUT_DIR, { recursive: true, force: true });
-await mkdir(OUTPUT_DIR, { recursive: true });
+// Clear and recreate OUTPUT_DIR — Bun.$ shells out to /bin/rm + mkdir, so
+// we use the standard $ template (Bun's recommended pathing primitive)
+// instead of `node:fs/promises`.
+await Bun.$`rm -rf ${OUTPUT_DIR}`.quiet();
+await Bun.$`mkdir -p ${OUTPUT_DIR}`.quiet();
 
 for (const entry of appstrateSchemas) {
   const jsonSchema = toJSONSchema(entry.schema, {
@@ -77,8 +79,8 @@ for (const entry of appstrateSchemas) {
     ...jsonSchema,
   };
 
-  const filePath = resolve(OUTPUT_DIR, entry.filename);
-  await writeFile(filePath, JSON.stringify(final, null, 2) + "\n");
+  const filePath = `${OUTPUT_DIR}/${entry.filename}`;
+  await Bun.write(filePath, JSON.stringify(final, null, 2) + "\n");
   console.log(`  ✓ ${entry.filename}`);
 }
 

--- a/packages/core/src/logger.ts
+++ b/packages/core/src/logger.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import pino from "pino";
+import { AsyncLocalStorage } from "node:async_hooks";
 
 /** A log function that accepts a message and optional structured data. */
 export type LogFn = (msg: string, data?: Record<string, unknown>) => void;
@@ -15,12 +16,63 @@ export interface Logger {
 }
 
 /**
+ * Per-request trace context — when set via {@link runWithTraceContext},
+ * `createLogger` mixes `trace_id` / `span_id` / `trace_flags` into every
+ * subsequent log line on this async chain. Matches the OpenTelemetry
+ * semantic conventions for log correlation, so a downstream collector
+ * can join logs ↔ traces without reading the body shape.
+ */
+export interface TraceContext {
+  /** Hex-encoded 32-char W3C trace-id. */
+  traceId: string;
+  /** Hex-encoded 16-char W3C span-id. */
+  spanId?: string;
+  /** Hex-encoded 2-char W3C trace-flags. */
+  traceFlags?: string;
+}
+
+const traceStorage = new AsyncLocalStorage<TraceContext>();
+
+/**
+ * Run `fn` with the supplied trace context bound on the current async
+ * chain. Logger calls inside `fn` (synchronous or awaited) will pick up
+ * the context via the pino mixin.
+ */
+export function runWithTraceContext<T>(ctx: TraceContext, fn: () => T): T {
+  return traceStorage.run(ctx, fn);
+}
+
+/**
+ * Read the current trace context — useful when forging child spans for
+ * outbound HTTP calls. Returns `undefined` outside a `runWithTraceContext`
+ * scope.
+ */
+export function getTraceContext(): TraceContext | undefined {
+  return traceStorage.getStore();
+}
+
+/**
  * Create a Pino-based structured JSON logger.
  * @param level - Pino log level (e.g. "debug", "info", "warn", "error")
  * @returns A Logger instance with debug/info/warn/error methods
  */
 export function createLogger(level: string): Logger {
-  const pinoLogger = pino({ level });
+  const pinoLogger = pino({
+    level,
+    // OpenTelemetry log correlation: emit `trace_id`, `span_id`,
+    // `trace_flags` on every line that's emitted inside a
+    // `runWithTraceContext` scope. The mixin runs once per log call;
+    // outside any trace scope the store is undefined and we emit
+    // nothing, so structured-only consumers see no extra fields.
+    mixin() {
+      const ctx = traceStorage.getStore();
+      if (!ctx) return {};
+      const out: Record<string, string> = { trace_id: ctx.traceId };
+      if (ctx.spanId) out.span_id = ctx.spanId;
+      if (ctx.traceFlags) out.trace_flags = ctx.traceFlags;
+      return out;
+    },
+  });
 
   function wrap(lvl: "debug" | "info" | "warn" | "error"): LogFn {
     return (msg, data) => {

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -114,8 +114,19 @@ export type ToolManifest = z.infer<typeof toolManifestSchema>;
 // Provider manifest schema — extends AFPS (superRefine inherited)
 // ─────────────────────────────────────────────
 
+/**
+ * Provider auth-mode Zod enum, re-exported from `@afps-spec/schema` so
+ * appstrate route validators can reference the canonical AFPS values
+ * without redeclaring the literal array. AFPS v1: `oauth2 | oauth1 |
+ * api_key | basic | custom`.
+ */
+export const authModeEnum = afpsAuthModeEnum;
+
+/** Closed list of valid auth-mode strings — derived from {@link authModeEnum}. */
+export const AUTH_MODES = authModeEnum.options;
+
 /** Auth mode union type derived from the AFPS Zod enum. */
-export type AuthMode = z.infer<typeof afpsAuthModeEnum>;
+export type AuthMode = z.infer<typeof authModeEnum>;
 
 const _setupGuideSchema = afpsSetupGuide;
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -29,7 +29,8 @@
     "better-auth": "^1.6.5",
     "drizzle-orm": "^0.45.2",
     "nodemailer": "^8.0.5",
-    "postgres": "^3.4.9"
+    "postgres": "^3.4.9",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/nodemailer": "^8.0.0",

--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -656,16 +656,43 @@ function buildAuth(
 
     trustedOrigins: env.TRUSTED_ORIGINS,
 
-    ...(env.COOKIE_DOMAIN
-      ? {
-          advanced: {
+    advanced: {
+      // Explicit per-cookie defaults — Better Auth applies these to the
+      // session cookie + every plugin-issued cookie (CSRF, etc.). Pinning
+      // them here removes "what does BA's default do?" from every
+      // security audit.
+      //
+      //   sameSite: "lax"   — allows top-level GET nav with the session
+      //                       (link clicks from email, social cards) but
+      //                       blocks cross-origin form-POSTs that could
+      //                       mount a CSRF amplifier on top of
+      //                       `cors({ credentials: true })`.
+      //   secure:   true    — forbids the cookie from leaving the TLS
+      //                       boundary. Browsers tolerate `Secure` on
+      //                       http://localhost in dev, so this is safe to
+      //                       hard-code on rather than gating on
+      //                       NODE_ENV.
+      //   httpOnly: true    — already BA's default; reasserted for
+      //                       consistency.
+      //   partitioned: true — opt-in to CHIPS so an embedded portal
+      //                       iframe gets its own cookie jar (Chromium /
+      //                       Edge / Firefox 128+); browsers that don't
+      //                       implement CHIPS just ignore the attribute.
+      defaultCookieAttributes: {
+        sameSite: "lax" as const,
+        secure: true,
+        httpOnly: true,
+        partitioned: true,
+      },
+      ...(env.COOKIE_DOMAIN
+        ? {
             crossSubDomainCookies: {
               enabled: true,
               domain: env.COOKIE_DOMAIN,
             },
-          },
-        }
-      : {}),
+          }
+        : {}),
+    },
 
     databaseHooks: {
       user: {

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -1,31 +1,57 @@
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * Co-located Drizzle `pgEnum` + Zod `z.enum` definitions. Each value
+ * list is declared once as a `const` tuple and re-used for both —
+ * adding a value updates the DB enum, the Zod validator, and the
+ * inferred TS union in lockstep.
+ *
+ * Route handlers should import the `z*Enum` siblings from
+ * `@appstrate/db/schema` (e.g. `zRunStatusEnum`) instead of
+ * redeclaring literal arrays inline.
+ */
+
+import { z } from "zod";
 import { pgEnum } from "drizzle-orm/pg-core";
 
-export const orgRoleEnum = pgEnum("org_role", ["owner", "admin", "member", "viewer"]);
+export const orgRoleValues = ["owner", "admin", "member", "viewer"] as const;
+export const orgRoleEnum = pgEnum("org_role", orgRoleValues);
+export const zOrgRoleEnum = z.enum(orgRoleValues);
+export type OrgRole = z.infer<typeof zOrgRoleEnum>;
 
-export const runStatusEnum = pgEnum("run_status", [
+export const runStatusValues = [
   "pending",
   "running",
   "success",
   "failed",
   "timeout",
   "cancelled",
-]);
+] as const;
+export const runStatusEnum = pgEnum("run_status", runStatusValues);
+export const zRunStatusEnum = z.enum(runStatusValues);
+export type RunStatus = z.infer<typeof zRunStatusEnum>;
 
-export const invitationStatusEnum = pgEnum("invitation_status", [
-  "pending",
-  "accepted",
-  "expired",
-  "cancelled",
-]);
+export const invitationStatusValues = ["pending", "accepted", "expired", "cancelled"] as const;
+export const invitationStatusEnum = pgEnum("invitation_status", invitationStatusValues);
+export const zInvitationStatusEnum = z.enum(invitationStatusValues);
+export type InvitationStatus = z.infer<typeof zInvitationStatusEnum>;
 
-export const packageTypeEnum = pgEnum("package_type", ["agent", "skill", "tool", "provider"]);
-export const packageSourceEnum = pgEnum("package_source", ["local", "system"]);
+export const packageTypeValues = ["agent", "skill", "tool", "provider"] as const;
+export const packageTypeEnum = pgEnum("package_type", packageTypeValues);
+export const zPackageTypeEnum = z.enum(packageTypeValues);
+export type PackageType = z.infer<typeof zPackageTypeEnum>;
+
+export const packageSourceValues = ["local", "system"] as const;
+export const packageSourceEnum = pgEnum("package_source", packageSourceValues);
+export const zPackageSourceEnum = z.enum(packageSourceValues);
+export type PackageSource = z.infer<typeof zPackageSourceEnum>;
 
 /**
  * Source discriminator for `llm_usage` rows. Each source has its own
  * dedup key: `proxy` rows dedup on `request_id`, `runner` rows dedup on
  * `(run_id, sequence)`.
  */
-export const llmUsageSourceEnum = pgEnum("llm_usage_source", ["proxy", "runner"]);
+export const llmUsageSourceValues = ["proxy", "runner"] as const;
+export const llmUsageSourceEnum = pgEnum("llm_usage_source", llmUsageSourceValues);
+export const zLlmUsageSourceEnum = z.enum(llmUsageSourceValues);
+export type LlmUsageSource = z.infer<typeof zLlmUsageSourceEnum>;

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -177,6 +177,18 @@ const envSchema = z
     // regardless of gaps.
     REMOTE_RUN_BUFFER_FLUSH_MS: z.coerce.number().int().positive().default(5000),
 
+    // Standard Webhooks `webhook-timestamp` tolerance window (seconds).
+    // Inbound run-event signatures with a timestamp drifting more than
+    // this from the server clock are rejected. The Standard Webhooks
+    // recommendation is 5 minutes (300s) — exposed here so hardened-clock
+    // environments can tighten and lossy CI receivers can loosen.
+    //
+    // Default 300s; floor enforced by the runtime verifier (`verify()`
+    // in `@appstrate/afps-runtime/events`). Must stay strictly less than
+    // REMOTE_RUN_REPLAY_WINDOW_SECONDS or a replayed event could slip
+    // past the dedup cache between expiries.
+    WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS: z.coerce.number().int().positive().default(300),
+
     // Runner liveness — the stall watchdog and the runner-side keep-alive
     // form a single unified detection path across every runner topology
     // (platform container, remote CLI, GitHub Action, …). See
@@ -374,6 +386,11 @@ const envSchema = z
   .refine((env) => !env.S3_BUCKET || env.S3_REGION, {
     message: "S3_REGION is required when S3_BUCKET is set",
     path: ["S3_REGION"],
+  })
+  .refine((env) => env.WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS < env.REMOTE_RUN_REPLAY_WINDOW_SECONDS, {
+    message:
+      "WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS must be strictly less than REMOTE_RUN_REPLAY_WINDOW_SECONDS so a replayed event cannot slip past the dedup cache between expiries",
+    path: ["WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS"],
   })
   .refine(
     (env) =>

--- a/packages/mcp-transport/src/transports/subprocess.ts
+++ b/packages/mcp-transport/src/transports/subprocess.ts
@@ -17,6 +17,11 @@
  * interface verbatim — it can be passed to `client.connect(transport)`
  * exactly like `StdioClientTransport`.
  *
+ * Runtime: this implementation uses `Bun.spawn`, matching the
+ * Bun-everywhere repo standard. Bun.spawn returns a Subprocess with
+ * `stdout` / `stderr` exposed as `ReadableStream<Uint8Array>` and
+ * `stdin` as a `FileSink`; we drive each via async iteration.
+ *
  * What it does NOT do (deferred to deployment-side hardening):
  *   - cgroup attachment (Linux-only, requires the runtime to be built
  *     into a container image with cgroup tooling). The transport
@@ -30,7 +35,6 @@
  * boring-but-correct part.
  */
 
-import { spawn, type ChildProcess } from "node:child_process";
 import type {
   Transport,
   TransportSendOptions,
@@ -104,6 +108,17 @@ export class SubprocessTransportError extends Error {
   override readonly name = "SubprocessTransportError";
 }
 
+/** Minimal shape of `Bun.spawn` we rely on — typed locally so the file
+ * compiles outside `tsconfig.types: ["bun-types"]` consumers. */
+interface BunSubprocessLike {
+  readonly stdin: { write(data: string | Uint8Array): number; end(): void };
+  readonly stdout: ReadableStream<Uint8Array>;
+  readonly stderr: ReadableStream<Uint8Array>;
+  readonly exited: Promise<number>;
+  readonly killed: boolean;
+  kill(signal?: number | string): void;
+}
+
 /**
  * Stdio-based MCP transport. Spawn the subprocess at `start()`,
  * forward each stdout JSON-RPC line as a parsed message via
@@ -116,7 +131,7 @@ export class SubprocessTransport implements Transport {
   onmessage?: (message: JSONRPCMessage) => void;
 
   private readonly options: SubprocessTransportOptions;
-  private child?: ChildProcess;
+  private child?: BunSubprocessLike;
   private stdoutBuffer = "";
   private stderrBuffer = "";
   private readonly stdoutLimiter: RateLimiter;
@@ -158,33 +173,94 @@ export class SubprocessTransport implements Transport {
     if (this.child) {
       throw new SubprocessTransportError("Transport already started");
     }
-    const child = spawn(this.options.command, this.options.args ?? [], {
-      stdio: ["pipe", "pipe", "pipe"],
-      env: this.buildEnv(),
+    // Bun.spawn signature — typed via globalThis to avoid pulling in
+    // bun-types as a hard import dep for downstream consumers.
+    const bunSpawn = (
+      globalThis as unknown as {
+        Bun?: {
+          spawn: (
+            cmd: string[],
+            opts: {
+              stdin: "pipe";
+              stdout: "pipe";
+              stderr: "pipe";
+              cwd?: string;
+              env: Record<string, string>;
+              onExit?: (
+                _proc: BunSubprocessLike,
+                exitCode: number | null,
+                signalCode: number | null,
+                error: Error | null,
+              ) => void;
+            },
+          ) => BunSubprocessLike;
+        };
+      }
+    ).Bun?.spawn;
+    if (!bunSpawn) {
+      throw new SubprocessTransportError(
+        "Bun.spawn is not available — SubprocessTransport requires Bun >= 1.3.9",
+      );
+    }
+    const child = bunSpawn([this.options.command, ...(this.options.args ?? [])], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
       ...(this.options.cwd ? { cwd: this.options.cwd } : {}),
-      // Detach false (default) so the parent's TERM also reaches the
-      // child. We rely on close() for orderly shutdown.
+      env: this.buildEnv(),
+      onExit: (_proc, exitCode, signalCode, error) => {
+        if (this.closed) return;
+        this.closed = true;
+        if (error) {
+          this.onerror?.(error);
+        } else {
+          const reason =
+            exitCode !== null
+              ? `subprocess exited with code ${exitCode}`
+              : `subprocess killed by signal ${signalCode}`;
+          this.onerror?.(new SubprocessTransportError(reason));
+        }
+        this.onclose?.();
+      },
     });
     this.child = child;
 
-    child.stdout?.setEncoding("utf8");
-    child.stdout?.on("data", (chunk: string) => this.handleStdout(chunk));
-    child.stderr?.setEncoding("utf8");
-    child.stderr?.on("data", (chunk: string) => this.handleStderr(chunk));
-    child.on("error", (err) => this.onerror?.(err));
-    child.on("exit", (code, signal) => {
-      if (this.closed) return;
-      this.closed = true;
-      const reason =
-        code !== null
-          ? `subprocess exited with code ${code}`
-          : `subprocess killed by signal ${signal}`;
-      this.onerror?.(new SubprocessTransportError(reason));
-      this.onclose?.();
-    });
+    // Drive stdout / stderr async — the read loops resolve when the
+    // streams close (which happens when the subprocess exits).
+    void this.readStream(child.stdout, (chunk) => this.handleStdout(chunk));
+    void this.readStream(child.stderr, (chunk) => this.handleStderr(chunk));
 
     // The SDK protocol layer awaits start() — we resolve immediately.
     // First message arrives via onmessage when the subprocess emits.
+  }
+
+  private async readStream(
+    stream: ReadableStream<Uint8Array>,
+    onChunk: (chunk: string) => void,
+  ): Promise<void> {
+    const decoder = new TextDecoder("utf-8", { fatal: false });
+    const reader = stream.getReader();
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        if (value && value.length > 0) {
+          onChunk(decoder.decode(value, { stream: true }));
+        }
+      }
+      // Final flush in case the stream ended mid-codepoint.
+      const tail = decoder.decode();
+      if (tail.length > 0) onChunk(tail);
+    } catch {
+      // Reader was cancelled or the subprocess crashed mid-stream;
+      // the onExit handler is the source of truth for closure.
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch {
+        // ignore
+      }
+    }
   }
 
   private handleStdout(chunk: string): void {
@@ -244,19 +320,14 @@ export class SubprocessTransport implements Transport {
   }
 
   async send(message: JSONRPCMessage, _options?: TransportSendOptions): Promise<void> {
-    if (!this.child || !this.child.stdin) {
+    if (!this.child) {
       throw new SubprocessTransportError("Transport not started");
     }
     if (this.closed) {
       throw new SubprocessTransportError("Transport closed");
     }
     const line = `${JSON.stringify(message)}\n`;
-    return new Promise<void>((resolve, reject) => {
-      this.child!.stdin!.write(line, (err) => {
-        if (err) reject(err);
-        else resolve();
-      });
-    });
+    this.child.stdin.write(line);
   }
 
   async close(): Promise<void> {
@@ -269,14 +340,12 @@ export class SubprocessTransport implements Transport {
     const child = this.child;
     const grace = this.options.killTimeoutMs ?? 1000;
     try {
-      child.stdin?.end();
+      child.stdin.end();
     } catch {
       // ignore
     }
     if (!child.killed) child.kill("SIGTERM");
-    const exitPromise = new Promise<void>((resolve) => {
-      child.once("exit", () => resolve());
-    });
+    const exitPromise = child.exited.then(() => undefined);
     const timeoutPromise = new Promise<"timeout">((resolve) => {
       const t = setTimeout(() => resolve("timeout"), grace);
       void exitPromise.then(() => clearTimeout(t));

--- a/packages/runner-pi/src/sink-heartbeat.ts
+++ b/packages/runner-pi/src/sink-heartbeat.ts
@@ -47,11 +47,34 @@ export interface StartSinkHeartbeatOptions {
   /** Event-id generator (testing). Defaults to `crypto.randomUUID`. */
   readonly generateId?: () => string;
   /**
-   * Optional error sink — invoked instead of `console.error` so the
-   * host application can route heartbeat failures through its own
-   * logger. Must never throw.
+   * Optional error sink — invoked instead of the default JSON-line
+   * stderr writer so the host application can route heartbeat
+   * failures through its own logger (e.g. pino in the platform API).
+   * Must never throw.
+   *
+   * The default emits a structured JSON line so platform consumers
+   * that scrape stderr (Docker / Coolify / pino) get parseable
+   * output without runner-pi taking a logger dependency.
    */
   readonly onError?: (err: unknown) => void;
+}
+
+function defaultErrorSink(err: unknown): void {
+  const line = {
+    level: "error" as const,
+    time: Date.now(),
+    component: "sink-heartbeat",
+    msg: err instanceof Error ? err.message : String(err),
+    ...(err instanceof Error && err.stack ? { stack: err.stack } : {}),
+  };
+  // stderr write — JSON line, pino-compatible enough that downstream
+  // platform consumers parse it without special-casing.
+  try {
+    process.stderr.write(`${JSON.stringify(line)}\n`);
+  } catch {
+    // last-resort fallback if stderr is unavailable
+    console.error("[sink-heartbeat]", err);
+  }
 }
 
 export interface SinkHeartbeatHandle {
@@ -71,7 +94,7 @@ export function startSinkHeartbeat(opts: StartSinkHeartbeatOptions): SinkHeartbe
   const fetchImpl = opts.fetch ?? fetch;
   const now = opts.now ?? Date.now;
   const generateId = opts.generateId ?? (() => crypto.randomUUID());
-  const onError = opts.onError ?? ((err) => console.error("[sink-heartbeat]", err));
+  const onError = opts.onError ?? defaultErrorSink;
 
   let stopped = false;
   let timer: ReturnType<typeof setTimeout> | null = null;

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -448,7 +448,7 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
       name: "run_history",
       description:
         "Fetch metadata and optionally the carry-over checkpoint or final output of the agent's " +
-        "most recent past runs (current run excluded). Returns JSON. " +
+        'most recent past runs (current run excluded). Returns JSON `{ object: "list", data: [...], hasMore }`. ' +
         "Use for trend analysis, auditing prior executions, or recovering from a failed run.",
       inputSchema: {
         type: "object",

--- a/runtime-pi/sidecar/test/mcp.test.ts
+++ b/runtime-pi/sidecar/test/mcp.test.ts
@@ -214,7 +214,7 @@ describe("POST /mcp — tools/call run_history", () => {
   it("delegates to the platform's /internal/run-history and returns the upstream JSON", async () => {
     const fetchFn = mock(
       async () =>
-        new Response('{"runs":[{"id":"r1"}]}', {
+        new Response('{"object":"list","data":[{"id":"r1"}],"hasMore":false}', {
           status: 200,
           headers: { "Content-Type": "application/json" },
         }),
@@ -228,7 +228,7 @@ describe("POST /mcp — tools/call run_history", () => {
     expect(res.status).toBe(200);
     const result = res.json.result as { content: Array<{ text: string }>; isError?: boolean };
     expect(result.isError).toBeUndefined();
-    expect(result.content[0]!.text).toBe('{"runs":[{"id":"r1"}]}');
+    expect(result.content[0]!.text).toBe('{"object":"list","data":[{"id":"r1"}],"hasMore":false}');
 
     // Verifies the `limit` and `fields` arguments propagated as query
     // parameters into the underlying platform call.


### PR DESCRIPTION
## Summary

Closes 14 of 17 findings from the [2026-04-25 modernization audit](claudedocs/modernization-audit-2026-04-25.md), then ships a follow-up commit that drops the dual-shape transition window: public list endpoints now emit only the canonical Stripe envelope `{ object: "list", data, hasMore, total? }`. Re-run the audit after merge to verify diff-vs-previous.

The two remaining 🟡 (E webhook dual-signature, H `fetchWithPolicy`) and two 🟢 (M tagged-union credentials, N auth-mode registry) findings are deferred — they're M-effort with broader blast radius and warrant dedicated PRs.

## Commits

1. `e77d4a20` — modernization-audit batch (14 findings)
2. `ca0aed77` — drop legacy list keys, use canonical Stripe envelope (breaking; baseline updated)

## What's in this batch

### Standards conformance + hardening
- **I** — `authMode` validated against the canonical AFPS `z.enum` at manifest parse time + route schemas; eliminates literal-array drift.
- **L** — `WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS` env (default 300) wired into `verifyRunSignatureHeaders`. Boot refinement: must be `< REMOTE_RUN_REPLAY_WINDOW_SECONDS` so a replayed event cannot slip past the dedup cache.
- **F** — explicit `defaultCookieAttributes` on Better Auth: `sameSite=lax`, `secure`, `httpOnly`, `partitioned`. Removes "what does BA's default do?" from every audit.
- **D** — Zod write boundary on `package_persistence.content` (memory + pinned slot + checkpoint). Closes the regression introduced by `816dcc24` on the same shape #6 fixed for `runs` columns.

### API surface + interop
- **A** — Canonical Stripe envelope `{ object: "list", data, hasMore, total? }` on every list endpoint. Both commits combined: the first introduced the envelope alongside legacy keys; the second drops the legacy keys entirely.
  - List endpoints converged: `/api/agents`, `/api/agents/:scope/:name/runs`, `/api/runs`, `/api/schedules/:id/runs`, `/api/app-profiles/:id/agents`, `/api/packages/{agents,skills,tools,providers}`, `/internal/run-history`.
  - `listRunsWithFilter` / `listGlobalRuns` now return `{ object, data, total, hasMore }`. The `runs:` / `agents:` / `skills:` / `tools:` / `providers:` keys are gone — frontend consumers and integration tests updated to read `.data`. **Breaking** (10 endpoints), accepted because no production data exists yet; OpenAPI baseline regenerated.
- **K** — RFC 5988 `Link` header helpers (cursor + offset) in `apps/api/src/lib/pagination-link.ts`. Wired on `/api/end-users` (cursor) and `/api/runs` + `/api/agents/:scope/:name/runs` + `/api/schedules/:id/runs` (offset) — generic SDK pagers no longer need to walk per-resource body shape.
- **B** — co-located `z.enum` siblings for every `pgEnum` (`orgRole`, `runStatus`, `invitationStatus`, `packageType`, `packageSource`, `llmUsageSource`). Refactored `services/state/runs.ts` to consume `runStatusValues` + `RunStatus` from db schema instead of redeclaring the literal array.

### Audit-trail coverage (continues 481cf96f)
- **C** — `recordAuditFromContext` wired on:
  - `applications` (create / update / delete)
  - `end-users` (create / update / delete)
  - `schedules` (create / update / delete)
  - `webhooks` (create / update / delete + `secret_rotated`)

  Remaining mutation routes (agents config, orgs, proxies, models, app-profiles, provider-keys) tracked as a follow-up.

### Observability
- **J** — pino mixin reads trace context from AsyncLocalStorage and emits `trace_id` / `span_id` / `trace_flags` per OTel semantic conventions. `request-id` middleware wraps `next()` in `runWithTraceContext` when an inbound `traceparent` is present.

### Cross-repo drift
- **G** — `packages/mcp-transport/src/transports/subprocess.ts` switched from `node:child_process` → `Bun.spawn` (repo Bun-everywhere standard).
- **O** — runner-pi `sink-heartbeat` default error sink writes structured pino-compatible JSON to stderr instead of plain `console.error`.
- **P** — `packages/core/scripts/generate-schemas.ts` uses `Bun.$` + `Bun.write` + `import.meta.dir` instead of `node:fs` / `node:path`. (`drizzle.config.ts` left alone — drizzle-kit's CJS transpiler is the documented exception.)

### Hygiene
- **Q** — schedule POST schema defaults `timezone="UTC"` and `input={}` so downstream cron + executor code stops relying on implicit defaults.

### Frontend alignment (commit 2)
- 8 hooks/components/pages updated to consume `.data` instead of legacy keys: `use-packages`, `use-runs`, `use-schedules`, `use-paginated-runs`, `use-connection-profiles`, `run-list`, `notification-bell`, `dashboard`, `schedule-detail`. The `PACKAGE_CONFIG.listKey` indirection (workaround for per-resource keys) is gone.

## Quality gates

- `bun run check` — 18/18 turbo tasks green (typecheck, lint, format, verify:openapi, detect:breaking, build:system-packages:check)
- `bun run test:unit` — 703 pass, 0 fail
- `packages/core` — 328 pass
- `packages/runner-pi/test/sink-heartbeat` — 5 pass
- `packages/mcp-transport` (incl. `subprocess.test`) — 67 pass
- `runtime-pi/sidecar` mcp tests — 39 pass

## Test plan

- [ ] Rerun `/audit-modernization` post-merge → expect 14 findings flip to **Resolved**, 3 carry forward (E, H, the agents-config/orgs slice of C)
- [ ] Verify `/api/end-users` returns `Link: <…?startingAfter=…>; rel="next"` when paginated
- [ ] Verify list endpoints (`/api/runs`, `/api/agents`, `/api/packages/agents`, …) return only `{ object: "list", data, hasMore, total? }` — no legacy `runs:` / `agents:` keys
- [ ] Smoke-test the dashboard, agents list, run history, and schedule detail in the SPA — all consume `.data` now
- [ ] Smoke-test webhook delivery with `WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS=60` to confirm new env is read
- [ ] Inspect a request log line — `trace_id` / `span_id` should appear when an inbound `traceparent` is sent
- [ ] Audit log: create + update + delete an application / end-user / schedule / webhook → `audit_events` rows present

🤖 Generated with [Claude Code](https://claude.com/claude-code)