### PR TITLE
fix(api): forward runs.modelSource to afterRun hook

### DIFF
--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -123,6 +123,7 @@ export async function getRunSinkContext(runId: string): Promise<RunSinkContext |
       sinkClosedAt: runs.sinkClosedAt,
       lastEventSequence: runs.lastEventSequence,
       startedAt: runs.startedAt,
+      modelSource: runs.modelSource,
     })
     .from(runs)
     .where(eq(runs.id, runId))
@@ -305,6 +306,10 @@ export async function finalizeRun(input: FinalizeRunInput): Promise<void> {
   // 5. afterRun hook — the hook SHOULD be idempotent (callers may retry on
   //    transient failures) so it runs before the CAS. Any metadata it
   //    returns is included atomically in the same UPDATE.
+  // Forward `runs.model_source` so the `afterRun` hook can distinguish
+  // platform-paid runs (system models) from BYOK runs (org models) without
+  // a re-query. Cloud's billing handler keys credit recording on this —
+  // omitting the field made it silently bill every run as `"system"`.
   const hookParams: RunStatusChangeParams = {
     orgId: run.orgId,
     runId: run.id,
@@ -314,6 +319,7 @@ export async function finalizeRun(input: FinalizeRunInput): Promise<void> {
     packageEphemeral,
     duration: resolvedDurationMs,
     ...(cost.total > 0 ? { cost: cost.total } : {}),
+    ...(run.modelSource !== null ? { modelSource: run.modelSource } : {}),
   };
   let metadata: Record<string, unknown> | null = null;
   try {

--- a/apps/api/src/types/run-sink.ts
+++ b/apps/api/src/types/run-sink.ts
@@ -27,4 +27,10 @@ export interface RunSinkContext {
   sinkClosedAt: Date | null;
   lastEventSequence: number;
   startedAt: Date;
+  /**
+   * Model source resolved at run creation time (`"system"` for platform-paid
+   * models, `"org"` for BYOK). Forwarded to the `afterRun` hook so module
+   * billing handlers can distinguish billable from non-billable runs.
+   */
+  modelSource: string | null;
 }

--- a/apps/api/test/integration/routes/runs-events-ingestion.test.ts
+++ b/apps/api/test/integration/routes/runs-events-ingestion.test.ts
@@ -27,7 +27,7 @@
  *      container POSTs a complete `result`, the row is complete too.
  */
 
-import { describe, it, expect, beforeEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { eq } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
 import { runs, runLogs, llmUsage } from "@appstrate/db/schema";
@@ -38,6 +38,8 @@ import { getTestApp } from "../../helpers/app.ts";
 import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
 import { seedPackage } from "../../helpers/seed.ts";
+import { loadModulesFromInstances, resetModules } from "../../../src/lib/modules/module-loader.ts";
+import type { AppstrateModule, RunStatusChangeParams } from "@appstrate/core/module";
 
 const app = getTestApp();
 
@@ -67,6 +69,8 @@ async function seedRunWithSink(
      * the row without usage (exercises the heuristic on purpose).
      */
     tokenUsage?: Record<string, number> | null;
+    /** Persisted on `runs.model_source` — forwarded to the `afterRun` hook. */
+    modelSource?: string | null;
   } = {},
 ): Promise<string> {
   const runId = `run_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
@@ -85,6 +89,7 @@ async function seedRunWithSink(
       overrides.tokenUsage === undefined
         ? { input_tokens: 100, output_tokens: 50 }
         : overrides.tokenUsage,
+    ...(overrides.modelSource !== undefined ? { modelSource: overrides.modelSource } : {}),
   });
   return runId;
 }
@@ -602,6 +607,95 @@ describe("POST /api/runs/:runId/events/finalize — complete result persistence"
     const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
     expect(row?.cost).toBeCloseTo(0.003, 5);
     expect(row?.tokenUsage).toMatchObject({ input_tokens: 300, output_tokens: 125 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// `afterRun` hook contract — finalize MUST forward `runs.model_source` so
+// module billing handlers can distinguish platform-paid (system) runs from
+// BYOK (org) runs. Skipping the field collapses every run to "system" in
+// cloud's `recordUsage` fallback and silently bills runs the platform was
+// never paid for.
+// ---------------------------------------------------------------------------
+describe("POST /api/runs/:runId/events/finalize — afterRun hook params", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    resetModules();
+    ctx = await createTestContext({ email: "hook@test.dev", orgSlug: "hook-org" });
+    await seedPackage({ orgId: ctx.orgId, id: "@test/hook-agent", type: "agent" });
+  });
+
+  afterAll(() => {
+    // Don't leak the spy module into sibling test files.
+    resetModules();
+  });
+
+  async function captureAfterRunParams(): Promise<{
+    captured: () => RunStatusChangeParams | null;
+  }> {
+    let last: RunStatusChangeParams | null = null;
+    const mod: AppstrateModule = {
+      manifest: { id: "afterrun-spy", name: "After-Run Spy", version: "1.0.0" },
+      async init() {},
+      hooks: {
+        afterRun: async (params) => {
+          last = params;
+          return null;
+        },
+      },
+    };
+    await loadModulesFromInstances([mod], {
+      databaseUrl: null,
+      redisUrl: null,
+      appUrl: "http://localhost:3000",
+      isEmbeddedDb: true,
+      applyMigrations: async () => {},
+      getSendMail: async () => () => {},
+      getOrgAdminEmails: async () => [],
+      services: {} as never,
+    });
+    return { captured: () => last };
+  }
+
+  it("forwards runs.modelSource = 'system' to the afterRun hook", async () => {
+    const { captured } = await captureAfterRunParams();
+    const runId = await seedRunWithSink(ctx, "@test/hook-agent", { modelSource: "system" });
+    const res = await postFinalize(runId, {
+      status: "success",
+      output: { ok: true },
+      durationMs: 100,
+    });
+    expect(res.status).toBe(200);
+    expect(captured()).not.toBeNull();
+    expect(captured()!.modelSource).toBe("system");
+  });
+
+  it("forwards runs.modelSource = 'org' (BYOK) to the afterRun hook so cloud skips billing", async () => {
+    const { captured } = await captureAfterRunParams();
+    const runId = await seedRunWithSink(ctx, "@test/hook-agent", { modelSource: "org" });
+    const res = await postFinalize(runId, {
+      status: "success",
+      output: { ok: true },
+      durationMs: 100,
+    });
+    expect(res.status).toBe(200);
+    expect(captured()).not.toBeNull();
+    expect(captured()!.modelSource).toBe("org");
+  });
+
+  it("omits modelSource when the run row has none (legacy / inline runs)", async () => {
+    const { captured } = await captureAfterRunParams();
+    const runId = await seedRunWithSink(ctx, "@test/hook-agent", { modelSource: null });
+    const res = await postFinalize(runId, {
+      status: "success",
+      output: { ok: true },
+      durationMs: 100,
+    });
+    expect(res.status).toBe(200);
+    expect(captured()).not.toBeNull();
+    expect(captured()!.modelSource).toBeUndefined();
   });
 });
 

--- a/apps/api/test/unit/services/run-event-ingestion.test.ts
+++ b/apps/api/test/unit/services/run-event-ingestion.test.ts
@@ -39,6 +39,7 @@ function makeRun(overrides: Partial<RunSinkContext> = {}): RunSinkContext {
     sinkClosedAt: null,
     lastEventSequence: 0,
     startedAt: new Date(),
+    modelSource: null,
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

The HttpSink finalize rewrite (PR #227 Part 8) silently dropped `modelSource` from the `RunStatusChangeParams` payload passed to the `afterRun` hook in `finalizeRun`. The type already allowed it and the column was populated at run creation, but `apps/api/src/services/run-event-ingestion.ts:308-317` simply did not forward it.

This regression breaks Cloud's billing contract:

```ts
// cloud/src/index.ts
afterRun: async (params) =>
  recordUsage(params.orgId, params.runId, params.cost, {
    modelSource: params.modelSource ?? "system",  // ← undefined → "system"
  });
```

`recordUsage` then checks `context.modelSource !== "system"` to decide whether to bill — with the field missing, every BYOK run falls through to `"system"` and is billed against the org's credit quota even though the platform was never paid for the model. Direct violation of `cloud/CLAUDE.md`'s "Only platform-provided models are billed".

## Fix

- Add `modelSource: string | null` to `RunSinkContext` (new field on the projection)
- Select it in `getRunSinkContext`
- Forward to `hookParams` in `finalizeRun` when non-null

## Test plan

- [x] `bun run check` (turbo + verify-openapi) — all 18 tasks green
- [x] `bun test apps/api/test/integration/routes/runs-events-ingestion.test.ts` — 23 pass (3 new)
- [x] `bun test apps/api/test/unit/services/run-event-ingestion.test.ts` — 14 pass
- [x] Regression suite (event-sink + watchdog + platform-container-sink + all routes) — 637 pass

Three new integration tests cover:
1. `modelSource = "system"` → forwarded so cloud bills
2. `modelSource = "org"` (BYOK) → forwarded so cloud skips billing
3. `modelSource = null` → omitted from hookParams (legacy / inline-run path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)