### PR TITLE
fix(oidc): url-decode pending-client cookie in headerless reader

### DIFF
--- a/apps/api/src/modules/oidc/services/pending-client-cookie.ts
+++ b/apps/api/src/modules/oidc/services/pending-client-cookie.ts
@@ -124,7 +124,11 @@ function parseAndVerify(raw: string): string | null {
 /**
  * Minimal cookie-header parser — we can't pull in a heavy dep just to read
  * one cookie out of band. Matches `name=value; name2=value2` format,
- * respects spaces and quoted values (RFC 6265 §5.4).
+ * respects spaces and quoted values (RFC 6265 §5.4). The value is
+ * URL-decoded to mirror what hono's `getCookie` does on the context path —
+ * Set-Cookie serialization runs every value through `encodeURIComponent`,
+ * so the signature's `kid$sig` separator arrives here as `kid%24sig` and
+ * would otherwise fail `verifyAuthHmac`'s prefixed-form check.
  */
 function parseCookieHeader(header: string, name: string): string | null {
   const target = `${name}=`;
@@ -135,7 +139,11 @@ function parseCookieHeader(header: string, name: string): string | null {
       if (value.startsWith('"') && value.endsWith('"')) {
         value = value.slice(1, -1);
       }
-      return value;
+      try {
+        return decodeURIComponent(value);
+      } catch {
+        return null;
+      }
     }
   }
   return null;


### PR DESCRIPTION
## Summary

- Fixes the CI failure on `main` for `oauth-enduser-pages.test.ts` ("POST /register tags the user with `realm='end_user:<applicationId>'`…") introduced by #291.
- `parseCookieHeader` in `pending-client-cookie.ts` now `decodeURIComponent`s the cookie value, matching what hono's `getCookie` does on the context path.

## Root cause

#291 (`feat(auth): versioned BETTER_AUTH secrets…`) changed the pending-client cookie signature format from raw base64url to `<kid>$<sig>`. Hono's `setCookie` runs every value through `encodeURIComponent`, so `$` lands back on the wire as `%24`.

- Hono-context reader (`getCookie`) decodes that transparently → still works.
- Headerless reader `readPendingClientCookieFromHeaders`, called from Better Auth's `databaseHooks.user.create.before` where there is no Hono context, used a hand-rolled `parseCookieHeader` that did **not** decode. `verifyAuthHmac` saw `k1%24…`, missed the `$` sentinel, fell through to legacy-format verification, and failed. The realm resolver then defaulted to `realm="platform"` instead of `end_user:<applicationId>`.

Pre-#291 signatures were pure base64url, so URL-encoding never changed them — this was invisible until the format flipped.

## Test plan

- [x] `bun test apps/api/src/modules/oidc/test/integration/routes/oauth-enduser-pages.test.ts -t "realm assignment at signup"` passes locally (2/2).
- [ ] Full CI green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)