### PR TITLE
chore(api,web): fix conformance C1–C3 + C6

### DIFF
--- a/apps/api/src/lib/list-response.ts
+++ b/apps/api/src/lib/list-response.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Stripe-canonical list envelope for HTTP list responses.
+ *
+ * Wire format: `{ object: "list", data: T[], hasMore: boolean, total?: number }`.
+ *
+ * Every list-shaped HTTP response goes through `listResponse()` so the wire
+ * format is enforced at a single call site instead of being repeated inline at
+ * each handler. Extra metadata (e.g. `limit` for cursor-style pagination) can
+ * be tacked on via spread at the call site without changing the helper.
+ */
+
+export interface ListResponse<T> {
+  object: "list";
+  data: T[];
+  hasMore: boolean;
+  total?: number;
+}
+
+export function listResponse<T>(
+  data: T[],
+  opts: { hasMore?: boolean; total?: number } = {},
+): ListResponse<T> {
+  const out: ListResponse<T> = {
+    object: "list",
+    data,
+    hasMore: opts.hasMore ?? false,
+  };
+  if (opts.total !== undefined) out.total = opts.total;
+  return out;
+}

--- a/apps/api/src/lib/modules/module-loader.ts
+++ b/apps/api/src/lib/modules/module-loader.ts
@@ -16,7 +16,6 @@ import {
   type OrgRole,
   type ModulePermissionsSnapshot,
 } from "@appstrate/core/permissions";
-import { readdirSync, statSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, resolve, join } from "node:path";
 import type { AppEnv } from "../../types/index.ts";
@@ -40,17 +39,14 @@ function getBuiltinModules(): Map<string, string> {
   const here = dirname(fileURLToPath(import.meta.url));
   const modulesDir = resolve(here, "../../modules");
 
-  if (existsSync(modulesDir)) {
-    for (const entry of readdirSync(modulesDir)) {
-      const entryPath = join(modulesDir, entry);
-      try {
-        if (!statSync(entryPath).isDirectory()) continue;
-      } catch {
-        continue;
-      }
-      const indexPath = join(entryPath, "index.ts");
-      if (existsSync(indexPath)) cache.set(entry, indexPath);
-    }
+  // Walk every `<moduleId>/index.ts` under `modules/` in a single Bun.Glob
+  // pass — implicitly handles missing directory, non-directory entries, and
+  // missing index.ts. Replaces three node:fs sync calls (Bun-native runtime).
+  const glob = new Bun.Glob("*/index.ts");
+  for (const match of glob.scanSync({ cwd: modulesDir, onlyFiles: true })) {
+    const moduleId = match.split("/")[0];
+    if (!moduleId) continue;
+    cache.set(moduleId, join(modulesDir, match));
   }
 
   _builtinCache = cache;

--- a/apps/api/src/modules/oidc/routes.ts
+++ b/apps/api/src/modules/oidc/routes.ts
@@ -23,6 +23,7 @@ import { rateLimit, rateLimitByIp } from "../../middleware/rate-limit.ts";
 import { idempotency } from "../../middleware/idempotency.ts";
 import { requireModulePermission, requireCorePermission } from "@appstrate/core/permissions";
 import { parseBody, notFound, invalidRequest, forbidden } from "../../lib/errors.ts";
+import { listResponse } from "../../lib/list-response.ts";
 import { logger } from "../../lib/logger.ts";
 import { getClientIp } from "../../lib/client-ip.ts";
 import { db } from "@appstrate/db/client";
@@ -499,7 +500,7 @@ export function createOidcRouter() {
         orgId,
         appRows.map((a) => a.id),
       );
-      return c.json({ object: "list", data: clients });
+      return c.json(listResponse(clients));
     },
   );
 
@@ -683,7 +684,7 @@ export function createOidcRouter() {
         if (message.includes("SMTP configuration not found")) {
           throw notFound(message);
         }
-        return c.json({ ok: false, error: message }, 400);
+        throw invalidRequest(message);
       }
     },
   );

--- a/apps/api/src/modules/webhooks/routes.ts
+++ b/apps/api/src/modules/webhooks/routes.ts
@@ -20,6 +20,7 @@ import { applications } from "@appstrate/db/schema";
 import type { AppEnv } from "../../types/index.ts";
 import { rateLimit } from "../../middleware/rate-limit.ts";
 import { idempotency } from "../../middleware/idempotency.ts";
+import { listResponse } from "../../lib/list-response.ts";
 import { recordAuditFromContext } from "../../services/audit.ts";
 import {
   createWebhook,
@@ -169,7 +170,7 @@ export function createWebhooksRouter() {
       // it ignores `opts` and returns only webhooks pinned to the key's app.
       if ("applicationId" in scope) {
         const result = await listWebhooks(scope);
-        return c.json({ object: "list", data: result });
+        return c.json(listResponse(result));
       }
 
       const all = c.req.query("all") === "true";
@@ -181,7 +182,7 @@ export function createWebhooksRouter() {
         await assertAppBelongsToOrg(applicationId, scope.orgId);
       }
       const result = await listWebhooks(scope, { applicationId, all });
-      return c.json({ object: "list", data: result });
+      return c.json(listResponse(result));
     },
   );
 
@@ -278,7 +279,7 @@ export function createWebhooksRouter() {
     async (c) => {
       const limit = c.req.query("limit") ? Number(c.req.query("limit")) : 20;
       const result = await listDeliveries(webhookScope(c), c.req.param("id")!, limit);
-      return c.json({ object: "list", data: result });
+      return c.json(listResponse(result));
     },
   );
 

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -2,6 +2,7 @@
 
 import { Hono } from "hono";
 import type { AppEnv } from "../types/index.ts";
+import { listResponse } from "../lib/list-response.ts";
 import {
   getRunningRunCounts,
   listPinnedSlots,
@@ -105,11 +106,7 @@ export function createAgentsRouter() {
       };
     });
 
-    return c.json({
-      object: "list" as const,
-      data: agentList,
-      hasMore: false,
-    });
+    return c.json(listResponse(agentList));
   });
 
   // PUT /api/agents/:scope/:name/config — save agent configuration (admin-only)

--- a/apps/api/src/routes/app-profiles.ts
+++ b/apps/api/src/routes/app-profiles.ts
@@ -8,6 +8,7 @@ import { packages, applicationPackages } from "@appstrate/db/schema";
 import type { AppEnv } from "../types/index.ts";
 import { logger } from "../lib/logger.ts";
 import { forbidden, invalidRequest, notFound, parseBody } from "../lib/errors.ts";
+import { listResponse } from "../lib/list-response.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
 import {
   getProfileForActor,
@@ -144,7 +145,7 @@ export function createAppProfilesRouter() {
       .innerJoin(packages, eq(packages.id, applicationPackages.packageId))
       .where(eq(applicationPackages.appProfileId, profileId));
 
-    return c.json({ object: "list" as const, data: rows, hasMore: false });
+    return c.json(listResponse(rows));
   });
 
   // GET /api/app-profiles/:id/bindings — list provider bindings for an app profile

--- a/apps/api/src/routes/applications.ts
+++ b/apps/api/src/routes/applications.ts
@@ -13,6 +13,7 @@ import {
   internalError,
   parseBody,
 } from "../lib/errors.ts";
+import { listResponse } from "../lib/list-response.ts";
 import {
   createApplication,
   listApplications,
@@ -85,10 +86,7 @@ export function createApplicationsRouter() {
     const authMethod = c.get("authMethod");
     const keyAppId = c.get("applicationId");
     const scoped = authMethod === "api_key" ? apps.filter((a) => a.id === keyAppId) : apps;
-    return c.json({
-      object: "list",
-      data: scoped.map((app) => ({ object: "application", ...app })),
-    });
+    return c.json(listResponse(scoped.map((app) => ({ object: "application", ...app }))));
   });
 
   // POST /api/applications — create a new application
@@ -214,10 +212,7 @@ export function createApplicationsRouter() {
     const orgId = c.get("orgId");
     const type = c.req.query("type") as PackageType | undefined;
     const rows = await listInstalledPackages({ orgId, applicationId: appId }, type);
-    return c.json({
-      object: "list",
-      data: rows.map((row) => ({ object: "application_package", ...row })),
-    });
+    return c.json(listResponse(rows.map((row) => ({ object: "application_package", ...row }))));
   });
 
   // POST /api/applications/:appId/packages — install a package
@@ -385,7 +380,7 @@ export function createApplicationsRouter() {
       appEnabled: row.enabled,
     }));
 
-    return c.json({ object: "list", data: overrides });
+    return c.json(listResponse(overrides));
   });
 
   return router;

--- a/apps/api/src/routes/credential-proxy.ts
+++ b/apps/api/src/routes/credential-proxy.ts
@@ -49,7 +49,13 @@ import { logger } from "../lib/logger.ts";
 import { rateLimit } from "../middleware/rate-limit.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
 import { requireAppContext } from "../middleware/app-context.ts";
-import { invalidRequest, forbidden, notFound, internalError } from "../lib/errors.ts";
+import {
+  invalidRequest,
+  forbidden,
+  notFound,
+  internalError,
+  payloadTooLarge,
+} from "../lib/errors.ts";
 import {
   proxyCall,
   ProxyAuthorizationError,
@@ -290,7 +296,7 @@ export function createCredentialProxyRouter() {
 
       // Guard: declared Content-Length already exceeds the hard cap.
       if (streamRequest && declaredLen > MAX_STREAMED_BODY_SIZE) {
-        return c.json({ error: "request body too large" }, 413);
+        throw payloadTooLarge("request body too large");
       }
 
       // Build a combined abort signal for streaming pipes: honours both the

--- a/apps/api/src/routes/internal.ts
+++ b/apps/api/src/routes/internal.ts
@@ -7,6 +7,7 @@ import { eq, and } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
 import { runs, userProviderConnections } from "@appstrate/db/schema";
 import { logger } from "../lib/logger.ts";
+import { listResponse } from "../lib/list-response.ts";
 import { parseSignedToken } from "../lib/run-token.ts";
 import { rateLimitByBearer } from "../middleware/rate-limit.ts";
 import {
@@ -193,7 +194,7 @@ export function createInternalRouter() {
         },
       );
 
-      return c.json({ object: "list" as const, data: recentRuns, hasMore: false });
+      return c.json(listResponse(recentRuns));
     } catch (err) {
       logger.error("Failed to fetch run history", {
         runId,

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -11,6 +11,7 @@ import { eq, and, inArray } from "drizzle-orm";
 import { packages, profiles, applicationProviderCredentials } from "@appstrate/db/schema";
 import { encryptCredentials } from "@appstrate/connect";
 import { db } from "@appstrate/db/client";
+import { listResponse } from "../lib/list-response.ts";
 import { postInstallPackage } from "../services/post-install-package.ts";
 import { handleImportBundle } from "../services/bundle-import.ts";
 import { installPackage, hasPackageAccess } from "../services/application-packages.ts";
@@ -396,7 +397,7 @@ function makeListHandler(rcfg: PackageRouteConfig) {
     const applicationId = c.get("applicationId");
     const items = await listOrgItems(orgId, rcfg.cfg, applicationId);
     const enriched = await enrichWithCreatorNames(items);
-    return c.json({ object: "list" as const, data: enriched, hasMore: false });
+    return c.json(listResponse(enriched));
   };
 }
 

--- a/apps/api/src/services/end-users.ts
+++ b/apps/api/src/services/end-users.ts
@@ -13,6 +13,7 @@ import { endUsers, applications, connectionProfiles } from "@appstrate/db/schema
 import type { EndUserInfo, EndUserListResponse } from "@appstrate/shared-types";
 import { logger } from "../lib/logger.ts";
 import { notFound, ApiError } from "../lib/errors.ts";
+import { listResponse } from "../lib/list-response.ts";
 import { prefixedId } from "../lib/ids.ts";
 import { buildUpdateSet } from "../lib/db-helpers.ts";
 import { toISORequired } from "../lib/date-helpers.ts";
@@ -163,7 +164,7 @@ export async function listEndUsers(
   const hasMore = rows.length > limit;
   const data = (hasMore ? rows.slice(0, limit) : rows).map(toEndUserResponse);
 
-  return { object: "list", data, hasMore, limit };
+  return { ...listResponse(data, { hasMore }), limit };
 }
 
 export async function getEndUser(scope: AppScope, endUserId: string): Promise<EndUserInfo> {

--- a/apps/api/src/services/state/runs.ts
+++ b/apps/api/src/services/state/runs.ts
@@ -28,6 +28,7 @@ import {
 } from "@appstrate/db/schema";
 import type { RunProviderSnapshot } from "@appstrate/shared-types";
 import { logger } from "../../lib/logger.ts";
+import { listResponse, type ListResponse } from "../../lib/list-response.ts";
 import { scopedWhere } from "../../lib/db-helpers.ts";
 import { type Actor, actorFilter } from "../../lib/actor.ts";
 import { runMetadataSchema, runConfigSchema, runLogDataSchema } from "../../lib/jsonb-schemas.ts";
@@ -563,12 +564,7 @@ export async function deletePackageRuns(scope: AppScope, packageId: string): Pro
   return deleted.length;
 }
 
-export interface RunListPage {
-  object: "list";
-  data: Record<string, unknown>[];
-  total: number;
-  hasMore: boolean;
-}
+export type RunListPage = ListResponse<Record<string, unknown>> & { total: number };
 
 export async function listRunsWithFilter(
   filter: SQL,
@@ -593,10 +589,8 @@ export async function listRunsWithFilter(
   const data = rows.map(mapEnrichedRun) as unknown as Record<string, unknown>[];
   const total = countRow?.count ?? 0;
   return {
-    object: "list",
-    data,
+    ...listResponse(data, { hasMore: offset + data.length < total }),
     total,
-    hasMore: offset + data.length < total,
   };
 }
 
@@ -683,10 +677,8 @@ export async function listGlobalRuns(
   const data = rows.map(mapEnrichedRun) as unknown as Record<string, unknown>[];
   const total = countRow?.count ?? 0;
   return {
-    object: "list",
-    data,
+    ...listResponse(data, { hasMore: offset + data.length < total }),
     total,
-    hasMore: offset + data.length < total,
   };
 }
 

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -100,6 +100,22 @@ export async function api<T = unknown>(path: string, options: RequestInit = {}):
   return apiFetch<T>(`${API_BASE}${path}`, options);
 }
 
+interface ListEnvelope<T> {
+  object: "list";
+  data: T[];
+  hasMore: boolean;
+  total?: number;
+}
+
+/**
+ * Typed reader for Stripe-canonical list responses (`{ object: "list", data, hasMore, total? }`).
+ * Returns the unwrapped `data` array so React Query hooks don't repeat the envelope shape.
+ */
+export async function apiList<T = unknown>(path: string, options: RequestInit = {}): Promise<T[]> {
+  const envelope = await api<ListEnvelope<T>>(path, options);
+  return envelope.data;
+}
+
 export async function uploadFormData<T = unknown>(
   path: string,
   formData: FormData,

--- a/apps/web/src/modules/oidc/hooks/use-oauth-clients.ts
+++ b/apps/web/src/modules/oidc/hooks/use-oauth-clients.ts
@@ -6,7 +6,7 @@
  */
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/api";
+import { api, apiList } from "@/api";
 import { useCurrentOrgId } from "@/hooks/use-org";
 import { useCurrentApplicationId } from "@/hooks/use-current-application";
 import type {
@@ -24,8 +24,8 @@ export function useOAuthClients(level?: "org" | "application") {
   return useQuery({
     queryKey: ["oauth-clients", orgId, isOrg ? "org" : appId],
     queryFn: () =>
-      api<{ object: "list"; data: OAuthClient[] }>("/oauth/clients").then((d) =>
-        level ? d.data.filter((c) => c.level === level) : d.data,
+      apiList<OAuthClient>("/oauth/clients").then((rows) =>
+        level ? rows.filter((c) => c.level === level) : rows,
       ),
     enabled: isOrg ? !!orgId : !!orgId && !!appId,
   });

--- a/apps/web/src/modules/webhooks/hooks/use-webhooks.ts
+++ b/apps/web/src/modules/webhooks/hooks/use-webhooks.ts
@@ -3,7 +3,7 @@
 import type { Dispatch, SetStateAction } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import type { WebhookInfo, WebhookCreateResponse, WebhookDelivery } from "@appstrate/shared-types";
-import { api } from "@/api";
+import { api, apiList } from "@/api";
 import { useCurrentOrgId } from "@/hooks/use-org";
 import { useCurrentApplicationId } from "@/hooks/use-current-application";
 
@@ -31,7 +31,7 @@ export function useWebhooks() {
   const appId = useCurrentApplicationId();
   return useQuery({
     queryKey: ["webhooks", orgId, appId],
-    queryFn: () => api<{ object: "list"; data: WebhookInfo[] }>("/webhooks").then((d) => d.data),
+    queryFn: () => apiList<WebhookInfo>("/webhooks"),
     enabled: !!orgId && !!appId,
   });
 }
@@ -133,10 +133,7 @@ export function useWebhookDeliveries(webhookId: string) {
   const appId = useCurrentApplicationId();
   return useQuery({
     queryKey: ["webhooks", orgId, appId, webhookId, "deliveries"],
-    queryFn: () =>
-      api<{ object: "list"; data: WebhookDelivery[] }>(`/webhooks/${webhookId}/deliveries`).then(
-        (d) => d.data,
-      ),
+    queryFn: () => apiList<WebhookDelivery>(`/webhooks/${webhookId}/deliveries`),
     enabled: !!orgId && !!appId && !!webhookId,
   });
 }


### PR DESCRIPTION
## Summary

Addresses the 2026-04-25 conformance report (`claudedocs/conformance-2026-04-25-2334.md`) — fixes the 4 actionable findings (2 ❌ FAIL, 2 ⚠️ WARN). Quality gate green; 703 API unit tests + 802 CLI tests pass.

| Finding | Before | After |
| --- | --- | --- |
| **C1** list envelope | helper `listResponse()` missing; ≥18 inline + raw legacy sites | helper added at `apps/api/src/lib/list-response.ts`; **all** list endpoints normalized to Stripe envelope |
| **C2** apiList helper | 0 hits | `apiList<T>()` exported from `apps/web/src/api.ts`; adopted in 13+ hook reads |
| **C3** RFC 9457 errors | 2 raw `c.json({ error }, 4xx)` | both routed through `payloadTooLarge()` / `invalidRequest()` |
| **C6** Bun-only | `node:fs` sync trio in `module-loader.ts` | single `Bun.Glob("*/index.ts")` scan |

## Detail

**Commit 1 (`e9052327`)** — Introduce helpers + fix non-breaking offenders:
- `listResponse(data, { hasMore?, total? })` enforces the `{ object: "list", data, hasMore, total? }` wire format. Migrates 15 inline `object: "list" as const, ...` sites to the helper across `routes/{agents,app-profiles,packages,applications,internal}.ts`, `modules/{oidc,webhooks}/routes.ts`, `services/state/runs.ts`, `services/end-users.ts`.
- `apiList<T>(path)` unwraps the envelope on the frontend; adopted in `use-oauth-clients` + `use-webhooks` (3 reads).
- `routes/credential-proxy.ts:293` now `throw payloadTooLarge("request body too large")`; `modules/oidc/routes.ts:686` now `throw invalidRequest(message)`.
- `lib/modules/module-loader.ts` replaces three `node:fs` sync calls with a single `Bun.Glob("*/index.ts").scanSync(...)`.

**Commit 2 (`c6460a7d`)** — Drop all remaining legacy list shapes (no production data, intentional breaking-change cleanup):
- Endpoints normalized (route + OpenAPI spec): `/api/me/orgs`, `/api/me/models`, `/api/orgs`, `/api/profiles/batch`, `/api/models`, `/api/models/openrouter`, `/api/proxies`, `/api/connection-profiles`, `/api/connections/integrations`, `/api/providers` (with sibling `callbackUrl` preserved), `/api/provider-keys`, `/api/app-profiles`, `/api/app-profiles/my-bindings`, `/api/app-profiles/connections`, `/api/app-profiles/{id}/connections`, `/api/orgs/{orgId}/cli-sessions`.
- Frontend hooks migrated to `apiList<T>()`: `useOrg`, `useModels`, `useOpenRouterModels`, `useProxies`, `useProviderKeys`, `useProfileConnections`, `useConnectionProfiles`, `useAllUserConnections`, `useAppProfiles`, `useAppProfileAgents`. `useProviders` keeps its `{ providers, callbackUrl }` domain shape but adapts from the wire envelope inside `queryFn`.
- Service / module contract: `listAllActorConnections()` returns `ListResponse<UserConnectionProviderGroup>`; `PlatformServices.connections.listAllForActor()` updated in `@appstrate/core/module` to use the new `PlatformListResponse<T>` type.
- CLI: `listOrgs`, `listModelPresets` read `.data`; CLI test mocks updated to emit the full envelope.
- Tests: 14 API integration + 3 OIDC-module integration + 4 CLI test files switched from `body.<key>` to `body.data` + matching `as { data: ... }` type assertions.
- OpenAPI baseline regenerated to absorb the wire shape changes.

C4 (RFC 3339 dates) and C5 (logger) were already PASS — untouched.

## Test plan

- [x] `bun run check` → 18/18 tasks ✓ (typecheck + eslint + prettier + verify-openapi + detect-breaking + system-packages)
- [x] API unit tests: 703 pass / 0 fail
- [x] CLI tests: 802 pass / 0 fail
- [ ] Smoke-check list endpoints in dev (frontend renders providers/orgs/models/connections/proxies)
- [ ] Smoke-check `/api/credential-proxy/proxy` 413 path (oversize Content-Length)
- [ ] Smoke-check OIDC SMTP test endpoint 400 path (problem+json shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)