### PR TITLE
chore(api,web,cli): drop legacy list shapes, normalize to Stripe envelope

### DIFF
--- a/apps/api/src/modules/oidc/openapi/paths.ts
+++ b/apps/api/src/modules/oidc/openapi/paths.ts
@@ -1020,9 +1020,10 @@ export const oidcPaths = {
             "application/json": {
               schema: {
                 type: "object",
-                required: ["sessions"],
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  sessions: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: {
                       type: "object",
@@ -1045,6 +1046,7 @@ export const oidcPaths = {
                       },
                     },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
             },

--- a/apps/api/src/modules/oidc/routes.ts
+++ b/apps/api/src/modules/oidc/routes.ts
@@ -2337,7 +2337,7 @@ export function createOidcRouter() {
     async (c) => {
       const orgId = c.req.param("orgId")!;
       const sessions = await listSessionsForOrg(orgId);
-      return c.json({ sessions });
+      return c.json(listResponse(sessions));
     },
   );
 

--- a/apps/api/src/modules/oidc/test/integration/routes/cli-sessions-admin.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/routes/cli-sessions-admin.test.ts
@@ -162,15 +162,15 @@ describe("GET /api/orgs/:orgId/cli-sessions (#251)", () => {
     });
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
-      sessions: Array<{
+      data: Array<{
         familyId: string;
         userId: string;
         userEmail: string | null;
         deviceName: string | null;
       }>;
     };
-    expect(body.sessions.length).toBe(2);
-    const byFamily = new Map(body.sessions.map((s) => [s.familyId, s]));
+    expect(body.data.length).toBe(2);
+    const byFamily = new Map(body.data.map((s) => [s.familyId, s]));
     expect(byFamily.get(memberFamily.familyId)?.userId).toBe(member.userId);
     expect(byFamily.get(memberFamily.familyId)?.userEmail).toBe("adminclisess1-member@example.com");
     expect(byFamily.get(memberFamily.familyId)?.deviceName).toBe("member-laptop");
@@ -205,9 +205,9 @@ describe("GET /api/orgs/:orgId/cli-sessions (#251)", () => {
       method: "GET",
       headers: { Cookie: a.admin.cookie },
     });
-    const aBody = (await aListedFromB.json()) as { sessions: Array<{ familyId: string }> };
+    const aBody = (await aListedFromB.json()) as { data: Array<{ familyId: string }> };
     // A's admin sees only A's member's session.
-    expect(aBody.sessions.map((s) => s.familyId)).not.toContain(bFamily.familyId);
+    expect(aBody.data.map((s) => s.familyId)).not.toContain(bFamily.familyId);
   });
 
   it("excludes sessions of users who left the org", async () => {
@@ -222,8 +222,8 @@ describe("GET /api/orgs/:orgId/cli-sessions (#251)", () => {
       headers: { Cookie: admin.cookie },
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { sessions: Array<unknown> };
-    expect(body.sessions.length).toBe(0);
+    const body = (await res.json()) as { data: Array<unknown> };
+    expect(body.data.length).toBe(0);
   });
 });
 

--- a/apps/api/src/modules/oidc/test/integration/services/cli-sessions.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/cli-sessions.test.ts
@@ -142,14 +142,14 @@ describe("GET /api/auth/cli/sessions (#251)", () => {
     });
     expect(list.status).toBe(200);
     const body = (await list.json()) as {
-      sessions: Array<{ familyId: string; deviceName: string | null; current: boolean }>;
+      data: Array<{ familyId: string; deviceName: string | null; current: boolean }>;
     };
-    expect(body.sessions.length).toBe(2);
+    expect(body.data.length).toBe(2);
     // laptop (no last_used → ranked by createdAt = newer) comes first.
-    expect(body.sessions[0]!.deviceName).toBe("laptop");
-    expect(body.sessions[1]!.deviceName).toBe("workstation");
-    expect(body.sessions[0]!.current).toBe(false);
-    expect(body.sessions[0]!.familyId).toBe(first.familyId);
+    expect(body.data[0]!.deviceName).toBe("laptop");
+    expect(body.data[1]!.deviceName).toBe("workstation");
+    expect(body.data[0]!.current).toBe(false);
+    expect(body.data[0]!.familyId).toBe(first.familyId);
   });
 
   it("rejects unauthenticated callers with 401", async () => {
@@ -167,16 +167,16 @@ describe("GET /api/auth/cli/sessions (#251)", () => {
       method: "GET",
       headers: { Cookie: a.cookie },
     });
-    const aBody = (await aList.json()) as { sessions: Array<{ familyId: string }> };
-    expect(aBody.sessions.length).toBe(1);
+    const aBody = (await aList.json()) as { data: Array<{ familyId: string }> };
+    expect(aBody.data.length).toBe(1);
 
     const bList = await app.request("/api/auth/cli/sessions", {
       method: "GET",
       headers: { Cookie: b.cookie },
     });
-    const bBody = (await bList.json()) as { sessions: Array<{ familyId: string }> };
-    expect(bBody.sessions.length).toBe(1);
-    expect(bBody.sessions[0]!.familyId).not.toBe(aBody.sessions[0]!.familyId);
+    const bBody = (await bList.json()) as { data: Array<{ familyId: string }> };
+    expect(bBody.data.length).toBe(1);
+    expect(bBody.data[0]!.familyId).not.toBe(aBody.data[0]!.familyId);
   });
 
   it("excludes revoked and expired families from the listing", async () => {
@@ -198,9 +198,9 @@ describe("GET /api/auth/cli/sessions (#251)", () => {
       method: "GET",
       headers: { Cookie: cookie },
     });
-    const body = (await res.json()) as { sessions: Array<{ familyId: string }> };
-    expect(body.sessions.length).toBe(1);
-    expect(body.sessions[0]!.familyId).toBe(active.familyId);
+    const body = (await res.json()) as { data: Array<{ familyId: string }> };
+    expect(body.data.length).toBe(1);
+    expect(body.data[0]!.familyId).toBe(active.familyId);
     // Sanity: the active row really is owned by the caller.
     const [row] = await db
       .select()

--- a/apps/api/src/openapi/baseline.json
+++ b/apps/api/src/openapi/baseline.json
@@ -748,7 +748,7 @@
         "operationId": "listAgentPersistence",
         "tags": ["Agents"],
         "summary": "List unified agent persistence (pinned slots + memories)",
-        "description": "Returns the agent's named pinned slots and archive memories visible to the caller's actor scope. Pinned slots include the legacy `checkpoint` carry-over slot alongside Letta-style named blocks (`persona`, `goals`, …). Admins inspecting at agent level (no `actorType` and no `runId`) see every actor's pinned slots; members always see their own actor scope plus shared rows. See ADR-011, ADR-013.",
+        "description": "Returns the agent's named pinned slots and archive memories visible to the caller's actor scope. Pinned slots include the `checkpoint` carry-over slot alongside Letta-style named blocks (`persona`, `goals`, …). Admins inspecting at agent level (no `actorType` and no `runId`) see every actor's pinned slots; members always see their own actor scope plus shared rows. See ADR-011, ADR-013.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -896,7 +896,7 @@
         "operationId": "deleteAgentPersistence",
         "tags": ["Agents"],
         "summary": "Bulk-delete persistence rows for an agent",
-        "description": "Wipes memories (always) and optionally the legacy `checkpoint` slot (when `actorType` + `actorId` resolve to a single scope). Other named pinned slots must be deleted individually via DELETE /persistence/pinned/{id}. Admin-only.",
+        "description": "Wipes memories (always) and optionally the `checkpoint` slot (when `actorType` + `actorId` resolve to a single scope). Other named pinned slots must be deleted individually via DELETE /persistence/pinned/{id}. Admin-only.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -1045,7 +1045,7 @@
         "operationId": "deleteAgentPersistencePinnedSlot",
         "tags": ["Agents"],
         "summary": "Delete a single pinned slot by id",
-        "description": "Admin-only. Deletes any named pinned slot (legacy `checkpoint`, `persona`, `goals`, …). The id must belong to the targeted agent in the current app.",
+        "description": "Admin-only. Deletes any named pinned slot (`checkpoint`, `persona`, `goals`, …). The id must belong to the targeted agent in the current app.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -3901,17 +3901,27 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "connections": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/ConnectionStatus"
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 },
                 "example": {
-                  "connections": [
+                  "object": "list",
+                  "hasMore": false,
+                  "data": [
                     {
                       "provider": "@appstrate/gmail",
                       "status": "connected",
@@ -4401,12 +4411,20 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "providers": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/ProviderConfig"
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     },
                     "callbackUrl": {
                       "type": "string"
@@ -4414,7 +4432,9 @@
                   }
                 },
                 "example": {
-                  "providers": [
+                  "object": "list",
+                  "hasMore": false,
+                  "data": [
                     {
                       "id": "@appstrate/gmail",
                       "displayName": "Gmail",
@@ -4761,17 +4781,27 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "models": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/OrgModel"
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 },
                 "example": {
-                  "models": [
+                  "object": "list",
+                  "hasMore": false,
+                  "data": [
                     {
                       "id": "gpt-4o",
                       "label": "GPT-4o",
@@ -5022,8 +5052,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "models": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -5057,11 +5092,16 @@
                           }
                         }
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 },
                 "example": {
-                  "models": [
+                  "object": "list",
+                  "hasMore": false,
+                  "data": [
                     {
                       "id": "anthropic/claude-sonnet-4",
                       "name": "Claude Sonnet 4",
@@ -5445,17 +5485,27 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "keys": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/OrgProviderKey"
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 },
                 "example": {
-                  "keys": [
+                  "object": "list",
+                  "hasMore": false,
+                  "data": [
                     {
                       "id": "cm7stu901",
                       "label": "OpenAI Production",
@@ -5837,17 +5887,27 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "proxies": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/OrgProxy"
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 },
                 "example": {
-                  "proxies": [
+                  "object": "list",
+                  "hasMore": false,
+                  "data": [
                     {
                       "id": "cm6pqr678",
                       "label": "US Residential Proxy",
@@ -6192,8 +6252,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "profiles": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -6221,11 +6286,16 @@
                           }
                         }
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 },
                 "example": {
-                  "profiles": [
+                  "object": "list",
+                  "hasMore": false,
+                  "data": [
                     {
                       "id": "550e8400-e29b-41d4-a716-446655440010",
                       "name": "Default",
@@ -6655,8 +6725,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "profiles": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -6684,11 +6759,16 @@
                           }
                         }
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 },
                 "example": {
-                  "profiles": [
+                  "object": "list",
+                  "hasMore": false,
+                  "data": [
                     {
                       "profile": {
                         "id": "550e8400-e29b-41d4-a716-446655440030",
@@ -6737,8 +6817,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "profiles": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -6766,11 +6851,16 @@
                           }
                         }
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 },
                 "example": {
-                  "profiles": [
+                  "object": "list",
+                  "hasMore": false,
+                  "data": [
                     {
                       "id": "550e8400-e29b-41d4-a716-446655440030",
                       "name": "Shared Production",
@@ -7236,8 +7326,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "connections": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -7273,6 +7368,9 @@
                           }
                         }
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 }
@@ -7575,17 +7673,27 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "organizations": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/Organization"
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 },
                 "example": {
-                  "organizations": [
+                  "object": "list",
+                  "hasMore": false,
+                  "data": [
                     {
                       "id": "550e8400-e29b-41d4-a716-446655440000",
                       "name": "Acme Corp",
@@ -8519,17 +8627,27 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "profiles": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/ProfileBatchItem"
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 },
                 "example": {
-                  "profiles": [
+                  "object": "list",
+                  "hasMore": false,
+                  "data": [
                     {
                       "id": "usr_abc123",
                       "displayName": "Alice Martin"
@@ -8570,8 +8688,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "orgs": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "type": "object",
@@ -8597,11 +8720,16 @@
                           }
                         }
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 },
                 "example": {
-                  "orgs": [
+                  "object": "list",
+                  "hasMore": false,
+                  "data": [
                     {
                       "id": "org_abc123",
                       "name": "Acme Corp",
@@ -8646,12 +8774,20 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["object", "data", "hasMore"],
                   "properties": {
-                    "models": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
                       "type": "array",
                       "items": {
                         "$ref": "#/components/schemas/OrgModel"
                       }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
                     }
                   }
                 }
@@ -15624,7 +15760,7 @@
             "name": "X-Run-Id",
             "in": "header",
             "required": false,
-            "description": "Optional run id (`exec_…`) used for per-run attribution in `credential_proxy_usage`. Not validated against the principal — a mismatched runId is a reporting oddity, not a security boundary.",
+            "description": "Optional run id (`run_…`) used for per-run attribution in `credential_proxy_usage`. Not validated against the principal — a mismatched runId is a reporting oddity, not a security boundary.",
             "schema": {
               "type": "string"
             }
@@ -15754,7 +15890,7 @@
             "name": "X-Run-Id",
             "in": "header",
             "required": false,
-            "description": "Optional run id (`exec_…`) used for per-run attribution in `credential_proxy_usage`. Not validated against the principal — a mismatched runId is a reporting oddity, not a security boundary.",
+            "description": "Optional run id (`run_…`) used for per-run attribution in `credential_proxy_usage`. Not validated against the principal — a mismatched runId is a reporting oddity, not a security boundary.",
             "schema": {
               "type": "string"
             }
@@ -15891,7 +16027,7 @@
             "name": "X-Run-Id",
             "in": "header",
             "required": false,
-            "description": "Optional run id (`exec_…`) used for per-run attribution in `credential_proxy_usage`. Not validated against the principal — a mismatched runId is a reporting oddity, not a security boundary.",
+            "description": "Optional run id (`run_…`) used for per-run attribution in `credential_proxy_usage`. Not validated against the principal — a mismatched runId is a reporting oddity, not a security boundary.",
             "schema": {
               "type": "string"
             }
@@ -16028,7 +16164,7 @@
             "name": "X-Run-Id",
             "in": "header",
             "required": false,
-            "description": "Optional run id (`exec_…`) used for per-run attribution in `credential_proxy_usage`. Not validated against the principal — a mismatched runId is a reporting oddity, not a security boundary.",
+            "description": "Optional run id (`run_…`) used for per-run attribution in `credential_proxy_usage`. Not validated against the principal — a mismatched runId is a reporting oddity, not a security boundary.",
             "schema": {
               "type": "string"
             }
@@ -16165,7 +16301,7 @@
             "name": "X-Run-Id",
             "in": "header",
             "required": false,
-            "description": "Optional run id (`exec_…`) used for per-run attribution in `credential_proxy_usage`. Not validated against the principal — a mismatched runId is a reporting oddity, not a security boundary.",
+            "description": "Optional run id (`run_…`) used for per-run attribution in `credential_proxy_usage`. Not validated against the principal — a mismatched runId is a reporting oddity, not a security boundary.",
             "schema": {
               "type": "string"
             }

--- a/apps/api/src/openapi/paths/app-profiles.ts
+++ b/apps/api/src/openapi/paths/app-profiles.ts
@@ -160,8 +160,10 @@ export const appProfilesPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  profiles: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: {
                       type: "object",
@@ -181,10 +183,13 @@ export const appProfilesPaths = {
                       },
                     },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
               example: {
-                profiles: [
+                object: "list",
+                hasMore: false,
+                data: [
                   {
                     profile: {
                       id: "550e8400-e29b-41d4-a716-446655440030",
@@ -224,8 +229,10 @@ export const appProfilesPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  profiles: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: {
                       type: "object",
@@ -239,10 +246,13 @@ export const appProfilesPaths = {
                       },
                     },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
               example: {
-                profiles: [
+                object: "list",
+                hasMore: false,
+                data: [
                   {
                     id: "550e8400-e29b-41d4-a716-446655440030",
                     name: "Shared Production",
@@ -540,8 +550,10 @@ export const appProfilesPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  connections: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: {
                       type: "object",
@@ -556,6 +568,7 @@ export const appProfilesPaths = {
                       },
                     },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
             },

--- a/apps/api/src/openapi/paths/connection-profiles.ts
+++ b/apps/api/src/openapi/paths/connection-profiles.ts
@@ -19,8 +19,10 @@ export const connectionProfilesPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  profiles: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: {
                       type: "object",
@@ -34,10 +36,13 @@ export const connectionProfilesPaths = {
                       },
                     },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
               example: {
-                profiles: [
+                object: "list",
+                hasMore: false,
+                data: [
                   {
                     id: "550e8400-e29b-41d4-a716-446655440010",
                     name: "Default",

--- a/apps/api/src/openapi/paths/connections.ts
+++ b/apps/api/src/openapi/paths/connections.ts
@@ -29,15 +29,20 @@ export const connectionsPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  connections: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/ConnectionStatus" },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
               example: {
-                connections: [
+                object: "list",
+                hasMore: false,
+                data: [
                   {
                     provider: "@appstrate/gmail",
                     status: "connected",

--- a/apps/api/src/openapi/paths/me.ts
+++ b/apps/api/src/openapi/paths/me.ts
@@ -34,8 +34,10 @@ export const mePaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  orgs: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: {
                       type: "object",
@@ -54,10 +56,13 @@ export const mePaths = {
                       },
                     },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
               example: {
-                orgs: [
+                object: "list",
+                hasMore: false,
+                data: [
                   {
                     id: "org_abc123",
                     name: "Acme Corp",
@@ -95,11 +100,14 @@ export const mePaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  models: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/OrgModel" },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
             },

--- a/apps/api/src/openapi/paths/models.ts
+++ b/apps/api/src/openapi/paths/models.ts
@@ -19,15 +19,20 @@ export const modelsPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  models: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/OrgModel" },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
               example: {
-                models: [
+                object: "list",
+                hasMore: false,
+                data: [
                   {
                     id: "gpt-4o",
                     label: "GPT-4o",
@@ -209,8 +214,10 @@ export const modelsPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  models: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: {
                       type: "object",
@@ -237,10 +244,13 @@ export const modelsPaths = {
                       },
                     },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
               example: {
-                models: [
+                object: "list",
+                hasMore: false,
+                data: [
                   {
                     id: "anthropic/claude-sonnet-4",
                     name: "Claude Sonnet 4",

--- a/apps/api/src/openapi/paths/organizations.ts
+++ b/apps/api/src/openapi/paths/organizations.ts
@@ -20,15 +20,20 @@ export const organizationsPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  organizations: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/Organization" },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
               example: {
-                organizations: [
+                object: "list",
+                hasMore: false,
+                data: [
                   {
                     id: "550e8400-e29b-41d4-a716-446655440000",
                     name: "Acme Corp",

--- a/apps/api/src/openapi/paths/profile.ts
+++ b/apps/api/src/openapi/paths/profile.ts
@@ -114,15 +114,20 @@ export const profilePaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  profiles: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/ProfileBatchItem" },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
               example: {
-                profiles: [
+                object: "list",
+                hasMore: false,
+                data: [
                   { id: "usr_abc123", displayName: "Alice Martin" },
                   { id: "usr_def456", displayName: "Bob Dupont" },
                 ],

--- a/apps/api/src/openapi/paths/provider-keys.ts
+++ b/apps/api/src/openapi/paths/provider-keys.ts
@@ -20,15 +20,20 @@ export const providerKeysPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  keys: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/OrgProviderKey" },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
               example: {
-                keys: [
+                object: "list",
+                hasMore: false,
+                data: [
                   {
                     id: "cm7stu901",
                     label: "OpenAI Production",

--- a/apps/api/src/openapi/paths/providers.ts
+++ b/apps/api/src/openapi/paths/providers.ts
@@ -23,16 +23,21 @@ export const providersPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  providers: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/ProviderConfig" },
                   },
+                  hasMore: { type: "boolean" },
                   callbackUrl: { type: "string" },
                 },
               },
               example: {
-                providers: [
+                object: "list",
+                hasMore: false,
+                data: [
                   {
                     id: "@appstrate/gmail",
                     displayName: "Gmail",

--- a/apps/api/src/openapi/paths/proxies.ts
+++ b/apps/api/src/openapi/paths/proxies.ts
@@ -19,15 +19,20 @@ export const proxiesPaths = {
             "application/json": {
               schema: {
                 type: "object",
+                required: ["object", "data", "hasMore"],
                 properties: {
-                  proxies: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
                     type: "array",
                     items: { $ref: "#/components/schemas/OrgProxy" },
                   },
+                  hasMore: { type: "boolean" },
                 },
               },
               example: {
-                proxies: [
+                object: "list",
+                hasMore: false,
+                data: [
                   {
                     id: "cm6pqr678",
                     label: "US Residential Proxy",

--- a/apps/api/src/routes/app-profiles.ts
+++ b/apps/api/src/routes/app-profiles.ts
@@ -73,14 +73,14 @@ export function createAppProfilesRouter() {
     const scope = getAppScope(c);
     const userId = c.get("user").id;
     const profiles = await listAppProfilesWithUserBindings(scope, userId);
-    return c.json({ profiles });
+    return c.json(listResponse(profiles));
   });
 
   // GET /api/app-profiles — list app profiles
   router.get("/", async (c) => {
     const scope = getAppScope(c);
     const profiles = await listAppProfiles(scope);
-    return c.json({ profiles });
+    return c.json(listResponse(profiles));
   });
 
   // POST /api/app-profiles — create an app profile
@@ -240,7 +240,7 @@ export function createAppProfilesRouter() {
     const connections = rawConnections.map(
       ({ credentialsEncrypted: _ce, providerCredentialId: _pc, expiresAt: _ex, ...c }) => c,
     );
-    return c.json({ connections });
+    return c.json(listResponse(connections));
   });
 
   return router;

--- a/apps/api/src/routes/connection-profiles.ts
+++ b/apps/api/src/routes/connection-profiles.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import type { AppEnv } from "../types/index.ts";
 import { logger } from "../lib/logger.ts";
 import { invalidRequest, parseBody } from "../lib/errors.ts";
+import { listResponse } from "../lib/list-response.ts";
 import {
   listProfiles,
   createProfile,
@@ -24,7 +25,7 @@ export function createConnectionProfilesRouter() {
   router.get("/", async (c) => {
     const actor = getActor(c);
     const profiles = await listProfiles(actor);
-    return c.json({ profiles });
+    return c.json(listResponse(profiles));
   });
 
   // POST /api/connection-profiles — create a new profile

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -7,6 +7,7 @@ import { getItemId } from "./packages.ts";
 import { logger } from "../lib/logger.ts";
 import { escapeHtml } from "../lib/html.ts";
 import { ApiError, forbidden, invalidRequest, internalError, parseBody } from "../lib/errors.ts";
+import { listResponse } from "../lib/list-response.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
 import {
   listActorConnections,
@@ -72,7 +73,7 @@ export function createConnectionsRouter() {
     }
 
     const connections = await listActorConnections(scope, profileId);
-    return c.json({ connections });
+    return c.json(listResponse(connections));
   });
 
   // POST /api/connections/connect/:provider — initiate OAuth or return authUrl

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -30,6 +30,7 @@ import { getOrgById, getUserOrganizations } from "../services/organizations.ts";
 import { listOrgModels } from "../services/org-models.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
 import { unauthorized } from "../lib/errors.ts";
+import { listResponse } from "../lib/list-response.ts";
 
 const router = new Hono<AppEnv>();
 
@@ -55,11 +56,11 @@ router.get("/orgs", async (c) => {
     // that single id and return a one-element list so the SPA org picker
     // has a stable shape across auth methods.
     const orgId = c.get("orgId");
-    if (!orgId) return c.json({ orgs: [] });
+    if (!orgId) return c.json(listResponse([]));
     const org = await getOrgById(orgId);
-    if (!org) return c.json({ orgs: [] });
-    return c.json({
-      orgs: [
+    if (!org) return c.json(listResponse([]));
+    return c.json(
+      listResponse([
         {
           id: org.id,
           name: org.name,
@@ -69,8 +70,8 @@ router.get("/orgs", async (c) => {
           role: "end_user" as const,
           createdAt: org.createdAt,
         },
-      ],
-    });
+      ]),
+    );
   }
 
   const user = c.get("user");
@@ -82,15 +83,17 @@ router.get("/orgs", async (c) => {
   const orgIdFilter = c.get("authMethod") === "api_key" ? c.get("orgId") : undefined;
   const orgs = await getUserOrganizations(user.id, orgIdFilter);
 
-  return c.json({
-    orgs: orgs.map((o) => ({
-      id: o.id,
-      name: o.name,
-      slug: o.slug,
-      role: o.role,
-      createdAt: o.createdAt,
-    })),
-  });
+  return c.json(
+    listResponse(
+      orgs.map((o) => ({
+        id: o.id,
+        name: o.name,
+        slug: o.slug,
+        role: o.role,
+        createdAt: o.createdAt,
+      })),
+    ),
+  );
 });
 
 /**
@@ -109,7 +112,7 @@ router.get("/orgs", async (c) => {
 router.get("/models", requirePermission("models", "read"), async (c) => {
   const orgId = c.get("orgId");
   const models = await listOrgModels(orgId);
-  return c.json({ models });
+  return c.json(listResponse(models));
 });
 
 export default router;

--- a/apps/api/src/routes/models.ts
+++ b/apps/api/src/routes/models.ts
@@ -3,6 +3,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import type { AppEnv } from "../types/index.ts";
+import { listResponse } from "../lib/list-response.ts";
 import { rateLimit } from "../middleware/rate-limit.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
 import { isSystemModel } from "../services/model-registry.ts";
@@ -73,7 +74,7 @@ export function createModelsRouter() {
   router.get("/", requirePermission("models", "read"), async (c) => {
     const orgId = c.get("orgId");
     const models = await listOrgModels(orgId);
-    return c.json({ models });
+    return c.json(listResponse(models));
   });
 
   // POST /api/models — create a custom model
@@ -153,7 +154,7 @@ export function createModelsRouter() {
       const rawModels = json?.data;
 
       if (!Array.isArray(rawModels)) {
-        return c.json({ models: [] });
+        return c.json(listResponse<unknown>([]));
       }
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -199,7 +200,7 @@ export function createModelsRouter() {
       // Limit results
       models = models.slice(0, 50);
 
-      return c.json({ models });
+      return c.json(listResponse(models));
     } catch (err) {
       if (err instanceof ApiError) throw err;
       if (err instanceof DOMException && err.name === "TimeoutError") {

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -23,6 +23,7 @@ import {
 } from "../services/organizations.ts";
 import { toSlug } from "@appstrate/core/naming";
 import { ApiError, forbidden, invalidRequest, notFound, parseBody } from "../lib/errors.ts";
+import { listResponse } from "../lib/list-response.ts";
 import {
   createInvitation,
   sendMagicLinkInvitation,
@@ -90,15 +91,17 @@ router.get("/", async (c) => {
   const orgIdFilter = c.get("authMethod") === "api_key" ? c.get("orgId") : undefined;
   const orgs = await getUserOrganizations(user.id, orgIdFilter);
 
-  return c.json({
-    organizations: orgs.map((o) => ({
-      id: o.id,
-      name: o.name,
-      slug: o.slug,
-      role: o.role,
-      createdAt: o.createdAt,
-    })),
-  });
+  return c.json(
+    listResponse(
+      orgs.map((o) => ({
+        id: o.id,
+        name: o.name,
+        slug: o.slug,
+        role: o.role,
+        createdAt: o.createdAt,
+      })),
+    ),
+  );
 });
 
 // POST /api/orgs — create an organization (no org context needed)

--- a/apps/api/src/routes/profile.ts
+++ b/apps/api/src/routes/profile.ts
@@ -8,6 +8,7 @@ import { profiles, user as userTable, organizationMembers } from "@appstrate/db/
 import { logger } from "../lib/logger.ts";
 import type { AppEnv } from "../types/index.ts";
 import { forbidden, internalError, notFound, parseBody } from "../lib/errors.ts";
+import { listResponse } from "../lib/list-response.ts";
 import { scopedWhere } from "../lib/db-helpers.ts";
 
 export const profileUpdateSchema = z.object({
@@ -103,7 +104,7 @@ profileRouter.post("/profiles/batch", async (c) => {
   const body = await c.req.json();
   const data = parseBody(batchLookupSchema, body);
   const ids = data.ids.filter(Boolean);
-  if (ids.length === 0) return c.json({ profiles: [] });
+  if (ids.length === 0) return c.json(listResponse([]));
 
   const rows = await db
     .select({ id: profiles.id, displayName: profiles.displayName })
@@ -111,7 +112,7 @@ profileRouter.post("/profiles/batch", async (c) => {
     .innerJoin(organizationMembers, eq(profiles.id, organizationMembers.userId))
     .where(scopedWhere(organizationMembers, { orgId, extra: [inArray(profiles.id, ids)] }));
 
-  return c.json({ profiles: rows });
+  return c.json(listResponse(rows));
 });
 
 export default profileRouter;

--- a/apps/api/src/routes/provider-keys.ts
+++ b/apps/api/src/routes/provider-keys.ts
@@ -3,6 +3,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import type { AppEnv } from "../types/index.ts";
+import { listResponse } from "../lib/list-response.ts";
 import { rateLimit } from "../middleware/rate-limit.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
 import { isSystemProviderKey } from "../services/model-registry.ts";
@@ -51,7 +52,7 @@ export function createProviderKeysRouter() {
   router.get("/", requirePermission("provider-keys", "read"), async (c) => {
     const orgId = c.get("orgId");
     const keys = await listOrgProviderKeys(orgId);
-    return c.json({ keys });
+    return c.json(listResponse(keys));
   });
 
   // POST /api/provider-keys

--- a/apps/api/src/routes/providers.ts
+++ b/apps/api/src/routes/providers.ts
@@ -7,6 +7,7 @@ import { getItemId } from "./packages.ts";
 import type { ProviderConfig } from "@appstrate/shared-types";
 import type { JSONSchemaObject } from "@appstrate/core/form";
 import { getOAuthCallbackUrl } from "../services/connection-manager/oauth.ts";
+import { listResponse } from "../lib/list-response.ts";
 import { checkScopeMatch } from "../middleware/guards.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
 import { logger } from "../lib/logger.ts";
@@ -234,7 +235,7 @@ export function createProvidersRouter() {
     });
 
     const callbackUrl = getOAuthCallbackUrl();
-    return c.json({ providers, callbackUrl });
+    return c.json({ ...listResponse(providers), callbackUrl });
   });
 
   // POST /api/providers — create a custom provider

--- a/apps/api/src/routes/proxies.ts
+++ b/apps/api/src/routes/proxies.ts
@@ -3,6 +3,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import type { AppEnv } from "../types/index.ts";
+import { listResponse } from "../lib/list-response.ts";
 import { rateLimit } from "../middleware/rate-limit.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
 import { isSystemProxy } from "../services/proxy-registry.ts";
@@ -45,7 +46,7 @@ export function createProxiesRouter() {
   router.get("/", async (c) => {
     const orgId = c.get("orgId");
     const proxies = await listOrgProxies(orgId);
-    return c.json({ proxies });
+    return c.json(listResponse(proxies));
   });
 
   // POST /api/proxies — create a custom proxy

--- a/apps/api/src/services/connection-manager/providers.ts
+++ b/apps/api/src/services/connection-manager/providers.ts
@@ -2,6 +2,7 @@
 
 import { db } from "@appstrate/db/client";
 import type { UserConnectionProviderGroup, AvailableProvider } from "@appstrate/shared-types";
+import { listResponse, type ListResponse } from "../../lib/list-response.ts";
 import { eq, inArray } from "drizzle-orm";
 import {
   userProviderConnections,
@@ -75,7 +76,7 @@ export async function getAvailableProvidersWithStatus(
 
 export async function listAllActorConnections(
   actor: Actor,
-): Promise<{ providers: UserConnectionProviderGroup[] }> {
+): Promise<ListResponse<UserConnectionProviderGroup>> {
   // Fetch all actor connections across ALL apps, joining through
   // applicationProviderCredentials → applications to get app context.
   // The preferences page needs to show "Gmail (App A)" vs "Gmail (App B)".
@@ -106,7 +107,7 @@ export async function listAllActorConnections(
       }),
     );
 
-  if (rows.length === 0) return { providers: [] };
+  if (rows.length === 0) return listResponse([]);
 
   // Fetch org names
   const userOrgs =
@@ -195,5 +196,5 @@ export async function listAllActorConnections(
     });
   }
 
-  return { providers };
+  return listResponse(providers);
 }

--- a/apps/api/test/integration/multi-tenancy.test.ts
+++ b/apps/api/test/integration/multi-tenancy.test.ts
@@ -292,8 +292,8 @@ describe("Multi-tenancy isolation", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { profiles: { id: string }[] };
-      const returnedIds = body.profiles.map((p) => p.id);
+      const body = (await res.json()) as { data: { id: string }[] };
+      const returnedIds = body.data.map((p) => p.id);
       expect(returnedIds).toContain(orgA.user.id);
       expect(returnedIds).not.toContain(orgB.user.id);
     });

--- a/apps/api/test/integration/routes/connection-profiles.test.ts
+++ b/apps/api/test/integration/routes/connection-profiles.test.ts
@@ -78,7 +78,7 @@ describe("Connection Profiles API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.profiles).toBeArray();
+      expect(body.data).toBeArray();
     });
   });
 
@@ -167,8 +167,8 @@ describe("Connection Profiles API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.profiles).toBeArray();
-      expect(body.profiles).toHaveLength(0);
+      expect(body.data).toBeArray();
+      expect(body.data).toHaveLength(0);
     });
 
     it("returns created app profiles", async () => {
@@ -180,8 +180,8 @@ describe("Connection Profiles API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.profiles).toHaveLength(1);
-      expect(body.profiles[0].name).toBe("App Profile 1");
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].name).toBe("App Profile 1");
     });
   });
 
@@ -461,7 +461,7 @@ describe("Connection Profiles API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.connections).toBeArray();
+      expect(body.data).toBeArray();
     });
 
     it("returns 404 for a profile from a non-member", async () => {
@@ -495,7 +495,7 @@ describe("Connection Profiles API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.connections).toBeArray();
+      expect(body.data).toBeArray();
     });
 
     it("returns connections for an app-level profile in the same org", async () => {
@@ -510,7 +510,7 @@ describe("Connection Profiles API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.connections).toBeArray();
+      expect(body.data).toBeArray();
     });
 
     it("returns 404 for a non-existent profile", async () => {

--- a/apps/api/test/integration/routes/me.test.ts
+++ b/apps/api/test/integration/routes/me.test.ts
@@ -43,10 +43,10 @@ describe("Me API (/api/me)", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
-        orgs: Array<{ id: string; name: string; slug: string; role: string }>;
+        data: Array<{ id: string; name: string; slug: string; role: string }>;
       };
-      expect(body.orgs).toBeArray();
-      const found = body.orgs.find((o) => o.id === ctx.orgId);
+      expect(body.data).toBeArray();
+      const found = body.data.find((o) => o.id === ctx.orgId);
       expect(found).toBeDefined();
       expect(found?.name).toBe("Acme");
       expect(found?.role).toBe("owner");
@@ -62,8 +62,8 @@ describe("Me API (/api/me)", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { orgs: Array<{ id: string }> };
-      const ids = body.orgs.map((o) => o.id);
+      const body = (await res.json()) as { data: Array<{ id: string }> };
+      const ids = body.data.map((o) => o.id);
       expect(ids).toContain(orgA.id);
       expect(ids).toContain(orgB.id);
     });
@@ -76,8 +76,8 @@ describe("Me API (/api/me)", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { orgs: unknown[] };
-      expect(body.orgs).toEqual([]);
+      const body = (await res.json()) as { data: unknown[] };
+      expect(body.data).toEqual([]);
     });
 
     it("API key sees ONLY its bound org even when the creator belongs to many", async () => {
@@ -97,10 +97,10 @@ describe("Me API (/api/me)", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { orgs: Array<{ id: string; slug: string }> };
-      expect(body.orgs).toHaveLength(1);
-      expect(body.orgs[0]?.id).toBe(ctx.orgId);
-      expect(body.orgs[0]?.slug).toBe("bound-org");
+      const body = (await res.json()) as { data: Array<{ id: string; slug: string }> };
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0]?.id).toBe(ctx.orgId);
+      expect(body.data[0]?.slug).toBe("bound-org");
     });
 
     it("returns 401 without authentication", async () => {
@@ -124,8 +124,8 @@ describe("Me API (/api/me)", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { models: unknown[] };
-      expect(body.models).toBeArray();
+      const body = (await res.json()) as { data: unknown[] };
+      expect(body.data).toBeArray();
     });
 
     it("works with API key auth (org pinned by the key)", async () => {
@@ -141,8 +141,8 @@ describe("Me API (/api/me)", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { models: unknown[] };
-      expect(body.models).toBeArray();
+      const body = (await res.json()) as { data: unknown[] };
+      expect(body.data).toBeArray();
     });
 
     it("rejects API keys without `models:read` scope with 403", async () => {
@@ -173,11 +173,11 @@ describe("Me API (/api/me)", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as {
-        models: Array<Record<string, unknown>>;
+        data: Array<Record<string, unknown>>;
       };
       // Catalog DTO must never include `apiKey` — that field is reserved
       // for `models.load()` (single-model resolution from PlatformServices).
-      for (const m of body.models) {
+      for (const m of body.data) {
         expect(m.apiKey).toBeUndefined();
       }
     });

--- a/apps/api/test/integration/routes/models.test.ts
+++ b/apps/api/test/integration/routes/models.test.ts
@@ -40,7 +40,7 @@ describe("Models API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.models).toBeArray();
+      expect(body.data).toBeArray();
     });
 
     it("returns 401 without authentication", async () => {

--- a/apps/api/test/integration/routes/openapi-response-validation.test.ts
+++ b/apps/api/test/integration/routes/openapi-response-validation.test.ts
@@ -190,9 +190,9 @@ describe("OpenAPI response validation", () => {
       }
 
       expect(result.valid).toBe(true);
-      expect(body).toHaveProperty("organizations");
-      expect((body as any).organizations).toBeArray();
-      expect((body as any).organizations.length).toBeGreaterThanOrEqual(1);
+      expect(body).toHaveProperty("data");
+      expect((body as any).data).toBeArray();
+      expect((body as any).data.length).toBeGreaterThanOrEqual(1);
     });
 
     it("each organization item conforms to Organization schema", async () => {
@@ -204,7 +204,7 @@ describe("OpenAPI response validation", () => {
       });
       const body = (await res.json()) as any;
 
-      for (const org of body.organizations) {
+      for (const org of body.data) {
         const result = validateResponse(org, orgSchema);
         if (!result.valid) {
           console.error(`Organization validation errors for ${org.id}:`, result.errors);

--- a/apps/api/test/integration/routes/organizations.test.ts
+++ b/apps/api/test/integration/routes/organizations.test.ts
@@ -34,9 +34,9 @@ describe("Organizations API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.organizations).toBeArray();
-      expect(body.organizations.length).toBeGreaterThanOrEqual(1);
-      const org = body.organizations.find((o: { id: string }) => o.id === ctx.orgId);
+      expect(body.data).toBeArray();
+      expect(body.data.length).toBeGreaterThanOrEqual(1);
+      const org = body.data.find((o: { id: string }) => o.id === ctx.orgId);
       expect(org).toBeDefined();
       expect(org.name).toBe("My Org");
       expect(org.role).toBe("owner");
@@ -51,8 +51,8 @@ describe("Organizations API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.organizations).toBeArray();
-      expect(body.organizations).toHaveLength(0);
+      expect(body.data).toBeArray();
+      expect(body.data).toHaveLength(0);
     });
 
     it("returns 401 without authentication", async () => {
@@ -325,11 +325,11 @@ describe("Organizations API", () => {
 
       const res = await app.request("/api/orgs", { headers: bearer });
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { organizations: { id: string }[] };
-      const ids = body.organizations.map((o) => o.id);
+      const body = (await res.json()) as { data: { id: string }[] };
+      const ids = body.data.map((o) => o.id);
       expect(ids).toContain(ctxA.orgId);
       expect(ids).not.toContain(orgB.id);
-      expect(body.organizations).toHaveLength(1);
+      expect(body.data).toHaveLength(1);
     });
 
     it("GET /api/orgs/:keyOrgId still works", async () => {
@@ -449,8 +449,8 @@ describe("Organizations API", () => {
         headers: { Cookie: ctxA.cookie },
       });
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { organizations: { id: string }[] };
-      const ids = body.organizations.map((o) => o.id);
+      const body = (await res.json()) as { data: { id: string }[] };
+      const ids = body.data.map((o) => o.id);
       expect(ids).toContain(ctxA.orgId);
       expect(ids).toContain(orgB.id);
     });

--- a/apps/api/test/integration/routes/profile-isolation.test.ts
+++ b/apps/api/test/integration/routes/profile-isolation.test.ts
@@ -40,7 +40,7 @@ describe("Multi-org profile isolation", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      const leaked = body.profiles.find((p: { id: string }) => p.id === profileB.id);
+      const leaked = body.data.find((p: { id: string }) => p.id === profileB.id);
       expect(leaked).toBeUndefined();
     });
 
@@ -199,7 +199,7 @@ describe("Multi-org profile isolation", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      const leaked = body.profiles.find((p: { name: string }) => p.name === "Owner Private");
+      const leaked = body.data.find((p: { name: string }) => p.name === "Owner Private");
       expect(leaked).toBeUndefined();
     });
 

--- a/apps/api/test/integration/routes/profile.test.ts
+++ b/apps/api/test/integration/routes/profile.test.ts
@@ -117,8 +117,8 @@ describe("Profile API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.profiles).toBeArray();
-      expect(body.profiles).toHaveLength(1);
+      expect(body.data).toBeArray();
+      expect(body.data).toHaveLength(1);
     });
 
     it("does not return profiles for users outside the org", async () => {
@@ -132,7 +132,7 @@ describe("Profile API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.profiles).toHaveLength(0);
+      expect(body.data).toHaveLength(0);
     });
 
     it("returns empty for unknown IDs", async () => {
@@ -144,7 +144,7 @@ describe("Profile API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.profiles).toHaveLength(0);
+      expect(body.data).toHaveLength(0);
     });
   });
 

--- a/apps/api/test/integration/routes/provider-keys.test.ts
+++ b/apps/api/test/integration/routes/provider-keys.test.ts
@@ -23,7 +23,7 @@ describe("Provider Keys API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.keys).toBeArray();
+      expect(body.data).toBeArray();
       // May include system provider keys loaded at boot — just verify shape
     });
 
@@ -111,7 +111,7 @@ describe("Provider Keys API", () => {
         headers: authHeaders(ctx),
       });
       const body = (await listRes.json()) as any;
-      const found = body.keys.find((k: { id: string }) => k.id === id);
+      const found = body.data.find((k: { id: string }) => k.id === id);
       expect(found).toBeUndefined();
     });
   });

--- a/apps/api/test/integration/routes/providers.test.ts
+++ b/apps/api/test/integration/routes/providers.test.ts
@@ -35,7 +35,7 @@ describe("Providers API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.providers).toBeArray();
+      expect(body.data).toBeArray();
       expect(body.callbackUrl).toBeString();
     });
 
@@ -79,7 +79,7 @@ describe("Providers API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      const found = body.providers.find((p: { id: string }) => p.id === "@provorg/my-provider");
+      const found = body.data.find((p: { id: string }) => p.id === "@provorg/my-provider");
       expect(found).toBeDefined();
     });
 
@@ -104,9 +104,7 @@ describe("Providers API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      const leaked = body.providers.find(
-        (p: { id: string }) => p.id === "@otherorg/secret-provider",
-      );
+      const leaked = body.data.find((p: { id: string }) => p.id === "@otherorg/secret-provider");
       expect(leaked).toBeUndefined();
     });
 

--- a/apps/api/test/integration/routes/proxies.test.ts
+++ b/apps/api/test/integration/routes/proxies.test.ts
@@ -23,7 +23,7 @@ describe("Proxies API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.proxies).toBeArray();
+      expect(body.data).toBeArray();
     });
   });
 

--- a/apps/api/test/integration/services/app-connection-scoping.test.ts
+++ b/apps/api/test/integration/services/app-connection-scoping.test.ts
@@ -93,10 +93,10 @@ describe("Application-scoped connection isolation", () => {
         headers: authHeaders(ctx),
       });
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { connections: Record<string, unknown>[] };
-      expect(body.connections).toHaveLength(1);
+      const body = (await res.json()) as { data: Record<string, unknown>[] };
+      expect(body.data).toHaveLength(1);
 
-      const conn = body.connections[0]!;
+      const conn = body.data[0]!;
       expect(conn.credentialsEncrypted).toBeUndefined();
       expect(conn.providerCredentialId).toBeUndefined();
       expect(conn.expiresAt).toBeUndefined();

--- a/apps/cli/src/lib/models.ts
+++ b/apps/cli/src/lib/models.ts
@@ -39,12 +39,14 @@ export interface ModelPreset {
 }
 
 interface ListResponse {
-  models?: ModelPreset[];
+  object?: "list";
+  data?: ModelPreset[];
+  hasMore?: boolean;
 }
 
 export async function listModelPresets(profileName: string): Promise<ModelPreset[]> {
   const res = await apiFetch<ListResponse>(profileName, "/api/models");
-  return Array.isArray(res.models) ? res.models : [];
+  return Array.isArray(res.data) ? res.data : [];
 }
 
 /**

--- a/apps/cli/src/lib/orgs.ts
+++ b/apps/cli/src/lib/orgs.ts
@@ -26,12 +26,14 @@ export interface Org {
 }
 
 interface ListResponse {
-  organizations: Org[];
+  object: "list";
+  data: Org[];
+  hasMore: boolean;
 }
 
 export async function listOrgs(profileName: string): Promise<Org[]> {
   const res = await apiFetch<ListResponse>(profileName, "/api/orgs");
-  return Array.isArray(res.organizations) ? res.organizations : [];
+  return Array.isArray(res.data) ? res.data : [];
 }
 
 export interface CreateOrgInput {

--- a/apps/cli/test/login-org.test.ts
+++ b/apps/cli/test/login-org.test.ts
@@ -141,7 +141,7 @@ function installDefaultResponders(overrides: ResponderMap = {}): void {
         { status: 200, headers: { "Content-Type": "application/json" } },
       ),
     listOrgs: () =>
-      new Response(JSON.stringify({ organizations: [] }), {
+      new Response(JSON.stringify({ object: "list", hasMore: false, data: [] }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
       }),
@@ -239,9 +239,9 @@ describe("login org-pin branch", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [
-              { id: "org_only", name: "Solo", slug: "solo", role: "owner", createdAt: "t" },
-            ],
+            object: "list",
+            hasMore: false,
+            data: [{ id: "org_only", name: "Solo", slug: "solo", role: "owner", createdAt: "t" }],
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
@@ -263,7 +263,9 @@ describe("login org-pin branch", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [
+            object: "list",
+            hasMore: false,
+            data: [
               { id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" },
               { id: "org_2", name: "Beta", slug: "beta", role: "member", createdAt: "t" },
             ],
@@ -324,7 +326,9 @@ describe("login org-pin branch", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [
+            object: "list",
+            hasMore: false,
+            data: [
               { id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" },
               { id: "org_2", name: "Beta", slug: "beta", role: "member", createdAt: "t" },
             ],
@@ -353,7 +357,9 @@ describe("login org-pin branch", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [
+            object: "list",
+            hasMore: false,
+            data: [
               { id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" },
               { id: "org_2", name: "Beta", slug: "beta", role: "member", createdAt: "t" },
             ],
@@ -376,9 +382,9 @@ describe("login org-pin branch", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [
-              { id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" },
-            ],
+            object: "list",
+            hasMore: false,
+            data: [{ id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" }],
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
@@ -401,7 +407,9 @@ describe("login org-pin branch", () => {
     installDefaultResponders({
       listOrgs: () => {
         listCalled = true;
-        return new Response(JSON.stringify({ organizations: [] }), { status: 200 });
+        return new Response(JSON.stringify({ object: "list", hasMore: false, data: [] }), {
+          status: 200,
+        });
       },
       createOrg: (body) => {
         createBody = body;
@@ -434,7 +442,9 @@ describe("login org-pin branch", () => {
     installDefaultResponders({
       listOrgs: () => {
         orgsCalled = true;
-        return new Response(JSON.stringify({ organizations: [] }), { status: 200 });
+        return new Response(JSON.stringify({ object: "list", hasMore: false, data: [] }), {
+          status: 200,
+        });
       },
     });
 
@@ -496,7 +506,9 @@ describe("login org-pin branch", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [
+            object: "list",
+            hasMore: false,
+            data: [
               { id: "org_first", name: "First", slug: "first", role: "owner", createdAt: "t" },
             ],
           }),
@@ -523,9 +535,9 @@ describe("login org-pin branch", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [
-              { id: "org_A", name: "Alpha", slug: "alpha", role: "owner", createdAt: "t" },
-            ],
+            object: "list",
+            hasMore: false,
+            data: [{ id: "org_A", name: "Alpha", slug: "alpha", role: "owner", createdAt: "t" }],
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
@@ -561,9 +573,9 @@ describe("login org-pin branch", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [
-              { id: "org_only", name: "Solo", slug: "solo", role: "owner", createdAt: "t" },
-            ],
+            object: "list",
+            hasMore: false,
+            data: [{ id: "org_only", name: "Solo", slug: "solo", role: "owner", createdAt: "t" }],
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
@@ -598,7 +610,9 @@ describe("login app-pin cascade", () => {
   const oneOrg = () =>
     new Response(
       JSON.stringify({
-        organizations: [{ id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" }],
+        object: "list",
+        hasMore: false,
+        data: [{ id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" }],
       }),
       { status: 200, headers: { "Content-Type": "application/json" } },
     );
@@ -676,9 +690,9 @@ describe("login app-pin cascade", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [
-              { id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" },
-            ],
+            object: "list",
+            hasMore: false,
+            data: [{ id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" }],
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
@@ -700,9 +714,9 @@ describe("login app-pin cascade", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [
-              { id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" },
-            ],
+            object: "list",
+            hasMore: false,
+            data: [{ id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" }],
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
@@ -733,9 +747,9 @@ describe("login app-pin cascade", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [
-              { id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" },
-            ],
+            object: "list",
+            hasMore: false,
+            data: [{ id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" }],
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
@@ -765,9 +779,9 @@ describe("login app-pin cascade", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [
-              { id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" },
-            ],
+            object: "list",
+            hasMore: false,
+            data: [{ id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" }],
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
@@ -843,9 +857,9 @@ describe("login app-pin cascade", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [
-              { id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" },
-            ],
+            object: "list",
+            hasMore: false,
+            data: [{ id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" }],
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
@@ -869,9 +883,9 @@ describe("login app-pin cascade", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [
-              { id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" },
-            ],
+            object: "list",
+            hasMore: false,
+            data: [{ id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" }],
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
@@ -893,9 +907,9 @@ describe("login app-pin cascade", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [
-              { id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" },
-            ],
+            object: "list",
+            hasMore: false,
+            data: [{ id: "org_1", name: "One", slug: "one", role: "owner", createdAt: "t" }],
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),
@@ -912,7 +926,9 @@ describe("login app-pin cascade", () => {
       listOrgs: () =>
         new Response(
           JSON.stringify({
-            organizations: [{ id: "org_A", name: "A", slug: "a", role: "owner", createdAt: "t" }],
+            object: "list",
+            hasMore: false,
+            data: [{ id: "org_A", name: "A", slug: "a", role: "owner", createdAt: "t" }],
           }),
           { status: 200, headers: { "Content-Type": "application/json" } },
         ),

--- a/apps/cli/test/org-command.test.ts
+++ b/apps/cli/test/org-command.test.ts
@@ -174,7 +174,9 @@ async function pinnedAppId(profile = "default"): Promise<string | undefined> {
 }
 
 const twoOrgs = {
-  organizations: [
+  object: "list",
+  hasMore: false,
+  data: [
     { id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" },
     { id: "org_2", name: "Beta", slug: "beta", role: "member", createdAt: "t" },
   ],
@@ -213,7 +215,7 @@ describe("org list", () => {
     await seedLoggedIn();
     installFetch({
       listOrgs: () =>
-        new Response(JSON.stringify({ organizations: [] }), {
+        new Response(JSON.stringify({ object: "list", hasMore: false, data: [] }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         }),
@@ -312,7 +314,7 @@ describe("org switch", () => {
     await seedLoggedIn("org_1");
     installFetch({
       listOrgs: () =>
-        new Response(JSON.stringify({ organizations: [] }), {
+        new Response(JSON.stringify({ object: "list", hasMore: false, data: [] }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         }),

--- a/apps/cli/test/orgs.test.ts
+++ b/apps/cli/test/orgs.test.ts
@@ -101,9 +101,9 @@ describe("listOrgs", () => {
       expect(url).toBe("https://app.example.com/api/orgs");
       return new Response(
         JSON.stringify({
-          organizations: [
-            { id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" },
-          ],
+          object: "list",
+          hasMore: false,
+          data: [{ id: "org_1", name: "Acme", slug: "acme", role: "owner", createdAt: "t" }],
         }),
         { status: 200, headers: { "Content-Type": "application/json" } },
       );
@@ -118,7 +118,7 @@ describe("listOrgs", () => {
     await seedAuth();
     installFetch(
       async () =>
-        new Response(JSON.stringify({ organizations: [] }), {
+        new Response(JSON.stringify({ object: "list", hasMore: false, data: [] }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         }),

--- a/apps/cli/test/whoami.test.ts
+++ b/apps/cli/test/whoami.test.ts
@@ -253,7 +253,9 @@ describe("whoami (happy path)", () => {
       if (url.endsWith("/api/orgs")) {
         return new Response(
           JSON.stringify({
-            organizations: [
+            object: "list",
+            hasMore: false,
+            data: [
               { id: "org_42", name: "Acme Corp", slug: "acme", role: "owner", createdAt: "t" },
             ],
           }),
@@ -285,7 +287,7 @@ describe("whoami (happy path)", () => {
         );
       }
       if (url.endsWith("/api/orgs")) {
-        return new Response(JSON.stringify({ organizations: [] }), {
+        return new Response(JSON.stringify({ object: "list", hasMore: false, data: [] }), {
           status: 200,
           headers: { "Content-Type": "application/json" },
         });

--- a/apps/web/src/hooks/use-connection-profiles.ts
+++ b/apps/web/src/hooks/use-connection-profiles.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "../api";
+import { api, apiList } from "../api";
 import { useCurrentOrgId } from "./use-org";
 import { useCurrentApplicationId } from "./use-current-application";
 import { onMutationError } from "./use-mutations";
@@ -31,10 +31,7 @@ export function useProfileConnections(profileId: string | null | undefined) {
   const appId = useCurrentApplicationId();
   return useQuery({
     queryKey: ["profile-connections", orgId, appId, profileId],
-    queryFn: () =>
-      api<{ connections: ConnectionInfo[] }>(`/app-profiles/${profileId}/connections`).then(
-        (r) => r.connections,
-      ),
+    queryFn: () => apiList<ConnectionInfo>(`/app-profiles/${profileId}/connections`),
     enabled: !!profileId && !!appId,
     staleTime: 30_000,
   });
@@ -49,8 +46,7 @@ export function useConnectionProfiles() {
   const orgId = useCurrentOrgId();
   return useQuery({
     queryKey: ["connection-profiles", orgId],
-    queryFn: () =>
-      api<{ profiles: ProfileWithConnections[] }>("/connection-profiles").then((r) => r.profiles),
+    queryFn: () => apiList<ProfileWithConnections>("/connection-profiles"),
   });
 }
 
@@ -59,7 +55,7 @@ export function useAllUserConnections() {
   const appId = useCurrentApplicationId();
   return useQuery({
     queryKey: ["user-connections", orgId, appId],
-    queryFn: () => api<{ providers: UserConnectionProviderGroup[] }>("/app-profiles/connections"),
+    queryFn: () => apiList<UserConnectionProviderGroup>("/app-profiles/connections"),
     enabled: !!appId,
   });
 }
@@ -124,8 +120,7 @@ export function useAppProfiles() {
   const appId = useCurrentApplicationId();
   return useQuery({
     queryKey: ["app-connection-profiles", orgId, appId],
-    queryFn: () =>
-      api<{ profiles: AppProfileWithBindings[] }>("/app-profiles").then((r) => r.profiles),
+    queryFn: () => apiList<AppProfileWithBindings>("/app-profiles"),
   });
 }
 
@@ -208,9 +203,7 @@ export function useAppProfileAgents(profileId: string | undefined) {
   return useQuery({
     queryKey: ["app-profile-agents", orgId, appId, profileId],
     queryFn: () =>
-      api<{ object: "list"; data: { id: string; displayName: string }[]; hasMore: boolean }>(
-        `/app-profiles/${profileId}/agents`,
-      ).then((r) => r.data),
+      apiList<{ id: string; displayName: string }>(`/app-profiles/${profileId}/agents`),
     enabled: !!profileId,
     staleTime: 30_000,
   });

--- a/apps/web/src/hooks/use-models.ts
+++ b/apps/web/src/hooks/use-models.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "../api";
+import { api, apiList } from "../api";
 import { useCurrentOrgId } from "./use-org";
 import { useCurrentApplicationId } from "./use-current-application";
 import type { OrgModelInfo, TestResult, ModelCost } from "@appstrate/shared-types";
@@ -13,7 +13,7 @@ export function useModels() {
   const orgId = useCurrentOrgId();
   return useQuery({
     queryKey: ["models", orgId],
-    queryFn: () => api<{ models: OrgModelInfo[] }>("/models").then((d) => d.models),
+    queryFn: () => apiList<OrgModelInfo>("/models"),
     enabled: !!orgId,
   });
 }
@@ -126,9 +126,9 @@ export function useOpenRouterModels(search: string | undefined) {
   return useQuery({
     queryKey: ["openrouter-models", search],
     queryFn: () =>
-      api<{ models: OpenRouterModel[] }>(
+      apiList<OpenRouterModel>(
         `/models/openrouter${search ? `?q=${encodeURIComponent(search)}` : ""}`,
-      ).then((d) => d.models),
+      ),
     enabled: search !== undefined,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,

--- a/apps/web/src/hooks/use-org.ts
+++ b/apps/web/src/hooks/use-org.ts
@@ -4,7 +4,7 @@ import { useCallback } from "react";
 import { useStore } from "zustand";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { isOwnedByOrg } from "@appstrate/core/naming";
-import { api } from "../api";
+import { apiList } from "../api";
 import { orgStore, getCurrentOrgId } from "../stores/org-store";
 import { appStore } from "../stores/app-store";
 import { useAutoSelect } from "./use-auto-select";
@@ -24,10 +24,7 @@ export function useOrg() {
 
   const { data: orgs = [], isLoading } = useQuery({
     queryKey: ["orgs"],
-    queryFn: async () => {
-      const data = await api<{ organizations: OrganizationWithRole[] }>("/orgs");
-      return data.organizations;
-    },
+    queryFn: () => apiList<OrganizationWithRole>("/orgs"),
   });
 
   const setOrgId = useCallback((id: string) => orgStore.getState().setId(id), []);

--- a/apps/web/src/hooks/use-provider-keys.ts
+++ b/apps/web/src/hooks/use-provider-keys.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "../api";
+import { api, apiList } from "../api";
 import { useCurrentOrgId } from "./use-org";
 import type { OrgProviderKeyInfo, TestResult } from "@appstrate/shared-types";
 
@@ -9,7 +9,7 @@ export function useProviderKeys() {
   const orgId = useCurrentOrgId();
   return useQuery({
     queryKey: ["provider-keys", orgId],
-    queryFn: () => api<{ keys: OrgProviderKeyInfo[] }>("/provider-keys").then((d) => d.keys),
+    queryFn: () => apiList<OrgProviderKeyInfo>("/provider-keys"),
     enabled: !!orgId,
   });
 }

--- a/apps/web/src/hooks/use-providers.ts
+++ b/apps/web/src/hooks/use-providers.ts
@@ -6,6 +6,13 @@ import { useCurrentOrgId } from "./use-org";
 import { useCurrentApplicationId } from "./use-current-application";
 import type { ProviderConfig } from "@appstrate/shared-types";
 
+interface ProvidersWireResponse {
+  object: "list";
+  data: ProviderConfig[];
+  hasMore: boolean;
+  callbackUrl?: string;
+}
+
 interface ProvidersResponse {
   providers: ProviderConfig[];
   callbackUrl?: string;
@@ -14,9 +21,12 @@ interface ProvidersResponse {
 export function useProviders() {
   const orgId = useCurrentOrgId();
   const appId = useCurrentApplicationId();
-  return useQuery({
+  return useQuery<ProvidersResponse>({
     queryKey: ["providers", orgId, appId],
-    queryFn: () => api<ProvidersResponse>("/providers"),
+    queryFn: async () => {
+      const env = await api<ProvidersWireResponse>("/providers");
+      return { providers: env.data, callbackUrl: env.callbackUrl };
+    },
     enabled: !!orgId && !!appId,
   });
 }

--- a/apps/web/src/hooks/use-proxies.ts
+++ b/apps/web/src/hooks/use-proxies.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "../api";
+import { api, apiList } from "../api";
 import { useCurrentOrgId } from "./use-org";
 import { useCurrentApplicationId } from "./use-current-application";
 import type { OrgProxyInfo, TestResult } from "@appstrate/shared-types";
@@ -10,7 +10,7 @@ export function useProxies() {
   const orgId = useCurrentOrgId();
   return useQuery({
     queryKey: ["proxies", orgId],
-    queryFn: () => api<{ proxies: OrgProxyInfo[] }>("/proxies").then((d) => d.proxies),
+    queryFn: () => apiList<OrgProxyInfo>("/proxies"),
     enabled: !!orgId,
   });
 }

--- a/apps/web/src/pages/preferences/connectors.tsx
+++ b/apps/web/src/pages/preferences/connectors.tsx
@@ -195,7 +195,7 @@ export function PreferencesConnectorsPage() {
   >(null);
 
   const providers = useMemo(
-    () => filterProviders(userConns?.providers, filterProfileId),
+    () => filterProviders(userConns, filterProfileId),
     [userConns, filterProfileId],
   );
 

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -21,6 +21,7 @@ import type {
   InlineRunBody,
   PlatformApplication,
   PlatformConnectionProviderGroup,
+  PlatformListResponse,
   PlatformModel,
   PlatformPackage,
   PubSub,
@@ -749,8 +750,8 @@ export interface PlatformServices {
   };
   /** Connection manager helpers. */
   connections: {
-    /** Returns `{ providers: [...] }` — not a bare array. */
-    listAllForActor(actor: Actor): Promise<{ providers: PlatformConnectionProviderGroup[] }>;
+    /** Returns the Stripe-canonical list envelope `{ object: "list", data, hasMore }`. */
+    listAllForActor(actor: Actor): Promise<PlatformListResponse<PlatformConnectionProviderGroup>>;
   };
   /**
    * Run lifecycle operations (append log, update, abort).

--- a/packages/core/src/platform-types.ts
+++ b/packages/core/src/platform-types.ts
@@ -142,6 +142,19 @@ export interface PlatformApplication {
   readonly isDefault: boolean;
 }
 
+/**
+ * Stripe-canonical list envelope for HTTP list responses.
+ *
+ * Wire format: `{ object: "list", data: T[], hasMore: boolean, total?: number }`.
+ * Mirrored verbatim by `apps/api/src/lib/list-response.ts::ListResponse<T>`.
+ */
+export interface PlatformListResponse<T> {
+  readonly object: "list";
+  readonly data: ReadonlyArray<T>;
+  readonly hasMore: boolean;
+  readonly total?: number;
+}
+
 /** A user's connections grouped by provider, then by org — shape returned by `connections.listAllForActor`. */
 export interface PlatformConnectionProviderGroup {
   readonly providerId: string;


### PR DESCRIPTION
## Summary

Migrates every remaining legacy `c.json({ orgs|models|profiles|… })` return to the Stripe-canonical envelope `{ object: "list", data, hasMore }` delivered by `listResponse()`. Completes the cleanup deferred from #297, where the wire-format change was documented as an intentional breaking change (no production data exists yet).

**Endpoints normalized** (route + OpenAPI spec): `/api/me/orgs`, `/api/me/models`, `/api/orgs`, `POST /api/profiles/batch`, `/api/models`, `/api/models/openrouter`, `/api/proxies`, `/api/connection-profiles`, `/api/connections/integrations`, `/api/providers` (with sibling `callbackUrl` preserved), `/api/provider-keys`, `/api/app-profiles`, `/api/app-profiles/my-bindings`, `/api/app-profiles/connections`, `/api/app-profiles/{id}/connections`, `/api/orgs/{orgId}/cli-sessions`.

**Frontend**: hooks migrated to `apiList<T>()` (`useOrg`, `useModels`, `useOpenRouterModels`, `useProxies`, `useProviderKeys`, `useProfileConnections`, `useConnectionProfiles`, `useAllUserConnections`, `useAppProfiles`, `useAppProfileAgents`). `useProviders` keeps its `{ providers, callbackUrl }` domain shape but adapts from the new envelope inside `queryFn`.

**Service-layer + module contract**: `listAllActorConnections()` now returns `ListResponse<UserConnectionProviderGroup>`; `PlatformServices.connections.listAllForActor()` updated in `@appstrate/core/module` to use the new `PlatformListResponse<T>` type exported from `platform-types.ts`.

**CLI**: `listOrgs`, `listModelPresets` read `.data` instead of `.organizations` / `.models`; mocks updated to emit the full envelope.

## Test plan

Already validated when commit was made (per commit body):

- [x] `bun run check` 18/18
- [x] API unit tests 703/703
- [x] CLI tests 802/802
- [x] OpenAPI baseline (`apps/api/src/openapi/baseline.json`) regenerated
- [ ] Re-run CI on this branch
- [ ] Smoke-test web UI (lists in Providers, Connections, Models, Org settings, App Profiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)