### PR TITLE
fix(db): emit started_at/completed_at as UTC in realtime NOTIFY payload

### DIFF
--- a/packages/db/src/notify.ts
+++ b/packages/db/src/notify.ts
@@ -24,8 +24,8 @@ export async function createNotifyTriggers(db: Db): Promise<void> {
         'application_id', NEW.application_id,
         'schedule_id', NEW.schedule_id,
         'error', NEW.error,
-        'started_at', to_char(NEW.started_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
-        'completed_at', to_char(NEW.completed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'started_at', to_char(NEW.started_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'completed_at', to_char(NEW.completed_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
         'duration', NEW.duration
       )::text);
       RETURN NEW;


### PR DESCRIPTION
## Summary

- The realtime NOTIFY trigger on `runs` rendered `started_at`/`completed_at` through `to_char(NEW.started_at AT TIME ZONE 'UTC', '...Z')`. With a non-UTC Postgres session, `to_char` formatted the resulting `timestamptz` in session time while suffixing a literal `Z`, so browsers parsed the string as UTC and were off by the session offset — making the live elapsed timer wildly inflated during runs.
- After completion, the row reads `run.duration` (computed in JS, never round-tripped through this trigger), which is why a refresh showed the correct value and the bug only surfaced during a live run.
- postgres.js writes a JS Date into `timestamp without time zone` by stripping the `Z` from `toISOString()`, so the stored naive clock is already UTC. Drop the `AT TIME ZONE 'UTC'` and just format the value with a literal `Z` — the wire value now matches what JS produced.
- `createNotifyTriggers()` runs at boot with `CREATE OR REPLACE FUNCTION`, so the fix applies on the next restart with no migration.

## Test plan

- [ ] Start a run and verify the live elapsed timer in `RunRow` matches wall-clock seconds (no multi-hour offset)
- [ ] After the run completes, refresh and confirm `run.duration` still displays correctly
- [ ] Reproduce on a non-UTC Postgres session to confirm the offset is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)