### PR TITLE
fix(web): unwrap list envelope on org CLI sessions admin page

### DIFF
--- a/apps/web/src/pages/org-settings/cli-sessions.tsx
+++ b/apps/web/src/pages/org-settings/cli-sessions.tsx
@@ -18,7 +18,9 @@ interface AdminCliSession extends CliSessionDisplay {
 }
 
 interface AdminCliSessionsResponse {
-  sessions: AdminCliSession[];
+  object: "list";
+  data: AdminCliSession[];
+  hasMore: boolean;
 }
 
 function memberLabel(s: AdminCliSession): string {
@@ -51,7 +53,7 @@ export function OrgSettingsCliSessionsPage() {
   if (isLoading) return <LoadingState />;
   if (error) return <ErrorState message={error.message} />;
 
-  const sessions = data?.sessions ?? [];
+  const sessions = data?.data ?? [];
 
   return (
     <>


### PR DESCRIPTION
## Summary

- The org admin tab **"Sessions CLI des membres"** (`/org-settings/cli-sessions`) always showed the empty state even when the org had active CLI sessions.
- Root cause: the page read `data.sessions` from the API response, but the route returns the Stripe-canonical envelope `{ object: "list", data, hasMore }` via `listResponse()` (`apps/api/src/lib/list-response.ts`). `data?.sessions` was always `undefined → []`.
- Sister page `/preferences/devices` was already aligned (`data?.data ?? []`) — only the org-admin variant was missed during the PR #299 list-envelope migration.

## Verification

Confirmed against a live local instance (PGlite, 2 active CLI sessions for the owner):

```sh
$ bunx appstrate api GET "/api/orgs/<orgId>/cli-sessions"
{"object":"list","data":[{"familyId":"crf_…",…},{"familyId":"crf_…",…}],"hasMore":false}
```

API returns 2 sessions, but the dashboard rendered `EmptyState`. After the fix, both sessions render in `CliSessionCard`s.

Audited the rest of `apps/web/src/` for the same pattern across all 37 `listResponse()` call sites and their consumers — no other instances. Helpers/hooks already unwrap correctly (`apiList<T>()`, `useProviders`, etc.).

## Test plan

- [ ] `appstrate login` against a local instance, then visit `/org-settings/cli-sessions` as an org admin → session(s) appear
- [ ] `bun run check` (turbo: tsc + eslint + prettier across all packages)
- [ ] Verify `/preferences/devices` still works (regression check on the sister page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)