### PR TITLE
refactor: extract RevealedSecret to dedupe secret-reveal pattern

### DIFF
--- a/apps/web/src/components/api-key-create-modal.tsx
+++ b/apps/web/src/components/api-key-create-modal.tsx
@@ -3,8 +3,8 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useForm, Controller } from "react-hook-form";
-import { useCopyToClipboard } from "../hooks/use-copy-to-clipboard";
 import { Modal } from "./modal";
+import { RevealedSecret } from "./revealed-secret";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -71,7 +71,6 @@ export function ApiKeyCreateModal({ open, onClose, onKeyCreated }: Props) {
   const [createdKey, setCreatedKey] = useState<string | null>(null);
   const [createdScopes, setCreatedScopes] = useState<string[]>([]);
   const [selectedScopes, setSelectedScopes] = useState<string[] | null>(null);
-  const { copied, copy } = useCopyToClipboard();
 
   const {
     register,
@@ -120,10 +119,6 @@ export function ApiKeyCreateModal({ open, onClose, onKeyCreated }: Props) {
 
   const onSubmit = handleSubmit(onFormSubmit);
 
-  const handleCopy = () => {
-    if (createdKey) copy(createdKey);
-  };
-
   // ── Success state ──
   if (createdKey) {
     const summary =
@@ -134,20 +129,7 @@ export function ApiKeyCreateModal({ open, onClose, onKeyCreated }: Props) {
 
     return (
       <Modal open={open} onClose={handleClose} title={t("apiKeys.created")} className="sm:max-w-lg">
-        <p className="text-warning bg-warning/10 rounded-md px-3 py-2 text-sm">
-          {t("apiKeys.createdWarning")}
-        </p>
-        <div className="border-border bg-muted/50 mt-3 flex items-center gap-2 rounded-md border px-3 py-2">
-          <code className="text-foreground flex-1 font-mono text-xs break-all">{createdKey}</code>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-primary shrink-0 text-xs hover:underline"
-            onClick={handleCopy}
-          >
-            {copied ? t("btn.copied") : t("btn.copy")}
-          </Button>
-        </div>
+        <RevealedSecret secret={createdKey} warning={t("apiKeys.createdWarning")} />
 
         {/* Scopes granted */}
         <div className="border-border mt-4 border-t pt-3">

--- a/apps/web/src/components/revealed-secret.tsx
+++ b/apps/web/src/components/revealed-secret.tsx
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTranslation } from "react-i18next";
+import { useCopyToClipboard } from "../hooks/use-copy-to-clipboard";
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  /** The secret value to reveal and copy. */
+  secret: string;
+  /** Warning banner shown above the secret box. */
+  warning: string;
+}
+
+/**
+ * Display a one-time-revealed secret (API key, webhook secret, ...) with a
+ * copy-to-clipboard button. The secret is shown verbatim — callers must only
+ * mount this component when they intend to reveal the value.
+ */
+export function RevealedSecret({ secret, warning }: Props) {
+  const { t } = useTranslation(["common"]);
+  const { copied, copy } = useCopyToClipboard();
+
+  return (
+    <>
+      <p className="text-warning bg-warning/10 rounded-md px-3 py-2 text-sm">{warning}</p>
+      <div className="border-border bg-muted/50 mt-3 flex items-center gap-2 rounded-md border px-3 py-2">
+        <code className="text-foreground flex-1 font-mono text-xs break-all">{secret}</code>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-primary shrink-0 text-xs hover:underline"
+          onClick={() => copy(secret)}
+        >
+          {copied ? t("common:btn.copied") : t("common:btn.copy")}
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/secret-reveal-modal.tsx
+++ b/apps/web/src/components/secret-reveal-modal.tsx
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Modal } from "./modal";
+import { RevealedSecret } from "./revealed-secret";
 import { Button } from "@/components/ui/button";
 
 interface Props {
@@ -14,37 +14,12 @@ interface Props {
 
 export function SecretRevealModal({ open, onClose, title, secret }: Props) {
   const { t } = useTranslation(["settings", "common"]);
-  const [copied, setCopied] = useState(false);
-
-  function handleCopy() {
-    navigator.clipboard.writeText(secret);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }
-
-  function handleClose() {
-    setCopied(false);
-    onClose();
-  }
 
   return (
-    <Modal open={open} onClose={handleClose} title={title}>
-      <p className="text-warning bg-warning/10 rounded-md px-3 py-2 text-sm">
-        {t("settings:webhooks.secretWarning")}
-      </p>
-      <div className="border-border bg-muted/50 mt-3 flex items-center gap-2 rounded-md border px-3 py-2">
-        <code className="text-foreground flex-1 font-mono text-xs break-all">{secret}</code>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="text-primary shrink-0 text-xs hover:underline"
-          onClick={handleCopy}
-        >
-          {copied ? t("common:btn.copied") : t("common:btn.copy")}
-        </Button>
-      </div>
+    <Modal open={open} onClose={onClose} title={title}>
+      <RevealedSecret secret={secret} warning={t("settings:webhooks.secretWarning")} />
       <div className="border-border mt-4 flex justify-end gap-2 border-t pt-4">
-        <Button onClick={handleClose}>{t("common:btn.done")}</Button>
+        <Button onClick={onClose}>{t("common:btn.done")}</Button>
       </div>
     </Modal>
   );


### PR DESCRIPTION
## Summary

After running a deep architectural audit (3 parallel Explore agents covering backend, frontend, runtime + cross-cutting), most findings turned out to be false positives or below the impact threshold on closer inspection. This PR ships the **one** legitimate simplification I could verify.

### Change

Both `SecretRevealModal` and `ApiKeyCreateModal` rendered an identical UI block (warning banner → monospace secret box → copy button), but with two different implementations of the copy state:

- `SecretRevealModal` inlined `useState(copied)` + `setTimeout` directly
- `ApiKeyCreateModal` used the existing `useCopyToClipboard()` hook

Extracted the shared block into a new `<RevealedSecret secret warning />` component. Both modals now share the same hook-backed implementation.

**Net diff:** +45 / −49 across 3 files (1 new component, 2 modals shrunk).

## Findings investigated and rejected

To be transparent, here is what was claimed by the audit agents but rejected after reading the actual code:

| Claim | Reality |
| --- | --- |
| `mcp-provider-resolver.ts` is dead code (~290 lines) | Imported by `mcp-direct.ts:31`, used at runtime |
| `extractManifestSchemas` is never imported (~20 lines) | Used by `agent-readiness.ts` and `env-builder.ts` |
| `useAppForm` is a useless wrapper | Has a real definition in `hooks/use-app-form.ts` (adds `showError` etc.) |
| Strip ~100 lines of pure re-exports from `shared-types` | Web doesn't depend on `@appstrate/db`; `shared-types` is the legitimate type bridge for the frontend |
| Inline ~60 lines of trivial mappers (`toOrgResult`, `toEndUserResponse`, `mapEnrichedRun`, etc.) | Each centralises ISO date conversion + null coalescing across 3–5 call sites; comments explicitly justify them as "single source of truth for the wire shape" |
| Consolidate 3 OIDC `mapRow()` helpers (~60 lines) | The shared work is just 2 lines of date conversion per helper; the bulk of each function is per-table field projection. `toISO` / `toISORequired` already exist for the date piece |
| `inline-manifest-validation.ts` duplicates `validateManifest` (~60 lines) | It calls `validateManifest()` once and adds 6 inline-specific layers (byte caps, dep counts, URI counts, wildcard rejection); the wrapper types are reasonable |
| `ModelFormFields` vs `ModelFormData` parallel types (~35 lines) | Deliberate boundary: `ModelFormFields` is the RHF form state (strings for `<input type=number>`, separate `inputText`/`inputImage` checkboxes); `ModelFormData` is the API contract (numbers, `input` array). Not duplication |
| `credential-proxy/core.ts` vs `runtime-pi/sidecar/credential-proxy.ts` duplicate ~350 lines | The shared primitives (`substituteVars`, `applyInjectedCredentialHeader`, `isBlockedUrl`, `matchesAuthorizedUri`, `PROVIDER_ID_RE`, …) are already extracted in `@appstrate/connect/proxy-primitives`. What remains is genuinely different orchestration: DB-direct credential resolution + single-attempt + force-refresh-on-401 vs HTTP credential fetch + retry-on-401 closure + auth-failure reporting. Not duplication |
| Modal `{ open, onClose }` Props in 12 files | Premature abstraction; the shared shape is two lines |
| Three `<Suspense fallback>` lazy patterns | Premature abstraction; <15 lines |
| Renamings (flow/run/execution, skill/tool/extension, connector/connection) | Cosmetic; no code deletion |

## Test plan

- [x] `bun run check` passes (turbo: typecheck + lint + format:check + verify:openapi + detect:breaking + build:system-packages:check)
- [x] Visual: open API key creation modal → secret reveal + copy state still works
- [x] Visual: open webhook secret reveal modal → secret reveal + copy state still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)