### PR TITLE
fix(db): journal entry for 0005_llm_usage was out of order

### DIFF
--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -40,7 +40,7 @@
     {
       "idx": 5,
       "version": "7",
-      "when": 1776957664000,
+      "when": 1777334500000,
       "tag": "0005_llm_usage",
       "breakpoints": true
     },


### PR DESCRIPTION
## Summary

Critical fix blocking v1.0.0-alpha.67 deploys against existing prod data. Migration 0005 was being silently skipped by drizzle's migrator due to an out-of-order \`when\` timestamp in \`_journal.json\`, causing the next migration that references \`llm_usage\` to fail with \`relation "llm_usage" does not exist\`.

## Root cause

drizzle-orm's PostgreSQL migrator compares each journal entry's \`folderMillis\` against the maximum \`created_at\` of the existing journal in the DB. The alpha.66 DB stored 0004's \`when=1777334400000\` as its last \`created_at\`. 0005's \`when=1776957664000\` was *before* that, so drizzle classified 0005 as "already applied" and skipped it.

## Fix

Bump 0005's \`when\` to 1777334500000 (between 0004 and 0006). Verified all 13 entries in core \`_journal.json\` now monotonic. The oidc, webhooks, and cloud journals were already monotonic — no other fixes needed.

## Why this wasn't caught earlier

- \`bun test\` runs against an empty DB, so all migrations apply cleanly regardless of journal order.
- \`bun run check\` doesn't simulate an alpha.66 → alpha.67 upgrade.
- This regression only surfaces when the DB has a populated journal whose max \`created_at\` lands between the out-of-order \`when\` and the next-correct \`when\`.

## Test plan

- [x] \`bun run check\` — green
- [x] Repro on real prod data: alpha.67 boot fails with \`llm_usage does not exist\` at 0008
- [ ] Re-deploy alpha.68 (with this fix) — boot to completion + all 8 new migrations applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)