### PR TITLE
fix(docker): pre-create writable .cache dirs for tool-bundler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,20 @@ COPY --from=build /app/apps/web/dist ./apps/web/dist
 # Create mount points for runtime volumes (data + storage)
 RUN mkdir -p data storage && chown -R bun:bun data storage
 
+# `@appstrate/core/tool-bundler` writes scratch builds to
+# `node_modules/.cache/afps-bundler/` so Bun.build resolves
+# bare-specifier imports (ajv, zod, …) against the caller's dep
+# graph. Default permissions on COPYed node_modules belong to root,
+# so the unprivileged `bun` user can't mkdir there. Pre-create the
+# `.cache` dir owned by `bun` for every workspace whose
+# node_modules tree is on the runtime image.
+RUN for ws in packages/core packages/connect packages/db packages/env \
+              packages/shared-types packages/afps-runtime packages/runner-pi \
+              apps/api; do \
+      mkdir -p /app/$ws/node_modules/.cache; \
+    done \
+ && chown -R bun:bun /app/packages /app/apps/api/node_modules
+
 # Root package.json needed for workspace resolution
 COPY --from=build /app/package.json ./
 COPY --from=build /app/system-packages ./system-packages


### PR DESCRIPTION
## Summary

Hot fix blocking v1.0.0-alpha.67/68 in production. \`POST /api/agents/.../run\` returns 500 with:

\`\`\`
EACCES: permission denied, mkdir '/app/packages/core/node_modules/.cache'
\`\`\`

## Root cause

\`@appstrate/core/tool-bundler\` (introduced in PR #227, post-alpha.66) writes scratch builds to \`node_modules/.cache/afps-bundler/\` so \`Bun.build\` resolves bare-specifier imports against the caller's dep graph. The walk-up resolver lands on \`/app/packages/core/node_modules/\` first, but the runtime image's node_modules trees are COPYed in as root — the unprivileged \`bun\` user can't \`mkdir\` there.

This is invisible locally (\`bun run dev\` uses the developer's own UID, which owns everything in the monorepo) and only surfaces in Docker prod with the runtime user/COPY-as-root combination.

## Fix

- Pre-create \`.cache/\` under each workspace's node_modules on the runtime image, owned by \`bun\`.
- \`chown -R bun:bun /app/packages /app/apps/api/node_modules\` so any future writes under those trees also work.

## Test

\`\`\`sh
docker build -t test .
docker run --rm --user bun --entrypoint sh test -c \\
  'mkdir -p /app/packages/core/node_modules/.cache/afps-bundler && echo OK'
# → OK
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)