### PR TITLE
fix(runner-pi): expose canonical body union in provider_call schema

### DIFF
--- a/packages/afps-runtime/src/resolvers/index.ts
+++ b/packages/afps-runtime/src/resolvers/index.ts
@@ -53,6 +53,7 @@ export {
   matchesAuthorizedUriSpec,
   readProviderMeta,
   isReproducibleBody,
+  providerCallRequestJsonSchema,
   resolveBodyForFetch,
   resolveBodyStream,
   resolveSafePath,

--- a/packages/afps-runtime/src/resolvers/provider-tool.ts
+++ b/packages/afps-runtime/src/resolvers/provider-tool.ts
@@ -189,6 +189,22 @@ export const providerCallRequestSchema = z.object({
 });
 
 /**
+ * JSON schema for `provider_call` arguments — derived once from
+ * `providerCallRequestSchema`. Exported so non-Zod consumers (notably
+ * `@appstrate/runner-pi`'s container-mode dispatcher, which composes its
+ * own parameters object around a `providerId` enum) can paste in the
+ * canonical discriminated body / responseMode shapes without re-deriving
+ * them. Without this, the LLM-facing schema for `body` is `{}` (any) and
+ * models routinely JSON-stringify object bodies — `{ fromFile: "x" }`
+ * arrives as a string, resolveBodyForFetch's file-reading branch never
+ * runs, and the literal `{"fromFile":"x"}` is forwarded upstream as the
+ * request body.
+ */
+export const providerCallRequestJsonSchema: JSONSchema = z.toJSONSchema(providerCallRequestSchema, {
+  target: "draft-7",
+}) as JSONSchema;
+
+/**
  * Runtime projection of the provider manifest — a flat view over the
  * subset of fields that `makeProviderTool` actually consumes. The
  * canonical wire shape nests these fields under `definition.*` per AFPS
@@ -427,14 +443,9 @@ export function makeProviderTool(
       `Pass binary uploads via { fromFile } and route binary downloads via responseMode.toFile — ` +
       `inline bytes are decoded as text and bloat the LLM context.`;
 
-  // Generate the JSON schema from the Zod definition — single source of truth.
-  // target: "draft-7" matches AJV's validator (used for dynamic manifest schemas
-  // elsewhere) and produces the same structural shape as the former hand-written
-  // schema. Post-processing adds "description" fields already carried in the Zod
-  // definitions via .describe().
-  const parameters: JSONSchema = z.toJSONSchema(providerCallRequestSchema, {
-    target: "draft-7",
-  }) as JSONSchema;
+  // Generate the JSON schema from the Zod definition — single source of
+  // truth, computed once at module load via providerCallRequestJsonSchema.
+  const parameters = providerCallRequestJsonSchema;
 
   const emit = opts.emitProviderEvent ?? true;
 

--- a/packages/runner-pi/src/provider-bridge.ts
+++ b/packages/runner-pi/src/provider-bridge.ts
@@ -15,12 +15,24 @@
 import { Type } from "@mariozechner/pi-ai";
 import type { ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import type { Bundle } from "@appstrate/afps-runtime/bundle";
-import type {
-  ProviderRef,
-  ProviderResolver,
-  Tool as AfpsTool,
-  ToolContext as AfpsToolContext,
+import {
+  providerCallRequestJsonSchema,
+  type ProviderRef,
+  type ProviderResolver,
+  type Tool as AfpsTool,
+  type ToolContext as AfpsToolContext,
 } from "@appstrate/afps-runtime/resolvers";
+
+// Pull body + responseMode JSON schemas from the canonical AFPS source so
+// the LLM-facing schema documents the discriminated body union (string |
+// { fromFile } | { fromBytes } | { multipart }). With `body: {}` the LLM
+// has zero shape guidance and tends to JSON-stringify object bodies —
+// `{ fromFile: "x" }` arrives as a string and the resolver's file-reading
+// branch never runs, so the literal `'{"fromFile":"x"}'` is sent upstream.
+const SCHEMA_PROPERTIES =
+  (providerCallRequestJsonSchema as { properties?: Record<string, unknown> }).properties ?? {};
+const BODY_SCHEMA = SCHEMA_PROPERTIES.body ?? {};
+const RESPONSE_MODE_SCHEMA = SCHEMA_PROPERTIES.responseMode ?? {};
 
 export type ProviderEventEmitter = (event: { type: string; [k: string]: unknown }) => void;
 
@@ -97,8 +109,8 @@ function makeProviderCallExtension(
             enum: ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD"],
           },
           headers: { type: "object", additionalProperties: { type: "string" } },
-          body: {},
-          responseMode: {},
+          body: BODY_SCHEMA,
+          responseMode: RESPONSE_MODE_SCHEMA,
           substituteBody: { type: "boolean" },
         },
       }),

--- a/packages/runner-pi/test/provider-bridge.test.ts
+++ b/packages/runner-pi/test/provider-bridge.test.ts
@@ -123,6 +123,34 @@ describe("buildProviderCallExtensionFactory", () => {
     expect(params.properties.providerId.enum).toEqual(["@appstrate/gmail", "@appstrate/clickup"]);
   });
 
+  it("exposes the canonical body union schema (string | fromFile | fromBytes | multipart)", async () => {
+    // Regression: a `body: {}` (any) schema gives the LLM no shape
+    // guidance, so models JSON-stringify object bodies. `{ fromFile: "x" }`
+    // then arrives as a string and resolveBodyForFetch's file-reading
+    // branch is skipped — the literal `{"fromFile":"x"}` is forwarded
+    // upstream verbatim. The fix is to surface the canonical AFPS body
+    // union JSON schema so the LLM picks the right shape.
+    const factories = await buildProviderCallExtensionFactory({
+      bundle: makeBundle({ "@appstrate/gmail": "1" }),
+      providerResolver: makeResolver({
+        "@appstrate/gmail": makeAfpsTool("appstrate_gmail_call", async () => ({ ok: true })),
+      }),
+      runId: "r",
+      workspace: "/w",
+      emitProvider: () => {},
+    });
+    const { api, tools } = makeFakePi();
+    factories[0]!(api);
+    const params = tools[0]!.parameters as {
+      properties: { body: unknown; responseMode: unknown };
+    };
+    const bodyJson = JSON.stringify(params.properties.body);
+    expect(bodyJson).toContain("fromFile");
+    expect(bodyJson).toContain("fromBytes");
+    expect(bodyJson).toContain("multipart");
+    expect(JSON.stringify(params.properties.responseMode)).toContain("toFile");
+  });
+
   it("dispatches by providerId, stripping it from the forwarded params", async () => {
     const seen: Array<{ tool: string; params: unknown }> = [];
     const factories = await buildProviderCallExtensionFactory({


### PR DESCRIPTION
## Summary

- The container-mode `provider_call` Pi tool declared `body: {}` (any) on its parameters schema, leaving the LLM no shape guidance for the body union. Models routinely JSON-stringified object bodies, so `body: { fromFile: "documents/x.xlsx" }` arrived as the literal string `'{"fromFile":"documents/x.xlsx"}'` — `resolveBodyForFetch`'s file-reading branch never ran and the JSON envelope was forwarded upstream as the request body.
- Surfaces the canonical AFPS schema (`providerCallRequestJsonSchema`) on the runner-pi tool so the LLM sees the discriminated body union (`string | { fromFile } | { fromBytes } | { multipart }`) and picks the right shape. CLI mode already exposed this schema via `makeProviderTool`; container mode is now consistent.
- Adds a regression test asserting the body schema documents `fromFile`, `fromBytes`, `multipart`, and that responseMode documents `toFile`.

## Why tests didn't catch this

Existing tests (e.g. `runtime-pi/test/mcp-provider-resolver.test.ts:137`) call `tool.execute({ body: { fromFile: "image.jpg" } })` directly with an object literal — they bypass the LLM JSON-encoding step. Real-world failure mode: agents using Google Drive `uploadType=media` with `{ fromFile }` get the JSON envelope uploaded instead of the file bytes.

## Test plan

- [x] `bun test packages/afps-runtime/test/resolvers/provider-tool.test.ts packages/runner-pi/test runtime-pi/test/mcp-direct.test.ts runtime-pi/test/mcp-provider-resolver.test.ts` — 122 pass
- [x] `bun run check` — all packages green, prettier clean
- [ ] Smoke test on prod after alpha.70 deploy: re-run an agent that uploads via `body: { fromFile: ... }`

🤖 Generated with [Claude Code](https://claude.com/claude-code)