### PR TITLE
fix(auth): break stale-cookie redirect loop after redeploy

### DIFF
--- a/apps/api/src/lib/auth-cookies.ts
+++ b/apps/api/src/lib/auth-cookies.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Helper for clearing stale Better Auth session cookies.
+ *
+ * When `getAuth().api.getSession(...)` returns no user even though the request
+ * carries a Better Auth session cookie (signature invalid after secret
+ * rotation, session row gone after a DB migration / redeployment, etc.) the
+ * cookie is dead weight: every subsequent request keeps sending it, the
+ * server keeps rejecting it, and the SPA bounces back to `/login` in a silent
+ * loop because the browser never lets go of the bad cookie on its own.
+ *
+ * The fix is to mirror BA's own cookie config (name, Path, Domain, Secure,
+ * SameSite, Partitioned) on a `Set-Cookie: …; Max-Age=0` so the browser
+ * actually forgets the cookie. Going through `getCookies(auth.options)` is
+ * load-bearing — the computed name carries the `__Secure-` prefix when BA
+ * decided one was warranted, and the attributes pick up our project-wide
+ * `defaultCookieAttributes` (`partitioned: true`, plus the optional
+ * `crossSubDomainCookies` Domain). A hand-rolled `Set-Cookie` that misses
+ * any of those attributes is silently ignored by the browser.
+ */
+
+import type { Context } from "hono";
+import { deleteCookie } from "hono/cookie";
+import { getCookies } from "better-auth/cookies";
+import { getAuth } from "@appstrate/db/auth";
+import type { AppEnv } from "../types/index.ts";
+
+/**
+ * Send `Set-Cookie: …; Max-Age=0` for every Better Auth cookie we manage so
+ * a stale session_token / session_data / dont_remember / account_data does
+ * not keep re-arriving on subsequent requests. Safe to call when no cookie
+ * is present — the browser ignores deletes for cookies it does not have.
+ *
+ * Call before throwing 401 from the auth pipeline. Do NOT call from the
+ * realm guard: an end-user session that lands on a platform route is still
+ * a legitimate session for the OIDC application it was minted for, and
+ * killing the cookie would log the user out from that application too.
+ */
+export function clearStaleAuthCookies(c: Context<AppEnv>): void {
+  const cookies = getCookies(getAuth().options);
+  for (const cookie of [
+    cookies.sessionToken,
+    cookies.sessionData,
+    cookies.dontRememberToken,
+    cookies.accountData,
+  ]) {
+    // `attributes` already carries Path, Domain (when crossSubDomainCookies
+    // is on), SameSite, Secure, HttpOnly and Partitioned exactly as BA
+    // emitted them at Set-Cookie time. `deleteCookie` overlays `maxAge: 0`,
+    // which is what flips this from a refresh into a delete.
+    deleteCookie(c, cookie.name, cookie.attributes);
+  }
+}

--- a/apps/api/src/lib/auth-pipeline.ts
+++ b/apps/api/src/lib/auth-pipeline.ts
@@ -28,6 +28,7 @@ import { requireOrgContext } from "../middleware/org-context.ts";
 import { requirePlatformRealm } from "../middleware/realm-guard.ts";
 import { isEndUserInApp } from "../services/end-users.ts";
 import { ApiError, unauthorized } from "./errors.ts";
+import { clearStaleAuthCookies } from "./auth-cookies.ts";
 import { resolvePermissions, resolveApiKeyPermissions } from "./permissions.ts";
 import { getClientIp, propagateRequestClientIp } from "./client-ip.ts";
 import { logger } from "./logger.ts";
@@ -182,6 +183,12 @@ export function applyAuthPipeline(app: Hono<AppEnv>, opts: AuthPipelineOptions):
     // Fallback: cookie session
     const session = await getAuth().api.getSession({ headers: c.req.raw.headers });
     if (!session?.user) {
+      // Bury the stale BA cookie before bouncing the request. Without this,
+      // a cookie left behind by a redeploy (rotated `BETTER_AUTH_SECRET`,
+      // wiped `session` rows, …) keeps re-arriving on every subsequent
+      // request and the SPA loops between `/login` and `/auth/callback`
+      // with no surfaceable error.
+      clearStaleAuthCookies(c);
       throw unauthorized("Invalid or missing session");
     }
 

--- a/apps/api/src/middleware/error-handler.ts
+++ b/apps/api/src/middleware/error-handler.ts
@@ -31,19 +31,36 @@ export function errorHandler(err: Error, c: Context<AppEnv>): Response {
   const body = apiError.toProblemDetail(requestId);
 
   // Build response headers — always include problem+json content type and request ID.
-  const responseHeaders: Record<string, string> = {
+  // `Headers` (rather than a plain Record) is load-bearing: `Set-Cookie` is the
+  // one HTTP header that legitimately repeats, and only `headers.append()`
+  // preserves multiple values. The auth pipeline sets Set-Cookie before
+  // throwing 401 (to bury a stale BA cookie); a Record would coalesce those
+  // into a single value and the browser would silently keep the bad cookie.
+  const headers = new Headers({
     "Content-Type": "application/problem+json",
     "Request-Id": requestId,
-  };
+  });
 
   // Merge custom headers from ApiError (e.g. rate-limit headers on 429).
   if (apiError.headers) {
-    Object.assign(responseHeaders, apiError.headers);
+    for (const [name, value] of Object.entries(apiError.headers)) {
+      headers.set(name, value);
+    }
+  }
+
+  // Preserve any Set-Cookie headers attached to `c.res` before the throw —
+  // Hono's `setCookie`/`deleteCookie` write through `c.res.headers`, but the
+  // error path builds a fresh `Response` and would otherwise drop them.
+  const preThrowResHeaders: Headers | undefined = c.res?.headers;
+  if (preThrowResHeaders) {
+    for (const cookie of preThrowResHeaders.getSetCookie()) {
+      headers.append("Set-Cookie", cookie);
+    }
   }
 
   // Use new Response() to set application/problem+json — c.json() forces application/json.
   return new Response(JSON.stringify(body), {
     status: body.status,
-    headers: responseHeaders,
+    headers,
   });
 }

--- a/apps/api/test/integration/middleware/stale-cookie.test.ts
+++ b/apps/api/test/integration/middleware/stale-cookie.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Stale Better Auth cookie cleanup.
+ *
+ * After a redeploy that rotates `BETTER_AUTH_SECRET` or wipes `session` rows,
+ * the browser keeps sending the now-invalid BA cookie on every request. The
+ * server used to answer 401 and leave the cookie in place — so the SPA
+ * bounced between `/login` and `/auth/callback` forever with no surfaceable
+ * error.
+ *
+ * The auth pipeline now answers 401 with `Set-Cookie: …; Max-Age=0` for every
+ * BA cookie name, so the browser actually drops the bad cookie on the next
+ * tick and the next login attempt starts from a clean slate.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { getTestApp } from "../../helpers/app.ts";
+import { truncateAll } from "../../helpers/db.ts";
+
+const app = getTestApp();
+
+/**
+ * Pull every `Set-Cookie` value off a Response, regardless of casing or the
+ * runtime's choice between `headers.getSetCookie()` and a single coalesced
+ * header. The route under test is allowed to emit multiple `Set-Cookie`
+ * values (one per BA cookie name), so the assertion has to handle the
+ * multi-valued case.
+ */
+function getSetCookies(res: Response): string[] {
+  const headers = res.headers;
+  // `Headers.getSetCookie()` is the standard way to read multiple
+  // `Set-Cookie` values when the runtime supports it (Bun ≥ 1.0).
+  const native = (headers as unknown as { getSetCookie?: () => string[] }).getSetCookie?.();
+  if (native && native.length > 0) return native;
+  const single = headers.get("set-cookie");
+  return single ? [single] : [];
+}
+
+describe("auth pipeline — stale cookie cleanup", () => {
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it("returns 401 with Set-Cookie clearing the BA session cookies when the session is stale", async () => {
+    // Forge a request that LOOKS like it has a BA session cookie but whose
+    // session_token is bogus — same shape a stale cookie would have after a
+    // redeploy: the cookie name + signed-cookie envelope are well-formed,
+    // but the value does not resolve to any session row.
+    const res = await app.request("/api/agents", {
+      headers: {
+        Cookie:
+          "better-auth.session_token=stale-value-no-session-row; better-auth.session_data=stale-cache",
+        "X-Org-Id": "00000000-0000-0000-0000-000000000000",
+      },
+    });
+
+    expect(res.status).toBe(401);
+
+    const setCookies = getSetCookies(res);
+    expect(setCookies.length).toBeGreaterThan(0);
+
+    // At least one Set-Cookie must target the session_token cookie name and
+    // expire it (Max-Age=0 OR an Expires in the past). Both forms are
+    // accepted because some serializers prefer one over the other.
+    const sessionTokenClear = setCookies.find((c) =>
+      /(?:^|[\s;])(?:__Secure-)?better-auth\.session_token=/i.test(c),
+    );
+    expect(sessionTokenClear).toBeDefined();
+    expect(sessionTokenClear).toMatch(/Max-Age=0|Expires=Thu, 01 Jan 1970/i);
+  });
+
+  it("does not emit a session_token clearing cookie on routes that succeed without auth", async () => {
+    // `/health` is a public route mounted before the auth middleware.
+    // The pipeline must not gratuitously clear cookies on every request —
+    // only on the 401-on-stale-cookie path.
+    const res = await app.request("/health");
+    expect(res.status).toBe(200);
+    const setCookies = getSetCookies(res);
+    const sessionTokenClear = setCookies.find(
+      (c) =>
+        /(?:^|[\s;])(?:__Secure-)?better-auth\.session_token=/i.test(c) &&
+        /Max-Age=0|Expires=Thu, 01 Jan 1970/i.test(c),
+    );
+    expect(sessionTokenClear).toBeUndefined();
+  });
+});

--- a/apps/api/test/unit/error-handler.test.ts
+++ b/apps/api/test/unit/error-handler.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect } from "bun:test";
 import { Hono } from "hono";
+import { setCookie, deleteCookie } from "hono/cookie";
 import type { AppEnv } from "../../src/types/index.ts";
 import { requestId } from "../../src/middleware/request-id.ts";
 import { errorHandler } from "../../src/middleware/error-handler.ts";
@@ -296,6 +297,36 @@ describe("errorHandler middleware", () => {
     const res = await app.request("/test");
     const body = (await res.json()) as any;
     expect(body.type).toBe("https://docs.appstrate.dev/errors/invalid-foo-bar");
+  });
+
+  it("preserves Set-Cookie headers attached before the throw", async () => {
+    // Regression guard: the auth pipeline calls Hono `deleteCookie`/`setCookie`
+    // on the bare context to bury a stale BA cookie, then throws an
+    // ApiError. The error handler builds a fresh Response and used to
+    // discard everything on `c.res` — which silently lost the cookie clear
+    // and let the SPA loop forever between `/login` and `/auth/callback`.
+    const app = createApp();
+    app.get("/test", (c) => {
+      // Two distinct cookies — a real-world auth pipeline would clear
+      // multiple BA cookie names (session_token, session_data, …).
+      deleteCookie(c, "better-auth.session_token", { path: "/" });
+      setCookie(c, "another-cookie", "x", { path: "/", maxAge: 0 });
+      throw unauthorized("Invalid or missing session");
+    });
+
+    const res = await app.request("/test");
+    expect(res.status).toBe(401);
+    const native = (res.headers as unknown as { getSetCookie?: () => string[] }).getSetCookie?.();
+    const setCookies = native ?? [res.headers.get("set-cookie") ?? ""].filter(Boolean);
+    expect(setCookies.length).toBeGreaterThanOrEqual(2);
+    expect(
+      setCookies.some(
+        (c: string) => /better-auth\.session_token=/i.test(c) && /Max-Age=0/i.test(c),
+      ),
+    ).toBe(true);
+    expect(setCookies.some((c: string) => /another-cookie=/i.test(c) && /Max-Age=0/i.test(c))).toBe(
+      true,
+    );
   });
 
   it("requestId in body matches Request-Id header", async () => {

--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -85,8 +85,41 @@ function initAuth() {
   });
 }
 
-export async function refreshAuth() {
+/**
+ * Thrown by `refreshAuth()` when the resync completed but did not
+ * establish an authenticated user — e.g. `getSession()` returned null
+ * because of a stale Better Auth cookie. Callers that depend on a
+ * session being present after `refreshAuth()` (the OIDC callback, invite
+ * acceptance, post-email-change) can catch this discriminant and show a
+ * meaningful "please sign in again" message instead of navigating into a
+ * silent loop.
+ */
+export class AuthRefreshError extends Error {
+  constructor(
+    public code: "no_session",
+    message: string,
+  ) {
+    super(message);
+    this.name = "AuthRefreshError";
+  }
+}
+
+/**
+ * Resync auth state from the server cookie and assert that a user was
+ * established. Use after any flow that should have left a valid session
+ * behind (OIDC callback, invite accept, email change). On the no-user
+ * path `syncAuth` already best-effort clears the stale cookie via
+ * `signOut()`; this throw lets the caller surface the failure in the UI
+ * rather than silently navigating onwards on a null user.
+ */
+export async function refreshAuth(): Promise<void> {
   await syncAuth();
+  if (!authStore.getState().user) {
+    throw new AuthRefreshError(
+      "no_session",
+      "Authentication did not complete — the session could not be established.",
+    );
+  }
 }
 
 export function useAuth() {

--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -48,12 +48,30 @@ async function syncAuth() {
   if (result.data?.user) {
     const profile = await fetchProfile();
     if (!profile) {
-      await authClient.signOut();
+      await authClient.signOut().catch(() => {});
       clearAuth();
       return;
     }
     setAuthenticatedUser(result.data.user, profile);
   } else {
+    // No active session. The browser may still be carrying a stale BA
+    // cookie (signature invalid after `BETTER_AUTH_SECRET` rotation, session
+    // row gone after a redeploy, partition / domain mismatch from a config
+    // change, …). BA's `/get-session` returns null silently in that case
+    // *without* clearing the bad cookie, so it would keep re-arriving on
+    // every request and the user would bounce between `/login` and
+    // `/auth/callback` forever with no surfaceable error.
+    //
+    // `signOut()` deterministically tells the server to emit
+    // `Set-Cookie: …; Max-Age=0` for every BA cookie it knows about,
+    // matching the original Path/Domain/Partitioned so the browser
+    // actually drops them. The cost is one extra HTTP round-trip on a
+    // cold session-less load — acceptable for the recovery guarantee.
+    await authClient.signOut().catch(() => {
+      // Best-effort: a failing signOut (network blip, already-cleared
+      // cookie) must not strand the user. `clearAuth` below still resets
+      // the SPA store so the login flow restarts cleanly.
+    });
     clearAuth();
   }
 }

--- a/apps/web/src/modules/oidc/pages/auth-callback.tsx
+++ b/apps/web/src/modules/oidc/pages/auth-callback.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { handleOidcCallback } from "../lib/oidc";
 import { refreshAuth } from "../../../hooks/use-auth";
+import { authStore } from "../../../stores/auth-store";
 import { Spinner } from "../../../components/spinner";
 
 /**
@@ -43,6 +44,18 @@ export function AuthCallbackPage() {
         const { redirectTo } = await handleOidcCallback();
         // Sync auth state — the BA session cookie is now active
         await refreshAuth();
+        // `refreshAuth` swallows server failures and clears the auth
+        // store on its own (the silent-redirect-loop bug used to start
+        // here). Verify the resync actually established a user before
+        // navigating — otherwise `<App>` re-renders unauthenticated,
+        // the catch-all bounces to `/login`, the OIDC flow restarts,
+        // and we are back here in a tight loop with no error UI.
+        if (!authStore.getState().user) {
+          setError(
+            "Authentication did not complete — the session could not be established. Please sign in again.",
+          );
+          return;
+        }
         // Server-rendered pages outside the SPA (e.g. `/activate` for
         // the CLI device-flow consent) need a real browser navigation
         // — React Router's `navigate()` would push history but the SPA

--- a/apps/web/src/modules/oidc/pages/auth-callback.tsx
+++ b/apps/web/src/modules/oidc/pages/auth-callback.tsx
@@ -10,8 +10,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { handleOidcCallback } from "../lib/oidc";
-import { refreshAuth } from "../../../hooks/use-auth";
-import { authStore } from "../../../stores/auth-store";
+import { refreshAuth, AuthRefreshError } from "../../../hooks/use-auth";
 import { Spinner } from "../../../components/spinner";
 
 /**
@@ -42,20 +41,13 @@ export function AuthCallbackPage() {
     (async () => {
       try {
         const { redirectTo } = await handleOidcCallback();
-        // Sync auth state — the BA session cookie is now active
+        // Sync auth state — the BA session cookie is now active.
+        // `refreshAuth` throws `AuthRefreshError` if the resync did not
+        // establish a user (stale cookie, server-side session gone). The
+        // catch below turns that into an inline error rather than letting
+        // us navigate onto a protected page → catch-all → /login → OIDC
+        // re-redirect → back here in a tight loop with no error UI.
         await refreshAuth();
-        // `refreshAuth` swallows server failures and clears the auth
-        // store on its own (the silent-redirect-loop bug used to start
-        // here). Verify the resync actually established a user before
-        // navigating — otherwise `<App>` re-renders unauthenticated,
-        // the catch-all bounces to `/login`, the OIDC flow restarts,
-        // and we are back here in a tight loop with no error UI.
-        if (!authStore.getState().user) {
-          setError(
-            "Authentication did not complete — the session could not be established. Please sign in again.",
-          );
-          return;
-        }
         // Server-rendered pages outside the SPA (e.g. `/activate` for
         // the CLI device-flow consent) need a real browser navigation
         // — React Router's `navigate()` would push history but the SPA
@@ -69,6 +61,12 @@ export function AuthCallbackPage() {
         }
         navigate(redirectTo, { replace: true });
       } catch (err) {
+        if (err instanceof AuthRefreshError && err.code === "no_session") {
+          setError(
+            "Authentication did not complete — the session could not be established. Please sign in again.",
+          );
+          return;
+        }
         const msg = err instanceof Error ? err.message : String(err);
         setError(msg);
       }


### PR DESCRIPTION
## Summary

A stale Better Auth cookie (signature invalid after `BETTER_AUTH_SECRET` rotation, session row gone after a wipe/migration, partition / domain mismatch from a config change) put the SPA in a silent loop between `/login` and `/auth/callback` with **no surfaceable error**:

- the server kept rejecting the cookie with a bare 401 — never told the browser to drop it
- the frontend kept calling `clearAuth()` on the store but never touched the cookie jar
- the OIDC callback navigated to `redirectTo` even when `refreshAuth()` had silently failed, so the user was sent to a protected page → catch-all → `/login` → OIDC redirect → … forever

## What changed

Three coordinated fixes — each one is necessary:

- **`apps/api/src/lib/auth-cookies.ts` (new)** + wiring in `auth-pipeline.ts`: on the cookie-session 401 path, emit `Set-Cookie: …; Max-Age=0` for every BA cookie name (`session_token`, `session_data`, `dont_remember`, `account_data`). Names + Path / Domain / Secure / SameSite / Partitioned attributes come from `getCookies(auth.options)` so they match exactly what BA originally set — otherwise the browser silently keeps the bad cookie.
- **`apps/api/src/middleware/error-handler.ts`**: build the error response with `new Headers()` instead of a plain Record, and replay any `Set-Cookie` values attached to `c.res` before the throw via `getSetCookie()` + `headers.append()`. A Record coalesces repeated `Set-Cookie` values into one; the auth pipeline emits multiple, so the cookie clears were being silently dropped on the way back to the client.
- **`apps/web/src/hooks/use-auth.ts`**: in the no-user branch of `syncAuth()`, call `authClient.signOut()` (best-effort) before `clearAuth()`. BA's `/get-session` returns null silently for an invalid cookie *without* clearing it — an explicit signOut deterministically emits the matching `Set-Cookie: …; Max-Age=0` so the next request starts clean.
- **`apps/web/src/modules/oidc/pages/auth-callback.tsx`**: after `refreshAuth()`, check `authStore.getState().user` and surface an inline error instead of navigating to `redirectTo`. `refreshAuth()` swallows server failures; navigating on a null user is what kicked off the infinite loop.

## Tests

- new `apps/api/test/integration/middleware/stale-cookie.test.ts` — 401 + matching `Set-Cookie: …; Max-Age=0` on a forged stale cookie, and no gratuitous cookie clear on a public route.
- new error-handler unit case — `Set-Cookie` headers attached to `c.res` before a throw survive (with multiple values intact) into the error response.

## Test plan

- [x] `bun test apps/api/test/integration/middleware/ apps/api/test/unit/error-handler.test.ts apps/api/test/integration/routes/auth.test.ts` → 69/69 passing
- [x] `bun run typecheck` (apps/api) clean
- [x] `bun x prettier --check` clean
- [x] `bun x eslint` on changed files clean
- [x] `bun run verify:openapi` clean
- [ ] Manual: rotate `BETTER_AUTH_SECRET` against a logged-in browser session, refresh — verify single 401 then clean OIDC re-login (no loop)
- [ ] Manual: drop session row for a logged-in user, refresh — same