### PR TITLE
fix(afps-runtime): allow contentType on multipart text parts

### DIFF
--- a/packages/afps-runtime/src/resolvers/provider-tool.ts
+++ b/packages/afps-runtime/src/resolvers/provider-tool.ts
@@ -108,6 +108,7 @@ const fromBytesBodySchema = z.object({
 const multipartTextPartSchema = z.object({
   name: z.string(),
   value: z.string(),
+  contentType: z.string().optional(),
 });
 
 const multipartFilePartSchema = z.object({
@@ -791,8 +792,16 @@ async function buildMultipartBytes(
   for (const part of parts) {
     if ("value" in part) {
       // Plain text field — byte-count via Buffer.byteLength so multi-byte
-      // Unicode characters (emoji, CJK, …) are counted correctly.
-      fd.append(part.name, part.value);
+      // Unicode characters (emoji, CJK, …) are counted correctly. When the
+      // caller supplies an explicit contentType (e.g. JSON metadata for
+      // Drive resumable upload), wrap the value in a Blob so FormData
+      // emits the correct `Content-Type` part header instead of defaulting
+      // to `text/plain`.
+      if (part.contentType) {
+        fd.append(part.name, new Blob([part.value], { type: part.contentType }));
+      } else {
+        fd.append(part.name, part.value);
+      }
       totalSize += Buffer.byteLength(part.value, "utf8");
     } else if ("fromFile" in part) {
       // Workspace file reference.

--- a/packages/afps-runtime/test/resolvers/provider-tool-schema.test.ts
+++ b/packages/afps-runtime/test/resolvers/provider-tool-schema.test.ts
@@ -110,6 +110,36 @@ describe("providerCallRequestSchema — valid inputs", () => {
     expect(body.multipart).toHaveLength(1);
   });
 
+  it("parses a multipart text part with explicit contentType (Drive metadata pattern)", () => {
+    // Google Drive multipart resumable upload requires the JSON metadata
+    // part to carry `Content-Type: application/json` — without this knob
+    // callers had to base64-encode the JSON via `fromBytes`.
+    const result = providerCallRequestSchema.safeParse({
+      method: "POST",
+      target: "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart",
+      body: {
+        multipart: [
+          {
+            name: "metadata",
+            value: '{"name":"file.xlsx","parents":["folder123"]}',
+            contentType: "application/json; charset=UTF-8",
+          },
+          {
+            name: "media",
+            fromFile: "out.xlsx",
+            contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          },
+        ],
+      },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    const body = result.data.body as {
+      multipart: Array<{ name: string; value?: string; contentType?: string }>;
+    };
+    expect(body.multipart[0]?.contentType).toBe("application/json; charset=UTF-8");
+  });
+
   it("parses a multipart body mixing text + file + bytes parts", () => {
     const result = providerCallRequestSchema.safeParse({
       method: "POST",

--- a/runtime-pi/test/mcp-provider-resolver.test.ts
+++ b/runtime-pi/test/mcp-provider-resolver.test.ts
@@ -219,6 +219,100 @@ describe("McpProviderResolver — body forwarding", () => {
     }
   });
 
+  it("emits explicit Content-Type on a multipart text part (Drive metadata pattern)", async () => {
+    // Drive multipart upload requires the metadata part to carry
+    // `Content-Type: application/json`. The text part schema accepts an
+    // optional `contentType` so callers do not have to base64-encode the
+    // JSON via `fromBytes` just to set the part header.
+    const { pair, mcp, captured } = await makeServer({});
+    try {
+      const resolver = new McpProviderResolver(mcp);
+      const [tool] = await resolver.resolve(
+        [{ name: "@test/echo", version: "^1.0.0" }],
+        makeBundle(),
+      );
+      const workspace = mkdtempSync(join(tmpdir(), "mcp-resolver-"));
+      writeFileSync(join(workspace, "out.xlsx"), "binary-bytes");
+
+      await tool!.execute(
+        {
+          method: "POST",
+          target: "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart",
+          body: {
+            multipart: [
+              {
+                name: "metadata",
+                value: '{"name":"file.xlsx"}',
+                contentType: "application/json; charset=UTF-8",
+              },
+              {
+                name: "media",
+                fromFile: "out.xlsx",
+                contentType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+              },
+            ],
+          },
+        },
+        ctxBase(workspace),
+      );
+
+      const arg = captured.arguments as {
+        body?: { fromBytes: string; encoding: string };
+      };
+      const decoded = Buffer.from(arg.body!.fromBytes, "base64").toString("utf-8");
+      // Metadata text part carries the requested JSON content-type instead
+      // of FormData's default `text/plain`. Bun's FormData lowercases the
+      // charset value and adds a stub `filename=""` for Blob-wrapped
+      // values — Drive's resumable upload tolerates both.
+      expect(decoded).toMatch(
+        /name="metadata"[^\r\n]*\r\nContent-Type: application\/json; charset=utf-8/i,
+      );
+      expect(decoded).toContain('{"name":"file.xlsx"}');
+      // File part still carries its own content-type alongside.
+      expect(decoded).toMatch(
+        /name="media"; filename="out\.xlsx"[\s\S]*?Content-Type: application\/vnd\.openxmlformats-officedocument\.spreadsheetml\.sheet/,
+      );
+    } finally {
+      await pair.close();
+    }
+  });
+
+  it("omits Content-Type on a multipart text part when contentType is not set", async () => {
+    // Backwards-compat: existing callers that pass `{ name, value }` without
+    // contentType continue to get FormData's plain-string serialization (no
+    // explicit `Content-Type` part header — server defaults to `text/plain`).
+    const { pair, mcp, captured } = await makeServer({});
+    try {
+      const resolver = new McpProviderResolver(mcp);
+      const [tool] = await resolver.resolve(
+        [{ name: "@test/echo", version: "^1.0.0" }],
+        makeBundle(),
+      );
+      const workspace = mkdtempSync(join(tmpdir(), "mcp-resolver-"));
+
+      await tool!.execute(
+        {
+          method: "POST",
+          target: "https://api.example.com/x",
+          body: { multipart: [{ name: "field", value: "plain" }] },
+        },
+        ctxBase(workspace),
+      );
+
+      const arg = captured.arguments as {
+        body?: { fromBytes: string; encoding: string };
+      };
+      const decoded = Buffer.from(arg.body!.fromBytes, "base64").toString("utf-8");
+      // Neither the value nor the surrounding part should carry an
+      // explicit Content-Type when none was requested.
+      const partRegion = decoded.match(/name="field"[\s\S]*?--/);
+      expect(partRegion).not.toBeNull();
+      expect(partRegion![0]).not.toContain("Content-Type:");
+    } finally {
+      await pair.close();
+    }
+  });
+
   it("rejects { fromFile } resolving outside the workspace (path traversal)", async () => {
     const { pair, mcp, captured } = await makeServer({});
     try {


### PR DESCRIPTION
## Summary

- **What**: Add an optional `contentType` field to the multipart text part schema in `provider_call`.
- **Why**: Google Drive's resumable multipart upload requires the JSON metadata part to carry `Content-Type: application/json`. The text part schema only accepted `{ name, value }`, so callers had to base64-encode the JSON and send it through `fromBytes` just to set the part header — anti-natural and a friction point in agent prompts.
- **How**: New optional `contentType` on `multipartTextPartSchema`. When set, `buildMultipartBytes` wraps the text in a `Blob` so FormData emits the requested type instead of the default `text/plain`. Backwards-compatible: existing `{ name, value }` callers stay on the plain-string append path.

## Context

Surfaced while debugging a real agent run (`@saneki/orgabusiness-export-compta`) on prod — the agent burned ~25 s of iterations on a Drive upload before figuring out the `fromBytes` workaround. Full diagnosis: 2 frictions identified, this PR resolves the platform-side one.

## Test plan

- [x] `bun test packages/afps-runtime/test/resolvers/provider-tool-schema.test.ts` — schema accepts `contentType` on text parts (Drive pattern), invalid shapes still rejected (27 pass)
- [x] `bun test runtime-pi/test/mcp-provider-resolver.test.ts` — end-to-end:
  - text part with `contentType` → serialized FormData carries `Content-Type: application/json; charset=utf-8` on the metadata part
  - text part without `contentType` → no explicit `Content-Type:` header (backwards-compat)
  - existing multipart Content-Type test still green (9 pass)
- [x] `bun test packages/afps-runtime runtime-pi packages/runner-pi` — 832 pass / 0 fail
- [x] `bun run check` — typecheck + lint + format + verify:openapi + detect:breaking + system-packages all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)