### PR TITLE
refactor: drop redundant indirection in cancel-fast-finalize path

### DIFF
--- a/apps/api/src/services/run-watchdog.ts
+++ b/apps/api/src/services/run-watchdog.ts
@@ -62,22 +62,10 @@ export interface RunWatchdogConfig {
   readonly maxFinalizesPerTick: number;
 }
 
-export const DEFAULT_WATCHDOG_CONFIG: RunWatchdogConfig = {
-  // Defaults match `packages/env` so test code that constructs a config
-  // without going through env stays in sync with production behaviour.
-  // See `RUN_*` envs for the rationale (cooperative finalize is the
-  // primary path; this watchdog is the crash-only backstop).
-  intervalSeconds: 15,
-  stallThresholdSeconds: 60,
-  maxFinalizesPerTick: 200,
-};
-
 let watchdogTimer: ReturnType<typeof setTimeout> | null = null;
 let stopped = false;
 
-export async function startRunWatchdog(
-  config: RunWatchdogConfig = DEFAULT_WATCHDOG_CONFIG,
-): Promise<void> {
+export async function startRunWatchdog(config: RunWatchdogConfig): Promise<void> {
   stopped = false;
   logger.info("run watchdog started", {
     intervalSeconds: config.intervalSeconds,
@@ -110,9 +98,7 @@ function scheduleNext(config: RunWatchdogConfig): void {
  * return the number of rows finalized. Exported for tests — production
  * code calls {@link startRunWatchdog} which schedules ticks on a loop.
  */
-export async function runWatchdogTick(
-  config: RunWatchdogConfig = DEFAULT_WATCHDOG_CONFIG,
-): Promise<number> {
+export async function runWatchdogTick(config: RunWatchdogConfig): Promise<number> {
   // Candidate collection is always a SELECT — in PostgreSQL mode we
   // wrap it in a transaction that tries the xact-lock first so
   // concurrent replicas don't duplicate scans. Session-scoped locks

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -248,11 +248,9 @@ async function runCommandInner(opts: RunCommandOptions): Promise<void> {
   // (provider extension build, runtime-ready emit, …) bypasses
   // PiRunner entirely. Without this safety net the run sits open
   // until the watchdog times out.
-  const trackedHttpSink = reportSession
-    ? wrapHttpSinkWithFinalizeTracker(reportSession.httpSink)
-    : null;
-  const sink = trackedHttpSink
-    ? new CompositeSink([consoleSink, trackedHttpSink.sink])
+  const wasHttpSinkFinalized = reportSession ? attachFinalizeTracker(reportSession.httpSink) : null;
+  const sink = reportSession
+    ? new CompositeSink([consoleSink, reportSession.httpSink])
     : consoleSink;
   if (!opts.json) {
     const reportNote = reportSession
@@ -342,7 +340,7 @@ async function runCommandInner(opts: RunCommandOptions): Promise<void> {
     // this whole change is trying to eliminate. Industry guidance for
     // graceful-shutdown cleanup is 5–10s; we sit at 5s and rely on the
     // watchdog (60s by default) for the abandoned cases.
-    if (trackedHttpSink && !trackedHttpSink.wasFinalized()) {
+    if (reportSession && wasHttpSinkFinalized && !wasHttpSinkFinalized()) {
       const aborted = controller.signal.aborted;
       const result: RunResult = emptyRunResult();
       result.status = aborted ? "cancelled" : "failed";
@@ -352,7 +350,7 @@ async function runCommandInner(opts: RunCommandOptions): Promise<void> {
           : "Runner exited before completion (CLI bootstrap or teardown error).",
       };
       await raceFinalizeAgainstTimeout(
-        trackedHttpSink.sink.finalize(result),
+        reportSession.httpSink.finalize(result),
         SAFETY_NET_FINALIZE_TIMEOUT_MS,
       ).catch((err) => {
         if (!opts.json) {
@@ -373,30 +371,20 @@ async function runCommandInner(opts: RunCommandOptions): Promise<void> {
 }
 
 /**
- * Wrap a finalize-capable EventSink so the caller can tell whether
- * `finalize` has been invoked (by the runner, mid-run). The CLI uses
- * this to avoid double-finalizing from its `finally` safety net.
+ * Patch an HttpSink's `finalize` in place so the caller can tell
+ * whether it has already been invoked (by the runner, mid-run). The
+ * CLI uses this to avoid double-finalizing from its `finally` safety
+ * net. Returns a getter for the flag — callers keep using the original
+ * sink reference.
  */
-interface TrackedHttpSink {
-  sink: HttpSink;
-  wasFinalized(): boolean;
-}
-
-function wrapHttpSinkWithFinalizeTracker(inner: HttpSink): TrackedHttpSink {
+function attachFinalizeTracker(sink: HttpSink): () => boolean {
   let finalized = false;
-  // Replace the original `finalize` in place rather than building a
-  // wrapper class — HttpSink is concrete and CompositeSink expects a
-  // structural EventSink. Patching the bound method preserves identity
-  // so any other code holding the reference still observes the flag.
-  const originalFinalize = inner.finalize.bind(inner);
-  inner.finalize = async (result) => {
+  const original = sink.finalize.bind(sink);
+  sink.finalize = async (result) => {
     finalized = true;
-    await originalFinalize(result);
+    await original(result);
   };
-  return {
-    sink: inner,
-    wasFinalized: () => finalized,
-  };
+  return () => finalized;
 }
 
 /**
@@ -732,20 +720,15 @@ export async function _buildResolverInputsForTesting(
 }
 
 /**
- * Test-only access to the finalize-tracker wrapper. Exercised by
- * `apps/cli/test/run-finalize-tracker.test.ts` to assert the
- * cancel-path safety net (PR: detect runner cancellation immediately
+ * Test-only access to the finalize tracker and safety-net timeout race.
+ * Exercised by `apps/cli/test/run-finalize-tracker.test.ts` to assert
+ * the cancel-path safety net (detect runner cancellation immediately
  * rather than waiting for the heartbeat watchdog).
  */
-export function _wrapHttpSinkWithFinalizeTrackerForTesting(inner: HttpSink): TrackedHttpSink {
-  return wrapHttpSinkWithFinalizeTracker(inner);
+export function _attachFinalizeTrackerForTesting(sink: HttpSink): () => boolean {
+  return attachFinalizeTracker(sink);
 }
 
-/**
- * Test-only access to the safety-net timeout race so we can assert
- * the cap is enforced (a partitioned platform must not hang the CLI
- * for tens of seconds on Ctrl-C — see SAFETY_NET_FINALIZE_TIMEOUT_MS).
- */
 export function _raceFinalizeAgainstTimeoutForTesting(
   p: Promise<void>,
   timeoutMs: number,

--- a/apps/cli/test/run-finalize-tracker.test.ts
+++ b/apps/cli/test/run-finalize-tracker.test.ts
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Tests for the CLI's `wrapHttpSinkWithFinalizeTracker` helper — the
- * safety net that lets the run command detect whether `PiRunner`
- * already finalized the sink, so the `finally` block on Ctrl-C /
- * SIGTERM doesn't double-post a `cancelled` finalize on top of a real
- * terminal status.
+ * Tests for the CLI's `attachFinalizeTracker` helper — the safety net
+ * that lets the run command detect whether `PiRunner` already
+ * finalized the sink, so the `finally` block on Ctrl-C / SIGTERM
+ * doesn't double-post a `cancelled` finalize on top of a real terminal
+ * status.
  *
- * The wrapper is the linchpin of the cooperative-shutdown fast path:
+ * The tracker is the linchpin of the cooperative-shutdown fast path:
  * without it the platform would have to wait the full
  * `RUN_STALL_THRESHOLD_SECONDS` (60s) for the watchdog to notice a
  * dead CLI. With it, the CLI sends an explicit finalize the moment
@@ -16,9 +16,9 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { HttpSink } from "@appstrate/afps-runtime/sinks";
-import type { RunResult } from "@appstrate/afps-runtime/runner";
+import { emptyRunResult, type RunResult } from "@appstrate/afps-runtime/runner";
 import {
-  _wrapHttpSinkWithFinalizeTrackerForTesting as wrap,
+  _attachFinalizeTrackerForTesting as attach,
   _raceFinalizeAgainstTimeoutForTesting as raceTimeout,
 } from "../src/commands/run.ts";
 
@@ -55,11 +55,7 @@ function startTestServer(): TestServer {
 
 const RUN_SECRET = "test-secret-finalize-tracker";
 
-function emptyResult(): RunResult {
-  return { memories: [], output: null, report: null, logs: [] };
-}
-
-describe("wrapHttpSinkWithFinalizeTracker", () => {
+describe("attachFinalizeTracker", () => {
   let server: TestServer;
 
   beforeEach(() => {
@@ -70,46 +66,43 @@ describe("wrapHttpSinkWithFinalizeTracker", () => {
     server.shutdown();
   });
 
-  it("reports wasFinalized() === false before any finalize call", () => {
-    const inner = new HttpSink({
+  it("reports false before any finalize call", () => {
+    const sink = new HttpSink({
       url: server.url,
       finalizeUrl: server.finalizeUrl,
       runSecret: RUN_SECRET,
     });
-    const tracked = wrap(inner);
-    expect(tracked.wasFinalized()).toBe(false);
+    const wasFinalized = attach(sink);
+    expect(wasFinalized()).toBe(false);
   });
 
-  it("flips wasFinalized() to true after the wrapped sink finalises", async () => {
-    const inner = new HttpSink({
+  it("flips to true after the patched sink finalises", async () => {
+    const sink = new HttpSink({
       url: server.url,
       finalizeUrl: server.finalizeUrl,
       runSecret: RUN_SECRET,
     });
-    const tracked = wrap(inner);
+    const wasFinalized = attach(sink);
 
-    expect(tracked.wasFinalized()).toBe(false);
-    await tracked.sink.finalize(emptyResult());
-    expect(tracked.wasFinalized()).toBe(true);
+    expect(wasFinalized()).toBe(false);
+    await sink.finalize(emptyRunResult());
+    expect(wasFinalized()).toBe(true);
   });
 
   it("forwards the finalize POST to the underlying sink (HTTP request reaches finalizeUrl)", async () => {
-    const inner = new HttpSink({
+    const sink = new HttpSink({
       url: server.url,
       finalizeUrl: server.finalizeUrl,
       runSecret: RUN_SECRET,
     });
-    const tracked = wrap(inner);
+    attach(sink);
 
     const result: RunResult = {
-      memories: [],
-      output: null,
-      report: null,
-      logs: [],
+      ...emptyRunResult(),
       status: "cancelled",
       error: { message: "Runner cancelled by user (CLI received signal)." },
     };
-    await tracked.sink.finalize(result);
+    await sink.finalize(result);
 
     const finalizePosts = server.received.filter((r) => r.url === "/events/finalize");
     expect(finalizePosts).toHaveLength(1);
@@ -119,22 +112,22 @@ describe("wrapHttpSinkWithFinalizeTracker", () => {
     expect(body.error?.message).toContain("cancelled by user");
   });
 
-  it("counts a single finalize even when called twice (each call still posts, but the flag stays true)", async () => {
-    // Belt-and-suspenders behaviour: the wrapper does not enforce
+  it("stays true on repeated finalize calls (each call still posts, flag stays true)", async () => {
+    // Belt-and-suspenders behaviour: the tracker does not enforce
     // single-call semantics — that's the platform's job (server CAS on
-    // `sink_closed_at IS NULL`). The wrapper only tracks "has finalize
+    // `sink_closed_at IS NULL`). The tracker only records "has finalize
     // been observed at least once". Double-finalize from the runner
-    // would be a runner bug, not something the wrapper needs to mask.
-    const inner = new HttpSink({
+    // would be a runner bug, not something the tracker needs to mask.
+    const sink = new HttpSink({
       url: server.url,
       finalizeUrl: server.finalizeUrl,
       runSecret: RUN_SECRET,
     });
-    const tracked = wrap(inner);
-    await tracked.sink.finalize(emptyResult());
-    expect(tracked.wasFinalized()).toBe(true);
-    await tracked.sink.finalize(emptyResult());
-    expect(tracked.wasFinalized()).toBe(true);
+    const wasFinalized = attach(sink);
+    await sink.finalize(emptyRunResult());
+    expect(wasFinalized()).toBe(true);
+    await sink.finalize(emptyRunResult());
+    expect(wasFinalized()).toBe(true);
     expect(server.received.filter((r) => r.url === "/events/finalize")).toHaveLength(2);
   });
 
@@ -164,20 +157,20 @@ describe("wrapHttpSinkWithFinalizeTracker", () => {
   });
 
   it("does not interfere with regular event POSTs (handle still works)", async () => {
-    const inner = new HttpSink({
+    const sink = new HttpSink({
       url: server.url,
       finalizeUrl: server.finalizeUrl,
       runSecret: RUN_SECRET,
     });
-    const tracked = wrap(inner);
+    const wasFinalized = attach(sink);
 
-    await tracked.sink.handle({
+    await sink.handle({
       type: "appstrate.progress",
       timestamp: Date.now(),
       runId: "run_track_test",
       message: "still running",
     });
-    expect(tracked.wasFinalized()).toBe(false);
+    expect(wasFinalized()).toBe(false);
     const eventPosts = server.received.filter((r) => r.url === "/events");
     expect(eventPosts).toHaveLength(1);
   });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -222,9 +222,11 @@ services:
       - REMOTE_RUN_BUFFER_FLUSH_MS=${REMOTE_RUN_BUFFER_FLUSH_MS:-5000}
       - REMOTE_RUN_EVENT_LIMITS=${REMOTE_RUN_EVENT_LIMITS:-{}}
       # ── Run liveness watchdog (optional, ratio: stall ≥ 3 × heartbeat) ──
-      - RUN_HEARTBEAT_INTERVAL_SECONDS=${RUN_HEARTBEAT_INTERVAL_SECONDS:-15}
-      - RUN_STALL_THRESHOLD_SECONDS=${RUN_STALL_THRESHOLD_SECONDS:-60}
-      - RUN_WATCHDOG_INTERVAL_SECONDS=${RUN_WATCHDOG_INTERVAL_SECONDS:-15}
+      # Defaults live in `packages/env` — passthrough means an unset host
+      # env falls back to the Zod schema's single source of truth.
+      - RUN_HEARTBEAT_INTERVAL_SECONDS
+      - RUN_STALL_THRESHOLD_SECONDS
+      - RUN_WATCHDOG_INTERVAL_SECONDS
       # ── Run limits (optional, see docs/specs/INLINE_RUNS.md) ──
       - PLATFORM_RUN_LIMITS=${PLATFORM_RUN_LIMITS:-{}}
       - INLINE_RUN_LIMITS=${INLINE_RUN_LIMITS:-{}}

--- a/examples/self-hosting/docker-compose.tier1.yml
+++ b/examples/self-hosting/docker-compose.tier1.yml
@@ -122,9 +122,11 @@ services:
       # ── Remote runner protocol + watchdog (optional) ──
       - REMOTE_RUN_SINK_DEFAULT_TTL_SECONDS=${REMOTE_RUN_SINK_DEFAULT_TTL_SECONDS:-7200}
       - REMOTE_RUN_SINK_MAX_TTL_SECONDS=${REMOTE_RUN_SINK_MAX_TTL_SECONDS:-86400}
-      - RUN_HEARTBEAT_INTERVAL_SECONDS=${RUN_HEARTBEAT_INTERVAL_SECONDS:-15}
-      - RUN_STALL_THRESHOLD_SECONDS=${RUN_STALL_THRESHOLD_SECONDS:-60}
-      - RUN_WATCHDOG_INTERVAL_SECONDS=${RUN_WATCHDOG_INTERVAL_SECONDS:-15}
+      # Defaults live in `packages/env` — passthrough means an unset host
+      # env falls back to the Zod schema's single source of truth.
+      - RUN_HEARTBEAT_INTERVAL_SECONDS
+      - RUN_STALL_THRESHOLD_SECONDS
+      - RUN_WATCHDOG_INTERVAL_SECONDS
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - storagedata:/data/storage

--- a/examples/self-hosting/docker-compose.tier2.yml
+++ b/examples/self-hosting/docker-compose.tier2.yml
@@ -132,9 +132,11 @@ services:
       # ── Remote runner protocol + watchdog (optional) ──
       - REMOTE_RUN_SINK_DEFAULT_TTL_SECONDS=${REMOTE_RUN_SINK_DEFAULT_TTL_SECONDS:-7200}
       - REMOTE_RUN_SINK_MAX_TTL_SECONDS=${REMOTE_RUN_SINK_MAX_TTL_SECONDS:-86400}
-      - RUN_HEARTBEAT_INTERVAL_SECONDS=${RUN_HEARTBEAT_INTERVAL_SECONDS:-15}
-      - RUN_STALL_THRESHOLD_SECONDS=${RUN_STALL_THRESHOLD_SECONDS:-60}
-      - RUN_WATCHDOG_INTERVAL_SECONDS=${RUN_WATCHDOG_INTERVAL_SECONDS:-15}
+      # Defaults live in `packages/env` — passthrough means an unset host
+      # env falls back to the Zod schema's single source of truth.
+      - RUN_HEARTBEAT_INTERVAL_SECONDS
+      - RUN_STALL_THRESHOLD_SECONDS
+      - RUN_WATCHDOG_INTERVAL_SECONDS
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - storagedata:/data/storage

--- a/examples/self-hosting/docker-compose.tier3.yml
+++ b/examples/self-hosting/docker-compose.tier3.yml
@@ -183,9 +183,11 @@ services:
       # ── Remote runner protocol + watchdog (optional) ──
       - REMOTE_RUN_SINK_DEFAULT_TTL_SECONDS=${REMOTE_RUN_SINK_DEFAULT_TTL_SECONDS:-7200}
       - REMOTE_RUN_SINK_MAX_TTL_SECONDS=${REMOTE_RUN_SINK_MAX_TTL_SECONDS:-86400}
-      - RUN_HEARTBEAT_INTERVAL_SECONDS=${RUN_HEARTBEAT_INTERVAL_SECONDS:-15}
-      - RUN_STALL_THRESHOLD_SECONDS=${RUN_STALL_THRESHOLD_SECONDS:-60}
-      - RUN_WATCHDOG_INTERVAL_SECONDS=${RUN_WATCHDOG_INTERVAL_SECONDS:-15}
+      # Defaults live in `packages/env` — passthrough means an unset host
+      # env falls back to the Zod schema's single source of truth.
+      - RUN_HEARTBEAT_INTERVAL_SECONDS
+      - RUN_STALL_THRESHOLD_SECONDS
+      - RUN_WATCHDOG_INTERVAL_SECONDS
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     healthcheck:

--- a/examples/self-hosting/docker-compose.yml
+++ b/examples/self-hosting/docker-compose.yml
@@ -178,9 +178,11 @@ services:
       # ── Remote runner protocol + watchdog (optional) ──
       - REMOTE_RUN_SINK_DEFAULT_TTL_SECONDS=${REMOTE_RUN_SINK_DEFAULT_TTL_SECONDS:-7200}
       - REMOTE_RUN_SINK_MAX_TTL_SECONDS=${REMOTE_RUN_SINK_MAX_TTL_SECONDS:-86400}
-      - RUN_HEARTBEAT_INTERVAL_SECONDS=${RUN_HEARTBEAT_INTERVAL_SECONDS:-15}
-      - RUN_STALL_THRESHOLD_SECONDS=${RUN_STALL_THRESHOLD_SECONDS:-60}
-      - RUN_WATCHDOG_INTERVAL_SECONDS=${RUN_WATCHDOG_INTERVAL_SECONDS:-15}
+      # Defaults live in `packages/env` — passthrough means an unset host
+      # env falls back to the Zod schema's single source of truth.
+      - RUN_HEARTBEAT_INTERVAL_SECONDS
+      - RUN_STALL_THRESHOLD_SECONDS
+      - RUN_WATCHDOG_INTERVAL_SECONDS
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     healthcheck:


### PR DESCRIPTION
Follow-up cleanup on the cancel-fast-finalize PR (already merged). Three architectural simplifications surfaced during a post-merge review — no behaviour change.

## Summary

- **Compose `:-N` defaults dropped** for `RUN_HEARTBEAT_INTERVAL_SECONDS` / `RUN_STALL_THRESHOLD_SECONDS` / `RUN_WATCHDOG_INTERVAL_SECONDS`. Switched to passthrough form (`- VAR_NAME`) in all 5 compose files so unset host envs fall back to the Zod schema in `packages/env` — flipping a default no longer needs synchronized edits across 5 yml files.
- **`DEFAULT_WATCHDOG_CONFIG` removed** from `apps/api/src/services/run-watchdog.ts`. Every caller (`boot.ts`, integration tests) already passes an explicit config, so the default fallback was dead weight that duplicated `packages/env` defaults.
- **`wrapHttpSinkWithFinalizeTracker` flattened** to `attachFinalizeTracker(sink) -> () => boolean`. The previous wrapper mutated the input sink in place AND returned a struct whose `sink` field re-pointed at the same input — pure indirection. Drops the `TrackedHttpSink` interface, the wrapper return object, and a test-only export. Callers keep using the original `HttpSink` reference.
- **Test corollary**: replaced the local `emptyResult()` helper with `emptyRunResult()` from `@appstrate/afps-runtime/runner` — same factory, single source of truth.

Net: −112 / +84 lines across 8 files.

## Test plan

- [x] `bun run check` — type-check + verify-openapi + format check pass
- [x] `bun test apps/cli/test/run-finalize-tracker.test.ts` — 8 pass
- [x] `bun test apps/api/test/integration/services/run-watchdog.test.ts` — 5 pass
- [x] `cd apps/cli && bun test` — 810 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)