### PR TITLE
fix(afps-runtime): root symlink-escape test outside /tmp

### DIFF
--- a/packages/afps-runtime/test/resolvers/resolve-safe-path.test.ts
+++ b/packages/afps-runtime/test/resolvers/resolve-safe-path.test.ts
@@ -16,7 +16,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdtempSync, writeFileSync, symlinkSync, rmSync, realpathSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { resolveSafeFile, resolveSafePath } from "../../src/resolvers/provider-tool.ts";
@@ -33,7 +33,12 @@ describe("resolveSafePath", () => {
 
   beforeEach(() => {
     workspace = realpathSync(mkdtempSync(join(tmpdir(), "rsp-ws-")));
-    outside = realpathSync(mkdtempSync(join(tmpdir(), "rsp-out-")));
+    // `outside` must canonicalize outside *every* allowed root (workspace
+    // and `/tmp`). On Linux, `tmpdir()` IS `/tmp`, so anchoring `outside`
+    // there would land it inside an allowed root and break the symlink-
+    // escape test. Use the home directory, which is guaranteed outside
+    // both `/tmp` and the workspace on every platform.
+    outside = realpathSync(mkdtempSync(join(homedir(), "rsp-out-")));
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary
- Fix CI failure on `main` introduced by #317 (which added `/tmp` to `resolveSafePath`'s allowed roots).
- The symlink-escape test created its "outside" directory under `tmpdir()`, which on Linux is `/tmp` itself — so the supposedly-outside target landed inside an allowed root and the resolver rightly accepted the symlink. Local macOS runs masked this because `tmpdir()` there is `/var/folders/...`, not `/tmp`.
- Anchor "outside" under `homedir()` instead — guaranteed outside both `/tmp` and the workspace on every platform.

## Test plan
- [x] `bun test packages/afps-runtime/test/resolvers/resolve-safe-path.test.ts` — 12/12 pass locally
- [x] `tsc --noEmit` clean
- [ ] CI Test workflow green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)