### PR TITLE
refactor: align per-run override naming + extract merge-and-validate helper

### DIFF
--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -24,8 +24,7 @@ import { emptyRunResult, type RunResult } from "@appstrate/afps-runtime/runner";
 import { getVersionDetail } from "../services/package-versions.ts";
 import { parseRequestInput } from "../services/input-parser.ts";
 import { asJSONSchemaObject } from "@appstrate/core/form";
-import { deepMergeConfig } from "@appstrate/core/schema-validation";
-import { validateMergedConfigOrThrow } from "../services/agent-readiness.ts";
+import { mergeAndValidateConfigOverride } from "../services/agent-readiness.ts";
 import { trackRun, untrackRun, abortRun } from "../services/run-tracker.ts";
 import { rateLimit } from "../middleware/rate-limit.ts";
 import { idempotency } from "../middleware/idempotency.ts";
@@ -306,26 +305,16 @@ export function createRunsRouter() {
       const {
         input: parsedInput,
         uploadedFiles,
-        modelId: modelIdOverride,
-        proxyId: proxyIdOverride,
+        modelIdOverride,
+        proxyIdOverride,
         configOverride,
       } = inputResult;
 
       // Deep-merge any per-run `config` override on top of the persisted
-      // application config. SOTA pattern (OpenAI Assistants, Argo
-      // Workflows): the merge happens server-side via the same
-      // `deepMergeConfig` shared with the CLI's local-run path, so every
-      // client reaches an identical resolved config for the same
-      // `(persisted, override)` pair.
-      const mergedConfig = configOverride ? deepMergeConfig(config, configOverride) : config;
-
-      // Re-validate the merged config against the manifest schema. The
-      // persisted side was vetted by `resolveRunPreflight`, but the override
-      // could push the result out of schema — the CLI's local-run path
-      // already gates this, the server must too. No-op when no override.
-      if (configOverride) {
-        validateMergedConfigOrThrow(effectiveAgent, mergedConfig);
-      }
+      // application config and re-validate against the manifest schema.
+      // Single helper shared with the scheduler so both paths converge to
+      // an identical resolved config for the same `(persisted, override)`.
+      const mergedConfig = mergeAndValidateConfigOverride(effectiveAgent, config, configOverride);
 
       // Single canonical prefix — `run_` — shared with inline + remote
       // origins. The legacy `exec_` prefix was a platform-only relic from

--- a/apps/api/src/services/agent-readiness.ts
+++ b/apps/api/src/services/agent-readiness.ts
@@ -10,6 +10,7 @@ import { collectDependencyErrors } from "./dependency-validation.ts";
 import { validateConfig } from "./schema.ts";
 import { resolveManifestProviders, extractManifestSchemas } from "../lib/manifest-utils.ts";
 import { isPromptEmpty, findMissingDependencies } from "@appstrate/core/validation";
+import { deepMergeConfig } from "@appstrate/core/schema-validation";
 import { ApiError, type ValidationFieldError } from "../lib/errors.ts";
 import { resolveProviderProfiles } from "./connection-profiles.ts";
 import type {
@@ -155,6 +156,27 @@ export function validateMergedConfigOrThrow(
     title: "Invalid Config",
     detail: first.field ? `config.${first.field}: ${first.message}` : first.message,
   });
+}
+
+/**
+ * Apply a per-run config override on top of the persisted config and re-validate
+ * against the manifest schema. No-op when `override` is null/undefined — returns
+ * `persisted` verbatim. Throws `ApiError(400, "invalid_config")` if the merged
+ * result violates the manifest schema (mirrors `validateMergedConfigOrThrow`).
+ *
+ * Single source of truth for the merge+validate sequence shared by `POST /run`
+ * and the scheduler — every per-run invocation reaches an identical resolved
+ * config for the same `(persisted, override)` pair.
+ */
+export function mergeAndValidateConfigOverride(
+  agent: LoadedPackage,
+  persisted: Record<string, unknown>,
+  override: Record<string, unknown> | null | undefined,
+): Record<string, unknown> {
+  if (!override) return persisted;
+  const merged = deepMergeConfig(persisted, override);
+  validateMergedConfigOrThrow(agent, merged);
+  return merged;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/services/input-parser.ts
+++ b/apps/api/src/services/input-parser.ts
@@ -19,16 +19,22 @@ import { consumeUpload, isUploadUri, parseUploadUri } from "./uploads.ts";
 export interface ParsedInput {
   input?: Record<string, unknown>;
   uploadedFiles?: UploadedFile[];
-  modelId?: string;
-  proxyId?: string;
+  /** Per-run model override (wire field `modelId` on the request body). */
+  modelIdOverride?: string;
+  /** Per-run proxy override (wire field `proxyId` on the request body). */
+  proxyIdOverride?: string;
   /**
-   * Per-run config override. Deep-merged with `application_packages.config`
-   * before the run is executed (see `deepMergeConfig` in
-   * `@appstrate/core/schema-validation`). Mirrors the OpenAI Assistants
-   * `runs.create { instructions, model, tools }` and Argo Workflows
-   * `submitOptions.parameters` SOTA: the merge happens server-side so
-   * UI / CLI / SDK clients all reach the same resolved config for the
-   * same `(persisted, override)` pair.
+   * Per-run config override (wire field `config` on the request body).
+   * Deep-merged with `application_packages.config` before the run is
+   * executed (see `deepMergeConfig` in `@appstrate/core/schema-validation`).
+   * Mirrors the OpenAI Assistants `runs.create { instructions, model, tools }`
+   * and Argo Workflows `submitOptions.parameters` SOTA: the merge happens
+   * server-side so UI / CLI / SDK clients all reach the same resolved config
+   * for the same `(persisted, override)` pair.
+   *
+   * Internal output names use the `*Override` suffix to match the schedule
+   * wire (`configOverride / modelIdOverride / proxyIdOverride / versionOverride`)
+   * and the run-record columns (`runs.config_override`, `model_overridden`, …).
    */
   configOverride?: Record<string, unknown>;
 }
@@ -162,8 +168,8 @@ export async function parseRequestInput(
   return {
     input,
     uploadedFiles: uploadedFiles.length > 0 ? uploadedFiles : undefined,
-    modelId: body.modelId,
-    proxyId: body.proxyId,
+    modelIdOverride: body.modelId,
+    proxyIdOverride: body.proxyId,
     configOverride: body.config,
   };
 }

--- a/apps/api/src/services/scheduler.ts
+++ b/apps/api/src/services/scheduler.ts
@@ -30,12 +30,11 @@ import { resolveManifestProviders } from "../lib/manifest-utils.ts";
 import { ApiError, internalError } from "../lib/errors.ts";
 import { scopedWhere } from "../lib/db-helpers.ts";
 import { validateInput } from "./schema.ts";
-import { validateMergedConfigOrThrow } from "./agent-readiness.ts";
+import { mergeAndValidateConfigOverride } from "./agent-readiness.ts";
 import { asJSONSchemaObject } from "@appstrate/core/form";
 import { computeNextRun } from "../lib/cron.ts";
 import { actorFromIds, type Actor } from "../lib/actor.ts";
 import type { AppScope } from "../lib/scope.ts";
-import { deepMergeConfig } from "@appstrate/core/schema-validation";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -344,35 +343,26 @@ async function triggerScheduledRun(
 
     const runId = `run_${crypto.randomUUID()}`;
 
-    // Apply per-schedule overrides on top of the resolved preflight values.
-    // Same shape as POST /run body — deep-merge for `config`, first-non-null
-    // for model/proxy/version. Stamped on the run record (not just used at
-    // execute time) so the dashboard can badge "default vs override".
-    const mergedConfig = overrides.configOverride
-      ? deepMergeConfig(config, overrides.configOverride)
-      : config;
-
-    // Re-validate against the manifest schema when an override is in play —
-    // the persisted side was vetted by `resolveRunPreflight`, but a frozen
-    // schedule override can push the merged config out of schema (especially
-    // after a manifest update tightened the schema). Mirrors the gate the
-    // run route runs on `POST /run`.
-    if (overrides.configOverride) {
-      try {
-        validateMergedConfigOrThrow(agent, mergedConfig);
-      } catch (err) {
-        if (err instanceof ApiError) {
-          logger.warn("Schedule config override no longer satisfies manifest schema", {
-            scheduleId,
-            packageId,
-            code: err.code,
-            detail: err.message,
-          });
-          await failSchedule(err.message, actor);
-          return;
-        }
-        throw err;
+    // Apply per-schedule overrides (deep-merge + re-validate) via the same
+    // helper used by `POST /run` so both paths converge to an identical
+    // resolved config. Wrapped in try/catch because a frozen schedule
+    // override can fall out of schema after a manifest update tightens it
+    // — the scheduler must `failSchedule` instead of throwing.
+    let mergedConfig: Record<string, unknown>;
+    try {
+      mergedConfig = mergeAndValidateConfigOverride(agent, config, overrides.configOverride);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        logger.warn("Schedule config override no longer satisfies manifest schema", {
+          scheduleId,
+          packageId,
+          code: err.code,
+          detail: err.message,
+        });
+        await failSchedule(err.message, actor);
+        return;
       }
+      throw err;
     }
 
     const finalModelId = overrides.modelIdOverride ?? preflightModelId;

--- a/apps/web/src/components/run-overrides-panel.tsx
+++ b/apps/web/src/components/run-overrides-panel.tsx
@@ -24,12 +24,14 @@ const INHERIT = "__inherit__";
 const NONE = "__none__";
 
 export interface RunOverridesValue {
-  /** Override delta — passed verbatim as the request body's `config` field. */
+  /** Override delta — deep-merged with persisted config on the server. */
   configOverride?: Record<string, unknown>;
-  modelId?: string;
-  proxyId?: string;
-  /** Version label or dist-tag. */
-  version?: string;
+  /** Per-run model id override. */
+  modelIdOverride?: string;
+  /** Per-run proxy id override. */
+  proxyIdOverride?: string;
+  /** Per-run version label or dist-tag override. */
+  versionOverride?: string;
 }
 
 export interface RunOverridesPanelProps {
@@ -98,31 +100,31 @@ export function RunOverridesPanel({
 
   const setModel = (next: string) => {
     if (next === INHERIT || next === persistedModelId) {
-      const { modelId: _omit, ...rest } = value;
+      const { modelIdOverride: _omit, ...rest } = value;
       void _omit;
       onChange(rest);
     } else {
-      onChange({ ...value, modelId: next });
+      onChange({ ...value, modelIdOverride: next });
     }
   };
 
   const setProxy = (next: string) => {
     if (next === INHERIT || next === (persistedProxyId ?? INHERIT)) {
-      const { proxyId: _omit, ...rest } = value;
+      const { proxyIdOverride: _omit, ...rest } = value;
       void _omit;
       onChange(rest);
     } else {
-      onChange({ ...value, proxyId: next });
+      onChange({ ...value, proxyIdOverride: next });
     }
   };
 
   const setVersion = (next: string) => {
     if (next === INHERIT || next === (persistedVersion ?? "latest")) {
-      const { version: _omit, ...rest } = value;
+      const { versionOverride: _omit, ...rest } = value;
       void _omit;
       onChange(rest);
     } else {
-      onChange({ ...value, version: next });
+      onChange({ ...value, versionOverride: next });
     }
   };
 
@@ -141,9 +143,9 @@ export function RunOverridesPanel({
   const orgDefaultModel = orgModels?.find((m) => m.isDefault && m.enabled);
   const orgDefaultProxy = orgProxies?.find((p) => p.isDefault && p.enabled);
 
-  const modelSelectValue = value.modelId ?? persistedModelId ?? INHERIT;
-  const proxySelectValue = value.proxyId ?? persistedProxyId ?? INHERIT;
-  const versionSelectValue = value.version ?? persistedVersion ?? INHERIT;
+  const modelSelectValue = value.modelIdOverride ?? persistedModelId ?? INHERIT;
+  const proxySelectValue = value.proxyIdOverride ?? persistedProxyId ?? INHERIT;
+  const versionSelectValue = value.versionOverride ?? persistedVersion ?? INHERIT;
 
   return (
     <div className="space-y-4">

--- a/apps/web/src/components/schedule-form.tsx
+++ b/apps/web/src/components/schedule-form.tsx
@@ -157,9 +157,9 @@ export function ScheduleForm({
   const [overrides, setOverrides] = useState<RunOverridesValue>(() => {
     const v: RunOverridesValue = {};
     if (defaultValues?.configOverride) v.configOverride = defaultValues.configOverride;
-    if (defaultValues?.modelIdOverride) v.modelId = defaultValues.modelIdOverride;
-    if (defaultValues?.proxyIdOverride) v.proxyId = defaultValues.proxyIdOverride;
-    if (defaultValues?.versionOverride) v.version = defaultValues.versionOverride;
+    if (defaultValues?.modelIdOverride) v.modelIdOverride = defaultValues.modelIdOverride;
+    if (defaultValues?.proxyIdOverride) v.proxyIdOverride = defaultValues.proxyIdOverride;
+    if (defaultValues?.versionOverride) v.versionOverride = defaultValues.versionOverride;
     return v;
   });
   const initialOverridesNonEmpty =
@@ -209,15 +209,15 @@ export function ScheduleForm({
     const overridePayload = isEdit
       ? {
           configOverride: overrides.configOverride ?? null,
-          modelIdOverride: overrides.modelId ?? null,
-          proxyIdOverride: overrides.proxyId ?? null,
-          versionOverride: overrides.version ?? null,
+          modelIdOverride: overrides.modelIdOverride ?? null,
+          proxyIdOverride: overrides.proxyIdOverride ?? null,
+          versionOverride: overrides.versionOverride ?? null,
         }
       : {
           ...(overrides.configOverride ? { configOverride: overrides.configOverride } : {}),
-          ...(overrides.modelId ? { modelIdOverride: overrides.modelId } : {}),
-          ...(overrides.proxyId ? { proxyIdOverride: overrides.proxyId } : {}),
-          ...(overrides.version ? { versionOverride: overrides.version } : {}),
+          ...(overrides.modelIdOverride ? { modelIdOverride: overrides.modelIdOverride } : {}),
+          ...(overrides.proxyIdOverride ? { proxyIdOverride: overrides.proxyIdOverride } : {}),
+          ...(overrides.versionOverride ? { versionOverride: overrides.versionOverride } : {}),
         };
 
     onSubmit({


### PR DESCRIPTION
## Summary

Three small architectural simplifications that fold cleanly onto the per-run override plumbing landing in #312. Stacks on top of #312 — should be reviewed/merged after it.

- **Internal naming alignment.** `ParsedInput` now exposes `modelIdOverride / proxyIdOverride` (was `modelId / proxyId`). Web's `RunOverridesValue` switches to `modelIdOverride / proxyIdOverride / versionOverride`. Wire shapes are unchanged — `POST /run` still accepts `{ config, modelId, proxyId }`, schedules keep `*Override`. The schedule form drops three blocks of field-renaming conversions that previously bridged the two vocabularies.

- **`mergeAndValidateConfigOverride()` helper.** The merge + manifest re-validation pair was inlined identically in `routes/runs.ts` and `services/scheduler.ts`. Extracted into `services/agent-readiness.ts` so both paths converge to the same resolved config for the same `(persisted, override)` pair. The scheduler keeps its `failSchedule` wrapping; the run route becomes a one-liner.

No behaviour change. Net diff: +91 / −82, mostly conversion-removal and a single new helper.

## Test plan

- [x] `bun run check` — turbo + verify-openapi green (0 breaking changes)
- [x] `bun test apps/api/test/integration/services/scheduler.test.ts apps/api/test/integration/routes/runs.test.ts` — 62 pass
- [x] `bun test apps/api/test/unit packages/core/test/schema-validation.test.ts` — 717 pass
- [x] `bun test apps/cli` — 885 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)