### PR TITLE
feat(cli): central shutdown coordinator for cooperative cancellation

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -62,6 +62,7 @@ import {
   runDualInstallCheck,
   shouldSkipDualInstallCheck,
 } from "./lib/dual-install-check.ts";
+import { installSignalHandlers, onShutdown } from "./lib/shutdown.ts";
 import { exitWithError } from "./lib/ui.ts";
 import { CLI_VERSION } from "./lib/version.ts";
 
@@ -71,8 +72,15 @@ import { CLI_VERSION } from "./lib/version.ts";
 // is open (crash, SIGINT, the Bun macOS keypress regression in #199)
 // the terminal is left unusable and only `reset` fixes it. Registering
 // a cooked-mode restore on every exit path is cheap and catches the
-// edge cases clack's own cleanup misses. Must be registered BEFORE the
-// error handlers below so a synchronous crash in startup still runs it.
+// edge cases clack's own cleanup misses.
+//
+// Wired through both `process.on("exit", …)` (covers normal completion
+// + sync crashes routed through `exitWithError`) and the shutdown
+// coordinator (covers signal-driven exits, where the coordinator awaits
+// hooks before calling `process.exit`). The coordinator route is what
+// lets subcommands like `appstrate run` complete their cooperative
+// cancellation (AbortController flip + safety-net finalize POST +
+// workspace teardown) before the process dies.
 const restoreCookedMode = (): void => {
   try {
     if (process.stdin.isTTY && typeof process.stdin.setRawMode === "function") {
@@ -86,18 +94,8 @@ const restoreCookedMode = (): void => {
   }
 };
 process.on("exit", restoreCookedMode);
-process.on("SIGINT", () => {
-  restoreCookedMode();
-  process.exit(130);
-});
-process.on("SIGTERM", () => {
-  restoreCookedMode();
-  process.exit(143);
-});
-process.on("SIGHUP", () => {
-  restoreCookedMode();
-  process.exit(129);
-});
+onShutdown(restoreCookedMode);
+installSignalHandlers();
 
 /**
  * Commander's idiomatic "collect repeated option into array" — needed

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -537,8 +537,31 @@ async function runCommandInner(opts: RunCommandOptions): Promise<void> {
     });
   } finally {
     unregisterCleanup();
-    await runCleanup();
+    // Swallow cleanup failures: every async op inside `runCleanup` has
+    // its own `.catch`, so the only way the IIFE rejects is a sync throw
+    // from `heartbeat?.stop()` or `restoreOutputSchema()`. If that
+    // happens on the signal path, propagating the rejection would race
+    // with — and beat, since commander's path has fewer microtask hops —
+    // the coordinator's `process.exit(130)`, silently turning a user
+    // cancel into exit 1. Surface the failure on stderr instead so it
+    // remains visible, but don't compete for the exit code.
+    await runCleanup().catch((err) => {
+      if (!opts.json) {
+        process.stderr.write(
+          `warn: cleanup failed: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    });
   }
+
+  // Defense in depth: the coordinator owns the exit on the signal path
+  // (it awaits `runCleanup` via the registered hook, then calls
+  // `process.exit(130)`), and a microtask analysis says its exit fires
+  // before node's natural exit. But that ordering is fragile — a future
+  // change inside `coordinator.trigger` that adds an extra `await` could
+  // flip the race. This guard is a no-op if the coordinator already
+  // exited, and a backstop if it hasn't.
+  if (shutdownSignal.aborted) process.exit(130);
 }
 
 /**

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -81,6 +81,7 @@ import {
 import { preflightCheck, PreflightAbortError } from "./run/preflight.ts";
 import { validateConfig } from "@appstrate/core/schema-validation";
 import type { JSONSchemaObject } from "@appstrate/core/form";
+import { onShutdown, shutdownSignal } from "../lib/shutdown.ts";
 
 export interface RunCommandOptions {
   profile?: string;
@@ -382,26 +383,26 @@ async function runCommandInner(opts: RunCommandOptions): Promise<void> {
   }
 
   // ─── 8. Cancellation wiring ───────────────────────────────────────
-  // SIGINT (Ctrl-C) and SIGTERM (docker stop / kubectl delete / supervisor kill)
-  // both cancel the run cooperatively. The handlers only flip the
-  // AbortController — the actual notification to the platform is sent
-  // from the `finally` below as an explicit finalize POST, so the
-  // server stops the run immediately instead of waiting for the
-  // heartbeat watchdog (~60s).
-  const controller = new AbortController();
-  const onCancel = (signalName: string) => () => {
-    if (!opts.json) process.stderr.write(`\n${signalName} cancelling...\n`);
-    controller.abort(new Error(`user cancelled (${signalName})`));
-  };
-  const onSigint = onCancel("^C");
-  const onSigterm = onCancel("SIGTERM");
-  process.on("SIGINT", onSigint);
-  process.on("SIGTERM", onSigterm);
+  // The CLI's central shutdown coordinator owns SIGINT/SIGTERM/SIGHUP
+  // and exposes a single AbortSignal we pass to the runner. Cleanup
+  // (heartbeat stop, safety-net finalize POST, workspace teardown) is
+  // factored into one idempotent function and registered as a shutdown
+  // hook AND awaited from the `finally` below. The coordinator awaits
+  // the hook before exiting, so the platform sees an explicit
+  // `cancelled` finalize instead of waiting on the heartbeat watchdog
+  // (~60s). On the success / non-signal-error path the `finally` runs
+  // the same cleanup; the idempotency guard makes both paths safe.
+  if (!opts.json) {
+    const onAbort = (): void => {
+      process.stderr.write(`\nshutdown received, cancelling run...\n`);
+    };
+    shutdownSignal.addEventListener("abort", onAbort, { once: true });
+  }
 
   // ─── 9. Run ───────────────────────────────────────────────────────
   const consoleSink = createConsoleSink({ json: opts.json, outputPath: opts.output });
   // Track whether finalize was already sent to the HttpSink so the
-  // CLI's safety-net finalize in the `finally` doesn't double-post.
+  // CLI's safety-net finalize in the cleanup doesn't double-post.
   // PiRunner finalises itself on success and on non-abort errors, but
   // explicitly does NOT on cancellation — and any throw during setup
   // (provider extension build, runtime-ready emit, …) bypasses
@@ -417,6 +418,62 @@ async function runCommandInner(opts: RunCommandOptions): Promise<void> {
       : "";
     process.stderr.write(`→ running ${bundleLabel}${reportNote}\n`);
   }
+
+  // Heartbeat is lifted out of the `try` so the cleanup hook can stop
+  // it whether or not the runner ever started. The shutdown coordinator
+  // can fire during setup (between here and `runner.run`).
+  let heartbeat: SinkHeartbeatHandle | null = null;
+
+  let cleanupPromise: Promise<void> | null = null;
+  const runCleanup = (): Promise<void> => {
+    // Idempotency: both the shutdown coordinator (on signal) and the
+    // outer `finally` (on completion / error) call this. Returning the
+    // same promise to both keeps each call site awaiting the real work,
+    // even when they overlap.
+    if (cleanupPromise !== null) return cleanupPromise;
+    cleanupPromise = (async (): Promise<void> => {
+      heartbeat?.stop();
+      // Safety-net finalize: notify the platform immediately on cancel
+      // or setup-time failure. Cheap (single signed POST), idempotent
+      // (server CAS on `sink_closed_at IS NULL`), and turns a 60-second
+      // watchdog wait into an instant transition. Best-effort — if it
+      // fails, the watchdog still backs us up.
+      //
+      // Bounded by `SAFETY_NET_FINALIZE_TIMEOUT_MS` because HttpSink
+      // retries 4× with exponential backoff and Bun's `fetch` has no
+      // default timeout — an unreachable platform would otherwise hang
+      // the CLI for tens of seconds after Ctrl-C. The coordinator's
+      // own 10-s ceiling is the outer bound; this 5-s cap leaves
+      // headroom for the filesystem teardown that follows.
+      if (reportSession && wasHttpSinkFinalized && !wasHttpSinkFinalized()) {
+        const aborted = shutdownSignal.aborted;
+        const result: RunResult = emptyRunResult();
+        result.status = aborted ? "cancelled" : "failed";
+        result.error = {
+          message: aborted
+            ? "Runner cancelled by user (CLI received signal)."
+            : "Runner exited before completion (CLI bootstrap or teardown error).",
+        };
+        await raceFinalizeAgainstTimeout(
+          reportSession.httpSink.finalize(result),
+          SAFETY_NET_FINALIZE_TIMEOUT_MS,
+        ).catch((err) => {
+          if (!opts.json) {
+            process.stderr.write(
+              `warn: finalize on cancel failed: ${err instanceof Error ? err.message : String(err)}\n`,
+            );
+          }
+        });
+      }
+      restoreOutputSchema();
+      await prepared.cleanup().catch(() => {});
+      await fs.rm(workspaceDir, { recursive: true, force: true }).catch(() => {});
+    })();
+    return cleanupPromise;
+  };
+
+  const unregisterCleanup = onShutdown(runCleanup);
+
   try {
     const runner = new PiRunner({
       model,
@@ -457,7 +514,6 @@ async function runCommandInner(opts: RunCommandOptions): Promise<void> {
     // watchdog sweeps rows whose heartbeat slipped past the threshold
     // and finalises them as `failed`. A local-only CLI run (no
     // reportSession) has no platform to talk to — skip.
-    let heartbeat: SinkHeartbeatHandle | null = null;
     if (reportSession) {
       heartbeat = startSinkHeartbeat({
         url: `${reportSession.sinkUrl.replace(/\/$/, "")}/heartbeat`,
@@ -472,60 +528,16 @@ async function runCommandInner(opts: RunCommandOptions): Promise<void> {
       });
     }
 
-    try {
-      await runner.run({
-        bundle,
-        context,
-        providerResolver,
-        eventSink: sink,
-        signal: controller.signal,
-      });
-    } finally {
-      heartbeat?.stop();
-    }
+    await runner.run({
+      bundle,
+      context,
+      providerResolver,
+      eventSink: sink,
+      signal: shutdownSignal,
+    });
   } finally {
-    process.removeListener("SIGINT", onSigint);
-    process.removeListener("SIGTERM", onSigterm);
-    // Safety-net finalize: notify the platform immediately on cancel
-    // or setup-time failure. Cheap (single signed POST), idempotent
-    // (server CAS on `sink_closed_at IS NULL`), and turns a 60-second
-    // watchdog wait into an instant transition. Best-effort — if it
-    // fails, the watchdog still backs us up.
-    //
-    // Bounded by `SAFETY_NET_FINALIZE_TIMEOUT_MS` because HttpSink
-    // retries 4× with exponential backoff and Bun's `fetch` has no
-    // default timeout — an unreachable platform would otherwise hang
-    // the CLI for tens of seconds after Ctrl-C, exactly the UX problem
-    // this whole change is trying to eliminate. Industry guidance for
-    // graceful-shutdown cleanup is 5–10s; we sit at 5s and rely on the
-    // watchdog (60s by default) for the abandoned cases.
-    if (reportSession && wasHttpSinkFinalized && !wasHttpSinkFinalized()) {
-      const aborted = controller.signal.aborted;
-      const result: RunResult = emptyRunResult();
-      result.status = aborted ? "cancelled" : "failed";
-      result.error = {
-        message: aborted
-          ? "Runner cancelled by user (CLI received signal)."
-          : "Runner exited before completion (CLI bootstrap or teardown error).",
-      };
-      await raceFinalizeAgainstTimeout(
-        reportSession.httpSink.finalize(result),
-        SAFETY_NET_FINALIZE_TIMEOUT_MS,
-      ).catch((err) => {
-        if (!opts.json) {
-          process.stderr.write(
-            `warn: finalize on cancel failed: ${err instanceof Error ? err.message : String(err)}\n`,
-          );
-        }
-      });
-    }
-    restoreOutputSchema();
-    await prepared.cleanup().catch(() => {});
-    await fs.rm(workspaceDir, { recursive: true, force: true }).catch(() => {});
-  }
-
-  if (controller.signal.aborted) {
-    process.exit(130);
+    unregisterCleanup();
+    await runCleanup();
   }
 }
 

--- a/apps/cli/src/lib/shutdown.ts
+++ b/apps/cli/src/lib/shutdown.ts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Central shutdown coordinator for the CLI process.
+ *
+ * Replaces the historical pattern where each command (and the CLI
+ * bootstrap itself) registered its own `process.on("SIGINT", …)` with
+ * a synchronous `process.exit()` inside. That pattern was order-fragile:
+ * the bootstrap handler always fired before a subcommand's, exited
+ * synchronously, and prevented the subcommand's cooperative cancel
+ * (AbortController flip + safety-net finalize POST + workspace teardown)
+ * from running. The result was platform-side runs sitting open for
+ * ~60 s until the watchdog swept them.
+ *
+ * Design contract:
+ * - One `AbortSignal` (`shutdownSignal`) shared across the process.
+ *   Subcommands pass it to async work (e.g. `runner.run({ signal })`)
+ *   and the work unwinds when a signal arrives.
+ * - Cleanup hooks registered via `onShutdown(fn)` are awaited (with
+ *   `Promise.allSettled`) before the process exits. A bounded timeout
+ *   (`SHUTDOWN_TIMEOUT_MS`) guarantees the CLI never hangs longer than
+ *   the user expects after Ctrl-C, even if a hook is wedged.
+ * - A second signal while shutdown is in flight short-circuits to
+ *   `process.exit` immediately — the standard "Ctrl-C twice to force"
+ *   UX every CLI user already knows.
+ *
+ * Crash paths (`uncaughtException`, `unhandledRejection`) intentionally
+ * do NOT route through this coordinator — they go through `exitWithError`
+ * for fast, sync exit. Hooks that must always run regardless of exit
+ * cause should also register with `process.on("exit", …)`.
+ */
+
+export type ShutdownHook = () => Promise<void> | void;
+
+type ShutdownOptions = {
+  /** Injected for tests so they can assert exit codes without killing the test runner. */
+  exit?: (code: number) => void;
+  /** Override the default 10s cleanup ceiling. Tests use a small value to keep the suite fast. */
+  timeoutMs?: number;
+};
+
+/**
+ * Maps each handled signal to its conventional POSIX exit code
+ * (128 + signal number). These are the codes Bash and most CLIs return
+ * when a process is terminated by the corresponding signal — preserving
+ * them keeps shell pipelines (`cmd && next`) and CI behaviour intact.
+ */
+const SIGNAL_EXIT_CODES = {
+  SIGINT: 130,
+  SIGTERM: 143,
+  SIGHUP: 129,
+} as const satisfies Partial<Record<NodeJS.Signals, number>>;
+
+const HANDLED_SIGNALS = Object.keys(SIGNAL_EXIT_CODES) as Array<keyof typeof SIGNAL_EXIT_CODES>;
+
+/**
+ * Hard ceiling on the time a shutdown waits for hooks to settle before
+ * exiting anyway. 10 s is the upper end of the industry-standard
+ * graceful-shutdown window (Kubernetes pre-stop hook default is 30 s,
+ * Node graceful-shutdown guides converge on 5–10 s). We sit at 10 s
+ * because the CLI's own safety-net finalize is internally bounded at 5 s
+ * and we want a small headroom for filesystem teardown after it.
+ */
+const SHUTDOWN_TIMEOUT_MS = 10_000;
+
+export class ShutdownCoordinator {
+  // Set instead of array: cheap O(1) `delete` for `unregister`, and the
+  // JS spec guarantees insertion-order iteration so registration order
+  // is preserved (matters for hooks that observe each other's effects,
+  // e.g. heartbeat-stop before finalize).
+  private readonly hooks = new Set<ShutdownHook>();
+  private readonly controller = new AbortController();
+  private readonly exit: (code: number) => void;
+  private readonly timeoutMs: number;
+  /** Tracks the in-flight shutdown so a second signal can short-circuit. */
+  private inFlight: Promise<void> | null = null;
+
+  constructor(options: ShutdownOptions = {}) {
+    this.exit = options.exit ?? ((code) => process.exit(code));
+    this.timeoutMs = options.timeoutMs ?? SHUTDOWN_TIMEOUT_MS;
+  }
+
+  get signal(): AbortSignal {
+    return this.controller.signal;
+  }
+
+  /** Returns an unregister function — symmetric with EventTarget's `addEventListener` API. */
+  onShutdown(hook: ShutdownHook): () => void {
+    this.hooks.add(hook);
+    return () => {
+      this.hooks.delete(hook);
+    };
+  }
+
+  /**
+   * Trigger shutdown. Idempotent on the abort/cleanup path; the second
+   * call (typically a second Ctrl-C) bypasses cleanup and exits.
+   */
+  async trigger(reason: string, exitCode: number): Promise<void> {
+    if (this.inFlight !== null) {
+      this.exit(exitCode);
+      return;
+    }
+    this.controller.abort(new Error(`shutdown (${reason})`));
+    this.inFlight = this.runHooks();
+    await this.inFlight;
+    this.exit(exitCode);
+  }
+
+  private async runHooks(): Promise<void> {
+    // `Promise.resolve().then(fn)` defends against a hook that throws
+    // synchronously — it would otherwise short-circuit `Array.prototype.map`
+    // before later hooks even started.
+    const settled = Promise.allSettled([...this.hooks].map((hook) => Promise.resolve().then(hook)));
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<void>((resolve) => {
+      timer = setTimeout(resolve, this.timeoutMs);
+      // Don't let the timer itself keep the loop alive once everything else has settled.
+      (timer as { unref?: () => void }).unref?.();
+    });
+    try {
+      await Promise.race([settled.then(() => undefined), timeout]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+}
+
+/**
+ * Process-wide singleton. The CLI entrypoint installs the signal
+ * listeners; subcommands import `shutdownSignal` and `onShutdown`
+ * directly without caring about the underlying instance.
+ */
+export const coordinator = new ShutdownCoordinator();
+
+export const shutdownSignal: AbortSignal = coordinator.signal;
+export const onShutdown = (hook: ShutdownHook): (() => void) => coordinator.onShutdown(hook);
+
+let signalHandlersInstalled = false;
+
+/**
+ * Wires the singleton coordinator to POSIX signals. Idempotent —
+ * calling more than once is safe (and a no-op). Tests that exercise
+ * the coordinator directly skip this and use a fresh
+ * `ShutdownCoordinator` to keep the test process clean.
+ */
+export function installSignalHandlers(): void {
+  if (signalHandlersInstalled) return;
+  signalHandlersInstalled = true;
+  for (const signal of HANDLED_SIGNALS) {
+    process.on(signal, () => {
+      // Fire-and-forget: signal handlers can't be async themselves, but
+      // `trigger` owns the exit so nothing meaningful happens after.
+      void coordinator.trigger(signal, SIGNAL_EXIT_CODES[signal]);
+    });
+  }
+}

--- a/apps/cli/test/shutdown.test.ts
+++ b/apps/cli/test/shutdown.test.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "bun:test";
+import { ShutdownCoordinator } from "../src/lib/shutdown.ts";
+
+/**
+ * Helper: builds a coordinator wired to a tiny fake `exit` so the test
+ * process survives. Returns the coordinator plus a getter for the
+ * captured exit codes (in call order).
+ */
+function makeCoordinator(timeoutMs = 50): {
+  coordinator: ShutdownCoordinator;
+  exitCodes: () => readonly number[];
+} {
+  const codes: number[] = [];
+  const coordinator = new ShutdownCoordinator({
+    exit: (code) => {
+      codes.push(code);
+    },
+    timeoutMs,
+  });
+  return { coordinator, exitCodes: () => codes };
+}
+
+describe("ShutdownCoordinator", () => {
+  it("aborts its signal as soon as trigger is called", async () => {
+    const { coordinator } = makeCoordinator();
+    expect(coordinator.signal.aborted).toBe(false);
+    const promise = coordinator.trigger("SIGINT", 130);
+    expect(coordinator.signal.aborted).toBe(true);
+    await promise;
+  });
+
+  it("invokes registered hooks before exiting with the requested code", async () => {
+    const { coordinator, exitCodes } = makeCoordinator();
+    const calls: string[] = [];
+    coordinator.onShutdown(() => {
+      calls.push("a");
+    });
+    coordinator.onShutdown(async () => {
+      await Promise.resolve();
+      calls.push("b");
+    });
+    await coordinator.trigger("SIGTERM", 143);
+    expect(calls.sort()).toEqual(["a", "b"]);
+    expect(exitCodes()).toEqual([143]);
+  });
+
+  it("preserves hook registration order", async () => {
+    // Some hooks observe each other's effects (heartbeat-stop must
+    // happen before the safety-net finalize, for instance), so order
+    // is part of the contract — not just an implementation detail.
+    const { coordinator } = makeCoordinator();
+    const calls: string[] = [];
+    coordinator.onShutdown(() => {
+      calls.push("first");
+    });
+    coordinator.onShutdown(() => {
+      calls.push("second");
+    });
+    coordinator.onShutdown(() => {
+      calls.push("third");
+    });
+    await coordinator.trigger("SIGINT", 130);
+    expect(calls).toEqual(["first", "second", "third"]);
+  });
+
+  it("isolates hook failures with allSettled semantics", async () => {
+    const { coordinator, exitCodes } = makeCoordinator();
+    let secondRan = false;
+    coordinator.onShutdown(() => {
+      throw new Error("boom");
+    });
+    coordinator.onShutdown(async () => {
+      await Promise.resolve();
+      throw new Error("async boom");
+    });
+    coordinator.onShutdown(() => {
+      secondRan = true;
+    });
+    await coordinator.trigger("SIGINT", 130);
+    expect(secondRan).toBe(true);
+    expect(exitCodes()).toEqual([130]);
+  });
+
+  it("exits even if a hook hangs forever, bounded by timeoutMs", async () => {
+    // The wedged hook must not prevent the CLI from exiting — that's
+    // the whole point of the bounded race. Use an unresolved promise to
+    // simulate a network call frozen behind a partition.
+    const { coordinator, exitCodes } = makeCoordinator(20);
+    coordinator.onShutdown(() => new Promise<void>(() => {}));
+    const start = Date.now();
+    await coordinator.trigger("SIGINT", 130);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(500);
+    expect(exitCodes()).toEqual([130]);
+  });
+
+  it("unregister stops the hook from running", async () => {
+    const { coordinator } = makeCoordinator();
+    let called = false;
+    const unregister = coordinator.onShutdown(() => {
+      called = true;
+    });
+    unregister();
+    await coordinator.trigger("SIGINT", 130);
+    expect(called).toBe(false);
+  });
+
+  it("a second trigger short-circuits to exit without re-running hooks", async () => {
+    // The second-Ctrl-C UX: the user signalled they want OUT, don't
+    // re-run cleanups (which might be the thing hanging in the first place).
+    const { coordinator, exitCodes } = makeCoordinator(50);
+    let runCount = 0;
+    coordinator.onShutdown(async () => {
+      runCount++;
+      // Hold the first shutdown open long enough for the second trigger
+      // to land before hooks have settled.
+      await new Promise((resolve) => setTimeout(resolve, 30));
+    });
+    const first = coordinator.trigger("SIGINT", 130);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    await coordinator.trigger("SIGINT", 130);
+    await first;
+    expect(runCount).toBe(1);
+    expect(exitCodes()).toEqual([130, 130]);
+  });
+
+  it("hooks registered after trigger are not invoked by the in-flight shutdown", async () => {
+    // Late registrations are a programmer error, but they shouldn't
+    // crash or stall the in-flight shutdown — just no-op.
+    const { coordinator } = makeCoordinator();
+    let lateCalled = false;
+    const promise = coordinator.trigger("SIGINT", 130);
+    coordinator.onShutdown(() => {
+      lateCalled = true;
+    });
+    await promise;
+    expect(lateCalled).toBe(false);
+  });
+
+  it("hook receives an aborted signal — hooks can branch on shutdown reason", async () => {
+    // Hooks that need to know whether they're being called from a
+    // signal vs a normal completion path can read `coordinator.signal`.
+    const { coordinator } = makeCoordinator();
+    const observed: { aborted: boolean | null } = { aborted: null };
+    coordinator.onShutdown(() => {
+      observed.aborted = coordinator.signal.aborted;
+    });
+    await coordinator.trigger("SIGINT", 130);
+    expect(observed.aborted).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces per-call signal handlers with a central `ShutdownCoordinator` so subcommands like `appstrate run` can finish their cooperative cancellation (AbortController flip + safety-net finalize POST + workspace teardown) **before** the process dies on Ctrl-C.

## Why

`apps/cli/src/cli.ts` registered SIGINT/SIGTERM/SIGHUP listeners at boot that called `process.exit()` synchronously inside. `apps/cli/src/commands/run.ts` registered its own listeners later that flipped an `AbortController` and ran a `finally` block to finalize the run server-side. **Node fires listeners in registration order, and `process.exit()` is synchronous** — so the bootstrap exit always won, the run's `finally` never executed, and platform-side runs sat open until the heartbeat watchdog (~60 s) swept them. Workspace dirs leaked too.

## What changed

- New `apps/cli/src/lib/shutdown.ts` — `ShutdownCoordinator` class:
  - Owns the SIGINT/SIGTERM/SIGHUP listeners (one place)
  - Exposes a single `AbortSignal` (`shutdownSignal`) shared across the process
  - `onShutdown(hook)` registers cleanup, returns an unregister fn
  - On signal: aborts the signal, awaits hooks via `Promise.allSettled` racing a 10 s ceiling, then exits with the conventional 128 + signal exit code
  - Second signal short-circuits to `process.exit` (standard "Ctrl-C twice to force" UX)
  - `installSignalHandlers()` is idempotent; tests use a fresh `ShutdownCoordinator` instance with an injected `exit` mock to avoid polluting the test process
- `apps/cli/src/cli.ts` — `restoreCookedMode` now registered as a coordinator hook (alongside the existing `process.on("exit", …)` for non-signal exits). Per-signal handlers gone.
- `apps/cli/src/commands/run.ts` — passes `shutdownSignal` to `runner.run`; lifts `heartbeat` out of the inner try; consolidates teardown into one idempotent `runCleanup` registered via `onShutdown` and also awaited from the outer `finally` (success / non-signal-error path).
- Crash paths (`uncaughtException`, `unhandledRejection`) intentionally bypass the coordinator and continue to fast-exit via `exitWithError` — async cleanup on a crash is risky and existing behavior is preserved.

## Tests

`apps/cli/test/shutdown.test.ts` — 9 unit tests covering:
- Signal aborts propagate to `coordinator.signal` immediately
- All registered hooks run, in registration order
- `allSettled` semantics — one hook's throw doesn't block the others
- The 10 s ceiling — a wedged hook does not hang the CLI
- `unregister()` removes a hook before it can run
- Second `trigger()` while shutdown is in flight short-circuits to exit (no double cleanup)
- Hooks registered after `trigger()` are skipped (defensive)
- Hooks can read `coordinator.signal.aborted` to branch on shutdown reason

Full suite green: `bun test` (894 / 894), `bun run check` (typecheck + lint + format + verify-openapi + breaking-change scan).

## Test plan

- [ ] `cd appstrate && bun run check` passes
- [ ] `cd appstrate/apps/cli && bun test` passes (894 tests)
- [ ] `appstrate run <bundle>` with Ctrl-C: stderr shows `shutdown received, cancelling run...`, platform run transitions to `cancelled` immediately (not 60 s later), workspace dir is removed, exit code is 130
- [ ] `appstrate run <bundle>` with Ctrl-C twice: second ^C exits immediately even if the safety-net finalize is hanging
- [ ] `appstrate whoami` / `appstrate org list` with Ctrl-C: exits 130 instantly (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)