### PR TITLE
fix(cli): bundle @appstrate/* workspace deps into npm tarball

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -45,10 +45,6 @@
   },
   "dependencies": {
     "@apidevtools/swagger-parser": "^12.1.0",
-    "@appstrate/afps-runtime": "workspace:*",
-    "@appstrate/core": "workspace:*",
-    "@appstrate/runner-pi": "workspace:*",
-    "@appstrate/shared-types": "workspace:*",
     "@clack/prompts": "^1.2.0",
     "@mariozechner/pi-ai": "^0.67.2",
     "@mariozechner/pi-coding-agent": "^0.67.2",
@@ -60,6 +56,10 @@
     "write-file-atomic": "^7"
   },
   "devDependencies": {
+    "@appstrate/afps-runtime": "workspace:*",
+    "@appstrate/core": "workspace:*",
+    "@appstrate/runner-pi": "workspace:*",
+    "@appstrate/shared-types": "workspace:*",
     "@types/bun": "latest",
     "@types/write-file-atomic": "^4.0.3"
   }

--- a/apps/cli/scripts/build.ts
+++ b/apps/cli/scripts/build.ts
@@ -4,12 +4,11 @@
 /**
  * Build wrapper for the npm channel of the CLI.
  *
- * Wraps `bun build --target=bun --packages external --outdir=dist src/cli.ts`
- * with a `--define` flag that stamps `INSTALL_SOURCE` (see
- * `src/lib/install-source.ts`). `package.json#scripts.build` calls this
- * instead of `bun build` directly so the `prepack` hook (run by `npm pack`
- * during the npm publish workflow) carries the stamp without manual escape
- * hell in `package.json`.
+ * Bundles `@appstrate/*` workspace dependencies into `dist/cli.js` (npm
+ * cannot resolve `workspace:*` from a published tarball), keeps every
+ * other npm package external (declared in `dependencies` so the consumer
+ * `npm install` resolves them). Stamps `INSTALL_SOURCE` via `--define`
+ * (see `src/lib/install-source.ts`).
  *
  * Channel selection:
  *   - `APPSTRATE_INSTALL_SOURCE=bun`  — set by `.github/workflows/publish-cli.yml`
@@ -21,7 +20,7 @@
  * `bun build --compile` directly with its own `--define` for the curl channel.
  */
 
-import { spawn } from "bun";
+import { spawn, file } from "bun";
 
 const VALID = new Set(["curl", "bun", "unknown"]);
 const raw = process.env.APPSTRATE_INSTALL_SOURCE?.trim() ?? "unknown";
@@ -33,13 +32,20 @@ if (raw !== source) {
   );
 }
 
+const pkg = (await file("package.json").json()) as {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+const allDeps = [...Object.keys(pkg.dependencies ?? {}), ...Object.keys(pkg.devDependencies ?? {})];
+const externals = allDeps.filter((d) => !d.startsWith("@appstrate/") && !d.startsWith("@types/"));
+const externalArgs = externals.flatMap((e) => ["--external", e]);
+
 const proc = spawn({
   cmd: [
     "bun",
     "build",
     "--target=bun",
-    "--packages",
-    "external",
+    ...externalArgs,
     "--outdir=dist",
     `--define=__APPSTRATE_INSTALL_SOURCE__="${source}"`,
     "src/cli.ts",


### PR DESCRIPTION
## Summary

- CLI npm publish broke at \`cli@1.0.0-beta.1\` — workspace deps added since alpha.64 (\`@appstrate/afps-runtime\`, \`@appstrate/core\`, \`@appstrate/runner-pi\`, \`@appstrate/shared-types\`) were leaking into the published \`dependencies\` as \`workspace:*\`, which npm cannot resolve from a tarball (\`EUNSUPPORTEDPROTOCOL\`).
- Switch \`bun build\` from \`--packages external\` to an explicit external list computed from \`package.json\` (everything except \`@appstrate/*\` and \`@types/*\`).
- Move the 4 workspace deps from \`dependencies\` to \`devDependencies\`.
- Bundle size: 280 KB → 1.54 MB. Consumers still install commander, @clack/prompts, @napi-rs/keyring, etc. as runtime deps.

## Test plan

- [x] \`APPSTRATE_INSTALL_SOURCE=bun bun run build\` produces \`dist/cli.js\` with no remaining \`from "@appstrate/…"\` imports
- [x] \`npm pack\` + \`npm install <tarball>\` succeeds
- [x] \`appstrate --help\` runs from the installed bin

🤖 Generated with [Claude Code](https://claude.com/claude-code)