### PR TITLE
fix(cli): shim pi-coding-agent package.json lookup in standalone binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,11 +183,19 @@ jobs:
             src/cli.ts \
             --outfile=${{ matrix.asset }}
 
-      - name: Smoke-test binary (--help + --version)
+      - name: Smoke-test binary (--help + --version) in clean dir
         working-directory: apps/cli
         run: |
-          ./${{ matrix.asset }} --help
-          REPORTED=$(./${{ matrix.asset }} --version)
+          # MUST run from a directory with no sibling package.json — otherwise
+          # bugs in transitive deps that resolve `dirname(process.execPath)/package.json`
+          # at module top-level (e.g. `@mariozechner/pi-coding-agent`) are masked
+          # by `apps/cli/package.json` and only crash on the user's machine.
+          # See `apps/cli/src/lib/pi-binary-shim.ts` for the post-mortem.
+          TMP="$(mktemp -d)"
+          cp "./${{ matrix.asset }}" "$TMP/appstrate"
+          "$TMP/appstrate" --help
+          REPORTED=$("$TMP/appstrate" --version)
+          rm -rf "$TMP"
           EXPECTED="${GITHUB_REF_NAME#v}"
           echo "Binary reports: $REPORTED / expected: $EXPECTED"
           if [ "$REPORTED" != "$EXPECTED" ]; then

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -25,6 +25,11 @@
  * with user-actionable text rather than raw stack traces.
  */
 
+// MUST be the first import — sets PI_PACKAGE_DIR before any module that
+// transitively loads `@mariozechner/pi-coding-agent` runs its top-level
+// `JSON.parse(readFileSync(...package.json...))`. Without this, the
+// curl-installed standalone binary crashes at startup with ENOENT.
+import "./lib/pi-binary-shim.ts";
 import { Command, InvalidArgumentError } from "commander";
 import { installCommand } from "./commands/install.ts";
 import { loginCommand } from "./commands/login.ts";

--- a/apps/cli/src/lib/pi-binary-shim.ts
+++ b/apps/cli/src/lib/pi-binary-shim.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Workaround for transitive `@mariozechner/pi-coding-agent` crash on Bun
+// `--compile`'d binaries.
+//
+// Pi's `dist/config.js` runs `JSON.parse(readFileSync(getPackageJsonPath()))`
+// at module top level. `getPackageJsonPath()` resolves to
+// `dirname(process.execPath)/package.json` when pi detects it is running
+// inside a Bun-compiled binary (no node_modules layout to walk up). Our
+// curl/bash installer drops the binary into `~/.local/bin/` (or wherever
+// `APPSTRATE_BIN_DIR` points) — there is no sibling `package.json` there,
+// so pi crashes with `ENOENT` before `main()` runs.
+//
+// Materialise a stub `package.json` under the user's XDG cache directory
+// (idempotent — same content every invocation, ~1 ms total) and override
+// pi's lookup via the `PI_PACKAGE_DIR` env var pi itself documents.
+//
+// MUST be the first import in `src/cli.ts`. ESM side effects run in
+// import-declaration order, and the shim has to land before any module
+// that transitively pulls in `@mariozechner/pi-coding-agent` (notably
+// `@appstrate/runner-pi`) and triggers pi's top-level `readFileSync`.
+//
+// The npm channel (`bun build --target=bun --outdir=dist`) is unaffected:
+// the bundled `dist/cli.js` lives next to its own
+// `node_modules/.../package.json`, and pi's `__dirname`-walk path resolves
+// correctly without this shim.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { CLI_VERSION } from "./version.ts";
+
+const isBunBinary =
+  import.meta.url.includes("$bunfs") ||
+  import.meta.url.includes("~BUN") ||
+  import.meta.url.includes("%7EBUN");
+
+if (isBunBinary && !process.env.PI_PACKAGE_DIR) {
+  const cacheRoot = process.env.XDG_CACHE_HOME || join(homedir(), ".cache");
+  const dir = join(cacheRoot, "appstrate", "pi-shim");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "package.json"),
+    JSON.stringify({
+      name: "appstrate",
+      version: CLI_VERSION,
+      // Re-brand pi's config layer under the appstrate namespace so any
+      // pi-internal state (sessions, caches) lives at `~/.appstrate/`
+      // alongside our own config — not in a stray `~/.pi/`.
+      piConfig: { name: "appstrate", configDir: ".appstrate" },
+    }),
+  );
+  process.env.PI_PACKAGE_DIR = dir;
+}


### PR DESCRIPTION
## Summary

The curl-installed CLI (\`bun build --compile\` → \`get.appstrate.dev/install.sh\`) crashed at startup with:

\`\`\`
ENOENT: no such file or directory, open '/Users/.../local/bin/package.json'
  at /\$bunfs/root/appstrate-darwin-arm64:222880:34
\`\`\`

Root cause: \`@mariozechner/pi-coding-agent\` (transitive via \`@appstrate/runner-pi\`, added in #227 / #299) runs \`JSON.parse(readFileSync(getPackageJsonPath()))\` at module top level. In Bun-compiled binaries pi resolves the path to \`dirname(process.execPath)/package.json\`. The curl installer drops the binary in \`~/.local/bin/\` (no sibling package.json) → pi crashes before \`main()\` runs.

## Fix

- **\`apps/cli/src/lib/pi-binary-shim.ts\`** — materialises a stub \`package.json\` under \`$XDG_CACHE_HOME/appstrate/pi-shim/\` (idempotent, ~1 ms) and overrides pi's lookup via \`PI_PACKAGE_DIR\`. Imported first in \`src/cli.ts\` so ESM side effects land before any module that transitively pulls in pi.
- **\`release.yml::Smoke-test binary\`** — runs the binary from a fresh \`mktemp -d\` (clean dir). Previously ran from \`apps/cli/\` where \`apps/cli/package.json\` masked every regression of this class.

The npm channel is unaffected — the bundled \`dist/cli.js\` lives next to its own \`node_modules/.../package.json\` and pi's \`__dirname\`-walk works.

## Test plan

- [x] \`bun build --compile\` + run from \`mktemp -d\` without shim → reproduces ENOENT at line 222880
- [x] \`bun build --compile\` + run from \`mktemp -d\` with shim → \`appstrate --help\` exits 0
- [x] 3 invocations → single \`~/.cache/appstrate/pi-shim/package.json\` (idempotent, no /tmp leak)
- [x] \`bun run check\` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)