### PR TITLE
fix: resolve BETTER_AUTH_SECRETS namespace collision with better-auth 1.6+

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,7 +205,12 @@ services:
       - AUTH_BOOTSTRAP_ORG_NAME=${AUTH_BOOTSTRAP_ORG_NAME:-Default}
       # ── Auth secret rotation (optional) ──
       - BETTER_AUTH_ACTIVE_KID=${BETTER_AUTH_ACTIVE_KID:-k1}
-      - BETTER_AUTH_SECRETS=${BETTER_AUTH_SECRETS:-{}}
+      # NOTE: empty default (NOT `{}`) — better-auth 1.6+ has its own
+      # `BETTER_AUTH_SECRETS` env var with CSV `v1:secret` format and crashes
+      # boot on a non-CSV value. Empty string is falsy for better-auth and
+      # treated as `{}` by `@appstrate/env`. Set this in `.env` only when
+      # rotating the kid map; see env docstring in `packages/env/src/index.ts`.
+      - BETTER_AUTH_SECRETS=${BETTER_AUTH_SECRETS:-}
       # ── Credential encryption rotation (optional) ──
       - CONNECTION_ENCRYPTION_KEY_ID=${CONNECTION_ENCRYPTION_KEY_ID:-k1}
       - CONNECTION_ENCRYPTION_KEYS=${CONNECTION_ENCRYPTION_KEYS:-{}}

--- a/examples/self-hosting/docker-compose.tier1.yml
+++ b/examples/self-hosting/docker-compose.tier1.yml
@@ -110,7 +110,12 @@ services:
       - AUTH_BOOTSTRAP_ORG_NAME=${AUTH_BOOTSTRAP_ORG_NAME:-Default}
       # ── Credential / auth secret rotation (optional) ──
       - BETTER_AUTH_ACTIVE_KID=${BETTER_AUTH_ACTIVE_KID:-k1}
-      - BETTER_AUTH_SECRETS=${BETTER_AUTH_SECRETS:-{}}
+      # NOTE: empty default (NOT `{}`) — better-auth 1.6+ has its own
+      # `BETTER_AUTH_SECRETS` env var with CSV `v1:secret` format and crashes
+      # boot on a non-CSV value. Empty string is falsy for better-auth and
+      # treated as `{}` by `@appstrate/env`. Set this in `.env` only when
+      # rotating the kid map; see env docstring in `packages/env/src/index.ts`.
+      - BETTER_AUTH_SECRETS=${BETTER_AUTH_SECRETS:-}
       - CONNECTION_ENCRYPTION_KEY_ID=${CONNECTION_ENCRYPTION_KEY_ID:-k1}
       - CONNECTION_ENCRYPTION_KEYS=${CONNECTION_ENCRYPTION_KEYS:-{}}
       # ── AFPS bundle signing (optional) ──

--- a/examples/self-hosting/docker-compose.tier2.yml
+++ b/examples/self-hosting/docker-compose.tier2.yml
@@ -120,7 +120,12 @@ services:
       - AUTH_BOOTSTRAP_ORG_NAME=${AUTH_BOOTSTRAP_ORG_NAME:-Default}
       # ── Credential / auth secret rotation (optional) ──
       - BETTER_AUTH_ACTIVE_KID=${BETTER_AUTH_ACTIVE_KID:-k1}
-      - BETTER_AUTH_SECRETS=${BETTER_AUTH_SECRETS:-{}}
+      # NOTE: empty default (NOT `{}`) — better-auth 1.6+ has its own
+      # `BETTER_AUTH_SECRETS` env var with CSV `v1:secret` format and crashes
+      # boot on a non-CSV value. Empty string is falsy for better-auth and
+      # treated as `{}` by `@appstrate/env`. Set this in `.env` only when
+      # rotating the kid map; see env docstring in `packages/env/src/index.ts`.
+      - BETTER_AUTH_SECRETS=${BETTER_AUTH_SECRETS:-}
       - CONNECTION_ENCRYPTION_KEY_ID=${CONNECTION_ENCRYPTION_KEY_ID:-k1}
       - CONNECTION_ENCRYPTION_KEYS=${CONNECTION_ENCRYPTION_KEYS:-{}}
       # ── AFPS bundle signing (optional) ──

--- a/examples/self-hosting/docker-compose.tier3.yml
+++ b/examples/self-hosting/docker-compose.tier3.yml
@@ -171,7 +171,12 @@ services:
       - AUTH_BOOTSTRAP_ORG_NAME=${AUTH_BOOTSTRAP_ORG_NAME:-Default}
       # ── Credential / auth secret rotation (optional) ──
       - BETTER_AUTH_ACTIVE_KID=${BETTER_AUTH_ACTIVE_KID:-k1}
-      - BETTER_AUTH_SECRETS=${BETTER_AUTH_SECRETS:-{}}
+      # NOTE: empty default (NOT `{}`) — better-auth 1.6+ has its own
+      # `BETTER_AUTH_SECRETS` env var with CSV `v1:secret` format and crashes
+      # boot on a non-CSV value. Empty string is falsy for better-auth and
+      # treated as `{}` by `@appstrate/env`. Set this in `.env` only when
+      # rotating the kid map; see env docstring in `packages/env/src/index.ts`.
+      - BETTER_AUTH_SECRETS=${BETTER_AUTH_SECRETS:-}
       - CONNECTION_ENCRYPTION_KEY_ID=${CONNECTION_ENCRYPTION_KEY_ID:-k1}
       - CONNECTION_ENCRYPTION_KEYS=${CONNECTION_ENCRYPTION_KEYS:-{}}
       # ── AFPS bundle signing (optional) ──

--- a/examples/self-hosting/docker-compose.yml
+++ b/examples/self-hosting/docker-compose.yml
@@ -166,7 +166,12 @@ services:
       - AUTH_BOOTSTRAP_ORG_NAME=${AUTH_BOOTSTRAP_ORG_NAME:-Default}
       # ── Credential / auth secret rotation (optional) ──
       - BETTER_AUTH_ACTIVE_KID=${BETTER_AUTH_ACTIVE_KID:-k1}
-      - BETTER_AUTH_SECRETS=${BETTER_AUTH_SECRETS:-{}}
+      # NOTE: empty default (NOT `{}`) — better-auth 1.6+ has its own
+      # `BETTER_AUTH_SECRETS` env var with CSV `v1:secret` format and crashes
+      # boot on a non-CSV value. Empty string is falsy for better-auth and
+      # treated as `{}` by `@appstrate/env`. Set this in `.env` only when
+      # rotating the kid map; see env docstring in `packages/env/src/index.ts`.
+      - BETTER_AUTH_SECRETS=${BETTER_AUTH_SECRETS:-}
       - CONNECTION_ENCRYPTION_KEY_ID=${CONNECTION_ENCRYPTION_KEY_ID:-k1}
       - CONNECTION_ENCRYPTION_KEYS=${CONNECTION_ENCRYPTION_KEYS:-{}}
       # ── AFPS bundle signing (optional) ──

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to `@appstrate/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.18.0] — 2026-04-27
+
+### Changed
+
+- `@appstrate/core/env::createEnvGetter` now coalesces empty-string env
+  values to `undefined` before Zod validation runs. Aligns the helper
+  with Docker Compose's `${VAR:-}` pattern (an unset host variable is
+  forwarded to the container as a literal `VAR=`, not as a missing
+  key) so Zod's `.default(...)` fires uniformly across every refined
+  field. Previously, `MY_VAR=` would fail boot for any field with a
+  refine guard or enum, with a cryptic `must be …` error.
+
+  Subtle observable change for `.optional()` fields: `MY_VAR=` now
+  parses to `undefined` instead of `""`. Safe for env vars in
+  practice (the host shell never assigns a meaningful empty string),
+  but downstream code that distinguished `""` from `undefined` would
+  need to be updated.
+
 ## [2.12.0] — 2026-04-19
 
 ### Added

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -12,8 +12,39 @@ export interface EnvGetter<T> {
 }
 
 /**
+ * Coalesce empty strings to `undefined` across the entire `process.env`
+ * snapshot before Zod sees it.
+ *
+ * Docker Compose's `${VAR:-}` pattern forwards an unset host variable to
+ * the container as an empty string (`VAR=`), not as a missing key. Zod's
+ * `.default(...)` only fires on `undefined`, so without this preprocess
+ * any refined-string field with a default (booleans, regex-validated kid
+ * IDs, enums) would crash boot on a literal `VAR=` with a cryptic
+ * "must be …" error.
+ *
+ * Coalescing once at the root makes `.default(...)` the single source of
+ * truth for fallback behavior on EVERY field — no per-field opt-in
+ * helper, no behavioral drift between fields. For env vars,
+ * "explicitly empty" and "unset" are conceptually identical (the host
+ * never sets a variable to a meaningful empty string), so the universal
+ * coalesce is safe.
+ */
+function sanitizeEnv(input: NodeJS.ProcessEnv): Record<string, string | undefined> {
+  const out: Record<string, string | undefined> = {};
+  for (const [k, v] of Object.entries(input)) {
+    out[k] = v === "" ? undefined : v;
+  }
+  return out;
+}
+
+/**
  * Create a cached, Zod-validated environment variable accessor.
- * Parses `process.env` against the provided schema on first call and caches the result.
+ *
+ * Parses `process.env` against the provided schema on first call and
+ * caches the result. Empty-string values are coalesced to `undefined`
+ * before validation so `.default(...)` fires uniformly for compose's
+ * `${VAR:-}` pattern (see {@link sanitizeEnv}).
+ *
  * @param schema - Zod schema to validate process.env against
  * @returns An EnvGetter with getEnv() and resetCache() methods
  * @throws Error if environment variables fail schema validation
@@ -23,7 +54,7 @@ export function createEnvGetter<T extends z.ZodType>(schema: T): EnvGetter<z.inf
 
   function getEnv(): z.infer<T> {
     if (cached) return cached;
-    const result = schema.safeParse(process.env);
+    const result = schema.safeParse(sanitizeEnv(process.env));
     if (!result.success) {
       const issues = result.error.issues.map(
         (i) => `  - ${String(i.path.join("."))}: ${i.message}`,

--- a/packages/core/test/env.test.ts
+++ b/packages/core/test/env.test.ts
@@ -62,4 +62,56 @@ describe("createEnvGetter", () => {
     const { getEnv } = createEnvGetter(schema);
     expect(getEnv().WITH_DEFAULT).toBe("fallback");
   });
+
+  describe("empty-string sanitization (compose `${VAR:-}` pattern)", () => {
+    it("treats empty string as unset so `.default()` fires", () => {
+      process.env.WITH_DEFAULT = "";
+      const schema = z.object({
+        WITH_DEFAULT: z.string().default("fallback"),
+      });
+      const { getEnv } = createEnvGetter(schema);
+      expect(getEnv().WITH_DEFAULT).toBe("fallback");
+    });
+
+    it("treats empty string as unset for refined-string fields", () => {
+      process.env.MODE = "";
+      const schema = z.object({
+        MODE: z
+          .string()
+          .default("auto")
+          .refine((v) => v === "auto" || v === "manual", {
+            message: "MODE must be 'auto' or 'manual'",
+          }),
+      });
+      const { getEnv } = createEnvGetter(schema);
+      expect(getEnv().MODE).toBe("auto");
+    });
+
+    it("treats empty string as unset for enum fields", () => {
+      process.env.LOG_LEVEL = "";
+      const schema = z.object({
+        LOG_LEVEL: z.enum(["debug", "info", "warn"]).default("info"),
+      });
+      const { getEnv } = createEnvGetter(schema);
+      expect(getEnv().LOG_LEVEL).toBe("info");
+    });
+
+    it("makes empty string indistinguishable from unset for `.optional()`", () => {
+      process.env.OPTIONAL_VAR = "";
+      const schema = z.object({
+        OPTIONAL_VAR: z.string().optional(),
+      });
+      const { getEnv } = createEnvGetter(schema);
+      expect(getEnv().OPTIONAL_VAR).toBeUndefined();
+    });
+
+    it("preserves non-empty values verbatim", () => {
+      process.env.NAMED_VAR = "actual-value";
+      const schema = z.object({
+        NAMED_VAR: z.string().default("fallback"),
+      });
+      const { getEnv } = createEnvGetter(schema);
+      expect(getEnv().NAMED_VAR).toBe("actual-value");
+    });
+  });
 });

--- a/packages/env/bunfig.toml
+++ b/packages/env/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+timeout = 5000

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -3,39 +3,6 @@
 import { z } from "zod";
 import { createEnvGetter } from "@appstrate/core/env";
 
-// ─── Helpers ─────────────────────────────────────────────────
-
-/**
- * Coalesce an empty string or `undefined` to the supplied fallback BEFORE
- * Zod string validation runs. This matters for Docker Compose's
- * `${VAR:-}` pattern: when the variable is unset on the host, compose
- * forwards it to the container as an empty string (`VAR=`) rather than
- * dropping it — so Zod sees `""` instead of `undefined` and `.default()`
- * never triggers. Without this, every refined string env (booleans,
- * enums, regex-validated kid IDs) would reject the empty value with a
- * cryptic "must be …" error at boot.
- */
-function emptyToDefault<T extends string>(fallback: T) {
-  return (v: unknown): unknown => (v === "" || v === undefined ? fallback : v);
-}
-
-/**
- * Boolean env var: accepts `"true"` | `"false"` | empty | unset.
- * Empty/unset both fall back to `defaultValue`.
- */
-function envBoolean(defaultValue: boolean): z.ZodType<boolean, unknown> {
-  const fallback = defaultValue ? "true" : "false";
-  return z.preprocess(
-    emptyToDefault(fallback),
-    z
-      .string()
-      .refine((v) => v === "true" || v === "false", {
-        message: "must be 'true' or 'false'",
-      })
-      .transform((v) => v === "true"),
-  );
-}
-
 // ─── Schema ──────────────────────────────────────────────────
 
 const envSchema = z
@@ -43,14 +10,12 @@ const envSchema = z
     // Node environment — gates production-only invariants (e.g. APP_URL https)
     NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
     // Trust proxy hops: "false" (default, ignore XFF) | "true" (=1) | "N" (N trusted hops)
-    TRUST_PROXY: z.preprocess(
-      emptyToDefault("false"),
-      z
-        .string()
-        .refine((v) => v === "false" || v === "true" || (/^\d+$/.test(v) && Number(v) >= 0), {
-          message: "TRUST_PROXY must be 'false', 'true', or a non-negative integer",
-        }),
-    ),
+    TRUST_PROXY: z
+      .string()
+      .default("false")
+      .refine((v) => v === "false" || v === "true" || (/^\d+$/.test(v) && Number(v) >= 0), {
+        message: "TRUST_PROXY must be 'false', 'true', or a non-negative integer",
+      }),
     // Database (optional — falls back to PGlite embedded Postgres when absent)
     DATABASE_URL: z.string().optional(),
     // PGlite data directory (used when DATABASE_URL is absent)
@@ -361,11 +326,23 @@ const envSchema = z
     //   1. Email matches a pending+non-expired invitation in `org_invitations`.
     //   2. Email is in AUTH_PLATFORM_ADMIN_EMAILS.
     //   3. Email matches AUTH_BOOTSTRAP_OWNER_EMAIL (1st run only).
-    AUTH_DISABLE_SIGNUP: envBoolean(false),
+    AUTH_DISABLE_SIGNUP: z
+      .string()
+      .default("false")
+      .refine((v) => v === "true" || v === "false", {
+        message: "AUTH_DISABLE_SIGNUP must be 'true' or 'false'",
+      })
+      .transform((v) => v === "true"),
     // AUTH_DISABLE_ORG_CREATION — when true, only platform admins (see
     // AUTH_PLATFORM_ADMIN_EMAILS) may call POST /api/orgs. Org-less users
     // see a "waiting for invitation" page instead of /onboarding/create.
-    AUTH_DISABLE_ORG_CREATION: envBoolean(false),
+    AUTH_DISABLE_ORG_CREATION: z
+      .string()
+      .default("false")
+      .refine((v) => v === "true" || v === "false", {
+        message: "AUTH_DISABLE_ORG_CREATION must be 'true' or 'false'",
+      })
+      .transform((v) => v === "true"),
     // AUTH_ALLOWED_SIGNUP_DOMAINS — comma-separated email domain allowlist.
     // When set, signups (outside the 3 exceptions above) are limited to
     // emails whose domain matches one entry. Empty / unset = no domain
@@ -453,9 +430,34 @@ const envSchema = z
 
 // ─── Getter ──────────────────────────────────────────────────
 
+/**
+ * Universal "empty string → unset" preprocessing.
+ *
+ * Docker Compose's `${VAR:-}` pattern forwards an unset host variable to
+ * the container as an empty string (`VAR=`), not as a missing key. Zod's
+ * `.default(...)` only fires on `undefined`, so without this preprocess
+ * any refined-string field (booleans, regex-validated kid IDs, enums)
+ * would crash boot on a literal `VAR=` with a cryptic "must be …" error.
+ *
+ * Coalescing `""` to `undefined` once, at the schema root, makes
+ * `.default(...)` the single source of truth for fallback behavior on
+ * EVERY field — no per-field opt-in helper, no behavioral drift between
+ * fields. For env vars, "explicitly empty" and "unset" are conceptually
+ * identical anyway (the host never sets a variable to a meaningful empty
+ * string).
+ */
+const sanitizedEnvSchema = z.preprocess((raw) => {
+  if (typeof raw !== "object" || raw === null) return raw;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
+    out[k] = v === "" ? undefined : v;
+  }
+  return out;
+}, envSchema);
+
 export type Env = z.infer<typeof envSchema>;
 
-const { getEnv, resetCache } = createEnvGetter(envSchema);
+const { getEnv, resetCache } = createEnvGetter(sanitizedEnvSchema);
 
 export { getEnv };
 export const _resetCacheForTesting = resetCache;

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -430,34 +430,13 @@ const envSchema = z
 
 // ─── Getter ──────────────────────────────────────────────────
 
-/**
- * Universal "empty string → unset" preprocessing.
- *
- * Docker Compose's `${VAR:-}` pattern forwards an unset host variable to
- * the container as an empty string (`VAR=`), not as a missing key. Zod's
- * `.default(...)` only fires on `undefined`, so without this preprocess
- * any refined-string field (booleans, regex-validated kid IDs, enums)
- * would crash boot on a literal `VAR=` with a cryptic "must be …" error.
- *
- * Coalescing `""` to `undefined` once, at the schema root, makes
- * `.default(...)` the single source of truth for fallback behavior on
- * EVERY field — no per-field opt-in helper, no behavioral drift between
- * fields. For env vars, "explicitly empty" and "unset" are conceptually
- * identical anyway (the host never sets a variable to a meaningful empty
- * string).
- */
-const sanitizedEnvSchema = z.preprocess((raw) => {
-  if (typeof raw !== "object" || raw === null) return raw;
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(raw as Record<string, unknown>)) {
-    out[k] = v === "" ? undefined : v;
-  }
-  return out;
-}, envSchema);
-
 export type Env = z.infer<typeof envSchema>;
 
-const { getEnv, resetCache } = createEnvGetter(sanitizedEnvSchema);
+// `createEnvGetter` coalesces `""` → `undefined` across the entire
+// process.env snapshot before validating, so `.default(...)` fires
+// uniformly for compose's `${VAR:-}` pattern. No per-field opt-in
+// needed; see `@appstrate/core/env::sanitizeEnv` for the rationale.
+const { getEnv, resetCache } = createEnvGetter(envSchema);
 
 export { getEnv };
 export const _resetCacheForTesting = resetCache;

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -51,8 +51,24 @@ const envSchema = z
       .string()
       .default("{}")
       .transform((s, ctx) => {
+        // Empty string == unset (compose `${VAR:-}` defaults to ""); fall back
+        // to "{}" so the JSON parse below succeeds.
+        const raw = s === "" ? "{}" : s;
         try {
-          return JSON.parse(s) as unknown;
+          const parsed = JSON.parse(raw) as unknown;
+          // ── Namespace-collision scrub ─────────────────────────────────────
+          // better-auth 1.6+ ships its own `BETTER_AUTH_SECRETS` env var with
+          // a different format (CSV `v1:secret,v2:secret`). It is read
+          // unconditionally inside `betterAuth()` regardless of whether we
+          // pass an explicit `secret:` option, so a non-CSV value (incl. our
+          // JSON `{}` default) crashes boot with `BetterAuthError: Invalid
+          // BETTER_AUTH_SECRETS entry`. We never want better-auth's own
+          // multi-secret rotation feature — `auth.ts` always passes `secret`
+          // explicitly via `env.BETTER_AUTH_SECRETS[…] ?? BETTER_AUTH_SECRET`
+          // — so unconditionally remove the raw env so better-auth falls back
+          // to its legacy single-secret path.
+          delete process.env.BETTER_AUTH_SECRETS;
+          return parsed;
         } catch {
           ctx.addIssue({
             code: "custom",

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -3,6 +3,39 @@
 import { z } from "zod";
 import { createEnvGetter } from "@appstrate/core/env";
 
+// ─── Helpers ─────────────────────────────────────────────────
+
+/**
+ * Coalesce an empty string or `undefined` to the supplied fallback BEFORE
+ * Zod string validation runs. This matters for Docker Compose's
+ * `${VAR:-}` pattern: when the variable is unset on the host, compose
+ * forwards it to the container as an empty string (`VAR=`) rather than
+ * dropping it — so Zod sees `""` instead of `undefined` and `.default()`
+ * never triggers. Without this, every refined string env (booleans,
+ * enums, regex-validated kid IDs) would reject the empty value with a
+ * cryptic "must be …" error at boot.
+ */
+function emptyToDefault<T extends string>(fallback: T) {
+  return (v: unknown): unknown => (v === "" || v === undefined ? fallback : v);
+}
+
+/**
+ * Boolean env var: accepts `"true"` | `"false"` | empty | unset.
+ * Empty/unset both fall back to `defaultValue`.
+ */
+function envBoolean(defaultValue: boolean): z.ZodType<boolean, unknown> {
+  const fallback = defaultValue ? "true" : "false";
+  return z.preprocess(
+    emptyToDefault(fallback),
+    z
+      .string()
+      .refine((v) => v === "true" || v === "false", {
+        message: "must be 'true' or 'false'",
+      })
+      .transform((v) => v === "true"),
+  );
+}
+
 // ─── Schema ──────────────────────────────────────────────────
 
 const envSchema = z
@@ -10,12 +43,14 @@ const envSchema = z
     // Node environment — gates production-only invariants (e.g. APP_URL https)
     NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
     // Trust proxy hops: "false" (default, ignore XFF) | "true" (=1) | "N" (N trusted hops)
-    TRUST_PROXY: z
-      .string()
-      .default("false")
-      .refine((v) => v === "false" || v === "true" || (/^\d+$/.test(v) && Number(v) >= 0), {
-        message: "TRUST_PROXY must be 'false', 'true', or a non-negative integer",
-      }),
+    TRUST_PROXY: z.preprocess(
+      emptyToDefault("false"),
+      z
+        .string()
+        .refine((v) => v === "false" || v === "true" || (/^\d+$/.test(v) && Number(v) >= 0), {
+          message: "TRUST_PROXY must be 'false', 'true', or a non-negative integer",
+        }),
+    ),
     // Database (optional — falls back to PGlite embedded Postgres when absent)
     DATABASE_URL: z.string().optional(),
     // PGlite data directory (used when DATABASE_URL is absent)
@@ -326,23 +361,11 @@ const envSchema = z
     //   1. Email matches a pending+non-expired invitation in `org_invitations`.
     //   2. Email is in AUTH_PLATFORM_ADMIN_EMAILS.
     //   3. Email matches AUTH_BOOTSTRAP_OWNER_EMAIL (1st run only).
-    AUTH_DISABLE_SIGNUP: z
-      .string()
-      .default("false")
-      .refine((v) => v === "true" || v === "false", {
-        message: "AUTH_DISABLE_SIGNUP must be 'true' or 'false'",
-      })
-      .transform((v) => v === "true"),
+    AUTH_DISABLE_SIGNUP: envBoolean(false),
     // AUTH_DISABLE_ORG_CREATION — when true, only platform admins (see
     // AUTH_PLATFORM_ADMIN_EMAILS) may call POST /api/orgs. Org-less users
     // see a "waiting for invitation" page instead of /onboarding/create.
-    AUTH_DISABLE_ORG_CREATION: z
-      .string()
-      .default("false")
-      .refine((v) => v === "true" || v === "false", {
-        message: "AUTH_DISABLE_ORG_CREATION must be 'true' or 'false'",
-      })
-      .transform((v) => v === "true"),
+    AUTH_DISABLE_ORG_CREATION: envBoolean(false),
     // AUTH_ALLOWED_SIGNUP_DOMAINS — comma-separated email domain allowlist.
     // When set, signups (outside the 3 exceptions above) are limited to
     // emails whose domain matches one entry. Empty / unset = no domain

--- a/packages/env/test/index.test.ts
+++ b/packages/env/test/index.test.ts
@@ -87,6 +87,41 @@ describe("BETTER_AUTH_SECRETS namespace-collision scrub", () => {
   });
 });
 
+describe("empty string is universally treated as unset (compose `${VAR:-}` pattern)", () => {
+  let s: Snap;
+
+  beforeEach(() => {
+    s = snap();
+    setBaseEnv();
+    _resetCacheForTesting();
+  });
+
+  afterEach(() => {
+    restore(s);
+    _resetCacheForTesting();
+  });
+
+  it('BETTER_AUTH_ACTIVE_KID: empty string falls back to default `"k1"`', () => {
+    process.env.BETTER_AUTH_ACTIVE_KID = "";
+    expect(getEnv().BETTER_AUTH_ACTIVE_KID).toBe("k1");
+  });
+
+  it("BETTER_AUTH_ACTIVE_KID: explicit value passes through", () => {
+    process.env.BETTER_AUTH_ACTIVE_KID = "k7";
+    expect(getEnv().BETTER_AUTH_ACTIVE_KID).toBe("k7");
+  });
+
+  it("BETTER_AUTH_ACTIVE_KID: invalid value (non-matching regex) still fails fast", () => {
+    process.env.BETTER_AUTH_ACTIVE_KID = "bad/kid";
+    expect(() => getEnv()).toThrow(/BETTER_AUTH_ACTIVE_KID/);
+  });
+
+  it('NODE_ENV: empty string falls back to default `"development"`', () => {
+    process.env.NODE_ENV = "";
+    expect(getEnv().NODE_ENV).toBe("development");
+  });
+});
+
 describe("boolean env vars accept empty string (compose `${VAR:-}` pattern)", () => {
   let s: Snap;
 

--- a/packages/env/test/index.test.ts
+++ b/packages/env/test/index.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { getEnv, _resetCacheForTesting } from "../src/index.ts";
+
+const TRACKED = [
+  "BETTER_AUTH_SECRET",
+  "BETTER_AUTH_ACTIVE_KID",
+  "BETTER_AUTH_SECRETS",
+  "CONNECTION_ENCRYPTION_KEY",
+  "UPLOAD_SIGNING_SECRET",
+  "APP_URL",
+  "NODE_ENV",
+] as const;
+
+type Snap = Record<(typeof TRACKED)[number], string | undefined>;
+
+function snap(): Snap {
+  return Object.fromEntries(TRACKED.map((k) => [k, process.env[k]])) as Snap;
+}
+
+function restore(s: Snap): void {
+  for (const k of TRACKED) {
+    if (s[k] === undefined) delete process.env[k];
+    else process.env[k] = s[k];
+  }
+}
+
+function setBaseEnv(): void {
+  process.env.BETTER_AUTH_SECRET = "x".repeat(32);
+  process.env.UPLOAD_SIGNING_SECRET = "y".repeat(32);
+  process.env.CONNECTION_ENCRYPTION_KEY = Buffer.alloc(32, 1).toString("base64");
+  process.env.NODE_ENV = "test";
+  delete process.env.APP_URL;
+  delete process.env.BETTER_AUTH_ACTIVE_KID;
+}
+
+describe("BETTER_AUTH_SECRETS namespace-collision scrub", () => {
+  let s: Snap;
+
+  beforeEach(() => {
+    s = snap();
+    setBaseEnv();
+    _resetCacheForTesting();
+  });
+
+  afterEach(() => {
+    restore(s);
+    _resetCacheForTesting();
+  });
+
+  it("removes process.env.BETTER_AUTH_SECRETS after parse (default empty case)", () => {
+    delete process.env.BETTER_AUTH_SECRETS;
+    const env = getEnv();
+    expect(env.BETTER_AUTH_SECRETS).toEqual({});
+    expect(process.env.BETTER_AUTH_SECRETS).toBeUndefined();
+  });
+
+  it("removes process.env.BETTER_AUTH_SECRETS after parse (literal `{}` from compose default)", () => {
+    process.env.BETTER_AUTH_SECRETS = "{}";
+    const env = getEnv();
+    expect(env.BETTER_AUTH_SECRETS).toEqual({});
+    expect(process.env.BETTER_AUTH_SECRETS).toBeUndefined();
+  });
+
+  it("removes process.env.BETTER_AUTH_SECRETS after parse (populated rotation map)", () => {
+    process.env.BETTER_AUTH_SECRETS = JSON.stringify({
+      k1: "old".repeat(11),
+      k2: "new".repeat(11),
+    });
+    const env = getEnv();
+    expect(env.BETTER_AUTH_SECRETS).toEqual({ k1: "old".repeat(11), k2: "new".repeat(11) });
+    expect(process.env.BETTER_AUTH_SECRETS).toBeUndefined();
+  });
+
+  it("treats empty string as `{}` (compose `${VAR:-}` fallback)", () => {
+    process.env.BETTER_AUTH_SECRETS = "";
+    const env = getEnv();
+    expect(env.BETTER_AUTH_SECRETS).toEqual({});
+    expect(process.env.BETTER_AUTH_SECRETS).toBeUndefined();
+  });
+
+  it("rejects non-JSON value with a clear error (e.g. better-auth's CSV format)", () => {
+    process.env.BETTER_AUTH_SECRETS = "v1:some-secret,v2:another";
+    expect(() => getEnv()).toThrow(/BETTER_AUTH_SECRETS must be valid JSON/);
+  });
+});

--- a/packages/env/test/index.test.ts
+++ b/packages/env/test/index.test.ts
@@ -9,6 +9,9 @@ const TRACKED = [
   "UPLOAD_SIGNING_SECRET",
   "APP_URL",
   "NODE_ENV",
+  "AUTH_DISABLE_SIGNUP",
+  "AUTH_DISABLE_ORG_CREATION",
+  "TRUST_PROXY",
 ] as const;
 
 type Snap = Record<(typeof TRACKED)[number], string | undefined>;
@@ -81,5 +84,70 @@ describe("BETTER_AUTH_SECRETS namespace-collision scrub", () => {
   it("rejects non-JSON value with a clear error (e.g. better-auth's CSV format)", () => {
     process.env.BETTER_AUTH_SECRETS = "v1:some-secret,v2:another";
     expect(() => getEnv()).toThrow(/BETTER_AUTH_SECRETS must be valid JSON/);
+  });
+});
+
+describe("boolean env vars accept empty string (compose `${VAR:-}` pattern)", () => {
+  let s: Snap;
+
+  beforeEach(() => {
+    s = snap();
+    setBaseEnv();
+    _resetCacheForTesting();
+  });
+
+  afterEach(() => {
+    restore(s);
+    _resetCacheForTesting();
+  });
+
+  it("AUTH_DISABLE_SIGNUP: empty string falls back to default `false`", () => {
+    process.env.AUTH_DISABLE_SIGNUP = "";
+    expect(getEnv().AUTH_DISABLE_SIGNUP).toBe(false);
+  });
+
+  it("AUTH_DISABLE_SIGNUP: unset falls back to default `false`", () => {
+    delete process.env.AUTH_DISABLE_SIGNUP;
+    expect(getEnv().AUTH_DISABLE_SIGNUP).toBe(false);
+  });
+
+  it('AUTH_DISABLE_SIGNUP: `"true"` parses to true', () => {
+    process.env.AUTH_DISABLE_SIGNUP = "true";
+    expect(getEnv().AUTH_DISABLE_SIGNUP).toBe(true);
+  });
+
+  it('AUTH_DISABLE_SIGNUP: `"false"` parses to false', () => {
+    process.env.AUTH_DISABLE_SIGNUP = "false";
+    expect(getEnv().AUTH_DISABLE_SIGNUP).toBe(false);
+  });
+
+  it("AUTH_DISABLE_SIGNUP: invalid value fails fast with a clear error", () => {
+    process.env.AUTH_DISABLE_SIGNUP = "yes";
+    expect(() => getEnv()).toThrow(/AUTH_DISABLE_SIGNUP/);
+  });
+
+  it("AUTH_DISABLE_ORG_CREATION: empty string falls back to default `false`", () => {
+    process.env.AUTH_DISABLE_ORG_CREATION = "";
+    expect(getEnv().AUTH_DISABLE_ORG_CREATION).toBe(false);
+  });
+
+  it('AUTH_DISABLE_ORG_CREATION: `"true"` parses to true', () => {
+    process.env.AUTH_DISABLE_ORG_CREATION = "true";
+    expect(getEnv().AUTH_DISABLE_ORG_CREATION).toBe(true);
+  });
+
+  it('TRUST_PROXY: empty string falls back to default `"false"`', () => {
+    process.env.TRUST_PROXY = "";
+    expect(getEnv().TRUST_PROXY).toBe("false");
+  });
+
+  it("TRUST_PROXY: integer string passes through", () => {
+    process.env.TRUST_PROXY = "2";
+    expect(getEnv().TRUST_PROXY).toBe("2");
+  });
+
+  it("TRUST_PROXY: invalid value fails fast", () => {
+    process.env.TRUST_PROXY = "maybe";
+    expect(() => getEnv()).toThrow(/TRUST_PROXY/);
   });
 });


### PR DESCRIPTION
## Summary

Two related self-hosting boot crashes caused by Docker Compose's `${VAR:-}` pattern interacting with overly strict env validation:

### 1. `BetterAuthError: Invalid BETTER_AUTH_SECRETS entry: "{}"`

- **Root cause**: better-auth 1.6+ introduced its own `BETTER_AUTH_SECRETS` env var with CSV `v1:secret,v2:secret` format — colliding with our pre-existing JSON `{ kid: secret }` map. The lib reads it unconditionally inside `betterAuth()` even when an explicit `secret:` option is passed, so the compose default of `${BETTER_AUTH_SECRETS:-{}}` placed a literal `{}` in the container env and crashed boot.
- **Fix (defense in depth)**:
  - `packages/env/src/index.ts`: scrub `process.env.BETTER_AUTH_SECRETS` after parsing so better-auth falls back to its legacy single-secret path. We never want better-auth's own multi-secret rotation — `auth.ts` always passes `secret` explicitly via our own kid map.
  - All 5 compose templates (`examples/self-hosting/docker-compose*.yml` + the root `docker-compose.yml`): change the default from `${VAR:-{}}` to `${VAR:-}` so the in-container value is empty string (falsy) rather than literal `{}`.

### 2. Empty-string env vars rejected universally

- **Root cause**: Docker Compose's `${VAR:-}` pattern forwards an unset host variable to the container as an empty string (`VAR=`), not as a missing key. Zod's `.default(...)` only fires on `undefined`, so a literal `AUTH_DISABLE_SIGNUP=` (or any other refined-string field with a default — `BETTER_AUTH_ACTIVE_KID`, `CONNECTION_ENCRYPTION_KEY_ID`, `NODE_ENV`, …) reached the refine guard and crashed boot with a cryptic "must be …" error.
- **Fix**: a single `z.preprocess` at the schema root that coalesces `""` to `undefined` for the entire input. Zod's `.default(...)` then becomes the single source of truth for fallback behavior on EVERY field — no per-field opt-in helper, no behavioral drift between fields. Original schemas read cleanly without helper indirection. For env vars, "explicitly empty" and "unset" are conceptually identical (the host never sets a variable to a meaningful empty string), so the universal coalesce is safe.

## Test plan

- [x] `bun test` in `packages/env/` — 19/19 pass:
  - 5 tests for the BETTER_AUTH_SECRETS namespace-collision scrub
  - 4 tests locking in universal empty-→-default behavior across heterogeneous fields (regex-validated kid ID, enum)
  - 10 tests covering the originally-reported booleans + TRUST_PROXY happy/sad paths
- [x] `bun run check` (turbo check + verify-openapi) — all green
- [x] CLI rebuilt — embedded compose templates use `:-` empty default
- [ ] After merge: re-run `curl -fsSL https://get.appstrate.dev | bash` against a fresh VM and confirm container boots cleanly with both default `.env` AND with `.env` containing arbitrary empty assignments (`AUTH_DISABLE_SIGNUP=`, `BETTER_AUTH_ACTIVE_KID=`, …)

🤖 Generated with [Claude Code](https://claude.com/claude-code)