### PR TITLE
fix(sidecar): copy logger.ts into Docker build context

### DIFF
--- a/runtime-pi/sidecar/Dockerfile
+++ b/runtime-pi/sidecar/Dockerfile
@@ -72,6 +72,7 @@ COPY runtime-pi/sidecar/server.ts           \
      runtime-pi/sidecar/blob-store.ts       \
      runtime-pi/sidecar/credential-proxy.ts \
      runtime-pi/sidecar/roots.ts            \
+     runtime-pi/sidecar/logger.ts           \
      runtime-pi/sidecar/
 
 WORKDIR /build/runtime-pi/sidecar


### PR DESCRIPTION
## Summary
- PR #339 added `runtime-pi/sidecar/logger.ts` (imported by `server.ts`) but the file was never added to the `COPY` list in `runtime-pi/sidecar/Dockerfile`.
- v1.0.0-beta.5 release CI failed: sidecar `bun build --compile` errored with `Could not resolve: ./logger.ts`, cancelling the parallel `appstrate` and `appstrate-pi` builds and starving cloud's `wait-for-oss-image` step.

## Test plan
- [x] `docker build -f runtime-pi/sidecar/Dockerfile .` succeeds locally with the fix (validates the `bun build --compile` step finds `logger.ts`).
- [ ] release.yml succeeds end-to-end on the next \`v*\` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)