### PR TITLE
fix(auth): purge stale BA cookies via Clear-Site-Data backstop

### DIFF
--- a/apps/api/src/lib/auth-cookies.ts
+++ b/apps/api/src/lib/auth-cookies.ts
@@ -36,6 +36,25 @@ import type { AppEnv } from "../types/index.ts";
  * realm guard: an end-user session that lands on a platform route is still
  * a legitimate session for the OIDC application it was minted for, and
  * killing the cookie would log the user out from that application too.
+ *
+ * Two complementary mechanisms run together — not a primary + legacy split,
+ * defense in depth with different trade-offs:
+ *
+ *   1. Targeted `Set-Cookie: Max-Age=0` (below): primary path for the 99%
+ *      case where the cookie was issued by the same instance config that
+ *      is now serving the request. Surgical (kills only the 4 BA cookies),
+ *      works on plain HTTP, works on legacy browsers.
+ *
+ *   2. `Clear-Site-Data: "cookies"`: backstop for config drift. When the
+ *      cookie was issued under a *previous* `COOKIE_DOMAIN` (e.g. set then
+ *      unset between deployments) or a different cookie-name prefix, RFC
+ *      6265 silently rejects the targeted delete because the `Domain`
+ *      attribute does not match. `Clear-Site-Data` purges every cookie
+ *      visible to the origin without needing `Domain` / `Path` to match —
+ *      precisely the property the targeted delete cannot offer when the
+ *      issuer config has drifted. Requires HTTPS or localhost (secure
+ *      context); ignored on plain HTTP, hence (1) remains as fallback.
+ *      Browser support: Chrome/Edge 61+, Firefox 63+, Safari 16.4+.
  */
 export function clearStaleAuthCookies(c: Context<AppEnv>): void {
   const cookies = getCookies(getAuth().options);
@@ -51,4 +70,8 @@ export function clearStaleAuthCookies(c: Context<AppEnv>): void {
     // which is what flips this from a refresh into a delete.
     deleteCookie(c, cookie.name, cookie.attributes);
   }
+  // Backstop for config drift (rotated `BETTER_AUTH_SECRET`, toggled
+  // `COOKIE_DOMAIN`, changed cookie-name prefix). Same-origin only,
+  // honored on HTTPS / localhost. See header docstring above.
+  c.header("Clear-Site-Data", '"cookies"');
 }

--- a/apps/api/test/integration/middleware/stale-cookie.test.ts
+++ b/apps/api/test/integration/middleware/stale-cookie.test.ts
@@ -9,9 +9,14 @@
  * bounced between `/login` and `/auth/callback` forever with no surfaceable
  * error.
  *
- * The auth pipeline now answers 401 with `Set-Cookie: …; Max-Age=0` for every
- * BA cookie name, so the browser actually drops the bad cookie on the next
- * tick and the next login attempt starts from a clean slate.
+ * The auth pipeline now answers 401 with two complementary mechanisms:
+ *   1. `Set-Cookie: …; Max-Age=0` for every BA cookie name (works when the
+ *      Domain/Path of the original cookie still match the current config).
+ *   2. `Clear-Site-Data: "cookies"` as a backstop for when a previous
+ *      deployment issued the cookie under a different `COOKIE_DOMAIN` —
+ *      RFC 6265 silently rejects the targeted delete in that case, but
+ *      `Clear-Site-Data` purges the origin's cookie jar without needing
+ *      Domain/Path to match. See `lib/auth-cookies.ts`.
  */
 
 import { describe, it, expect, beforeEach } from "bun:test";
@@ -70,6 +75,21 @@ describe("auth pipeline — stale cookie cleanup", () => {
     expect(sessionTokenClear).toMatch(/Max-Age=0|Expires=Thu, 01 Jan 1970/i);
   });
 
+  it('emits Clear-Site-Data: "cookies" as backstop when the session is stale', async () => {
+    // Backstop for the case where the cookie was issued under a previous
+    // `COOKIE_DOMAIN` and the targeted Set-Cookie delete cannot match.
+    const res = await app.request("/api/agents", {
+      headers: {
+        Cookie:
+          "better-auth.session_token=stale-value-no-session-row; better-auth.session_data=stale-cache",
+        "X-Org-Id": "00000000-0000-0000-0000-000000000000",
+      },
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.headers.get("clear-site-data")).toBe('"cookies"');
+  });
+
   it("does not emit a session_token clearing cookie on routes that succeed without auth", async () => {
     // `/health` is a public route mounted before the auth middleware.
     // The pipeline must not gratuitously clear cookies on every request —
@@ -83,5 +103,7 @@ describe("auth pipeline — stale cookie cleanup", () => {
         /Max-Age=0|Expires=Thu, 01 Jan 1970/i.test(c),
     );
     expect(sessionTokenClear).toBeUndefined();
+    // And no Clear-Site-Data on a healthy public response.
+    expect(res.headers.get("clear-site-data")).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Adds `Clear-Site-Data: "cookies"` to the 401 response from the auth pipeline as a backstop for the stale-cookie loop described in #345.
- Keeps the existing targeted `Set-Cookie: Max-Age=0` delete — the two mechanisms are complementary, not a primary/legacy split.
- Extends `stale-cookie.test.ts` with coverage for the new header (asserted on the 401 path, asserted absent on the public health path).

## Why

When `BETTER_AUTH_SECRET` rotates, `session` rows are wiped, or `COOKIE_DOMAIN` toggles between deployments, the targeted delete in `clearStaleAuthCookies` is silently rejected by the browser per RFC 6265 (Domain/Path mismatch). The browser keeps re-sending the bad cookie and the SPA loops between `/login` and `/auth/callback` with no surfaceable error.

`Clear-Site-Data: "cookies"` purges every cookie visible to the origin without needing Domain/Path to match — exactly the property the targeted delete cannot offer when the issuer config has drifted.

| Cas                              | Targeted delete | Clear-Site-Data |
| -------------------------------- | --------------- | --------------- |
| Config stable, HTTPS             | ✅ Primary       | ✅ no-op         |
| Config stable, HTTP              | ✅ Primary       | ❌ ignored       |
| Config dérivée, HTTPS            | ❌ silent fail   | ✅ Backstop      |
| Config dérivée, HTTP legacy <61  | ❌ silent fail   | ❌ unfixed       |

The bottom-right corner is theoretical in 2026 (HTTP non-localhost + Chrome <61 / Firefox <63 / Safari <16.4 — statistically null for Appstrate self-host).

## Test plan

- [x] `bun test apps/api/test/integration/middleware/stale-cookie.test.ts` (3 tests pass — existing 2 + new Clear-Site-Data assertion + negative on public route)
- [x] `bun run check` (turbo check + verify-openapi all green)
- [ ] Manual repro from issue: deploy with `COOKIE_DOMAIN=.example.com`, sign in, redeploy without `COOKIE_DOMAIN`, reload SPA → expect clean recovery instead of silent loop

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)