### PR TITLE
fix(web): keep slug auto-syncing after first-org pre-fill

### DIFF
--- a/apps/web/src/pages/onboarding/create-step.tsx
+++ b/apps/web/src/pages/onboarding/create-step.tsx
@@ -71,24 +71,17 @@ export function OnboardingCreateStep() {
   const slugValue = useWatch({ control, name: "slug" });
 
   // Pre-fill form for first org once user data is available.
-  // reset() sets both fields atomically without triggering the name→slug watcher.
-  // setSlugEdited is intentional here: one-shot init, not a cascading pattern.
+  // The suggested slug intentionally differs from toSlug(name) (e.g. "pierre" vs
+  // "pierres-organization"), so name→slug sync is driven by the name field's
+  // onChange — not a useEffect watcher that would clobber the suggestion.
   const defaultAppliedRef = useRef(false);
   useEffect(() => {
     if (defaultAppliedRef.current) return;
     const isFirstOrg = !fromSwitcher && orgs.length === 0;
     if (!isFirstOrg || !user) return;
     defaultAppliedRef.current = true;
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- one-shot pre-fill, not cascading
-    setSlugEdited(true);
     reset(suggestOrgDefaults(user, i18n.language));
   }, [fromSwitcher, orgs, user, i18n.language, reset]);
-
-  useEffect(() => {
-    if (!slugEdited && !defaultAppliedRef.current) {
-      setValue("slug", toSlug(nameValue));
-    }
-  }, [nameValue, slugEdited, setValue]);
 
   const createMutation = useMutation({
     mutationFn: async (body: { name: string; slug: string }) => {
@@ -137,6 +130,9 @@ export function OnboardingCreateStep() {
                 validate: (v) => {
                   if (!v.trim()) return t("validation.required", { ns: "common" });
                   return true;
+                },
+                onChange: (e) => {
+                  if (!slugEdited) setValue("slug", toSlug(e.target.value));
                 },
               })}
               placeholder={t("createOrg.namePlaceholder")}


### PR DESCRIPTION
## Summary

Closes #346.

On `/onboarding/create`, the slug field stopped tracking the organization name after the first-org pre-fill ran. The user had to manually open the slug input and retype it to recover from a stale `pierre` after typing `Acme Corp`.

The pre-fill effect was setting `slugEdited = true` to prevent the `reset()` from cascading through the name→slug `useEffect` watcher. That worked for the initial atomic write, but the flag stayed set for the rest of the session — permanently disabling auto-sync even though the user had not actually edited the slug.

## Fix

- Drop the `slugEdited = true` shortcut in the pre-fill effect.
- Remove the `useEffect` watcher entirely; drive name→slug from the name field's `onChange` instead (symmetric with the slug field's `onChange` that flips `slugEdited`).
- Keep `defaultAppliedRef` as the one-shot guard for the pre-fill (covers re-renders from `i18n.language` / `orgs` refetch).

`reset()` doesn't fire DOM `onChange` events, so the suggested slug from `suggestOrgDefaults` (intentionally `toSlug(displayName)`, e.g. `pierre`, not `toSlug(name)` like `pierres-organization`) survives the pre-fill — a regression that the original watcher-based fix proposed in the issue would have introduced.

## Test plan

- [ ] Sign up as a new user → land on `/onboarding/create`.
- [ ] Verify name pre-fills with `Pierre's Organization` and slug pre-fills with `pierre`.
- [ ] Clear name, type `Acme Corp` → slug updates to `acme-corp`.
- [ ] Open the slug field, type a custom slug `acme-prod` → slug stays `acme-prod`.
- [ ] Re-edit the name to `Foo Bar` → slug stays `acme-prod` (user intent preserved).
- [ ] Repeat in the non-first-org path (open from org switcher) — same behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)