### PR TITLE
fix(web): show user alongside machine in CLI run trigger badge

### DIFF
--- a/apps/web/src/components/run-trigger.tsx
+++ b/apps/web/src/components/run-trigger.tsx
@@ -44,13 +44,21 @@ export function RunTrigger({ run }: { run: EnrichedRun }) {
     );
   }
   if (run.runnerName) {
+    const tooltip = run.runnerKind ? `${run.runnerName} (${run.runnerKind})` : run.runnerName;
     return (
       <span
         className="text-muted-foreground inline-flex min-w-0 items-center gap-1 text-xs"
-        title={run.runnerKind ? `${run.runnerName} (${run.runnerKind})` : run.runnerName}
+        title={run.dashboardUserName ? `${tooltip} · ${run.dashboardUserName}` : tooltip}
       >
         <RunnerIcon kind={run.runnerKind} />
         <span className="truncate">{run.runnerName}</span>
+        {run.dashboardUserName ? (
+          <>
+            <span className="shrink-0">·</span>
+            <User size={12} className="shrink-0" />
+            <span className="truncate">{run.dashboardUserName}</span>
+          </>
+        ) : null}
       </span>
     );
   }


### PR DESCRIPTION
## Summary
- When a run is triggered from the CLI, the run-trigger badge previously displayed only the machine name (`runner_name`). The dashboard user who actually triggered it was hidden because the `runnerName` branch matched before `dashboardUserName` in the priority chain.
- Append the dashboard user after a `·` separator (with `User` icon) when both `runnerName` and `dashboardUserName` are present, so attribution is visible at a glance.
- Tooltip mirrors the combined label. Other trigger branches (schedule, end-user, API key, dashboard-only) are unchanged.

## Test plan
- [ ] Visual: trigger a CLI run, confirm the runs list shows `<machine> · <user>` with the terminal + user icons
- [ ] Visual: confirm GitHub Action runs also show the workflow + user combo
- [ ] Visual: confirm schedule/end-user/API-key/dashboard runs render unchanged
- [ ] `bun run check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)