### PR TITLE
fix(prompt): conditional ./documents/ bullet + render named pinned slots

### DIFF
--- a/apps/api/src/services/env-builder.ts
+++ b/apps/api/src/services/env-builder.ts
@@ -166,7 +166,10 @@ export async function buildRunContext(params: {
   // Collapse pinned slot rows to a key→content map. We exclude `checkpoint`
   // (already surfaced as `context.checkpoint` and rendered as `## Checkpoint`)
   // and rely on the desc-by-updatedAt order from `listPinnedSlots` for
-  // last-write-wins across actor scopes (shared > member-specific).
+  // last-write-wins: when both an actor-specific and a shared row exist for
+  // the same key, the most recently written one is kept regardless of scope.
+  // Visibility itself is already enforced upstream by `buildVisibilityFilter`
+  // (the caller's scope determines which rows are eligible).
   const pinnedSlots: Record<string, unknown> = {};
   for (const row of pinnedSlotRows) {
     if (row.key === CHECKPOINT_KEY) continue;

--- a/apps/api/src/services/env-builder.ts
+++ b/apps/api/src/services/env-builder.ts
@@ -13,7 +13,13 @@ import { db } from "@appstrate/db/client";
 import { getEnv } from "@appstrate/env";
 import { signRunToken } from "../lib/run-token.ts";
 import { buildProviderTokens } from "./token-resolver.ts";
-import { getCheckpoint, listPinnedMemories, scopeFromActor } from "./state/index.ts";
+import {
+  CHECKPOINT_KEY,
+  getCheckpoint,
+  listPinnedMemories,
+  listPinnedSlots,
+  scopeFromActor,
+} from "./state/index.ts";
 import { getPackageConfig } from "./application-packages.ts";
 import type { Actor } from "../lib/actor.ts";
 import { buildAgentPackage } from "./package-storage.ts";
@@ -92,6 +98,7 @@ export async function buildRunContext(params: {
     agentPackageResult,
     latestVersion,
     memories,
+    pinnedSlotRows,
   ] = await Promise.all([
     buildProviderTokens(manifestProviders, providerProfiles, orgId, applicationId),
     skipConfigFetch ? null : getPackageConfig(applicationId, agent.id),
@@ -106,6 +113,12 @@ export async function buildRunContext(params: {
     // Only pinned memories enter the prompt; archive memories load via the
     // `recall_memory` tool on demand. See ADR-012.
     listPinnedMemories(agent.id, applicationId, persistenceScope),
+    // Named pinned slots (any non-null key, EXCEPT "checkpoint" which is
+    // already loaded above as `previousCheckpoint`). Renders in the prompt's
+    // `## Pinned Slots` section so cross-run state under custom keys is
+    // visible to the agent. Honors the documented contract: `pin({key, ...})`
+    // with any key produces a slot rendered in this prompt on every run.
+    listPinnedSlots(agent.id, applicationId, persistenceScope),
   ]);
 
   const config = params.config ?? configFull?.config ?? {};
@@ -150,6 +163,16 @@ export async function buildRunContext(params: {
     versionDirty = updatedAt > latestVersion.createdAt;
   }
 
+  // Collapse pinned slot rows to a key→content map. We exclude `checkpoint`
+  // (already surfaced as `context.checkpoint` and rendered as `## Checkpoint`)
+  // and rely on the desc-by-updatedAt order from `listPinnedSlots` for
+  // last-write-wins across actor scopes (shared > member-specific).
+  const pinnedSlots: Record<string, unknown> = {};
+  for (const row of pinnedSlotRows) {
+    if (row.key === CHECKPOINT_KEY) continue;
+    if (!(row.key in pinnedSlots)) pinnedSlots[row.key] = row.content;
+  }
+
   // Step 4: assemble AFPS execution context + platform plan
   const apiEnv = getEnv();
   const runApiUrl =
@@ -169,6 +192,7 @@ export async function buildRunContext(params: {
       createdAt: toEpochMs(m.createdAt),
     })),
     ...(previousCheckpoint !== null ? { checkpoint: previousCheckpoint } : {}),
+    ...(Object.keys(pinnedSlots).length > 0 ? { pinnedSlots } : {}),
     config,
     ...(params.traceparent ? { traceparent: params.traceparent } : {}),
   };

--- a/packages/afps-runtime/src/bundle/platform-prompt.ts
+++ b/packages/afps-runtime/src/bundle/platform-prompt.ts
@@ -330,6 +330,34 @@ export function renderPlatformPrompt(opts: PlatformPromptOptions): string {
     );
   }
 
+  // --- Pinned Slots (named, non-checkpoint) ---
+  // Surface pinned slots written via `pin({ key, content })` with any key
+  // other than "checkpoint". Honors the documented contract that custom
+  // keys (e.g. "persona", "goals", or app-specific state slots like
+  // "sync_state", "last_processed") render as additional pinned blocks
+  // visible to the agent on every run.
+  if (context.pinnedSlots && Object.keys(context.pinnedSlots).length > 0) {
+    sections.push("## Pinned Slots\n");
+    sections.push(
+      "Named pinned slots written via `pin({ key, content })` (always visible across runs):\n",
+    );
+    // Sort keys for deterministic output (snapshot-friendly).
+    for (const key of Object.keys(context.pinnedSlots).sort()) {
+      const value = context.pinnedSlots[key];
+      // Plain strings render as-is for readability; structured values get a
+      // fenced JSON block so the agent can parse them unambiguously.
+      if (typeof value === "string") {
+        sections.push(`### ${key}`, value, "");
+      } else {
+        sections.push(`### ${key}`, "```json", JSON.stringify(value, null, 2), "```", "");
+      }
+    }
+    sections.push(
+      'To update a slot for the next run, call `pin({ key: "<your-key>", content: ..., scope: "shared" })`. ' +
+        'Use `key: "checkpoint"` for the carry-over slot rendered as `## Checkpoint` instead.\n',
+    );
+  }
+
   // --- Memory ---
   // Two tiers (ADR-012, ADR-013):
   //   - Pinned memories (rendered here)  → working set, always visible.

--- a/packages/afps-runtime/src/bundle/platform-prompt.ts
+++ b/packages/afps-runtime/src/bundle/platform-prompt.ts
@@ -147,9 +147,17 @@ export function renderPlatformPrompt(opts: PlatformPromptOptions): string {
         "Work efficiently and output your result promptly.",
     );
   }
+  // Workspace bullet — only mention `./documents/` when uploads are actually
+  // wired. Surfacing it unconditionally caused agents with no file fields to
+  // burn tokens listing an empty directory and hypothesising about missing
+  // attachments. The matching `## Documents` section below is also gated on
+  // `opts.uploads`, so the two stay consistent.
+  const hasUploads = (opts.uploads?.length ?? 0) > 0;
   sections.push(
     "- **Workspace**: Your current working directory is the agent workspace. " +
-      "Uploaded documents are available under `./documents/` (relative to cwd). " +
+      (hasUploads
+        ? "Uploaded documents are available under `./documents/` (relative to cwd) and listed in the `## Documents` section below. "
+        : "") +
       "You may use the filesystem for temporary processing during this run only.\n",
   );
 

--- a/packages/afps-runtime/src/types/execution-context.ts
+++ b/packages/afps-runtime/src/types/execution-context.ts
@@ -84,6 +84,14 @@ export const executionContextSchema = z.object({
   // See AFPS_EXTENSION_ARCHITECTURE.md §3.2 "pure template / impure context".
   memories: z.array(memorySnapshotSchema).optional(),
   checkpoint: z.unknown().optional(),
+  /**
+   * Named pinned slots written via `pin({ key, content })` with any key
+   * other than `"checkpoint"`. Each entry is last-write-wins per `(scope, key)`
+   * after upstream visibility filtering. Surfaced in the prompt's
+   * `## Pinned Slots` section. The `"checkpoint"` slot is intentionally
+   * excluded — it is rendered separately as `## Checkpoint`.
+   */
+  pinnedSlots: z.record(z.string(), z.unknown()).optional(),
   history: z.array(historyEntrySchema).optional(),
 
   /**

--- a/packages/afps-runtime/test/bundle/platform-prompt-parity.test.ts
+++ b/packages/afps-runtime/test/bundle/platform-prompt-parity.test.ts
@@ -119,6 +119,12 @@ function canonicalize(prompt: string): string {
       .replace(/running on the [^\n]* platform\./g, "running on the <PLATFORM> platform.")
       // strip the `## Documents` section (platform-only, DB-backed)
       .replace(/## Documents\n[\s\S]*?(?=\n## |\n---|$)/g, "")
+      // strip the uploads-related sentence in the Workspace bullet
+      // (platform-only when uploads are wired; CLI paths omit it)
+      .replace(
+        /Uploaded documents are available under `\.\/documents\/` \(relative to cwd\) and listed in the `## Documents` section below\. /g,
+        "",
+      )
       // strip the `## Connected Providers` section (may be filtered on
       // the platform by credential availability; CLI paths list all)
       .replace(/## Connected Providers\n[\s\S]*?(?=\n## |\n---|$)/g, "")

--- a/packages/afps-runtime/test/bundle/platform-prompt.test.ts
+++ b/packages/afps-runtime/test/bundle/platform-prompt.test.ts
@@ -189,6 +189,28 @@ describe("renderPlatformPrompt", () => {
     expect(out).toContain("**report.pdf** (application/pdf, 2.0 KB) → `./documents/report.pdf`");
   });
 
+  it("mentions `./documents/` in the Workspace bullet when uploads are wired", () => {
+    const out = renderPlatformPrompt({
+      template: "T",
+      context: ctx(),
+      uploads: [{ name: "r.pdf", path: "./documents/r.pdf", size: 100, type: "application/pdf" }],
+    });
+    // Workspace bullet should reference ./documents/ exactly when uploads exist
+    // — paired with the `## Documents` section gated on the same condition.
+    expect(out).toContain("**Workspace**");
+    expect(out).toContain("./documents/");
+    expect(out).toContain("`## Documents` section");
+  });
+
+  it("omits the `./documents/` mention from the Workspace bullet when no uploads are wired", () => {
+    const out = renderPlatformPrompt({ template: "T", context: ctx() });
+    // Workspace bullet itself must still render — only the uploads sentence is gated.
+    expect(out).toContain("**Workspace**");
+    expect(out).toContain("filesystem for temporary processing");
+    expect(out).not.toContain("./documents/");
+    expect(out).not.toContain("## Documents");
+  });
+
   it("renders the Checkpoint section when context.checkpoint is set", () => {
     const out = renderPlatformPrompt({
       template: "T",
@@ -199,6 +221,95 @@ describe("renderPlatformPrompt", () => {
     expect(out).toContain('"cursor": "abc"');
     expect(out).toContain('"count": 12');
     expect(out).toContain('pin({ key: "checkpoint"');
+  });
+
+  describe("Pinned Slots section", () => {
+    it("omits the section when pinnedSlots is undefined", () => {
+      const out = renderPlatformPrompt({ template: "T", context: ctx() });
+      expect(out).not.toContain("## Pinned Slots");
+    });
+
+    it("omits the section when pinnedSlots is an empty object", () => {
+      const out = renderPlatformPrompt({
+        template: "T",
+        context: ctx({ pinnedSlots: {} }),
+      });
+      expect(out).not.toContain("## Pinned Slots");
+    });
+
+    it("renders the section with sorted keys for deterministic output", () => {
+      const out = renderPlatformPrompt({
+        template: "T",
+        context: ctx({
+          pinnedSlots: {
+            zeta: "last alphabetically",
+            alpha: "first alphabetically",
+            mu: "middle",
+          },
+        }),
+      });
+      expect(out).toContain("## Pinned Slots");
+      const alphaIdx = out.indexOf("### alpha");
+      const muIdx = out.indexOf("### mu");
+      const zetaIdx = out.indexOf("### zeta");
+      expect(alphaIdx).toBeGreaterThan(-1);
+      expect(muIdx).toBeGreaterThan(alphaIdx);
+      expect(zetaIdx).toBeGreaterThan(muIdx);
+    });
+
+    it("renders string values plain (no JSON fence)", () => {
+      const out = renderPlatformPrompt({
+        template: "T",
+        context: ctx({ pinnedSlots: { persona: "You are a helpful assistant." } }),
+      });
+      expect(out).toContain("### persona");
+      expect(out).toContain("You are a helpful assistant.");
+      // The string slot itself must not be wrapped in a json fence.
+      const slotIdx = out.indexOf("### persona");
+      const slotEnd = out.indexOf("###", slotIdx + 1);
+      const slotBlock = out.slice(slotIdx, slotEnd > -1 ? slotEnd : undefined);
+      expect(slotBlock).not.toContain("```json");
+    });
+
+    it("renders structured values inside a fenced JSON block", () => {
+      const out = renderPlatformPrompt({
+        template: "T",
+        context: ctx({
+          pinnedSlots: {
+            goals: { primary: "ship", secondary: ["test", "doc"] },
+          },
+        }),
+      });
+      expect(out).toContain("### goals");
+      expect(out).toContain("```json");
+      expect(out).toContain('"primary": "ship"');
+      expect(out).toContain('"secondary"');
+    });
+
+    it("includes a footer telling the agent how to update slots and where checkpoint goes", () => {
+      const out = renderPlatformPrompt({
+        template: "T",
+        context: ctx({ pinnedSlots: { persona: "anything" } }),
+      });
+      expect(out).toContain('pin({ key: "<your-key>"');
+      // Must redirect agents to the dedicated checkpoint key for carry-over,
+      // so the two surfaces don't get conflated.
+      expect(out).toContain('key: "checkpoint"');
+    });
+
+    it("renders after the Checkpoint section when both are present", () => {
+      const out = renderPlatformPrompt({
+        template: "T",
+        context: ctx({
+          checkpoint: { cursor: "x" },
+          pinnedSlots: { persona: "you are X" },
+        }),
+      });
+      const checkpointIdx = out.indexOf("## Checkpoint");
+      const pinnedIdx = out.indexOf("## Pinned Slots");
+      expect(checkpointIdx).toBeGreaterThan(-1);
+      expect(pinnedIdx).toBeGreaterThan(checkpointIdx);
+    });
   });
 
   it("renders the Memory section with pinned memories listed", () => {


### PR DESCRIPTION
Two related fixes to platform prompt rendering. Both touch `packages/afps-runtime/src/bundle/platform-prompt.ts`.

## 1. \`./documents/\` mentioned even without uploads (item 2.1)

Line 152 of `platform-prompt.ts` unconditionally added \"Uploaded documents are available under `./documents/` (relative to cwd).\" to the **Workspace** bullet of `## System`, regardless of whether uploads were declared. Agents without a file-field input kept running `ls ./documents/`, finding nothing, and burning tokens looking for files that didn't exist. Cost ~1h of debugging during edwix-extraction development.

**Fix**: gate on `(opts.uploads?.length ?? 0) > 0` — same guard as the `## Documents` section (now consistent: all-or-nothing). Cross-path parity test updated: `canonicalize` strips the upload-related sentence the same way it already strips `## Documents`.

## 2. \`pin(key=<custom>)\` stored but never rendered in prompt (item 2.4)

`platform-prompt.ts:319-350` and `CLAUDE.md` advertised: *\"Use `pin({ key, content })` ... or any other key (e.g. `persona`, `goals`) for additional pinned blocks\"*. In practice:
- `getCheckpoint()` filtered `key=\"checkpoint\"` only
- `listPinnedMemories()` filtered `isNull(key)` only

→ any slot with a custom key was stored in DB but **never rendered** in the prompt. An agent writing `pin(key=\"sync_state\")` couldn't read it back at the next run. The `fathom-to-automations` agent was reprocessing 30 candidates on every run because of this silent drop.

**Fix**: `listPinnedSlots()` already existed but was only called from the admin `/persistence` route. Wire it into `env-builder.ts`, propagate via `context.pinnedSlots`, render a new section `## Pinned Slots > <key>` (deterministic sort, fenced JSON for structured payloads, plain text for strings). Excludes `key=\"checkpoint\"` (already rendered as `## Checkpoint`). No regression — an agent that never wrote a custom slot sees an identical prompt.

## Test plan

- [ ] Agent without uploads → prompt has no `./documents/` mention
- [ ] Agent with uploads → prompt mentions `./documents/` as before
- [ ] Agent calls `pin({ key: \"sync_state\", content: { lastSyncedAt: \"2026-05-08\" } })` → next run prompt contains `## Pinned Slots > sync_state` with the JSON
- [ ] Agent that writes only \"checkpoint\" pin → prompt unchanged (only `## Checkpoint`, no `## Pinned Slots`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)