### PR TITLE
fix(runtime): propagate provider_call substituteBody flag from agent to sidecar

### DIFF
--- a/packages/afps-runtime/src/resolvers/provider-tool.ts
+++ b/packages/afps-runtime/src/resolvers/provider-tool.ts
@@ -227,6 +227,12 @@ export const providerCallRequestSchema = z.object({
         `{ fromBytes, encoding: 'base64' } for inline binary payloads up to ${MAX_REQUEST_BODY_DISPLAY} (standard base64 RFC 4648 §4 only — alphabet \`+/\`, no URL-safe \`-_\` or MIME line-folding), ` +
         "or { multipart: [...] } to compose a multipart/form-data body mixing text fields and workspace files.",
     ),
+  substituteBody: z
+    .boolean()
+    .optional()
+    .describe(
+      "When true, the sidecar substitutes `{{credential}}` placeholders inside the request body before forwarding upstream. Off by default to avoid accidental token leaks into payloads. Requires a text body (string) — incompatible with { fromBytes } / { fromFile } / { multipart }.",
+    ),
   responseMode: responseModeSchema,
 });
 

--- a/packages/afps-runtime/test/resolvers/provider-tool-schema.test.ts
+++ b/packages/afps-runtime/test/resolvers/provider-tool-schema.test.ts
@@ -202,6 +202,58 @@ describe("providerCallRequestSchema — valid inputs", () => {
       expect(result.success).toBe(true);
     }
   });
+
+  // Regression: `substituteBody` must be declared on the schema so
+  // `safeParse` does NOT silently strip it before the resolver sees it.
+  // Without this declaration, the `username/password` body-substitution
+  // path documented in PROVIDER.md files is dead — the sidecar receives
+  // no opt-in flag and forwards `{{email}}` / `{{password}}` placeholders
+  // verbatim to upstream.
+  it("preserves substituteBody=true through safeParse", () => {
+    const result = providerCallRequestSchema.safeParse({
+      method: "POST",
+      target: "https://api.example.com/login",
+      body: '{"login":"{{email}}","password":"{{password}}"}',
+      substituteBody: true,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.substituteBody).toBe(true);
+  });
+
+  it("preserves substituteBody=false through safeParse", () => {
+    const result = providerCallRequestSchema.safeParse({
+      method: "POST",
+      target: "https://api.example.com/x",
+      body: "literal",
+      substituteBody: false,
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.substituteBody).toBe(false);
+  });
+
+  it("treats missing substituteBody as undefined (default off)", () => {
+    const result = providerCallRequestSchema.safeParse({
+      method: "POST",
+      target: "https://api.example.com/x",
+      body: "no opt-in",
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.substituteBody).toBeUndefined();
+  });
+
+  it("rejects substituteBody as a non-boolean", () => {
+    const result = providerCallRequestSchema.safeParse({
+      method: "POST",
+      target: "https://api.example.com/x",
+      substituteBody: "yes",
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.error.issues.some((i) => i.path.includes("substituteBody"))).toBe(true);
+  });
 });
 
 describe("providerCallRequestSchema — invalid inputs", () => {

--- a/runtime-pi/mcp/provider-resolver.ts
+++ b/runtime-pi/mcp/provider-resolver.ts
@@ -149,6 +149,12 @@ export class McpProviderResolver implements ProviderResolver {
     };
     if (Object.keys(headers).length > 0) args.headers = headers;
     if (mcpBody !== undefined) args.body = mcpBody;
+    // Forward the substituteBody flag so the sidecar can perform
+    // `{{credential}}` placeholder substitution on the buffered text
+    // body before sending upstream. Without this propagation the agent's
+    // declared substituteBody is silently dropped at the resolver and
+    // upstream receives literal `{{email}}`/`{{password}}` strings.
+    if (req.substituteBody) args.substituteBody = true;
     return args;
   }
 

--- a/runtime-pi/test/mcp-provider-resolver.test.ts
+++ b/runtime-pi/test/mcp-provider-resolver.test.ts
@@ -375,6 +375,84 @@ describe("McpProviderResolver — body forwarding", () => {
     }
   });
 
+  // Regression: the agent-side resolver must propagate `substituteBody`
+  // into the MCP `provider_call` arguments. Without this, the sidecar
+  // never sees the opt-in flag and forwards `{{credential}}` placeholders
+  // to upstream verbatim, breaking every transparent username/password
+  // login flow documented in PROVIDER.md (Saneki, Amisgest, OrgaBusiness…).
+  it("forwards substituteBody=true into the MCP arguments", async () => {
+    const { pair, mcp, captured } = await makeServer({});
+    try {
+      const resolver = new McpProviderResolver(mcp);
+      const [tool] = await resolver.resolve(
+        [{ name: "@test/echo", version: "^1.0.0" }],
+        makeBundle(),
+      );
+      const workspace = mkdtempSync(join(tmpdir(), "mcp-resolver-"));
+      await tool!.execute(
+        {
+          method: "POST",
+          target: "https://api.example.com/login",
+          body: '{"login":"{{email}}","password":"{{password}}"}',
+          substituteBody: true,
+        },
+        ctxBase(workspace),
+      );
+      expect(captured.arguments?.substituteBody).toBe(true);
+    } finally {
+      await pair.close();
+    }
+  });
+
+  it("omits substituteBody when not set (default off)", async () => {
+    const { pair, mcp, captured } = await makeServer({});
+    try {
+      const resolver = new McpProviderResolver(mcp);
+      const [tool] = await resolver.resolve(
+        [{ name: "@test/echo", version: "^1.0.0" }],
+        makeBundle(),
+      );
+      const workspace = mkdtempSync(join(tmpdir(), "mcp-resolver-"));
+      await tool!.execute(
+        {
+          method: "POST",
+          target: "https://api.example.com/x",
+          body: "no-op",
+        },
+        ctxBase(workspace),
+      );
+      // Absent rather than `false` — the sidecar defaults to off, so we
+      // keep the wire payload minimal when the agent did not opt in.
+      expect(captured.arguments).not.toHaveProperty("substituteBody");
+    } finally {
+      await pair.close();
+    }
+  });
+
+  it("omits substituteBody when explicitly false (no wire noise)", async () => {
+    const { pair, mcp, captured } = await makeServer({});
+    try {
+      const resolver = new McpProviderResolver(mcp);
+      const [tool] = await resolver.resolve(
+        [{ name: "@test/echo", version: "^1.0.0" }],
+        makeBundle(),
+      );
+      const workspace = mkdtempSync(join(tmpdir(), "mcp-resolver-"));
+      await tool!.execute(
+        {
+          method: "POST",
+          target: "https://api.example.com/x",
+          body: "no-op",
+          substituteBody: false,
+        },
+        ctxBase(workspace),
+      );
+      expect(captured.arguments).not.toHaveProperty("substituteBody");
+    } finally {
+      await pair.close();
+    }
+  });
+
   it("rejects { fromFile } resolving outside the workspace (path traversal)", async () => {
     const { pair, mcp, captured } = await makeServer({});
     try {


### PR DESCRIPTION
## Problem

The official mechanism for transparent `username/password` auth — where the sidecar substitutes `{{email}}`/`{{password}}` server-side in the request body, so the agent never sees credentials — **does not work**. Reproduced identically on `local` (image `1.0.0-beta.6`) and on `cloud` (`https://app.appstrate.com`).

## Repro

Provider `@oli/auth-substest` with `authMode: \"custom\"`, schema `{email, password}`, `authorizedUris: [\"https://httpbin.org/*\"]`, credentials `{email:\"alice@example.com\", password:\"PWD-12345\"}` saved via `/api/connections/connect/.../credentials`.

Inline run with body `{\"login\":\"{{email}}\",\"password\":\"{{password}}\"}` + `substituteBody: true` → httpbin echoes back:

```json
{ \"json\": { \"login\": \"{{email}}\", \"password\": \"{{password}}\" } }
```

Instead of `{\"login\":\"alice@example.com\",\"password\":\"PWD-12345\"}`.

**Discriminating test**: the same request with a placeholder in a **header** (`X-Email: {{email}}`, no opt-in flag) substitutes correctly → `alice@example.com`. So `fetchCredentials` works, `substituteVars` works, the payload returned by the API to `/internal/credentials` is correct. **The bug is exclusively on the body path**.

## Root cause — schema inconsistency across 3 layers

1. **Sidecar** (`runtime-pi/sidecar/mcp.ts`, `credential-proxy.ts`) — declares `substituteBody?: boolean` in tool schema, parses the flag, performs conditional substitution. ✅ correct.
2. **Resolver agent-side** (`runtime-pi/mcp/provider-resolver.ts:145-152`) — `buildMcpArgs` builds the MCP args object **without** propagating `req.substituteBody`. ❌ silently dropped.
3. **AFPS runtime schema** (`packages/afps-runtime/src/resolvers/provider-tool.ts:214` — `providerCallRequestSchema`) — Zod schema **doesn't declare** `substituteBody`. `safeParse` agent-side strips the unknown field before it reaches the resolver. ❌ silently dropped.

Result: regardless of what the LLM passes to `provider_call`, the sidecar never sees `substituteBody: true`, so it always falls into the `body.kind === \"buffered\"` branch WITHOUT substitution → forwards the raw body with placeholders intact. The sidecar's `substituteVars` function works fine — it's just never called for the body.

**Why headers + URL still work**: those substitutions are **automatic** in the sidecar (`credential-proxy.ts:142, 177`), not opt-in. So even without the flag being transmitted, they fire. Only the body is gated by `substituteBody`.

## Fix

2 lines added in 2 files.

`packages/afps-runtime/src/resolvers/provider-tool.ts` — add to `providerCallRequestSchema`:
```ts
substituteBody: z.boolean().optional().describe(
  \"When true, the sidecar substitutes \\\`{{credential}}\\\` placeholders inside the request body before forwarding upstream. Off by default to avoid accidental token leaks into payloads. Requires a text body (string) — incompatible with { fromBytes } / { fromFile } / { multipart }.\"
),
```

`runtime-pi/mcp/provider-resolver.ts:152` — in `buildMcpArgs`:
```ts
if (req.substituteBody) args.substituteBody = true;
```

## Implication

**No OSS Appstrate agent can perform a programmatic `username/password` login via `substituteBody` today without this patch.** The pattern documented in several `PROVIDER.md` files (Saneki OrgaBusiness, skill examples, etc.) is dead without this fix. Either those providers are never actually used at runtime, or they silently migrated to a workaround (clear-text key in config), or they run on internal forks that already include this patch.

For local-only use cases requiring this flag (ClassDojo, journalapetitspas/Amisgest, OrgaBusiness, any SaaS demanding JSON `{email, password}` login instead of a Bearer header): **this patch is mandatory**.

## Test plan

- [ ] Reproduce with `@oli/auth-substest` test provider above → expect `\"login\": \"alice@example.com\"` in echo response after fix
- [ ] Verify `substituteBody: false` (default) still passes literal placeholders unchanged (no regression)
- [ ] Verify `substituteBody: true` with `{ fromBytes }` body returns a clear error (incompatible — text body required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)