### PR TITLE
fix(sidecar): don't cap response payloads at 256 KB when BlobStore is present

### DIFF
--- a/packages/afps-runtime/src/resolvers/provider-tool.ts
+++ b/packages/afps-runtime/src/resolvers/provider-tool.ts
@@ -27,9 +27,16 @@ import { ProviderAuthorizationError, ResolverError } from "../errors.ts";
 export const defaultInlineLimit = 256 * 1024;
 
 /**
- * Hard upper bound on `responseMode.maxInlineBytes`. Mirrors
- * `ABSOLUTE_MAX_RESPONSE_SIZE` in `runtime-pi/sidecar/helpers.ts`. Any
- * agent-supplied value above this is silently capped.
+ * Hard upper bound on `responseMode.maxInlineBytes` — the agent-supplied
+ * inline-bytes budget that controls how much of an upstream response is
+ * returned inline (vs. spilled to a file or blob). 1 MB is deliberately
+ * smaller than the sidecar's `ABSOLUTE_MAX_RESPONSE_SIZE` (32 MB, used as
+ * the upstream-buffer ceiling before spillover): inlining a 32 MB blob into
+ * the agent's tool result would poison its context regardless of whether
+ * the sidecar can buffer it. The two constants thus serve distinct roles
+ * — schema cap for inline payloads vs. transport buffer ceiling — and
+ * intentionally differ. Any agent-supplied value above this is silently
+ * capped.
  */
 export const ABSOLUTE_MAX_RESPONSE_SIZE = 1_000_000;
 

--- a/runtime-pi/sidecar/README.md
+++ b/runtime-pi/sidecar/README.md
@@ -38,7 +38,7 @@ The only path that decodes the request body to UTF-8 is the optional `substitute
 | Constant                     | Value  | Purpose                                                                |
 | ---------------------------- | ------ | ---------------------------------------------------------------------- |
 | `MAX_RESPONSE_SIZE`          | 256 KB | Default cap on upstream response bytes returned inline to the agent.   |
-| `ABSOLUTE_MAX_RESPONSE_SIZE` | 1 MB   | Ceiling on `responseMode.maxInlineBytes` regardless of caller request. |
+| `ABSOLUTE_MAX_RESPONSE_SIZE` | 32 MB  | Ceiling on upstream bytes the sidecar buffers before refusing — only applied when a `BlobStore` is configured (otherwise `MAX_RESPONSE_SIZE` is the cap). Sized to cover real-world binaries (PDFs, images, archives) routed through the spillover path. |
 | `MAX_SUBSTITUTE_BODY_SIZE`   | 5 MB   | Maximum buffered request body size accepted with `substituteBody`.     |
 | `STREAMING_THRESHOLD`        | 1 MB   | Above this `Content-Length` `provider_call` switches to streaming.     |
 | `MAX_STREAMED_BODY_SIZE`     | 100 MB | Ceiling on streamed request and response bodies.                       |

--- a/runtime-pi/sidecar/helpers.ts
+++ b/runtime-pi/sidecar/helpers.ts
@@ -21,7 +21,7 @@ export const PROVIDER_ID_RE = /^(@[a-z0-9][a-z0-9-]*\/)?[a-z0-9]([a-z0-9-]*[a-z0
 // to the run-scoped BlobStore and surface as MCP `resource_link`
 // blocks; the absolute ceiling is `ABSOLUTE_MAX_RESPONSE_SIZE`.
 export const MAX_RESPONSE_SIZE = 256 * 1024; // 256 KB
-export const ABSOLUTE_MAX_RESPONSE_SIZE = 1_000_000; // 1MB — hard cap, even when X-Max-Response-Size is larger
+export const ABSOLUTE_MAX_RESPONSE_SIZE = 32 * 1024 * 1024; // 32 MB — hard cap when blob store is present (covers PDFs/images/archives), aligned with MAX_MCP_ENVELOPE_SIZE × 2
 export const OUTBOUND_TIMEOUT_MS = 30_000;
 export const MAX_SUBSTITUTE_BODY_SIZE = 5 * 1024 * 1024; // 5MB
 export const LLM_PROXY_TIMEOUT_MS = 300_000; // 5 minutes

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -667,14 +667,20 @@ async function responseToToolResult(
       };
     }
     // Spill to blob store and return a resource_link.
-    const bytes = await readBodyToBuffer(res, MAX_RESPONSE_SIZE);
+    // When a blob store is available, raise the cap to ABSOLUTE_MAX_RESPONSE_SIZE
+    // (32 MB): the spillover path exists precisely for bodies larger than
+    // MAX_RESPONSE_SIZE, so capping the read at MAX_RESPONSE_SIZE refuses real-world
+    // binaries (PDFs 1-10 MB, images, ZIPs) that the agent would consume via
+    // pdf-toolkit, vision, etc. Symmetrical to the text path below (~ line 720).
+    const binaryReadCap = options.blobStore ? ABSOLUTE_MAX_RESPONSE_SIZE : MAX_RESPONSE_SIZE;
+    const bytes = await readBodyToBuffer(res, binaryReadCap);
     if (bytes === "exceeded") {
       return {
         content: [
           {
             type: "text",
             text:
-              `provider_call: response exceeds ${MAX_RESPONSE_SIZE} bytes — refused without truncation ` +
+              `provider_call: response exceeds ${binaryReadCap} bytes — refused without truncation ` +
               `(truncating an opaque binary blob is unsafe).`,
           },
         ],

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -56,6 +56,7 @@ import {
   type Resource,
 } from "@appstrate/mcp-transport";
 import {
+  ABSOLUTE_MAX_RESPONSE_SIZE,
   MAX_MCP_ENVELOPE_SIZE,
   MAX_REQUEST_BODY_SIZE,
   MAX_RESPONSE_SIZE,
@@ -709,7 +710,15 @@ async function responseToToolResult(
   // Text — bound the read. We stream into a buffer rather than calling
   // res.text() directly so a hypothetical multi-GB response can never
   // be fully materialised before the cap kicks in.
-  const text = await readBodyBounded(res, MAX_RESPONSE_SIZE);
+  //
+  // When a blob store is available, raise the cap to ABSOLUTE_MAX_RESPONSE_SIZE
+  // (1 MB): the spillover path exists precisely to handle bodies larger than
+  // MAX_RESPONSE_SIZE, so capping the read at MAX_RESPONSE_SIZE before deciding
+  // to spill silently truncated text bodies in [256 KB, 1 MB] (they were
+  // spilled, but with a `[truncated]` marker poisoning the JSON). Without a
+  // blob store there's no recovery path, so the conservative cap stays.
+  const readCap = options.blobStore ? ABSOLUTE_MAX_RESPONSE_SIZE : MAX_RESPONSE_SIZE;
+  const text = await readBodyBounded(res, readCap);
 
   // If the text body breaches the inline threshold AND we have a blob
   // store, spill it. The agent gets a pointer instead of poisoning its

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -667,11 +667,11 @@ async function responseToToolResult(
       };
     }
     // Spill to blob store and return a resource_link.
-    // When a blob store is available, raise the cap to ABSOLUTE_MAX_RESPONSE_SIZE
-    // (32 MB): the spillover path exists precisely for bodies larger than
-    // MAX_RESPONSE_SIZE, so capping the read at MAX_RESPONSE_SIZE refuses real-world
-    // binaries (PDFs 1-10 MB, images, ZIPs) that the agent would consume via
-    // pdf-toolkit, vision, etc. Symmetrical to the text path below (~ line 720).
+    // When a blob store is available, raise the cap to ABSOLUTE_MAX_RESPONSE_SIZE:
+    // the spillover path exists precisely for bodies larger than MAX_RESPONSE_SIZE,
+    // so capping the read at MAX_RESPONSE_SIZE refuses real-world binaries
+    // (PDFs 1-10 MB, images, ZIPs) that the agent would consume via pdf-toolkit,
+    // vision, etc. Symmetrical to the text path below.
     const binaryReadCap = options.blobStore ? ABSOLUTE_MAX_RESPONSE_SIZE : MAX_RESPONSE_SIZE;
     const bytes = await readBodyToBuffer(res, binaryReadCap);
     if (bytes === "exceeded") {
@@ -680,7 +680,7 @@ async function responseToToolResult(
           {
             type: "text",
             text:
-              `provider_call: response exceeds ${binaryReadCap} bytes — refused without truncation ` +
+              `provider_call: response exceeds ${binaryReadCap} bytes (${binaryReadCap >= 1024 * 1024 ? `${Math.round(binaryReadCap / 1024 / 1024)} MB` : `${Math.round(binaryReadCap / 1024)} KB`}) — refused without truncation ` +
               `(truncating an opaque binary blob is unsafe).`,
           },
         ],
@@ -717,12 +717,12 @@ async function responseToToolResult(
   // res.text() directly so a hypothetical multi-GB response can never
   // be fully materialised before the cap kicks in.
   //
-  // When a blob store is available, raise the cap to ABSOLUTE_MAX_RESPONSE_SIZE
-  // (1 MB): the spillover path exists precisely to handle bodies larger than
+  // When a blob store is available, raise the cap to ABSOLUTE_MAX_RESPONSE_SIZE:
+  // the spillover path exists precisely to handle bodies larger than
   // MAX_RESPONSE_SIZE, so capping the read at MAX_RESPONSE_SIZE before deciding
-  // to spill silently truncated text bodies in [256 KB, 1 MB] (they were
-  // spilled, but with a `[truncated]` marker poisoning the JSON). Without a
-  // blob store there's no recovery path, so the conservative cap stays.
+  // to spill silently truncated text bodies above 256 KB (they were spilled,
+  // but with a `[truncated]` marker poisoning the JSON). Without a blob store
+  // there's no recovery path, so the conservative cap stays.
   const readCap = options.blobStore ? ABSOLUTE_MAX_RESPONSE_SIZE : MAX_RESPONSE_SIZE;
   const text = await readBodyBounded(res, readCap);
 

--- a/runtime-pi/sidecar/test/helpers.test.ts
+++ b/runtime-pi/sidecar/test/helpers.test.ts
@@ -24,8 +24,8 @@ describe("constants", () => {
     expect(MAX_RESPONSE_SIZE).toBe(256 * 1024);
   });
 
-  it("ABSOLUTE_MAX_RESPONSE_SIZE is 1_000_000", () => {
-    expect(ABSOLUTE_MAX_RESPONSE_SIZE).toBe(1_000_000);
+  it("ABSOLUTE_MAX_RESPONSE_SIZE is 32 MB", () => {
+    expect(ABSOLUTE_MAX_RESPONSE_SIZE).toBe(32 * 1024 * 1024);
   });
 
   it("OUTBOUND_TIMEOUT_MS is 30_000", () => {

--- a/runtime-pi/sidecar/test/mcp-resources.test.ts
+++ b/runtime-pi/sidecar/test/mcp-resources.test.ts
@@ -137,6 +137,97 @@ describe("POST /mcp — provider_call resource spillover", () => {
     expect(result.content[0]!.mimeType).toContain("json");
   });
 
+  it("spills 500 KB text bodies cleanly (no [truncated] marker leaking into the JSON)", async () => {
+    // Regression test: previously a body in [256 KB, 1 MB] was capped at
+    // MAX_RESPONSE_SIZE before the spillover branch decided to spill, so
+    // the stored blob was truncated and carried the `[truncated: ...]`
+    // marker that polluted downstream JSON parsing.
+    const big = JSON.stringify({ data: "x".repeat(500 * 1024) }); // ~500 KB > 256 KB
+    const fetchFn = mock(
+      async () =>
+        new Response(big, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const app = createApp(makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }));
+    const callRes = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "test-provider",
+          target: "https://api.example.com/medium.json",
+        },
+      },
+    });
+    const callResult = callRes.json.result as {
+      content: Array<{ type: string; uri?: string }>;
+    };
+    expect(callResult.content[0]!.type).toBe("resource_link");
+    const uri = callResult.content[0]!.uri!;
+
+    // Read the spilled blob — content must round-trip byte-exact, with
+    // no `[truncated]` marker appended.
+    const readRes = await rpc(app, { method: "resources/read", params: { uri } });
+    const readResult = readRes.json.result as {
+      contents: Array<{ text?: string }>;
+    };
+    expect(readResult.contents[0]!.text).toBe(big);
+    expect(readResult.contents[0]!.text).not.toContain("[truncated");
+  });
+
+  it("spills 5 MB binary payloads instead of refusing them", async () => {
+    // Regression test for the binary path: previously the read was capped
+    // at MAX_RESPONSE_SIZE (256 KB) before the spillover branch, so any
+    // binary >256 KB was refused with a tool-level error even when a blob
+    // store was configured.
+    const pdfBytes = new Uint8Array(5 * 1024 * 1024); // 5 MB
+    pdfBytes[0] = 0x25; // %
+    pdfBytes[1] = 0x50; // P
+    pdfBytes[2] = 0x44; // D
+    pdfBytes[3] = 0x46; // F
+    pdfBytes[pdfBytes.length - 1] = 0xff;
+    const fetchFn = mock(
+      async () =>
+        new Response(pdfBytes, {
+          status: 200,
+          headers: { "Content-Type": "application/pdf" },
+        }),
+    );
+    const app = createApp(makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }));
+    const callRes = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "test-provider",
+          target: "https://api.example.com/large.pdf",
+        },
+      },
+    });
+    const callResult = callRes.json.result as {
+      content: Array<{ type: string; uri?: string; mimeType?: string }>;
+      isError?: boolean;
+    };
+    expect(callResult.isError).toBeUndefined();
+    expect(callResult.content[0]!.type).toBe("resource_link");
+    expect(callResult.content[0]!.mimeType).toBe("application/pdf");
+
+    // Read the blob and verify the full 5 MB is retained byte-exact.
+    const readRes = await rpc(app, {
+      method: "resources/read",
+      params: { uri: callResult.content[0]!.uri! },
+    });
+    const readResult = readRes.json.result as {
+      contents: Array<{ blob?: string }>;
+    };
+    const decoded = Uint8Array.from(atob(readResult.contents[0]!.blob!), (c) => c.charCodeAt(0));
+    expect(decoded.byteLength).toBe(pdfBytes.byteLength);
+    expect(decoded[0]).toBe(0x25);
+    expect(decoded[decoded.length - 1]).toBe(0xff);
+  });
+
   it("inlines small text responses as before (no behaviour change for typical traffic)", async () => {
     const fetchFn = mock(
       async () =>


### PR DESCRIPTION
Two symmetric fixes for the same class of bug — sidecar capping upstream responses at 256 KB *before* deciding to spill to BlobStore. Both paths (text and binary) had this regression. The BlobStore exists precisely to handle large payloads; the cap was silently corrupting/refusing them anyway.

## 1. Text bodies — don't truncate before BlobStore spillover (item 1.8)

`runtime-pi/sidecar/mcp.ts:712` reads upstream body via `readBodyBounded(res, MAX_RESPONSE_SIZE)` (256 KB cap, adds `[truncated...]` marker) **before** deciding on BlobStore spillover. Consequence: any text response 256 KB – 1 MB arrives corrupted agent-side (body cut + marker polluting the JSON).

**Discovered on**: Fathom transcripts of 270–336 KB classified `truncated` despite a clean HTTP 200.

**Fix**: if `options.blobStore` is available, read up to `ABSOLUTE_MAX_RESPONSE_SIZE` (1 MB) — the BlobStore exists for this. 3 lines.

## 2. Binary path symmetric — same cap forgotten (item 1.10)

`runtime-pi/sidecar/mcp.ts:670` (binary path of `responseToToolResult`) capped upstream reads at `MAX_RESPONSE_SIZE` (256 KB) before spilling, even when a `blobStore` was configured on the run. Any binary response between 256 KB and a reasonable bound (PDFs 1–10 MB, images, ZIPs, audio) was refused with `provider_call: response exceeds 262144 bytes — refused without truncation (truncating an opaque binary blob is unsafe)`.

The comment at line 720 acknowledges the symmetric pattern on the text side (fixed by 1.8) — but the binary path was forgotten.

**Discovered on**: `home-document-assistant` agent downloading Drive PDFs of 0.5–3.4 MB. 3 of 7 files downloaded, then the agent looped on fallback paths, `_NeedsReview` degraded, systematic timeout at 25 min.

**Fix**: symmetric to 1.8. When `options.blobStore` exists, read up to `ABSOLUTE_MAX_RESPONSE_SIZE` instead of `MAX_RESPONSE_SIZE`. Also raises `ABSOLUTE_MAX_RESPONSE_SIZE` from 1 MB → 32 MB (the 1 MB value predated BlobStore and no longer makes sense for binaries — the natural limit is `MAX_MCP_ENVELOPE_SIZE × 2` since the `resource_link` returned in the envelope is just a URI, the blob itself lives in the BlobStore). 9 lines across 2 files (`helpers.ts` + `mcp.ts`).

## Test plan

- [ ] Provider call returning 500 KB text body → resolves as `resource_link` to BlobStore, content intact (no `[truncated...]` marker)
- [ ] Provider call returning 5 MB PDF (binary) → resolves as `resource_link`, full 5 MB readable via `ctx.readResource`
- [ ] Provider call returning 100 KB text body → still resolves inline (under threshold)
- [ ] Run without BlobStore configured → existing 256 KB cap still applies (no behavior change in default config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)