### PR TITLE
fix: lift the 5-minute wall on agentic runs (sidecar + api timeouts)

### DIFF
--- a/apps/api/src/services/docker.ts
+++ b/apps/api/src/services/docker.ts
@@ -290,16 +290,26 @@ export async function* streamLogs(
 }
 
 export async function waitForExit(containerId: string): Promise<number> {
-  const res = await dockerFetch(
-    `/containers/${containerId}/wait`,
-    { method: "POST" },
-    false, // Long-running — blocks until container exits
-  );
-
-  await assertDockerOk(res, "wait for container");
-
-  const data = (await res.json()) as { StatusCode: number };
-  return data.StatusCode;
+  // PATCH (local) — bypass Docker's POST /wait which is blocking long-running.
+  // Bun's fetch with unix: option has an internal headers timeout (~5 min) that
+  // can't be disabled via signal:undefined or globalThis.fetch replacement.
+  // Polling /containers/{id}/json every 2s keeps each fetch short (< 30s
+  // dockerFetch timeout) and avoids the wall entirely. The CPU cost of
+  // polling is negligible compared to the cost of agent runs failing at 5 min.
+  while (true) {
+    const res = await dockerFetch(`/containers/${containerId}/json`);
+    if (!res.ok) {
+      // Container removed mid-poll → treat as exit code 137 (SIGKILL).
+      if (res.status === 404) return 137;
+      await assertDockerOk(res, "inspect container during waitForExit");
+    }
+    const data = (await res.json()) as { State?: { Status?: string; ExitCode?: number } };
+    const status = data.State?.Status;
+    if (status === "exited" || status === "dead") {
+      return data.State?.ExitCode ?? 0;
+    }
+    await new Promise((r) => setTimeout(r, 2000));
+  }
 }
 
 export async function removeContainer(containerId: string): Promise<void> {

--- a/apps/api/src/services/sidecar-pool.ts
+++ b/apps/api/src/services/sidecar-pool.ts
@@ -27,12 +27,19 @@ export const getSidecarImage = () => getEnv().SIDECAR_IMAGE;
 // systematically too short, causing every fresh sidecar to be marked failed
 // before it had a chance to listen, and silently breaking the pool replenisher
 // (initSidecarPool() returns size:0 with two "Failed to create pooled sidecar"
-// logs on every API boot). Budget bumped to ~75 seconds total — covers the
-// observed 24–45 sec cold-starts plus margin without being insanely lax.
-const HEALTH_CHECK_RETRIES = 30;
+// logs on every API boot).
+//
+// The shape preserves the original fine-grained head (catches warm starts in
+// <500 ms — pool replenish, hot Docker daemon, cached image) and only adds a
+// coarse tail for the cold-start case. Total budget ~75 s, dominated by the
+// tail; the warm path is unchanged.
+const HEALTH_CHECK_RETRIES = 35;
 const HEALTH_CHECK_DELAYS_MS = [
-  100, 200, 200, 500, 500, 1000, 1000, 1000, 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000,
-  2000, 2000, 2000, 3000, 3000, 3000, 3000, 3000, 3000, 3000, 3000, 3000, 3000,
+  // Original fast-path (sum ~4 s) — catches warm starts quickly.
+  25, 50, 50, 100, 100, 200, 200, 400, 400, 400, 400, 400, 400, 400, 400,
+  // Cold-start tail (sum ~71 s) — covers 24–45 s container boot.
+  1000, 1000, 1000, 2000, 2000, 2000, 3000, 3000, 3000, 3000, 5000, 5000, 5000, 5000, 5000, 5000,
+  5000, 5000, 5000, 5000,
 ];
 
 interface PooledSidecar {

--- a/apps/api/src/services/sidecar-pool.ts
+++ b/apps/api/src/services/sidecar-pool.ts
@@ -21,9 +21,18 @@ import {
   SIDECAR_INTERNAL_PORT,
 } from "./orchestrator/constants.ts";
 export const getSidecarImage = () => getEnv().SIDECAR_IMAGE;
-const HEALTH_CHECK_RETRIES = 15;
+// Sidecar cold-start can legitimately take 20–45 seconds in Tier 3 self-hosted
+// installs (image pull + container start + Bun runtime warmup + first /health).
+// The original 15 retries × short delays gave a total budget of ~4 seconds —
+// systematically too short, causing every fresh sidecar to be marked failed
+// before it had a chance to listen, and silently breaking the pool replenisher
+// (initSidecarPool() returns size:0 with two "Failed to create pooled sidecar"
+// logs on every API boot). Budget bumped to ~75 seconds total — covers the
+// observed 24–45 sec cold-starts plus margin without being insanely lax.
+const HEALTH_CHECK_RETRIES = 30;
 const HEALTH_CHECK_DELAYS_MS = [
-  25, 50, 50, 100, 100, 200, 200, 400, 400, 400, 400, 400, 400, 400, 400,
+  100, 200, 200, 500, 500, 1000, 1000, 1000, 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000, 2000,
+  2000, 2000, 2000, 3000, 3000, 3000, 3000, 3000, 3000, 3000, 3000, 3000, 3000,
 ];
 
 interface PooledSidecar {

--- a/apps/api/test/unit/sidecar-pool.test.ts
+++ b/apps/api/test/unit/sidecar-pool.test.ts
@@ -24,7 +24,7 @@ describe("waitForSidecarHealth", () => {
       expect(err).toBeInstanceOf(Error);
       expect((err as Error).message).toContain("health check failed");
     }
-  }, 30_000); // Long timeout because it retries
+  }, 90_000); // Long timeout because it retries (full budget ~58s of delays + per-attempt fetch timeouts)
 });
 
 describe("getSidecarImage", () => {

--- a/runtime-pi/sidecar/helpers.ts
+++ b/runtime-pi/sidecar/helpers.ts
@@ -24,7 +24,7 @@ export const MAX_RESPONSE_SIZE = 256 * 1024; // 256 KB
 export const ABSOLUTE_MAX_RESPONSE_SIZE = 1_000_000; // 1MB — hard cap, even when X-Max-Response-Size is larger
 export const OUTBOUND_TIMEOUT_MS = 30_000;
 export const MAX_SUBSTITUTE_BODY_SIZE = 5 * 1024 * 1024; // 5MB
-export const LLM_PROXY_TIMEOUT_MS = 300_000; // 5 minutes
+export const LLM_PROXY_TIMEOUT_MS = 1_800_000; // 30 minutes (patched from 300_000 — was killing legitimate long-running agentic runs at exactly 5 min)
 
 /** Absolute hard-cap for any body-size env override. Above this, raising
  *  the limit requires real engineering (streaming refactor, chunked

--- a/runtime-pi/sidecar/server.ts
+++ b/runtime-pi/sidecar/server.ts
@@ -1,27 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { Agent, fetch as undiciFetch, setGlobalDispatcher } from "undici";
 import { createApp } from "./app.ts";
 import { createForwardProxy } from "./forward-proxy.ts";
 import type { CredentialsResponse } from "./helpers.ts";
 import { logger } from "./logger.ts";
-
-// PATCH (local) — undici h2 client has a hardcoded `bodyTimeout = 300_000`
-// (5 min) default that kills LLM streaming for long agentic conversations.
-// The bodyTimeout is the elapsed wall-clock between any TWO chunks of the
-// streamed response — Claude can pause for >5 min between chunks when the
-// agent context is large and the model is processing many tool calls.
-// `setGlobalDispatcher` alone wasn't enough because Bun's native fetch
-// (Zig-based) doesn't honour it; we explicitly replace globalThis.fetch
-// with the undici-backed fetch using a custom agent that disables both
-// timeouts. This is the actual fix that resolves the silent 5-min wall.
-const undiciAgent = new Agent({ bodyTimeout: 0, headersTimeout: 0 });
-setGlobalDispatcher(undiciAgent);
-globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) =>
-  undiciFetch(
-    input as never,
-    { ...(init as never), dispatcher: undiciAgent } as never,
-  )) as typeof fetch;
 
 // Mutable config — can be set via env vars at startup or updated at runtime
 // via POST /configure (used by sidecar pool for pre-warmed containers).

--- a/runtime-pi/sidecar/server.ts
+++ b/runtime-pi/sidecar/server.ts
@@ -1,9 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { Agent, fetch as undiciFetch, setGlobalDispatcher } from "undici";
 import { createApp } from "./app.ts";
 import { createForwardProxy } from "./forward-proxy.ts";
 import type { CredentialsResponse } from "./helpers.ts";
 import { logger } from "./logger.ts";
+
+// PATCH (local) — undici h2 client has a hardcoded `bodyTimeout = 300_000`
+// (5 min) default that kills LLM streaming for long agentic conversations.
+// The bodyTimeout is the elapsed wall-clock between any TWO chunks of the
+// streamed response — Claude can pause for >5 min between chunks when the
+// agent context is large and the model is processing many tool calls.
+// `setGlobalDispatcher` alone wasn't enough because Bun's native fetch
+// (Zig-based) doesn't honour it; we explicitly replace globalThis.fetch
+// with the undici-backed fetch using a custom agent that disables both
+// timeouts. This is the actual fix that resolves the silent 5-min wall.
+const undiciAgent = new Agent({ bodyTimeout: 0, headersTimeout: 0 });
+setGlobalDispatcher(undiciAgent);
+globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) =>
+  undiciFetch(
+    input as never,
+    { ...(init as never), dispatcher: undiciAgent } as never,
+  )) as typeof fetch;
 
 // Mutable config — can be set via env vars at startup or updated at runtime
 // via POST /configure (used by sidecar pool for pre-warmed containers).


### PR DESCRIPTION
Four fixes that together remove the silent 5-minute ceiling on agentic runs. Symptoms manifest differently across code paths but root cause is the same: hardcoded ~5-minute timeouts in the sidecar pool, the LLM proxy, and undici's h2 client defaults.

Validation: `compta-trimestrielle` agent run that previously failed at 268–300s exactly (DOMException: TimeoutError, no stack) now completes in 5m19s with `success`. Tested with image rebuild containing only these 4 patches.

## 1. Sidecar pool — replenish/health-check budget too tight (item 1.11)

`apps/api` — sidecar pool's health-check timeout was ~4s. Sidecar cold-start (fresh container, no pre-warm hit) takes 24–45s. The orchestrator times out before the sidecar reports healthy, falls into a fail-fast retry loop, and the pool never replenishes after the first acquire. After 2–3 successive runs, all subsequent runs fail with `Sidecar health check failed after retries` *before the agent even starts*. Workaround was to `docker restart` the API container between runs.

**Fix**: raise the sidecar health-check budget to ~75s. Conservative — accommodates cold-start without masking actual sidecar boot failures.

## 2. LLM proxy — hardcoded 5-min timeout (item 1.12)

`runtime-pi/sidecar/helpers.ts` exported `LLM_PROXY_TIMEOUT_MS = 300_000` (5 min). This constant gates the sidecar's `/llm/*` proxy timeout — every LLM completion streamed through it is killed at 5 min, regardless of the agent's manifest timeout (e.g. 1800s). Long agentic conversations (Opus + 5 skill references + batch classification of 10 docs + structured output generation) hit this wall.

**Fix**: `LLM_PROXY_TIMEOUT_MS = 1_800_000` (30 min) — aligned with realistic agentic run budgets. Ideally externalize as `SIDECAR_LLM_PROXY_TIMEOUT_MS` env var in a follow-up.

## 3. Docker `/wait` — undici h2 hardcoded headersTimeout (item 1.13)

`apps/api/src/services/docker.ts:waitForExit` called `dockerFetch('/containers/{id}/wait', method:POST, timeoutMs:false)`. Docker's `/wait` is blocking long-running — keeps the HTTP connection open without sending headers until the container exits. Bun's fetch with `unix:` (used by `dockerFetch` for the Docker socket) routes through undici's h2 client, which has a **hardcoded `headersTimeout = 300_000` that cannot be disabled via signal:undefined or globalThis.fetch replacement**:

```js
// node_modules/.bun/undici@7.24.6/.../lib/dispatcher/client.js
this[kHeadersTimeout] = headersTimeout != null ? headersTimeout : 300e3
```

Result: every run > 5 min was killed by undici aborting the `/wait` fetch with `TimeoutError`. The `timeoutMs: false` argument to `dockerFetch` only avoided the *explicit* AbortSignal; undici applied its own internal timeout regardless.

**Fix**: replace blocking `POST /wait` with a 2-second polling loop on `GET /containers/{id}/json`. Each fetch stays well under `DOCKER_API_TIMEOUT_MS` (30s), so no undici/Bun timeout can fire. CPU cost negligible vs runs failing at 5 min.

```ts
export async function waitForExit(containerId: string): Promise<number> {
  while (true) {
    const res = await dockerFetch(\`/containers/\${containerId}/json\`);
    if (!res.ok) {
      if (res.status === 404) return 137; // container removed → SIGKILL
      await assertDockerOk(res, \"inspect container during waitForExit\");
    }
    const data = (await res.json()) as { State?: { Status?: string; ExitCode?: number } };
    const status = data.State?.Status;
    if (status === \"exited\" || status === \"dead\") return data.State?.ExitCode ?? 0;
    await new Promise((r) => setTimeout(r, 2000));
  }
}
```

Followup ideas: env var `WAITFOREXIT_POLL_INTERVAL_MS` (default 2000) for tuning, or wrap `dockerFetch('/wait')` with `bun:net` raw to bypass undici entirely.

## 4. Sidecar outbound fetches — undici h2 bodyTimeout (item 1.14, defense-in-depth)

Defense-in-depth complement to (2). Patch (2) addresses the *explicit* `AbortSignal.timeout()` in `runtime-pi/sidecar/app.ts:168` for `/llm/*` proxy calls. But the sidecar also makes *implicit* outbound fetches (forward-proxy SSRF, credential proxy `/proxy`) where no explicit `AbortSignal` is added. On those fetches, if Bun's fetch routes through undici (HTTPS h2 to LLM providers), undici's defaults `bodyTimeout = 300e3` AND `headersTimeout = 300e3` kill streaming after 5 min between chunks. Same symptom as (2) but on a different code path.

**Fix**: replace `globalThis.fetch` with undici fetch + custom Agent disabling both timeouts at the top of `runtime-pi/sidecar/server.ts`:

```ts
import { Agent, fetch as undiciFetch, setGlobalDispatcher } from \"undici\";

const undiciAgent = new Agent({ bodyTimeout: 0, headersTimeout: 0 });
setGlobalDispatcher(undiciAgent);
globalThis.fetch = ((input, init) =>
  undiciFetch(input, { ...init, dispatcher: undiciAgent })) as typeof fetch;
```

Why not just `setGlobalDispatcher`: Bun's native fetch (Zig) ignores `setGlobalDispatcher`, but respects `globalThis.fetch` reassignment when the `unix:` option isn't used (which is the case for HTTPS outbound fetches from the sidecar).

Followup architectural cleanup: merge with (2) by replacing the `LLM_PROXY_TIMEOUT_MS` constant with a unified approach (disable all undici timeouts by default, let callers add `AbortSignal.timeout()` explicitly). Cleaner.

## Test plan

- [ ] Run an agent with manifest timeout 1800s and a workload that genuinely takes 8–10 min (e.g. multi-doc classification batch). Expect success completion, not `DOMException: TimeoutError`.
- [ ] Run 5 agents in succession. Pool should replenish; no `Sidecar health check failed after retries` after the 2nd–3rd run.
- [ ] Run an agent that streams a large LLM response over 6+ min between chunks. Expect no `bodyTimeout` from undici.
- [ ] Run a < 1-min agent. Expect no regression — overhead of polling vs `/wait` is invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)