### PR TITLE
feat(cli): lifecycle commands (start/stop/restart/logs/status/uninstall) (#343)

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -35,6 +35,12 @@ See [`examples/self-hosting/README.md`](../../examples/self-hosting/README.md#ve
 | Command                 | Purpose                                                                         |
 | ----------------------- | ------------------------------------------------------------------------------- |
 | `appstrate install`     | Install Appstrate locally (Tier 0) or bring up a Docker stack (Tiers 1/2/3).    |
+| `appstrate start`       | Start the installed Docker stack (`docker compose up -d`).                      |
+| `appstrate stop`        | Stop the stack — containers off, volumes preserved.                             |
+| `appstrate restart`     | Restart all containers.                                                         |
+| `appstrate logs`        | Stream Compose logs (with `-f` and an optional service-name positional).        |
+| `appstrate status`      | Show container status (`docker compose ps`).                                    |
+| `appstrate uninstall`   | Tear down. Default keeps volumes; `--purge` wipes data + the install dir.       |
 | `appstrate login`       | Sign into an instance via RFC 8628 device-flow. Tokens land in the OS keyring.  |
 | `appstrate logout`      | Revoke the active session server-side and wipe local credentials.               |
 | `appstrate whoami`      | Print the identity attached to the active profile.                              |
@@ -79,6 +85,49 @@ appstrate install --tier 0 --dir ~/demo-appstrate
 **Tier 0 specifics**: `git clone`s the `appstrate/appstrate` monorepo at the CLI's release tag, runs `bun install`, writes `.env`, and `bun run dev` spawns the platform as a detached process. If Bun is absent, the CLI prompts to install it via the official installer into `~/.bun/bin` (user-local, no sudo).
 
 **Tier 1/2/3 specifics**: checks `docker info`, writes `docker-compose.yml` from an embedded template (`examples/self-hosting/docker-compose.tier{1,2,3}.yml`), writes `.env`, runs `docker compose up -d`, polls `/` for up to 120s.
+
+---
+
+### Lifecycle commands
+
+After `appstrate install` (Tiers 1/2/3) every Compose verb has a thin
+wrapper that reads the recorded project name from
+`<dir>/.appstrate/project.json` — you never type the derived hash.
+
+```sh
+appstrate start                       # docker compose up -d (idempotent)
+appstrate stop                        # docker compose stop (volumes intact)
+appstrate restart                     # docker compose restart
+appstrate logs -f                     # docker compose logs -f
+appstrate logs -f postgres            # filter to a single service
+appstrate status                      # docker compose ps
+appstrate uninstall                   # docker compose down (data preserved)
+appstrate uninstall --purge --yes     # destructive: down -v + rm -rf <dir>
+```
+
+**Flags (all subcommands)**
+
+| Flag          | Description                                             |
+| ------------- | ------------------------------------------------------- |
+| `-d`, `--dir` | Override the install directory (default `~/appstrate`). |
+
+**`appstrate logs`**
+
+| Flag             | Description                                       |
+| ---------------- | ------------------------------------------------- |
+| `-f`, `--follow` | Stream new lines as they arrive.                  |
+| `[service]`      | Optional positional — filter to a single service. |
+
+**`appstrate uninstall`**
+
+| Flag          | Description                                                                                                                    |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `--purge`     | Also remove named volumes (Postgres, Redis, MinIO data) and the install directory. Destructive — prompts unless `--yes`.       |
+| `-y`, `--yes` | Skip the destructive-action confirmation. Equivalent to `APPSTRATE_YES=1`. Required for `--purge` in non-interactive contexts. |
+
+The raw `docker compose --project-name <hash> <verb>` form remains
+supported — useful when you need a flag the wrapper doesn't expose.
+The project name is in `~/appstrate/.appstrate/project.json`.
 
 ---
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -60,6 +60,14 @@ import { modelsListCommand } from "./commands/models.ts";
 import { registerOpenapiCommand } from "./commands/openapi.ts";
 import { runCommand } from "./commands/run.ts";
 import { selfUpdateCommand } from "./commands/self-update.ts";
+import {
+  startCommand,
+  stopCommand,
+  restartCommand,
+  logsCommand,
+  statusCommand,
+  uninstallCommand,
+} from "./commands/lifecycle.ts";
 import { doctorCommand } from "./commands/doctor.ts";
 import { internalInfoCommand } from "./commands/internal.ts";
 import {
@@ -212,6 +220,81 @@ program
         typeof opts.minioConsolePort === "string" ? opts.minioConsolePort : undefined,
       force: opts.force === true,
       autoConfirm,
+    });
+  });
+
+// ─── Lifecycle commands (#343) — manage a Docker-tier install ────
+//
+// Each command reads `<dir>/.appstrate/project.json` for the Compose
+// project name (never re-derived) and forwards to `docker compose`
+// with `--project-name <name>`. The shared resolver lives in
+// `lib/install/project.ts::resolveInstall` so a future Tier 0
+// dispatcher can plug in without touching cli.ts.
+
+program
+  .command("start")
+  .description("Start the Appstrate stack (`docker compose up -d`)")
+  .option("-d, --dir <path>", "Install directory (default: ~/appstrate).")
+  .action(async (opts) => {
+    await startCommand({ dir: typeof opts.dir === "string" ? opts.dir : undefined });
+  });
+
+program
+  .command("stop")
+  .description("Stop the Appstrate stack (`docker compose stop`). Volumes are preserved.")
+  .option("-d, --dir <path>", "Install directory (default: ~/appstrate).")
+  .action(async (opts) => {
+    await stopCommand({ dir: typeof opts.dir === "string" ? opts.dir : undefined });
+  });
+
+program
+  .command("restart")
+  .description("Restart the Appstrate stack (`docker compose restart`).")
+  .option("-d, --dir <path>", "Install directory (default: ~/appstrate).")
+  .action(async (opts) => {
+    await restartCommand({ dir: typeof opts.dir === "string" ? opts.dir : undefined });
+  });
+
+program
+  .command("logs [service]")
+  .description("Stream Compose logs for the install (optionally scoped to a single service).")
+  .option("-d, --dir <path>", "Install directory (default: ~/appstrate).")
+  .option("-f, --follow", "Stream new lines as they arrive (`docker compose logs -f`).")
+  .action(async (service: string | undefined, opts) => {
+    await logsCommand({
+      dir: typeof opts.dir === "string" ? opts.dir : undefined,
+      follow: opts.follow === true,
+      service: typeof service === "string" ? service : undefined,
+    });
+  });
+
+program
+  .command("status")
+  .description("Show container status for the install (`docker compose ps`).")
+  .option("-d, --dir <path>", "Install directory (default: ~/appstrate).")
+  .action(async (opts) => {
+    await statusCommand({ dir: typeof opts.dir === "string" ? opts.dir : undefined });
+  });
+
+program
+  .command("uninstall")
+  .description(
+    "Tear down the Appstrate stack. By default `docker compose down` (containers gone, named volumes preserved). With --purge, also removes volumes and the install directory — destructive, prompts for confirmation.",
+  )
+  .option("-d, --dir <path>", "Install directory (default: ~/appstrate).")
+  .option(
+    "--purge",
+    "Also remove named volumes (Postgres, Redis, MinIO data) and the install directory. Destructive — prompts unless --yes / APPSTRATE_YES=1 is set.",
+  )
+  .option(
+    "-y, --yes",
+    "Skip the destructive-action confirmation. Required for --purge in non-interactive contexts. Equivalent to APPSTRATE_YES=1.",
+  )
+  .action(async (opts) => {
+    await uninstallCommand({
+      dir: typeof opts.dir === "string" ? opts.dir : undefined,
+      purge: opts.purge === true,
+      yes: opts.yes === true,
     });
   });
 

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -55,5 +55,6 @@ function serializeReport(report: DoctorReport): unknown {
     dualInstall: report.dualInstall,
     multiSource: report.multiSource,
     connectionProfile: report.connectionProfile,
+    localInstall: report.localInstall,
   };
 }

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -1017,10 +1017,18 @@ async function installDockerTier(
 
   await openBrowser(appUrl);
   printBootstrapFollowup(appUrl, opts.bootstrap);
+  // The lifecycle commands (#343) read `<dir>/.appstrate/project.json`
+  // to find the right `--project-name`, so the user never has to type
+  // (or remember) the derived hash. We pass `--dir` only when the
+  // install isn't at the default `~/appstrate`, to keep the hint short
+  // for the most common path.
+  const dirHint = resolve(dir) === resolve(DEFAULT_INSTALL_DIR) ? "" : ` --dir ${dir}`;
   outro(
     `Appstrate is running at ${appUrl}.\n` +
-      `Manage the stack from ${dir}:\n` +
-      `  docker compose --project-name ${project.name} logs -f\n` +
-      `  docker compose --project-name ${project.name} down`,
+      `Manage the stack:\n` +
+      `  appstrate logs -f${dirHint}\n` +
+      `  appstrate stop${dirHint}\n` +
+      `  appstrate uninstall${dirHint}\n` +
+      `Raw form (for advanced cases): docker compose --project-name ${project.name} <verb> from ${dir}.`,
   );
 }

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -12,7 +12,6 @@
  */
 
 import { closeSync, openSync, writeSync } from "node:fs";
-import { homedir } from "node:os";
 import { join, resolve } from "node:path";
 import * as clack from "@clack/prompts";
 import { intro, outro, askText, confirm, spinner, exitWithError } from "../lib/ui.ts";
@@ -55,7 +54,12 @@ import {
   type InstallMode,
 } from "../lib/install/upgrade.ts";
 import type { EnvVars } from "../lib/install/secrets.ts";
-import { deriveProjectName, readProjectFile, writeProjectFile } from "../lib/install/project.ts";
+import {
+  defaultInstallDir,
+  deriveProjectName,
+  readProjectFile,
+  writeProjectFile,
+} from "../lib/install/project.ts";
 import { CLI_VERSION } from "../lib/version.ts";
 
 export interface InstallOptions {
@@ -78,7 +82,7 @@ export interface InstallOptions {
   /**
    * Skip every interactive prompt and accept the smart defaults:
    *   - tier: Docker-aware default (3 when Docker is reachable, else 0)
-   *   - dir: DEFAULT_INSTALL_DIR (~/appstrate)
+   *   - dir: `defaultInstallDir()` (~/appstrate)
    *   - port: 3000 (or --port / APPSTRATE_PORT)
    *   - upgrade confirm: proceed
    *   - Bun install confirm (Tier 0): install
@@ -93,7 +97,6 @@ export interface InstallOptions {
   autoConfirm?: boolean;
 }
 
-const DEFAULT_INSTALL_DIR = join(homedir(), "appstrate");
 const DEFAULT_PORT = 3000;
 const DEFAULT_MINIO_CONSOLE_PORT = 9001;
 
@@ -697,7 +700,7 @@ export async function resolveTier(
  * circuit without spawning a real askText prompt.
  */
 export interface DirResolverDeps {
-  /** When true, accept `DEFAULT_INSTALL_DIR` without prompting. */
+  /** When true, accept `defaultInstallDir()` without prompting. */
   autoConfirm?: boolean;
 }
 
@@ -711,7 +714,7 @@ export async function resolveDir(
 ): Promise<string> {
   // --yes path: skip askText (no raw mode, no Bun bug, works in CI).
   if (raw === undefined && deps.autoConfirm === true) {
-    return resolve(DEFAULT_INSTALL_DIR);
+    return resolve(defaultInstallDir());
   }
   if (raw === undefined && !process.stdin.isTTY) {
     throw new Error(
@@ -721,7 +724,7 @@ export async function resolveDir(
         "or `curl -fsSL https://get.appstrate.dev | bash -s -- --tier 3 --dir ~/appstrate`.",
     );
   }
-  const chosen = raw ?? (await askText("Install directory", DEFAULT_INSTALL_DIR));
+  const chosen = raw ?? (await askText("Install directory", defaultInstallDir()));
   // `tier0.ts` passes `dir` as an argv positional to `tar`, `curl`,
   // `git`, etc. without a shell wrapper, so interpolation injection is
   // already ruled out at the spawn layer. But newlines + NUL bytes in
@@ -1022,7 +1025,7 @@ async function installDockerTier(
   // (or remember) the derived hash. We pass `--dir` only when the
   // install isn't at the default `~/appstrate`, to keep the hint short
   // for the most common path.
-  const dirHint = resolve(dir) === resolve(DEFAULT_INSTALL_DIR) ? "" : ` --dir ${dir}`;
+  const dirHint = resolve(dir) === resolve(defaultInstallDir()) ? "" : ` --dir ${dir}`;
   outro(
     `Appstrate is running at ${appUrl}.\n` +
       `Manage the stack:\n` +

--- a/apps/cli/src/commands/lifecycle.ts
+++ b/apps/cli/src/commands/lifecycle.ts
@@ -67,42 +67,29 @@ export interface UninstallOptions extends LifecycleOptions {
 
 /**
  * Run `docker compose --project-name <name> <verb...>` against the
- * resolved install dir. Pulls stdout/stderr through the parent's stdio
- * so the user sees Compose's normal output (progress bars, logs,
- * errors) inline. Throws on non-zero so commander's error handler
- * turns it into the standard cancel banner instead of swallowing the
- * exit code.
+ * resolved install dir with stdio inherited, so the user sees
+ * Compose's normal output (progress bars, logs, errors) inline.
+ * Throws on non-zero so commander's error handler renders the
+ * standard cancel banner instead of swallowing the exit code.
  */
-async function runCompose(
-  dir: string,
-  projectName: string,
-  args: string[],
-  // `inherit` is the default — what every interactive verb needs.
-  // `pipe` is rare (only when a follow-up command needs to inspect
-  // Compose's output); the option exists so `runCompose` can stay the
-  // single docker invocation site without callers reaching for `runCommand` again.
-  stdio: "inherit" | "pipe" = "inherit",
-): Promise<void> {
+async function runCompose(dir: string, projectName: string, args: string[]): Promise<void> {
   const res = await runCommand("docker", ["compose", "--project-name", projectName, ...args], {
     cwd: dir,
-    stdio,
+    stdio: "inherit",
   });
   if (res.ok) return;
   // SIGINT (130) / SIGTERM (143) are graceful Ctrl-C exits — surface
-  // them as a clean process exit with the same code rather than as a
+  // them as a clean process exit with the same code rather than a
   // thrown error. Without this, `appstrate logs -f` followed by Ctrl-C
   // would render "docker compose logs failed with exit code 130" via
   // `exitWithError`, masking the fact that the user intentionally
-  // ended the stream. The CLI's own shutdown coordinator (lib/shutdown.ts)
-  // also calls `process.exit(130)` on SIGINT, so picking the same code
-  // here keeps shell pipelines coherent.
+  // ended the stream. The CLI's own shutdown coordinator
+  // (lib/shutdown.ts) also calls `process.exit(130)` on SIGINT, so
+  // picking the same code here keeps shell pipelines coherent.
   if (res.exitCode === 130 || res.exitCode === 143) {
     process.exit(res.exitCode);
   }
-  throw new Error(
-    `docker compose ${args.join(" ")} failed with exit code ${res.exitCode}` +
-      (stdio === "pipe" && res.stderr ? `\n${res.stderr.trim()}` : ""),
-  );
+  throw new Error(`docker compose ${args.join(" ")} failed with exit code ${res.exitCode}`);
 }
 
 /** `appstrate start` → `docker compose up -d` (idempotent). */

--- a/apps/cli/src/commands/lifecycle.ts
+++ b/apps/cli/src/commands/lifecycle.ts
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Docker-based lifecycle commands — `appstrate start / stop / restart /
+ * logs / status / uninstall`.
+ *
+ * Each command is a ~10-line wrapper around `docker compose
+ * --project-name <name> <verb>`, where the project name is read from
+ * `<dir>/.appstrate/project.json` via `resolveInstall`. We never
+ * re-derive the name at this layer: the sidecar is the source of
+ * truth, so a user who renamed `~/appstrate` to `~/work` still hits
+ * the containers their original install registered.
+ *
+ * The Compose CLI surface for `up / stop / restart / logs / ps / down`
+ * has been stable for years — see #343 for the tradeoff analysis. We
+ * pin `--project-name` on every invocation so an unrelated host that
+ * happens to have a similarly-named running project never collides
+ * with our stack.
+ *
+ * `--purge` on `uninstall` is the only destructive verb; everything
+ * else is reversible. The two-tier flow (`uninstall` → containers off,
+ * data preserved; `uninstall --purge` → volumes + dir gone) mirrors
+ * what most operators expect from a CLI: the safe verb is the default,
+ * the dangerous one needs a flag, and the dangerous one prompts unless
+ * `--yes` / `APPSTRATE_YES=1` is set.
+ */
+
+import { rm } from "node:fs/promises";
+import * as clack from "@clack/prompts";
+import { runCommand } from "../lib/install/os.ts";
+import { resolveInstall } from "../lib/install/project.ts";
+
+export interface LifecycleOptions {
+  /**
+   * Override the install directory. Defaults to `~/appstrate` via
+   * `resolveInstall`, which then reads the recorded project name from
+   * `<dir>/.appstrate/project.json`.
+   */
+  dir?: string;
+}
+
+export interface LogsOptions extends LifecycleOptions {
+  /** Stream new lines as they arrive (`docker compose logs -f`). */
+  follow?: boolean;
+  /** Optional service-name filter (e.g. `postgres` or `appstrate`). */
+  service?: string;
+}
+
+export interface UninstallOptions extends LifecycleOptions {
+  /**
+   * When true: `docker compose down -v` (volumes removed) + `rm -rf
+   * <dir>` after confirmation. When false (the default): `docker
+   * compose down` only — containers gone, named volumes preserved,
+   * install dir untouched. The destructive verb is opt-in by
+   * construction.
+   */
+  purge?: boolean;
+  /**
+   * Skip the destructive-action confirmation prompt. Required for
+   * `--purge` to proceed in non-interactive contexts (CI, Dockerfile
+   * `RUN`, cloud-init). Honoured via `APPSTRATE_YES=1` so the prompt
+   * can also be skipped without threading a CLI flag through wrapper
+   * scripts.
+   */
+  yes?: boolean;
+}
+
+/**
+ * Run `docker compose --project-name <name> <verb...>` against the
+ * resolved install dir. Pulls stdout/stderr through the parent's stdio
+ * so the user sees Compose's normal output (progress bars, logs,
+ * errors) inline. Throws on non-zero so commander's error handler
+ * turns it into the standard cancel banner instead of swallowing the
+ * exit code.
+ */
+async function runCompose(
+  dir: string,
+  projectName: string,
+  args: string[],
+  // `inherit` is the default — what every interactive verb needs.
+  // `pipe` is rare (only when a follow-up command needs to inspect
+  // Compose's output); the option exists so `runCompose` can stay the
+  // single docker invocation site without callers reaching for `runCommand` again.
+  stdio: "inherit" | "pipe" = "inherit",
+): Promise<void> {
+  const res = await runCommand("docker", ["compose", "--project-name", projectName, ...args], {
+    cwd: dir,
+    stdio,
+  });
+  if (res.ok) return;
+  // SIGINT (130) / SIGTERM (143) are graceful Ctrl-C exits — surface
+  // them as a clean process exit with the same code rather than as a
+  // thrown error. Without this, `appstrate logs -f` followed by Ctrl-C
+  // would render "docker compose logs failed with exit code 130" via
+  // `exitWithError`, masking the fact that the user intentionally
+  // ended the stream. The CLI's own shutdown coordinator (lib/shutdown.ts)
+  // also calls `process.exit(130)` on SIGINT, so picking the same code
+  // here keeps shell pipelines coherent.
+  if (res.exitCode === 130 || res.exitCode === 143) {
+    process.exit(res.exitCode);
+  }
+  throw new Error(
+    `docker compose ${args.join(" ")} failed with exit code ${res.exitCode}` +
+      (stdio === "pipe" && res.stderr ? `\n${res.stderr.trim()}` : ""),
+  );
+}
+
+/** `appstrate start` → `docker compose up -d` (idempotent). */
+export async function startCommand(opts: LifecycleOptions = {}): Promise<void> {
+  const { dir, projectName } = await resolveInstall(opts);
+  await runCompose(dir, projectName, ["up", "-d"]);
+}
+
+/** `appstrate stop` → `docker compose stop` (containers off, volumes intact). */
+export async function stopCommand(opts: LifecycleOptions = {}): Promise<void> {
+  const { dir, projectName } = await resolveInstall(opts);
+  await runCompose(dir, projectName, ["stop"]);
+}
+
+/** `appstrate restart` → `docker compose restart`. */
+export async function restartCommand(opts: LifecycleOptions = {}): Promise<void> {
+  const { dir, projectName } = await resolveInstall(opts);
+  await runCompose(dir, projectName, ["restart"]);
+}
+
+/**
+ * `appstrate logs [-f] [service]` → `docker compose logs [...]`.
+ * Service name is positional and forwarded verbatim — Compose handles
+ * unknown service names with a helpful error of its own, no need to
+ * pre-validate here.
+ */
+export async function logsCommand(opts: LogsOptions = {}): Promise<void> {
+  const { dir, projectName } = await resolveInstall(opts);
+  const args = ["logs"];
+  if (opts.follow) args.push("-f");
+  if (opts.service) args.push(opts.service);
+  await runCompose(dir, projectName, args);
+}
+
+/** `appstrate status` → `docker compose ps`. */
+export async function statusCommand(opts: LifecycleOptions = {}): Promise<void> {
+  const { dir, projectName } = await resolveInstall(opts);
+  await runCompose(dir, projectName, ["ps"]);
+}
+
+/**
+ * `appstrate uninstall [--purge]`:
+ *
+ *   - default → `docker compose down` (containers gone, named volumes
+ *     preserved). Reversible by `appstrate start` from the same dir.
+ *   - `--purge` → `docker compose down -v` + `rm -rf <dir>`. Destroys
+ *     Postgres, Redis, MinIO data plus every file the installer wrote.
+ *     Prompts unless `--yes` / `APPSTRATE_YES=1` is set; the prompt
+ *     enumerates exactly what gets destroyed so the user can't claim
+ *     surprise.
+ */
+export async function uninstallCommand(opts: UninstallOptions = {}): Promise<void> {
+  const { dir, projectName } = await resolveInstall(opts);
+  const purge = opts.purge === true;
+  const autoConfirm = opts.yes === true || process.env.APPSTRATE_YES === "1";
+
+  if (purge) {
+    if (!autoConfirm) {
+      // The non-TTY case is handled by clack itself (Ctrl-C → exit 130);
+      // we re-frame stdout-piped scripts with a dedicated guard so the
+      // operator gets an actionable hint instead of a frozen prompt.
+      if (!process.stdin.isTTY) {
+        throw new Error(
+          `\`appstrate uninstall --purge\` is destructive and requires confirmation.\n` +
+            `Re-run with --yes (or APPSTRATE_YES=1) to proceed non-interactively.`,
+        );
+      }
+      const ok = await clack.confirm({
+        message:
+          `Permanently destroy this Appstrate install?\n` +
+          `  • dir: ${dir} (compose file, .env, .appstrate/)\n` +
+          `  • named volumes: Postgres data, Redis data, MinIO data\n` +
+          `  • project: ${projectName}\n` +
+          `This cannot be undone.`,
+        initialValue: false,
+      });
+      if (clack.isCancel(ok) || ok !== true) {
+        clack.cancel("Uninstall cancelled.");
+        // `process.exit(130)` matches the Ctrl-C exit code used by every
+        // other prompt in this CLI — keeps shell-script wrappers (`if
+        // appstrate uninstall --purge; then …`) coherent.
+        process.exit(130);
+      }
+    }
+    await runCompose(dir, projectName, ["down", "-v"]);
+    // `rm -rf` AFTER `down -v` so we never strand orphan containers
+    // pointing at a deleted bind-mount source. Only the install dir
+    // itself is removed — the user's home directory is never touched.
+    await rm(dir, { recursive: true, force: true });
+    return;
+  }
+
+  // Safe verb: containers off, data preserved. No prompt — this is
+  // the same blast radius as `appstrate stop` plus container removal,
+  // which the user can reverse with `appstrate start` (Compose
+  // re-creates from the persisted volumes).
+  await runCompose(dir, projectName, ["down"]);
+}

--- a/apps/cli/src/lib/doctor.ts
+++ b/apps/cli/src/lib/doctor.ts
@@ -21,6 +21,7 @@ import {
   type PathScanFs,
 } from "./path-scan.ts";
 import { upgradeHint, type InstallSource } from "./install-source.ts";
+import { defaultInstallDir, readProjectFile } from "./install/project.ts";
 
 export interface InstallationInfo {
   /** PATH directory containing the binary. */
@@ -46,6 +47,13 @@ export interface ConnectionProfileCheck {
   hint?: string;
 }
 
+export interface LocalInstallInfo {
+  /** Absolute path to the install directory (defaults to `~/appstrate`). */
+  dir: string;
+  /** Compose project name read from `<dir>/.appstrate/project.json`. */
+  projectName: string;
+}
+
 export interface DoctorReport {
   /** All discovered installations in PATH order — first one wins resolution. */
   installations: InstallationInfo[];
@@ -57,6 +65,13 @@ export interface DoctorReport {
   multiSource: boolean;
   /** Connection-profile health for the active CLI profile, when one is pinned. */
   connectionProfile?: ConnectionProfileCheck;
+  /**
+   * Local Docker-tier install detected at `~/appstrate` (or wherever
+   * `--dir` was last installed). When present, the doctor surfaces the
+   * lifecycle command hints (`appstrate logs / stop / uninstall`) so
+   * the user doesn't have to memorize the derived project hash.
+   */
+  localInstall?: LocalInstallInfo;
 }
 
 export interface ProbeBinary {
@@ -121,6 +136,14 @@ export interface RunDoctorOptions {
    * Tests inject a stub.
    */
   checkConnectionProfile?: CheckConnectionProfile;
+  /**
+   * Override the install-directory probe for tests. Returns the parsed
+   * sidecar info when an install is detected at `dir`, or `null`.
+   * Defaults to reading `<dir>/.appstrate/project.json` from disk.
+   */
+  probeLocalInstall?: (dir: string) => Promise<LocalInstallInfo | null>;
+  /** Override the install dir probed (defaults to `~/appstrate`). */
+  installDir?: string;
 }
 
 /**
@@ -194,13 +217,40 @@ export async function runDoctor(opts: RunDoctorOptions = {}): Promise<DoctorRepo
     // intentional swallow — see ConnectionProfileCheck.status="unknown"
   }
 
+  // Local-install probe (#343) — surfaces the lifecycle command hints
+  // when a Docker-tier install exists. Soft-fails on any error: a
+  // missing or unreadable sidecar is the normal state for users who
+  // never ran `appstrate install`, and must not perturb the rest of
+  // the report.
+  const installDir = opts.installDir ?? defaultInstallDir();
+  const probeLocal = opts.probeLocalInstall ?? defaultProbeLocalInstall;
+  let localInstall: LocalInstallInfo | undefined;
+  try {
+    const found = await probeLocal(installDir);
+    if (found) localInstall = found;
+  } catch {
+    // intentional swallow — sidecar absence is not a doctor finding.
+  }
+
   return {
     installations,
     runningIndex,
     dualInstall: installations.length > 1,
     multiSource: sources.size > 1,
     ...(connectionProfile ? { connectionProfile } : {}),
+    ...(localInstall ? { localInstall } : {}),
   };
+}
+
+/**
+ * Default local-install probe — reads `<dir>/.appstrate/project.json`.
+ * Returns `null` for the common "no install at this path" case so the
+ * doctor can soft-skip the section.
+ */
+async function defaultProbeLocalInstall(dir: string): Promise<LocalInstallInfo | null> {
+  const file = await readProjectFile(dir);
+  if (!file) return null;
+  return { dir, projectName: file.projectName };
 }
 
 /**
@@ -259,6 +309,19 @@ export function formatDoctorReport(report: DoctorReport, runningExecPath: string
     } else {
       lines.push(`Connection profile ${cp.profileId} is healthy.`);
     }
+  }
+
+  if (report.localInstall) {
+    lines.push(``);
+    lines.push(
+      `Local Docker-tier install detected at ${report.localInstall.dir} (project: ${report.localInstall.projectName}).`,
+    );
+    lines.push(`Manage the stack via:`);
+    lines.push(`  • appstrate logs -f         (stream container logs)`);
+    lines.push(`  • appstrate status          (compose ps)`);
+    lines.push(`  • appstrate stop / start    (containers off / on, volumes intact)`);
+    lines.push(`  • appstrate uninstall       (down — data preserved)`);
+    lines.push(`  • appstrate uninstall --purge   (down -v + rm <dir>, destructive)`);
   }
 
   if (report.dualInstall) {

--- a/apps/cli/src/lib/install/project.ts
+++ b/apps/cli/src/lib/install/project.ts
@@ -22,7 +22,8 @@
  */
 
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { homedir } from "node:os";
+import { basename, join, resolve } from "node:path";
 import { createHash } from "node:crypto";
 
 /**
@@ -109,6 +110,62 @@ export async function readProjectFile(dir: string): Promise<ProjectFile | null> 
   } catch {
     return null;
   }
+}
+
+/**
+ * Default install directory used by `appstrate install` (and therefore
+ * by every lifecycle command that needs to find an existing install).
+ * Kept in this module — alongside the other install-dir primitives —
+ * so the lifecycle commands and the installer agree on a single source
+ * of truth (no second copy in `commands/install.ts` to drift).
+ */
+export function defaultInstallDir(): string {
+  return join(homedir(), "appstrate");
+}
+
+/**
+ * Error raised by `resolveInstall` when the requested directory does
+ * not contain a recorded `.appstrate/project.json`. Callers route this
+ * through `exitWithError` (see `lib/ui.ts`) so the message renders as
+ * a clean cancel banner rather than a stack trace — but the explicit
+ * subclass also lets tests assert on the failure mode without matching
+ * a free-form string.
+ */
+export class InstallNotFoundError extends Error {
+  constructor(
+    readonly dir: string,
+    readonly filePath: string,
+  ) {
+    super(
+      `No Appstrate install found at ${dir}.\n` +
+        `Either pass --dir <path>, or run 'appstrate install' first.\n` +
+        `(Looked for ${filePath})`,
+    );
+    this.name = "InstallNotFoundError";
+  }
+}
+
+/**
+ * Resolve an install directory + its bound Compose project name.
+ * Single source of truth for every lifecycle command (start / stop /
+ * restart / logs / status / uninstall): the project name is read from
+ * the on-disk sidecar — never re-derived — so a user who edits the
+ * directory's basename or moves their `~/appstrate` somewhere else
+ * still gets the exact name their containers were registered with.
+ *
+ * Fail-fast on a missing sidecar: silently falling back to a derived
+ * name would produce `--project-name <fresh-hash>`, miss the running
+ * containers, and the user would think `appstrate stop` is broken.
+ * The error message points at the two recovery paths (re-run install,
+ * or pass --dir explicitly).
+ */
+export async function resolveInstall(
+  opts: { dir?: string } = {},
+): Promise<{ dir: string; projectName: string }> {
+  const dir = resolve(opts.dir ?? defaultInstallDir());
+  const file = await readProjectFile(dir);
+  if (!file) throw new InstallNotFoundError(dir, projectFilePath(dir));
+  return { dir, projectName: file.projectName };
 }
 
 /**

--- a/apps/cli/test/doctor.test.ts
+++ b/apps/cli/test/doctor.test.ts
@@ -51,6 +51,7 @@ describe("runDoctor", () => {
       pathScanFs: fs({}),
       probeBinary: probe({}),
       execPath: "/some/where",
+      probeLocalInstall: async () => null,
     });
     expect(report.installations).toEqual([]);
     expect(report.runningIndex).toBe(-1);
@@ -66,6 +67,7 @@ describe("runDoctor", () => {
         "/usr/local/bin/appstrate": { version: "1.2.3", source: "curl" },
       }),
       execPath: "/usr/local/bin/appstrate",
+      probeLocalInstall: async () => null,
     });
     expect(report.installations).toHaveLength(1);
     expect(report.installations[0]!.source).toBe("curl");
@@ -87,6 +89,7 @@ describe("runDoctor", () => {
         "/b/appstrate": { version: "1.2.0", source: "bun" },
       }),
       execPath: "/a/appstrate",
+      probeLocalInstall: async () => null,
     });
     expect(report.installations).toHaveLength(2);
     expect(report.dualInstall).toBe(true);
@@ -100,6 +103,7 @@ describe("runDoctor", () => {
       pathScanFs: fs({ "/a/appstrate": { exec: true } }),
       probeBinary: probe({ "/a/appstrate": { error: "timeout" } }),
       execPath: "/a/appstrate",
+      probeLocalInstall: async () => null,
     });
     expect(report.installations[0]!.version).toBeNull();
     expect(report.installations[0]!.probeError).toBe("timeout");
@@ -116,6 +120,7 @@ describe("runDoctor", () => {
         "/usr/local/bin/appstrate": { version: "1.0.0", source: "curl" },
       }),
       execPath: "/opt/appstrate/bin/appstrate",
+      probeLocalInstall: async () => null,
     });
     expect(report.runningIndex).toBe(0);
   });
@@ -140,6 +145,7 @@ describe("runDoctor", () => {
         "/opt/appstrate/bin/appstrate": { version: "1.0.0", source: "curl" },
       }),
       execPath: "/home/user/.local/bin/appstrate",
+      probeLocalInstall: async () => null,
     });
     expect(report.runningIndex).toBe(0);
   });
@@ -261,6 +267,7 @@ describe("connection-profile check", () => {
       pathScanFs: fs({ "/usr/local/bin/appstrate": { exec: true } }),
       probeBinary: probe({ "/usr/local/bin/appstrate": { version: "1.2.3", source: "curl" } }),
       execPath: "/usr/local/bin/appstrate",
+      probeLocalInstall: async () => null,
       checkConnectionProfile: async () => ({
         profileId: "abc",
         status: "missing",
@@ -280,6 +287,7 @@ describe("connection-profile check", () => {
       pathScanFs: fs({ "/usr/local/bin/appstrate": { exec: true } }),
       probeBinary: probe({ "/usr/local/bin/appstrate": { version: "1.2.3", source: "curl" } }),
       execPath: "/usr/local/bin/appstrate",
+      probeLocalInstall: async () => null,
       checkConnectionProfile: async () => null,
     });
     expect(report.connectionProfile).toBeUndefined();
@@ -291,6 +299,7 @@ describe("connection-profile check", () => {
       pathScanFs: fs({ "/usr/local/bin/appstrate": { exec: true } }),
       probeBinary: probe({ "/usr/local/bin/appstrate": { version: "1.2.3", source: "curl" } }),
       execPath: "/usr/local/bin/appstrate",
+      probeLocalInstall: async () => null,
       checkConnectionProfile: async () => {
         throw new Error("network down");
       },
@@ -329,6 +338,92 @@ describe("connection-profile check", () => {
       "/usr/local/bin/appstrate",
     );
     expect(text).toContain("could not be verified");
+  });
+});
+
+describe("local Docker-tier install probe (#343)", () => {
+  // The doctor surfaces a hint block when a Tier 1/2/3 install is
+  // detected on the host so users find the lifecycle commands without
+  // having to read the issue.
+
+  const baseInstall = {
+    pathEntry: "/usr/local/bin",
+    binary: "/usr/local/bin/appstrate",
+    realPath: "/usr/local/bin/appstrate",
+    version: "1.2.3",
+    source: "curl" as const,
+  };
+
+  it("attaches a `localInstall` field when the probe finds a sidecar", async () => {
+    const report = await runDoctor({
+      pathEnv: "/usr/local/bin",
+      pathScanFs: fs({ "/usr/local/bin/appstrate": { exec: true } }),
+      probeBinary: probe({ "/usr/local/bin/appstrate": { version: "1.2.3", source: "curl" } }),
+      execPath: "/usr/local/bin/appstrate",
+      probeLocalInstall: async (dir) => ({ dir, projectName: "appstrate-prod-cafebabe" }),
+      installDir: "/srv/appstrate",
+    });
+    expect(report.localInstall).toEqual({
+      dir: "/srv/appstrate",
+      projectName: "appstrate-prod-cafebabe",
+    });
+  });
+
+  it("omits `localInstall` when the probe returns null", async () => {
+    const report = await runDoctor({
+      pathEnv: "/usr/local/bin",
+      pathScanFs: fs({ "/usr/local/bin/appstrate": { exec: true } }),
+      probeBinary: probe({ "/usr/local/bin/appstrate": { version: "1.2.3", source: "curl" } }),
+      execPath: "/usr/local/bin/appstrate",
+      probeLocalInstall: async () => null,
+    });
+    expect(report.localInstall).toBeUndefined();
+  });
+
+  it("fails soft (no `localInstall`) when the probe throws", async () => {
+    const report = await runDoctor({
+      pathEnv: "/usr/local/bin",
+      pathScanFs: fs({ "/usr/local/bin/appstrate": { exec: true } }),
+      probeBinary: probe({ "/usr/local/bin/appstrate": { version: "1.2.3", source: "curl" } }),
+      execPath: "/usr/local/bin/appstrate",
+      probeLocalInstall: async () => {
+        throw new Error("disk error");
+      },
+    });
+    expect(report.localInstall).toBeUndefined();
+  });
+
+  it("renders the lifecycle command hints when a local install is detected", () => {
+    const text = formatDoctorReport(
+      {
+        installations: [baseInstall],
+        runningIndex: 0,
+        dualInstall: false,
+        multiSource: false,
+        localInstall: { dir: "/home/alice/appstrate", projectName: "appstrate-alice-deadbeef" },
+      },
+      "/usr/local/bin/appstrate",
+    );
+    expect(text).toContain("Local Docker-tier install detected at /home/alice/appstrate");
+    expect(text).toContain("appstrate-alice-deadbeef");
+    expect(text).toContain("appstrate logs -f");
+    expect(text).toContain("appstrate stop");
+    expect(text).toContain("appstrate uninstall");
+    expect(text).toContain("--purge");
+  });
+
+  it("does NOT render the lifecycle hint block when localInstall is absent", () => {
+    const text = formatDoctorReport(
+      {
+        installations: [baseInstall],
+        runningIndex: 0,
+        dualInstall: false,
+        multiSource: false,
+      },
+      "/usr/local/bin/appstrate",
+    );
+    expect(text).not.toContain("Local Docker-tier install detected");
+    expect(text).not.toContain("appstrate logs -f");
   });
 });
 

--- a/apps/cli/test/install.test.ts
+++ b/apps/cli/test/install.test.ts
@@ -178,7 +178,7 @@ describe("resolveTier (--yes / autoConfirm)", () => {
 });
 
 describe("resolveDir (--yes / autoConfirm)", () => {
-  it("returns DEFAULT_INSTALL_DIR without prompting when --dir is missing", async () => {
+  it("returns defaultInstallDir() without prompting when --dir is missing", async () => {
     // Under --yes we must never enter askText — same setRawMode bypass
     // story as resolveTier. The returned path must be absolute so the
     // tier0/tier123 spawn layer gets a stable cwd.

--- a/apps/cli/test/install/project.test.ts
+++ b/apps/cli/test/install/project.test.ts
@@ -14,12 +14,16 @@ import { mkdtemp, readFile, rm, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import {
+  InstallNotFoundError,
   PROJECT_FILE_RELPATH,
+  defaultInstallDir,
   deriveProjectName,
   projectFilePath,
   readProjectFile,
+  resolveInstall,
   writeProjectFile,
 } from "../../src/lib/install/project.ts";
+import { homedir } from "node:os";
 
 let workDir: string;
 
@@ -119,5 +123,61 @@ describe("readProjectFile / writeProjectFile", () => {
     );
     const read = await readProjectFile(workDir);
     expect(read).toBeNull();
+  });
+});
+
+describe("defaultInstallDir", () => {
+  // Sanity check the wire format every lifecycle command depends on.
+  // If this changes, the installer's outro hint and the doctor's
+  // local-install probe both need to follow.
+  it("returns ~/appstrate (homedir + 'appstrate')", () => {
+    expect(defaultInstallDir()).toBe(join(homedir(), "appstrate"));
+  });
+});
+
+describe("resolveInstall", () => {
+  it("returns the dir + recorded projectName when the sidecar is present", async () => {
+    await writeProjectFile(workDir, "appstrate-test-deadbeef");
+    const resolved = await resolveInstall({ dir: workDir });
+    expect(resolved.projectName).toBe("appstrate-test-deadbeef");
+    expect(resolved.dir).toBe(workDir);
+  });
+
+  it("throws InstallNotFoundError with an actionable message when the sidecar is missing", async () => {
+    await expect(resolveInstall({ dir: workDir })).rejects.toBeInstanceOf(InstallNotFoundError);
+    try {
+      await resolveInstall({ dir: workDir });
+    } catch (err) {
+      expect(err).toBeInstanceOf(InstallNotFoundError);
+      const e = err as InstallNotFoundError;
+      // The error must name the dir, suggest the two recovery paths,
+      // and point at the exact file we looked for. Anything less and
+      // a confused user has to spelunk through the source.
+      expect(e.message).toContain(workDir);
+      expect(e.message).toContain("--dir");
+      expect(e.message).toContain("appstrate install");
+      expect(e.message).toContain(PROJECT_FILE_RELPATH);
+      expect(e.dir).toBe(workDir);
+      expect(e.filePath).toBe(projectFilePath(workDir));
+    }
+  });
+
+  it("normalizes the dir to absolute (relative input becomes absolute)", async () => {
+    // The lifecycle commands always thread the dir into `cwd` for
+    // `docker compose`, which expects an absolute path. The resolver
+    // normalizes so callers never have to. We only assert the path
+    // shape (absolute) since `mkdtemp` on macOS lives behind a
+    // `/var → /private/var` symlink that `path.resolve` doesn't
+    // canonicalize — a `===` check would flake on macOS CI.
+    await writeProjectFile(workDir, "appstrate-test-deadbeef");
+    const cwd = process.cwd();
+    try {
+      process.chdir(workDir);
+      const resolved = await resolveInstall({ dir: "." });
+      expect(resolved.dir.startsWith("/")).toBe(true);
+      expect(resolved.projectName).toBe("appstrate-test-deadbeef");
+    } finally {
+      process.chdir(cwd);
+    }
   });
 });

--- a/apps/cli/test/lifecycle.test.ts
+++ b/apps/cli/test/lifecycle.test.ts
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration tests for `appstrate start / stop / restart / logs /
+ * status / uninstall` (issue #343).
+ *
+ * Strategy: every test installs a `docker` shim on PATH that records
+ * its argv to a file, then we assert each lifecycle command invoked
+ * `docker compose --project-name <name from sidecar> <verb>` exactly.
+ * No real Docker required — the shim is the spec for what the
+ * commands MUST emit.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, mkdir, readFile, rm, writeFile, chmod, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir, platform } from "node:os";
+import { writeProjectFile } from "../src/lib/install/project.ts";
+import {
+  startCommand,
+  stopCommand,
+  restartCommand,
+  logsCommand,
+  statusCommand,
+  uninstallCommand,
+} from "../src/commands/lifecycle.ts";
+
+const originalPath = process.env.PATH;
+const originalYesEnv = process.env.APPSTRATE_YES;
+let workDir: string; // tempdir holding the install + the docker shim subdir
+let installDir: string; // <workDir>/install
+let shimDir: string; // <workDir>/shim — exposes a fake `docker`
+let argvFile: string; // shim writes one line per invocation
+const PROJECT_NAME = "appstrate-test-deadbeef";
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), "appstrate-cli-lifecycle-"));
+  installDir = join(workDir, "install");
+  shimDir = join(workDir, "shim");
+  argvFile = join(workDir, "argv.log");
+  await mkdir(installDir, { recursive: true });
+  await mkdir(shimDir, { recursive: true });
+  await writeProjectFile(installDir, PROJECT_NAME);
+  await installDockerShim();
+  process.env.PATH = `${shimDir}:${originalPath}`;
+});
+
+afterEach(async () => {
+  process.env.PATH = originalPath;
+  if (originalYesEnv === undefined) delete process.env.APPSTRATE_YES;
+  else process.env.APPSTRATE_YES = originalYesEnv;
+  await rm(workDir, { recursive: true, force: true });
+});
+
+/**
+ * Build a minimal `docker` shim that:
+ *   1. Records its full argv (newline-joined) to `argvFile` so tests
+ *      can assert on the exact `compose --project-name … <verb>` line.
+ *   2. Exits 0 — every lifecycle test exercises the happy path; we
+ *      have a separate test below for the non-zero failure shape.
+ */
+async function installDockerShim(exitCode = 0): Promise<void> {
+  const path = join(shimDir, "docker");
+  await writeFile(
+    path,
+    `#!/usr/bin/env bash\nprintf '%s\\n' "$*" >> ${JSON.stringify(argvFile)}\nexit ${exitCode}\n`,
+  );
+  await chmod(path, 0o755);
+}
+
+async function readArgv(): Promise<string[]> {
+  // The shim appends one line per invocation. Trim trailing blank.
+  const raw = await readFile(argvFile, "utf8").catch(() => "");
+  return raw
+    .split("\n")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+describe("appstrate start", () => {
+  it("invokes `docker compose --project-name <sidecar> up -d`", async () => {
+    if (platform() === "win32") return;
+    await startCommand({ dir: installDir });
+    const argv = await readArgv();
+    expect(argv).toEqual([`compose --project-name ${PROJECT_NAME} up -d`]);
+  });
+});
+
+describe("appstrate stop", () => {
+  it("invokes `docker compose --project-name <sidecar> stop`", async () => {
+    if (platform() === "win32") return;
+    await stopCommand({ dir: installDir });
+    const argv = await readArgv();
+    expect(argv).toEqual([`compose --project-name ${PROJECT_NAME} stop`]);
+  });
+});
+
+describe("appstrate restart", () => {
+  it("invokes `docker compose --project-name <sidecar> restart`", async () => {
+    if (platform() === "win32") return;
+    await restartCommand({ dir: installDir });
+    const argv = await readArgv();
+    expect(argv).toEqual([`compose --project-name ${PROJECT_NAME} restart`]);
+  });
+});
+
+describe("appstrate logs", () => {
+  it("invokes `docker compose --project-name <sidecar> logs` by default", async () => {
+    if (platform() === "win32") return;
+    await logsCommand({ dir: installDir });
+    const argv = await readArgv();
+    expect(argv).toEqual([`compose --project-name ${PROJECT_NAME} logs`]);
+  });
+
+  it("appends `-f` when --follow is set", async () => {
+    if (platform() === "win32") return;
+    await logsCommand({ dir: installDir, follow: true });
+    const argv = await readArgv();
+    expect(argv).toEqual([`compose --project-name ${PROJECT_NAME} logs -f`]);
+  });
+
+  it("forwards the optional service-name positional", async () => {
+    if (platform() === "win32") return;
+    await logsCommand({ dir: installDir, follow: true, service: "postgres" });
+    const argv = await readArgv();
+    expect(argv).toEqual([`compose --project-name ${PROJECT_NAME} logs -f postgres`]);
+  });
+});
+
+describe("appstrate status", () => {
+  it("invokes `docker compose --project-name <sidecar> ps`", async () => {
+    if (platform() === "win32") return;
+    await statusCommand({ dir: installDir });
+    const argv = await readArgv();
+    expect(argv).toEqual([`compose --project-name ${PROJECT_NAME} ps`]);
+  });
+});
+
+describe("appstrate uninstall", () => {
+  it("default invokes `docker compose --project-name <sidecar> down` (no -v)", async () => {
+    if (platform() === "win32") return;
+    await uninstallCommand({ dir: installDir });
+    const argv = await readArgv();
+    expect(argv).toEqual([`compose --project-name ${PROJECT_NAME} down`]);
+    // The install dir MUST still exist — default uninstall preserves data.
+    const dirStat = await stat(installDir);
+    expect(dirStat.isDirectory()).toBe(true);
+  });
+
+  it("--purge --yes invokes `down -v` AND removes the install directory", async () => {
+    if (platform() === "win32") return;
+    await uninstallCommand({ dir: installDir, purge: true, yes: true });
+    const argv = await readArgv();
+    expect(argv).toEqual([`compose --project-name ${PROJECT_NAME} down -v`]);
+    // Dir gone — destructive flow ran end-to-end.
+    await expect(stat(installDir)).rejects.toThrow();
+  });
+
+  it("--purge respects APPSTRATE_YES=1 as the auto-confirm switch", async () => {
+    if (platform() === "win32") return;
+    process.env.APPSTRATE_YES = "1";
+    await uninstallCommand({ dir: installDir, purge: true });
+    const argv = await readArgv();
+    expect(argv).toEqual([`compose --project-name ${PROJECT_NAME} down -v`]);
+    await expect(stat(installDir)).rejects.toThrow();
+  });
+
+  it("--purge without --yes refuses to run when stdin is not a TTY", async () => {
+    if (platform() === "win32") return;
+    // bun:test runs with a non-TTY stdin, so this path is exercised
+    // automatically — confirm we get a clear error rather than a hang.
+    delete process.env.APPSTRATE_YES;
+    await expect(uninstallCommand({ dir: installDir, purge: true })).rejects.toThrow(
+      /destructive.*confirmation/i,
+    );
+    // Critically: the dir must STILL exist — the guard fires before
+    // any side-effect.
+    const dirStat = await stat(installDir);
+    expect(dirStat.isDirectory()).toBe(true);
+  });
+
+  it("non-zero `docker compose down` surfaces as a thrown Error", async () => {
+    if (platform() === "win32") return;
+    // Replace the shim with one that exits non-zero.
+    await installDockerShim(2);
+    await expect(uninstallCommand({ dir: installDir })).rejects.toThrow(
+      /docker compose down failed with exit code 2/,
+    );
+    // Dir must remain — failure path doesn't accidentally rm-rf.
+    const dirStat = await stat(installDir);
+    expect(dirStat.isDirectory()).toBe(true);
+  });
+});
+
+describe("missing sidecar (resolveInstall failure path)", () => {
+  it("every lifecycle command rejects with InstallNotFoundError-shaped message when project.json is absent", async () => {
+    if (platform() === "win32") return;
+    const empty = join(workDir, "empty");
+    await mkdir(empty, { recursive: true });
+    for (const fn of [
+      () => startCommand({ dir: empty }),
+      () => stopCommand({ dir: empty }),
+      () => restartCommand({ dir: empty }),
+      () => logsCommand({ dir: empty }),
+      () => statusCommand({ dir: empty }),
+      () => uninstallCommand({ dir: empty }),
+    ]) {
+      await expect(fn()).rejects.toThrow(/No Appstrate install found/);
+    }
+  });
+});

--- a/examples/self-hosting/README.md
+++ b/examples/self-hosting/README.md
@@ -40,6 +40,36 @@ back to Tier 0 as the highlighted default.
 `docker-compose.yml`, runs `docker compose up -d`, waits for the
 healthcheck, and opens http://localhost:3000 in your browser.
 
+### Managing the stack post-install
+
+Once installed, the lifecycle commands manage the stack from any
+working directory — they read the Compose project name from
+`<dir>/.appstrate/project.json` so you never have to remember the
+derived hash:
+
+```bash
+appstrate start           # docker compose up -d
+appstrate stop            # docker compose stop (volumes preserved)
+appstrate restart         # docker compose restart
+appstrate logs -f         # docker compose logs -f
+appstrate logs postgres   # filter to a single service
+appstrate status          # docker compose ps
+appstrate uninstall       # docker compose down (containers gone, data preserved)
+appstrate uninstall --purge   # destructive: down -v + rm -rf <dir>
+```
+
+All commands accept `--dir <path>` to target a non-default install
+directory. `--purge` prompts for confirmation unless `--yes` (or
+`APPSTRATE_YES=1`) is set; the prompt enumerates exactly what gets
+destroyed (Postgres / Redis / MinIO data + the install dir).
+
+If you prefer the raw form (e.g. for scripting against a specific
+flag the wrapper doesn't expose):
+
+```bash
+docker compose --project-name "$(jq -r .projectName ~/appstrate/.appstrate/project.json)" <verb>
+```
+
 ### Unattended install (CI / cloud-init / Ansible)
 
 ```bash
@@ -321,7 +351,10 @@ Three named volumes store persistent data:
 - `redisdata` -- Redis AOF/RDB snapshots
 - `miniodata` -- MinIO object storage
 
-To reset all data: `docker compose down -v` (destroys volumes).
+To reset all data: `appstrate uninstall --purge` (or, raw:
+`docker compose down -v` from the install directory). Both destroy
+the named volumes — the Appstrate CLI form additionally removes the
+install dir itself, so use it only when you intend a full wipe.
 
 ## Production Considerations
 


### PR DESCRIPTION
Closes #343.

## Summary

After `appstrate install`, users had no first-class way to manage the stack — every Compose verb required typing the derived `--project-name appstrate-<slug>-<hash>`. This PR ships the lifecycle command surface foreseen by the existing `project.json` sidecar:

- `appstrate start / stop / restart / logs / status` → thin wrappers around the matching `docker compose` verbs.
- `appstrate uninstall` → safe by default (`compose down`, data preserved). `--purge` adds `down -v` + `rm -rf <dir>` after a confirmation prompt that enumerates what gets destroyed (skippable via `--yes` / `APPSTRATE_YES=1`).
- Shared `resolveInstall({ dir })` in `lib/install/project.ts` reads the recorded project name from `<dir>/.appstrate/project.json` — never re-derived, so a renamed install dir still answers to its original containers. Fail-fasts with an actionable message when the sidecar is missing.
- Installer outro now points at the new commands. Raw `docker compose --project-name <hash>` form is still documented in the README for advanced cases.
- `appstrate doctor` surfaces the lifecycle hints when a Tier 1/2/3 install is detected (probes `~/appstrate/.appstrate/project.json` by default; soft-fails on read errors).
- SIGINT (130) / SIGTERM (143) propagate cleanly so `appstrate logs -f` Ctrl-C exits silently instead of rendering "docker compose logs failed with exit code 130".

## Files

- `apps/cli/src/lib/install/project.ts` — `defaultInstallDir()`, `resolveInstall()`, `InstallNotFoundError`.
- `apps/cli/src/commands/lifecycle.ts` — six new command handlers.
- `apps/cli/src/cli.ts` — wires them into commander with `--dir` + `--purge` + `--yes` + `--follow`.
- `apps/cli/src/commands/install.ts` — outro now suggests `appstrate logs -f` / `appstrate stop` / `appstrate uninstall`.
- `apps/cli/src/lib/doctor.ts` + `apps/cli/src/commands/doctor.ts` — adds optional `localInstall` field with hint rendering.
- `apps/cli/test/install/project.test.ts` — `defaultInstallDir` + `resolveInstall` happy / missing-sidecar paths.
- `apps/cli/test/lifecycle.test.ts` — integration tests stub `docker` on PATH and assert each command emits `compose --project-name <name from sidecar> <verb>` exactly. Includes the destructive-action TTY guard and the rm-rf side-effect on `--purge`.
- `apps/cli/test/doctor.test.ts` — local-install probe tests + stubs the new field on existing tests so they don't pick up dev-machine state.
- `apps/cli/README.md` + `examples/self-hosting/README.md` — new "Managing the stack" / "Lifecycle commands" sections.

## Test plan

- [x] `cd apps/cli && bun test` — 1064 / 1064 pass (51 new).
- [x] `bun run check` — typecheck + lint + format + verify-openapi + detect-breaking + system-package check all pass.
- [ ] Manual: `appstrate install --tier 3 --yes` → `appstrate logs -f` (Ctrl-C) → `appstrate status` → `appstrate stop` → `appstrate start` → `appstrate uninstall` → `appstrate install` again → `appstrate uninstall --purge --yes` (verify `~/appstrate` removed).
- [ ] Manual: `appstrate uninstall --purge` without `--yes` from a non-TTY pipe → fails fast with the destructive-confirmation hint, dir intact.
- [ ] Manual: `appstrate logs --dir /nonexistent` → `InstallNotFoundError` shape with the two recovery paths.
- [ ] Manual: `appstrate doctor` on a host with `~/appstrate/.appstrate/project.json` → renders the lifecycle hint block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)