### PR TITLE
chore(core): rename Profile to UserProfile

### DIFF
--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -6,13 +6,13 @@ import { authClient } from "../lib/auth-client";
 import { api } from "../api";
 import { authStore } from "../stores/auth-store";
 import i18n from "../i18n";
-import type { Profile } from "@appstrate/shared-types";
+import type { UserProfile } from "@appstrate/shared-types";
 
-async function fetchProfile(): Promise<Profile | null> {
+async function fetchProfile(): Promise<UserProfile | null> {
   try {
     const data = await api<{ id: string; displayName: string; language: string }>("/profile");
     const language = data.language === "fr" || data.language === "en" ? data.language : "fr";
-    const profile: Profile = {
+    const profile: UserProfile = {
       id: data.id,
       displayName: data.displayName,
       language,
@@ -34,7 +34,7 @@ function clearAuth() {
 
 function setAuthenticatedUser(
   user: { id: string; email: string; emailVerified: boolean; name: string },
-  profile: Profile | null,
+  profile: UserProfile | null,
 ) {
   authStore.setState({
     user: { id: user.id, email: user.email, emailVerified: user.emailVerified, name: user.name },

--- a/apps/web/src/stores/auth-store.ts
+++ b/apps/web/src/stores/auth-store.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createStore } from "zustand/vanilla";
-import type { Profile } from "@appstrate/shared-types";
+import type { UserProfile } from "@appstrate/shared-types";
 
 interface AuthState {
   user: { id: string; email: string; emailVerified: boolean; name?: string } | null;
-  profile: Profile | null;
+  profile: UserProfile | null;
   loading: boolean;
 }
 

--- a/packages/db/src/schema/types.ts
+++ b/packages/db/src/schema/types.ts
@@ -30,7 +30,7 @@ import type {
   orgModels,
 } from "./organizations.ts";
 
-export type Profile = InferSelectModel<typeof profiles>;
+export type UserProfile = InferSelectModel<typeof profiles>;
 
 export type Package = InferSelectModel<typeof packages>;
 

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 
 export type { WebhookInfo, WebhookCreateResponse, WebhookDelivery } from "./webhooks.ts";
 
-export type { Profile, RunLog, ConnectionProfile } from "@appstrate/db/schema";
+export type { UserProfile, RunLog, ConnectionProfile } from "@appstrate/db/schema";
 import type {
   PackageType,
   ProviderSetupGuide,


### PR DESCRIPTION
## Summary

The unqualified `Profile` type was overloaded in this codebase — alongside the user profile (display name + language preference, stored in `profiles` keyed by `user.id`), the codebase also has `ConnectionProfile`, app profiles, `UserAgentProviderProfile`, `UserApplicationProfile`, `ProviderProfile`, and end-user OIDC profiles. Reading `Profile | null` at a call site forced the reader to recover the intent from imports.

Renaming the type to **`UserProfile`** makes the call sites self-documenting:
- `profile: UserProfile | null` is unambiguous.
- The type now visually sorts alongside its siblings (`ConnectionProfile`, `UserApplicationProfile`, `UserAgentProviderProfile`, …) when scanning `@appstrate/db/schema/types.ts`.

## Rationale

The `profiles` table holds a Better-Auth-extended user metadata row keyed by `user.id` (display name, language). It is purely a per-user resource. Among the codebase's 6+ "profile" concepts, this one is the most canonically "user-level", and `UserProfile` is the standard naming used by every other auth-aware system. The other competing names (`ConnectionProfile`, `AppProfile`, `UserApplicationProfile`, `UserAgentProviderProfile`, `ProviderProfile`) already coexist with their adjective prefixes, so adding `User` to disambiguate this last one is the cheapest possible disambiguation.

## Internal-only

`UserProfile` is **not** on any wire format. `GET /api/profile` returns the inline shape `{ id, displayName, language }` — not a typed schema reference. No client SDK breaks, no OpenAPI changes, no DB migration.

The DB table name (`profiles`), route paths (`/api/profile`, `/api/profiles/batch`), and RBAC scopes (`profiles:read|write|delete`) are intentionally **untouched** — they live in their own namespaces (SQL, URLs, permission strings) where the "profile" word is not ambiguous.

## File count

4 files, 8 line changes (+8 / −8):

| File | Role |
|---|---|
| `packages/db/src/schema/types.ts` | Source declaration |
| `packages/shared-types/src/index.ts` | Re-export |
| `apps/web/src/stores/auth-store.ts` | Consumer |
| `apps/web/src/hooks/use-auth.ts` | Consumer (4 sites) |

## Coordination

Independent of #13 (`profileId` → `connectionProfileId` field rename). This PR touches only the TYPE name; #13 touches field names. No expected conflicts on overlapping lines.

## Test plan

- [x] `bun run check` — 18/18 green (typecheck + format + lint + verify-openapi)
- [x] No other consumers of `import { Profile } from "@appstrate/shared-types"` remain (verified by grep across `apps/`, `packages/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)