### PR TITLE
chore(rename): unify profileId/appProfileId/sourceProfileId

### DIFF
--- a/apps/api/src/openapi/baseline.json
+++ b/apps/api/src/openapi/baseline.json
@@ -1585,13 +1585,13 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["providerId", "profileId"],
+                "required": ["providerId", "connectionProfileId"],
                 "properties": {
                   "providerId": {
                     "type": "string",
                     "minLength": 1
                   },
-                  "profileId": {
+                  "connectionProfileId": {
                     "type": "string",
                     "format": "uuid"
                   }
@@ -1835,12 +1835,12 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["providerId", "profileId", "reason", "message"],
+                        "required": ["providerId", "connectionProfileId", "reason", "message"],
                         "properties": {
                           "providerId": {
                             "type": "string"
                           },
-                          "profileId": {
+                          "connectionProfileId": {
                             "type": ["string", "null"],
                             "format": "uuid"
                           },
@@ -1866,7 +1866,7 @@
                   "missing": [
                     {
                       "providerId": "@afps/gmail",
-                      "profileId": "550e8400-e29b-41d4-a716-446655440010",
+                      "connectionProfileId": "550e8400-e29b-41d4-a716-446655440010",
                       "reason": "no_connection",
                       "message": "Provider '@afps/gmail' is not connected"
                     }
@@ -4185,7 +4185,7 @@
             "$ref": "#/components/parameters/XAppId"
           },
           {
-            "name": "profileId",
+            "name": "connectionProfileId",
             "in": "query",
             "required": false,
             "description": "Connection profile ID (defaults to user's default profile)",
@@ -4270,7 +4270,7 @@
             "$ref": "#/components/parameters/XAppId"
           },
           {
-            "name": "profileId",
+            "name": "connectionProfileId",
             "in": "query",
             "required": false,
             "description": "Connection profile ID (defaults to user's default profile)",
@@ -4317,7 +4317,7 @@
         "operationId": "connectOAuth",
         "tags": ["Connections"],
         "summary": "Start OAuth connection flow",
-        "description": "Initiates OAuth authorization flow (OAuth2 or OAuth1 depending on provider). Returns `authUrl` to redirect the user. If `profileId` is provided, it must belong to the authenticated actor (returns 403 otherwise).",
+        "description": "Initiates OAuth authorization flow (OAuth2 or OAuth1 depending on provider). Returns `authUrl` to redirect the user. If `connectionProfileId` is provided, it must belong to the authenticated actor (returns 403 otherwise).",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -4344,7 +4344,7 @@
                       "type": "string"
                     }
                   },
-                  "profileId": {
+                  "connectionProfileId": {
                     "type": "string",
                     "description": "Connection profile ID"
                   }
@@ -4394,7 +4394,7 @@
         "operationId": "connectApiKey",
         "tags": ["Connections"],
         "summary": "Save API key credential",
-        "description": "Save an API key credential for a provider that uses api_key auth mode. If `profileId` is provided, it must belong to the authenticated actor (returns 403 otherwise).",
+        "description": "Save an API key credential for a provider that uses api_key auth mode. If `connectionProfileId` is provided, it must belong to the authenticated actor (returns 403 otherwise).",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -4422,7 +4422,7 @@
                     "minLength": 1,
                     "description": "API key value"
                   },
-                  "profileId": {
+                  "connectionProfileId": {
                     "type": "string",
                     "format": "uuid",
                     "description": "Connection profile ID (defaults to user's default profile)"
@@ -4473,7 +4473,7 @@
         "operationId": "connectCredentials",
         "tags": ["Connections"],
         "summary": "Save custom credentials",
-        "description": "Save generic credentials for a provider that uses basic or custom auth mode. Fields depend on provider's credential schema. If `profileId` is provided, it must belong to the authenticated actor (returns 403 otherwise).",
+        "description": "Save generic credentials for a provider that uses basic or custom auth mode. Fields depend on provider's credential schema. If `connectionProfileId` is provided, it must belong to the authenticated actor (returns 403 otherwise).",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -4503,7 +4503,7 @@
                     },
                     "description": "Credential fields matching the provider's credential schema"
                   },
-                  "profileId": {
+                  "connectionProfileId": {
                     "type": "string",
                     "format": "uuid",
                     "description": "Connection profile ID (defaults to user's default profile)"
@@ -4638,7 +4638,7 @@
             "$ref": "#/components/parameters/PackageName"
           },
           {
-            "name": "profileId",
+            "name": "connectionProfileId",
             "in": "query",
             "required": false,
             "description": "Connection profile ID (defaults to user's default profile)",
@@ -4650,7 +4650,7 @@
             "name": "connectionId",
             "in": "query",
             "required": false,
-            "description": "Specific connection ID to delete. When provided, only this connection is removed (ignores profileId).",
+            "description": "Specific connection ID to delete. When provided, only this connection is removed (ignores connectionProfileId).",
             "schema": {
               "type": "string",
               "format": "uuid"
@@ -7649,7 +7649,7 @@
                             "type": "string",
                             "format": "uuid"
                           },
-                          "profileId": {
+                          "connectionProfileId": {
                             "type": "string",
                             "format": "uuid"
                           },
@@ -9061,7 +9061,7 @@
         "operationId": "getMyApplicationProfile",
         "tags": ["Profile"],
         "summary": "Get the caller's pinned default profile for the active app",
-        "description": "Returns the connection profile id the caller has pinned as their personal default for the active application, or `null` if no sticky is set. The credential proxy's `resolveProfileId` cascade consults this between the explicit per-run override (`X-Connection-Profile-Id`) and the application default. Member-only — end-user callers always receive `{ profileId: null }`.",
+        "description": "Returns the connection profile id the caller has pinned as their personal default for the active application, or `null` if no sticky is set. The credential proxy's `resolveProfileId` cascade consults this between the explicit per-run override (`X-Connection-Profile-Id`) and the application default. Member-only — end-user callers always receive `{ connectionProfileId: null }`.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -9085,9 +9085,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["profileId"],
+                  "required": ["connectionProfileId"],
                   "properties": {
-                    "profileId": {
+                    "connectionProfileId": {
                       "oneOf": [
                         {
                           "type": "string",
@@ -9127,9 +9127,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["profileId"],
+                "required": ["connectionProfileId"],
                 "properties": {
-                  "profileId": {
+                  "connectionProfileId": {
                     "type": "string",
                     "format": "uuid"
                   }
@@ -9145,9 +9145,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["profileId"],
+                  "required": ["connectionProfileId"],
                   "properties": {
-                    "profileId": {
+                    "connectionProfileId": {
                       "type": "string",
                       "format": "uuid"
                     }

--- a/apps/api/src/openapi/paths/agents.ts
+++ b/apps/api/src/openapi/paths/agents.ts
@@ -690,10 +690,10 @@ export const agentsPaths = {
           "application/json": {
             schema: {
               type: "object",
-              required: ["providerId", "profileId"],
+              required: ["providerId", "connectionProfileId"],
               properties: {
                 providerId: { type: "string", minLength: 1 },
-                profileId: { type: "string", format: "uuid" },
+                connectionProfileId: { type: "string", format: "uuid" },
               },
             },
           },
@@ -851,10 +851,10 @@ export const agentsPaths = {
                     type: "array",
                     items: {
                       type: "object",
-                      required: ["providerId", "profileId", "reason", "message"],
+                      required: ["providerId", "connectionProfileId", "reason", "message"],
                       properties: {
                         providerId: { type: "string" },
-                        profileId: { type: ["string", "null"], format: "uuid" },
+                        connectionProfileId: { type: ["string", "null"], format: "uuid" },
                         reason: {
                           type: "string",
                           enum: [
@@ -875,7 +875,7 @@ export const agentsPaths = {
                 missing: [
                   {
                     providerId: "@afps/gmail",
-                    profileId: "550e8400-e29b-41d4-a716-446655440010",
+                    connectionProfileId: "550e8400-e29b-41d4-a716-446655440010",
                     reason: "no_connection",
                     message: "Provider '@afps/gmail' is not connected",
                   },

--- a/apps/api/src/openapi/paths/app-profiles.ts
+++ b/apps/api/src/openapi/paths/app-profiles.ts
@@ -559,7 +559,7 @@ export const appProfilesPaths = {
                       type: "object",
                       properties: {
                         id: { type: "string", format: "uuid" },
-                        profileId: { type: "string", format: "uuid" },
+                        connectionProfileId: { type: "string", format: "uuid" },
                         providerId: { type: "string" },
                         orgId: { type: "string", format: "uuid" },
                         scopesGranted: { type: "array", items: { type: "string" } },

--- a/apps/api/src/openapi/paths/connections.ts
+++ b/apps/api/src/openapi/paths/connections.ts
@@ -11,7 +11,7 @@ export const connectionsPaths = {
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
         {
-          name: "profileId",
+          name: "connectionProfileId",
           in: "query",
           required: false,
           description: "Connection profile ID (defaults to user's default profile)",
@@ -78,7 +78,7 @@ export const connectionsPaths = {
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
         {
-          name: "profileId",
+          name: "connectionProfileId",
           in: "query",
           required: false,
           description: "Connection profile ID (defaults to user's default profile)",
@@ -116,7 +116,7 @@ export const connectionsPaths = {
       tags: ["Connections"],
       summary: "Start OAuth connection flow",
       description:
-        "Initiates OAuth authorization flow (OAuth2 or OAuth1 depending on provider). Returns `authUrl` to redirect the user. If `profileId` is provided, it must belong to the authenticated actor (returns 403 otherwise).",
+        "Initiates OAuth authorization flow (OAuth2 or OAuth1 depending on provider). Returns `authUrl` to redirect the user. If `connectionProfileId` is provided, it must belong to the authenticated actor (returns 403 otherwise).",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -130,7 +130,7 @@ export const connectionsPaths = {
               type: "object",
               properties: {
                 scopes: { type: "array", items: { type: "string" } },
-                profileId: { type: "string", description: "Connection profile ID" },
+                connectionProfileId: { type: "string", description: "Connection profile ID" },
               },
             },
           },
@@ -166,7 +166,7 @@ export const connectionsPaths = {
       tags: ["Connections"],
       summary: "Save API key credential",
       description:
-        "Save an API key credential for a provider that uses api_key auth mode. If `profileId` is provided, it must belong to the authenticated actor (returns 403 otherwise).",
+        "Save an API key credential for a provider that uses api_key auth mode. If `connectionProfileId` is provided, it must belong to the authenticated actor (returns 403 otherwise).",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -182,7 +182,7 @@ export const connectionsPaths = {
               required: ["apiKey"],
               properties: {
                 apiKey: { type: "string", minLength: 1, description: "API key value" },
-                profileId: {
+                connectionProfileId: {
                   type: "string",
                   format: "uuid",
                   description: "Connection profile ID (defaults to user's default profile)",
@@ -220,7 +220,7 @@ export const connectionsPaths = {
       tags: ["Connections"],
       summary: "Save custom credentials",
       description:
-        "Save generic credentials for a provider that uses basic or custom auth mode. Fields depend on provider's credential schema. If `profileId` is provided, it must belong to the authenticated actor (returns 403 otherwise).",
+        "Save generic credentials for a provider that uses basic or custom auth mode. Fields depend on provider's credential schema. If `connectionProfileId` is provided, it must belong to the authenticated actor (returns 403 otherwise).",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -240,7 +240,7 @@ export const connectionsPaths = {
                   additionalProperties: { type: "string" },
                   description: "Credential fields matching the provider's credential schema",
                 },
-                profileId: {
+                connectionProfileId: {
                   type: "string",
                   format: "uuid",
                   description: "Connection profile ID (defaults to user's default profile)",
@@ -341,7 +341,7 @@ export const connectionsPaths = {
         { $ref: "#/components/parameters/PackageScope" },
         { $ref: "#/components/parameters/PackageName" },
         {
-          name: "profileId",
+          name: "connectionProfileId",
           in: "query",
           required: false,
           description: "Connection profile ID (defaults to user's default profile)",
@@ -352,7 +352,7 @@ export const connectionsPaths = {
           in: "query",
           required: false,
           description:
-            "Specific connection ID to delete. When provided, only this connection is removed (ignores profileId).",
+            "Specific connection ID to delete. When provided, only this connection is removed (ignores connectionProfileId).",
           schema: { type: "string", format: "uuid" },
         },
       ],

--- a/apps/api/src/openapi/paths/me.ts
+++ b/apps/api/src/openapi/paths/me.ts
@@ -89,7 +89,7 @@ export const mePaths = {
         "for the active application, or `null` if no sticky is set. The credential proxy's " +
         "`resolveProfileId` cascade consults this between the explicit per-run override " +
         "(`X-Connection-Profile-Id`) and the application default. Member-only — end-user " +
-        "callers always receive `{ profileId: null }`.",
+        "callers always receive `{ connectionProfileId: null }`.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -105,9 +105,9 @@ export const mePaths = {
             "application/json": {
               schema: {
                 type: "object",
-                required: ["profileId"],
+                required: ["connectionProfileId"],
                 properties: {
-                  profileId: {
+                  connectionProfileId: {
                     oneOf: [{ type: "string", format: "uuid" }, { type: "null" }],
                   },
                 },
@@ -136,9 +136,9 @@ export const mePaths = {
           "application/json": {
             schema: {
               type: "object",
-              required: ["profileId"],
+              required: ["connectionProfileId"],
               properties: {
-                profileId: { type: "string", format: "uuid" },
+                connectionProfileId: { type: "string", format: "uuid" },
               },
             },
           },
@@ -151,8 +151,8 @@ export const mePaths = {
             "application/json": {
               schema: {
                 type: "object",
-                required: ["profileId"],
-                properties: { profileId: { type: "string", format: "uuid" } },
+                required: ["connectionProfileId"],
+                properties: { connectionProfileId: { type: "string", format: "uuid" } },
               },
             },
           },

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -54,7 +54,7 @@ export const modelIdSchema = z.object({ modelId: z.string().nullable() });
 export const appProfileIdSchema = z.object({ appProfileId: z.uuid().nullable() });
 export const setProviderProfileSchema = z.object({
   providerId: z.string().min(1),
-  profileId: z.uuid(),
+  connectionProfileId: z.uuid(),
 });
 export const removeProviderProfileSchema = z.object({ providerId: z.string().min(1) });
 
@@ -175,7 +175,7 @@ export function createAgentsRouter() {
       const data = parseBody(setProviderProfileSchema, body);
 
       // Validate ownership — user can only set overrides to their own profiles
-      const profile = await getAccessibleProfile(data.profileId, actor, {
+      const profile = await getAccessibleProfile(data.connectionProfileId, actor, {
         orgId: c.get("orgId"),
         applicationId: c.get("applicationId")!,
       });
@@ -183,12 +183,17 @@ export function createAgentsRouter() {
         throw forbidden("Cannot use a profile you do not own");
       }
 
-      await setUserAgentProviderOverride(actor, agent.id, data.providerId, data.profileId);
+      await setUserAgentProviderOverride(
+        actor,
+        agent.id,
+        data.providerId,
+        data.connectionProfileId,
+      );
       await recordAuditFromContext(c, {
         action: "agent.provider_profile_set",
         resourceType: "agent",
         resourceId: agent.id,
-        after: { providerId: data.providerId, profileId: data.profileId },
+        after: { providerId: data.providerId, connectionProfileId: data.connectionProfileId },
       });
       return c.json({ success: true });
     },

--- a/apps/api/src/routes/app-profiles.ts
+++ b/apps/api/src/routes/app-profiles.ts
@@ -43,8 +43,11 @@ export const bindAppProfileSchema = z.object({
   sourceProfileId: z.uuid(),
 });
 
-async function requireAppProfile(scope: import("../lib/scope.ts").AppScope, profileId: string) {
-  const profile = await getAppProfile(scope, profileId);
+async function requireAppProfile(
+  scope: import("../lib/scope.ts").AppScope,
+  connectionProfileId: string,
+) {
+  const profile = await getAppProfile(scope, connectionProfileId);
   if (!profile) throw notFound("Profile not found");
   return profile;
 }
@@ -105,22 +108,22 @@ export function createAppProfilesRouter() {
   // PUT /api/app-profiles/:id — rename an app profile
   router.put("/:id", requirePermission("app-profiles", "write"), async (c) => {
     const scope = getAppScope(c);
-    const profileId = c.req.param("id")!;
+    const connectionProfileId = c.req.param("id")!;
     const body = await c.req.json();
     const data = parseBody(profileNameSchema, body, "name");
     try {
-      await renameAppProfile(scope, profileId, data.name.trim());
+      await renameAppProfile(scope, connectionProfileId, data.name.trim());
       await recordAuditFromContext(c, {
         action: "app_profile.renamed",
         resourceType: "app_profile",
-        resourceId: profileId,
+        resourceId: connectionProfileId,
         after: { name: data.name.trim() },
       });
       return c.json({ ok: true });
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to rename profile";
       logger.warn("Failed to rename app profile", {
-        profileId,
+        connectionProfileId,
         applicationId: scope.applicationId,
         error: message,
       });
@@ -131,19 +134,19 @@ export function createAppProfilesRouter() {
   // DELETE /api/app-profiles/:id — delete an app profile
   router.delete("/:id", requirePermission("app-profiles", "delete"), async (c) => {
     const scope = getAppScope(c);
-    const profileId = c.req.param("id")!;
+    const connectionProfileId = c.req.param("id")!;
     try {
-      await deleteAppProfile(scope, profileId);
+      await deleteAppProfile(scope, connectionProfileId);
       await recordAuditFromContext(c, {
         action: "app_profile.deleted",
         resourceType: "app_profile",
-        resourceId: profileId,
+        resourceId: connectionProfileId,
       });
       return c.json({ ok: true });
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to delete profile";
       logger.warn("Failed to delete app profile", {
-        profileId,
+        connectionProfileId,
         applicationId: scope.applicationId,
         error: message,
       });
@@ -154,8 +157,8 @@ export function createAppProfilesRouter() {
   // GET /api/app-profiles/:id/agents — list agents using this app profile
   router.get("/:id/agents", async (c) => {
     const scope = getAppScope(c);
-    const profileId = c.req.param("id")!;
-    await requireAppProfile(scope, profileId);
+    const connectionProfileId = c.req.param("id")!;
+    await requireAppProfile(scope, connectionProfileId);
 
     const rows = await db
       .select({
@@ -164,7 +167,7 @@ export function createAppProfilesRouter() {
       })
       .from(applicationPackages)
       .innerJoin(packages, eq(packages.id, applicationPackages.packageId))
-      .where(eq(applicationPackages.appProfileId, profileId));
+      .where(eq(applicationPackages.appProfileId, connectionProfileId));
 
     return c.json(listResponse(rows));
   });
@@ -172,9 +175,9 @@ export function createAppProfilesRouter() {
   // GET /api/app-profiles/:id/bindings — list provider bindings for an app profile
   router.get("/:id/bindings", async (c) => {
     const scope = getAppScope(c);
-    const profileId = c.req.param("id")!;
-    await requireAppProfile(scope, profileId);
-    const bindings = await getAppProfileBindingsEnriched(profileId, scope.applicationId);
+    const connectionProfileId = c.req.param("id")!;
+    await requireAppProfile(scope, connectionProfileId);
+    const bindings = await getAppProfileBindingsEnriched(connectionProfileId, scope.applicationId);
     return c.json({ bindings });
   });
 
@@ -182,8 +185,8 @@ export function createAppProfilesRouter() {
   router.post("/:id/bind", rateLimit(10), requirePermission("app-profiles", "bind"), async (c) => {
     const scope = getAppScope(c);
     const userId = c.get("user").id;
-    const profileId = c.req.param("id")!;
-    await requireAppProfile(scope, profileId);
+    const connectionProfileId = c.req.param("id")!;
+    await requireAppProfile(scope, connectionProfileId);
 
     const body = await c.req.json();
     const data = parseBody(bindAppProfileSchema, body);
@@ -196,7 +199,7 @@ export function createAppProfilesRouter() {
     }
 
     // Ownership check: can't overwrite another user's binding without app-profiles:write
-    const existingOwner = await getBindingOwner(profileId, data.providerId);
+    const existingOwner = await getBindingOwner(connectionProfileId, data.providerId);
     if (existingOwner && existingOwner !== userId) {
       const perms = c.get("permissions");
       if (!perms?.has("app-profiles:write")) {
@@ -212,11 +215,16 @@ export function createAppProfilesRouter() {
       );
     }
 
-    await bindAppProfileProvider(profileId, data.providerId, data.sourceProfileId, userId);
+    await bindAppProfileProvider(
+      connectionProfileId,
+      data.providerId,
+      data.sourceProfileId,
+      userId,
+    );
     await recordAuditFromContext(c, {
       action: "app_profile.bound",
       resourceType: "app_profile",
-      resourceId: profileId,
+      resourceId: connectionProfileId,
       after: { providerId: data.providerId, sourceProfileId: data.sourceProfileId },
     });
     return c.json({ bound: true });
@@ -229,12 +237,12 @@ export function createAppProfilesRouter() {
     async (c) => {
       const scope = getAppScope(c);
       const userId = c.get("user").id;
-      const profileId = c.req.param("id")!;
+      const connectionProfileId = c.req.param("id")!;
       const providerId = `${c.req.param("providerScope")}/${c.req.param("providerName")}`;
-      await requireAppProfile(scope, profileId);
+      await requireAppProfile(scope, connectionProfileId);
 
       // Ownership check: can't unbind another user's binding without app-profiles:write
-      const existingOwner = await getBindingOwner(profileId, providerId);
+      const existingOwner = await getBindingOwner(connectionProfileId, providerId);
       if (existingOwner && existingOwner !== userId) {
         const perms = c.get("permissions");
         if (!perms?.has("app-profiles:write")) {
@@ -242,11 +250,11 @@ export function createAppProfilesRouter() {
         }
       }
 
-      await unbindAppProfileProvider(profileId, providerId);
+      await unbindAppProfileProvider(connectionProfileId, providerId);
       await recordAuditFromContext(c, {
         action: "app_profile.unbound",
         resourceType: "app_profile",
-        resourceId: profileId,
+        resourceId: connectionProfileId,
         after: { providerId },
       });
       return c.json({ unbound: true });
@@ -257,18 +265,23 @@ export function createAppProfilesRouter() {
   router.get("/:id/connections", async (c) => {
     const scope = getAppScope(c);
     const actor = getActor(c);
-    const profileId = c.req.param("id")!;
+    const connectionProfileId = c.req.param("id")!;
     // Allow access if: own profile, app profile, or profile of another org member (read-only view)
     const profile =
-      (await getProfileForActor(profileId, actor)) ??
-      (await getAppProfile(scope, profileId)) ??
-      (await getOrgMemberProfile(profileId, scope.orgId));
+      (await getProfileForActor(connectionProfileId, actor)) ??
+      (await getAppProfile(scope, connectionProfileId)) ??
+      (await getOrgMemberProfile(connectionProfileId, scope.orgId));
     if (!profile) {
       throw notFound("Profile not found");
     }
     // Scope connections to the application's credentials
     const credentialIds = await listProviderCredentialIds(db, scope.applicationId);
-    const rawConnections = await listConnections(db, profileId, scope.orgId, credentialIds);
+    const rawConnections = await listConnections(
+      db,
+      connectionProfileId,
+      scope.orgId,
+      credentialIds,
+    );
     // Strip sensitive fields — never expose encrypted credentials to the client
     const connections = rawConnections.map(
       ({ credentialsEncrypted: _ce, providerCredentialId: _pc, expiresAt: _ex, ...c }) => c,

--- a/apps/api/src/routes/connection-profiles.ts
+++ b/apps/api/src/routes/connection-profiles.ts
@@ -40,15 +40,19 @@ export function createConnectionProfilesRouter() {
   // PUT /api/connection-profiles/:id — rename a profile
   router.put("/:id", async (c) => {
     const actor = getActor(c);
-    const profileId = c.req.param("id")!;
+    const connectionProfileId = c.req.param("id")!;
     const body = await c.req.json();
     const data = parseBody(profileNameSchema, body, "name");
     try {
-      await renameProfile(profileId, actor, data.name.trim());
+      await renameProfile(connectionProfileId, actor, data.name.trim());
       return c.json({ ok: true });
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to rename profile";
-      logger.warn("Failed to rename profile", { profileId, actorId: actor.id, error: message });
+      logger.warn("Failed to rename profile", {
+        connectionProfileId,
+        actorId: actor.id,
+        error: message,
+      });
       throw invalidRequest(message);
     }
   });
@@ -56,13 +60,17 @@ export function createConnectionProfilesRouter() {
   // DELETE /api/connection-profiles/:id — delete a profile
   router.delete("/:id", async (c) => {
     const actor = getActor(c);
-    const profileId = c.req.param("id")!;
+    const connectionProfileId = c.req.param("id")!;
     try {
-      await deleteProfile(profileId, actor);
+      await deleteProfile(connectionProfileId, actor);
       return c.json({ ok: true });
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to delete profile";
-      logger.warn("Failed to delete profile", { profileId, actorId: actor.id, error: message });
+      logger.warn("Failed to delete profile", {
+        connectionProfileId,
+        actorId: actor.id,
+        error: message,
+      });
       throw invalidRequest(message);
     }
   });

--- a/apps/api/src/routes/connections.ts
+++ b/apps/api/src/routes/connections.ts
@@ -38,25 +38,25 @@ import { recordAuditFromContext } from "../services/audit.ts";
 
 export const connectOAuthSchema = z.object({
   scopes: z.array(z.string()).optional(),
-  profileId: z.uuid().optional(),
+  connectionProfileId: z.uuid().optional(),
 });
 
 export const connectApiKeySchema = z.object({
   apiKey: z.string().min(1, "API key is required"),
-  profileId: z.uuid().optional(),
+  connectionProfileId: z.uuid().optional(),
 });
 
 export const connectCredentialsSchema = z.object({
   credentials: z.record(z.string(), z.string()),
-  profileId: z.uuid().optional(),
+  connectionProfileId: z.uuid().optional(),
 });
 
 async function resolveProfileId(c: Context<AppEnv>, actor: Actor): Promise<string> {
-  const profileId = c.req.query("profileId");
-  if (profileId) {
-    const parsed = z.uuid().safeParse(profileId);
+  const connectionProfileId = c.req.query("connectionProfileId");
+  if (connectionProfileId) {
+    const parsed = z.uuid().safeParse(connectionProfileId);
     if (!parsed.success) {
-      throw invalidRequest("Invalid profileId format", "profileId");
+      throw invalidRequest("Invalid connectionProfileId format", "connectionProfileId");
     }
     return parsed.data;
   }
@@ -70,15 +70,15 @@ export function createConnectionsRouter() {
   router.get("/", async (c) => {
     const actor = getActor(c);
     const scope = getAppScope(c);
-    const profileId = await resolveProfileId(c, actor);
+    const connectionProfileId = await resolveProfileId(c, actor);
 
     // Validate ownership — user can use their own profiles or app profiles
-    const profile = await getAccessibleProfile(profileId, actor, scope);
+    const profile = await getAccessibleProfile(connectionProfileId, actor, scope);
     if (!profile) {
       throw forbidden("Cannot view connections for a profile you do not own");
     }
 
-    const connections = await listActorConnections(scope, profileId);
+    const connections = await listActorConnections(scope, connectionProfileId);
     return c.json(listResponse(connections));
   });
 
@@ -97,9 +97,9 @@ export function createConnectionsRouter() {
 
       try {
         const body = parseBody(connectOAuthSchema, await c.req.json());
-        const { scopes, profileId } = body;
+        const { scopes, connectionProfileId } = body;
 
-        const effectiveProfileId = profileId ?? (await resolveProfileId(c, actor));
+        const effectiveProfileId = connectionProfileId ?? (await resolveProfileId(c, actor));
 
         // Validate ownership — user can use their own profiles or app profiles
         const profile = await getAccessibleProfile(effectiveProfileId, actor, scope);
@@ -132,20 +132,20 @@ export function createConnectionsRouter() {
       try {
         const body = await c.req.json();
         const data = parseBody(connectApiKeySchema, body, "apiKey");
-        const profileId = data.profileId ?? (await getDefaultProfileId(actor));
+        const connectionProfileId = data.connectionProfileId ?? (await getDefaultProfileId(actor));
 
         // Validate ownership — user can use their own profiles or app profiles
-        const ownedProfile = await getAccessibleProfile(profileId, actor, scope);
+        const ownedProfile = await getAccessibleProfile(connectionProfileId, actor, scope);
         if (!ownedProfile) {
           throw forbidden("Cannot connect on a profile you do not own");
         }
 
-        await saveApiKeyConnection(scope, provider, data.apiKey.trim(), profileId);
+        await saveApiKeyConnection(scope, provider, data.apiKey.trim(), connectionProfileId);
         await recordAuditFromContext(c, {
           action: "connection.created",
           resourceType: "connection",
           resourceId: provider,
-          after: { provider, profileId, mode: "api_key" },
+          after: { provider, connectionProfileId, mode: "api_key" },
         });
         return c.json({ success: true });
       } catch (err: unknown) {
@@ -176,20 +176,26 @@ export function createConnectionsRouter() {
         const authMode = await getProviderAuthMode(scope, provider);
         const mode = authMode === "basic" ? "basic" : "custom";
 
-        const profileId = data.profileId ?? (await getDefaultProfileId(actor));
+        const connectionProfileId = data.connectionProfileId ?? (await getDefaultProfileId(actor));
 
         // Validate ownership — user can use their own profiles or app profiles
-        const ownedProfile = await getAccessibleProfile(profileId, actor, scope);
+        const ownedProfile = await getAccessibleProfile(connectionProfileId, actor, scope);
         if (!ownedProfile) {
           throw forbidden("Cannot connect on a profile you do not own");
         }
 
-        await saveCredentialsConnection(scope, provider, mode, data.credentials, profileId);
+        await saveCredentialsConnection(
+          scope,
+          provider,
+          mode,
+          data.credentials,
+          connectionProfileId,
+        );
         await recordAuditFromContext(c, {
           action: "connection.created",
           resourceType: "connection",
           resourceId: provider,
-          after: { provider, profileId, mode },
+          after: { provider, connectionProfileId, mode },
         });
         return c.json({ success: true });
       } catch (err: unknown) {
@@ -276,15 +282,15 @@ export function createConnectionsRouter() {
   router.get("/integrations", async (c) => {
     const actor = getActor(c);
     const scope = getAppScope(c);
-    const profileId = await resolveProfileId(c, actor);
+    const connectionProfileId = await resolveProfileId(c, actor);
 
     // Validate ownership — user can use their own profiles or app profiles
-    const profile = await getAccessibleProfile(profileId, actor, scope);
+    const profile = await getAccessibleProfile(connectionProfileId, actor, scope);
     if (!profile) {
       throw forbidden("Cannot view integrations for a profile you do not own");
     }
 
-    const integrations = await getAvailableProvidersWithStatus(scope, profileId);
+    const integrations = await getAvailableProvidersWithStatus(scope, connectionProfileId);
     return c.json({ integrations });
   });
 
@@ -303,10 +309,10 @@ export function createConnectionsRouter() {
         if (connectionId) {
           await disconnectConnectionById(scope, connectionId, actor);
         } else {
-          const profileId = await resolveProfileId(c, actor);
+          const connectionProfileId = await resolveProfileId(c, actor);
 
           // Validate ownership — user can use their own profiles or app profiles
-          const profile = await getAccessibleProfile(profileId, actor, scope);
+          const profile = await getAccessibleProfile(connectionProfileId, actor, scope);
           if (!profile) {
             throw forbidden("Cannot disconnect from a profile you do not own");
           }
@@ -316,7 +322,7 @@ export function createConnectionsRouter() {
               `Provider '${provider}' is not configured in the current application`,
             );
           }
-          await disconnectProvider(scope, provider, profileId, credentialId);
+          await disconnectProvider(scope, provider, connectionProfileId, credentialId);
         }
         await recordAuditFromContext(c, {
           action: "connection.deleted",

--- a/apps/api/src/routes/credential-proxy.ts
+++ b/apps/api/src/routes/credential-proxy.ts
@@ -137,7 +137,7 @@ export async function resolveProfileId(args: {
   // to an explicit per-run override above.
   if (args.userId) {
     const stickyRows = await db
-      .select({ id: userApplicationProfiles.profileId })
+      .select({ id: userApplicationProfiles.connectionProfileId })
       .from(userApplicationProfiles)
       .where(
         and(
@@ -288,9 +288,9 @@ export function createCredentialProxyRouter() {
       //     only — API keys operate on apps, not users).
       const userFallback =
         authMethod === "oauth2-dashboard" || authMethod === "oauth2-instance" ? userId : undefined;
-      let profileId: string | null;
+      let connectionProfileId: string | null;
       try {
-        profileId = await resolveProfileId({
+        connectionProfileId = await resolveProfileId({
           applicationId,
           endUserId: endUser?.id,
           ...(userFallback ? { userId: userFallback } : {}),
@@ -304,7 +304,7 @@ export function createCredentialProxyRouter() {
         });
         throw internalError();
       }
-      if (!profileId) {
+      if (!connectionProfileId) {
         throw notFound(
           endUser
             ? `End-user ${endUser.id} has no connection profile in application ${applicationId}`
@@ -392,7 +392,7 @@ export function createCredentialProxyRouter() {
         const result = await proxyCall(db, {
           applicationId,
           orgId,
-          profileId,
+          connectionProfileId,
           providerId,
           method,
           target,

--- a/apps/api/src/routes/internal.ts
+++ b/apps/api/src/routes/internal.ts
@@ -274,9 +274,9 @@ export function createInternalRouter() {
       throw notFound(`Provider '${providerId}' is not required by this agent`);
     }
 
-    // Look up the stored profileId from the run record
-    const profileId = run.providerProfileIds?.[providerId];
-    if (!profileId) {
+    // Look up the stored connectionProfileId from the run record
+    const connectionProfileId = run.providerProfileIds?.[providerId];
+    if (!connectionProfileId) {
       throw notFound(`No profile resolved for provider '${providerId}'`);
     }
 
@@ -286,7 +286,7 @@ export function createInternalRouter() {
     }
     const result = await resolveCredentialsForProxy(
       db,
-      profileId,
+      connectionProfileId,
       provider.id,
       run.orgId,
       credentialId,
@@ -300,7 +300,7 @@ export function createInternalRouter() {
       runId,
       providerId,
       packageId: run.packageId,
-      profileId,
+      connectionProfileId,
     });
 
     return c.json(result);
@@ -311,8 +311,8 @@ export function createInternalRouter() {
     const { runId, run } = await verifyRunToken(c);
     const providerId = `${c.req.param("scope")}/${c.req.param("name")}`;
 
-    const profileId = run.providerProfileIds?.[providerId];
-    if (!profileId) {
+    const connectionProfileId = run.providerProfileIds?.[providerId];
+    if (!connectionProfileId) {
       throw notFound(`No profile resolved for provider '${providerId}'`);
     }
 
@@ -327,11 +327,17 @@ export function createInternalRouter() {
     // (wrong header, wrong endpoint, missing scope). Refreshing here would
     // burn provider rate limits, add latency, and churn rotating
     // refresh_tokens for no benefit.
-    const connection = await getConnection(db, profileId, providerId, run.orgId, credentialId);
+    const connection = await getConnection(
+      db,
+      connectionProfileId,
+      providerId,
+      run.orgId,
+      credentialId,
+    );
     if (connection && isTokenFresh(connection.expiresAt)) {
       const passthrough = await resolveCredentialsForProxy(
         db,
-        profileId,
+        connectionProfileId,
         providerId,
         run.orgId,
         credentialId,
@@ -343,7 +349,7 @@ export function createInternalRouter() {
       logger.info("Skipping refresh — stored token still fresh", {
         runId,
         providerId,
-        profileId,
+        connectionProfileId,
         expiresInMs: Date.parse(connection.expiresAt!) - Date.now(),
       });
 
@@ -353,7 +359,7 @@ export function createInternalRouter() {
     try {
       const result = await forceRefreshCredentials(
         db,
-        profileId,
+        connectionProfileId,
         providerId,
         run.orgId,
         credentialId,
@@ -362,7 +368,7 @@ export function createInternalRouter() {
         throw notFound(`No credentials for provider '${providerId}'`);
       }
 
-      logger.info("Forced credential refresh", { runId, providerId, profileId });
+      logger.info("Forced credential refresh", { runId, providerId, connectionProfileId });
       return c.json(result);
     } catch (err) {
       // Only a definitive "refresh_token is dead" signal (RFC 6749 §5.2:
@@ -377,7 +383,7 @@ export function createInternalRouter() {
           .set({ needsReconnection: true, updatedAt: new Date() })
           .where(
             and(
-              eq(userProviderConnections.profileId, profileId),
+              eq(userProviderConnections.connectionProfileId, connectionProfileId),
               eq(userProviderConnections.providerId, providerId),
               eq(userProviderConnections.orgId, run.orgId),
               eq(userProviderConnections.providerCredentialId, credentialId),
@@ -387,7 +393,7 @@ export function createInternalRouter() {
         logger.warn("Refresh token revoked, connection flagged for reconnection", {
           runId,
           providerId,
-          profileId,
+          connectionProfileId,
           status: err.status,
         });
 
@@ -397,7 +403,7 @@ export function createInternalRouter() {
       logger.warn("Transient refresh failure, connection left unchanged", {
         runId,
         providerId,
-        profileId,
+        connectionProfileId,
         kind: err instanceof RefreshError ? err.kind : "unknown",
         status: err instanceof RefreshError ? err.status : undefined,
         error: getErrorMessage(err),

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -134,17 +134,17 @@ router.get("/models", requirePermission("models", "read"), async (c) => {
  * callers. The application id comes from `requireAppContext()` (header
  * `X-Application-Id` for cookie sessions, embedded for API keys).
  */
-const setProfileSchema = z.object({ profileId: z.uuid() });
+const setProfileSchema = z.object({ connectionProfileId: z.uuid() });
 
 router.get("/application-profile", requireAppContext(), async (c) => {
   const user = c.get("user");
   if (!user) throw unauthorized("Authentication required");
   if (c.get("endUser")) {
-    return c.json({ profileId: null });
+    return c.json({ connectionProfileId: null });
   }
   const applicationId = c.get("applicationId")!;
-  const profileId = await getMemberApplicationProfileId(user.id, applicationId);
-  return c.json({ profileId });
+  const connectionProfileId = await getMemberApplicationProfileId(user.id, applicationId);
+  return c.json({ connectionProfileId });
 });
 
 router.put("/application-profile", requireAppContext(), async (c) => {
@@ -155,9 +155,9 @@ router.put("/application-profile", requireAppContext(), async (c) => {
   }
   const applicationId = c.get("applicationId")!;
   const body = await c.req.json().catch(() => ({}));
-  const { profileId } = parseBody(setProfileSchema, body);
-  await setMemberApplicationProfileId(user.id, applicationId, profileId);
-  return c.json({ profileId });
+  const { connectionProfileId } = parseBody(setProfileSchema, body);
+  await setMemberApplicationProfileId(user.id, applicationId, connectionProfileId);
+  return c.json({ connectionProfileId });
 });
 
 router.delete("/application-profile", requireAppContext(), async (c) => {

--- a/apps/api/src/services/agent-readiness.ts
+++ b/apps/api/src/services/agent-readiness.ts
@@ -232,7 +232,7 @@ export async function resolveAgentReadiness(query: ReadinessQuery): Promise<Read
     seen.add(providerId);
     missing.push({
       providerId,
-      profileId: providerProfiles[providerId]?.profileId ?? null,
+      connectionProfileId: providerProfiles[providerId]?.connectionProfileId ?? null,
       reason: mapReason(err.code),
       message: err.message,
     });

--- a/apps/api/src/services/connection-manager/connections.ts
+++ b/apps/api/src/services/connection-manager/connections.ts
@@ -10,7 +10,7 @@ export async function saveApiKeyConnection(
   scope: AppScope,
   provider: string,
   apiKey: string,
-  profileId: string,
+  connectionProfileId: string,
 ): Promise<void> {
   // Fire both lookups concurrently — they hit independent tables
   // (applicationProviderCredentials vs packages) and neither depends on the
@@ -28,7 +28,7 @@ export async function saveApiKeyConnection(
 
   await saveConnection(
     db,
-    profileId,
+    connectionProfileId,
     provider,
     scope.orgId,
     { [fieldName]: apiKey },
@@ -37,7 +37,7 @@ export async function saveApiKeyConnection(
 
   logger.info("API key connection saved", {
     provider,
-    profileId,
+    connectionProfileId,
     orgId: scope.orgId,
     fieldName,
   });
@@ -48,18 +48,18 @@ export async function saveCredentialsConnection(
   provider: string,
   authMode: "basic" | "custom",
   credentials: Record<string, string>,
-  profileId: string,
+  connectionProfileId: string,
 ): Promise<void> {
   const providerCredentialId = await resolveProviderCredentialId(scope.applicationId, provider);
 
-  await saveConnection(db, profileId, provider, scope.orgId, credentials, {
+  await saveConnection(db, connectionProfileId, provider, scope.orgId, credentials, {
     providerCredentialId,
   });
 
   logger.info("Credentials connection saved", {
     provider,
     authMode,
-    profileId,
+    connectionProfileId,
     orgId: scope.orgId,
   });
 }

--- a/apps/api/src/services/connection-manager/oauth.ts
+++ b/apps/api/src/services/connection-manager/oauth.ts
@@ -26,7 +26,7 @@ export async function initiateConnection(
   scope: AppScope,
   provider: string,
   actor: Actor,
-  profileId: string,
+  connectionProfileId: string,
   requestedScopes?: string[],
 ): Promise<{ authUrl: string; state: string }> {
   const redirectUri = getOAuthCallbackUrl();
@@ -39,7 +39,7 @@ export async function initiateConnection(
       oauthStateStore,
       scope.orgId,
       actor,
-      profileId,
+      connectionProfileId,
       provider,
       redirectUri,
       scope.applicationId,
@@ -51,7 +51,7 @@ export async function initiateConnection(
     oauthStateStore,
     scope.orgId,
     actor,
-    profileId,
+    connectionProfileId,
     provider,
     redirectUri,
     requestedScopes,
@@ -75,14 +75,14 @@ export async function handleCallback(code: string, state: string): Promise<OAuth
   if (needsReconnection) {
     logger.warn("OAuth scope shortfall — flagging connection as needsReconnection", {
       providerId: result.providerId,
-      profileId: result.profileId,
+      connectionProfileId: result.connectionProfileId,
       shortfall: result.scopeShortfall,
     });
   }
 
   await saveConnection(
     db,
-    result.profileId,
+    result.connectionProfileId,
     result.providerId,
     result.orgId,
     {
@@ -102,14 +102,14 @@ export async function handleCallback(code: string, state: string): Promise<OAuth
   if (result.scopeCreep.length > 0) {
     logger.warn("OAuth scope creep — provider granted unrequested scopes", {
       providerId: result.providerId,
-      profileId: result.profileId,
+      connectionProfileId: result.connectionProfileId,
       creep: result.scopeCreep,
     });
   }
 
   logger.info("OAuth connection established", {
     providerId: result.providerId,
-    profileId: result.profileId,
+    connectionProfileId: result.connectionProfileId,
     scopes: result.scopesGranted,
     shortfall: result.scopeShortfall.length > 0 ? result.scopeShortfall : undefined,
   });
@@ -130,7 +130,7 @@ export async function handleOAuth1CallbackAndSave(
 
   await saveConnection(
     db,
-    result.profileId,
+    result.connectionProfileId,
     result.providerId,
     result.orgId,
     {
@@ -145,7 +145,7 @@ export async function handleOAuth1CallbackAndSave(
 
   logger.info("OAuth1 connection established", {
     providerId: result.providerId,
-    profileId: result.profileId,
+    connectionProfileId: result.connectionProfileId,
   });
 
   return result;

--- a/apps/api/src/services/connection-manager/operations.ts
+++ b/apps/api/src/services/connection-manager/operations.ts
@@ -18,10 +18,10 @@ import type { AppScope, OrgScope } from "../../lib/scope.ts";
 
 export async function listActorConnections(
   scope: AppScope,
-  profileId: string,
+  connectionProfileId: string,
 ): Promise<ConnectionStatus[]> {
   const credentialIds = await listProviderCredentialIds(db, scope.applicationId);
-  const connections = await listConnectionsRaw(db, profileId, scope.orgId, credentialIds);
+  const connections = await listConnectionsRaw(db, connectionProfileId, scope.orgId, credentialIds);
   return connections.map((c) => ({
     provider: c.providerId,
     status: c.needsReconnection ? ("needs_reconnection" as const) : ("connected" as const),
@@ -40,13 +40,13 @@ export async function listActorConnections(
 export async function disconnectProvider(
   scope: OrgScope,
   provider: string,
-  profileId: string,
+  connectionProfileId: string,
   providerCredentialId: string,
 ): Promise<void> {
-  await deleteConnectionRaw(db, profileId, provider, scope.orgId, providerCredentialId);
+  await deleteConnectionRaw(db, connectionProfileId, provider, scope.orgId, providerCredentialId);
   logger.info("Connection deleted", {
     provider,
-    profileId,
+    connectionProfileId,
     orgId: scope.orgId,
     providerCredentialId,
   });
@@ -66,7 +66,10 @@ export async function disconnectConnectionById(
   const rows = await db
     .select({ id: userProviderConnections.id })
     .from(userProviderConnections)
-    .innerJoin(connectionProfiles, eq(userProviderConnections.profileId, connectionProfiles.id))
+    .innerJoin(
+      connectionProfiles,
+      eq(userProviderConnections.connectionProfileId, connectionProfiles.id),
+    )
     .where(
       and(
         eq(userProviderConnections.id, connectionId),
@@ -112,7 +115,7 @@ export async function deleteAllActorConnections(scope: AppScope, actor: Actor): 
   await db.delete(userProviderConnections).where(
     and(
       inArray(
-        userProviderConnections.profileId,
+        userProviderConnections.connectionProfileId,
         profiles.map((p) => p.id),
       ),
       inArray(userProviderConnections.providerCredentialId, credentialIds),

--- a/apps/api/src/services/connection-manager/providers.ts
+++ b/apps/api/src/services/connection-manager/providers.ts
@@ -36,14 +36,14 @@ export async function getProviderAuthMode(
 
 export async function getAvailableProvidersWithStatus(
   scope: AppScope,
-  profileId: string,
+  connectionProfileId: string,
 ): Promise<AvailableProvider[]> {
   const [providers, credentialIds, configuredProviderIds] = await Promise.all([
     listProviders(db, scope.orgId),
     listProviderCredentialIds(db, scope.applicationId),
     listConfiguredProviderIds(db, scope.applicationId),
   ]);
-  const connections = await listConnectionsRaw(db, profileId, scope.orgId, credentialIds);
+  const connections = await listConnectionsRaw(db, connectionProfileId, scope.orgId, credentialIds);
   const configuredSet = new Set(configuredProviderIds);
 
   return providers
@@ -87,14 +87,17 @@ export async function listAllActorConnections(
       orgId: userProviderConnections.orgId,
       scopesGranted: userProviderConnections.scopesGranted,
       connectedAt: userProviderConnections.createdAt,
-      profileId: connectionProfiles.id,
+      connectionProfileId: connectionProfiles.id,
       profileName: connectionProfiles.name,
       isDefault: connectionProfiles.isDefault,
       applicationId: applicationProviderCredentials.applicationId,
       applicationName: applications.name,
     })
     .from(userProviderConnections)
-    .innerJoin(connectionProfiles, eq(userProviderConnections.profileId, connectionProfiles.id))
+    .innerJoin(
+      connectionProfiles,
+      eq(userProviderConnections.connectionProfileId, connectionProfiles.id),
+    )
     .innerJoin(
       applicationProviderCredentials,
       eq(userProviderConnections.providerCredentialId, applicationProviderCredentials.id),
@@ -182,7 +185,7 @@ export async function listAllActorConnections(
           ? r.scopesGranted
           : []) as string[],
         connectedAt: toISORequired(r.connectedAt),
-        profile: { id: r.profileId, name: r.profileName, isDefault: r.isDefault },
+        profile: { id: r.connectionProfileId, name: r.profileName, isDefault: r.isDefault },
         application: { id: r.applicationId, name: r.applicationName },
       })),
     }));

--- a/apps/api/src/services/connection-manager/status.ts
+++ b/apps/api/src/services/connection-manager/status.ts
@@ -71,7 +71,7 @@ export async function hasActiveConnection(
     .from(userProviderConnections)
     .where(
       and(
-        eq(userProviderConnections.profileId, connectionProfileId),
+        eq(userProviderConnections.connectionProfileId, connectionProfileId),
         eq(userProviderConnections.providerId, provider),
         eq(userProviderConnections.orgId, scope.orgId),
         eq(userProviderConnections.providerCredentialId, credentialId),
@@ -134,9 +134,9 @@ async function buildProfileInfoMap(
 }
 
 /**
- * Batch-fetch connection statuses for all (profileId, orgId) pairs in a single query.
+ * Batch-fetch connection statuses for all (connectionProfileId, orgId) pairs in a single query.
  * Filters by providerCredentialId when available to ensure per-app isolation.
- * Returns a Map keyed by "profileId:providerId" → connection row.
+ * Returns a Map keyed by "connectionProfileId:providerId" → connection row.
  */
 async function batchGetConnectionStatuses(
   profileIds: string[],
@@ -151,7 +151,7 @@ async function batchGetConnectionStatuses(
   if (profileIds.length === 0) return new Map();
 
   const conditions = [
-    inArray(userProviderConnections.profileId, profileIds),
+    inArray(userProviderConnections.connectionProfileId, profileIds),
     eq(userProviderConnections.orgId, orgId),
   ];
 
@@ -164,7 +164,7 @@ async function batchGetConnectionStatuses(
   const rows = await db
     .select({
       id: userProviderConnections.id,
-      profileId: userProviderConnections.profileId,
+      connectionProfileId: userProviderConnections.connectionProfileId,
       providerId: userProviderConnections.providerId,
       createdAt: userProviderConnections.createdAt,
       scopesGranted: userProviderConnections.scopesGranted,
@@ -178,7 +178,7 @@ async function batchGetConnectionStatuses(
     { id: string; createdAt: string; scopesGranted: string[] | null; needsReconnection: boolean }
   >();
   for (const row of rows) {
-    const key = `${row.profileId}:${row.providerId}`;
+    const key = `${row.connectionProfileId}:${row.providerId}`;
     map.set(key, {
       id: row.id,
       createdAt: toISORequired(row.createdAt) || toISORequired(new Date()),
@@ -203,7 +203,7 @@ export async function resolveProviderStatuses(
   const profileIds = [
     ...new Set(
       Object.values(providerProfiles)
-        .map((e) => e.profileId)
+        .map((e) => e.connectionProfileId)
         .filter(Boolean),
     ),
   ];
@@ -256,7 +256,7 @@ export async function resolveProviderStatuses(
     }
 
     // Look up connection from batch-fetched map
-    const connKey = `${entry.profileId}:${svc.id}`;
+    const connKey = `${entry.connectionProfileId}:${svc.id}`;
     const conn = connectionMap.get(connKey);
     const connStatus: ConnectionStatusValue = conn
       ? conn.needsReconnection
@@ -264,7 +264,7 @@ export async function resolveProviderStatuses(
         : "connected"
       : "not_connected";
 
-    const profileInfo = profileInfoMap.get(entry.profileId) ?? {
+    const profileInfo = profileInfoMap.get(entry.connectionProfileId) ?? {
       profileName: null,
       profileOwnerName: null,
     };

--- a/apps/api/src/services/connection-profiles.ts
+++ b/apps/api/src/services/connection-profiles.ts
@@ -85,7 +85,10 @@ export async function listProfiles(
       connectionCount: count(userProviderConnections.id),
     })
     .from(connectionProfiles)
-    .leftJoin(userProviderConnections, eq(userProviderConnections.profileId, connectionProfiles.id))
+    .leftJoin(
+      userProviderConnections,
+      eq(userProviderConnections.connectionProfileId, connectionProfiles.id),
+    )
     .where(actorFilter(actor, PROFILE_ACTOR_COLUMNS))
     .groupBy(connectionProfiles.id);
 
@@ -96,13 +99,18 @@ export async function listProfiles(
  * Get a single profile by ID, scoped to the actor. Returns null if not found.
  */
 export async function getProfileForActor(
-  profileId: string,
+  connectionProfileId: string,
   actor: Actor,
 ): Promise<ConnectionProfile | null> {
   const [row] = await db
     .select()
     .from(connectionProfiles)
-    .where(and(eq(connectionProfiles.id, profileId), actorFilter(actor, PROFILE_ACTOR_COLUMNS)))
+    .where(
+      and(
+        eq(connectionProfiles.id, connectionProfileId),
+        actorFilter(actor, PROFILE_ACTOR_COLUMNS),
+      ),
+    )
     .limit(1);
   return row ?? null;
 }
@@ -112,11 +120,14 @@ export async function getProfileForActor(
  * or an app profile belonging to the actor's current application.
  */
 export async function getAccessibleProfile(
-  profileId: string,
+  connectionProfileId: string,
   actor: Actor,
   scope: AppScope,
 ): Promise<ConnectionProfile | null> {
-  return (await getProfileForActor(profileId, actor)) ?? (await getAppProfile(scope, profileId));
+  return (
+    (await getProfileForActor(connectionProfileId, actor)) ??
+    (await getAppProfile(scope, connectionProfileId))
+  );
 }
 
 /**
@@ -124,7 +135,7 @@ export async function getAccessibleProfile(
  * Used for read-only access (e.g. viewing schedule provider status).
  */
 export async function getOrgMemberProfile(
-  profileId: string,
+  connectionProfileId: string,
   orgId: string,
 ): Promise<ConnectionProfile | null> {
   const [row] = await db
@@ -137,7 +148,7 @@ export async function getOrgMemberProfile(
         eq(organizationMembers.orgId, orgId),
       ),
     )
-    .where(eq(connectionProfiles.id, profileId))
+    .where(eq(connectionProfiles.id, connectionProfileId))
     .limit(1);
   return row?.profile ?? null;
 }
@@ -150,22 +161,36 @@ export async function createProfile(actor: Actor, name: string): Promise<Connect
   return created!;
 }
 
-export async function renameProfile(profileId: string, actor: Actor, name: string): Promise<void> {
+export async function renameProfile(
+  connectionProfileId: string,
+  actor: Actor,
+  name: string,
+): Promise<void> {
   const [updated] = await db
     .update(connectionProfiles)
     .set({ name, updatedAt: new Date() })
-    .where(and(eq(connectionProfiles.id, profileId), actorFilter(actor, PROFILE_ACTOR_COLUMNS)))
+    .where(
+      and(
+        eq(connectionProfiles.id, connectionProfileId),
+        actorFilter(actor, PROFILE_ACTOR_COLUMNS),
+      ),
+    )
     .returning({ id: connectionProfiles.id });
 
   if (!updated) throw notFound("Profile not found");
 }
 
-export async function deleteProfile(profileId: string, actor: Actor): Promise<void> {
+export async function deleteProfile(connectionProfileId: string, actor: Actor): Promise<void> {
   // Check it's not the default
   const [profile] = await db
     .select()
     .from(connectionProfiles)
-    .where(and(eq(connectionProfiles.id, profileId), actorFilter(actor, PROFILE_ACTOR_COLUMNS)))
+    .where(
+      and(
+        eq(connectionProfiles.id, connectionProfileId),
+        actorFilter(actor, PROFILE_ACTOR_COLUMNS),
+      ),
+    )
     .limit(1);
 
   if (!profile) throw notFound("Profile not found");
@@ -173,7 +198,12 @@ export async function deleteProfile(profileId: string, actor: Actor): Promise<vo
 
   await db
     .delete(connectionProfiles)
-    .where(and(eq(connectionProfiles.id, profileId), actorFilter(actor, PROFILE_ACTOR_COLUMNS)));
+    .where(
+      and(
+        eq(connectionProfiles.id, connectionProfileId),
+        actorFilter(actor, PROFILE_ACTOR_COLUMNS),
+      ),
+    );
 }
 
 // ─── App Profile CRUD ───────────────────────────────────────
@@ -223,14 +253,14 @@ export async function createAppProfile(scope: AppScope, name: string): Promise<C
 
 export async function getAppProfile(
   scope: AppScope,
-  profileId: string,
+  connectionProfileId: string,
 ): Promise<ConnectionProfile | null> {
   const [row] = await db
     .select()
     .from(connectionProfiles)
     .where(
       and(
-        eq(connectionProfiles.id, profileId),
+        eq(connectionProfiles.id, connectionProfileId),
         eq(connectionProfiles.applicationId, scope.applicationId),
       ),
     )
@@ -254,7 +284,7 @@ export async function getAgentAppProfile(
 
 export async function renameAppProfile(
   scope: AppScope,
-  profileId: string,
+  connectionProfileId: string,
   name: string,
 ): Promise<void> {
   const [updated] = await db
@@ -262,7 +292,7 @@ export async function renameAppProfile(
     .set({ name, updatedAt: new Date() })
     .where(
       and(
-        eq(connectionProfiles.id, profileId),
+        eq(connectionProfiles.id, connectionProfileId),
         eq(connectionProfiles.applicationId, scope.applicationId),
       ),
     )
@@ -271,13 +301,16 @@ export async function renameAppProfile(
   if (!updated) throw notFound("Profile not found");
 }
 
-export async function deleteAppProfile(scope: AppScope, profileId: string): Promise<void> {
+export async function deleteAppProfile(
+  scope: AppScope,
+  connectionProfileId: string,
+): Promise<void> {
   const [profile] = await db
     .select()
     .from(connectionProfiles)
     .where(
       and(
-        eq(connectionProfiles.id, profileId),
+        eq(connectionProfiles.id, connectionProfileId),
         eq(connectionProfiles.applicationId, scope.applicationId),
       ),
     )
@@ -290,13 +323,13 @@ export async function deleteAppProfile(scope: AppScope, profileId: string): Prom
   await db
     .update(applicationPackages)
     .set({ appProfileId: null, updatedAt: new Date() })
-    .where(eq(applicationPackages.appProfileId, profileId));
+    .where(eq(applicationPackages.appProfileId, connectionProfileId));
 
   await db
     .delete(connectionProfiles)
     .where(
       and(
-        eq(connectionProfiles.id, profileId),
+        eq(connectionProfiles.id, connectionProfileId),
         eq(connectionProfiles.applicationId, scope.applicationId),
       ),
     );
@@ -345,9 +378,9 @@ export async function listAppProfilesWithUserBindings(
     grouped.set(row.appProfileId, entry);
   }
 
-  return Array.from(grouped.entries()).map(([profileId, data]) => ({
+  return Array.from(grouped.entries()).map(([connectionProfileId, data]) => ({
     profile: {
-      id: profileId,
+      id: connectionProfileId,
       userId: null,
       endUserId: null,
       applicationId: scope.applicationId,
@@ -370,7 +403,7 @@ export async function getUserAgentProviderOverrides(
   const rows = await db
     .select({
       providerId: userAgentProviderProfiles.providerId,
-      profileId: userAgentProviderProfiles.profileId,
+      connectionProfileId: userAgentProviderProfiles.connectionProfileId,
     })
     .from(userAgentProviderProfiles)
     .where(
@@ -385,7 +418,7 @@ export async function getUserAgentProviderOverrides(
 
   const map: Record<string, string> = {};
   for (const row of rows) {
-    map[row.providerId] = row.profileId;
+    map[row.providerId] = row.connectionProfileId;
   }
   return map;
 }
@@ -395,7 +428,7 @@ export async function setUserAgentProviderOverride(
   actor: Actor,
   packageId: string,
   providerId: string,
-  profileId: string,
+  connectionProfileId: string,
 ): Promise<void> {
   const actorValues = actorInsert(actor);
   const userId = actorValues.userId ?? null;
@@ -409,7 +442,7 @@ export async function setUserAgentProviderOverride(
   // cannot be targeted by Drizzle's onConflictDoUpdate, so we use raw SQL.
   await db.execute(sql`
     INSERT INTO user_agent_provider_profiles (user_id, end_user_id, package_id, provider_id, profile_id, updated_at)
-    VALUES (${userId}, ${endUserId}, ${packageId}, ${providerId}, ${profileId}, NOW())
+    VALUES (${userId}, ${endUserId}, ${packageId}, ${providerId}, ${connectionProfileId}, NOW())
     ON CONFLICT (${userId !== null ? sql`user_id` : sql`end_user_id`}, package_id, provider_id)
       WHERE ${userId !== null ? sql`user_id IS NOT NULL` : sql`end_user_id IS NOT NULL`}
     DO UPDATE SET profile_id = EXCLUDED.profile_id, updated_at = NOW()
@@ -484,11 +517,13 @@ export async function resolveActorProfileContext(
  * by orgId would miss them. The caller (scheduler) already validates the schedule
  * belongs to the requesting org.
  */
-export async function getProfileByIdUnsafe(profileId: string): Promise<ConnectionProfile | null> {
+export async function getProfileByIdUnsafe(
+  connectionProfileId: string,
+): Promise<ConnectionProfile | null> {
   const [row] = await db
     .select()
     .from(connectionProfiles)
-    .where(eq(connectionProfiles.id, profileId))
+    .where(eq(connectionProfiles.id, connectionProfileId))
     .limit(1);
   return row ?? null;
 }
@@ -505,7 +540,7 @@ export async function getMemberApplicationProfileId(
   applicationId: string,
 ): Promise<string | null> {
   const [row] = await db
-    .select({ profileId: userApplicationProfiles.profileId })
+    .select({ connectionProfileId: userApplicationProfiles.connectionProfileId })
     .from(userApplicationProfiles)
     .where(
       and(
@@ -514,7 +549,7 @@ export async function getMemberApplicationProfileId(
       ),
     )
     .limit(1);
-  return row?.profileId ?? null;
+  return row?.connectionProfileId ?? null;
 }
 
 /**
@@ -529,7 +564,7 @@ export async function getMemberApplicationProfileId(
 export async function setMemberApplicationProfileId(
   userId: string,
   applicationId: string,
-  profileId: string,
+  connectionProfileId: string,
 ): Promise<void> {
   const [row] = await db
     .select({
@@ -537,7 +572,7 @@ export async function setMemberApplicationProfileId(
       applicationId: connectionProfiles.applicationId,
     })
     .from(connectionProfiles)
-    .where(eq(connectionProfiles.id, profileId))
+    .where(eq(connectionProfiles.id, connectionProfileId))
     .limit(1);
   if (!row) {
     throw notFound("profile");
@@ -549,10 +584,10 @@ export async function setMemberApplicationProfileId(
   }
   await db
     .insert(userApplicationProfiles)
-    .values({ userId, applicationId, profileId })
+    .values({ userId, applicationId, connectionProfileId })
     .onConflictDoUpdate({
       target: [userApplicationProfiles.userId, userApplicationProfiles.applicationId],
-      set: { profileId, updatedAt: new Date() },
+      set: { connectionProfileId, updatedAt: new Date() },
     });
 }
 
@@ -639,11 +674,11 @@ export async function resolveProviderProfiles(
   for (const svc of providers) {
     const appBinding = appProfileId ? bindings[svc.id] : undefined;
     if (appBinding) {
-      map[svc.id] = { profileId: appBinding, source: "app_binding" };
+      map[svc.id] = { connectionProfileId: appBinding, source: "app_binding" };
     } else {
       const fallbackId = userProviderOverrides?.[svc.id] ?? defaultUserProfileId;
       if (fallbackId) {
-        map[svc.id] = { profileId: fallbackId, source: "user_profile" };
+        map[svc.id] = { connectionProfileId: fallbackId, source: "user_profile" };
       }
       // If no fallback (app-only mode), provider simply not in map — dependency validation will catch it
     }

--- a/apps/api/src/services/credential-proxy/core.ts
+++ b/apps/api/src/services/credential-proxy/core.ts
@@ -62,7 +62,7 @@ export interface ProxyCallInput {
    * end-user's `connectionProfileId`; for application-scoped keys it's
    * the application's default profile.
    */
-  profileId: string;
+  connectionProfileId: string;
 
   /** Scoped provider package name (e.g. `@afps/gmail`). */
   providerId: string;
@@ -186,7 +186,7 @@ export async function proxyCall(db: Db, input: ProxyCallInput): Promise<ProxyCal
   }
   const resolved = await resolveCredentialsForProxy(
     db,
-    input.profileId,
+    input.connectionProfileId,
     input.providerId,
     input.orgId,
     credentialId,
@@ -301,7 +301,7 @@ export async function proxyCall(db: Db, input: ProxyCallInput): Promise<ProxyCal
     try {
       const refreshed = await forceRefreshCredentials(
         db,
-        input.profileId,
+        input.connectionProfileId,
         input.providerId,
         input.orgId,
         credentialId,
@@ -344,7 +344,7 @@ export async function proxyCall(db: Db, input: ProxyCallInput): Promise<ProxyCal
     try {
       await forceRefreshCredentials(
         db,
-        input.profileId,
+        input.connectionProfileId,
         input.providerId,
         input.orgId,
         credentialId,

--- a/apps/api/src/services/dependency-validation.ts
+++ b/apps/api/src/services/dependency-validation.ts
@@ -116,7 +116,12 @@ export async function collectDependencyErrors(
   const statusIds = [...credentialById.keys()];
   const statuses = await Promise.all(
     statusIds.map((id) =>
-      deps.getConnectionStatus(id, providerProfiles[id]!.profileId, orgId, credentialById.get(id)!),
+      deps.getConnectionStatus(
+        id,
+        providerProfiles[id]!.connectionProfileId,
+        orgId,
+        credentialById.get(id)!,
+      ),
     ),
   );
   const statusById = new Map(statusIds.map((id, i) => [id, statuses[i]!] as const));

--- a/apps/api/src/services/run-creation.ts
+++ b/apps/api/src/services/run-creation.ts
@@ -215,7 +215,7 @@ async function createRemoteRun(input: CreateRunInput): Promise<CreateRunResult> 
   //     sink bookkeeping consistently across both origins).
   const agentDenorm = extractRunAgentDenorm(agent);
   const profileIdMap = Object.fromEntries(
-    Object.entries(providerProfiles).map(([k, v]) => [k, v.profileId]),
+    Object.entries(providerProfiles).map(([k, v]) => [k, v.connectionProfileId]),
   );
 
   await createRunRow(

--- a/apps/api/src/services/run-pipeline.ts
+++ b/apps/api/src/services/run-pipeline.ts
@@ -252,7 +252,7 @@ export async function prepareAndExecuteRun(params: RunPipelineParams): Promise<R
 
   // --- Step 2: Extract profile ID map ---
   const profileIdMap = Object.fromEntries(
-    Object.entries(providerProfiles).map(([k, v]) => [k, v.profileId]),
+    Object.entries(providerProfiles).map(([k, v]) => [k, v.connectionProfileId]),
   );
 
   // --- Step 5: Mint sink credentials ---

--- a/apps/api/src/services/scheduler.ts
+++ b/apps/api/src/services/scheduler.ts
@@ -521,7 +521,7 @@ async function computeScheduleReadiness(
 
 /**
  * Enrich schedules with profile info and readiness status.
- * Batches lookups by unique profileId and packageId for efficiency.
+ * Batches lookups by unique connectionProfileId and packageId for efficiency.
  */
 async function enrichSchedules(schedules: Schedule[], orgId: string): Promise<EnrichedSchedule[]> {
   if (schedules.length === 0) return [];

--- a/apps/api/src/services/state/app-profile-bindings.ts
+++ b/apps/api/src/services/state/app-profile-bindings.ts
@@ -93,7 +93,7 @@ export async function getAppProfileBindingsEnriched(
     .leftJoin(
       userProviderConnections,
       and(
-        eq(userProviderConnections.profileId, appProfileProviderBindings.sourceProfileId),
+        eq(userProviderConnections.connectionProfileId, appProfileProviderBindings.sourceProfileId),
         eq(userProviderConnections.providerId, appProfileProviderBindings.providerId),
         eq(userProviderConnections.needsReconnection, false),
         credentialIds.length > 0

--- a/apps/api/src/services/token-resolver.ts
+++ b/apps/api/src/services/token-resolver.ts
@@ -38,7 +38,7 @@ export async function buildProviderTokens(
       .map(async (svc) => {
         const entry = providerProfiles[svc.id];
         if (!entry) return [svc.id, null] as const;
-        const connectionProfileId = entry.profileId;
+        const connectionProfileId = entry.connectionProfileId;
 
         const credentialId = await getProviderCredentialId(db, applicationId, svc.id);
         if (!credentialId) {

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -31,7 +31,7 @@ export interface AgentProviderRequirement {
  * 3. Default user profile (`source: "user_profile"`) — actor's default connection profile
  */
 export interface ProviderProfileEntry {
-  profileId: string;
+  connectionProfileId: string;
   source: ProviderProfileSource;
 }
 

--- a/apps/api/test/helpers/seed.ts
+++ b/apps/api/test/helpers/seed.ts
@@ -303,7 +303,7 @@ export async function seedConnectionProfile(
 // ─── User Provider Connections ────────────────────────────
 
 type UserConnectionInsert = Partial<InferInsertModel<typeof userProviderConnections>> & {
-  profileId: string;
+  connectionProfileId: string;
   providerId: string;
   orgId: string;
   providerCredentialId: string;
@@ -362,7 +362,7 @@ import { saveConnection } from "@appstrate/connect";
  * Simplifies tests by handling the providerCredentialId requirement.
  */
 export async function seedConnectionForApp(
-  profileId: string,
+  connectionProfileId: string,
   providerId: string,
   orgId: string,
   applicationId: string,
@@ -374,7 +374,7 @@ export async function seedConnectionForApp(
     () => {},
   );
   const cred = await seedProviderCredentials({ applicationId, providerId });
-  await saveConnection(db, profileId, providerId, orgId, credentials, {
+  await saveConnection(db, connectionProfileId, providerId, orgId, credentials, {
     providerCredentialId: cred.id,
     ...options,
   });

--- a/apps/api/test/integration/routes/agents-readiness.test.ts
+++ b/apps/api/test/integration/routes/agents-readiness.test.ts
@@ -124,13 +124,13 @@ describe("GET /api/agents/:scope/:name/readiness", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       ready: boolean;
-      missing: Array<{ providerId: string; reason: string; profileId: string | null }>;
+      missing: Array<{ providerId: string; reason: string; connectionProfileId: string | null }>;
     };
     expect(body.ready).toBe(false);
     expect(body.missing).toHaveLength(1);
     expect(body.missing[0]?.providerId).toBe(PROVIDER_ID);
     expect(body.missing[0]?.reason).toBe("no_connection");
-    expect(body.missing[0]?.profileId).toBe(profile.id);
+    expect(body.missing[0]?.connectionProfileId).toBe(profile.id);
   });
 
   it("flags needs_reconnection when the underlying connection is marked stale", async () => {
@@ -148,7 +148,7 @@ describe("GET /api/agents/:scope/:name/readiness", () => {
     await db
       .update(userProviderConnections)
       .set({ needsReconnection: true })
-      .where(eq(userProviderConnections.profileId, profile.id));
+      .where(eq(userProviderConnections.connectionProfileId, profile.id));
 
     const res = await app.request(
       `/api/agents/@readyorg/agent/readiness?connectionProfileId=${profile.id}`,

--- a/apps/api/test/integration/routes/agents.test.ts
+++ b/apps/api/test/integration/routes/agents.test.ts
@@ -428,7 +428,7 @@ describe("Agents API", () => {
       await app.request("/api/agents/@myorg/pp-agent-set/provider-profiles", {
         method: "PUT",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ providerId: "@system/gmail", profileId: profile.id }),
+        body: JSON.stringify({ providerId: "@system/gmail", connectionProfileId: profile.id }),
       });
 
       const res = await app.request("/api/agents/@myorg/pp-agent-set/provider-profiles", {
@@ -453,14 +453,14 @@ describe("Agents API", () => {
       const res = await app.request("/api/agents/@myorg/pp-put/provider-profiles", {
         method: "PUT",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ providerId: "@system/gmail", profileId: profile.id }),
+        body: JSON.stringify({ providerId: "@system/gmail", connectionProfileId: profile.id }),
       });
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
       expect(body.success).toBe(true);
     });
 
-    it("returns 400 with invalid profileId", async () => {
+    it("returns 400 with invalid connectionProfileId", async () => {
       await seedInstalledAgent({
         id: "@myorg/pp-put-bad",
         orgId: ctx.orgId,
@@ -471,7 +471,7 @@ describe("Agents API", () => {
       const res = await app.request("/api/agents/@myorg/pp-put-bad/provider-profiles", {
         method: "PUT",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ providerId: "@system/gmail", profileId: "not-a-uuid" }),
+        body: JSON.stringify({ providerId: "@system/gmail", connectionProfileId: "not-a-uuid" }),
       });
       expect(res.status).toBe(400);
     });
@@ -487,7 +487,7 @@ describe("Agents API", () => {
       const res = await app.request("/api/agents/@myorg/pp-put-noprov/provider-profiles", {
         method: "PUT",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ profileId: "00000000-0000-0000-0000-000000000000" }),
+        body: JSON.stringify({ connectionProfileId: "00000000-0000-0000-0000-000000000000" }),
       });
       expect(res.status).toBe(400);
     });
@@ -507,7 +507,7 @@ describe("Agents API", () => {
       const res = await app.request("/api/agents/@myorg/pp-put-app/provider-profiles", {
         method: "PUT",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ providerId: "@system/gmail", profileId: appProfile.id }),
+        body: JSON.stringify({ providerId: "@system/gmail", connectionProfileId: appProfile.id }),
       });
       expect(res.status).toBe(200);
     });
@@ -527,7 +527,7 @@ describe("Agents API", () => {
       await app.request("/api/agents/@myorg/pp-del/provider-profiles", {
         method: "PUT",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ providerId: "@system/gmail", profileId: profile.id }),
+        body: JSON.stringify({ providerId: "@system/gmail", connectionProfileId: profile.id }),
       });
 
       const res = await app.request("/api/agents/@myorg/pp-del/provider-profiles", {

--- a/apps/api/test/integration/routes/connection-profiles.test.ts
+++ b/apps/api/test/integration/routes/connection-profiles.test.ts
@@ -551,7 +551,7 @@ describe("Connection Profiles API", () => {
       const res = await app.request(`/api/connections/connect/${providerId}`, {
         method: "POST",
         headers: { ...authHeaders(user2Ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ profileId: user1Profile.id }),
+        body: JSON.stringify({ connectionProfileId: user1Profile.id }),
       });
 
       expect(res.status).toBe(403);
@@ -571,7 +571,7 @@ describe("Connection Profiles API", () => {
       const res = await app.request(`/api/connections/connect/${providerId}`, {
         method: "POST",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ profileId: appProfile.id }),
+        body: JSON.stringify({ connectionProfileId: appProfile.id }),
       });
 
       // Should not get 403 — ownership check passes for app profiles
@@ -593,7 +593,7 @@ describe("Connection Profiles API", () => {
       const res = await app.request(`/api/connections/connect/${providerId}`, {
         method: "POST",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ profileId: ownProfile.id }),
+        body: JSON.stringify({ connectionProfileId: ownProfile.id }),
       });
 
       // 403 with "profile you do not own" means the ownership check failed
@@ -624,7 +624,7 @@ describe("Connection Profiles API", () => {
       const res = await app.request(`/api/connections/connect/${providerId}/api-key`, {
         method: "POST",
         headers: { ...authHeaders(user2Ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ apiKey: "fake-key-123", profileId: user1Profile.id }),
+        body: JSON.stringify({ apiKey: "fake-key-123", connectionProfileId: user1Profile.id }),
       });
 
       expect(res.status).toBe(403);
@@ -644,7 +644,7 @@ describe("Connection Profiles API", () => {
       const res = await app.request(`/api/connections/connect/${providerId}/api-key`, {
         method: "POST",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ apiKey: "test-key-123", profileId: appProfile.id }),
+        body: JSON.stringify({ apiKey: "test-key-123", connectionProfileId: appProfile.id }),
       });
 
       expect(res.status).not.toBe(403);
@@ -676,7 +676,7 @@ describe("Connection Profiles API", () => {
         headers: { ...authHeaders(user2Ctx), "Content-Type": "application/json" },
         body: JSON.stringify({
           credentials: { username: "user", password: "pass" },
-          profileId: user1Profile.id,
+          connectionProfileId: user1Profile.id,
         }),
       });
 
@@ -699,7 +699,7 @@ describe("Connection Profiles API", () => {
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
         body: JSON.stringify({
           credentials: { username: "user", password: "pass" },
-          profileId: appProfile.id,
+          connectionProfileId: appProfile.id,
         }),
       });
 
@@ -724,7 +724,7 @@ describe("Connection Profiles API", () => {
         defaultAppId: ctx.defaultAppId,
       };
 
-      const res = await app.request(`/api/connections?profileId=${user1Profile.id}`, {
+      const res = await app.request(`/api/connections?connectionProfileId=${user1Profile.id}`, {
         headers: authHeaders(user2Ctx),
       });
 
@@ -739,7 +739,7 @@ describe("Connection Profiles API", () => {
         name: "My Profile",
       });
 
-      const res = await app.request(`/api/connections?profileId=${ownProfile.id}`, {
+      const res = await app.request(`/api/connections?connectionProfileId=${ownProfile.id}`, {
         headers: authHeaders(ctx),
       });
 
@@ -752,7 +752,7 @@ describe("Connection Profiles API", () => {
         name: "App Profile",
       });
 
-      const res = await app.request(`/api/connections?profileId=${appProfile.id}`, {
+      const res = await app.request(`/api/connections?connectionProfileId=${appProfile.id}`, {
         headers: authHeaders(ctx),
       });
 
@@ -777,7 +777,7 @@ describe("Connection Profiles API", () => {
         defaultAppId: ctx.defaultAppId,
       };
 
-      const res = await app.request(`/api/connections/integrations?profileId=${user1Profile.id}`, {
+      const res = await app.request(`/api/connections/integrations?connectionProfileId=${user1Profile.id}`, {
         headers: authHeaders(user2Ctx),
       });
 
@@ -792,7 +792,7 @@ describe("Connection Profiles API", () => {
         name: "My Profile",
       });
 
-      const res = await app.request(`/api/connections/integrations?profileId=${ownProfile.id}`, {
+      const res = await app.request(`/api/connections/integrations?connectionProfileId=${ownProfile.id}`, {
         headers: authHeaders(ctx),
       });
 
@@ -805,7 +805,7 @@ describe("Connection Profiles API", () => {
         name: "App Profile",
       });
 
-      const res = await app.request(`/api/connections/integrations?profileId=${appProfile.id}`, {
+      const res = await app.request(`/api/connections/integrations?connectionProfileId=${appProfile.id}`, {
         headers: authHeaders(ctx),
       });
 

--- a/apps/api/test/integration/routes/internal.test.ts
+++ b/apps/api/test/integration/routes/internal.test.ts
@@ -748,7 +748,7 @@ describe("Internal API", () => {
 
     async function seedRunWithProfile(expiresAt: string | null): Promise<{
       runToken: string;
-      profileId: string;
+      connectionProfileId: string;
     }> {
       const profile = await seedConnectionProfile({
         userId: ctx.user.id,
@@ -771,7 +771,7 @@ describe("Internal API", () => {
         status: "running",
         providerProfileIds: { [providerId]: profile.id },
       });
-      return { runToken: signRunToken(run.id), profileId: profile.id };
+      return { runToken: signRunToken(run.id), connectionProfileId: profile.id };
     }
 
     it("returns 401 without token", async () => {
@@ -784,7 +784,7 @@ describe("Internal API", () => {
     it("skips the refresh when the stored token is still fresh", async () => {
       // 30 minutes of lifetime left — well above the 60s safety margin
       const freshExpiry = new Date(Date.now() + 30 * 60_000).toISOString();
-      const { runToken, profileId } = await seedRunWithProfile(freshExpiry);
+      const { runToken, connectionProfileId } = await seedRunWithProfile(freshExpiry);
 
       const rowBefore = (
         await db
@@ -792,7 +792,7 @@ describe("Internal API", () => {
           .from(userProviderConnections)
           .where(
             and(
-              eq(userProviderConnections.profileId, profileId),
+              eq(userProviderConnections.connectionProfileId, connectionProfileId),
               eq(userProviderConnections.providerId, providerId),
             ),
           )
@@ -815,7 +815,7 @@ describe("Internal API", () => {
           .from(userProviderConnections)
           .where(
             and(
-              eq(userProviderConnections.profileId, profileId),
+              eq(userProviderConnections.connectionProfileId, connectionProfileId),
               eq(userProviderConnections.providerId, providerId),
             ),
           )

--- a/apps/api/test/integration/routes/me.test.ts
+++ b/apps/api/test/integration/routes/me.test.ts
@@ -190,8 +190,8 @@ describe("Me API (/api/me)", () => {
         headers: authHeaders(ctx),
       });
       expect(res.status).toBe(200);
-      const body = (await res.json()) as { profileId: string | null };
-      expect(body.profileId).toBeNull();
+      const body = (await res.json()) as { connectionProfileId: string | null };
+      expect(body.connectionProfileId).toBeNull();
     });
 
     it("PUT pins a profile owned by the caller and round-trips on GET", async () => {
@@ -205,15 +205,15 @@ describe("Me API (/api/me)", () => {
       const putRes = await app.request("/api/me/application-profile", {
         method: "PUT",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ profileId: profile.id }),
+        body: JSON.stringify({ connectionProfileId: profile.id }),
       });
       expect(putRes.status).toBe(200);
 
       const getRes = await app.request("/api/me/application-profile", {
         headers: authHeaders(ctx),
       });
-      const body = (await getRes.json()) as { profileId: string | null };
-      expect(body.profileId).toBe(profile.id);
+      const body = (await getRes.json()) as { connectionProfileId: string | null };
+      expect(body.connectionProfileId).toBe(profile.id);
     });
 
     it("PUT accepts an app profile of the same application", async () => {
@@ -226,7 +226,7 @@ describe("Me API (/api/me)", () => {
       const res = await app.request("/api/me/application-profile", {
         method: "PUT",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ profileId: appProfile.id }),
+        body: JSON.stringify({ connectionProfileId: appProfile.id }),
       });
       expect(res.status).toBe(200);
     });
@@ -242,7 +242,7 @@ describe("Me API (/api/me)", () => {
       const res = await app.request("/api/me/application-profile", {
         method: "PUT",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ profileId: otherProfile.id }),
+        body: JSON.stringify({ connectionProfileId: otherProfile.id }),
       });
       expect(res.status).toBe(400);
     });
@@ -257,7 +257,7 @@ describe("Me API (/api/me)", () => {
       await app.request("/api/me/application-profile", {
         method: "PUT",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ profileId: profile.id }),
+        body: JSON.stringify({ connectionProfileId: profile.id }),
       });
       const del1 = await app.request("/api/me/application-profile", {
         method: "DELETE",
@@ -273,8 +273,8 @@ describe("Me API (/api/me)", () => {
       const getRes = await app.request("/api/me/application-profile", {
         headers: authHeaders(ctx),
       });
-      const body = (await getRes.json()) as { profileId: string | null };
-      expect(body.profileId).toBeNull();
+      const body = (await getRes.json()) as { connectionProfileId: string | null };
+      expect(body.connectionProfileId).toBeNull();
     });
   });
 });

--- a/apps/api/test/integration/routes/providers.test.ts
+++ b/apps/api/test/integration/routes/providers.test.ts
@@ -402,7 +402,7 @@ describe("Providers API", () => {
       });
 
       await seedUserConnection({
-        profileId: profile.id,
+        connectionProfileId: profile.id,
         providerId,
         orgId: ctx.orgId,
         providerCredentialId: cred.id,

--- a/apps/api/test/integration/routes/schedules.test.ts
+++ b/apps/api/test/integration/routes/schedules.test.ts
@@ -11,13 +11,13 @@ const app = getTestApp();
 
 describe("Schedules API", () => {
   let ctx: TestContext;
-  let profileId: string;
+  let connectionProfileId: string;
 
   beforeEach(async () => {
     await truncateAll();
     ctx = await createTestContext();
     const profile = await seedConnectionProfile({ userId: ctx.user.id, name: "Default" });
-    profileId = profile.id;
+    connectionProfileId = profile.id;
   });
 
   function agentId(name: string) {
@@ -43,7 +43,7 @@ describe("Schedules API", () => {
         packageId: agent.id,
         orgId: ctx.orgId,
         applicationId: ctx.defaultAppId,
-        connectionProfileId: profileId,
+        connectionProfileId: connectionProfileId,
         cronExpression: "0 * * * *",
         name: "Hourly",
       });
@@ -96,7 +96,7 @@ describe("Schedules API", () => {
         method: "POST",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
         body: JSON.stringify({
-          connectionProfileId: profileId,
+          connectionProfileId: connectionProfileId,
           cronExpression: "0 9 * * 1-5",
           input: { note: "hello" },
         }),
@@ -115,7 +115,7 @@ describe("Schedules API", () => {
         method: "POST",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
         body: JSON.stringify({
-          connectionProfileId: profileId,
+          connectionProfileId: connectionProfileId,
           cronExpression: "0 9 * * 1-5",
         }),
       });
@@ -131,7 +131,7 @@ describe("Schedules API", () => {
         method: "POST",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
         body: JSON.stringify({
-          connectionProfileId: profileId,
+          connectionProfileId: connectionProfileId,
           cronExpression: "0 9 * * 1-5",
           input: { email: "" },
         }),
@@ -148,7 +148,7 @@ describe("Schedules API", () => {
         method: "POST",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
         body: JSON.stringify({
-          connectionProfileId: profileId,
+          connectionProfileId: connectionProfileId,
           cronExpression: "0 9 * * 1-5",
           input: { email: "test@example.com" },
         }),
@@ -168,7 +168,7 @@ describe("Schedules API", () => {
         method: "POST",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
         body: JSON.stringify({
-          connectionProfileId: profileId,
+          connectionProfileId: connectionProfileId,
           cronExpression: "0 9 * * 1-5",
           name: "Weekday 9am",
           timezone: "Europe/Paris",
@@ -190,7 +190,7 @@ describe("Schedules API", () => {
       const res = await app.request(`/api/agents/${fid}/schedules`, {
         method: "POST",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ connectionProfileId: profileId, cronExpression: "not-valid-cron" }),
+        body: JSON.stringify({ connectionProfileId: connectionProfileId, cronExpression: "not-valid-cron" }),
       });
 
       expect(res.status).toBe(400);
@@ -205,7 +205,7 @@ describe("Schedules API", () => {
         packageId: agent.id,
         orgId: ctx.orgId,
         applicationId: ctx.defaultAppId,
-        connectionProfileId: profileId,
+        connectionProfileId: connectionProfileId,
         cronExpression: "0 * * * *",
         name: "Old Name",
       });
@@ -231,7 +231,7 @@ describe("Schedules API", () => {
         packageId: agent.id,
         orgId: ctx.orgId,
         applicationId: ctx.defaultAppId,
-        connectionProfileId: profileId,
+        connectionProfileId: connectionProfileId,
         cronExpression: "0 * * * *",
       });
 
@@ -252,7 +252,7 @@ describe("Schedules API", () => {
         packageId: agent.id,
         orgId: ctx.orgId,
         applicationId: ctx.defaultAppId,
-        connectionProfileId: profileId,
+        connectionProfileId: connectionProfileId,
         cronExpression: "0 * * * *",
         name: "Hourly Run",
       });
@@ -307,7 +307,7 @@ describe("Schedules API", () => {
         packageId: agent.id,
         orgId: ctx.orgId,
         applicationId: ctx.defaultAppId,
-        connectionProfileId: profileId,
+        connectionProfileId: connectionProfileId,
         cronExpression: "0 * * * *",
       });
 
@@ -340,7 +340,7 @@ describe("Schedules API", () => {
         packageId: agent.id,
         orgId: ctx.orgId,
         applicationId: ctx.defaultAppId,
-        connectionProfileId: profileId,
+        connectionProfileId: connectionProfileId,
         cronExpression: "0 * * * *",
       });
 
@@ -392,7 +392,7 @@ describe("Schedules API", () => {
         packageId: agent.id,
         orgId: ctx.orgId,
         applicationId: ctx.defaultAppId,
-        connectionProfileId: profileId,
+        connectionProfileId: connectionProfileId,
         cronExpression: "0 * * * *",
       });
 

--- a/apps/api/test/integration/services/app-connection-scoping.test.ts
+++ b/apps/api/test/integration/services/app-connection-scoping.test.ts
@@ -26,7 +26,7 @@ const app = getTestApp();
 
 describe("Application-scoped connection isolation", () => {
   let ctx: TestContext;
-  let profileId: string;
+  let connectionProfileId: string;
   let appAId: string;
   let appBId: string;
   const providerId = "@system/gmail";
@@ -46,7 +46,7 @@ describe("Application-scoped connection isolation", () => {
       name: "Default",
       isDefault: true,
     });
-    profileId = profile.id;
+    connectionProfileId = profile.id;
 
     // Ensure provider package exists
     await seedPackage({ orgId: null, id: providerId, type: "provider", source: "system" }).catch(
@@ -59,23 +59,23 @@ describe("Application-scoped connection isolation", () => {
   describe("multi-app isolation", () => {
     it("connections created in app A are not visible from app B credentials", async () => {
       // Create connection in app A
-      await seedConnectionForApp(profileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
+      await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
 
       // Get app B's credential IDs — should not include app A's
       const credB = await seedProviderCredentials({ applicationId: appBId, providerId });
-      const result = await listConnections(db, profileId, ctx.orgId, [credB.id]);
+      const result = await listConnections(db, connectionProfileId, ctx.orgId, [credB.id]);
       expect(result).toHaveLength(0);
     });
 
     it("same provider can have separate connections per app", async () => {
-      await seedConnectionForApp(profileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
-      await seedConnectionForApp(profileId, providerId, ctx.orgId, appBId, { api_key: "key-b" });
+      await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
+      await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, appBId, { api_key: "key-b" });
 
       const credIdsA = await listProviderCredentialIds(db, appAId);
       const credIdsB = await listProviderCredentialIds(db, appBId);
 
-      const connA = await listConnections(db, profileId, ctx.orgId, credIdsA);
-      const connB = await listConnections(db, profileId, ctx.orgId, credIdsB);
+      const connA = await listConnections(db, connectionProfileId, ctx.orgId, credIdsA);
+      const connB = await listConnections(db, connectionProfileId, ctx.orgId, credIdsB);
 
       expect(connA).toHaveLength(1);
       expect(connB).toHaveLength(1);
@@ -87,9 +87,9 @@ describe("Application-scoped connection isolation", () => {
 
   describe("credential leak prevention", () => {
     it("GET /connections does NOT expose credentialsEncrypted", async () => {
-      await seedConnectionForApp(profileId, providerId, ctx.orgId, appAId, { api_key: "secret" });
+      await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, appAId, { api_key: "secret" });
 
-      const res = await app.request(`/api/connections?profileId=${profileId}`, {
+      const res = await app.request(`/api/connections?connectionProfileId=${connectionProfileId}`, {
         headers: authHeaders(ctx),
       });
       expect(res.status).toBe(200);
@@ -106,13 +106,13 @@ describe("Application-scoped connection isolation", () => {
     });
 
     it("GET /connection-profiles/:id/connections does NOT expose credentialsEncrypted", async () => {
-      await seedConnectionForApp(profileId, providerId, ctx.orgId, appAId, { api_key: "secret" });
+      await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, appAId, { api_key: "secret" });
 
       // This endpoint is not app-scoped (no X-Application-Id middleware), so returns empty.
       // When app-scoped, it should strip sensitive fields.
       // Test that the raw listConnections result never leaks credentials.
       const credentialIds = await listProviderCredentialIds(db, appAId);
-      const rawConns = await listConnections(db, profileId, ctx.orgId, credentialIds);
+      const rawConns = await listConnections(db, connectionProfileId, ctx.orgId, credentialIds);
       expect(rawConns).toHaveLength(1);
       // The raw ConnectionRecord HAS credentialsEncrypted — that's expected at the data layer
       expect(rawConns[0]!.credentialsEncrypted).toBeDefined();
@@ -124,9 +124,9 @@ describe("Application-scoped connection isolation", () => {
   describe("disconnect scoping", () => {
     it("disconnectConnectionById rejects connections from other apps", async () => {
       // Create connection in app A
-      await seedConnectionForApp(profileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
+      await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
       const credIdsA = await listProviderCredentialIds(db, appAId);
-      const connA = await listConnections(db, profileId, ctx.orgId, credIdsA);
+      const connA = await listConnections(db, connectionProfileId, ctx.orgId, credIdsA);
       const connId = connA[0]!.id;
 
       // Try to delete from app B context — should fail (connection not found in app B's scope)
@@ -139,9 +139,9 @@ describe("Application-scoped connection isolation", () => {
     });
 
     it("disconnectConnectionById succeeds for connections in the correct app", async () => {
-      await seedConnectionForApp(profileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
+      await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
       const credIdsA = await listProviderCredentialIds(db, appAId);
-      const connA = await listConnections(db, profileId, ctx.orgId, credIdsA);
+      const connA = await listConnections(db, connectionProfileId, ctx.orgId, credIdsA);
       const connId = connA[0]!.id;
 
       const res = await app.request(`/api/connections/${providerId}?connectionId=${connId}`, {
@@ -151,7 +151,7 @@ describe("Application-scoped connection isolation", () => {
       expect(res.status).toBe(200);
 
       // Verify connection is gone
-      const remaining = await listConnections(db, profileId, ctx.orgId, credIdsA);
+      const remaining = await listConnections(db, connectionProfileId, ctx.orgId, credIdsA);
       expect(remaining).toHaveLength(0);
     });
   });
@@ -160,12 +160,12 @@ describe("Application-scoped connection isolation", () => {
 
   describe("cascade delete", () => {
     it("deleting applicationProviderCredentials cascades to connections", async () => {
-      await seedConnectionForApp(profileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
+      await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
 
       // Verify connection exists
       const credIdsA = await listProviderCredentialIds(db, appAId);
       expect(credIdsA).toHaveLength(1);
-      const before = await listConnections(db, profileId, ctx.orgId, credIdsA);
+      const before = await listConnections(db, connectionProfileId, ctx.orgId, credIdsA);
       expect(before).toHaveLength(1);
 
       // Delete the application provider credentials
@@ -184,7 +184,7 @@ describe("Application-scoped connection isolation", () => {
         .from(userProviderConnections)
         .where(
           and(
-            eq(userProviderConnections.profileId, profileId),
+            eq(userProviderConnections.connectionProfileId, connectionProfileId),
             eq(userProviderConnections.providerId, providerId),
           ),
         );
@@ -192,8 +192,8 @@ describe("Application-scoped connection isolation", () => {
     });
 
     it("deleting app A credentials does not affect app B connections", async () => {
-      await seedConnectionForApp(profileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
-      await seedConnectionForApp(profileId, providerId, ctx.orgId, appBId, { api_key: "key-b" });
+      await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
+      await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, appBId, { api_key: "key-b" });
 
       // Delete app A credentials only
       await db
@@ -207,7 +207,7 @@ describe("Application-scoped connection isolation", () => {
 
       // App B connections should still exist
       const credIdsB = await listProviderCredentialIds(db, appBId);
-      const connB = await listConnections(db, profileId, ctx.orgId, credIdsB);
+      const connB = await listConnections(db, connectionProfileId, ctx.orgId, credIdsB);
       expect(connB).toHaveLength(1);
     });
   });
@@ -216,15 +216,15 @@ describe("Application-scoped connection isolation", () => {
 
   describe("token refresh per-app isolation", () => {
     it("updating connection credentials in app A does not affect app B", async () => {
-      await seedConnectionForApp(profileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
-      await seedConnectionForApp(profileId, providerId, ctx.orgId, appBId, { api_key: "key-b" });
+      await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
+      await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, appBId, { api_key: "key-b" });
 
       const credIdsA = await listProviderCredentialIds(db, appAId);
       const credIdsB = await listProviderCredentialIds(db, appBId);
 
       // Get both connections
-      const connA = await getConnection(db, profileId, providerId, ctx.orgId, credIdsA[0]!);
-      const connB = await getConnection(db, profileId, providerId, ctx.orgId, credIdsB[0]!);
+      const connA = await getConnection(db, connectionProfileId, providerId, ctx.orgId, credIdsA[0]!);
+      const connB = await getConnection(db, connectionProfileId, providerId, ctx.orgId, credIdsB[0]!);
       expect(connA).not.toBeNull();
       expect(connB).not.toBeNull();
 
@@ -235,7 +235,7 @@ describe("Application-scoped connection isolation", () => {
         .where(eq(userProviderConnections.id, connA!.id));
 
       // Verify App B's connection is untouched
-      const connBAfter = await getConnection(db, profileId, providerId, ctx.orgId, credIdsB[0]!);
+      const connBAfter = await getConnection(db, connectionProfileId, providerId, ctx.orgId, credIdsB[0]!);
       expect(connBAfter!.credentialsEncrypted).not.toBe("refreshed-token-app-a");
       expect(connBAfter!.credentialsEncrypted).toBe(connB!.credentialsEncrypted);
     });
@@ -245,8 +245,8 @@ describe("Application-scoped connection isolation", () => {
 
   describe("needsReconnection per-providerCredentialId", () => {
     it("flagging reconnection in app A does not affect app B", async () => {
-      await seedConnectionForApp(profileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
-      await seedConnectionForApp(profileId, providerId, ctx.orgId, appBId, { api_key: "key-b" });
+      await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, appAId, { api_key: "key-a" });
+      await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, appBId, { api_key: "key-b" });
 
       const credIdsA = await listProviderCredentialIds(db, appAId);
       const credIdsB = await listProviderCredentialIds(db, appBId);
@@ -257,18 +257,18 @@ describe("Application-scoped connection isolation", () => {
         .set({ needsReconnection: true, updatedAt: new Date() })
         .where(
           and(
-            eq(userProviderConnections.profileId, profileId),
+            eq(userProviderConnections.connectionProfileId, connectionProfileId),
             eq(userProviderConnections.providerId, providerId),
             eq(userProviderConnections.providerCredentialId, credIdsA[0]!),
           ),
         );
 
       // App A connection should need reconnection
-      const connA = await getConnection(db, profileId, providerId, ctx.orgId, credIdsA[0]!);
+      const connA = await getConnection(db, connectionProfileId, providerId, ctx.orgId, credIdsA[0]!);
       expect(connA!.needsReconnection).toBe(true);
 
       // App B connection should NOT need reconnection
-      const connB = await getConnection(db, profileId, providerId, ctx.orgId, credIdsB[0]!);
+      const connB = await getConnection(db, connectionProfileId, providerId, ctx.orgId, credIdsB[0]!);
       expect(connB!.needsReconnection).toBe(false);
     });
   });

--- a/apps/api/test/integration/services/app-profile-bindings.test.ts
+++ b/apps/api/test/integration/services/app-profile-bindings.test.ts
@@ -133,7 +133,7 @@ describe("app-profile-bindings", () => {
         .set({ needsReconnection: true, updatedAt: new Date() })
         .where(
           and(
-            eq(userProviderConnections.profileId, userProfileId),
+            eq(userProviderConnections.connectionProfileId, userProfileId),
             eq(userProviderConnections.providerId, "@test/gmail"),
             eq(userProviderConnections.providerCredentialId, credB!.id),
           ),

--- a/apps/api/test/integration/services/available-providers.test.ts
+++ b/apps/api/test/integration/services/available-providers.test.ts
@@ -24,7 +24,7 @@ describe("getAvailableProvidersWithStatus", () => {
   let orgId: string;
   let app1Id: string;
   let app2Id: string;
-  let profileId: string;
+  let connectionProfileId: string;
 
   /** Seed a system provider package with api_key auth mode. */
   async function seedSystemProvider(id: string) {
@@ -55,7 +55,7 @@ describe("getAvailableProvidersWithStatus", () => {
     app2Id = app2.id;
 
     const profile = await seedConnectionProfile({ userId, name: "Default", isDefault: true });
-    profileId = profile.id;
+    connectionProfileId = profile.id;
   });
 
   it("includes provider when app has enabled credentials configured", async () => {
@@ -65,7 +65,7 @@ describe("getAvailableProvidersWithStatus", () => {
 
     const result = await getAvailableProvidersWithStatus(
       { orgId: orgId, applicationId: app1Id },
-      profileId,
+      connectionProfileId,
     );
     const providerIds = result.map((p) => p.provider);
     expect(providerIds).toContain(providerId);
@@ -81,7 +81,7 @@ describe("getAvailableProvidersWithStatus", () => {
     // App2 has no credentials — provider should not appear
     const result = await getAvailableProvidersWithStatus(
       { orgId: orgId, applicationId: app2Id },
-      profileId,
+      connectionProfileId,
     );
     const providerIds = result.map((p) => p.provider);
     expect(providerIds).not.toContain(providerId);
@@ -90,11 +90,11 @@ describe("getAvailableProvidersWithStatus", () => {
   it("shows connected status when user has a connection for the app", async () => {
     const providerId = "@system/clickup";
     await seedSystemProvider(providerId);
-    await seedConnectionForApp(profileId, providerId, orgId, app1Id, { api_key: "ck1" });
+    await seedConnectionForApp(connectionProfileId, providerId, orgId, app1Id, { api_key: "ck1" });
 
     const result = await getAvailableProvidersWithStatus(
       { orgId: orgId, applicationId: app1Id },
-      profileId,
+      connectionProfileId,
     );
     const provider = result.find((p) => p.provider === providerId);
     expect(provider).toBeDefined();
@@ -108,7 +108,7 @@ describe("getAvailableProvidersWithStatus", () => {
 
     const result = await getAvailableProvidersWithStatus(
       { orgId: orgId, applicationId: app1Id },
-      profileId,
+      connectionProfileId,
     );
     const provider = result.find((p) => p.provider === providerId);
     expect(provider).toBeDefined();

--- a/apps/api/test/integration/services/cascade-deletion.test.ts
+++ b/apps/api/test/integration/services/cascade-deletion.test.ts
@@ -85,16 +85,16 @@ describe("Cascade Deletion", () => {
       // Verify override exists
       await assertDbHas(
         userAgentProviderProfiles,
-        eq(userAgentProviderProfiles.profileId, userProfile.id),
+        eq(userAgentProviderProfiles.connectionProfileId, userProfile.id),
       );
 
       // Delete the profile
       await db.delete(connectionProfiles).where(eq(connectionProfiles.id, userProfile.id));
 
-      // Override should be gone via FK CASCADE on profileId
+      // Override should be gone via FK CASCADE on connectionProfileId
       await assertDbMissing(
         userAgentProviderProfiles,
-        eq(userAgentProviderProfiles.profileId, userProfile.id),
+        eq(userAgentProviderProfiles.connectionProfileId, userProfile.id),
       );
     });
   });

--- a/apps/api/test/integration/services/connection-manager.test.ts
+++ b/apps/api/test/integration/services/connection-manager.test.ts
@@ -24,7 +24,7 @@ import type { Actor } from "../../../src/lib/actor.ts";
 
 /** Insert a raw connection row for a profile + provider + org. */
 async function seedConnection(
-  profileId: string,
+  connectionProfileId: string,
   providerId: string,
   orgId: string,
   applicationId: string,
@@ -38,7 +38,7 @@ async function seedConnection(
   const [row] = await db
     .insert(userProviderConnections)
     .values({
-      profileId,
+      connectionProfileId,
       providerId: pkgId,
       orgId,
       providerCredentialId: cred.id,
@@ -55,7 +55,7 @@ async function seedConnection(
 describe("connection-manager", () => {
   let userId: string;
   let orgId: string;
-  let profileId: string;
+  let connectionProfileId: string;
   let applicationId: string;
 
   beforeEach(async () => {
@@ -67,7 +67,7 @@ describe("connection-manager", () => {
     applicationId = defaultAppId;
 
     const profile = await seedConnectionProfile({ userId, name: "Default", isDefault: true });
-    profileId = profile.id;
+    connectionProfileId = profile.id;
   });
 
   // ── authModeLabel ─────────────────────────────────────
@@ -124,13 +124,13 @@ describe("connection-manager", () => {
         { orgId, applicationId },
         "@system/test-provider",
         "sk-test-key-12345",
-        profileId,
+        connectionProfileId,
       );
 
       const rows = await db
         .select()
         .from(userProviderConnections)
-        .where(eq(userProviderConnections.profileId, profileId));
+        .where(eq(userProviderConnections.connectionProfileId, connectionProfileId));
 
       expect(rows).toHaveLength(1);
       expect(rows[0]!.providerId).toBe("@system/test-provider");
@@ -171,19 +171,19 @@ describe("connection-manager", () => {
         { orgId, applicationId },
         "@system/test-provider",
         "key-v1",
-        profileId,
+        connectionProfileId,
       );
       await saveApiKeyConnection(
         { orgId, applicationId },
         "@system/test-provider",
         "key-v2",
-        profileId,
+        connectionProfileId,
       );
 
       const rows = await db
         .select()
         .from(userProviderConnections)
-        .where(eq(userProviderConnections.profileId, profileId));
+        .where(eq(userProviderConnections.connectionProfileId, connectionProfileId));
 
       expect(rows).toHaveLength(1);
 
@@ -208,13 +208,13 @@ describe("connection-manager", () => {
         "@system/basic-provider",
         "basic",
         { username: "admin", password: "secret123" },
-        profileId,
+        connectionProfileId,
       );
 
       const rows = await db
         .select()
         .from(userProviderConnections)
-        .where(eq(userProviderConnections.profileId, profileId));
+        .where(eq(userProviderConnections.connectionProfileId, connectionProfileId));
 
       expect(rows).toHaveLength(1);
       expect(rows[0]!.providerId).toBe("@system/basic-provider");
@@ -237,13 +237,13 @@ describe("connection-manager", () => {
         "@system/custom-provider",
         "custom",
         { token: "abc", workspace_id: "ws-1" },
-        profileId,
+        connectionProfileId,
       );
 
       const rows = await db
         .select()
         .from(userProviderConnections)
-        .where(eq(userProviderConnections.profileId, profileId));
+        .where(eq(userProviderConnections.connectionProfileId, connectionProfileId));
 
       expect(rows).toHaveLength(1);
 
@@ -257,12 +257,12 @@ describe("connection-manager", () => {
 
   describe("listActorConnections", () => {
     it("returns connections for a profile", async () => {
-      await seedConnection(profileId, "gmail", orgId, applicationId);
-      await seedConnection(profileId, "clickup", orgId, applicationId);
+      await seedConnection(connectionProfileId, "gmail", orgId, applicationId);
+      await seedConnection(connectionProfileId, "clickup", orgId, applicationId);
 
       const connections = await listActorConnections(
         { orgId: orgId, applicationId: applicationId },
-        profileId,
+        connectionProfileId,
       );
 
       expect(connections).toHaveLength(2);
@@ -280,7 +280,7 @@ describe("connection-manager", () => {
     it("returns empty array for a profile with no connections", async () => {
       const connections = await listActorConnections(
         { orgId: orgId, applicationId: applicationId },
-        profileId,
+        connectionProfileId,
       );
       expect(connections).toBeArray();
       expect(connections).toHaveLength(0);
@@ -297,7 +297,7 @@ describe("connection-manager", () => {
 
       const connections = await listActorConnections(
         { orgId: orgId, applicationId: applicationId },
-        profileId,
+        connectionProfileId,
       );
       expect(connections).toHaveLength(0);
     });
@@ -308,11 +308,11 @@ describe("connection-manager", () => {
         slug: "otherorg",
       });
 
-      await seedConnection(profileId, "gmail", otherOrg.id, otherAppId);
+      await seedConnection(connectionProfileId, "gmail", otherOrg.id, otherAppId);
 
       const connections = await listActorConnections(
         { orgId: orgId, applicationId: applicationId },
-        profileId,
+        connectionProfileId,
       );
       expect(connections).toHaveLength(0);
     });
@@ -322,14 +322,14 @@ describe("connection-manager", () => {
 
   describe("disconnectProvider", () => {
     it("removes connection for the given provider", async () => {
-      const gmail = await seedConnection(profileId, "gmail", orgId, applicationId);
-      await seedConnection(profileId, "clickup", orgId, applicationId);
+      const gmail = await seedConnection(connectionProfileId, "gmail", orgId, applicationId);
+      await seedConnection(connectionProfileId, "clickup", orgId, applicationId);
 
-      await disconnectProvider({ orgId: orgId }, "@system/gmail", profileId, gmail.credentialId);
+      await disconnectProvider({ orgId: orgId }, "@system/gmail", connectionProfileId, gmail.credentialId);
 
       const connections = await listActorConnections(
         { orgId: orgId, applicationId: applicationId },
-        profileId,
+        connectionProfileId,
       );
       expect(connections).toHaveLength(1);
       expect(connections[0]!.provider).toBe("@system/clickup");
@@ -339,13 +339,13 @@ describe("connection-manager", () => {
       await disconnectProvider(
         { orgId: orgId },
         "nonexistent",
-        profileId,
+        connectionProfileId,
         "00000000-0000-0000-0000-000000000000",
       );
 
       const connections = await listActorConnections(
         { orgId: orgId, applicationId: applicationId },
-        profileId,
+        connectionProfileId,
       );
       expect(connections).toHaveLength(0);
     });
@@ -355,22 +355,22 @@ describe("connection-manager", () => {
 
   describe("disconnectConnectionById", () => {
     it("removes a specific connection by ID", async () => {
-      const { connectionId } = await seedConnection(profileId, "gmail", orgId, applicationId);
-      await seedConnection(profileId, "clickup", orgId, applicationId);
+      const { connectionId } = await seedConnection(connectionProfileId, "gmail", orgId, applicationId);
+      await seedConnection(connectionProfileId, "clickup", orgId, applicationId);
 
       const actor: Actor = { type: "user", id: userId };
       await disconnectConnectionById({ orgId, applicationId: applicationId }, connectionId, actor);
 
       const connections = await listActorConnections(
         { orgId: orgId, applicationId: applicationId },
-        profileId,
+        connectionProfileId,
       );
       expect(connections).toHaveLength(1);
       expect(connections[0]!.provider).toBe("@system/clickup");
     });
 
     it("throws when connection does not belong to the actor", async () => {
-      const { connectionId } = await seedConnection(profileId, "gmail", orgId, applicationId);
+      const { connectionId } = await seedConnection(connectionProfileId, "gmail", orgId, applicationId);
 
       const otherUser = await createTestUser({ email: "hacker@test.com" });
       const actor: Actor = { type: "user", id: otherUser.id };
@@ -397,8 +397,8 @@ describe("connection-manager", () => {
       // Create a second profile for the same user
       const profile2 = await seedConnectionProfile({ userId, name: "Profile 2" });
 
-      await seedConnection(profileId, "gmail", orgId, applicationId);
-      await seedConnection(profileId, "clickup", orgId, applicationId);
+      await seedConnection(connectionProfileId, "gmail", orgId, applicationId);
+      await seedConnection(connectionProfileId, "clickup", orgId, applicationId);
       await seedConnection(profile2.id, "slack", orgId, applicationId);
 
       const actor: Actor = { type: "user", id: userId };
@@ -406,7 +406,7 @@ describe("connection-manager", () => {
 
       const conn1 = await listActorConnections(
         { orgId: orgId, applicationId: applicationId },
-        profileId,
+        connectionProfileId,
       );
       const conn2 = await listActorConnections({ orgId, applicationId }, profile2.id);
 
@@ -424,7 +424,7 @@ describe("connection-manager", () => {
         name: "Keep Profile",
       });
 
-      await seedConnection(profileId, "gmail", orgId, applicationId);
+      await seedConnection(connectionProfileId, "gmail", orgId, applicationId);
       await seedConnection(otherProfile.id, "clickup", otherOrg.id, otherAppId);
 
       const actor: Actor = { type: "user", id: userId };
@@ -433,7 +433,7 @@ describe("connection-manager", () => {
       // Actor's connections are gone
       const actorConns = await listActorConnections(
         { orgId: orgId, applicationId: applicationId },
-        profileId,
+        connectionProfileId,
       );
       expect(actorConns).toHaveLength(0);
 
@@ -468,14 +468,14 @@ describe("connection-manager", () => {
       const app2Id = app2!.id;
 
       // Connect the same provider in both apps (different credentials)
-      await seedConnection(profileId, "gmail", orgId, applicationId);
-      await seedConnection(profileId, "clickup", orgId, applicationId);
-      await seedConnection(profileId, "gmail", orgId, app2Id);
+      await seedConnection(connectionProfileId, "gmail", orgId, applicationId);
+      await seedConnection(connectionProfileId, "clickup", orgId, applicationId);
+      await seedConnection(connectionProfileId, "gmail", orgId, app2Id);
 
       // App 1 should only see its own connections
       const app1Conns = await listActorConnections(
         { orgId: orgId, applicationId: applicationId },
-        profileId,
+        connectionProfileId,
       );
       expect(app1Conns).toHaveLength(2);
       expect(app1Conns.map((c) => c.provider)).toContain("@system/gmail");
@@ -484,7 +484,7 @@ describe("connection-manager", () => {
       // App 2 should only see its own connection
       const app2Conns = await listActorConnections(
         { orgId: orgId, applicationId: app2Id },
-        profileId,
+        connectionProfileId,
       );
       expect(app2Conns).toHaveLength(1);
       expect(app2Conns[0]!.provider).toBe("@system/gmail");
@@ -498,23 +498,23 @@ describe("connection-manager", () => {
         .returning();
       const app2Id = app2!.id;
 
-      const conn1 = await seedConnection(profileId, "gmail", orgId, applicationId);
-      await seedConnection(profileId, "gmail", orgId, app2Id);
+      const conn1 = await seedConnection(connectionProfileId, "gmail", orgId, applicationId);
+      await seedConnection(connectionProfileId, "gmail", orgId, app2Id);
 
       // Disconnect gmail from app 1 only
-      await disconnectProvider({ orgId: orgId }, "@system/gmail", profileId, conn1.credentialId);
+      await disconnectProvider({ orgId: orgId }, "@system/gmail", connectionProfileId, conn1.credentialId);
 
       // App 1: no connections
       const app1Conns = await listActorConnections(
         { orgId: orgId, applicationId: applicationId },
-        profileId,
+        connectionProfileId,
       );
       expect(app1Conns).toHaveLength(0);
 
       // App 2: still has gmail
       const app2Conns = await listActorConnections(
         { orgId: orgId, applicationId: app2Id },
-        profileId,
+        connectionProfileId,
       );
       expect(app2Conns).toHaveLength(1);
       expect(app2Conns[0]!.provider).toBe("@system/gmail");

--- a/apps/api/test/integration/services/connections.test.ts
+++ b/apps/api/test/integration/services/connections.test.ts
@@ -19,7 +19,7 @@ describe("listConnections filtering", () => {
   let userId: string;
   let orgId: string;
   let applicationId: string;
-  let profileId: string;
+  let connectionProfileId: string;
 
   beforeEach(async () => {
     await truncateAll();
@@ -30,15 +30,15 @@ describe("listConnections filtering", () => {
     applicationId = defaultAppId;
 
     const profile = await seedConnectionProfile({ userId, name: "Default", isDefault: true });
-    profileId = profile.id;
+    connectionProfileId = profile.id;
   });
 
   it("returns empty array when providerCredentialIds is empty", async () => {
     // Even if connections exist, passing [] should return nothing
     const providerId = "@system/gmail";
-    await seedConnectionForApp(profileId, providerId, orgId, applicationId, { api_key: "k1" });
+    await seedConnectionForApp(connectionProfileId, providerId, orgId, applicationId, { api_key: "k1" });
 
-    const result = await listConnections(db, profileId, orgId, []);
+    const result = await listConnections(db, connectionProfileId, orgId, []);
     expect(result).toEqual([]);
   });
 
@@ -47,13 +47,13 @@ describe("listConnections filtering", () => {
     const providerA = "@system/gmail";
     const providerB = "@system/clickup";
 
-    await seedConnectionForApp(profileId, providerA, orgId, applicationId, { api_key: "ka" });
-    await seedConnectionForApp(profileId, providerB, orgId, applicationId, { api_key: "kb" });
+    await seedConnectionForApp(connectionProfileId, providerA, orgId, applicationId, { api_key: "ka" });
+    await seedConnectionForApp(connectionProfileId, providerB, orgId, applicationId, { api_key: "kb" });
 
     // Get credential ID for provider A only
     const credA = await seedProviderCredentials({ applicationId: applicationId, providerId: providerA });
 
-    const result = await listConnections(db, profileId, orgId, [credA.id]);
+    const result = await listConnections(db, connectionProfileId, orgId, [credA.id]);
     expect(result).toHaveLength(1);
     expect(result[0]!.providerId).toBe(providerA);
   });
@@ -62,14 +62,14 @@ describe("listConnections filtering", () => {
     const providerId = "@system/gmail";
 
     // Create connection in app A
-    await seedConnectionForApp(profileId, providerId, orgId, applicationId, { api_key: "ka" });
+    await seedConnectionForApp(connectionProfileId, providerId, orgId, applicationId, { api_key: "ka" });
 
     // Create a second application and seed credentials there
     const appB = await seedApplication({ orgId, name: "AppB" });
     const credB = await seedProviderCredentials({ applicationId: appB.id, providerId });
 
     // Query using only appB's credential ID — should not see appA's connection
-    const result = await listConnections(db, profileId, orgId, [credB.id]);
+    const result = await listConnections(db, connectionProfileId, orgId, [credB.id]);
     expect(result).toHaveLength(0);
   });
 });

--- a/apps/api/test/integration/services/credential-proxy-injection.test.ts
+++ b/apps/api/test/integration/services/credential-proxy-injection.test.ts
@@ -28,7 +28,7 @@ import { proxyCall } from "../../../src/services/credential-proxy/core.ts";
 
 describe("proxyCall — server-side credential injection", () => {
   let ctx: TestContext;
-  let profileId: string;
+  let connectionProfileId: string;
 
   beforeEach(async () => {
     await truncateAll();
@@ -38,7 +38,7 @@ describe("proxyCall — server-side credential injection", () => {
       name: "Default",
       isDefault: true,
     });
-    profileId = profile.id;
+    connectionProfileId = profile.id;
   });
 
   it("injects Authorization: Bearer <token> for an OAuth2 provider", async () => {
@@ -60,7 +60,7 @@ describe("proxyCall — server-side credential injection", () => {
         },
       },
     });
-    await seedConnectionForApp(profileId, providerId, ctx.orgId, ctx.defaultAppId, {
+    await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, ctx.defaultAppId, {
       access_token: "ya29.live-oauth-token",
     });
 
@@ -82,7 +82,7 @@ describe("proxyCall — server-side credential injection", () => {
     const res = await proxyCall(db, {
       applicationId: ctx.defaultAppId,
       orgId: ctx.orgId,
-      profileId,
+      connectionProfileId,
       providerId,
       method: "GET",
       target: "https://gmail.googleapis.com/gmail/v1/users/me/messages",
@@ -114,7 +114,7 @@ describe("proxyCall — server-side credential injection", () => {
         },
       },
     });
-    await seedConnectionForApp(profileId, providerId, ctx.orgId, ctx.defaultAppId, {
+    await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, ctx.defaultAppId, {
       api_key: "sk_live_abc",
     });
 
@@ -130,7 +130,7 @@ describe("proxyCall — server-side credential injection", () => {
     const res = await proxyCall(db, {
       applicationId: ctx.defaultAppId,
       orgId: ctx.orgId,
-      profileId,
+      connectionProfileId,
       providerId,
       method: "GET",
       target: "https://api.example.com/resource",
@@ -165,7 +165,7 @@ describe("proxyCall — server-side credential injection", () => {
         },
       },
     });
-    await seedConnectionForApp(profileId, providerId, ctx.orgId, ctx.defaultAppId, {
+    await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, ctx.defaultAppId, {
       username: "admin",
       password: "s3cret",
     });
@@ -182,7 +182,7 @@ describe("proxyCall — server-side credential injection", () => {
     await proxyCall(db, {
       applicationId: ctx.defaultAppId,
       orgId: ctx.orgId,
-      profileId,
+      connectionProfileId,
       providerId,
       method: "GET",
       target: "https://api.example.com/thing",
@@ -217,7 +217,7 @@ describe("proxyCall — server-side credential injection", () => {
         },
       },
     });
-    await seedConnectionForApp(profileId, providerId, ctx.orgId, ctx.defaultAppId, {
+    await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, ctx.defaultAppId, {
       api_key: "platform-pinned-key",
     });
 
@@ -233,7 +233,7 @@ describe("proxyCall — server-side credential injection", () => {
     await proxyCall(db, {
       applicationId: ctx.defaultAppId,
       orgId: ctx.orgId,
-      profileId,
+      connectionProfileId,
       providerId,
       method: "GET",
       target: "https://api.example.com/thing",

--- a/apps/api/test/integration/services/credential-proxy-refresh.test.ts
+++ b/apps/api/test/integration/services/credential-proxy-refresh.test.ts
@@ -54,7 +54,7 @@ afterAll(() => {
 
 describe("proxyCall — 401 refresh-retry on buffered bodies", () => {
   let ctx: TestContext;
-  let profileId: string;
+  let connectionProfileId: string;
 
   beforeEach(async () => {
     await truncateAll();
@@ -66,7 +66,7 @@ describe("proxyCall — 401 refresh-retry on buffered bodies", () => {
       name: "Default",
       isDefault: true,
     });
-    profileId = profile.id;
+    connectionProfileId = profile.id;
   });
 
   it("refreshes the OAuth2 token and retries the call when upstream returns 401", async () => {
@@ -98,7 +98,7 @@ describe("proxyCall — 401 refresh-retry on buffered bodies", () => {
     // creates the admin credentials row with a dummy ciphertext — replace
     // it with real clientId/clientSecret so the OAuth2 refresh path can
     // build its RefreshContext.
-    await seedConnectionForApp(profileId, providerId, ctx.orgId, ctx.defaultAppId, {
+    await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, ctx.defaultAppId, {
       access_token: "stale_token",
       refresh_token: "rt_valid",
     });
@@ -136,7 +136,7 @@ describe("proxyCall — 401 refresh-retry on buffered bodies", () => {
     const res = await proxyCall(db, {
       applicationId: ctx.defaultAppId,
       orgId: ctx.orgId,
-      profileId,
+      connectionProfileId,
       providerId,
       method: "GET",
       target: "https://gmail.googleapis.com/gmail/v1/users/me/messages",
@@ -182,7 +182,7 @@ describe("proxyCall — 401 refresh-retry on buffered bodies", () => {
       },
     });
 
-    await seedConnectionForApp(profileId, providerId, ctx.orgId, ctx.defaultAppId, {
+    await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, ctx.defaultAppId, {
       access_token: "stale_token",
       refresh_token: "rt_revoked",
     });
@@ -206,7 +206,7 @@ describe("proxyCall — 401 refresh-retry on buffered bodies", () => {
     const res = await proxyCall(db, {
       applicationId: ctx.defaultAppId,
       orgId: ctx.orgId,
-      profileId,
+      connectionProfileId,
       providerId,
       method: "GET",
       target: "https://gmail.googleapis.com/gmail/v1/users/me/messages",
@@ -244,7 +244,7 @@ describe("proxyCall — 401 refresh-retry on buffered bodies", () => {
       },
     });
 
-    await seedConnectionForApp(profileId, providerId, ctx.orgId, ctx.defaultAppId, {
+    await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, ctx.defaultAppId, {
       access_token: "valid_token",
       refresh_token: "rt_valid",
     });
@@ -264,7 +264,7 @@ describe("proxyCall — 401 refresh-retry on buffered bodies", () => {
     const res = await proxyCall(db, {
       applicationId: ctx.defaultAppId,
       orgId: ctx.orgId,
-      profileId,
+      connectionProfileId,
       providerId,
       method: "GET",
       target: "https://gmail.googleapis.com/gmail/v1/users/me/messages",
@@ -303,7 +303,7 @@ describe("proxyCall — 401 refresh-retry on buffered bodies", () => {
       },
     });
 
-    await seedConnectionForApp(profileId, providerId, ctx.orgId, ctx.defaultAppId, {
+    await seedConnectionForApp(connectionProfileId, providerId, ctx.orgId, ctx.defaultAppId, {
       access_token: "stale_token",
       refresh_token: "rt_valid",
     });
@@ -336,7 +336,7 @@ describe("proxyCall — 401 refresh-retry on buffered bodies", () => {
     const res = await proxyCall(db, {
       applicationId: ctx.defaultAppId,
       orgId: ctx.orgId,
-      profileId,
+      connectionProfileId,
       providerId,
       method: "POST",
       target: "https://gmail.googleapis.com/gmail/v1/users/me/messages",

--- a/apps/api/test/integration/services/oauth-flows.test.ts
+++ b/apps/api/test/integration/services/oauth-flows.test.ts
@@ -88,7 +88,7 @@ describe("OAuth2 flows", () => {
   let userId: string;
   let orgId: string;
   let applicationId: string;
-  let profileId: string;
+  let connectionProfileId: string;
   let actor: Actor;
 
   const PROVIDER_ID = "@testorg/test-oauth-provider";
@@ -114,7 +114,7 @@ describe("OAuth2 flows", () => {
     actor = { type: "user", id: userId };
 
     const profile = await seedConnectionProfile({ userId, name: "Default", isDefault: true });
-    profileId = profile.id;
+    connectionProfileId = profile.id;
 
     await seedOAuth2Provider(orgId, PROVIDER_ID);
     await seedProviderCredentialsForApp(PROVIDER_ID, applicationId, {
@@ -131,7 +131,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       expect(result.authUrl).toBeString();
@@ -150,7 +150,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       const url = new URL(result.authUrl);
@@ -163,7 +163,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       const url = new URL(result.authUrl);
@@ -177,7 +177,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
         ["admin", "read"],
       );
 
@@ -193,14 +193,14 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       const row = await oauthStateStore.get(result.state);
       expect(row).not.toBeNull();
       expect(row!.orgId).toBe(orgId);
       expect(row!.userId).toBe(userId);
-      expect(row!.profileId).toBe(profileId);
+      expect(row!.connectionProfileId).toBe(connectionProfileId);
       expect(row!.providerId).toBe(PROVIDER_ID);
       expect(row!.codeVerifier).toBeString();
       expect(row!.codeVerifier.length).toBeGreaterThan(10);
@@ -213,13 +213,13 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
       const r2 = await initiateConnection(
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       expect(r1.state).not.toBe(r2.state);
@@ -231,7 +231,7 @@ describe("OAuth2 flows", () => {
           { orgId: orgId, applicationId: applicationId },
           "@testorg/nonexistent",
           actor,
-          profileId,
+          connectionProfileId,
         ),
       ).rejects.toThrow("not found");
     });
@@ -245,7 +245,7 @@ describe("OAuth2 flows", () => {
           { orgId: orgId, applicationId: applicationId },
           "@testorg/no-creds-provider",
           actor,
-          profileId,
+          connectionProfileId,
         ),
       ).rejects.toThrow("No OAuth credentials configured");
     });
@@ -260,7 +260,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       // Step 2: Handle callback with a mock code
@@ -268,7 +268,7 @@ describe("OAuth2 flows", () => {
 
       expect(result.providerId).toBe(PROVIDER_ID);
       expect(result.orgId).toBe(orgId);
-      expect(result.profileId).toBe(profileId);
+      expect(result.connectionProfileId).toBe(connectionProfileId);
       expect(result.accessToken).toBe("mock_access_token_abc123");
       expect(result.refreshToken).toBe("mock_refresh_token_xyz789");
       expect(result.scopesGranted).toContain("read");
@@ -280,7 +280,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
       mockServer.clearRequests(); // Clear the initiate-phase requests
 
@@ -306,14 +306,14 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
       await handleCallback("mock-code", state);
 
       const rows = await db
         .select()
         .from(userProviderConnections)
-        .where(eq(userProviderConnections.profileId, profileId));
+        .where(eq(userProviderConnections.connectionProfileId, connectionProfileId));
 
       expect(rows).toHaveLength(1);
       const conn = rows[0]!;
@@ -334,7 +334,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
       await handleCallback("mock-code", state);
 
@@ -353,7 +353,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       // Evict from the store to simulate TTL expiry
@@ -370,7 +370,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       await expect(handleCallback("bad-code", state)).rejects.toThrow("Token exchange failed");
@@ -391,7 +391,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       let caught: unknown;
@@ -416,7 +416,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       let caught: unknown;
@@ -449,7 +449,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       let caught: unknown;
@@ -486,7 +486,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       // State row exists pre-callback.
@@ -512,7 +512,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       try {
@@ -534,7 +534,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       await expect(handleCallback("mock-code", state)).rejects.toThrow("No access_token");
@@ -551,7 +551,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
       const result = await handleCallback("mock-code", state);
 
@@ -572,7 +572,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
       const result = await handleCallback("mock-code", state);
 
@@ -596,14 +596,14 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
       await handleCallback("mock-code", state);
 
       const [conn] = await db
         .select()
         .from(userProviderConnections)
-        .where(eq(userProviderConnections.profileId, profileId));
+        .where(eq(userProviderConnections.connectionProfileId, connectionProfileId));
       expect(conn).toBeDefined();
       expect(conn!.needsReconnection).toBe(true);
       expect(conn!.scopesGranted).toEqual(["read"]);
@@ -622,7 +622,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
       const result = await handleCallback("mock-code", state);
       expect(result.scopeCreep).toEqual(["admin"]);
@@ -631,7 +631,7 @@ describe("OAuth2 flows", () => {
       const [conn] = await db
         .select()
         .from(userProviderConnections)
-        .where(eq(userProviderConnections.profileId, profileId));
+        .where(eq(userProviderConnections.connectionProfileId, connectionProfileId));
       expect(conn!.needsReconnection).toBe(false);
     });
   });
@@ -644,7 +644,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         PROVIDER_ID,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       const stateRow = await oauthStateStore.get(state);
@@ -670,7 +670,7 @@ describe("OAuth2 flows", () => {
         { orgId, applicationId: applicationId },
         noPkceProvider,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       // Auth URL should not have code_challenge
@@ -705,7 +705,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         basicProvider,
         actor,
-        profileId,
+        connectionProfileId,
       );
 
       mockServer.clearRequests();
@@ -745,7 +745,7 @@ describe("OAuth2 flows", () => {
         { orgId: orgId, applicationId: applicationId },
         systemProvider,
         actor,
-        profileId,
+        connectionProfileId,
       );
       expect(result.authUrl).toContain("/authorize");
       expect(result.state).toBeString();

--- a/apps/api/test/integration/services/provider-status.test.ts
+++ b/apps/api/test/integration/services/provider-status.test.ts
@@ -12,7 +12,7 @@ describe("resolveProviderStatuses", () => {
   let userId: string;
   let orgId: string;
   let applicationId: string;
-  let profileId: string;
+  let connectionProfileId: string;
 
   beforeEach(async () => {
     await truncateAll();
@@ -23,7 +23,7 @@ describe("resolveProviderStatuses", () => {
     applicationId = defaultAppId;
 
     const profile = await seedConnectionProfile({ userId, name: "Alice Profile" });
-    profileId = profile.id;
+    connectionProfileId = profile.id;
   });
 
   async function seedProvider(id: string) {
@@ -51,11 +51,11 @@ describe("resolveProviderStatuses", () => {
   it("returns source and profileName for user_profile entry", async () => {
     const providerId = "@system/test-status";
     await seedProvider(providerId);
-    await seedConnectionForApp(profileId, providerId, orgId, applicationId, { api_key: "k" });
+    await seedConnectionForApp(connectionProfileId, providerId, orgId, applicationId, { api_key: "k" });
 
     const providers: AgentProviderRequirement[] = [{ id: providerId }];
     const profiles: ProviderProfileMap = {
-      [providerId]: { profileId, source: "user_profile" },
+      [providerId]: { connectionProfileId, source: "user_profile" },
     };
 
     const statuses = await resolveProviderStatuses(
@@ -74,11 +74,11 @@ describe("resolveProviderStatuses", () => {
   it("returns source org_binding with correct profile info", async () => {
     const providerId = "@system/test-org-bind";
     await seedProvider(providerId);
-    await seedConnectionForApp(profileId, providerId, orgId, applicationId, { api_key: "k" });
+    await seedConnectionForApp(connectionProfileId, providerId, orgId, applicationId, { api_key: "k" });
 
     const providers: AgentProviderRequirement[] = [{ id: providerId }];
     const profiles: ProviderProfileMap = {
-      [providerId]: { profileId, source: "app_binding" },
+      [providerId]: { connectionProfileId, source: "app_binding" },
     };
 
     const statuses = await resolveProviderStatuses(
@@ -99,7 +99,7 @@ describe("resolveProviderStatuses", () => {
     const providers: AgentProviderRequirement[] = [{ id: providerId }];
     const profiles: ProviderProfileMap = {
       [providerId]: {
-        profileId: "00000000-0000-0000-0000-000000000000",
+        connectionProfileId: "00000000-0000-0000-0000-000000000000",
         source: "user_profile",
       },
     };

--- a/apps/api/test/integration/services/run-preflight.test.ts
+++ b/apps/api/test/integration/services/run-preflight.test.ts
@@ -157,9 +157,9 @@ describe("run preflight — provider profile resolution", () => {
       defaultUserProfileId: defaultProfileId,
     });
 
-    expect(providerProfiles["@system/gmail"]!.profileId).toBe(defaultProfileId);
+    expect(providerProfiles["@system/gmail"]!.connectionProfileId).toBe(defaultProfileId);
     expect(providerProfiles["@system/gmail"]!.source).toBe("user_profile");
-    expect(providerProfiles["@system/clickup"]!.profileId).toBe(defaultProfileId);
+    expect(providerProfiles["@system/clickup"]!.connectionProfileId).toBe(defaultProfileId);
     expect(providerProfiles["@system/clickup"]!.source).toBe("user_profile");
   });
 
@@ -176,9 +176,9 @@ describe("run preflight — provider profile resolution", () => {
       userProviderOverrides: { "@system/gmail": altProfileId },
     });
 
-    expect(providerProfiles["@system/gmail"]!.profileId).toBe(altProfileId);
+    expect(providerProfiles["@system/gmail"]!.connectionProfileId).toBe(altProfileId);
     expect(providerProfiles["@system/gmail"]!.source).toBe("user_profile");
-    expect(providerProfiles["@system/clickup"]!.profileId).toBe(defaultProfileId);
+    expect(providerProfiles["@system/clickup"]!.connectionProfileId).toBe(defaultProfileId);
   });
 
   it("org binding takes priority over per-provider override", async () => {
@@ -199,10 +199,10 @@ describe("run preflight — provider profile resolution", () => {
       appProfileId: appProfile.id,
     });
 
-    expect(providerProfiles["@system/gmail"]!.profileId).toBe(altProfileId);
+    expect(providerProfiles["@system/gmail"]!.connectionProfileId).toBe(altProfileId);
     expect(providerProfiles["@system/gmail"]!.source).toBe("app_binding");
     // clickup not bound in app profile -> falls back to user override or default
-    expect(providerProfiles["@system/clickup"]!.profileId).toBe(defaultProfileId);
+    expect(providerProfiles["@system/clickup"]!.connectionProfileId).toBe(defaultProfileId);
     expect(providerProfiles["@system/clickup"]!.source).toBe("user_profile");
   });
 
@@ -230,7 +230,7 @@ describe("run preflight — provider profile resolution", () => {
     });
 
     expect(providerProfiles["@system/gmail"]!.source).toBe("app_binding");
-    expect(providerProfiles["@system/clickup"]!.profileId).toBe(altProfileId);
+    expect(providerProfiles["@system/clickup"]!.connectionProfileId).toBe(altProfileId);
     expect(providerProfiles["@system/clickup"]!.source).toBe("user_profile");
   });
 });

--- a/apps/api/test/integration/services/run-profiles.test.ts
+++ b/apps/api/test/integration/services/run-profiles.test.ts
@@ -173,9 +173,9 @@ describe("Run with provider profiles", () => {
         orgId,
       );
 
-      expect(map["@system/gmail"]!.profileId).toBe(altProfile.id);
+      expect(map["@system/gmail"]!.connectionProfileId).toBe(altProfile.id);
       expect(map["@system/gmail"]!.source).toBe("user_profile");
-      expect(map["@system/clickup"]!.profileId).toBe(defaultProfileId);
+      expect(map["@system/clickup"]!.connectionProfileId).toBe(defaultProfileId);
       expect(map["@system/clickup"]!.source).toBe("user_profile");
     });
 
@@ -199,10 +199,10 @@ describe("Run with provider profiles", () => {
       );
 
       // gmail is bound in app profile -> uses app binding
-      expect(map["@system/gmail"]!.profileId).toBe(altProfile.id);
+      expect(map["@system/gmail"]!.connectionProfileId).toBe(altProfile.id);
       expect(map["@system/gmail"]!.source).toBe("app_binding");
       // clickup is not bound -> falls back to default
-      expect(map["@system/clickup"]!.profileId).toBe(defaultProfileId);
+      expect(map["@system/clickup"]!.connectionProfileId).toBe(defaultProfileId);
       expect(map["@system/clickup"]!.source).toBe("user_profile");
     });
 
@@ -218,7 +218,7 @@ describe("Run with provider profiles", () => {
       );
 
       for (const pid of providerIds) {
-        expect(map[pid]!.profileId).toBe(defaultProfileId);
+        expect(map[pid]!.connectionProfileId).toBe(defaultProfileId);
         expect(map[pid]!.source).toBe("user_profile");
       }
     });
@@ -248,7 +248,7 @@ describe("Run with provider profiles", () => {
       );
 
       // App binding wins over user override
-      expect(map["@system/gmail"]!.profileId).toBe(appBoundProfile.id);
+      expect(map["@system/gmail"]!.connectionProfileId).toBe(appBoundProfile.id);
       expect(map["@system/gmail"]!.source).toBe("app_binding");
     });
 
@@ -276,13 +276,13 @@ describe("Run with provider profiles", () => {
       );
 
       // gmail: app binding
-      expect(map["@system/gmail"]!.profileId).toBe(gmailBound.id);
+      expect(map["@system/gmail"]!.connectionProfileId).toBe(gmailBound.id);
       expect(map["@system/gmail"]!.source).toBe("app_binding");
       // clickup: no app binding, no user override -> default
-      expect(map["@system/clickup"]!.profileId).toBe(defaultProfileId);
+      expect(map["@system/clickup"]!.connectionProfileId).toBe(defaultProfileId);
       expect(map["@system/clickup"]!.source).toBe("user_profile");
       // notion: no app binding, but has user override
-      expect(map["@system/notion"]!.profileId).toBe(notionOverride.id);
+      expect(map["@system/notion"]!.connectionProfileId).toBe(notionOverride.id);
       expect(map["@system/notion"]!.source).toBe("user_profile");
     });
 
@@ -366,11 +366,11 @@ describe("Run with provider profiles", () => {
         appProfileId: appProfile.id,
       });
 
-      expect(providerProfiles["@system/gmail"]!.profileId).toBe(boundProfile.id);
+      expect(providerProfiles["@system/gmail"]!.connectionProfileId).toBe(boundProfile.id);
       expect(providerProfiles["@system/gmail"]!.source).toBe("app_binding");
       // Other providers fall back to default
-      expect(providerProfiles["@system/clickup"]!.profileId).toBe(defaultProfileId);
-      expect(providerProfiles["@system/notion"]!.profileId).toBe(defaultProfileId);
+      expect(providerProfiles["@system/clickup"]!.connectionProfileId).toBe(defaultProfileId);
+      expect(providerProfiles["@system/notion"]!.connectionProfileId).toBe(defaultProfileId);
     });
 
     it("falls back to user defaults when app profile has no bindings", async () => {
@@ -395,7 +395,7 @@ describe("Run with provider profiles", () => {
 
       // All providers fall back to user default
       for (const pid of providerIds) {
-        expect(providerProfiles[pid]!.profileId).toBe(defaultProfileId);
+        expect(providerProfiles[pid]!.connectionProfileId).toBe(defaultProfileId);
         expect(providerProfiles[pid]!.source).toBe("user_profile");
       }
     });

--- a/apps/api/test/integration/services/scheduler-app-readiness.test.ts
+++ b/apps/api/test/integration/services/scheduler-app-readiness.test.ts
@@ -211,7 +211,7 @@ describe("scheduler app-profile readiness", () => {
     // Provider should be resolved via app binding
     expect(providerProfiles[providerId]).toBeDefined();
     expect(providerProfiles[providerId]!.source).toBe("app_binding");
-    expect(providerProfiles[providerId]!.profileId).toBe(userProfileId);
+    expect(providerProfiles[providerId]!.connectionProfileId).toBe(userProfileId);
   });
 
   it("omits provider when app profile has no binding and no user fallback (run path)", async () => {

--- a/apps/api/test/integration/services/scheduler.test.ts
+++ b/apps/api/test/integration/services/scheduler.test.ts
@@ -33,7 +33,7 @@ describe("scheduler service", () => {
   let orgSlug: string;
   let defaultAppId: string;
   let packageId: string;
-  let profileId: string;
+  let connectionProfileId: string;
 
   beforeEach(async () => {
     await truncateAll();
@@ -46,7 +46,7 @@ describe("scheduler service", () => {
     defaultAppId = applicationId;
 
     const profile = await seedConnectionProfile({ userId, name: "Default" });
-    profileId = profile.id;
+    connectionProfileId = profile.id;
 
     // Seed an agent package that schedules will reference
     const pkg = await seedPackage({
@@ -73,7 +73,7 @@ describe("scheduler service", () => {
       const schedule = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           name: "Every hour",
           cronExpression: "0 * * * *",
@@ -84,7 +84,7 @@ describe("scheduler service", () => {
       expect(schedule.id).toMatch(/^sched_/);
       expect(schedule.packageId).toBe(packageId);
       expect(schedule.orgId).toBe(orgId);
-      expect(schedule.connectionProfileId).toBe(profileId);
+      expect(schedule.connectionProfileId).toBe(connectionProfileId);
       expect(schedule.cronExpression).toBe("0 * * * *");
       expect(schedule.timezone).toBe("UTC");
       expect(schedule.enabled).toBe(true);
@@ -99,7 +99,7 @@ describe("scheduler service", () => {
       const schedule = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           cronExpression: "*/5 * * * *",
           input: inputData,
@@ -113,7 +113,7 @@ describe("scheduler service", () => {
       const schedule = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           cronExpression: "0 9 * * *",
         },
@@ -126,7 +126,7 @@ describe("scheduler service", () => {
       const schedule = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           cronExpression: "0 * * * *",
           timezone: "UTC",
@@ -141,7 +141,7 @@ describe("scheduler service", () => {
       const schedule = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           cronExpression: "0 9 * * *",
           configOverride: { providers: { gmail: { scopes: ["read"] } } },
@@ -163,7 +163,7 @@ describe("scheduler service", () => {
       const schedule = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           cronExpression: "0 9 * * *",
         },
@@ -180,11 +180,11 @@ describe("scheduler service", () => {
 
   describe("listSchedules", () => {
     it("returns schedules for the org", async () => {
-      await createSchedule({ orgId: orgId, applicationId: defaultAppId }, packageId, profileId, {
+      await createSchedule({ orgId: orgId, applicationId: defaultAppId }, packageId, connectionProfileId, {
         name: "Schedule A",
         cronExpression: "0 * * * *",
       });
-      await createSchedule({ orgId: orgId, applicationId: defaultAppId }, packageId, profileId, {
+      await createSchedule({ orgId: orgId, applicationId: defaultAppId }, packageId, connectionProfileId, {
         name: "Schedule B",
         cronExpression: "*/30 * * * *",
       });
@@ -198,7 +198,7 @@ describe("scheduler service", () => {
     });
 
     it("does not return schedules from other orgs", async () => {
-      await createSchedule({ orgId: orgId, applicationId: defaultAppId }, packageId, profileId, {
+      await createSchedule({ orgId: orgId, applicationId: defaultAppId }, packageId, connectionProfileId, {
         name: "My Schedule",
         cronExpression: "0 * * * *",
       });
@@ -262,11 +262,11 @@ describe("scheduler service", () => {
         },
       });
 
-      await createSchedule({ orgId: orgId, applicationId: defaultAppId }, packageId, profileId, {
+      await createSchedule({ orgId: orgId, applicationId: defaultAppId }, packageId, connectionProfileId, {
         name: "Agent 1 Schedule",
         cronExpression: "0 * * * *",
       });
-      await createSchedule({ orgId: orgId, applicationId: defaultAppId }, pkg2.id, profileId, {
+      await createSchedule({ orgId: orgId, applicationId: defaultAppId }, pkg2.id, connectionProfileId, {
         name: "Agent 2 Schedule",
         cronExpression: "*/15 * * * *",
       });
@@ -303,7 +303,7 @@ describe("scheduler service", () => {
       const created = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           name: "Hourly Run",
           cronExpression: "0 * * * *",
@@ -334,7 +334,7 @@ describe("scheduler service", () => {
       const created = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           cronExpression: "0 * * * *",
         },
@@ -358,7 +358,7 @@ describe("scheduler service", () => {
       const created = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           name: "Original Name",
           cronExpression: "0 * * * *",
@@ -381,7 +381,7 @@ describe("scheduler service", () => {
       const created = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           cronExpression: "0 9 * * *",
           configOverride: { foo: "bar" },
@@ -423,7 +423,7 @@ describe("scheduler service", () => {
       const created = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           cronExpression: "0 * * * *",
         },
@@ -449,7 +449,7 @@ describe("scheduler service", () => {
       const created = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           cronExpression: "0 * * * *",
         },
@@ -475,7 +475,7 @@ describe("scheduler service", () => {
       const created = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           cronExpression: "0 * * * *",
           input: { key: "original" },
@@ -513,7 +513,7 @@ describe("scheduler service", () => {
       const created = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           cronExpression: "0 * * * *",
         },
@@ -541,7 +541,7 @@ describe("scheduler service", () => {
       const schedule1 = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           name: "Keep This",
           cronExpression: "0 * * * *",
@@ -550,7 +550,7 @@ describe("scheduler service", () => {
       const schedule2 = await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
-        profileId,
+        connectionProfileId,
         {
           name: "Delete This",
           cronExpression: "*/30 * * * *",
@@ -592,7 +592,7 @@ describe("scheduler service", () => {
     }
 
     it("returns profileName and readiness 'ready' when agent has no providers", async () => {
-      await createSchedule({ orgId: orgId, applicationId: defaultAppId }, packageId, profileId, {
+      await createSchedule({ orgId: orgId, applicationId: defaultAppId }, packageId, connectionProfileId, {
         name: "No Providers",
         cronExpression: "0 * * * *",
       });
@@ -630,7 +630,7 @@ describe("scheduler service", () => {
       await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         agentWithProvider.id,
-        profileId,
+        connectionProfileId,
         {
           name: "Missing Connection",
           cronExpression: "0 * * * *",
@@ -649,7 +649,7 @@ describe("scheduler service", () => {
     it("returns readiness 'ready' when provider is connected", async () => {
       const providerId = "@system/sched-connected";
       await seedProviderPackage(providerId);
-      await seedConnectionForApp(profileId, providerId, orgId, defaultAppId, { api_key: "k" });
+      await seedConnectionForApp(connectionProfileId, providerId, orgId, defaultAppId, { api_key: "k" });
 
       const agentConnected = await seedPackage({
         orgId,
@@ -666,7 +666,7 @@ describe("scheduler service", () => {
       await createSchedule(
         { orgId: orgId, applicationId: defaultAppId },
         agentConnected.id,
-        profileId,
+        connectionProfileId,
         {
           name: "Connected Schedule",
           cronExpression: "0 * * * *",

--- a/apps/api/test/integration/services/token-resolver.test.ts
+++ b/apps/api/test/integration/services/token-resolver.test.ts
@@ -8,11 +8,11 @@ import { saveConnection } from "@appstrate/connect";
 import { buildProviderTokens } from "../../../src/services/token-resolver.ts";
 import type { AgentProviderRequirement, ProviderProfileMap } from "../../../src/types/index.ts";
 
-/** Helper to build a ProviderProfileMap from simple id → profileId pairs. */
+/** Helper to build a ProviderProfileMap from simple id → connectionProfileId pairs. */
 function pm(entries: Record<string, string>): ProviderProfileMap {
   const map: ProviderProfileMap = {};
   for (const [id, pid] of Object.entries(entries)) {
-    map[id] = { profileId: pid, source: "user_profile" };
+    map[id] = { connectionProfileId: pid, source: "user_profile" };
   }
   return map;
 }
@@ -21,7 +21,7 @@ describe("token-resolver", () => {
   let userId: string;
   let orgId: string;
   let defaultAppId: string;
-  let profileId: string;
+  let connectionProfileId: string;
 
   beforeEach(async () => {
     await truncateAll();
@@ -33,7 +33,7 @@ describe("token-resolver", () => {
 
     // Create a default connection profile for this user
     const profile = await seedConnectionProfile({ userId, name: "Default", isDefault: true });
-    profileId = profile.id;
+    connectionProfileId = profile.id;
   });
 
   // ── Helper: seed a provider package with a definition ──────
@@ -96,7 +96,7 @@ describe("token-resolver", () => {
       });
 
       // Save a connection with an access_token
-      await seedConnection(profileId, providerId, orgId, {
+      await seedConnection(connectionProfileId, providerId, orgId, {
         access_token: "oauth-token-abc123",
         refresh_token: "refresh-xyz",
       });
@@ -104,7 +104,7 @@ describe("token-resolver", () => {
       const providers: AgentProviderRequirement[] = [{ id: providerId }];
       const tokens = await buildProviderTokens(
         providers,
-        pm({ [providerId]: profileId }),
+        pm({ [providerId]: connectionProfileId }),
         orgId,
         defaultAppId,
       );
@@ -118,14 +118,14 @@ describe("token-resolver", () => {
         authMode: "api_key",
       });
 
-      await seedConnection(profileId, providerId, orgId, {
+      await seedConnection(connectionProfileId, providerId, orgId, {
         api_key: "key-secret-456",
       });
 
       const providers: AgentProviderRequirement[] = [{ id: providerId }];
       const tokens = await buildProviderTokens(
         providers,
-        pm({ [providerId]: profileId }),
+        pm({ [providerId]: connectionProfileId }),
         orgId,
         defaultAppId,
       );
@@ -139,7 +139,7 @@ describe("token-resolver", () => {
         authMode: "api_key",
       });
 
-      await seedConnection(profileId, providerId, orgId, {
+      await seedConnection(connectionProfileId, providerId, orgId, {
         access_token: "preferred-token",
         api_key: "fallback-key",
       });
@@ -147,7 +147,7 @@ describe("token-resolver", () => {
       const providers: AgentProviderRequirement[] = [{ id: providerId }];
       const tokens = await buildProviderTokens(
         providers,
-        pm({ [providerId]: profileId }),
+        pm({ [providerId]: connectionProfileId }),
         orgId,
         defaultAppId,
       );
@@ -168,7 +168,7 @@ describe("token-resolver", () => {
         },
       });
 
-      await seedConnection(profileId, providerId, orgId, {
+      await seedConnection(connectionProfileId, providerId, orgId, {
         username: "admin",
         password: "secret",
       });
@@ -176,7 +176,7 @@ describe("token-resolver", () => {
       const providers: AgentProviderRequirement[] = [{ id: providerId }];
       const tokens = await buildProviderTokens(
         providers,
-        pm({ [providerId]: profileId }),
+        pm({ [providerId]: connectionProfileId }),
         orgId,
         defaultAppId,
       );
@@ -190,7 +190,7 @@ describe("token-resolver", () => {
         authMode: "basic",
       });
 
-      await seedConnection(profileId, providerId, orgId, {
+      await seedConnection(connectionProfileId, providerId, orgId, {
         username: "user",
         password: "pass",
       });
@@ -198,7 +198,7 @@ describe("token-resolver", () => {
       const providers: AgentProviderRequirement[] = [{ id: providerId }];
       const tokens = await buildProviderTokens(
         providers,
-        pm({ [providerId]: profileId }),
+        pm({ [providerId]: connectionProfileId }),
         orgId,
         defaultAppId,
       );
@@ -218,7 +218,7 @@ describe("token-resolver", () => {
       const providers: AgentProviderRequirement[] = [{ id: providerId }];
       const tokens = await buildProviderTokens(
         providers,
-        pm({ [providerId]: profileId }),
+        pm({ [providerId]: connectionProfileId }),
         orgId,
         defaultAppId,
       );
@@ -235,7 +235,7 @@ describe("token-resolver", () => {
 
       const providers: AgentProviderRequirement[] = [{ id: providerId }];
       expect(
-        buildProviderTokens(providers, pm({ [providerId]: profileId }), orgId, defaultAppId),
+        buildProviderTokens(providers, pm({ [providerId]: connectionProfileId }), orgId, defaultAppId),
       ).rejects.toThrow("credential missing for application");
     });
 
@@ -248,13 +248,13 @@ describe("token-resolver", () => {
       await seedProvider(providerB, { authMode: "api_key" });
       await seedProvider(providerC, { authMode: "custom" });
 
-      await seedConnection(profileId, providerA, orgId, {
+      await seedConnection(connectionProfileId, providerA, orgId, {
         access_token: "token-a",
       });
-      await seedConnection(profileId, providerB, orgId, {
+      await seedConnection(connectionProfileId, providerB, orgId, {
         api_key: "key-b",
       });
-      await seedConnection(profileId, providerC, orgId, {
+      await seedConnection(connectionProfileId, providerC, orgId, {
         host: "example.com",
         token: "custom-c",
       });
@@ -266,7 +266,7 @@ describe("token-resolver", () => {
       ];
       const tokens = await buildProviderTokens(
         providers,
-        pm({ [providerA]: profileId, [providerB]: profileId, [providerC]: profileId }),
+        pm({ [providerA]: connectionProfileId, [providerB]: connectionProfileId, [providerC]: connectionProfileId }),
         orgId,
         defaultAppId,
       );
@@ -284,10 +284,10 @@ describe("token-resolver", () => {
       await seedProvider(providerMapped, { authMode: "api_key" });
       await seedProvider(providerUnmapped, { authMode: "api_key" });
 
-      await seedConnection(profileId, providerMapped, orgId, {
+      await seedConnection(connectionProfileId, providerMapped, orgId, {
         api_key: "mapped-key",
       });
-      await seedConnection(profileId, providerUnmapped, orgId, {
+      await seedConnection(connectionProfileId, providerUnmapped, orgId, {
         api_key: "unmapped-key",
       });
 
@@ -298,7 +298,7 @@ describe("token-resolver", () => {
       // Only providerMapped has a profile mapping
       const tokens = await buildProviderTokens(
         providers,
-        pm({ [providerMapped]: profileId }),
+        pm({ [providerMapped]: connectionProfileId }),
         orgId,
         defaultAppId,
       );
@@ -315,12 +315,12 @@ describe("token-resolver", () => {
       });
 
       // Save a connection with empty credentials
-      await seedConnection(profileId, providerId, orgId, {});
+      await seedConnection(connectionProfileId, providerId, orgId, {});
 
       const providers: AgentProviderRequirement[] = [{ id: providerId }];
       const tokens = await buildProviderTokens(
         providers,
-        pm({ [providerId]: profileId }),
+        pm({ [providerId]: connectionProfileId }),
         orgId,
         defaultAppId,
       );
@@ -340,7 +340,7 @@ describe("token-resolver", () => {
       await seedProvider(providerA, { authMode: "api_key" });
       await seedProvider(providerB, { authMode: "api_key" });
 
-      await seedConnection(profileId, providerA, orgId, {
+      await seedConnection(connectionProfileId, providerA, orgId, {
         api_key: "key-from-profile-1",
       });
       await seedConnection(profileId2, providerB, orgId, {
@@ -350,7 +350,7 @@ describe("token-resolver", () => {
       const providers: AgentProviderRequirement[] = [{ id: providerA }, { id: providerB }];
       const tokens = await buildProviderTokens(
         providers,
-        pm({ [providerA]: profileId, [providerB]: profileId2 }),
+        pm({ [providerA]: connectionProfileId, [providerB]: profileId2 }),
         orgId,
         defaultAppId,
       );

--- a/apps/api/test/unit/dependency-validation.test.ts
+++ b/apps/api/test/unit/dependency-validation.test.ts
@@ -9,11 +9,11 @@ import {
 } from "../../src/services/dependency-validation.ts";
 import type { ProviderProfileMap } from "../../src/types/index.ts";
 
-/** Helper to build a ProviderProfileMap from simple id → profileId pairs. */
+/** Helper to build a ProviderProfileMap from simple id → connectionProfileId pairs. */
 function profileMap(entries: Record<string, string>): ProviderProfileMap {
   const map: ProviderProfileMap = {};
-  for (const [id, profileId] of Object.entries(entries)) {
-    map[id] = { profileId, source: "user_profile" };
+  for (const [id, connectionProfileId] of Object.entries(entries)) {
+    map[id] = { connectionProfileId, source: "user_profile" };
   }
   return map;
 }
@@ -202,8 +202,8 @@ describe("validateAgentDependencies", () => {
     const deps = createMockDeps();
     const providers = [{ id: "@test/gmail" }, { id: "@test/gdrive" }];
     const profiles: ProviderProfileMap = {
-      "@test/gmail": { profileId: "user-profile-1", source: "user_profile" },
-      "@test/gdrive": { profileId: "admin-profile-1", source: "app_binding" },
+      "@test/gmail": { connectionProfileId: "user-profile-1", source: "user_profile" },
+      "@test/gdrive": { connectionProfileId: "admin-profile-1", source: "app_binding" },
     };
 
     await validateAgentDependencies(providers, profiles, "org-1", "app-1", deps);

--- a/apps/api/test/unit/resolve-provider-profiles.test.ts
+++ b/apps/api/test/unit/resolve-provider-profiles.test.ts
@@ -32,8 +32,8 @@ describe("resolveProviderProfiles", () => {
     );
 
     expect(result).toEqual({
-      "@test/gmail": { profileId: "default-profile", source: "user_profile" },
-      "@test/clickup": { profileId: "default-profile", source: "user_profile" },
+      "@test/gmail": { connectionProfileId: "default-profile", source: "user_profile" },
+      "@test/clickup": { connectionProfileId: "default-profile", source: "user_profile" },
     });
   });
 
@@ -51,8 +51,8 @@ describe("resolveProviderProfiles", () => {
     );
 
     expect(result).toEqual({
-      "@test/gmail": { profileId: "gmail-override-profile", source: "user_profile" },
-      "@test/clickup": { profileId: "default-profile", source: "user_profile" },
+      "@test/gmail": { connectionProfileId: "gmail-override-profile", source: "user_profile" },
+      "@test/clickup": { connectionProfileId: "default-profile", source: "user_profile" },
     });
   });
 
@@ -71,8 +71,8 @@ describe("resolveProviderProfiles", () => {
     );
 
     expect(result).toEqual({
-      "@test/gmail": { profileId: "org-gmail-profile", source: "app_binding" },
-      "@test/clickup": { profileId: "default-profile", source: "user_profile" },
+      "@test/gmail": { connectionProfileId: "org-gmail-profile", source: "app_binding" },
+      "@test/clickup": { connectionProfileId: "default-profile", source: "user_profile" },
     });
   });
 
@@ -92,7 +92,7 @@ describe("resolveProviderProfiles", () => {
     );
 
     expect(result).toEqual({
-      "@test/gmail": { profileId: "org-gmail-profile", source: "app_binding" },
+      "@test/gmail": { connectionProfileId: "org-gmail-profile", source: "app_binding" },
     });
   });
 
@@ -112,8 +112,8 @@ describe("resolveProviderProfiles", () => {
     );
 
     expect(result).toEqual({
-      "@test/gmail": { profileId: "org-gmail-profile", source: "app_binding" },
-      "@test/clickup": { profileId: "clickup-override-profile", source: "user_profile" },
+      "@test/gmail": { connectionProfileId: "org-gmail-profile", source: "app_binding" },
+      "@test/clickup": { connectionProfileId: "clickup-override-profile", source: "user_profile" },
     });
   });
 
@@ -208,11 +208,11 @@ describe("resolveProviderProfiles", () => {
 
     expect(result).toEqual({
       // app binding wins over user override
-      "@test/gmail": { profileId: "org-gmail-profile", source: "app_binding" },
+      "@test/gmail": { connectionProfileId: "org-gmail-profile", source: "app_binding" },
       // user override wins over default (no org binding for clickup)
-      "@test/clickup": { profileId: "user-clickup-override", source: "user_profile" },
+      "@test/clickup": { connectionProfileId: "user-clickup-override", source: "user_profile" },
       // app binding (no user override needed)
-      "@test/stripe": { profileId: "org-stripe-profile", source: "app_binding" },
+      "@test/stripe": { connectionProfileId: "org-stripe-profile", source: "app_binding" },
     });
   });
 
@@ -234,8 +234,8 @@ describe("resolveProviderProfiles", () => {
     );
 
     expect(result).toEqual({
-      "@test/gmail": { profileId: "deleted-profile-id", source: "app_binding" },
-      "@test/clickup": { profileId: "default-profile", source: "user_profile" },
+      "@test/gmail": { connectionProfileId: "deleted-profile-id", source: "app_binding" },
+      "@test/clickup": { connectionProfileId: "default-profile", source: "user_profile" },
     });
   });
 
@@ -268,8 +268,8 @@ describe("resolveProviderProfiles", () => {
     );
 
     expect(result).toEqual({
-      "@test/gmail": { profileId: "gmail-override", source: "user_profile" },
-      "@test/clickup": { profileId: "default-profile", source: "user_profile" },
+      "@test/gmail": { connectionProfileId: "gmail-override", source: "user_profile" },
+      "@test/clickup": { connectionProfileId: "default-profile", source: "user_profile" },
     });
   });
 });

--- a/apps/cli/src/commands/run/connection-profiles.ts
+++ b/apps/cli/src/commands/run/connection-profiles.ts
@@ -84,7 +84,7 @@ export interface ConnectionProfileSelectionInputs {
 export interface ConnectionProfileSelection {
   /** Resolved default profile id (for `X-Connection-Profile-Id`), or undefined. */
   connectionProfileId: string | undefined;
-  /** `{ providerId: profileId }` map applied per-call by the resolver. */
+  /** `{ providerId: connectionProfileId }` map applied per-call by the resolver. */
   providerProfileOverrides: Record<string, string>;
 }
 

--- a/apps/cli/src/commands/run/preflight.ts
+++ b/apps/cli/src/commands/run/preflight.ts
@@ -218,8 +218,10 @@ function buildReadinessUrl(instance: string, inputs: PreflightInputs): string {
   if (inputs.connectionProfileId) {
     params.set("connectionProfileId", inputs.connectionProfileId);
   }
-  for (const [providerId, profileId] of Object.entries(inputs.perProviderOverrides ?? {})) {
-    params.set(`providerProfile.${providerId}`, profileId);
+  for (const [providerId, connectionProfileId] of Object.entries(
+    inputs.perProviderOverrides ?? {},
+  )) {
+    params.set(`providerProfile.${providerId}`, connectionProfileId);
   }
   const qs = params.toString();
   // See bundle-fetch.ts:buildBundleUrl — `@` in scope must NOT be percent-encoded

--- a/apps/cli/src/lib/connection-profiles.ts
+++ b/apps/cli/src/lib/connection-profiles.ts
@@ -107,7 +107,7 @@ export function resolveConnectionProfileRef(
 export interface UserConnection {
   id: string;
   providerId: string;
-  profileId: string;
+  connectionProfileId: string;
   profileName: string;
   status: string;
   createdAt: string;
@@ -137,7 +137,7 @@ export async function listUserConnections(profileName: string): Promise<UserConn
         out.push({
           id: conn.id,
           providerId: provider.providerId,
-          profileId: conn.profile.id,
+          connectionProfileId: conn.profile.id,
           profileName: conn.profile.name,
           status: conn.status,
           createdAt: conn.createdAt,

--- a/apps/cli/src/lib/doctor.ts
+++ b/apps/cli/src/lib/doctor.ts
@@ -40,7 +40,7 @@ export interface InstallationInfo {
 
 export interface ConnectionProfileCheck {
   /** Profile UUID pinned in the active CLI profile (`connectionProfileId` in config.toml). */
-  profileId: string;
+  connectionProfileId: string;
   /** Result status: ok = exists, missing = 404 (warn), unknown = the check could not run (no token / offline / 5xx). */
   status: "ok" | "missing" | "unknown";
   /** Free-form remediation hint surfaced in the rendered report. */
@@ -300,14 +300,14 @@ export function formatDoctorReport(report: DoctorReport, runningExecPath: string
     lines.push(``);
     const cp = report.connectionProfile;
     if (cp.status === "missing") {
-      lines.push(`⚠ Connection profile ${cp.profileId} is pinned but no longer exists.`);
+      lines.push(`⚠ Connection profile ${cp.connectionProfileId} is pinned but no longer exists.`);
       if (cp.hint) lines.push(`  ${cp.hint}`);
     } else if (cp.status === "unknown") {
       lines.push(
-        `Connection profile ${cp.profileId} could not be verified (offline or not logged in).`,
+        `Connection profile ${cp.connectionProfileId} could not be verified (offline or not logged in).`,
       );
     } else {
-      lines.push(`Connection profile ${cp.profileId} is healthy.`);
+      lines.push(`Connection profile ${cp.connectionProfileId} is healthy.`);
     }
   }
 
@@ -362,20 +362,20 @@ export const defaultCheckConnectionProfile: CheckConnectionProfile = async () =>
   const profileName = resolveProfileName(undefined, config);
   const profile = await getProfile(profileName);
   if (!profile?.connectionProfileId) return null;
-  const profileId = profile.connectionProfileId;
+  const connectionProfileId = profile.connectionProfileId;
 
   try {
     const { listConnectionProfiles } = await import("./connection-profiles.ts");
     const profiles = await listConnectionProfiles(profileName);
-    const found = profiles.some((p) => p.id === profileId);
-    if (found) return { profileId, status: "ok" };
+    const found = profiles.some((p) => p.id === connectionProfileId);
+    if (found) return { connectionProfileId, status: "ok" };
     return {
-      profileId,
+      connectionProfileId,
       status: "missing",
       hint: "Run `appstrate connections profile switch <name>` to repin a valid profile.",
     };
   } catch {
-    return { profileId, status: "unknown" };
+    return { connectionProfileId, status: "unknown" };
   }
 };
 

--- a/apps/cli/test/doctor.test.ts
+++ b/apps/cli/test/doctor.test.ts
@@ -269,13 +269,13 @@ describe("connection-profile check", () => {
       execPath: "/usr/local/bin/appstrate",
       probeLocalInstall: async () => null,
       checkConnectionProfile: async () => ({
-        profileId: "abc",
+        connectionProfileId: "abc",
         status: "missing",
         hint: "Run `appstrate connections profile switch <name>`.",
       }),
     });
     expect(report.connectionProfile).toEqual({
-      profileId: "abc",
+      connectionProfileId: "abc",
       status: "missing",
       hint: "Run `appstrate connections profile switch <name>`.",
     });
@@ -315,7 +315,7 @@ describe("connection-profile check", () => {
         dualInstall: false,
         multiSource: false,
         connectionProfile: {
-          profileId: "abc",
+          connectionProfileId: "abc",
           status: "missing",
           hint: "Run `appstrate connections profile switch <name>`.",
         },
@@ -333,7 +333,7 @@ describe("connection-profile check", () => {
         runningIndex: 0,
         dualInstall: false,
         multiSource: false,
-        connectionProfile: { profileId: "abc", status: "unknown" },
+        connectionProfile: { connectionProfileId: "abc", status: "unknown" },
       },
       "/usr/local/bin/appstrate",
     );

--- a/apps/cli/test/run-preflight.test.ts
+++ b/apps/cli/test/run-preflight.test.ts
@@ -76,7 +76,7 @@ describe("preflightCheck", () => {
     const missing = [
       {
         providerId: "@afps/gmail",
-        profileId: null,
+        connectionProfileId: null,
         reason: "no_connection",
         message: "not connected",
       },
@@ -113,7 +113,7 @@ describe("preflightCheck", () => {
         missing: [
           {
             providerId: "@afps/gmail",
-            profileId: null,
+            connectionProfileId: null,
             reason: "no_connection",
             message: "not connected",
           },
@@ -143,7 +143,7 @@ describe("preflightCheck", () => {
         missing: [
           {
             providerId: "@afps/gmail",
-            profileId: null,
+            connectionProfileId: null,
             reason: "no_connection",
             message: "not connected",
           },
@@ -187,7 +187,7 @@ describe("preflightCheck", () => {
         missing: [
           {
             providerId: "@afps/gmail",
-            profileId: null,
+            connectionProfileId: null,
             reason: "no_connection",
             message: "not connected",
           },
@@ -218,7 +218,7 @@ describe("preflightCheck", () => {
     const missing = [
       {
         providerId: "@afps/gmail",
-        profileId: null,
+        connectionProfileId: null,
         reason: "no_connection",
         message: "not connected",
       },
@@ -281,7 +281,7 @@ describe("preflightCheck", () => {
     const missing = [
       {
         providerId: "@afps/gmail",
-        profileId: null,
+        connectionProfileId: null,
         reason: "no_connection",
         message: "not connected",
       },

--- a/apps/web/src/components/combined-profile-select.tsx
+++ b/apps/web/src/components/combined-profile-select.tsx
@@ -24,7 +24,7 @@ interface CombinedProfileSelectProps {
   /** Current value */
   value: string | null;
   /** Change callback (null = "all" selected) */
-  onChange: (profileId: string | null) => void;
+  onChange: (connectionProfileId: string | null) => void;
   /** Show "All" as first option */
   showAllOption?: boolean;
   /** Trigger className override */

--- a/apps/web/src/components/my-application-profile-section.tsx
+++ b/apps/web/src/components/my-application-profile-section.tsx
@@ -47,7 +47,7 @@ export function MyApplicationProfileSection() {
 
   if (!applicationId || !currentApp) return null;
 
-  const stickyId = sticky?.profileId ?? null;
+  const stickyId = sticky?.connectionProfileId ?? null;
 
   const hasOptions = (userProfiles?.length ?? 0) + (appProfiles?.length ?? 0) > 0;
 

--- a/apps/web/src/components/profile-selector.tsx
+++ b/apps/web/src/components/profile-selector.tsx
@@ -18,7 +18,7 @@ interface ProfileSelectorProps {
   /** Current value (null = "all" when showAllOption is true) */
   value: string | null;
   /** Callback when profile changes */
-  onChange: (profileId: string | null) => void;
+  onChange: (connectionProfileId: string | null) => void;
   label?: string;
 }
 

--- a/apps/web/src/components/provider-connect-button.tsx
+++ b/apps/web/src/components/provider-connect-button.tsx
@@ -17,13 +17,13 @@ import type { JSONSchemaObject } from "@appstrate/core/form";
 
 export function ProviderConnectButton({
   provider,
-  profileId,
+  connectionProfileId,
 }: {
   provider: ProviderConfig;
-  profileId?: string | null;
+  connectionProfileId?: string | null;
 }) {
   const { t } = useTranslation(["settings", "agents"]);
-  const { data: availableProviders } = useAvailableProviders(profileId);
+  const { data: availableProviders } = useAvailableProviders(connectionProfileId);
 
   const connectMutation = useConnect();
   const connectApiKeyMutation = useConnectApiKey();
@@ -60,12 +60,18 @@ export function ProviderConnectButton({
         schema: provider.credentialSchema as unknown as JSONSchemaObject,
       });
     } else {
-      connectMutation.mutate({ provider: provider.id, profileId: profileId ?? undefined });
+      connectMutation.mutate({
+        provider: provider.id,
+        connectionProfileId: connectionProfileId ?? undefined,
+      });
     }
   };
 
   const handleDisconnect = () => {
-    disconnectMutation.mutate({ provider: provider.id, profileId: profileId ?? undefined });
+    disconnectMutation.mutate({
+      provider: provider.id,
+      connectionProfileId: connectionProfileId ?? undefined,
+    });
   };
 
   return (
@@ -103,7 +109,11 @@ export function ProviderConnectButton({
         onSubmit={(apiKey) => {
           if (!apiKeyProvider) return;
           connectApiKeyMutation.mutate(
-            { provider: apiKeyProvider.id, apiKey, profileId: profileId ?? undefined },
+            {
+              provider: apiKeyProvider.id,
+              apiKey,
+              connectionProfileId: connectionProfileId ?? undefined,
+            },
             { onSuccess: () => setApiKeyProvider(null) },
           );
         }}
@@ -118,7 +128,11 @@ export function ProviderConnectButton({
           isPending={connectCredentialsMutation.isPending}
           onSubmit={(credentials) => {
             connectCredentialsMutation.mutate(
-              { provider: customCredProvider.id, credentials, profileId: profileId ?? undefined },
+              {
+                provider: customCredProvider.id,
+                credentials,
+                connectionProfileId: connectionProfileId ?? undefined,
+              },
               { onSuccess: () => setCustomCredProvider(null) },
             );
           }}

--- a/apps/web/src/components/run-modal.tsx
+++ b/apps/web/src/components/run-modal.tsx
@@ -89,9 +89,9 @@ function RunModalForm({
   const { data: sticky } = useMyApplicationProfile();
   const { data: userProfiles } = useConnectionProfiles();
   const { data: appProfiles } = useAppProfiles();
-  const stickyProfile = sticky?.profileId
-    ? (userProfiles?.find((p) => p.id === sticky.profileId) ??
-      appProfiles?.find((p) => p.id === sticky.profileId) ??
+  const stickyProfile = sticky?.connectionProfileId
+    ? (userProfiles?.find((p) => p.id === sticky.connectionProfileId) ??
+      appProfiles?.find((p) => p.id === sticky.connectionProfileId) ??
       null)
     : null;
 

--- a/apps/web/src/hooks/use-available-providers.ts
+++ b/apps/web/src/hooks/use-available-providers.ts
@@ -6,12 +6,12 @@ import { useCurrentOrgId } from "./use-org";
 import { useCurrentApplicationId } from "./use-current-application";
 import type { AvailableProvider } from "@appstrate/shared-types";
 
-export function useAvailableProviders(profileId?: string | null) {
+export function useAvailableProviders(connectionProfileId?: string | null) {
   const orgId = useCurrentOrgId();
   const applicationId = useCurrentApplicationId();
-  const qs = profileId ? `?profileId=${profileId}` : "";
+  const qs = connectionProfileId ? `?connectionProfileId=${connectionProfileId}` : "";
   return useQuery({
-    queryKey: ["available-providers", orgId, applicationId, profileId ?? null],
+    queryKey: ["available-providers", orgId, applicationId, connectionProfileId ?? null],
     queryFn: async () => {
       const data = await apiFetch<{ integrations: AvailableProvider[] }>(
         `/api/connections/integrations${qs}`,

--- a/apps/web/src/hooks/use-connection-profiles.ts
+++ b/apps/web/src/hooks/use-connection-profiles.ts
@@ -26,13 +26,13 @@ interface ProfileWithConnections extends ConnectionProfile {
  * from different apps accumulate on the same profile, but this hook only
  * returns the current app's connections.
  */
-export function useProfileConnections(profileId: string | null | undefined) {
+export function useProfileConnections(connectionProfileId: string | null | undefined) {
   const orgId = useCurrentOrgId();
   const applicationId = useCurrentApplicationId();
   return useQuery({
-    queryKey: ["profile-connections", orgId, applicationId, profileId],
-    queryFn: () => apiList<ConnectionInfo>(`/app-profiles/${profileId}/connections`),
-    enabled: !!profileId && !!applicationId,
+    queryKey: ["profile-connections", orgId, applicationId, connectionProfileId],
+    queryFn: () => apiList<ConnectionInfo>(`/app-profiles/${connectionProfileId}/connections`),
+    enabled: !!connectionProfileId && !!applicationId,
     staleTime: 30_000,
   });
 }
@@ -129,16 +129,16 @@ export const useCreateAppProfile = appProfileMutations.useCreate;
 export const useRenameAppProfile = appProfileMutations.useRename;
 export const useDeleteAppProfile = appProfileMutations.useDelete;
 
-export function useAppProfileBindings(profileId: string | undefined) {
+export function useAppProfileBindings(connectionProfileId: string | undefined) {
   const orgId = useCurrentOrgId();
   const applicationId = useCurrentApplicationId();
   return useQuery({
-    queryKey: ["app-profile-bindings", orgId, applicationId, profileId],
+    queryKey: ["app-profile-bindings", orgId, applicationId, connectionProfileId],
     queryFn: () =>
-      api<{ bindings: EnrichedBinding[] }>(`/app-profiles/${profileId}/bindings`).then(
+      api<{ bindings: EnrichedBinding[] }>(`/app-profiles/${connectionProfileId}/bindings`).then(
         (r) => r.bindings,
       ),
-    enabled: !!profileId,
+    enabled: !!connectionProfileId,
     staleTime: 30_000,
   });
 }
@@ -147,15 +147,15 @@ export function useBindAppProvider() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({
-      profileId,
+      connectionProfileId,
       providerId,
       sourceProfileId,
     }: {
-      profileId: string;
+      connectionProfileId: string;
       providerId: string;
       sourceProfileId: string;
     }) =>
-      api(`/app-profiles/${profileId}/bind`, {
+      api(`/app-profiles/${connectionProfileId}/bind`, {
         method: "POST",
         body: JSON.stringify({ providerId, sourceProfileId }),
       }),
@@ -167,8 +167,14 @@ export function useBindAppProvider() {
 export function useUnbindAppProvider() {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ profileId, providerId }: { profileId: string; providerId: string }) =>
-      api(`/app-profiles/${profileId}/bind/${providerId}`, {
+    mutationFn: ({
+      connectionProfileId,
+      providerId,
+    }: {
+      connectionProfileId: string;
+      providerId: string;
+    }) =>
+      api(`/app-profiles/${connectionProfileId}/bind/${providerId}`, {
         method: "DELETE",
       }),
     onSuccess: () => invalidateConnectionRelated(qc),
@@ -192,7 +198,7 @@ export function useMyApplicationProfile() {
   const applicationId = useCurrentApplicationId();
   return useQuery({
     queryKey: ["my-application-profile", orgId, applicationId],
-    queryFn: () => api<{ profileId: string | null }>("/me/application-profile"),
+    queryFn: () => api<{ connectionProfileId: string | null }>("/me/application-profile"),
     enabled: !!applicationId,
   });
 }
@@ -202,13 +208,13 @@ export function useSetMyApplicationProfile() {
   const orgId = useCurrentOrgId();
   const applicationId = useCurrentApplicationId();
   return useMutation({
-    mutationFn: async (profileId: string | null) => {
-      if (profileId === null) {
+    mutationFn: async (connectionProfileId: string | null) => {
+      if (connectionProfileId === null) {
         return api("/me/application-profile", { method: "DELETE" });
       }
       return api("/me/application-profile", {
         method: "PUT",
-        body: JSON.stringify({ profileId }),
+        body: JSON.stringify({ connectionProfileId }),
       });
     },
     onSuccess: () => {
@@ -239,14 +245,14 @@ export function useSetAgentAppProfile(packageId: string) {
 
 // ─── App Profile Linked Agents ────────────────────────────
 
-export function useAppProfileAgents(profileId: string | undefined) {
+export function useAppProfileAgents(connectionProfileId: string | undefined) {
   const orgId = useCurrentOrgId();
   const applicationId = useCurrentApplicationId();
   return useQuery({
-    queryKey: ["app-profile-agents", orgId, applicationId, profileId],
+    queryKey: ["app-profile-agents", orgId, applicationId, connectionProfileId],
     queryFn: () =>
-      apiList<{ id: string; displayName: string }>(`/app-profiles/${profileId}/agents`),
-    enabled: !!profileId,
+      apiList<{ id: string; displayName: string }>(`/app-profiles/${connectionProfileId}/agents`),
+    enabled: !!connectionProfileId,
     staleTime: 30_000,
   });
 }
@@ -270,10 +276,16 @@ export function useAgentProviderProfiles(packageId: string | undefined) {
 export function useSetAgentProviderProfile(packageId: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async ({ providerId, profileId }: { providerId: string; profileId: string }) => {
+    mutationFn: async ({
+      providerId,
+      connectionProfileId,
+    }: {
+      providerId: string;
+      connectionProfileId: string;
+    }) => {
       return api(`/agents/${packageId}/provider-profiles`, {
         method: "PUT",
-        body: JSON.stringify({ providerId, profileId }),
+        body: JSON.stringify({ providerId, connectionProfileId }),
       });
     },
     onSuccess: () => {

--- a/apps/web/src/hooks/use-mutations.ts
+++ b/apps/web/src/hooks/use-mutations.ts
@@ -63,15 +63,16 @@ export function useConnect() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (
-      params: string | { provider: string; scopes?: string[]; profileId?: string },
+      params: string | { provider: string; scopes?: string[]; connectionProfileId?: string },
     ) => {
       const provider = typeof params === "string" ? params : params.provider;
       const scopes = typeof params === "string" ? undefined : params.scopes;
-      const profileId = typeof params === "string" ? undefined : params.profileId;
+      const connectionProfileId =
+        typeof params === "string" ? undefined : params.connectionProfileId;
 
       const body: Record<string, unknown> = {};
       if (scopes) body.scopes = scopes;
-      if (profileId) body.profileId = profileId;
+      if (connectionProfileId) body.connectionProfileId = connectionProfileId;
 
       const session = await apiFetch<{ authUrl: string }>(`/api/connections/connect/${provider}`, {
         method: "POST",
@@ -109,15 +110,15 @@ export function useConnectApiKey() {
     mutationFn: async ({
       provider,
       apiKey,
-      profileId,
+      connectionProfileId,
     }: {
       provider: string;
       apiKey: string;
-      profileId?: string;
+      connectionProfileId?: string;
     }) => {
       return apiFetch(`/api/connections/connect/${provider}/api-key`, {
         method: "POST",
-        body: JSON.stringify({ apiKey, ...(profileId ? { profileId } : {}) }),
+        body: JSON.stringify({ apiKey, ...(connectionProfileId ? { connectionProfileId } : {}) }),
       });
     },
     onSuccess: () => {
@@ -132,14 +133,15 @@ export function useDisconnect() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (
-      params: string | { provider: string; profileId?: string; connectionId?: string },
+      params: string | { provider: string; connectionProfileId?: string; connectionId?: string },
     ) => {
       const provider = typeof params === "string" ? params : params.provider;
-      const profileId = typeof params === "string" ? undefined : params.profileId;
+      const connectionProfileId =
+        typeof params === "string" ? undefined : params.connectionProfileId;
       const connectionId = typeof params === "string" ? undefined : params.connectionId;
       const qs = buildQs({
         connectionId,
-        ...(!connectionId ? { profileId } : {}),
+        ...(!connectionId ? { connectionProfileId } : {}),
       });
       return apiFetch(`/api/connections/${provider}${qs}`, { method: "DELETE" });
     },
@@ -230,15 +232,18 @@ export function useConnectCredentials() {
     mutationFn: async ({
       provider,
       credentials,
-      profileId,
+      connectionProfileId,
     }: {
       provider: string;
       credentials: Record<string, string>;
-      profileId?: string;
+      connectionProfileId?: string;
     }) => {
       return apiFetch(`/api/connections/connect/${provider}/credentials`, {
         method: "POST",
-        body: JSON.stringify({ credentials, ...(profileId ? { profileId } : {}) }),
+        body: JSON.stringify({
+          credentials,
+          ...(connectionProfileId ? { connectionProfileId } : {}),
+        }),
       });
     },
     onSuccess: () => {

--- a/apps/web/src/hooks/use-packages.ts
+++ b/apps/web/src/hooks/use-packages.ts
@@ -9,7 +9,7 @@ import { stripScope } from "@appstrate/core/naming";
 import { api, apiList, uploadFormData, apiBlob } from "../api";
 import { useCurrentOrgId } from "./use-org";
 import { useCurrentApplicationId } from "./use-current-application";
-// Profile resolution is now per-provider (server-side), no global profileId needed
+// Profile resolution is now per-provider (server-side), no global connectionProfileId needed
 import type {
   OrgPackageItem,
   OrgPackageItemDetail,

--- a/apps/web/src/hooks/use-provider-connection.ts
+++ b/apps/web/src/hooks/use-provider-connection.ts
@@ -74,18 +74,18 @@ export function useProviderConnection({
     bindMutation.isPending ||
     unbindMutation.isPending;
 
-  const profileParam = effectiveProfileId ? { profileId: effectiveProfileId } : {};
+  const profileParam = effectiveProfileId ? { connectionProfileId: effectiveProfileId } : {};
 
-  const handleProfileChange = (profileId: string) => {
+  const handleProfileChange = (connectionProfileId: string) => {
     if (packageId) {
-      setProviderProfile.mutate({ providerId, profileId });
+      setProviderProfile.mutate({ providerId, connectionProfileId });
     }
   };
 
   const doBind = () => {
     if (!appProfileId || !effectiveProfileId) return;
     bindMutation.mutate({
-      profileId: appProfileId,
+      connectionProfileId: appProfileId,
       providerId,
       sourceProfileId: effectiveProfileId,
     });
@@ -93,7 +93,7 @@ export function useProviderConnection({
 
   const handleUnbind = () => {
     if (!appProfileId) return;
-    unbindMutation.mutate({ profileId: appProfileId, providerId });
+    unbindMutation.mutate({ connectionProfileId: appProfileId, providerId });
   };
 
   return {

--- a/apps/web/src/pages/preferences/connectors.tsx
+++ b/apps/web/src/pages/preferences/connectors.tsx
@@ -19,16 +19,16 @@ import type { AvailableScope } from "@appstrate/core/validation";
 
 function filterProviders(
   providers: UserConnectionProviderGroup[] | undefined,
-  profileId: string | null,
+  connectionProfileId: string | null,
 ): UserConnectionProviderGroup[] {
   if (!providers) return [];
-  if (!profileId) return providers;
+  if (!connectionProfileId) return providers;
   return providers
     .map((pg) => {
       const orgs = pg.orgs
         .map((og) => ({
           ...og,
-          connections: og.connections.filter((c) => c.profile.id === profileId),
+          connections: og.connections.filter((c) => c.profile.id === connectionProfileId),
         }))
         .filter((og) => og.connections.length > 0);
       const totalConnections = orgs.reduce((sum, og) => sum + og.connections.length, 0);

--- a/apps/web/src/pages/providers-page.tsx
+++ b/apps/web/src/pages/providers-page.tsx
@@ -28,7 +28,7 @@ export function ProvidersPage() {
   const { data: callbackUrl } = useProviderCallbackUrl();
 
   // Resolve effective profile: user selection → default profile → first profile
-  const profileId = useMemo(() => {
+  const connectionProfileId = useMemo(() => {
     if (selectedProfileId) return selectedProfileId;
     if (!profiles?.length) return null;
     return (profiles.find((p) => p.isDefault) ?? profiles[0])?.id ?? null;
@@ -53,14 +53,14 @@ export function ProvidersPage() {
         actions.set(
           p.id,
           <div className="ml-auto flex items-center gap-2">
-            <ProviderConnectButton provider={p} profileId={profileId} />
+            <ProviderConnectButton provider={p} connectionProfileId={connectionProfileId} />
             {configButton}
           </div>,
         );
       }
     }
     return { badgeMap: badges, actionsMap: actions, iconMap: icons };
-  }, [providers, callbackUrl, profileId]);
+  }, [providers, callbackUrl, connectionProfileId]);
 
   // Filter: enabled providers (default) or all
   const enabledIds = new Set<string>();
@@ -80,7 +80,7 @@ export function ProvidersPage() {
         </TabsList>
       </Tabs>
       <div className="flex-1" />
-      <ProfileSelector value={profileId} onChange={setSelectedProfileId} />
+      <ProfileSelector value={connectionProfileId} onChange={setSelectedProfileId} />
     </div>
   );
 

--- a/apps/web/src/pages/schedule-edit.tsx
+++ b/apps/web/src/pages/schedule-edit.tsx
@@ -33,13 +33,13 @@ export function ScheduleEditPage() {
   // Build foreign profile when the schedule's profile belongs to another user
   const foreignProfile = useMemo<ForeignProfile | undefined>(() => {
     if (!schedule) return undefined;
-    const profileId = schedule.connectionProfileId;
-    const inUser = userProfiles?.some((p) => p.id === profileId) ?? false;
-    const inApp = appProfiles?.some((p) => p.id === profileId) ?? false;
+    const connectionProfileId = schedule.connectionProfileId;
+    const inUser = userProfiles?.some((p) => p.id === connectionProfileId) ?? false;
+    const inApp = appProfiles?.some((p) => p.id === connectionProfileId) ?? false;
     if (inUser || inApp) return undefined;
     if (schedule.profileType !== "user" || !schedule.profileName) return undefined;
     return {
-      id: profileId,
+      id: connectionProfileId,
       name: schedule.profileName,
       ownerName: schedule.profileOwnerName ?? "",
     };

--- a/packages/connect/src/credentials.ts
+++ b/packages/connect/src/credentials.ts
@@ -23,13 +23,13 @@ import type {
  */
 export async function getConnection(
   db: Db,
-  profileId: string,
+  connectionProfileId: string,
   providerId: string,
   orgId: string,
   providerCredentialId: string,
 ): Promise<ConnectionRecord | null> {
   const conditions = [
-    eq(userProviderConnections.profileId, profileId),
+    eq(userProviderConnections.connectionProfileId, connectionProfileId),
     eq(userProviderConnections.providerId, providerId),
     eq(userProviderConnections.orgId, orgId),
     eq(userProviderConnections.providerCredentialId, providerCredentialId),
@@ -51,7 +51,7 @@ export async function getConnection(
  */
 export async function listConnections(
   db: Db,
-  profileId: string,
+  connectionProfileId: string,
   orgId: string,
   providerCredentialIds: string[],
 ): Promise<ConnectionRecord[]> {
@@ -62,7 +62,7 @@ export async function listConnections(
     .from(userProviderConnections)
     .where(
       and(
-        eq(userProviderConnections.profileId, profileId),
+        eq(userProviderConnections.connectionProfileId, connectionProfileId),
         eq(userProviderConnections.orgId, orgId),
         inArray(userProviderConnections.providerCredentialId, providerCredentialIds),
       ),
@@ -90,7 +90,7 @@ async function getProviderDefinition(db: Db, providerId: string): Promise<Record
  */
 export async function getCredentials(
   db: Db,
-  profileId: string,
+  connectionProfileId: string,
   providerId: string,
   orgId: string,
   providerCredentialId: string,
@@ -99,7 +99,13 @@ export async function getCredentials(
   connection: ConnectionRecord;
   definition: Record<string, unknown>;
 } | null> {
-  const connection = await getConnection(db, profileId, providerId, orgId, providerCredentialId);
+  const connection = await getConnection(
+    db,
+    connectionProfileId,
+    providerId,
+    orgId,
+    providerCredentialId,
+  );
   if (!connection) return null;
 
   const def = await getProviderDefinition(db, providerId);
@@ -130,12 +136,18 @@ import type { ProxyCredentialsPayload } from "./proxy-primitives.ts";
  */
 export async function resolveCredentialsForProxy(
   db: Db,
-  profileId: string,
+  connectionProfileId: string,
   providerId: string,
   orgId: string,
   providerCredentialId: string,
 ): Promise<ProxyCredentialsPayload | null> {
-  const result = await getCredentials(db, profileId, providerId, orgId, providerCredentialId);
+  const result = await getCredentials(
+    db,
+    connectionProfileId,
+    providerId,
+    orgId,
+    providerCredentialId,
+  );
   if (!result) return null;
 
   const def = result.definition;
@@ -155,12 +167,18 @@ export async function resolveCredentialsForProxy(
  */
 export async function forceRefreshCredentials(
   db: Db,
-  profileId: string,
+  connectionProfileId: string,
   providerId: string,
   orgId: string,
   providerCredentialId: string,
 ): Promise<ProxyCredentialsPayload | null> {
-  const connection = await getConnection(db, profileId, providerId, orgId, providerCredentialId);
+  const connection = await getConnection(
+    db,
+    connectionProfileId,
+    providerId,
+    orgId,
+    providerCredentialId,
+  );
   if (!connection) return null;
 
   const def = await getProviderDefinition(db, providerId);
@@ -196,11 +214,11 @@ export async function forceRefreshCredentials(
 }
 
 /**
- * Save a connection (upsert on profileId + providerId + orgId + providerCredentialId).
+ * Save a connection (upsert on connectionProfileId + providerId + orgId + providerCredentialId).
  */
 export async function saveConnection(
   db: Db,
-  profileId: string,
+  connectionProfileId: string,
   providerId: string,
   orgId: string,
   credentials: Record<string, unknown>,
@@ -233,7 +251,7 @@ export async function saveConnection(
   await db
     .insert(userProviderConnections)
     .values({
-      profileId,
+      connectionProfileId,
       providerId,
       orgId,
       ...connectionData,
@@ -241,7 +259,7 @@ export async function saveConnection(
     })
     .onConflictDoUpdate({
       target: [
-        userProviderConnections.profileId,
+        userProviderConnections.connectionProfileId,
         userProviderConnections.providerId,
         userProviderConnections.orgId,
         userProviderConnections.providerCredentialId,
@@ -258,7 +276,7 @@ export async function saveConnection(
  */
 export async function deleteConnection(
   db: Db,
-  profileId: string,
+  connectionProfileId: string,
   providerId: string,
   orgId: string,
   providerCredentialId: string,
@@ -267,7 +285,7 @@ export async function deleteConnection(
     .delete(userProviderConnections)
     .where(
       and(
-        eq(userProviderConnections.profileId, profileId),
+        eq(userProviderConnections.connectionProfileId, connectionProfileId),
         eq(userProviderConnections.providerId, providerId),
         eq(userProviderConnections.orgId, orgId),
         eq(userProviderConnections.providerCredentialId, providerCredentialId),
@@ -287,7 +305,7 @@ export async function deleteConnectionById(db: Db, connectionId: string): Promis
 function rowToConnection(row: typeof userProviderConnections.$inferSelect): ConnectionRecord {
   return {
     id: row.id,
-    profileId: row.profileId,
+    connectionProfileId: row.connectionProfileId,
     providerId: row.providerId,
     orgId: row.orgId,
     providerCredentialId: row.providerCredentialId,

--- a/packages/connect/src/oauth.ts
+++ b/packages/connect/src/oauth.ts
@@ -71,14 +71,14 @@ export interface InitiateOAuthResult {
  * Initiate an OAuth2 authorization flow.
  * Creates a PKCE challenge (if supported), stores state in DB, and returns the auth URL.
  * orgId is needed for provider config lookup during OAuth.
- * profileId is stored in oauth_states for the callback.
+ * connectionProfileId is stored in oauth_states for the callback.
  */
 export async function initiateOAuth(
   db: Db,
   store: OAuthStateStore,
   orgId: string,
   actor: Actor,
-  profileId: string,
+  connectionProfileId: string,
   providerId: string,
   redirectUri: string,
   requestedScopes?: string[],
@@ -111,7 +111,7 @@ export async function initiateOAuth(
     userId: actor.type === "user" ? actor.id : null,
     endUserId: actor.type === "end_user" ? actor.id : null,
     applicationId,
-    profileId,
+    connectionProfileId,
     providerId,
     codeVerifier,
     scopesRequested: uniqueScopes,
@@ -148,7 +148,7 @@ export interface OAuthCallbackResult {
   orgId: string;
   userId: string | null;
   actor: Actor;
-  profileId: string;
+  connectionProfileId: string;
   applicationId: string;
   accessToken: string;
   refreshToken?: string;
@@ -173,7 +173,7 @@ export interface OAuthCallbackResult {
 /**
  * Handle the OAuth2 callback.
  * Exchanges the authorization code for tokens using PKCE.
- * Returns profileId from the stored oauth state.
+ * Returns connectionProfileId from the stored oauth state.
  */
 export async function handleOAuthCallback(
   db: Db,
@@ -301,7 +301,7 @@ export async function handleOAuthCallback(
     orgId: stateRow.orgId,
     userId: stateRow.userId ?? null,
     actor,
-    profileId: stateRow.profileId,
+    connectionProfileId: stateRow.connectionProfileId,
     applicationId: stateRow.applicationId,
     accessToken: parsed.accessToken,
     refreshToken: parsed.refreshToken,

--- a/packages/connect/src/oauth1.ts
+++ b/packages/connect/src/oauth1.ts
@@ -79,7 +79,7 @@ export async function initiateOAuth1(
   store: OAuthStateStore,
   orgId: string,
   actor: Actor,
-  profileId: string,
+  connectionProfileId: string,
   providerId: string,
   callbackUrl: string,
   applicationId?: string,
@@ -154,7 +154,7 @@ export async function initiateOAuth1(
     userId: actor.type === "user" ? actor.id : null,
     endUserId: actor.type === "end_user" ? actor.id : null,
     applicationId,
-    profileId,
+    connectionProfileId,
     providerId,
     codeVerifier: "",
     oauthTokenSecret,
@@ -183,7 +183,7 @@ export interface OAuth1CallbackResult {
   orgId: string;
   userId: string | null;
   actor: Actor;
-  profileId: string;
+  connectionProfileId: string;
   applicationId: string;
   consumerKey: string;
   accessToken: string;
@@ -287,7 +287,7 @@ export async function handleOAuth1Callback(
     orgId: stateRow.orgId,
     userId: stateRow.userId ?? null,
     actor,
-    profileId: stateRow.profileId,
+    connectionProfileId: stateRow.connectionProfileId,
     applicationId: stateRow.applicationId,
     consumerKey: creds.consumerKey,
     accessToken,

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -12,7 +12,7 @@ export type ProviderDefinition = ResolvedProviderDefinition;
 
 export interface ConnectionRecord {
   id: string;
-  profileId: string;
+  connectionProfileId: string;
   providerId: string;
   orgId: string;
   providerCredentialId: string;
@@ -39,7 +39,7 @@ export interface OAuthStateRecord {
   userId: string | null;
   endUserId?: string | null;
   applicationId: string;
-  profileId: string;
+  connectionProfileId: string;
   providerId: string;
   codeVerifier: string;
   scopesRequested: string[];

--- a/packages/db/src/schema/connections.ts
+++ b/packages/db/src/schema/connections.ts
@@ -66,7 +66,7 @@ export const userAgentProviderProfiles = pgTable(
       .notNull()
       .references(() => packages.id, { onDelete: "cascade" }),
     providerId: text("provider_id").notNull(),
-    profileId: uuid("profile_id")
+    connectionProfileId: uuid("profile_id")
       .notNull()
       .references(() => connectionProfiles.id, { onDelete: "cascade" }),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
@@ -79,7 +79,7 @@ export const userAgentProviderProfiles = pgTable(
       .on(table.endUserId, table.packageId, table.providerId)
       .where(sql`${table.endUserId} IS NOT NULL`),
     index("idx_ufpp_package_id").on(table.packageId),
-    index("idx_ufpp_profile_id").on(table.profileId),
+    index("idx_ufpp_profile_id").on(table.connectionProfileId),
     check(
       "ufpp_exactly_one_actor",
       sql`(user_id IS NOT NULL AND end_user_id IS NULL) OR (user_id IS NULL AND end_user_id IS NOT NULL)`,
@@ -102,7 +102,7 @@ export const userApplicationProfiles = pgTable(
     applicationId: text("application_id")
       .notNull()
       .references(() => applications.id, { onDelete: "cascade" }),
-    profileId: uuid("profile_id")
+    connectionProfileId: uuid("profile_id")
       .notNull()
       .references(() => connectionProfiles.id, { onDelete: "cascade" }),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),
@@ -110,7 +110,7 @@ export const userApplicationProfiles = pgTable(
   (table) => [
     primaryKey({ columns: [table.userId, table.applicationId] }),
     index("idx_uap_application_id").on(table.applicationId),
-    index("idx_uap_profile_id").on(table.profileId),
+    index("idx_uap_profile_id").on(table.connectionProfileId),
   ],
 );
 
@@ -165,13 +165,13 @@ export const applicationProviderCredentials = pgTable(
 // Connection profiles (user and org) are independent of applications.
 // Connections from different apps accumulate on the same profile — each connection
 // is tagged with a providerCredentialId linking it to one application's credentials.
-// The unique index on (profileId, providerId, orgId, providerCredentialId) allows
+// The unique index on (connectionProfileId, providerId, orgId, providerCredentialId) allows
 // one connection per provider per app per profile.
 export const userProviderConnections = pgTable(
   "user_provider_connections",
   {
     id: uuid("id").defaultRandom().primaryKey(),
-    profileId: uuid("profile_id")
+    connectionProfileId: uuid("profile_id")
       .notNull()
       .references(() => connectionProfiles.id, { onDelete: "cascade" }),
     providerId: text("provider_id").notNull(),
@@ -193,13 +193,16 @@ export const userProviderConnections = pgTable(
   },
   (table) => [
     uniqueIndex("idx_user_provider_connections_unique").on(
-      table.profileId,
+      table.connectionProfileId,
       table.providerId,
       table.orgId,
       table.providerCredentialId,
     ),
-    index("idx_user_provider_connections_profile").on(table.profileId),
-    index("idx_user_provider_connections_profile_provider").on(table.profileId, table.providerId),
+    index("idx_user_provider_connections_profile").on(table.connectionProfileId),
+    index("idx_user_provider_connections_profile_provider").on(
+      table.connectionProfileId,
+      table.providerId,
+    ),
     index("idx_user_provider_connections_org_id").on(table.orgId),
     index("idx_user_provider_connections_cred_id").on(table.providerCredentialId),
     index("idx_user_provider_connections_org_provider").on(table.orgId, table.providerId),

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -174,7 +174,7 @@ import type { JSONSchemaObject, SchemaWrapper } from "@appstrate/core/form";
 /** Connection record as returned by the API (no encrypted credentials). */
 export interface ConnectionInfo {
   id: string;
-  profileId: string;
+  connectionProfileId: string;
   providerId: string;
   orgId: string;
   scopesGranted?: string[];
@@ -633,7 +633,7 @@ export type ReadinessReason = (typeof READINESS_REASONS)[number];
 
 export interface ReadinessProviderEntry {
   providerId: string;
-  profileId: string | null;
+  connectionProfileId: string | null;
   reason: ReadinessReason;
   message: string;
 }


### PR DESCRIPTION
## Summary

Unifies the bare/generic `profileId` term to the canonical `connectionProfileId` everywhere it appears as a TS field, function parameter, URL query param, JSON body field, OpenAPI parameter, or Drizzle field name. The disambiguating role-qualifier names `appProfileId` and `sourceProfileId` are intentionally **kept** (see Scope below).

77 files changed | 809 insertions, 671 deletions | 18/18 quality-gate tasks pass | 750/750 unit tests pass.

## Canonical name + rationale

**`connectionProfileId`** — already canonical in the CLI config (`config.toml`), in the schedules wire shape (`schedules.connectionProfileId`), and matches the underlying SQL table `connection_profiles` exactly. Picking it avoids the open collision with PR #16 (connection-vs-credentials rename), since `connectionId` is reserved there for a different concept (the `userProviderConnections` row, i.e. an actual provider connection rather than a profile).

## Scope — what was renamed

| Source form | Canonical form |
| --- | --- |
| `profileId` (TS field, parameter, query param, body field, Drizzle field) | `connectionProfileId` |
| `appProfileId` | **kept** — see below |
| `sourceProfileId` | **kept** — see below |

### Why `appProfileId` and `sourceProfileId` are intentionally kept

The audit framed these as "3 redundant terms for the same entity" — that's true at the table level (all three reference rows in `connection_profiles`), but they encode **distinct semantic roles** in the same context:

- `appProfileProviderBindings` has **two** FKs into `connection_profiles`: `app_profile_id` (the binding owner) and `source_profile_id` (the user-owned profile being delegated to). Renaming both to `connectionProfileId` would cause a real column-name collision.
- The same role distinction surfaces in service signatures (`bindAppProfileProvider(appProfileId, providerId, sourceProfileId, ...)`) and URL routes (`/app-profiles/:appProfileId/bindings/:providerId`).

Renaming them to a single name would lose semantic distinction and force re-introducing prefix-based qualifiers (`appConnectionProfileId`, `sourceConnectionProfileId`) — an obvious wash. They stay.

## Database migration: NONE

Drizzle TS field names are renamed; SQL column names are preserved:

```diff
- profileId: uuid("profile_id").notNull()...
+ connectionProfileId: uuid("profile_id").notNull()...
```

No migration needed, no destructive `ALTER TABLE`, rollback-safe. Index names containing `profile_id` (e.g. `idx_ufpp_profile_id`) are kept as-is to match the underlying DB columns they index.

This is intentional — the rename's value is on the developer-facing TS surface (no more "is this an app profile, source profile, or connection profile?" guessing). The DB column name is invisible to consumers and renaming it would have been needlessly destructive.

## Wire breaking changes (`detect:breaking` will flag these — expected)

| Endpoint | Field |
| --- | --- |
| `POST /api/agents/{scope}/{name}/providers` | body `profileId` -> `connectionProfileId` |
| `GET /api/agents/{scope}/{name}/readiness` | response `profileId` -> `connectionProfileId` |
| `GET /api/connections` | query `profileId` -> `connectionProfileId` |
| `GET /api/connections/connect/{provider}` | query `profileId` -> `connectionProfileId` |
| `POST /api/connections/connect/{provider}` | body `profileId` -> `connectionProfileId` |
| `POST /api/connections/api-key/{provider}` | body `profileId` -> `connectionProfileId` |
| `POST /api/connections/credentials/{provider}` | body `profileId` -> `connectionProfileId` |
| `POST /api/internal/connections/profiles` | body `profileId` -> `connectionProfileId` |
| `POST /api/me/default-profile` | body `profileId` -> `connectionProfileId` |

Baseline regenerated in lockstep so `detect:breaking` shows "No changes detected against baseline" — the diff is in the baseline itself.

## Multi-repo follow-ups (out of scope for this PR)

| Repo | Status |
| --- | --- |
| `registry/` | No `profileId`/`appProfileId`/`sourceProfileId` references — verified |
| `cloud/` | Needs separate audit (private repo) |
| `portal/` | Needs separate audit (private repo) |
| `github-action/` | No references — verified |

## Quality gate

- `bun run check` (force) — 18/18 turbo tasks pass
- `bun run test:unit` — 750/750 tests pass
- `verify:openapi` — OK on all 5 sub-checks (coverage, structural, lint, Zod<>OpenAPI, Code subset Spec)
- `detect:breaking` — clean against regenerated baseline

## Test plan

- [ ] Manual: connect a Gmail provider via the dashboard, verify the OAuth callback round-trip succeeds with the new `connectionProfileId` query param
- [ ] Manual: create a schedule via UI, verify the `connectionProfileId` body field is accepted
- [ ] CLI: run `appstrate doctor` against a CLI-pinned profile to verify the config reads the same way
- [ ] Integration suite: run `bun test` (Docker required — could not run locally in worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)