### PR TITLE
fix(e2e): drop stale agent envelope from package detail assertions

### DIFF
--- a/e2e/tests/agents/default-app.api.spec.ts
+++ b/e2e/tests/agents/default-app.api.spec.ts
@@ -213,8 +213,8 @@ test.describe("Default app vs custom app access", () => {
 
     const detailA = await resDetailA.json();
     const detailB = await resDetailB.json();
-    expect(detailA.agent?.config?.current?.mode).toBe("default-app-value");
-    expect(detailB.agent?.config?.current?.mode).toBe("custom-app-value");
+    expect(detailA.config?.current?.mode).toBe("default-app-value");
+    expect(detailB.config?.current?.mode).toBe("custom-app-value");
   });
 
   test("Installed packages list is per-app", async ({


### PR DESCRIPTION
## Summary

The \`{ agent: ... }\` wire envelope was removed from the package detail response in [batch 3 (#376, finding #6)](https://github.com/appstrate/appstrate/pull/376), but \`e2e/tests/agents/default-app.api.spec.ts\` still reads \`detailA.agent?.config?.current?.mode\`. With the envelope gone that resolves to \`undefined\` and the test fails.

Symptom on \`main\` :

\`\`\`
Expected: "default-app-value"
Received: undefined
   at e2e/tests/agents/default-app.api.spec.ts:216:50
\`\`\`

Aligns the assertion with the flat shape returned by \`agent-detail-handler.ts\` — same pattern already used by every other E2E spec hitting \`/packages/agents/{scope}/{name}\`.

## Test plan

- [x] CI E2E suite green