### PR TITLE
fix(sidecar): copy upstream-meta.ts + packages/core/src into build stage

### DIFF
--- a/runtime-pi/sidecar/Dockerfile
+++ b/runtime-pi/sidecar/Dockerfile
@@ -57,9 +57,13 @@ RUN --mount=type=cache,target=/root/.bun/install/cache,sharing=locked \
 #                                             by proxy-primitives
 #   - @appstrate/mcp-transport                MCP adapter on the official SDK,
 #                                             used by mcp.ts to expose `tools/*`
+#   - @appstrate/core/{errors,ssrf}           getErrorMessage + isBlockedHost/Url,
+#                                             imported by credential-proxy.ts /
+#                                             mcp.ts / ssrf.ts
 COPY packages/connect/src        packages/connect/src
 COPY packages/afps-runtime/src   packages/afps-runtime/src
 COPY packages/mcp-transport/src  packages/mcp-transport/src
+COPY packages/core/src           packages/core/src
 
 # Sidecar sources.
 COPY runtime-pi/sidecar/server.ts           \
@@ -73,6 +77,7 @@ COPY runtime-pi/sidecar/server.ts           \
      runtime-pi/sidecar/credential-proxy.ts \
      runtime-pi/sidecar/roots.ts            \
      runtime-pi/sidecar/logger.ts           \
+     runtime-pi/sidecar/upstream-meta.ts    \
      runtime-pi/sidecar/
 
 WORKDIR /build/runtime-pi/sidecar


### PR DESCRIPTION
## Summary

The \`release.yml\` run for \`v1.0.0-beta.7\` failed with:

\`\`\`
error: Could not resolve: "@appstrate/core/errors"
error: Could not resolve: "./upstream-meta.ts"
error: Could not resolve: "@appstrate/core/ssrf"
\`\`\`

Two regressions slipped past local builds because the sidecar Dockerfile COPY list never grew with the source tree:

1. **#372 (provider_upload)** added \`runtime-pi/sidecar/upstream-meta.ts\` imported by \`mcp.ts\`, but the multi-line COPY block in the Dockerfile was not extended.
2. **#376 (simplification batch 3)** introduced \`@appstrate/core/errors\` and \`@appstrate/core/ssrf\` imports in \`credential-proxy.ts\`, \`mcp.ts\`, and \`ssrf.ts\`, but the Dockerfile only copies the core \`package.json\` stub, not its \`src/\`.

The local docker-check passed because it builds the **main** Dockerfile, not the sidecar one. Worth a follow-up to extend docker-check.sh.

## Fix

- Add \`packages/core/src\` to the workspace-sources COPY list (next to connect / afps-runtime / mcp-transport).
- Add \`upstream-meta.ts\` to the sidecar-sources COPY list.

## Test plan

- [x] CI: sidecar build step in \`release.yml\` succeeds when re-tagged