### PR TITLE
fix(sidecar): declare @appstrate/core as a workspace dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -362,6 +362,7 @@
       "name": "appstrate-sidecar",
       "dependencies": {
         "@appstrate/connect": "workspace:*",
+        "@appstrate/core": "workspace:*",
         "@appstrate/mcp-transport": "workspace:*",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "hono": "^4.12.15",

--- a/runtime-pi/sidecar/package.json
+++ b/runtime-pi/sidecar/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@appstrate/connect": "workspace:*",
+    "@appstrate/core": "workspace:*",
     "@appstrate/mcp-transport": "workspace:*",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "hono": "^4.12.15"


### PR DESCRIPTION
## Summary

PR #386 added \`COPY packages/core/src\` to the sidecar Dockerfile, which was necessary but not sufficient. Bun resolves \`@appstrate/core/errors\` via \`node_modules/@appstrate/core\` — that symlink only exists when the package is declared in the consuming workspace's \`dependencies\`. The sidecar's \`package.json\` never listed core, so \`v1.0.0-beta.8\`'s \`release.yml\` failed with the same "Could not resolve" error as beta.7.

\`\`\`
error: Could not resolve: "@appstrate/core/errors"
error: Could not resolve: "@appstrate/core/ssrf"
\`\`\`

## Local repro

Before:

\`\`\`
$ ls runtime-pi/sidecar/node_modules/@appstrate/
connect  mcp-transport          # ← no core
\`\`\`

After adding the dep + \`bun install\`:

\`\`\`
$ ls runtime-pi/sidecar/node_modules/@appstrate/
connect  core  mcp-transport

$ cd runtime-pi/sidecar && bun build --compile --minify server.ts -o /tmp/x
[bundles cleanly, 386 modules, 61 MB binary]
\`\`\`

Same pattern as the existing \`connect\` / \`mcp-transport\` entries.

## Test plan

- [x] Local \`bun build --compile\` of sidecar passes
- [x] CI: sidecar build step in \`release.yml\` succeeds when re-tagged