### PR TITLE
fix(runtime-pi): copy packages/core/node_modules into runtime image

### DIFF
--- a/runtime-pi/Dockerfile
+++ b/runtime-pi/Dockerfile
@@ -123,6 +123,7 @@ WORKDIR /runtime
 # per-package trees into it — both levels are required at import time.
 COPY --from=deps --chown=pi:pi /build/node_modules                       ./node_modules
 COPY --from=deps --chown=pi:pi /build/packages/afps-runtime/node_modules  ./packages/afps-runtime/node_modules
+COPY --from=deps --chown=pi:pi /build/packages/core/node_modules          ./packages/core/node_modules
 COPY --from=deps --chown=pi:pi /build/packages/mcp-transport/node_modules ./packages/mcp-transport/node_modules
 COPY --from=deps --chown=pi:pi /build/packages/runner-pi/node_modules     ./packages/runner-pi/node_modules
 COPY --from=deps --chown=pi:pi /build/runtime-pi/node_modules             ./runtime-pi/node_modules


### PR DESCRIPTION
## Summary

- Hotfix for beta.10: agent containers crashed at boot with `error: Cannot find package 'zod' from '/runtime/packages/core/src/validation.ts'`.
- Bun installs workspaces in isolated mode — each workspace owns its own `node_modules/` with relative symlinks to `/runtime/node_modules/.bun/`. PR #388 restored `packages/core/src` and the `@appstrate/core` symlink but left `packages/core/node_modules` behind, so transitive imports (`zod`, `ajv`, `pino`, `semver`, `fflate`, `ajv-formats`) couldn't resolve.
- Mirror the COPY pattern already used for `afps-runtime` / `mcp-transport` / `runner-pi`.

## Test plan
- [ ] `release.yml` builds appstrate-pi:1.0.0-beta.11 successfully
- [ ] Coolify redeploys with PI_IMAGE=…:beta.11
- [ ] `@tractr/hello-world` agent run completes (the run that broke beta.10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)