### PR TITLE
feat(sidecar): token-aware context budgeting for tool outputs (#390)

### DIFF
--- a/runtime-pi/sidecar/README.md
+++ b/runtime-pi/sidecar/README.md
@@ -79,7 +79,11 @@ Each text-path tool result carries an `appstrate://token-budget` `_meta` payload
 }
 ```
 
-`reason` is one of `under_inline_cap`, `exceeds_inline_cap`, `exceeds_run_budget`, or `no_blob_store_fallback_inline` (the last set when a forced spill failed because the blob store was already full — the agent paid the context cost as a last resort and the meta records the override).
+`reason` is one of:
+
+- `under_inline_cap` / `exceeds_inline_cap` / `exceeds_run_budget` — what the budget tracker decided.
+- `blob_store_full` — the budget said spill but the blob store rejected the put (cumulative cap reached); the agent gets the content inline as a last resort and the override is recorded in the meta.
+- `no_blob_store_configured` — the budget said spill but no blob store was wired (tests / embedders); same forced-inline outcome, but a distinct reason so operators can tell misconfiguration from saturation.
 
 ## The `body.fromFile` contract
 

--- a/runtime-pi/sidecar/README.md
+++ b/runtime-pi/sidecar/README.md
@@ -29,24 +29,57 @@ Third-party MCP servers can be mounted alongside the first-party tools via `Subp
 
 ## Binary safety
 
-`provider_call` upstream responses are byte-exact: the sidecar reads the upstream body via `arrayBuffer()` and either returns the bytes inline (text under `INLINE_RESPONSE_THRESHOLD`) or stores them in the run-scoped `BlobStore` and returns a `resource_link` block. No `.text()` decode, no UTF-8 round-trip, no implicit Content-Type rewriting.
+`provider_call` upstream responses are byte-exact: the sidecar reads the upstream body via `arrayBuffer()` and either returns the bytes inline (text under the per-call token cap and within the run-level cumulative budget — see "Token-aware context budgeting" below) or stores them in the run-scoped `BlobStore` and returns a `resource_link` block. No `.text()` decode, no UTF-8 round-trip, no implicit Content-Type rewriting.
 
 The only path that decodes the request body to UTF-8 is the optional `substituteBody: true` argument, which performs `{{variable}}` placeholder substitution on a buffered body.
 
 ## Size limits
 
-| Constant                     | Value  | Purpose                                                                                                                                                                                                                                                  |
-| ---------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `MAX_RESPONSE_SIZE`          | 256 KB | Default cap on upstream response bytes returned inline to the agent.                                                                                                                                                                                     |
-| `ABSOLUTE_MAX_RESPONSE_SIZE` | 32 MB  | Ceiling on upstream bytes the sidecar buffers before refusing — only applied when a `BlobStore` is configured (otherwise `MAX_RESPONSE_SIZE` is the cap). Sized to cover real-world binaries (PDFs, images, archives) routed through the spillover path. |
-| `MAX_SUBSTITUTE_BODY_SIZE`   | 5 MB   | Maximum buffered request body size accepted with `substituteBody`.                                                                                                                                                                                       |
-| `STREAMING_THRESHOLD`        | 1 MB   | Above this `Content-Length` `provider_call` switches to streaming.                                                                                                                                                                                       |
-| `MAX_STREAMED_BODY_SIZE`     | 100 MB | Ceiling on streamed request and response bodies.                                                                                                                                                                                                         |
-| `INLINE_RESPONSE_THRESHOLD`  | 32 KB  | Above this responses spill to the `BlobStore` as a `resource_link`.                                                                                                                                                                                      |
-| `OUTBOUND_TIMEOUT_MS`        | 30 s   | Upstream `provider_call` request timeout.                                                                                                                                                                                                                |
-| `LLM_PROXY_TIMEOUT_MS`       | 5 min  | `/llm/*` HTTP passthrough timeout (long enough for streamed completions).                                                                                                                                                                                |
+| Constant                          | Value  | Purpose                                                                                                                                                                                                                                                  |
+| --------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MAX_RESPONSE_SIZE`               | 256 KB | Default cap on upstream response bytes returned inline to the agent.                                                                                                                                                                                     |
+| `ABSOLUTE_MAX_RESPONSE_SIZE`      | 32 MB  | Ceiling on upstream bytes the sidecar buffers before refusing — only applied when a `BlobStore` is configured (otherwise `MAX_RESPONSE_SIZE` is the cap). Sized to cover real-world binaries (PDFs, images, archives) routed through the spillover path. |
+| `MAX_SUBSTITUTE_BODY_SIZE`        | 5 MB   | Maximum buffered request body size accepted with `substituteBody`.                                                                                                                                                                                       |
+| `STREAMING_THRESHOLD`             | 1 MB   | Above this `Content-Length` `provider_call` switches to streaming.                                                                                                                                                                                       |
+| `MAX_STREAMED_BODY_SIZE`          | 100 MB | Ceiling on streamed request and response bodies.                                                                                                                                                                                                         |
+| `INLINE_RESPONSE_THRESHOLD_BYTES` | 32 KB  | Legacy byte threshold; only consulted when no `TokenBudget` is configured. Production always wires a budget — see "Token-aware context budgeting" below.                                                                                                 |
+| `OUTBOUND_TIMEOUT_MS`             | 30 s   | Upstream `provider_call` request timeout.                                                                                                                                                                                                                |
+| `LLM_PROXY_TIMEOUT_MS`            | 5 min  | `/llm/*` HTTP passthrough timeout (long enough for streamed completions).                                                                                                                                                                                |
 
 When the upstream response exceeds the inline threshold, the bytes are stored in the run-scoped `BlobStore` (256 MB cap, ULID URIs, traversal-safe) and the tool returns a `resource_link` block. The agent reads the bytes on demand via `client.readResource({ uri })`.
+
+## Token-aware context budgeting
+
+Byte caps protect the sidecar from OOM but do not reflect the true cost of a tool output in the agent's **context window**: 256 KB of dense JSON or base64 ≈ 60-90 K tokens, and 50 successive 30 KB calls (each well under the byte threshold) accumulate ~450 K tokens of context with no guard rail under a byte-only policy.
+
+The sidecar layers two token-aware checks on top of the byte caps (see `token-budget.ts`):
+
+| Knob                                    | Default        | Purpose                                                                                                                                                                                                                 |
+| --------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SIDECAR_INLINE_TOOL_OUTPUT_TOKENS`     | 8 000 tokens   | Per-call inline cap. Tool outputs above this spill to the `BlobStore` regardless of size — keeps the agent's context cost per call bounded.                                                                             |
+| `SIDECAR_RUN_TOOL_OUTPUT_BUDGET_TOKENS` | 200 000 tokens | Cumulative ceiling per run. As the agent's tool outputs accumulate, the inline path tightens; once the ceiling is breached, every text response spills. Operators on 1 M-context Sonnet 4.6 deployments can raise this. |
+
+Token estimation uses the Anthropic-recommended **3.5 chars/token** heuristic — deterministic, allocation-free, suitable for the hot path of every `provider_call`. The official `@anthropic-ai/tokenizer` is no longer accurate for Claude 3+ models, and a real tokenizer (tiktoken / `count_tokens` API) would add 5-50 ms per call to the credential-injection round-trip.
+
+Each text-path tool result carries an `appstrate://token-budget` `_meta` payload so the agent runtime can surface accounting and react to structured truncation events:
+
+```jsonc
+{
+  "content": [{ "type": "text", "text": "<upstream body>" }],
+  "_meta": {
+    "appstrate://token-budget": {
+      "estimatedTokens": 1234,
+      "consumedTokens": 5000,
+      "runBudgetTokens": 200000,
+      "inlineCapTokens": 8000,
+      "decision": "inline",
+      "reason": "under_inline_cap",
+    },
+  },
+}
+```
+
+`reason` is one of `under_inline_cap`, `exceeds_inline_cap`, `exceeds_run_budget`, or `no_blob_store_fallback_inline` (the last set when a forced spill failed because the blob store was already full — the agent paid the context cost as a last resort and the meta records the override).
 
 ## The `body.fromFile` contract
 

--- a/runtime-pi/sidecar/app.ts
+++ b/runtime-pi/sidecar/app.ts
@@ -12,6 +12,12 @@ import {
   type CredentialsResponse,
   type LlmProxyConfig,
 } from "./helpers.ts";
+import {
+  DEFAULT_INLINE_OUTPUT_TOKENS,
+  DEFAULT_RUN_OUTPUT_BUDGET_TOKENS,
+  TokenBudget,
+  readPositiveTokenEnv,
+} from "./token-budget.ts";
 
 export type { SidecarConfig } from "./helpers.ts";
 
@@ -199,8 +205,22 @@ export function createApp(deps: AppDeps): Hono {
   // `provider_call` directly to `executeProviderCall` via the shared
   // `proxyDeps` (no header round-trip).
   const blobStore = new BlobStore(deps.runId ?? "unknown");
+  // Token-aware budgeting (issue #390): every tool output is gated by
+  // a per-call inline cap and a cumulative run-level ceiling. Both
+  // are configurable via env vars; defaults stay conservative for
+  // OSS / dev (200 K-token context window equivalent).
+  const inlineCapTokens = readPositiveTokenEnv(
+    "SIDECAR_INLINE_TOOL_OUTPUT_TOKENS",
+    DEFAULT_INLINE_OUTPUT_TOKENS,
+  );
+  const runBudgetTokens = readPositiveTokenEnv(
+    "SIDECAR_RUN_TOOL_OUTPUT_BUDGET_TOKENS",
+    DEFAULT_RUN_OUTPUT_BUDGET_TOKENS,
+  );
+  const tokenBudget = new TokenBudget({ inlineCapTokens, runBudgetTokens });
   mountMcp(app, {
     blobStore,
+    tokenBudget,
     proxyDeps: {
       config,
       cookieJar,

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -259,10 +259,13 @@ interface TokenBudgetMeta {
  * call `proxyDeps.fetchFn` against the platform upstream. None of
  * these tools round-trip through a Hono HTTP envelope.
  *
- * When a `provider_call` upstream response is binary or exceeds
- * {@link INLINE_RESPONSE_THRESHOLD}, the bytes are stored in the
- * supplied {@link BlobStore} and the tool returns a `resource_link`
- * block instead of an inline text body.
+ * When a `provider_call` upstream response is binary, exceeds the
+ * per-call token cap, or would push the run-level cumulative budget
+ * past its ceiling (see {@link TokenBudget}), the bytes are stored in
+ * the supplied {@link BlobStore} and the tool returns a `resource_link`
+ * block instead of an inline text body. The legacy byte threshold
+ * {@link INLINE_RESPONSE_THRESHOLD_BYTES} is consulted only when no
+ * {@link TokenBudget} is wired (tests / embedders).
  */
 function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] {
   const { blobStore, proxyDeps, tokenBudget } = options;

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -63,7 +63,8 @@ import {
   MAX_RESPONSE_SIZE,
   PROVIDER_ID_RE,
 } from "./helpers.ts";
-import { TokenBudget, estimateTokens, type BudgetDecision } from "./token-budget.ts";
+import { TokenBudget } from "./token-budget.ts";
+import { logger } from "./logger.ts";
 
 /**
  * Strict standard base64 decoder (RFC 4648 §4). Refuses URL-safe
@@ -233,6 +234,19 @@ const INLINE_RESPONSE_THRESHOLD_BYTES = 32 * 1024;
 export const TOKEN_BUDGET_META_KEY = "appstrate://token-budget";
 
 /**
+ * Discriminated reason surfaced in the agent-facing `_meta` payload.
+ * Wider than {@link BudgetDecision.reason} because it adds the
+ * caller-driven fallback states (no blob store wired, blob store full)
+ * the budget tracker itself cannot produce.
+ */
+type TokenBudgetMetaReason =
+  | "under_inline_cap"
+  | "exceeds_inline_cap"
+  | "exceeds_run_budget"
+  | "blob_store_full"
+  | "no_blob_store_configured";
+
+/**
  * Shape of the {@link TOKEN_BUDGET_META_KEY} payload. Stable wire
  * contract — extensions append, never rename.
  */
@@ -245,10 +259,10 @@ interface TokenBudgetMeta {
   runBudgetTokens: number;
   /** Configured per-call inline cap. */
   inlineCapTokens: number;
-  /** What the budget tracker decided. */
-  decision: BudgetDecision["decision"];
+  /** What the budget tracker decided (after caller overrides). */
+  decision: "inline" | "spill";
   /** Why it decided that way (machine-readable). */
-  reason: BudgetDecision["reason"];
+  reason: TokenBudgetMetaReason;
 }
 
 /**
@@ -713,6 +727,43 @@ interface ResponseToToolResultOptions {
 }
 
 /**
+ * Pure helper: decide whether a text body should spill, and produce
+ * the agent-facing `_meta` payload describing the decision.
+ *
+ * Folded out of {@link responseToToolResult} so the budget logic is
+ * unit-testable in isolation and the surrounding async flow stays
+ * linear. When a {@link TokenBudget} is wired, calls
+ * {@link TokenBudget.tryReserve} so the inline-record is atomic with
+ * the decision (no decide/record interleave under concurrent calls).
+ *
+ * Returns `meta: undefined` when no budget is configured — the agent
+ * sees no `_meta` payload and the legacy byte threshold drives the
+ * spill decision.
+ */
+function evaluateBudget(args: {
+  text: string;
+  tokenBudget: TokenBudget | undefined;
+  byteThreshold: number;
+}): { shouldSpill: boolean; meta: TokenBudgetMeta | undefined } {
+  if (!args.tokenBudget) {
+    return { shouldSpill: args.text.length > args.byteThreshold, meta: undefined };
+  }
+  const estimated = args.tokenBudget.estimate(args.text);
+  const decision = args.tokenBudget.tryReserve(estimated);
+  return {
+    shouldSpill: decision.decision === "spill",
+    meta: {
+      estimatedTokens: estimated,
+      consumedTokens: decision.consumedTokens,
+      runBudgetTokens: decision.runBudgetTokens,
+      inlineCapTokens: decision.inlineCapTokens,
+      decision: decision.decision,
+      reason: decision.reason,
+    },
+  };
+}
+
+/**
  * Convert an upstream `Response` into an MCP CallToolResult.
  *
  * Non-OK responses become tool-level errors (`isError: true`) — the
@@ -868,27 +919,19 @@ async function responseToToolResult(
   const readCap = options.blobStore ? ABSOLUTE_MAX_RESPONSE_SIZE : MAX_RESPONSE_SIZE;
   const text = await readBodyBounded(res, readCap);
 
-  // Token-aware spill decision. With a TokenBudget we estimate the
-  // tokens this response would burn, then ask the budget tracker
-  // whether it fits inline (per-call cap + cumulative budget). Without
-  // a TokenBudget we fall back to the legacy byte threshold so older
+  // Token-aware spill decision. The token-budget path uses an atomic
+  // tryReserve() so cumulative state doesn't drift under concurrent
+  // calls (two awaits between decide() and record() would otherwise
+  // let two callers both observe a stale `consumed`). Without a
+  // TokenBudget we fall back to the legacy byte threshold so older
   // tests + embedders that don't wire a budget keep working.
-  const shouldSpillForBudget = ((): boolean => {
-    if (options.tokenBudget) {
-      const estimated = estimateTokens(text);
-      const decision = options.tokenBudget.decide(estimated);
-      budgetMeta = {
-        estimatedTokens: estimated,
-        consumedTokens: decision.consumedTokens,
-        runBudgetTokens: decision.runBudgetTokens,
-        inlineCapTokens: decision.inlineCapTokens,
-        decision: decision.decision,
-        reason: decision.reason,
-      };
-      return decision.decision === "spill";
-    }
-    return text.length > byteThreshold;
-  })();
+  const evaluation = evaluateBudget({
+    text,
+    tokenBudget: options.tokenBudget,
+    byteThreshold,
+  });
+  budgetMeta = evaluation.meta;
+  const shouldSpillForBudget = evaluation.shouldSpill;
 
   // If the text body should spill AND we have a blob store, spill it.
   // The agent gets a pointer instead of poisoning its context with a
@@ -901,30 +944,32 @@ async function responseToToolResult(
         mimeType: ct || "text/plain",
         ...(options.source !== undefined ? { source: options.source } : {}),
       });
-    } catch {
-      // Blob store full — fall back to inline. We do NOT record the
-      // tokens against the budget when the blob store rejects the put
-      // because the budget is a *delivery* counter (we are about to
-      // deliver this content inline as a last resort) — recording
-      // happens below on the inline path.
-      if (options.tokenBudget && budgetMeta) {
-        // Update the meta to reflect the forced fallback so the agent
-        // can see we exceeded the inline cap but had no spill path.
-        budgetMeta = {
-          ...budgetMeta,
-          decision: "inline",
-          reason: "no_blob_store_fallback_inline",
-        };
+    } catch (err) {
+      // Blob store full — surface a distinct reason and record the
+      // forced-inline tokens against the budget. tryReserve() did NOT
+      // record on the spill path, so we record explicitly here.
+      if (budgetMeta) {
+        budgetMeta = { ...budgetMeta, decision: "inline", reason: "blob_store_full" };
+        options.tokenBudget?.record(budgetMeta.estimatedTokens);
       }
+      logger.warn("token-budget: blob store full, forced inline", {
+        source: options.source,
+        estimatedTokens: budgetMeta?.estimatedTokens,
+        consumedTokens: options.tokenBudget?.consumedTokens(),
+        error: getErrorMessage(err),
+      });
       const fallback: Result = res.ok
         ? { content: [{ type: "text", text }] }
         : { content: [{ type: "text", text }], isError: true };
-      // Best-effort recording — caller already paid the context cost.
-      if (options.tokenBudget && budgetMeta) {
-        options.tokenBudget.record(budgetMeta.estimatedTokens);
-      }
       return withMeta(fallback);
     }
+    logger.info("token-budget: spilled to blob store", {
+      source: options.source,
+      reason: budgetMeta?.reason,
+      estimatedTokens: budgetMeta?.estimatedTokens,
+      consumedTokens: budgetMeta?.consumedTokens,
+      uri: record.uri,
+    });
     const link = {
       type: "resource_link" as const,
       uri: record.uri,
@@ -934,19 +979,18 @@ async function responseToToolResult(
     return withMeta(res.ok ? { content: [link] } : { content: [link], isError: true });
   }
 
-  // Inline path — record the actual delivered tokens against the
-  // budget. If the budget said `spill` but no blob store was
-  // configured, surface the forced-inline reason so the agent can
-  // flag the missing spill path rather than silently overspending.
-  if (options.tokenBudget && budgetMeta) {
-    if (shouldSpillForBudget && !options.blobStore) {
-      budgetMeta = {
-        ...budgetMeta,
-        decision: "inline",
-        reason: "no_blob_store_fallback_inline",
-      };
-    }
-    options.tokenBudget.record(budgetMeta.estimatedTokens);
+  // Inline path — when the budget said spill but no blob store is
+  // configured, surface the distinct reason and record the
+  // forced-inline tokens. tryReserve() did NOT record on the spill
+  // path, so we record explicitly here.
+  if (shouldSpillForBudget && !options.blobStore && budgetMeta) {
+    budgetMeta = { ...budgetMeta, decision: "inline", reason: "no_blob_store_configured" };
+    options.tokenBudget?.record(budgetMeta.estimatedTokens);
+    logger.warn("token-budget: no blob store configured, forced inline", {
+      source: options.source,
+      estimatedTokens: budgetMeta.estimatedTokens,
+      consumedTokens: options.tokenBudget?.consumedTokens(),
+    });
   }
 
   if (!res.ok) {

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -63,6 +63,7 @@ import {
   MAX_RESPONSE_SIZE,
   PROVIDER_ID_RE,
 } from "./helpers.ts";
+import { TokenBudget, estimateTokens, type BudgetDecision } from "./token-budget.ts";
 
 /**
  * Strict standard base64 decoder (RFC 4648 §4). Refuses URL-safe
@@ -209,19 +210,46 @@ function sanitiseProviderCallHeaders(raw: Record<string, string> | undefined): {
 }
 
 /**
- * Inline payload threshold for `provider_call`. Above this size the
- * response is stored in the BlobStore and the tool returns a
- * `resource_link` content block — saves the agent from blowing its
- * context window on a 5MB JSON dump. The agent reads
- * via `client.readResource({ uri })` only if it actually needs the
- * bytes.
+ * Legacy byte-based inline threshold. Kept as a defence-in-depth
+ * fallback when no {@link TokenBudget} is configured (today: never in
+ * production, but the option keeps tests and embedders simple).
  *
- * 32KB is generous for typical LLM-targeted text payloads (a verbose
- * Gmail thread or a Notion page rarely exceeds that), and small enough
- * that >100KB JSON dumps from heavy enterprise APIs spill to blob
- * automatically.
+ * The token-aware path (see {@link TokenBudget}) is the primary
+ * gate: dense JSON / base64 hits the agent's context budget far
+ * harder than a byte cap suggests, and small calls accumulate.
  */
-const INLINE_RESPONSE_THRESHOLD = 32 * 1024;
+const INLINE_RESPONSE_THRESHOLD_BYTES = 32 * 1024;
+
+/**
+ * MCP `_meta` key under which the sidecar surfaces token-budget
+ * accounting to the agent runtime. Agent-side resolvers can read this
+ * to display "X / Y tokens of run budget consumed" or to react to
+ * structured truncation events.
+ *
+ * Distinct from {@link UPSTREAM_META_KEY} (which carries upstream
+ * `{ status, headers }`) so a CallToolResult can carry both without
+ * collision.
+ */
+export const TOKEN_BUDGET_META_KEY = "appstrate://token-budget";
+
+/**
+ * Shape of the {@link TOKEN_BUDGET_META_KEY} payload. Stable wire
+ * contract — extensions append, never rename.
+ */
+interface TokenBudgetMeta {
+  /** Tokens estimated for *this* tool output. */
+  estimatedTokens: number;
+  /** Cumulative tool-output tokens consumed in the run so far. */
+  consumedTokens: number;
+  /** Configured run-level ceiling. */
+  runBudgetTokens: number;
+  /** Configured per-call inline cap. */
+  inlineCapTokens: number;
+  /** What the budget tracker decided. */
+  decision: BudgetDecision["decision"];
+  /** Why it decided that way (machine-readable). */
+  reason: BudgetDecision["reason"];
+}
 
 /**
  * Build the `provider_call`, `run_history`, and `recall_memory` MCP
@@ -237,7 +265,7 @@ const INLINE_RESPONSE_THRESHOLD = 32 * 1024;
  * block instead of an inline text body.
  */
 function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] {
-  const { blobStore, proxyDeps } = options;
+  const { blobStore, proxyDeps, tokenBudget } = options;
   const { config, fetchFn } = proxyDeps;
   const providerCall: AppstrateToolDefinition = {
     descriptor: {
@@ -464,6 +492,7 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
       }
       return responseToToolResult(result.response, {
         ...(blobStore ? { blobStore } : {}),
+        ...(tokenBudget ? { tokenBudget } : {}),
         source: `provider:${args.providerId}`,
         // Attach upstream `{ status, headers }` to the CallToolResult
         // `_meta` payload so the agent-side resolver can surface real
@@ -523,7 +552,11 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
           isError: true,
         };
       }
-      return responseToToolResult(res, { source: "run_history" });
+      return responseToToolResult(res, {
+        source: "run_history",
+        ...(blobStore ? { blobStore } : {}),
+        ...(tokenBudget ? { tokenBudget } : {}),
+      });
     },
   };
 
@@ -584,7 +617,11 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
           isError: true,
         };
       }
-      return responseToToolResult(res, { source: "recall_memory" });
+      return responseToToolResult(res, {
+        source: "recall_memory",
+        ...(blobStore ? { blobStore } : {}),
+        ...(tokenBudget ? { tokenBudget } : {}),
+      });
     },
   };
 
@@ -641,14 +678,22 @@ function buildBlobResourceProvider(blobStore: BlobStore) {
 interface ResponseToToolResultOptions {
   /** Run-scoped blob store; required to spill non-text or oversized responses. */
   blobStore?: BlobStore;
+  /**
+   * Run-scoped token budget. When provided, the inline-vs-spill
+   * decision for text responses is made on **estimated tokens**, not
+   * raw bytes — dense JSON or base64 that would otherwise sneak under
+   * the 32 KB byte threshold spills correctly, and a cumulative
+   * counter tightens the inline path as the agent's run budget runs
+   * down. Absent → fall back to the legacy byte threshold.
+   */
+  tokenBudget?: TokenBudget;
   /** Source label propagated to the BlobStore record (for observability). */
   source?: string;
   /**
-   * Inline threshold override. Above this size, even text responses
-   * spill to the blob store so the agent context isn't poisoned by
-   * very large dumps. Defaults to {@link INLINE_RESPONSE_THRESHOLD}.
+   * Legacy byte threshold override (used when no `tokenBudget` is
+   * configured). Defaults to {@link INLINE_RESPONSE_THRESHOLD_BYTES}.
    */
-  inlineThreshold?: number;
+  inlineThresholdBytes?: number;
   /**
    * When true, attach upstream `{ status, headers }` to the
    * `CallToolResult._meta` payload under {@link UPSTREAM_META_KEY}.
@@ -673,12 +718,23 @@ interface ResponseToToolResultOptions {
  * domain-level signals.
  *
  * Behaviour:
- * - Text/JSON/XML under {@link INLINE_RESPONSE_THRESHOLD} → inline `text` block.
- * - Text/JSON/XML over the threshold OR binary content → spilled to
- *   the BlobStore, returned as a `resource_link` block. The agent
- *   reads the bytes via `client.readResource({ uri })` only if needed.
- * - No BlobStore configured → binary rejected with a clear tool-level
- *   error (production always supplies a BlobStore via `mountMcp`).
+ * - Text/JSON/XML whose **estimated token count** fits under the
+ *   per-call inline cap AND the run-level cumulative budget → inline
+ *   `text` block. Token estimation uses the Anthropic-recommended
+ *   ~3.5 chars/token heuristic (see `./token-budget.ts`).
+ * - Text/JSON/XML that exceeds the per-call cap OR would push the
+ *   cumulative budget past its ceiling → spilled to the BlobStore as
+ *   a `resource_link`. The agent reads the bytes via
+ *   `client.readResource({ uri })` only if needed.
+ * - Binary content → always spilled regardless of size (binary in the
+ *   agent's context window is never useful).
+ * - No BlobStore configured → binary rejected; text falls back to the
+ *   legacy byte threshold. Production always supplies a BlobStore +
+ *   TokenBudget via `mountMcp`.
+ *
+ * Every text-path result carries an `appstrate://token-budget` `_meta`
+ * payload (when a TokenBudget is configured) so the agent runtime can
+ * surface accounting and react to structured truncation events.
  */
 async function responseToToolResult(
   res: Response,
@@ -703,14 +759,13 @@ async function responseToToolResult(
   const upstreamMeta: UpstreamMeta | undefined = options.attachUpstreamMeta
     ? buildUpstreamMeta(res)
     : undefined;
-  const metaField: Record<string, unknown> | undefined = upstreamMeta
-    ? { [UPSTREAM_META_KEY]: upstreamMeta }
-    : undefined;
 
-  // Helper: attach `_meta` to every return path. The meta payload is
-  // identical across happy/error paths (it describes the upstream
-  // exchange, not the agent-side mapping), so we centralise the merge
-  // rather than duplicate the field in every literal below.
+  // Budget meta accumulates per-response: estimated cost + the
+  // tracker's decision are folded in by the text path below. Stays
+  // undefined for binary spills (no estimate is meaningful) and when
+  // no TokenBudget is configured.
+  let budgetMeta: TokenBudgetMeta | undefined;
+
   type Result = {
     content: Array<
       | { type: "text"; text: string }
@@ -719,11 +774,21 @@ async function responseToToolResult(
     isError?: boolean;
     _meta?: Record<string, unknown>;
   };
-  const withMeta = (r: Result): Result => (metaField ? { ...r, _meta: metaField } : r);
+  // Helper: attach `_meta` to every return path. We merge upstream-
+  // exchange meta and token-budget meta into a single payload — both
+  // are independent of agent-side mapping, both can be present
+  // simultaneously.
+  const withMeta = (r: Result): Result => {
+    if (!upstreamMeta && !budgetMeta) return r;
+    const meta: Record<string, unknown> = {};
+    if (upstreamMeta) meta[UPSTREAM_META_KEY] = upstreamMeta;
+    if (budgetMeta) meta[TOKEN_BUDGET_META_KEY] = budgetMeta;
+    return { ...r, _meta: meta };
+  };
 
   const ct = res.headers.get("content-type") ?? "";
   const isText = ct.startsWith("text/") || ct.includes("json") || ct.includes("xml");
-  const threshold = options.inlineThreshold ?? INLINE_RESPONSE_THRESHOLD;
+  const byteThreshold = options.inlineThresholdBytes ?? INLINE_RESPONSE_THRESHOLD_BYTES;
 
   if (!isText) {
     if (!options.blobStore) {
@@ -800,10 +865,32 @@ async function responseToToolResult(
   const readCap = options.blobStore ? ABSOLUTE_MAX_RESPONSE_SIZE : MAX_RESPONSE_SIZE;
   const text = await readBodyBounded(res, readCap);
 
-  // If the text body breaches the inline threshold AND we have a blob
-  // store, spill it. The agent gets a pointer instead of poisoning its
-  // context with a multi-megabyte dump.
-  if (options.blobStore && text.length > threshold) {
+  // Token-aware spill decision. With a TokenBudget we estimate the
+  // tokens this response would burn, then ask the budget tracker
+  // whether it fits inline (per-call cap + cumulative budget). Without
+  // a TokenBudget we fall back to the legacy byte threshold so older
+  // tests + embedders that don't wire a budget keep working.
+  const shouldSpillForBudget = ((): boolean => {
+    if (options.tokenBudget) {
+      const estimated = estimateTokens(text);
+      const decision = options.tokenBudget.decide(estimated);
+      budgetMeta = {
+        estimatedTokens: estimated,
+        consumedTokens: decision.consumedTokens,
+        runBudgetTokens: decision.runBudgetTokens,
+        inlineCapTokens: decision.inlineCapTokens,
+        decision: decision.decision,
+        reason: decision.reason,
+      };
+      return decision.decision === "spill";
+    }
+    return text.length > byteThreshold;
+  })();
+
+  // If the text body should spill AND we have a blob store, spill it.
+  // The agent gets a pointer instead of poisoning its context with a
+  // dense JSON dump that would silently consume its run budget.
+  if (options.blobStore && shouldSpillForBudget) {
     const bytes = new TextEncoder().encode(text);
     let record;
     try {
@@ -812,12 +899,28 @@ async function responseToToolResult(
         ...(options.source !== undefined ? { source: options.source } : {}),
       });
     } catch {
-      // Blob store full — fall back to inline truncation.
-      return withMeta(
-        res.ok
-          ? { content: [{ type: "text", text }] }
-          : { content: [{ type: "text", text }], isError: true },
-      );
+      // Blob store full — fall back to inline. We do NOT record the
+      // tokens against the budget when the blob store rejects the put
+      // because the budget is a *delivery* counter (we are about to
+      // deliver this content inline as a last resort) — recording
+      // happens below on the inline path.
+      if (options.tokenBudget && budgetMeta) {
+        // Update the meta to reflect the forced fallback so the agent
+        // can see we exceeded the inline cap but had no spill path.
+        budgetMeta = {
+          ...budgetMeta,
+          decision: "inline",
+          reason: "no_blob_store_fallback_inline",
+        };
+      }
+      const fallback: Result = res.ok
+        ? { content: [{ type: "text", text }] }
+        : { content: [{ type: "text", text }], isError: true };
+      // Best-effort recording — caller already paid the context cost.
+      if (options.tokenBudget && budgetMeta) {
+        options.tokenBudget.record(budgetMeta.estimatedTokens);
+      }
+      return withMeta(fallback);
     }
     const link = {
       type: "resource_link" as const,
@@ -826,6 +929,21 @@ async function responseToToolResult(
       mimeType: record.mimeType,
     };
     return withMeta(res.ok ? { content: [link] } : { content: [link], isError: true });
+  }
+
+  // Inline path — record the actual delivered tokens against the
+  // budget. If the budget said `spill` but no blob store was
+  // configured, surface the forced-inline reason so the agent can
+  // flag the missing spill path rather than silently overspending.
+  if (options.tokenBudget && budgetMeta) {
+    if (shouldSpillForBudget && !options.blobStore) {
+      budgetMeta = {
+        ...budgetMeta,
+        decision: "inline",
+        reason: "no_blob_store_fallback_inline",
+      };
+    }
+    options.tokenBudget.record(budgetMeta.estimatedTokens);
   }
 
   if (!res.ok) {
@@ -940,6 +1058,18 @@ export interface MountMcpOptions {
    * HTTP-route fallback.
    */
   proxyDeps: ProviderCallDeps;
+  /**
+   * Run-scoped token budget. When present, every tool output is run
+   * through the budget tracker before being delivered to the agent —
+   * dense JSON that fits under the byte cap but would exhaust the
+   * context window now spills to the blob store, and a structured
+   * `appstrate://token-budget` `_meta` payload records the accounting.
+   *
+   * Optional only so tests and embedders that don't care about the
+   * token path can omit it; production wires a `TokenBudget`
+   * unconditionally via `createApp` (see `app.ts`).
+   */
+  tokenBudget?: TokenBudget;
 }
 
 export function mountMcp(app: Hono, options: MountMcpOptions): void {

--- a/runtime-pi/sidecar/test/mcp.test.ts
+++ b/runtime-pi/sidecar/test/mcp.test.ts
@@ -971,15 +971,16 @@ describe("POST /mcp — bounded response read", () => {
   // memory or context window even when no upstream-side cap fires
   // first. Defence-in-depth.
 
-  it("truncates oversized upstream responses with an explicit marker", async () => {
-    const oversized = "y".repeat(512 * 1024); // 512 KB > 256 KB MAX_RESPONSE_SIZE
+  it("spills oversized upstream responses to the blob store as a resource_link", async () => {
+    const oversized = "y".repeat(512 * 1024); // 512 KB → far above any inline budget
     const fetchFn = mock(
       async () =>
         new Response(oversized, {
           status: 200,
           // Hit `run_history`, mocked to return the oversized body
-          // directly, so the MCP-layer cap is the only thing standing
-          // between us and the full 512 KB.
+          // directly. With the token-budget guard wired into
+          // run_history, the response should spill to the blob store
+          // rather than poison the agent's context.
           headers: { "Content-Type": "application/json" },
         }),
     );
@@ -988,14 +989,14 @@ describe("POST /mcp — bounded response read", () => {
       method: "tools/call",
       params: { name: "run_history", arguments: { limit: 1 } },
     });
-    const result = res.json.result as { content: Array<{ text: string }> };
-    // The MCP-layer cap must have kicked in. The result is bounded —
-    // never the full 512 KB.
-    expect(result.content[0]!.text.length).toBeLessThanOrEqual(MAX_RESPONSE_SIZE_PLUS_MARKER);
+    const result = res.json.result as {
+      content: Array<{ type: string; uri?: string; text?: string }>;
+    };
+    // The token-budget gate must have triggered the blob spill.
+    expect(result.content[0]!.type).toBe("resource_link");
+    expect(result.content[0]!.uri).toMatch(/^appstrate:\/\/provider-response\//);
   });
 });
-
-const MAX_RESPONSE_SIZE_PLUS_MARKER = 256 * 1024 + 200; // 256 KB + room for "[truncated: ...]"
 
 describe("StreamableHTTPClientTransport interop (smoke test)", () => {
   it("`enableJsonResponse: true` is wired so SDK clients without SSE work", async () => {

--- a/runtime-pi/sidecar/test/token-budget-integration.test.ts
+++ b/runtime-pi/sidecar/test/token-budget-integration.test.ts
@@ -1,0 +1,539 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration tests for token-aware context budgeting end-to-end
+ * through the MCP `/mcp` endpoint.
+ *
+ * These tests exercise the full path:
+ *
+ *   agent → POST /mcp (JSON-RPC) → mountMcp → tools/call →
+ *     provider_call / run_history / recall_memory →
+ *       executeProviderCall (or platform fetchFn) →
+ *         responseToToolResult — the function under test, where the
+ *         token-budget tracker is consulted.
+ *
+ * Coverage focus:
+ *   - dense JSON below the byte threshold but above the token cap
+ *     spills correctly (issue #390 primary scenario).
+ *   - 50× small-call cumulative pressure forces spill once the run
+ *     budget is exhausted, without any single call hitting the
+ *     per-call cap (issue #390 secondary scenario).
+ *   - `_meta` payload carries the budget accounting so the agent
+ *     runtime can react to structured truncation events.
+ *   - `run_history` and `recall_memory` honour the same gate as
+ *     `provider_call`.
+ *   - Without a token budget configured, the legacy byte threshold
+ *     remains in force (no regression for embedders that don't wire
+ *     the budget).
+ */
+
+import { describe, it, expect, mock } from "bun:test";
+import { Hono } from "hono";
+import { createApp, type AppDeps } from "../app.ts";
+import { mountMcp } from "../mcp.ts";
+import { BlobStore } from "../blob-store.ts";
+import { TokenBudget, estimateTokens } from "../token-budget.ts";
+import type { CredentialsResponse } from "../helpers.ts";
+
+function makeDeps(overrides?: Partial<AppDeps>): AppDeps {
+  return {
+    config: { platformApiUrl: "http://mock:3000", runToken: "tok", proxyUrl: "" },
+    fetchCredentials: mock(
+      async (): Promise<CredentialsResponse> => ({
+        credentials: { access_token: "test-123" },
+        authorizedUris: ["https://api.example.com/**"],
+        allowAllUris: false,
+        credentialHeaderName: "Authorization",
+        credentialHeaderPrefix: "Bearer",
+        credentialFieldName: "access_token",
+      }),
+    ),
+    cookieJar: new Map(),
+    fetchFn: mock(async () => new Response("{}", { status: 200 })),
+    isReady: () => true,
+    ...overrides,
+  };
+}
+
+async function rpc(
+  app: ReturnType<typeof createApp>,
+  body: { method: string; params?: unknown },
+): Promise<{ status: number; json: Record<string, unknown> }> {
+  const res = await app.request("/mcp", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      Host: "localhost",
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, ...body }),
+  });
+  const text = await res.text();
+  return { status: res.status, json: JSON.parse(text) };
+}
+
+const TOKEN_BUDGET_META_KEY = "appstrate://token-budget";
+
+interface BudgetMeta {
+  estimatedTokens: number;
+  consumedTokens: number;
+  runBudgetTokens: number;
+  inlineCapTokens: number;
+  decision: "inline" | "spill";
+  reason:
+    | "under_inline_cap"
+    | "exceeds_inline_cap"
+    | "exceeds_run_budget"
+    | "no_blob_store_fallback_inline";
+}
+
+interface ContentBlock {
+  type: string;
+  text?: string;
+  uri?: string;
+  name?: string;
+  mimeType?: string;
+}
+
+interface CallToolResult {
+  content: ContentBlock[];
+  isError?: boolean;
+  _meta?: Record<string, unknown>;
+}
+
+/**
+ * Build a Hono app wired with a custom `TokenBudget`. Bypasses
+ * `createApp` so tests can drive the budget independently of env vars
+ * (which createApp reads at boot).
+ */
+function buildTestApp(opts: {
+  deps: AppDeps;
+  tokenBudget?: TokenBudget;
+  blobStore?: BlobStore;
+}): Hono {
+  const app = new Hono();
+  const blobStore = opts.blobStore ?? new BlobStore("run-test");
+  mountMcp(app, {
+    blobStore,
+    ...(opts.tokenBudget ? { tokenBudget: opts.tokenBudget } : {}),
+    proxyDeps: {
+      config: opts.deps.config,
+      cookieJar: opts.deps.cookieJar,
+      fetchFn: opts.deps.fetchFn ?? fetch,
+      fetchCredentials: opts.deps.fetchCredentials,
+      reportedAuthFailures: new Set<string>(),
+    },
+  });
+  return app;
+}
+
+describe("token-aware spill — dense JSON (issue #390 primary)", () => {
+  // 30 KB of dense JSON ≈ 8572 tokens. Under the 32 KB legacy byte
+  // threshold but ABOVE a tight 4000-token inline cap. With the token
+  // budget configured, this MUST spill — the legacy byte path would
+  // have inlined it and burned 8.5 K of context for free.
+
+  it("spills 30 KB JSON when token cap is 4000 tokens (legacy byte path would inline)", async () => {
+    const denseJson = JSON.stringify({ items: "x".repeat(30_000) });
+    const fetchFn = mock(
+      async () =>
+        new Response(denseJson, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 100_000 });
+    const app = buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget });
+
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "test-provider",
+          target: "https://api.example.com/items",
+          method: "GET",
+        },
+      },
+    });
+    const result = res.json.result as CallToolResult;
+    expect(result.content[0]!.type).toBe("resource_link");
+    expect(result.content[0]!.uri).toMatch(/^appstrate:\/\/provider-response\//);
+
+    const meta = result._meta?.[TOKEN_BUDGET_META_KEY] as BudgetMeta | undefined;
+    expect(meta).toBeDefined();
+    expect(meta!.decision).toBe("spill");
+    expect(meta!.reason).toBe("exceeds_inline_cap");
+    expect(meta!.estimatedTokens).toBeGreaterThan(4_000);
+    expect(meta!.inlineCapTokens).toBe(4_000);
+  });
+
+  it("inlines small JSON that comfortably fits the per-call cap", async () => {
+    const smallJson = JSON.stringify({ ok: true, value: 42 });
+    const fetchFn = mock(
+      async () =>
+        new Response(smallJson, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 100_000 });
+    const app = buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget });
+
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "test-provider",
+          target: "https://api.example.com/items",
+          method: "GET",
+        },
+      },
+    });
+    const result = res.json.result as CallToolResult;
+    expect(result.content[0]!.type).toBe("text");
+    expect(result.content[0]!.text).toBe(smallJson);
+
+    const meta = result._meta?.[TOKEN_BUDGET_META_KEY] as BudgetMeta | undefined;
+    expect(meta).toBeDefined();
+    expect(meta!.decision).toBe("inline");
+    expect(meta!.reason).toBe("under_inline_cap");
+    expect(meta!.estimatedTokens).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("token-aware spill — cumulative pressure (issue #390 secondary)", () => {
+  // 50 successive calls, each well under the per-call cap, should
+  // eventually trip the run-level budget — the scenario the byte cap
+  // cannot detect because each call is judged in isolation.
+
+  it("forces spill once cumulative budget is exhausted, never before", async () => {
+    // Per-call payload: ~3 K tokens (10500 chars / 3.5).
+    const perCallPayload = JSON.stringify({ rows: "x".repeat(10_500 - 13) });
+    expect(estimateTokens(perCallPayload)).toBeGreaterThan(2_000);
+    expect(estimateTokens(perCallPayload)).toBeLessThan(4_000);
+
+    const fetchFn = mock(
+      async () =>
+        new Response(perCallPayload, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    // Inline cap allows each call individually; run budget tight
+    // enough to exhaust within 50 calls.
+    const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 20_000 });
+    const app = buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget });
+
+    let inlineCount = 0;
+    let spillCount = 0;
+    let firstSpillReason: string | undefined;
+
+    for (let i = 0; i < 30; i++) {
+      const res = await rpc(app, {
+        method: "tools/call",
+        params: {
+          name: "provider_call",
+          arguments: {
+            providerId: "test-provider",
+            target: "https://api.example.com/items",
+            method: "GET",
+          },
+        },
+      });
+      const result = res.json.result as CallToolResult;
+      const meta = result._meta?.[TOKEN_BUDGET_META_KEY] as BudgetMeta | undefined;
+      if (result.content[0]!.type === "text") {
+        inlineCount++;
+        expect(meta!.decision).toBe("inline");
+      } else {
+        spillCount++;
+        if (!firstSpillReason) firstSpillReason = meta!.reason;
+        expect(meta!.decision).toBe("spill");
+      }
+    }
+
+    // Some calls should inline (early), others spill (late).
+    expect(inlineCount).toBeGreaterThan(0);
+    expect(spillCount).toBeGreaterThan(0);
+    // The first spill should be due to the cumulative budget — no
+    // single call exceeds the per-call cap.
+    expect(firstSpillReason).toBe("exceeds_run_budget");
+  });
+});
+
+describe("token-aware spill — `_meta` accounting", () => {
+  it("attaches token-budget meta to every tool result (text path)", async () => {
+    const fetchFn = mock(
+      async () =>
+        new Response('{"hello":"world"}', {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 100_000 });
+    const app = buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget });
+
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "test-provider",
+          target: "https://api.example.com/items",
+          method: "GET",
+        },
+      },
+    });
+    const result = res.json.result as CallToolResult;
+    const meta = result._meta?.[TOKEN_BUDGET_META_KEY] as BudgetMeta | undefined;
+    expect(meta).toBeDefined();
+    expect(meta!.runBudgetTokens).toBe(100_000);
+    expect(meta!.inlineCapTokens).toBe(4_000);
+    expect(meta!.consumedTokens).toBe(0); // before this call
+    expect(meta!.estimatedTokens).toBeGreaterThan(0);
+  });
+
+  it("reports increasing consumedTokens across successive inline calls", async () => {
+    const payload = '{"hello":"world","data":"' + "x".repeat(100) + '"}';
+    const fetchFn = mock(
+      async () =>
+        new Response(payload, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 100_000 });
+    const app = buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget });
+
+    const consumed: number[] = [];
+    for (let i = 0; i < 3; i++) {
+      const res = await rpc(app, {
+        method: "tools/call",
+        params: {
+          name: "provider_call",
+          arguments: {
+            providerId: "test-provider",
+            target: "https://api.example.com/items",
+            method: "GET",
+          },
+        },
+      });
+      const result = res.json.result as CallToolResult;
+      const meta = result._meta?.[TOKEN_BUDGET_META_KEY] as BudgetMeta;
+      consumed.push(meta.consumedTokens);
+    }
+    // The reported `consumedTokens` is the value BEFORE this call's
+    // record(), so call N+1 sees what call N delivered.
+    expect(consumed[0]).toBe(0);
+    expect(consumed[1]).toBeGreaterThan(consumed[0]!);
+    expect(consumed[2]).toBeGreaterThan(consumed[1]!);
+  });
+});
+
+describe("token-aware spill — applied to all platform tools", () => {
+  it("run_history is gated by the token budget", async () => {
+    const oversized = "y".repeat(60_000); // ~17 K tokens
+    const fetchFn = mock(
+      async () =>
+        new Response(oversized, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 100_000 });
+    const app = buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget });
+
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: { name: "run_history", arguments: { limit: 1 } },
+    });
+    const result = res.json.result as CallToolResult;
+    expect(result.content[0]!.type).toBe("resource_link");
+    const meta = result._meta?.[TOKEN_BUDGET_META_KEY] as BudgetMeta;
+    expect(meta.decision).toBe("spill");
+    expect(meta.reason).toBe("exceeds_inline_cap");
+  });
+
+  it("recall_memory is gated by the token budget", async () => {
+    const oversized = "z".repeat(60_000);
+    const fetchFn = mock(
+      async () =>
+        new Response(oversized, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 100_000 });
+    const app = buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget });
+
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: { name: "recall_memory", arguments: { q: "foo" } },
+    });
+    const result = res.json.result as CallToolResult;
+    expect(result.content[0]!.type).toBe("resource_link");
+    const meta = result._meta?.[TOKEN_BUDGET_META_KEY] as BudgetMeta;
+    expect(meta.decision).toBe("spill");
+  });
+});
+
+describe("token-aware spill — backwards compatibility", () => {
+  it("without a TokenBudget, the legacy byte threshold still applies", async () => {
+    // 40 KB > 32 KB legacy threshold. With no TokenBudget wired, this
+    // should still spill via the byte path.
+    const payload = "y".repeat(40 * 1024);
+    const fetchFn = mock(
+      async () =>
+        new Response(payload, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    // Build app with NO tokenBudget passed — exercise the legacy path.
+    const app = buildTestApp({ deps: makeDeps({ fetchFn }) });
+
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "test-provider",
+          target: "https://api.example.com/items",
+          method: "GET",
+        },
+      },
+    });
+    const result = res.json.result as CallToolResult;
+    expect(result.content[0]!.type).toBe("resource_link");
+    // No token-budget meta should be attached when the budget isn't wired.
+    expect(result._meta?.[TOKEN_BUDGET_META_KEY]).toBeUndefined();
+  });
+
+  it("without a TokenBudget, small responses inline as before", async () => {
+    const fetchFn = mock(
+      async () =>
+        new Response('{"ok":true}', {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const app = buildTestApp({ deps: makeDeps({ fetchFn }) });
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "test-provider",
+          target: "https://api.example.com/items",
+          method: "GET",
+        },
+      },
+    });
+    const result = res.json.result as CallToolResult;
+    expect(result.content[0]!.type).toBe("text");
+    expect(result.content[0]!.text).toBe('{"ok":true}');
+    expect(result._meta?.[TOKEN_BUDGET_META_KEY]).toBeUndefined();
+  });
+});
+
+describe("token-aware spill — env-var configuration via createApp", () => {
+  // `createApp` reads the env vars at boot; verify the wiring runs.
+  // The actual TokenBudget constructor invariants are tested in
+  // token-budget.test.ts.
+
+  it("respects SIDECAR_INLINE_TOOL_OUTPUT_TOKENS / SIDECAR_RUN_TOOL_OUTPUT_BUDGET_TOKENS", async () => {
+    const original = {
+      inline: process.env.SIDECAR_INLINE_TOOL_OUTPUT_TOKENS,
+      run: process.env.SIDECAR_RUN_TOOL_OUTPUT_BUDGET_TOKENS,
+    };
+    try {
+      process.env.SIDECAR_INLINE_TOOL_OUTPUT_TOKENS = "100";
+      process.env.SIDECAR_RUN_TOOL_OUTPUT_BUDGET_TOKENS = "1000";
+
+      const fetchFn = mock(
+        async () =>
+          new Response('{"big":"' + "x".repeat(2000) + '"}', {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      );
+      const app = createApp(makeDeps({ fetchFn }));
+      const res = await rpc(app, {
+        method: "tools/call",
+        params: {
+          name: "provider_call",
+          arguments: {
+            providerId: "test-provider",
+            target: "https://api.example.com/items",
+            method: "GET",
+          },
+        },
+      });
+      const result = res.json.result as CallToolResult;
+      // 2000 chars / 3.5 ≈ 572 tokens — above the 100-token cap.
+      expect(result.content[0]!.type).toBe("resource_link");
+      const meta = result._meta?.[TOKEN_BUDGET_META_KEY] as BudgetMeta;
+      expect(meta.inlineCapTokens).toBe(100);
+      expect(meta.runBudgetTokens).toBe(1000);
+    } finally {
+      // Restore env so we don't leak state into the next test file.
+      if (original.inline === undefined) delete process.env.SIDECAR_INLINE_TOOL_OUTPUT_TOKENS;
+      else process.env.SIDECAR_INLINE_TOOL_OUTPUT_TOKENS = original.inline;
+      if (original.run === undefined) delete process.env.SIDECAR_RUN_TOOL_OUTPUT_BUDGET_TOKENS;
+      else process.env.SIDECAR_RUN_TOOL_OUTPUT_BUDGET_TOKENS = original.run;
+    }
+  });
+
+  it("createApp throws at boot when env vars are malformed", () => {
+    const original = process.env.SIDECAR_INLINE_TOOL_OUTPUT_TOKENS;
+    process.env.SIDECAR_INLINE_TOOL_OUTPUT_TOKENS = "not-a-number";
+    try {
+      expect(() => createApp(makeDeps())).toThrow(/positive integer/);
+    } finally {
+      if (original === undefined) delete process.env.SIDECAR_INLINE_TOOL_OUTPUT_TOKENS;
+      else process.env.SIDECAR_INLINE_TOOL_OUTPUT_TOKENS = original;
+    }
+  });
+});
+
+describe("token-aware spill — fallback when blob store is full", () => {
+  it("falls back to inline with no_blob_store_fallback_inline reason when blob store is full", async () => {
+    // Blob store with cumulative cap of 100 bytes; first put exhausts.
+    const blobStore = new BlobStore("run-test", { maxTotalBytes: 100 });
+    blobStore.put(new Uint8Array(95)); // leave only 5 bytes
+
+    const payload = JSON.stringify({ data: "x".repeat(40_000) }); // ~11 K tokens
+    const fetchFn = mock(
+      async () =>
+        new Response(payload, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+    const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 100_000 });
+    const app = buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget, blobStore });
+
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "test-provider",
+          target: "https://api.example.com/items",
+          method: "GET",
+        },
+      },
+    });
+    const result = res.json.result as CallToolResult;
+    // Spill failed → forced inline.
+    expect(result.content[0]!.type).toBe("text");
+    const meta = result._meta?.[TOKEN_BUDGET_META_KEY] as BudgetMeta;
+    expect(meta.decision).toBe("inline");
+    expect(meta.reason).toBe("no_blob_store_fallback_inline");
+    // The forced-inline tokens are still recorded against the budget
+    // — the agent paid the context cost.
+    expect(tokenBudget.consumedTokens()).toBe(meta.estimatedTokens);
+  });
+});

--- a/runtime-pi/sidecar/test/token-budget-integration.test.ts
+++ b/runtime-pi/sidecar/test/token-budget-integration.test.ts
@@ -84,7 +84,8 @@ interface BudgetMeta {
     | "under_inline_cap"
     | "exceeds_inline_cap"
     | "exceeds_run_budget"
-    | "no_blob_store_fallback_inline";
+    | "blob_store_full"
+    | "no_blob_store_configured";
 }
 
 interface ContentBlock {
@@ -291,8 +292,10 @@ describe("token-aware spill — `_meta` accounting", () => {
     expect(meta).toBeDefined();
     expect(meta!.runBudgetTokens).toBe(100_000);
     expect(meta!.inlineCapTokens).toBe(4_000);
-    expect(meta!.consumedTokens).toBe(0); // before this call
     expect(meta!.estimatedTokens).toBeGreaterThan(0);
+    // tryReserve records on inline before returning the snapshot, so
+    // consumedTokens reflects the post-record total (this call included).
+    expect(meta!.consumedTokens).toBe(meta!.estimatedTokens);
   });
 
   it("reports increasing consumedTokens across successive inline calls", async () => {
@@ -324,9 +327,10 @@ describe("token-aware spill — `_meta` accounting", () => {
       const meta = result._meta?.[TOKEN_BUDGET_META_KEY] as BudgetMeta;
       consumed.push(meta.consumedTokens);
     }
-    // The reported `consumedTokens` is the value BEFORE this call's
-    // record(), so call N+1 sees what call N delivered.
-    expect(consumed[0]).toBe(0);
+    // tryReserve records before returning the snapshot, so each meta
+    // includes its own call's contribution. Call N's reported
+    // consumedTokens equals the running total through call N.
+    expect(consumed[0]).toBeGreaterThan(0);
     expect(consumed[1]).toBeGreaterThan(consumed[0]!);
     expect(consumed[2]).toBeGreaterThan(consumed[1]!);
   });
@@ -499,7 +503,7 @@ describe("token-aware spill — env-var configuration via createApp", () => {
 });
 
 describe("token-aware spill — fallback when blob store is full", () => {
-  it("falls back to inline with no_blob_store_fallback_inline reason when blob store is full", async () => {
+  it("falls back to inline with blob_store_full reason when blob store is full", async () => {
     // Blob store with cumulative cap of 100 bytes; first put exhausts.
     const blobStore = new BlobStore("run-test", { maxTotalBytes: 100 });
     blobStore.put(new Uint8Array(95)); // leave only 5 bytes
@@ -531,7 +535,7 @@ describe("token-aware spill — fallback when blob store is full", () => {
     expect(result.content[0]!.type).toBe("text");
     const meta = result._meta?.[TOKEN_BUDGET_META_KEY] as BudgetMeta;
     expect(meta.decision).toBe("inline");
-    expect(meta.reason).toBe("no_blob_store_fallback_inline");
+    expect(meta.reason).toBe("blob_store_full");
     // The forced-inline tokens are still recorded against the budget
     // — the agent paid the context cost.
     expect(tokenBudget.consumedTokens()).toBe(meta.estimatedTokens);

--- a/runtime-pi/sidecar/test/token-budget.test.ts
+++ b/runtime-pi/sidecar/test/token-budget.test.ts
@@ -1,0 +1,314 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the token-aware context-budget primitives that the
+ * sidecar uses to gate `provider_call` / `run_history` / `recall_memory`
+ * tool outputs against the agent's run-level context budget.
+ *
+ * Coverage focus:
+ *   - estimateTokens — chars/3.5 heuristic, edge cases (empty, unicode,
+ *     short strings round up).
+ *   - estimateBinaryTokens — base64 inflation factor applied.
+ *   - readPositiveTokenEnv — fail-loud parsing of env overrides.
+ *   - TokenBudget — constructor invariants, decide() rules, record()
+ *     accumulation + saturation, run-level cumulative pressure.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  DEFAULT_INLINE_OUTPUT_TOKENS,
+  DEFAULT_RUN_OUTPUT_BUDGET_TOKENS,
+  TokenBudget,
+  estimateBinaryTokens,
+  estimateTokens,
+  readPositiveTokenEnv,
+} from "../token-budget.ts";
+
+describe("estimateTokens", () => {
+  it("returns 0 for the empty string", () => {
+    expect(estimateTokens("")).toBe(0);
+  });
+
+  it("rounds up so any non-empty string costs at least 1 token", () => {
+    expect(estimateTokens("a")).toBe(1);
+    expect(estimateTokens("ab")).toBe(1);
+    expect(estimateTokens("abc")).toBe(1);
+    expect(estimateTokens("abcd")).toBe(2); // 4 / 3.5 = 1.14 → ceil → 2
+  });
+
+  it("matches the Anthropic-recommended 3.5 chars/token ratio for medium inputs", () => {
+    // 350 chars should map to 100 tokens.
+    expect(estimateTokens("x".repeat(350))).toBe(100);
+    // 700 chars should map to 200 tokens.
+    expect(estimateTokens("y".repeat(700))).toBe(200);
+  });
+
+  it("handles unicode by code-unit length (consistent with String#length)", () => {
+    // Surrogate pairs count as 2 UTF-16 code units, which is what the
+    // estimator is designed around.
+    expect(estimateTokens("😀😀😀😀")).toBe(Math.ceil(8 / 3.5));
+  });
+
+  it("is monotonic in input length", () => {
+    let last = 0;
+    for (const n of [10, 50, 100, 500, 1000, 5000, 50000]) {
+      const t = estimateTokens("a".repeat(n));
+      expect(t).toBeGreaterThanOrEqual(last);
+      last = t;
+    }
+  });
+
+  it("is deterministic (same input → same output)", () => {
+    const s = "lorem ipsum dolor sit amet ".repeat(500);
+    expect(estimateTokens(s)).toBe(estimateTokens(s));
+  });
+});
+
+describe("estimateBinaryTokens", () => {
+  it("returns 0 for zero or negative byte length", () => {
+    expect(estimateBinaryTokens(0)).toBe(0);
+    expect(estimateBinaryTokens(-100)).toBe(0);
+  });
+
+  it("applies base64 inflation (4/3) and chars-per-token (3.5)", () => {
+    // 1024 bytes → 1024 * 4 / 3 ≈ 1365 base64 chars → /3.5 ≈ 390 tokens
+    expect(estimateBinaryTokens(1024)).toBe(Math.ceil((1024 * 4) / 3 / 3.5));
+  });
+
+  it("monotonically increases with byte length", () => {
+    // Adjacent small inputs may tie at the ceil() floor, so step up
+    // to inputs large enough that the ratio dominates.
+    expect(estimateBinaryTokens(100)).toBeLessThanOrEqual(estimateBinaryTokens(200));
+    expect(estimateBinaryTokens(1_000_000)).toBeGreaterThan(estimateBinaryTokens(100_000));
+  });
+});
+
+describe("readPositiveTokenEnv", () => {
+  const envName = "TEST_TOKEN_BUDGET_ENV_VAR";
+  it("returns default when unset", () => {
+    delete process.env[envName];
+    expect(readPositiveTokenEnv(envName, 1234)).toBe(1234);
+  });
+
+  it("returns default when empty string", () => {
+    process.env[envName] = "";
+    expect(readPositiveTokenEnv(envName, 99)).toBe(99);
+    delete process.env[envName];
+  });
+
+  it("parses positive integers", () => {
+    process.env[envName] = "5000";
+    expect(readPositiveTokenEnv(envName, 99)).toBe(5000);
+    delete process.env[envName];
+  });
+
+  it("throws on non-integer", () => {
+    process.env[envName] = "5.5";
+    expect(() => readPositiveTokenEnv(envName, 1)).toThrow(/positive integer/);
+    delete process.env[envName];
+  });
+
+  it("throws on zero / negative", () => {
+    for (const v of ["0", "-1", "-100"]) {
+      process.env[envName] = v;
+      expect(() => readPositiveTokenEnv(envName, 1)).toThrow(/positive integer/);
+    }
+    delete process.env[envName];
+  });
+
+  it("throws on non-numeric", () => {
+    process.env[envName] = "not-a-number";
+    expect(() => readPositiveTokenEnv(envName, 1)).toThrow(/positive integer/);
+    delete process.env[envName];
+  });
+
+  it("includes the variable name in the error", () => {
+    process.env[envName] = "abc";
+    expect(() => readPositiveTokenEnv(envName, 1)).toThrow(envName);
+    delete process.env[envName];
+  });
+});
+
+describe("TokenBudget — construction", () => {
+  it("uses sane defaults", () => {
+    const b = new TokenBudget();
+    expect(b.inlineCapTokens).toBe(DEFAULT_INLINE_OUTPUT_TOKENS);
+    expect(b.runBudgetTokens).toBe(DEFAULT_RUN_OUTPUT_BUDGET_TOKENS);
+    expect(b.consumedTokens()).toBe(0);
+    expect(b.remainingTokens()).toBe(DEFAULT_RUN_OUTPUT_BUDGET_TOKENS);
+  });
+
+  it("accepts overrides", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 1000 });
+    expect(b.inlineCapTokens).toBe(100);
+    expect(b.runBudgetTokens).toBe(1000);
+  });
+
+  it("rejects non-positive inlineCapTokens", () => {
+    expect(() => new TokenBudget({ inlineCapTokens: 0, runBudgetTokens: 100 })).toThrow(
+      /positive integer/,
+    );
+    expect(() => new TokenBudget({ inlineCapTokens: -1, runBudgetTokens: 100 })).toThrow(
+      /positive integer/,
+    );
+  });
+
+  it("rejects non-integer inlineCapTokens", () => {
+    expect(() => new TokenBudget({ inlineCapTokens: 1.5, runBudgetTokens: 100 })).toThrow(
+      /positive integer/,
+    );
+  });
+
+  it("rejects non-positive runBudgetTokens", () => {
+    expect(() => new TokenBudget({ inlineCapTokens: 1, runBudgetTokens: 0 })).toThrow(
+      /positive integer/,
+    );
+  });
+
+  it("rejects inlineCap > runBudget (would never inline)", () => {
+    expect(() => new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 50 })).toThrow(
+      /cannot exceed/,
+    );
+  });
+
+  it("accepts inlineCap === runBudget (single-call run)", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 100 });
+    expect(b.inlineCapTokens).toBe(100);
+  });
+});
+
+describe("TokenBudget — decide()", () => {
+  it("returns inline / under_inline_cap when comfortably under both caps", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 1000 });
+    const d = b.decide(50);
+    expect(d.decision).toBe("inline");
+    expect(d.reason).toBe("under_inline_cap");
+    expect(d.estimatedTokens).toBe(50);
+    expect(d.consumedTokens).toBe(0);
+    expect(d.runBudgetTokens).toBe(1000);
+    expect(d.inlineCapTokens).toBe(100);
+  });
+
+  it("returns spill / exceeds_inline_cap when this single call overflows the per-call cap", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 10000 });
+    const d = b.decide(150);
+    expect(d.decision).toBe("spill");
+    expect(d.reason).toBe("exceeds_inline_cap");
+  });
+
+  it("returns spill / exceeds_run_budget when cumulative overflow happens", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 200 });
+    b.record(150); // consumed = 150, remaining = 50
+    const d = b.decide(60); // 150 + 60 = 210 > 200
+    expect(d.decision).toBe("spill");
+    expect(d.reason).toBe("exceeds_run_budget");
+  });
+
+  it("inline-cap check takes priority over run-budget check", () => {
+    // If a call simultaneously exceeds both caps, we report the
+    // inline-cap reason — it is the more actionable signal (the
+    // agent learns "this single call was too big" rather than
+    // "the run is full").
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 200 });
+    b.record(150);
+    const d = b.decide(120); // 120 > inlineCap AND 150+120 > runBudget
+    expect(d.reason).toBe("exceeds_inline_cap");
+  });
+
+  it("calls equal to the inline cap are inlined", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 1000 });
+    const d = b.decide(100);
+    expect(d.decision).toBe("inline");
+  });
+
+  it("does NOT mutate state — decide() is pure", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 1000 });
+    b.decide(80);
+    b.decide(80);
+    b.decide(80);
+    expect(b.consumedTokens()).toBe(0);
+  });
+});
+
+describe("TokenBudget — record() + accumulation", () => {
+  it("accumulates over multiple calls", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 1000 });
+    b.record(50);
+    b.record(50);
+    expect(b.consumedTokens()).toBe(100);
+    expect(b.remainingTokens()).toBe(900);
+  });
+
+  it("ignores zero / negative / non-finite", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 1000 });
+    b.record(0);
+    b.record(-50);
+    b.record(NaN);
+    b.record(Infinity);
+    expect(b.consumedTokens()).toBe(0);
+  });
+
+  it("rounds up fractional inputs (defence-in-depth — caller should pass integers)", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 1000 });
+    b.record(2.3);
+    expect(b.consumedTokens()).toBe(3);
+  });
+
+  it("saturates at runBudgetTokens (never reports negative remaining)", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 200 });
+    b.record(150);
+    b.record(150); // would be 300; saturates at 200
+    expect(b.consumedTokens()).toBe(200);
+    expect(b.remainingTokens()).toBe(0);
+  });
+
+  it("models the issue #390 scenario: 50 small calls accumulate budget pressure", () => {
+    // 50 × 30 KB JSON ≈ 50 × 9000 tokens (30000 chars / 3.5) = 450 K
+    // tokens. With a 200 K-token budget the tracker should hit
+    // exhaustion long before the 50th call.
+    const inlineCap = 10_000; // raise above 9000 so per-call doesn't trigger
+    const runBudget = 200_000;
+    const b = new TokenBudget({ inlineCapTokens: inlineCap, runBudgetTokens: runBudget });
+    const perCall = estimateTokens("x".repeat(30_000)); // ≈ 8572 tokens
+    let inlineCount = 0;
+    let spillCount = 0;
+    for (let i = 0; i < 50; i++) {
+      const d = b.decide(perCall);
+      if (d.decision === "inline") {
+        b.record(perCall);
+        inlineCount++;
+      } else {
+        spillCount++;
+      }
+    }
+    // Around 200_000 / 8572 ≈ 23 calls fit before run-budget triggers.
+    expect(inlineCount).toBeLessThan(50);
+    expect(spillCount).toBeGreaterThan(0);
+    expect(b.consumedTokens()).toBeLessThanOrEqual(runBudget);
+  });
+
+  it("reset() clears consumed back to zero (test-only)", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 1000 });
+    b.record(500);
+    b.reset();
+    expect(b.consumedTokens()).toBe(0);
+    expect(b.remainingTokens()).toBe(1000);
+  });
+});
+
+describe("TokenBudget — defaults reflect SOTA expectations", () => {
+  it("DEFAULT_INLINE_OUTPUT_TOKENS is around 1 LLM-targeted page (8K)", () => {
+    expect(DEFAULT_INLINE_OUTPUT_TOKENS).toBeGreaterThanOrEqual(4_000);
+    expect(DEFAULT_INLINE_OUTPUT_TOKENS).toBeLessThanOrEqual(16_000);
+  });
+
+  it("DEFAULT_RUN_OUTPUT_BUDGET_TOKENS covers a Claude-default-context run", () => {
+    // Default budgets stay conservative for the 200 K-token context
+    // window. Operators on 1 M Sonnet 4.6 can raise via env var.
+    expect(DEFAULT_RUN_OUTPUT_BUDGET_TOKENS).toBeGreaterThanOrEqual(100_000);
+  });
+
+  it("inline cap is materially smaller than run budget (otherwise no cumulative gate)", () => {
+    expect(DEFAULT_INLINE_OUTPUT_TOKENS).toBeLessThan(DEFAULT_RUN_OUTPUT_BUDGET_TOKENS);
+  });
+});

--- a/runtime-pi/sidecar/test/token-budget.test.ts
+++ b/runtime-pi/sidecar/test/token-budget.test.ts
@@ -8,10 +8,10 @@
  * Coverage focus:
  *   - estimateTokens — chars/3.5 heuristic, edge cases (empty, unicode,
  *     short strings round up).
- *   - estimateBinaryTokens — base64 inflation factor applied.
  *   - readPositiveTokenEnv — fail-loud parsing of env overrides.
- *   - TokenBudget — constructor invariants, decide() rules, record()
- *     accumulation + saturation, run-level cumulative pressure.
+ *   - TokenBudget — constructor invariants, decide() purity, record()
+ *     accumulation + saturation, run-level cumulative pressure,
+ *     tryReserve() atomicity, injected estimator, dev-loud record().
  */
 
 import { describe, it, expect } from "bun:test";
@@ -19,9 +19,9 @@ import {
   DEFAULT_INLINE_OUTPUT_TOKENS,
   DEFAULT_RUN_OUTPUT_BUDGET_TOKENS,
   TokenBudget,
-  estimateBinaryTokens,
   estimateTokens,
   readPositiveTokenEnv,
+  type TokenEstimator,
 } from "../token-budget.ts";
 
 describe("estimateTokens", () => {
@@ -61,25 +61,6 @@ describe("estimateTokens", () => {
   it("is deterministic (same input → same output)", () => {
     const s = "lorem ipsum dolor sit amet ".repeat(500);
     expect(estimateTokens(s)).toBe(estimateTokens(s));
-  });
-});
-
-describe("estimateBinaryTokens", () => {
-  it("returns 0 for zero or negative byte length", () => {
-    expect(estimateBinaryTokens(0)).toBe(0);
-    expect(estimateBinaryTokens(-100)).toBe(0);
-  });
-
-  it("applies base64 inflation (4/3) and chars-per-token (3.5)", () => {
-    // 1024 bytes → 1024 * 4 / 3 ≈ 1365 base64 chars → /3.5 ≈ 390 tokens
-    expect(estimateBinaryTokens(1024)).toBe(Math.ceil((1024 * 4) / 3 / 3.5));
-  });
-
-  it("monotonically increases with byte length", () => {
-    // Adjacent small inputs may tie at the ceil() floor, so step up
-    // to inputs large enough that the ratio dominates.
-    expect(estimateBinaryTokens(100)).toBeLessThanOrEqual(estimateBinaryTokens(200));
-    expect(estimateBinaryTokens(1_000_000)).toBeGreaterThan(estimateBinaryTokens(100_000));
   });
 });
 
@@ -230,6 +211,43 @@ describe("TokenBudget — decide()", () => {
   });
 });
 
+describe("TokenBudget — tryReserve() atomicity", () => {
+  it("records on inline so subsequent calls see the updated consumed count", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 100 });
+    const first = b.tryReserve(80);
+    expect(first.decision).toBe("inline");
+    expect(first.consumedTokens).toBe(80); // post-record snapshot
+    expect(b.consumedTokens()).toBe(80);
+
+    // Without atomic record, the second call would still see consumed=0
+    // and decide inline; with atomic record it sees 80 and spills.
+    const second = b.tryReserve(80);
+    expect(second.decision).toBe("spill");
+    expect(second.reason).toBe("exceeds_run_budget");
+    expect(b.consumedTokens()).toBe(80); // spill did NOT record
+  });
+
+  it("does not record on spill (per-call cap exceeded)", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 1000 });
+    b.tryReserve(150);
+    expect(b.consumedTokens()).toBe(0);
+  });
+
+  it("does not record on spill (run budget exhausted)", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 100 });
+    b.tryReserve(80); // inline → consumed = 80
+    const d = b.tryReserve(80); // 80+80 > 100 → spill
+    expect(d.decision).toBe("spill");
+    expect(b.consumedTokens()).toBe(80); // unchanged
+  });
+
+  it("preserves the same reason union as decide()", () => {
+    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 1000 });
+    const d = b.tryReserve(50);
+    expect(d.reason).toBe("under_inline_cap");
+  });
+});
+
 describe("TokenBudget — record() + accumulation", () => {
   it("accumulates over multiple calls", () => {
     const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 1000 });
@@ -237,15 +255,6 @@ describe("TokenBudget — record() + accumulation", () => {
     b.record(50);
     expect(b.consumedTokens()).toBe(100);
     expect(b.remainingTokens()).toBe(900);
-  });
-
-  it("ignores zero / negative / non-finite", () => {
-    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 1000 });
-    b.record(0);
-    b.record(-50);
-    b.record(NaN);
-    b.record(Infinity);
-    expect(b.consumedTokens()).toBe(0);
   });
 
   it("rounds up fractional inputs (defence-in-depth — caller should pass integers)", () => {
@@ -262,6 +271,37 @@ describe("TokenBudget — record() + accumulation", () => {
     expect(b.remainingTokens()).toBe(0);
   });
 
+  it("throws in non-production on invalid input (catches caller bugs)", () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+    try {
+      const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 1000 });
+      expect(() => b.record(0)).toThrow(/positive finite/);
+      expect(() => b.record(-50)).toThrow(/positive finite/);
+      expect(() => b.record(NaN)).toThrow(/positive finite/);
+      expect(() => b.record(Infinity)).toThrow(/positive finite/);
+    } finally {
+      if (original === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = original;
+    }
+  });
+
+  it("silently ignores invalid input in production (defence-in-depth)", () => {
+    const original = process.env.NODE_ENV;
+    process.env.NODE_ENV = "production";
+    try {
+      const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 1000 });
+      b.record(0);
+      b.record(-50);
+      b.record(NaN);
+      b.record(Infinity);
+      expect(b.consumedTokens()).toBe(0);
+    } finally {
+      if (original === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = original;
+    }
+  });
+
   it("models the issue #390 scenario: 50 small calls accumulate budget pressure", () => {
     // 50 × 30 KB JSON ≈ 50 × 9000 tokens (30000 chars / 3.5) = 450 K
     // tokens. With a 200 K-token budget the tracker should hit
@@ -273,26 +313,47 @@ describe("TokenBudget — record() + accumulation", () => {
     let inlineCount = 0;
     let spillCount = 0;
     for (let i = 0; i < 50; i++) {
-      const d = b.decide(perCall);
-      if (d.decision === "inline") {
-        b.record(perCall);
-        inlineCount++;
-      } else {
-        spillCount++;
-      }
+      const d = b.tryReserve(perCall);
+      if (d.decision === "inline") inlineCount++;
+      else spillCount++;
     }
     // Around 200_000 / 8572 ≈ 23 calls fit before run-budget triggers.
     expect(inlineCount).toBeLessThan(50);
     expect(spillCount).toBeGreaterThan(0);
     expect(b.consumedTokens()).toBeLessThanOrEqual(runBudget);
   });
+});
 
-  it("reset() clears consumed back to zero (test-only)", () => {
-    const b = new TokenBudget({ inlineCapTokens: 100, runBudgetTokens: 1000 });
-    b.record(500);
-    b.reset();
-    expect(b.consumedTokens()).toBe(0);
-    expect(b.remainingTokens()).toBe(1000);
+describe("TokenBudget — pluggable estimator", () => {
+  it("uses the default heuristic when no estimator is injected", () => {
+    const b = new TokenBudget();
+    expect(b.estimate("x".repeat(350))).toBe(100);
+  });
+
+  it("uses the injected estimator for estimate() and budget decisions", () => {
+    // Mock tokenizer that always returns 5 — operators wiring a real
+    // tokenizer get the same code path.
+    const fakeEstimator: TokenEstimator = () => 5;
+    const b = new TokenBudget({
+      inlineCapTokens: 10,
+      runBudgetTokens: 100,
+      estimate: fakeEstimator,
+    });
+    expect(b.estimate("anything")).toBe(5);
+    expect(b.estimate("a".repeat(100_000))).toBe(5);
+  });
+
+  it("the injected estimator drives spill decisions in tryReserve()", () => {
+    // Estimator overstates so even short text spills.
+    const overEstimator: TokenEstimator = () => 999_999;
+    const b = new TokenBudget({
+      inlineCapTokens: 1_000,
+      runBudgetTokens: 10_000,
+      estimate: overEstimator,
+    });
+    const d = b.tryReserve(b.estimate("hi"));
+    expect(d.decision).toBe("spill");
+    expect(d.reason).toBe("exceeds_inline_cap");
   });
 });
 

--- a/runtime-pi/sidecar/token-budget.ts
+++ b/runtime-pi/sidecar/token-budget.ts
@@ -245,9 +245,10 @@ export class TokenBudget {
    * Decide whether a response of `estimatedTokens` should be inlined.
    *
    * The caller still has the option of forcing `spill` (e.g. when no
-   * blob store is configured we have no spill path). This method only
-   * answers the budget question — see {@link decideForResponse} for
-   * the full integration helper.
+   * blob store is configured we have no spill path). This method
+   * only answers the budget question; the integration is in
+   * `responseToToolResult` (`mcp.ts`), which combines this decision
+   * with the blob-store presence check.
    */
   decide(estimatedTokens: number): BudgetDecision {
     if (estimatedTokens > this.inlineCapTokens) {

--- a/runtime-pi/sidecar/token-budget.ts
+++ b/runtime-pi/sidecar/token-budget.ts
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Appstrate
+
+/**
+ * Token-aware context budgeting for `provider_call` tool outputs.
+ *
+ * Background — see issue #390. The byte-based caps in `helpers.ts`
+ * (`MAX_RESPONSE_SIZE`, `ABSOLUTE_MAX_RESPONSE_SIZE`) protect against
+ * OOM and "agent downloads a 10 MB PDF" scenarios but do not reflect
+ * the true cost of a tool output in the agent's context window:
+ *
+ *   - 256 KB of dense JSON ≈ 65-90 K tokens (ratio 3-4×).
+ *   - 256 KB of natural-language prose ≈ 60-80 K tokens.
+ *   - 256 KB of base64-encoded binary ≈ 80 K tokens.
+ *
+ * A 256 KB JSON response that fits under the byte cap can therefore
+ * burn through a 200 K-token context window in a single call. Worse,
+ * 50 successive `provider_call`s each at ~30 KB JSON (well under the
+ * 32 KB inline threshold) accumulate ~400 K tokens of context with no
+ * guard-rail — every call is judged in isolation.
+ *
+ * This module adds two layers on top of the existing byte caps:
+ *
+ *   1. **Per-call token estimate** — `estimateTokens()` converts a
+ *      response body to an estimated token count via the
+ *      Anthropic-recommended heuristic of ~3.5 chars/token. The
+ *      sidecar chooses inline vs. spill on tokens, not bytes.
+ *
+ *   2. **Cumulative budget per run** — `TokenBudget` tracks how many
+ *      tool-output tokens the agent has consumed over the run's
+ *      lifetime. As the budget approaches exhaustion, the inline
+ *      threshold tightens (we spill more aggressively). Beyond the
+ *      ceiling, every text response spills to the blob store with a
+ *      structured truncation marker.
+ *
+ * Why a heuristic and not the real Anthropic / OpenAI tokenizer?
+ *
+ *   - The sidecar runs in-container, on the hot path of every
+ *     `provider_call`. A real tokenizer (`@anthropic-ai/tokenizer`
+ *     for legacy Claude, `js-tiktoken` with `p50k_base` as a Claude
+ *     proxy, or the Anthropic `count_tokens` API) costs anywhere from
+ *     5-50 ms per call — adding 50-500 ms of overhead to typical
+ *     LLM-driven tool sequences.
+ *
+ *   - The official `@anthropic-ai/tokenizer` package is itself
+ *     deprecated for Claude 3+ models — Anthropic explicitly
+ *     recommends the 3.5 chars/token heuristic for offline
+ *     estimation in their token-counting docs.
+ *
+ *   - The decision we are making is "spill or inline?" — a rough
+ *     order-of-magnitude estimate is sufficient. Exact counts are
+ *     the LLM provider's responsibility (and modern Sonnet/Opus
+ *     models surface remaining context themselves).
+ *
+ *   - The heuristic is deterministic, allocation-free, and so cheap
+ *     it is dominated by the upstream HTTP hop the tool already
+ *     performs.
+ *
+ * Operators who need exact counts can run a tokenizer-backed proxy
+ * upstream of the sidecar. The shape of the contract here is the same.
+ *
+ * Out of scope (issue #390 deliberately leaves these to follow-ups):
+ *   - Auto-compaction of conversational history (lives above the SDK).
+ *   - Per-tool / per-provider caps (one knob is enough at this stage).
+ *   - LLM-backed summarisation of spilled blobs (separate feature).
+ */
+
+/**
+ * Anthropic-recommended chars-per-token ratio for offline estimation.
+ * Documented in the Claude API token-counting guide as
+ * "1 token ≈ 3.5 English characters". Conservative for JSON / code
+ * (which trends slightly higher tokens-per-char), generous for prose.
+ *
+ * We treat one byte of a non-text payload (binary spill candidate) as
+ * one token equivalent so callers don't have to special-case binary —
+ * the calling code already routes binary responses through the blob
+ * store before consulting the budget.
+ */
+const CHARS_PER_TOKEN = 3.5;
+
+/**
+ * Default per-call inline budget. ~8000 tokens ≈ 28 KB of English text
+ * — the existing 32 KB byte threshold expressed in tokens. Anything
+ * above this spills to the blob store regardless of the cumulative
+ * budget state. Override via `SIDECAR_INLINE_TOOL_OUTPUT_TOKENS`.
+ */
+export const DEFAULT_INLINE_OUTPUT_TOKENS = 8_000;
+
+/**
+ * Default cumulative budget per run. 200 K tokens — the full default
+ * Claude / Opus context window. The platform reserves additional space
+ * for the system prompt, agent instructions, and conversation
+ * history; this budget covers tool outputs only.
+ *
+ * Operators on 1 M-token Sonnet 4.6 deployments will likely raise this
+ * via `SIDECAR_RUN_TOOL_OUTPUT_BUDGET_TOKENS`; OSS / dev defaults
+ * stay conservative.
+ */
+export const DEFAULT_RUN_OUTPUT_BUDGET_TOKENS = 200_000;
+
+/**
+ * Estimate the token count of a string using the Anthropic-recommended
+ * heuristic. Returns a non-negative integer. Empty input returns 0.
+ *
+ * Uses `Math.ceil` so any non-empty string costs at least one token —
+ * matches real tokenizer behaviour (the smallest encoded sequence is a
+ * single piece) and avoids a pathological "free" path for short inputs.
+ *
+ * The implementation is intentionally O(1) — JavaScript's `.length` on
+ * a string is the UTF-16 code-unit count, computed from the string
+ * header, not by iterating. This keeps the sidecar's hot path
+ * allocation-free.
+ */
+export function estimateTokens(text: string): number {
+  if (text.length === 0) return 0;
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+/**
+ * Estimate the token cost of a binary payload (base64 inflation
+ * factor applied if/when the agent reads it). Used for symmetry with
+ * `estimateTokens` so callers don't branch on text vs. binary —
+ * binary always spills, but the budget bookkeeper still wants a number.
+ *
+ * Conservative: assumes the agent will eventually base64-read the
+ * blob (1.37× inflation) and tokenise the resulting string at the
+ * heuristic ratio.
+ */
+export function estimateBinaryTokens(byteLength: number): number {
+  if (byteLength <= 0) return 0;
+  // Base64 inflates by 4/3, then chars-per-token.
+  return Math.ceil((byteLength * 4) / 3 / CHARS_PER_TOKEN);
+}
+
+/**
+ * Decision returned by `TokenBudget.decide()`. The caller (today:
+ * `responseToToolResult` in `mcp.ts`) acts on `decision`; `reason` is
+ * surfaced to the agent as structured `_meta` so it can react.
+ */
+export interface BudgetDecision {
+  /**
+   * - `inline`  — agent receives the full content as a `text` block.
+   * - `spill`   — agent receives a `resource_link`; bytes are stashed
+   *               in the blob store. May be triggered by per-call
+   *               size, by cumulative budget pressure, or by absence
+   *               of a viable inline path.
+   */
+  decision: "inline" | "spill";
+  /**
+   * Discriminated reason for the decision. Always set, including on
+   * `inline` — observability and tests both depend on the reason
+   * being explicit rather than implied by `decision === "inline"`.
+   */
+  reason:
+    | "under_inline_cap"
+    | "exceeds_inline_cap"
+    | "exceeds_run_budget"
+    | "no_blob_store_fallback_inline";
+  /** Estimated tokens for *this* response. */
+  estimatedTokens: number;
+  /** Cumulative tokens consumed by tool outputs so far in this run. */
+  consumedTokens: number;
+  /** Configured ceiling for the run. */
+  runBudgetTokens: number;
+  /** Configured per-call inline cap. */
+  inlineCapTokens: number;
+}
+
+export interface TokenBudgetOptions {
+  /**
+   * Per-call cap. Anything strictly above this spills, regardless of
+   * how much budget is left.
+   */
+  inlineCapTokens?: number;
+  /**
+   * Cumulative ceiling per run. When `consumedTokens + estimated >
+   * runBudgetTokens`, the response spills (and is truncated /
+   * summarised by the spill path) — even if it would otherwise fit
+   * inline.
+   */
+  runBudgetTokens?: number;
+}
+
+/**
+ * Read a positive-integer token cap from an env var, falling back to
+ * `defaultValue` when unset/empty. Mirrors `readPositiveByteEnv` in
+ * `helpers.ts` so misconfiguration fails loud at boot.
+ */
+export function readPositiveTokenEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return defaultValue;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer (tokens), got ${JSON.stringify(raw)}.`);
+  }
+  return parsed;
+}
+
+/**
+ * Run-scoped cumulative token budget tracker.
+ *
+ * One instance per sidecar process (each sidecar serves exactly one
+ * run). The tracker is consulted by `responseToToolResult` for every
+ * provider tool output, and only output paths that actually deliver
+ * content to the agent (`inline`) are recorded. Spilled content is
+ * not recorded — the agent reads bytes from the blob store on demand,
+ * and at read time the bytes are tokenised by the LLM's actual
+ * tokenizer, not by our heuristic. Double-counting would penalise
+ * the agent for content it never read.
+ */
+export class TokenBudget {
+  readonly inlineCapTokens: number;
+  readonly runBudgetTokens: number;
+  private consumed = 0;
+
+  constructor(options: TokenBudgetOptions = {}) {
+    const inlineCap = options.inlineCapTokens ?? DEFAULT_INLINE_OUTPUT_TOKENS;
+    const runBudget = options.runBudgetTokens ?? DEFAULT_RUN_OUTPUT_BUDGET_TOKENS;
+    if (!Number.isFinite(inlineCap) || !Number.isInteger(inlineCap) || inlineCap <= 0) {
+      throw new Error(`TokenBudget: inlineCapTokens must be a positive integer, got ${inlineCap}`);
+    }
+    if (!Number.isFinite(runBudget) || !Number.isInteger(runBudget) || runBudget <= 0) {
+      throw new Error(`TokenBudget: runBudgetTokens must be a positive integer, got ${runBudget}`);
+    }
+    if (inlineCap > runBudget) {
+      throw new Error(
+        `TokenBudget: inlineCapTokens (${inlineCap}) cannot exceed runBudgetTokens (${runBudget}).`,
+      );
+    }
+    this.inlineCapTokens = inlineCap;
+    this.runBudgetTokens = runBudget;
+  }
+
+  /** Tokens consumed so far by inline tool outputs in this run. */
+  consumedTokens(): number {
+    return this.consumed;
+  }
+
+  /** Tokens still available before the run-level ceiling kicks in. */
+  remainingTokens(): number {
+    return Math.max(0, this.runBudgetTokens - this.consumed);
+  }
+
+  /**
+   * Decide whether a response of `estimatedTokens` should be inlined.
+   *
+   * The caller still has the option of forcing `spill` (e.g. when no
+   * blob store is configured we have no spill path). This method only
+   * answers the budget question — see {@link decideForResponse} for
+   * the full integration helper.
+   */
+  decide(estimatedTokens: number): BudgetDecision {
+    if (estimatedTokens > this.inlineCapTokens) {
+      return {
+        decision: "spill",
+        reason: "exceeds_inline_cap",
+        estimatedTokens,
+        consumedTokens: this.consumed,
+        runBudgetTokens: this.runBudgetTokens,
+        inlineCapTokens: this.inlineCapTokens,
+      };
+    }
+    if (this.consumed + estimatedTokens > this.runBudgetTokens) {
+      return {
+        decision: "spill",
+        reason: "exceeds_run_budget",
+        estimatedTokens,
+        consumedTokens: this.consumed,
+        runBudgetTokens: this.runBudgetTokens,
+        inlineCapTokens: this.inlineCapTokens,
+      };
+    }
+    return {
+      decision: "inline",
+      reason: "under_inline_cap",
+      estimatedTokens,
+      consumedTokens: this.consumed,
+      runBudgetTokens: this.runBudgetTokens,
+      inlineCapTokens: this.inlineCapTokens,
+    };
+  }
+
+  /**
+   * Record `tokens` against the budget. Saturates at the ceiling so
+   * the tracker never reports a negative remaining figure even if a
+   * caller records more than `decide()` recommended (the caller
+   * always gets the chance to abort first; record-after-deliver is
+   * the contract).
+   */
+  record(tokens: number): void {
+    if (!Number.isFinite(tokens) || tokens <= 0) return;
+    this.consumed = Math.min(this.runBudgetTokens, this.consumed + Math.ceil(tokens));
+  }
+
+  /** Test-only: reset the tracker. */
+  reset(): void {
+    this.consumed = 0;
+  }
+}

--- a/runtime-pi/sidecar/token-budget.ts
+++ b/runtime-pi/sidecar/token-budget.ts
@@ -21,10 +21,11 @@
  *
  * This module adds two layers on top of the existing byte caps:
  *
- *   1. **Per-call token estimate** — `estimateTokens()` converts a
- *      response body to an estimated token count via the
- *      Anthropic-recommended heuristic of ~3.5 chars/token. The
- *      sidecar chooses inline vs. spill on tokens, not bytes.
+ *   1. **Per-call token estimate** — the configured estimator converts
+ *      a response body to an estimated token count. The default uses
+ *      the Anthropic-recommended ~3.5 chars/token heuristic; operators
+ *      can inject a real tokenizer via {@link TokenBudgetOptions.estimate}.
+ *      The sidecar chooses inline vs. spill on tokens, not bytes.
  *
  *   2. **Cumulative budget per run** — `TokenBudget` tracks how many
  *      tool-output tokens the agent has consumed over the run's
@@ -33,7 +34,7 @@
  *      ceiling, every text response spills to the blob store with a
  *      structured truncation marker.
  *
- * Why a heuristic and not the real Anthropic / OpenAI tokenizer?
+ * Why a heuristic by default?
  *
  *   - The sidecar runs in-container, on the hot path of every
  *     `provider_call`. A real tokenizer (`@anthropic-ai/tokenizer`
@@ -52,12 +53,9 @@
  *     the LLM provider's responsibility (and modern Sonnet/Opus
  *     models surface remaining context themselves).
  *
- *   - The heuristic is deterministic, allocation-free, and so cheap
- *     it is dominated by the upstream HTTP hop the tool already
- *     performs.
- *
- * Operators who need exact counts can run a tokenizer-backed proxy
- * upstream of the sidecar. The shape of the contract here is the same.
+ *   - Operators who *do* need exact counts can pass a custom
+ *     `estimate` callback at construction time. The shape of the
+ *     contract is the same; only the cost of the estimate changes.
  *
  * Out of scope (issue #390 deliberately leaves these to follow-ups):
  *   - Auto-compaction of conversational history (lives above the SDK).
@@ -70,11 +68,6 @@
  * Documented in the Claude API token-counting guide as
  * "1 token ≈ 3.5 English characters". Conservative for JSON / code
  * (which trends slightly higher tokens-per-char), generous for prose.
- *
- * We treat one byte of a non-text payload (binary spill candidate) as
- * one token equivalent so callers don't have to special-case binary —
- * the calling code already routes binary responses through the blob
- * store before consulting the budget.
  */
 const CHARS_PER_TOKEN = 3.5;
 
@@ -99,8 +92,18 @@ export const DEFAULT_INLINE_OUTPUT_TOKENS = 8_000;
 export const DEFAULT_RUN_OUTPUT_BUDGET_TOKENS = 200_000;
 
 /**
- * Estimate the token count of a string using the Anthropic-recommended
- * heuristic. Returns a non-negative integer. Empty input returns 0.
+ * Pluggable token estimator. Receives a text payload, returns a
+ * non-negative integer count. Implementations should be deterministic
+ * for a given input. The default is the Anthropic-recommended
+ * heuristic ({@link estimateTokens}); operators can inject a real
+ * tokenizer (tiktoken, `count_tokens` API, …) at the cost of a
+ * per-call hop.
+ */
+export type TokenEstimator = (text: string) => number;
+
+/**
+ * Default estimator using the Anthropic-recommended chars/token ratio.
+ * Returns a non-negative integer. Empty input returns 0.
  *
  * Uses `Math.ceil` so any non-empty string costs at least one token —
  * matches real tokenizer behaviour (the smallest encoded sequence is a
@@ -111,39 +114,27 @@ export const DEFAULT_RUN_OUTPUT_BUDGET_TOKENS = 200_000;
  * header, not by iterating. This keeps the sidecar's hot path
  * allocation-free.
  */
-export function estimateTokens(text: string): number {
+export const estimateTokens: TokenEstimator = (text) => {
   if (text.length === 0) return 0;
   return Math.ceil(text.length / CHARS_PER_TOKEN);
-}
+};
 
 /**
- * Estimate the token cost of a binary payload (base64 inflation
- * factor applied if/when the agent reads it). Used for symmetry with
- * `estimateTokens` so callers don't branch on text vs. binary —
- * binary always spills, but the budget bookkeeper still wants a number.
+ * Decision returned by {@link TokenBudget.decide} and
+ * {@link TokenBudget.tryReserve}.
  *
- * Conservative: assumes the agent will eventually base64-read the
- * blob (1.37× inflation) and tokenise the resulting string at the
- * heuristic ratio.
- */
-export function estimateBinaryTokens(byteLength: number): number {
-  if (byteLength <= 0) return 0;
-  // Base64 inflates by 4/3, then chars-per-token.
-  return Math.ceil((byteLength * 4) / 3 / CHARS_PER_TOKEN);
-}
-
-/**
- * Decision returned by `TokenBudget.decide()`. The caller (today:
- * `responseToToolResult` in `mcp.ts`) acts on `decision`; `reason` is
- * surfaced to the agent as structured `_meta` so it can react.
+ * The reason union is intentionally narrow: only the three states the
+ * tracker itself can produce. Fallback states triggered by the caller
+ * (no blob store configured, blob store full, …) are surfaced through
+ * a wider union in the agent-facing `_meta` payload — they are not
+ * decisions the budget can make.
  */
 export interface BudgetDecision {
   /**
    * - `inline`  — agent receives the full content as a `text` block.
    * - `spill`   — agent receives a `resource_link`; bytes are stashed
-   *               in the blob store. May be triggered by per-call
-   *               size, by cumulative budget pressure, or by absence
-   *               of a viable inline path.
+   *               in the blob store. Triggered by per-call size or
+   *               by cumulative budget pressure.
    */
   decision: "inline" | "spill";
   /**
@@ -151,11 +142,7 @@ export interface BudgetDecision {
    * `inline` — observability and tests both depend on the reason
    * being explicit rather than implied by `decision === "inline"`.
    */
-  reason:
-    | "under_inline_cap"
-    | "exceeds_inline_cap"
-    | "exceeds_run_budget"
-    | "no_blob_store_fallback_inline";
+  reason: "under_inline_cap" | "exceeds_inline_cap" | "exceeds_run_budget";
   /** Estimated tokens for *this* response. */
   estimatedTokens: number;
   /** Cumulative tokens consumed by tool outputs so far in this run. */
@@ -179,6 +166,13 @@ export interface TokenBudgetOptions {
    * inline.
    */
   runBudgetTokens?: number;
+  /**
+   * Optional override of the token-counting function. Defaults to
+   * {@link estimateTokens} (the chars/3.5 heuristic). Operators who
+   * need exact counts can inject a real tokenizer here at the cost
+   * of a per-call hop.
+   */
+  estimate?: TokenEstimator;
 }
 
 /**
@@ -207,10 +201,25 @@ export function readPositiveTokenEnv(name: string, defaultValue: number): number
  * and at read time the bytes are tokenised by the LLM's actual
  * tokenizer, not by our heuristic. Double-counting would penalise
  * the agent for content it never read.
+ *
+ * **Concurrency model.** The sidecar runs on Bun's single-threaded
+ * event loop, so no two `decide()` calls execute simultaneously.
+ * However, `responseToToolResult` is async: between `decide()` and
+ * `record()`, the event loop may interleave another tool call. Two
+ * parallel calls could therefore both observe the pre-record
+ * `consumed` snapshot and both decide `inline`, then both record —
+ * briefly over-spending the inline budget by one call's worth.
+ *
+ * Use {@link tryReserve} for the inline path: it folds decide + record
+ * into a single synchronous step, eliminating the interleave window.
+ * The two-phase {@link decide} + {@link record} API is preserved for
+ * paths that deliver content the budget didn't authorize (e.g.
+ * blob-store-full fallback) and need to record after the fact.
  */
 export class TokenBudget {
   readonly inlineCapTokens: number;
   readonly runBudgetTokens: number;
+  private readonly estimator: TokenEstimator;
   private consumed = 0;
 
   constructor(options: TokenBudgetOptions = {}) {
@@ -229,6 +238,7 @@ export class TokenBudget {
     }
     this.inlineCapTokens = inlineCap;
     this.runBudgetTokens = runBudget;
+    this.estimator = options.estimate ?? estimateTokens;
   }
 
   /** Tokens consumed so far by inline tool outputs in this run. */
@@ -242,59 +252,93 @@ export class TokenBudget {
   }
 
   /**
-   * Decide whether a response of `estimatedTokens` should be inlined.
+   * Estimate the token cost of a text payload using the configured
+   * estimator (defaults to the {@link estimateTokens} heuristic).
+   * Exposed so callers don't need to know which estimator was wired
+   * at construction time.
+   */
+  estimate(text: string): number {
+    return this.estimator(text);
+  }
+
+  /**
+   * Pure decision function — answers "would `estimatedTokens` fit?"
+   * without mutating budget state. Use this when the caller may
+   * deliver content the budget didn't authorize (blob-store-full
+   * fallback) and needs to {@link record} after the fact.
    *
-   * The caller still has the option of forcing `spill` (e.g. when no
-   * blob store is configured we have no spill path). This method
-   * only answers the budget question; the integration is in
-   * `responseToToolResult` (`mcp.ts`), which combines this decision
-   * with the blob-store presence check.
+   * For the common inline path, prefer {@link tryReserve} which folds
+   * decide + record into a single synchronous step.
    */
   decide(estimatedTokens: number): BudgetDecision {
     if (estimatedTokens > this.inlineCapTokens) {
-      return {
-        decision: "spill",
-        reason: "exceeds_inline_cap",
-        estimatedTokens,
-        consumedTokens: this.consumed,
-        runBudgetTokens: this.runBudgetTokens,
-        inlineCapTokens: this.inlineCapTokens,
-      };
+      return this.snapshot("spill", "exceeds_inline_cap", estimatedTokens);
     }
     if (this.consumed + estimatedTokens > this.runBudgetTokens) {
-      return {
-        decision: "spill",
-        reason: "exceeds_run_budget",
-        estimatedTokens,
-        consumedTokens: this.consumed,
-        runBudgetTokens: this.runBudgetTokens,
-        inlineCapTokens: this.inlineCapTokens,
-      };
+      return this.snapshot("spill", "exceeds_run_budget", estimatedTokens);
     }
+    return this.snapshot("inline", "under_inline_cap", estimatedTokens);
+  }
+
+  /**
+   * Atomic decide-and-reserve. If the decision is `inline`, records
+   * the tokens against the budget *before returning*, eliminating the
+   * decide/record interleave window described in the class JSDoc.
+   * On `spill`, the budget is left unchanged.
+   *
+   * The returned snapshot reflects the *post-record* consumed count,
+   * so callers building observability `_meta` see the same total the
+   * next caller will see.
+   */
+  tryReserve(estimatedTokens: number): BudgetDecision {
+    const decision = this.decide(estimatedTokens);
+    if (decision.decision === "inline") {
+      this.commit(estimatedTokens);
+      return this.snapshot(decision.decision, decision.reason, estimatedTokens);
+    }
+    return decision;
+  }
+
+  /**
+   * Record tokens delivered outside the {@link tryReserve} path
+   * (e.g. blob-store-full fallback where we deliver inline despite a
+   * spill decision). Saturates at the ceiling.
+   *
+   * In non-production environments invalid input throws — internal
+   * callers should never pass a bad number, and a silent no-op masks
+   * real bugs. Production stays defensive (silent no-op) so a runtime
+   * misuse cannot crash an active run.
+   */
+  record(tokens: number): void {
+    if (!Number.isFinite(tokens) || tokens <= 0) {
+      if (process.env.NODE_ENV !== "production") {
+        throw new Error(
+          `TokenBudget.record: expected a positive finite number, got ${String(tokens)}`,
+        );
+      }
+      return;
+    }
+    this.commit(tokens);
+  }
+
+  /** Internal: actually mutate the consumed counter (saturating). */
+  private commit(tokens: number): void {
+    this.consumed = Math.min(this.runBudgetTokens, this.consumed + Math.ceil(tokens));
+  }
+
+  /** Internal: build a {@link BudgetDecision} from current state. */
+  private snapshot(
+    decision: BudgetDecision["decision"],
+    reason: BudgetDecision["reason"],
+    estimatedTokens: number,
+  ): BudgetDecision {
     return {
-      decision: "inline",
-      reason: "under_inline_cap",
+      decision,
+      reason,
       estimatedTokens,
       consumedTokens: this.consumed,
       runBudgetTokens: this.runBudgetTokens,
       inlineCapTokens: this.inlineCapTokens,
     };
-  }
-
-  /**
-   * Record `tokens` against the budget. Saturates at the ceiling so
-   * the tracker never reports a negative remaining figure even if a
-   * caller records more than `decide()` recommended (the caller
-   * always gets the chance to abort first; record-after-deliver is
-   * the contract).
-   */
-  record(tokens: number): void {
-    if (!Number.isFinite(tokens) || tokens <= 0) return;
-    this.consumed = Math.min(this.runBudgetTokens, this.consumed + Math.ceil(tokens));
-  }
-
-  /** Test-only: reset the tracker. */
-  reset(): void {
-    this.consumed = 0;
   }
 }


### PR DESCRIPTION
## Summary

Closes #390.

The sidecar already caps `provider_call` upstream response **bytes** to protect the agent from OOM (32 KB → blob spill, 256 KB hard cap, 32 MB ceiling, 256 MB run total). Bytes are not tokens, though:

- **256 KB of dense JSON** ≈ 65-90 K tokens (ratio 3-4×) — fits the byte cap, blows the context window.
- **50 × 30 KB `provider_call`** ≈ ~450 K tokens accumulated context — every call passes the per-call byte gate; nothing watches the cumulative cost.

This PR layers two token-aware checks on top of the existing byte caps:

1. **Per-call inline cap** (default 8 000 tokens, ≈ 28 KB of English text) — tool outputs above this spill to the `BlobStore` regardless of byte size.
2. **Cumulative run budget** (default 200 000 tokens — full Claude default-context window equivalent) — once the running total of inline tool outputs would breach the ceiling, every text response spills.

Token estimation uses the **Anthropic-recommended ~3.5 chars/token heuristic** (documented in [Claude API token-counting docs](https://platform.claude.com/docs/en/build-with-claude/token-counting)). The official `@anthropic-ai/tokenizer` package is deprecated for Claude 3+; tiktoken / `count_tokens` API would add 5-50 ms per call. The decision we make is "spill or inline?" — a rough order-of-magnitude estimate is sufficient.

Each text-path tool result carries an `appstrate://token-budget` `_meta` payload so the agent runtime can surface accounting and react to structured truncation events:

```jsonc
{
  "_meta": {
    "appstrate://token-budget": {
      "estimatedTokens": 1234,
      "consumedTokens": 5000,
      "runBudgetTokens": 200000,
      "inlineCapTokens": 8000,
      "decision": "inline" | "spill",
      "reason": "under_inline_cap" | "exceeds_inline_cap" | "exceeds_run_budget" | "no_blob_store_fallback_inline"
    }
  }
}
```

Operators on 1 M-context Sonnet 4.6 deployments raise via env vars:

- `SIDECAR_INLINE_TOOL_OUTPUT_TOKENS` (default 8 000)
- `SIDECAR_RUN_TOOL_OUTPUT_BUDGET_TOKENS` (default 200 000)

Both are validated at boot via the same `readPositiveTokenEnv` pattern used by the byte-cap env vars (fail-loud on malformed values).

## Files

- `runtime-pi/sidecar/token-budget.ts` (new) — pure utilities + `TokenBudget` class.
- `runtime-pi/sidecar/mcp.ts` — `responseToToolResult` consults the budget; `provider_call` / `run_history` / `recall_memory` all forward the budget; `_meta` payload added.
- `runtime-pi/sidecar/app.ts` — `createApp` instantiates the budget from env vars at boot.
- `runtime-pi/sidecar/test/token-budget.test.ts` (new) — 38 unit tests covering estimator + tracker invariants + cumulative scenarios.
- `runtime-pi/sidecar/test/token-budget-integration.test.ts` (new) — 12 integration tests exercising the full MCP `/mcp` path: dense-JSON spill, 30× cumulative pressure, `_meta` accounting, all three platform tools, backwards compatibility, env-var wiring, blob-store-full fallback.
- `runtime-pi/sidecar/test/mcp.test.ts` — updated the `bounded response read` assertion (oversized `run_history` response now spills as a `resource_link` instead of inline-truncating, which is the intended improvement).
- `runtime-pi/sidecar/README.md` — new "Token-aware context budgeting" section documenting the wire format and env-var knobs.

## Out of scope (issue #390 explicit deferrals)

- Auto-compaction of conversational history (lives above the SDK).
- Per-tool / per-provider caps (one knob is enough at this stage).
- LLM-backed summarisation of spilled blobs (separate feature).

## Test plan

- [x] `bun test` in `runtime-pi/sidecar` — 280 pass (50 new).
- [x] `bun test` in `runtime-pi/test` — 369 pass.
- [x] `bun run check` from monorepo root — 18 / 18 tasks succeed (TS + ESLint + Prettier + OpenAPI verify).
- [x] Backwards compatibility verified: with no `TokenBudget` wired, existing byte-threshold behaviour stays — covered by integration tests.
- [x] Failure modes verified: blob-store-full falls back to inline with `no_blob_store_fallback_inline` reason; budget invariants reject misconfiguration loud at boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)