### PR TITLE
feat: stream live token usage & cost during run execution (#391)

### DIFF
--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -25,6 +25,8 @@ function stripPayload(evt: RealtimeEvent): Record<string, unknown> {
     const { data: _data, ...rest } = evt.data;
     return rest;
   }
+  // `run_metric` carries only bounded numeric fields + four small
+  // identifiers — no user content to strip. Pass through unmodified.
   return evt.data;
 }
 

--- a/apps/api/src/services/realtime.ts
+++ b/apps/api/src/services/realtime.ts
@@ -78,6 +78,31 @@ export async function initRealtime(): Promise<void> {
     }
   });
 
+  // `run_metric` carries the running cumulative cost + token usage
+  // emitted by the event sink after each `appstrate.metric` event,
+  // throttled per run by the broadcaster. Routed to the same
+  // org/application/run filters as `run_update` and `run_log_insert`
+  // — no new isolation rule. The scope filters here are the ONLY
+  // tenant gate for this channel; do not relax without updating the
+  // broadcaster payload contract.
+  await listenClient.listen("run_metric", (payload) => {
+    try {
+      const raw = JSON.parse(payload) as Record<string, unknown>;
+      const data = snakeToCamel(raw);
+      for (const sub of subscribers.values()) {
+        if (sub.filter.orgId !== raw.org_id) continue;
+        if (sub.filter.applicationId !== raw.application_id) continue;
+        if (sub.filter.runId && sub.filter.runId !== raw.run_id) continue;
+        if (sub.filter.packageId && sub.filter.packageId !== raw.package_id) continue;
+        sub.send({ event: "run_metric", data });
+      }
+    } catch (err) {
+      logger.error("Failed to parse run_metric payload", {
+        error: getErrorMessage(err),
+      });
+    }
+  });
+
   logger.info("Realtime LISTEN channels initialized");
 }
 

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -50,6 +50,7 @@ import { isInlineShadowPackageId } from "./inline-run.ts";
 import type { RunStatusChangeParams } from "@appstrate/core/module";
 import { computeRunCost } from "./credential-proxy-usage.ts";
 import { assertSinkOpen, verifyRunSignatureHeaders } from "../lib/run-signature.ts";
+import { clearRunMetricBroadcastState } from "./run-metric-broadcaster.ts";
 import type { TokenUsage } from "@appstrate/shared-types";
 
 // Re-export the pure helpers so callers that already import from this
@@ -352,8 +353,16 @@ export async function finalizeRun(input: FinalizeRunInput): Promise<void> {
 
   if (rowsAffected.length === 0) {
     logger.debug("finalizeRun idempotent — sink already closed", { runId: run.id });
+    // Even on the no-op branch, clear any lingering throttle state so
+    // a long-running API process doesn't leak entries for retry-storm
+    // runs that all collapse onto the same id.
+    clearRunMetricBroadcastState(run.id);
     return;
   }
+
+  // Drop the per-run throttle state — the run is terminal, no further
+  // metric events will arrive. Bounds the broadcaster's in-memory map.
+  clearRunMetricBroadcastState(run.id);
 
   // 7. Side effects — only the CAS winner reaches here, so memories and
   //    log rows are written exactly once.

--- a/apps/api/src/services/run-launcher/appstrate-event-sink.ts
+++ b/apps/api/src/services/run-launcher/appstrate-event-sink.ts
@@ -51,12 +51,14 @@ import type { RunResult } from "@appstrate/afps-runtime/runner";
 import { isPlainObject } from "@appstrate/core/safe-json";
 import { db } from "@appstrate/db/client";
 import { llmUsage } from "@appstrate/db/schema";
+import { sql } from "drizzle-orm";
 import type { AppScope } from "../../lib/scope.ts";
 import { appendRunLog, updateRun } from "../state/runs.ts";
 import { logger } from "../../lib/logger.ts";
 import { accumulateTokenUsage } from "@appstrate/shared-types";
 import { getErrorMessage } from "@appstrate/core/errors";
 import type { TokenUsage } from "./types.ts";
+import { scheduleRunMetricBroadcast } from "../run-metric-broadcaster.ts";
 
 export interface PersistingEventSinkOptions {
   scope: AppScope;
@@ -188,10 +190,17 @@ export class PersistingEventSink implements EventSink {
             tokenUsage: usage as unknown as Record<string, unknown>,
           });
         }
-        // Ledger row — only the ingestion path opts in. Concurrent
-        // writers race via ON CONFLICT DO NOTHING.
+        // Ledger row — only the ingestion path opts in. The runner
+        // emits cumulative running totals on each metric event, so
+        // concurrent writers (a later metric event, the finalize-time
+        // fallback) UPSERT the row with monotonic-max semantics.
         if (this.writeLedger) {
           await writeRunnerLedgerRow(this.scope, this.runId, { cost, usage });
+          // Best-effort live broadcast — never blocks the ingestion
+          // hot path nor fails it. The broadcaster throttles per-run
+          // to avoid flooding SSE subscribers under bursty metric
+          // emission (e.g. tool-heavy turns).
+          scheduleRunMetricBroadcast(this.runId);
         }
         break;
       }
@@ -279,13 +288,20 @@ function resolveLogLevel(value: unknown): "debug" | "info" | "warn" | "error" | 
 }
 
 /**
- * Write the runner-source row for a run to the `llm_usage` ledger.
+ * Write (upsert) the runner-source row for a run in the `llm_usage` ledger.
  *
- * The metric event carries the runner's full LLM cost + token usage for
- * the run. At most one runner row per run — concurrent writers (the
- * `appstrate.metric` event handler and the finalize-time fallback)
- * race via the partial unique index `uq_llm_usage_runner_run_id`;
- * whichever lands first wins, the other no-ops.
+ * The runner emits cumulative running totals on every `appstrate.metric`
+ * event, so the row tracks the latest total seen — concurrent writers
+ * (a later metric event, the finalize-time fallback) UPSERT into the
+ * partial unique index `uq_llm_usage_runner_run_id`. The conflict
+ * clause is monotonic: an UPDATE only takes effect when the incoming
+ * `cost_usd` is at least as large as the stored value, so:
+ *
+ *   - rapid-fire metric events keep the row in sync with the latest total
+ *   - a finalize-fallback emit with a smaller `result.cost` (e.g. when
+ *     a fresh metric already landed) cannot regress the bill
+ *   - reorder is safe — the highest-seen cost wins regardless of arrival
+ *     order
  *
  * Best-effort: metric persistence MUST NOT fail the ingestion path.
  * Errors are logged.
@@ -315,7 +331,24 @@ export async function writeRunnerLedgerRow(
         cacheWriteTokens: row.usage?.cache_creation_input_tokens ?? null,
         costUsd: row.cost ?? 0,
       })
-      .onConflictDoNothing();
+      // Upsert via the partial unique index. `setWhere` keeps the
+      // update monotonic — only the highest-seen cumulative total ever
+      // wins, so out-of-order metric events and the finalize fallback
+      // can never regress the recorded cost. Token columns are bumped
+      // alongside the cost so the snapshot stays internally consistent
+      // (cost ≥ stored cost ⇒ tokens are at least as large too).
+      .onConflictDoUpdate({
+        target: llmUsage.runId,
+        targetWhere: sql`source = 'runner' AND run_id IS NOT NULL`,
+        set: {
+          inputTokens: sql`EXCLUDED.input_tokens`,
+          outputTokens: sql`EXCLUDED.output_tokens`,
+          cacheReadTokens: sql`EXCLUDED.cache_read_tokens`,
+          cacheWriteTokens: sql`EXCLUDED.cache_write_tokens`,
+          costUsd: sql`EXCLUDED.cost_usd`,
+        },
+        setWhere: sql`EXCLUDED.cost_usd >= ${llmUsage.costUsd}`,
+      });
   } catch (err) {
     logger.error("Failed to write runner ledger row", {
       runId,

--- a/apps/api/src/services/run-metric-broadcaster.ts
+++ b/apps/api/src/services/run-metric-broadcaster.ts
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Per-run throttled fan-out for `appstrate.metric` events. Sits between
+ * the `PersistingEventSink` (which calls
+ * {@link scheduleRunMetricBroadcast} on every metric persistence) and
+ * Postgres `NOTIFY run_metric` (which the realtime SSE service relays
+ * to UI subscribers).
+ *
+ * Why a separate module — the broadcaster reads
+ * `runs (org_id, application_id, package_id)` and aggregates
+ * `llm_usage.cost_usd` for the run. Doing that inline in
+ * {@link PersistingEventSink} would couple the metric write-through to
+ * the broadcast read path (two extra queries inside the ingestion hot
+ * path) and force the throttle state into the per-event sink instances
+ * that are spun up + dropped per HTTP request. Lifting the throttle
+ * map to module scope keeps it stable across requests.
+ *
+ * Throttle policy — leading + trailing per run:
+ *
+ *   - first call for a run fires `pg_notify` immediately
+ *   - subsequent calls within {@link THROTTLE_WINDOW_MS} land on a
+ *     trailing timer that fires once at the end of the window
+ *   - the trailing tick always re-runs the read path, so the broadcast
+ *     reflects the latest persisted state at flush time (not the value
+ *     captured when the timer was scheduled)
+ *
+ * This matches the streaming-UI state of the art: emit fast on the
+ * leading edge for low latency, coalesce bursts on the trailing edge
+ * to bound subscriber load. Idle entries are GC'd via {@link clearRunMetricBroadcastState}
+ * once the run finalizes (callers in the run-event-ingestion path).
+ *
+ * Best-effort: failures in the read or NOTIFY path are logged and
+ * dropped — the broadcaster never fails the metric ingestion that
+ * triggered it. Realtime UX is non-load-bearing relative to the
+ * authoritative `runs.cost` value written at finalize.
+ */
+
+import { db } from "@appstrate/db/client";
+import { runs, llmUsage } from "@appstrate/db/schema";
+import { eq, sql } from "drizzle-orm";
+import { notifyRunMetric, type RunMetricNotifyPayload } from "@appstrate/db/notify";
+import { logger } from "../lib/logger.ts";
+import { getErrorMessage } from "@appstrate/core/errors";
+
+/**
+ * How long after a leading-edge broadcast we coalesce subsequent
+ * triggers into a single trailing emit. 250 ms balances UI latency
+ * (perceptibly live) with subscriber load under bursty metric
+ * emission (a tool-heavy turn can fire 5+ metric events per second).
+ */
+const THROTTLE_WINDOW_MS = 250;
+
+interface ThrottleState {
+  /** Timestamp (ms) of the last fired NOTIFY for this run. */
+  lastFiredAt: number;
+  /** Pending trailing timer, or null if no broadcast is queued. */
+  trailingTimer: ReturnType<typeof setTimeout> | null;
+}
+
+const throttleByRunId = new Map<string, ThrottleState>();
+
+/**
+ * Schedule a `run_metric` broadcast for the given run. Safe to call on
+ * every metric event — the per-run throttle handles coalescing.
+ */
+export function scheduleRunMetricBroadcast(runId: string): void {
+  const state = throttleByRunId.get(runId);
+  const now = Date.now();
+
+  if (!state) {
+    // First emit ever for this run — fire on the leading edge so the
+    // UI sees the first metric immediately.
+    throttleByRunId.set(runId, { lastFiredAt: now, trailingTimer: null });
+    void fireBroadcast(runId);
+    return;
+  }
+
+  const elapsed = now - state.lastFiredAt;
+  if (elapsed >= THROTTLE_WINDOW_MS && state.trailingTimer === null) {
+    // Window has elapsed and no trailing tick is pending — fire now.
+    state.lastFiredAt = now;
+    void fireBroadcast(runId);
+    return;
+  }
+
+  // Coalesce — schedule (or keep) a single trailing tick at window end.
+  if (state.trailingTimer !== null) return;
+  const delay = Math.max(0, THROTTLE_WINDOW_MS - elapsed);
+  state.trailingTimer = setTimeout(() => {
+    const current = throttleByRunId.get(runId);
+    if (!current) return;
+    current.trailingTimer = null;
+    current.lastFiredAt = Date.now();
+    void fireBroadcast(runId);
+  }, delay);
+  // Don't keep the event loop alive on shutdown for the trailing tick.
+  state.trailingTimer.unref?.();
+}
+
+/**
+ * Drop the throttle state for a run. Call from `finalizeRun` so a run
+ * id never leaks past its lifecycle (the in-memory map is otherwise
+ * unbounded for long-lived API processes).
+ */
+export function clearRunMetricBroadcastState(runId: string): void {
+  const state = throttleByRunId.get(runId);
+  if (state?.trailingTimer) {
+    clearTimeout(state.trailingTimer);
+  }
+  throttleByRunId.delete(runId);
+}
+
+/**
+ * Test helper — drop ALL throttle state. Production code never calls
+ * this; tests use it between cases to keep state isolated.
+ */
+export function _resetRunMetricBroadcasterForTests(): void {
+  for (const state of throttleByRunId.values()) {
+    if (state.trailingTimer) clearTimeout(state.trailingTimer);
+  }
+  throttleByRunId.clear();
+}
+
+async function fireBroadcast(runId: string): Promise<void> {
+  try {
+    const payload = await loadRunMetricPayload(runId);
+    if (!payload) return;
+    await notifyRunMetric(db, payload);
+  } catch (err) {
+    logger.warn("run_metric broadcast failed", {
+      runId,
+      error: getErrorMessage(err),
+    });
+  }
+}
+
+async function loadRunMetricPayload(runId: string): Promise<RunMetricNotifyPayload | null> {
+  // Two reads — kept separate because the run row + ledger sum hit
+  // different indexes; combining them would force a JOIN on every
+  // tick. Both are PK / index lookups, sub-millisecond on healthy
+  // PG. The pg_notify is fire-and-forget so the cost is bounded
+  // regardless of subscriber count.
+  const [runRow] = await db
+    .select({
+      orgId: runs.orgId,
+      applicationId: runs.applicationId,
+      packageId: runs.packageId,
+      tokenUsage: runs.tokenUsage,
+    })
+    .from(runs)
+    .where(eq(runs.id, runId))
+    .limit(1);
+
+  if (!runRow) return null;
+  // `runs.package_id` is `ON DELETE SET NULL`, so an in-flight metric
+  // for a run whose package was just deleted hits this branch. The
+  // SSE filter on `packageId` would never match anyway — drop the
+  // broadcast so subscribers aren't confused by a payload with a
+  // missing package id.
+  if (!runRow.packageId) return null;
+
+  const [costRow] = await db
+    .select({
+      total: sql<string>`COALESCE(SUM(${llmUsage.costUsd}), 0)`,
+    })
+    .from(llmUsage)
+    .where(eq(llmUsage.runId, runId));
+
+  return {
+    run_id: runId,
+    org_id: runRow.orgId,
+    application_id: runRow.applicationId,
+    package_id: runRow.packageId,
+    token_usage: (runRow.tokenUsage as RunMetricNotifyPayload["token_usage"]) ?? null,
+    cost_so_far: Number(costRow?.total ?? 0),
+  };
+}

--- a/apps/api/src/services/run-metric-broadcaster.ts
+++ b/apps/api/src/services/run-metric-broadcaster.ts
@@ -125,7 +125,15 @@ export function _resetRunMetricBroadcasterForTests(): void {
 async function fireBroadcast(runId: string): Promise<void> {
   try {
     const payload = await loadRunMetricPayload(runId);
-    if (!payload) return;
+    if (!payload) {
+      // Run vanished (deleted, or `package_id` set to NULL by cascade).
+      // Drop the throttle entry so a long-lived API process doesn't
+      // accumulate a leak entry per orphaned run id — the run will
+      // never finalize and `clearRunMetricBroadcastState` would
+      // otherwise never be called for it.
+      clearRunMetricBroadcastState(runId);
+      return;
+    }
     await notifyRunMetric(db, payload);
   } catch (err) {
     logger.warn("run_metric broadcast failed", {

--- a/apps/api/src/services/run-metric-broadcaster.ts
+++ b/apps/api/src/services/run-metric-broadcaster.ts
@@ -38,7 +38,7 @@
 
 import { db } from "@appstrate/db/client";
 import { runs, llmUsage } from "@appstrate/db/schema";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, isNull, lt, or, sql } from "drizzle-orm";
 import { notifyRunMetric, type RunMetricNotifyPayload } from "@appstrate/db/notify";
 import { logger } from "../lib/logger.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
@@ -133,6 +133,19 @@ async function fireBroadcast(runId: string): Promise<void> {
       // otherwise never be called for it.
       clearRunMetricBroadcastState(runId);
       return;
+    }
+    // Persist the running cost on the run row so a hard refresh during
+    // a streaming run sees the latest value, not stale `null`. The SSE
+    // payload was previously the only path delivering `cost_so_far`, so
+    // a refresh refetched `runs.cost` (null until finalize) and the UI
+    // jumped back to $0. Bounded by the throttle (one UPDATE per 250 ms
+    // window per run). Monotonic-max via WHERE keeps a late finalize
+    // race or out-of-order tick from regressing the persisted aggregate.
+    if (payload.cost_so_far > 0) {
+      await db
+        .update(runs)
+        .set({ cost: payload.cost_so_far })
+        .where(and(eq(runs.id, runId), or(isNull(runs.cost), lt(runs.cost, payload.cost_so_far))));
     }
     await notifyRunMetric(db, payload);
   } catch (err) {

--- a/apps/api/test/integration/services/appstrate-event-sink.test.ts
+++ b/apps/api/test/integration/services/appstrate-event-sink.test.ts
@@ -277,13 +277,12 @@ describe("PersistingEventSink", () => {
     expect(runRow?.cost).toBeNull();
   });
 
-  it("concurrent metric writes for the same run land at most one runner row", async () => {
+  it("concurrent metric writes for the same run land at most one runner row (max wins)", async () => {
     // The runner row is dedup'd via the partial unique index
-    // `uq_llm_usage_runner_run_id`. Multiple concurrent writers (the
-    // metric event handler and the finalize fallback) both target the
-    // same key — whichever lands first owns the row, the others no-op
-    // via ON CONFLICT DO NOTHING. The total row count is 1 regardless
-    // of how many writers raced.
+    // `uq_llm_usage_runner_run_id`. The runner emits cumulative
+    // running totals on every metric event, so concurrent writers
+    // UPSERT with monotonic-max semantics — the highest-seen
+    // `cost_usd` wins regardless of arrival order.
     const totals = [0.001, 0.003, 0.006, 0.01, 0.015];
     await Promise.all(
       totals.map((cost) => {
@@ -306,6 +305,72 @@ describe("PersistingEventSink", () => {
       .from(llmUsage)
       .where(and(eq(llmUsage.runId, runId), eq(llmUsage.source, "runner")));
     expect(rows).toHaveLength(1);
+    // Whichever order the writers landed in, the surviving row holds
+    // the maximum cost — never a regressed value.
+    expect(rows[0]!.costUsd).toBeCloseTo(0.015, 5);
+  });
+
+  it("monotonic upsert: a smaller subsequent cost cannot regress the recorded value", async () => {
+    const sink = new PersistingEventSink({
+      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      runId,
+      writeLedger: true,
+    });
+
+    // First emit — cost 0.01, tokens 200/100
+    await sink.handle(
+      event("appstrate.metric", {
+        usage: { input_tokens: 200, output_tokens: 100 },
+        cost: 0.01,
+      }),
+    );
+
+    // Second emit — REGRESSES to cost 0.005 (a finalize fallback that
+    // raced an earlier metric event with a higher running total). The
+    // monotonic guard MUST keep the higher value.
+    await sink.handle(
+      event("appstrate.metric", {
+        usage: { input_tokens: 50, output_tokens: 25 },
+        cost: 0.005,
+      }),
+    );
+
+    const rows = await db
+      .select()
+      .from(llmUsage)
+      .where(and(eq(llmUsage.runId, runId), eq(llmUsage.source, "runner")));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.costUsd).toBeCloseTo(0.01, 5);
+    expect(rows[0]!.inputTokens).toBe(200);
+    expect(rows[0]!.outputTokens).toBe(100);
+  });
+
+  it("monotonic upsert: a larger subsequent cost replaces the recorded value (streaming totals)", async () => {
+    const sink = new PersistingEventSink({
+      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      runId,
+      writeLedger: true,
+    });
+
+    // Three increasing emits — each must replace the previous row.
+    await sink.handle(
+      event("appstrate.metric", { usage: { input_tokens: 100, output_tokens: 0 }, cost: 0.001 }),
+    );
+    await sink.handle(
+      event("appstrate.metric", { usage: { input_tokens: 200, output_tokens: 50 }, cost: 0.005 }),
+    );
+    await sink.handle(
+      event("appstrate.metric", { usage: { input_tokens: 350, output_tokens: 120 }, cost: 0.012 }),
+    );
+
+    const rows = await db
+      .select()
+      .from(llmUsage)
+      .where(and(eq(llmUsage.runId, runId), eq(llmUsage.source, "runner")));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.costUsd).toBeCloseTo(0.012, 5);
+    expect(rows[0]!.inputTokens).toBe(350);
+    expect(rows[0]!.outputTokens).toBe(120);
   });
 
   it("writeLedger off (default) → metric event still writes tokenUsage but no ledger row", async () => {

--- a/apps/api/test/integration/services/realtime.test.ts
+++ b/apps/api/test/integration/services/realtime.test.ts
@@ -375,6 +375,143 @@ describe("realtime service (integration)", () => {
     });
   });
 
+  // ── run_metric dispatching ───────────────────────────────
+
+  describe("run_metric", () => {
+    it("dispatches to subscriber matching orgId, applicationId, and runId", async () => {
+      const send = mock((_e: RealtimeEvent) => {});
+      const id = "sub-metric-match";
+      trackSubscriber(id);
+      addSubscriber({
+        id,
+        filter: { orgId: "org-m", applicationId: "app-m", runId: "exec-m", isAdmin: true },
+        send,
+      });
+
+      await pgNotify("run_metric", {
+        org_id: "org-m",
+        application_id: "app-m",
+        run_id: "exec-m",
+        package_id: "@scope/agent",
+        token_usage: { input_tokens: 10, output_tokens: 5 },
+        cost_so_far: 0.0042,
+      });
+      await wait();
+
+      expect(send).toHaveBeenCalledTimes(1);
+      const call = send.mock.calls[0]![0]!;
+      expect(call.event).toBe("run_metric");
+      expect(call.data).toEqual({
+        orgId: "org-m",
+        applicationId: "app-m",
+        runId: "exec-m",
+        packageId: "@scope/agent",
+        tokenUsage: { input_tokens: 10, output_tokens: 5 },
+        costSoFar: 0.0042,
+      });
+    });
+
+    it("filters by runId", async () => {
+      const send = mock((_e: RealtimeEvent) => {});
+      const id = "sub-metric-run-filter";
+      trackSubscriber(id);
+      addSubscriber({
+        id,
+        filter: { orgId: "org-mr", applicationId: "app-mr", runId: "target", isAdmin: true },
+        send,
+      });
+
+      await pgNotify("run_metric", {
+        org_id: "org-mr",
+        application_id: "app-mr",
+        run_id: "other",
+        package_id: "@scope/agent",
+        token_usage: null,
+        cost_so_far: 0,
+      });
+      await wait();
+      expect(send).not.toHaveBeenCalled();
+
+      await pgNotify("run_metric", {
+        org_id: "org-mr",
+        application_id: "app-mr",
+        run_id: "target",
+        package_id: "@scope/agent",
+        token_usage: null,
+        cost_so_far: 0,
+      });
+      await wait();
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    it("filters by packageId for agent-scoped streams", async () => {
+      const send = mock((_e: RealtimeEvent) => {});
+      const id = "sub-metric-pkg-filter";
+      trackSubscriber(id);
+      addSubscriber({
+        id,
+        filter: {
+          orgId: "org-mp",
+          applicationId: "app-mp",
+          packageId: "@scope/want",
+          isAdmin: true,
+        },
+        send,
+      });
+
+      await pgNotify("run_metric", {
+        org_id: "org-mp",
+        application_id: "app-mp",
+        run_id: "rA",
+        package_id: "@scope/skip",
+        token_usage: null,
+        cost_so_far: 0,
+      });
+      await wait();
+      expect(send).not.toHaveBeenCalled();
+
+      await pgNotify("run_metric", {
+        org_id: "org-mp",
+        application_id: "app-mp",
+        run_id: "rB",
+        package_id: "@scope/want",
+        token_usage: null,
+        cost_so_far: 0,
+      });
+      await wait();
+      expect(send).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not leak across orgs", async () => {
+      const sendA = mock((_e: RealtimeEvent) => {});
+      const sendB = mock((_e: RealtimeEvent) => {});
+      trackSubscriber("sub-metric-orgA");
+      trackSubscriber("sub-metric-orgB");
+      addSubscriber({
+        id: "sub-metric-orgA",
+        filter: { orgId: "org-A", applicationId: "app-A", isAdmin: true },
+        send: sendA,
+      });
+      addSubscriber({
+        id: "sub-metric-orgB",
+        filter: { orgId: "org-B", applicationId: "app-B", isAdmin: true },
+        send: sendB,
+      });
+
+      await pgNotify("run_metric", {
+        org_id: "org-A",
+        application_id: "app-A",
+        run_id: "x",
+        package_id: "@scope/p",
+        token_usage: null,
+        cost_so_far: 0,
+      });
+      await wait();
+      expect(sendA).toHaveBeenCalledTimes(1);
+      expect(sendB).not.toHaveBeenCalled();
+    });
+  });
+
   // ── initRealtime idempotency ────────────────────────────────
 
   describe("initRealtime idempotency", () => {

--- a/apps/api/test/integration/services/run-metric-broadcaster.test.ts
+++ b/apps/api/test/integration/services/run-metric-broadcaster.test.ts
@@ -225,4 +225,34 @@ describe("run-metric-broadcaster (integration)", () => {
     expect(() => scheduleRunMetricBroadcast("non-existent-run")).not.toThrow();
     await wait(50);
   });
+
+  it("a vanished run drops its throttle entry to bound the in-memory map", async () => {
+    // Simulates the edge case where the run row was deleted (or its
+    // `package_id` SET NULL by cascade) between the metric event
+    // landing and `loadRunMetricPayload` running. The broadcaster
+    // must not accumulate a permanent throttle entry — the run will
+    // never finalize, so `clearRunMetricBroadcastState` will never
+    // be called from the ingestion path either.
+    const send = mock((_e: RealtimeEvent) => {});
+    const subId = "sub-vanished";
+    trackSubscriber(subId);
+    addSubscriber({
+      id: subId,
+      filter: { orgId: ctx.orgId, applicationId: ctx.defaultAppId, isAdmin: true },
+      send,
+    });
+
+    scheduleRunMetricBroadcast("non-existent-run");
+    // Schedule again immediately — if the throttle entry from the
+    // first call leaked, this second call would coalesce as a
+    // trailing tick. After self-cleanup, the second call should
+    // create a fresh entry that ALSO sees no run row and self-
+    // cleans, never producing a NOTIFY.
+    scheduleRunMetricBroadcast("non-existent-run");
+
+    await wait(80);
+    // No SSE delivery — the broadcaster's null-payload guard fires
+    // every time, never reaching pg_notify.
+    expect(send).not.toHaveBeenCalled();
+  });
 });

--- a/apps/api/test/integration/services/run-metric-broadcaster.test.ts
+++ b/apps/api/test/integration/services/run-metric-broadcaster.test.ts
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration tests for the per-run throttled `run_metric` broadcaster.
+ *
+ * Covers:
+ *   - leading-edge: first call for a run fires NOTIFY immediately
+ *   - trailing-edge: bursts within the throttle window collapse to one
+ *     trailing emit at window end
+ *   - payload shape: org/application/package ids, latest tokenUsage,
+ *     `cost_so_far` aggregated from `llm_usage`
+ *   - cross-tenant isolation: filter delivery on orgId + applicationId
+ *   - lifecycle: `clearRunMetricBroadcastState` removes pending timers
+ *   - graceful degradation: missing run row drops the broadcast
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, mock } from "bun:test";
+import { db, truncateAll } from "../../helpers/db.ts";
+import { createTestContext, type TestContext } from "../../helpers/auth.ts";
+import { seedAgent, seedRun } from "../../helpers/seed.ts";
+import { installPackage } from "../../../src/services/application-packages.ts";
+import {
+  scheduleRunMetricBroadcast,
+  clearRunMetricBroadcastState,
+  _resetRunMetricBroadcasterForTests,
+} from "../../../src/services/run-metric-broadcaster.ts";
+import {
+  addSubscriber,
+  removeSubscriber,
+  initRealtime,
+  type RealtimeEvent,
+} from "../../../src/services/realtime.ts";
+import { llmUsage } from "@appstrate/db/schema";
+
+const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const activeSubscribers: string[] = [];
+function trackSubscriber(id: string) {
+  activeSubscribers.push(id);
+}
+
+describe("run-metric-broadcaster (integration)", () => {
+  let ctx: TestContext;
+  const agentId = "@testorg/metrics-agent";
+  let runId: string;
+
+  beforeAll(async () => {
+    await initRealtime();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+    _resetRunMetricBroadcasterForTests();
+    ctx = await createTestContext();
+    await seedAgent({ id: agentId, orgId: ctx.orgId, createdBy: ctx.user.id });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, agentId);
+    const run = await seedRun({
+      packageId: agentId,
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      userId: ctx.user.id,
+      status: "running",
+      tokenUsage: { input_tokens: 100, output_tokens: 50 },
+    });
+    runId = run.id;
+  });
+
+  afterEach(() => {
+    for (const id of activeSubscribers) removeSubscriber(id);
+    activeSubscribers.length = 0;
+    _resetRunMetricBroadcasterForTests();
+  });
+
+  // ── leading edge ─────────────────────────────────────────
+
+  it("first schedule fires NOTIFY immediately on the leading edge", async () => {
+    const send = mock((_e: RealtimeEvent) => {});
+    const subId = "sub-leading";
+    trackSubscriber(subId);
+    addSubscriber({
+      id: subId,
+      filter: { orgId: ctx.orgId, applicationId: ctx.defaultAppId, runId, isAdmin: true },
+      send,
+    });
+
+    // Seed a ledger row so cost_so_far has a known non-zero value
+    await db.insert(llmUsage).values({
+      source: "runner",
+      orgId: ctx.orgId,
+      runId,
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 0.0042,
+    });
+
+    scheduleRunMetricBroadcast(runId);
+    await wait(50); // allow PG NOTIFY round-trip
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const evt = send.mock.calls[0]![0]!;
+    expect(evt.event).toBe("run_metric");
+    expect(evt.data).toMatchObject({
+      runId,
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      packageId: agentId,
+      tokenUsage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(evt.data.costSoFar).toBeCloseTo(0.0042, 5);
+  });
+
+  // ── trailing edge throttling ─────────────────────────────
+
+  it("bursts within the throttle window collapse to one trailing emit", async () => {
+    const send = mock((_e: RealtimeEvent) => {});
+    const subId = "sub-burst";
+    trackSubscriber(subId);
+    addSubscriber({
+      id: subId,
+      filter: { orgId: ctx.orgId, applicationId: ctx.defaultAppId, runId, isAdmin: true },
+      send,
+    });
+
+    // Burst — three back-to-back calls. Leading fires immediately;
+    // the next two should coalesce into a single trailing emit.
+    scheduleRunMetricBroadcast(runId);
+    scheduleRunMetricBroadcast(runId);
+    scheduleRunMetricBroadcast(runId);
+
+    // Right after the burst — only the leading emit has fired.
+    await wait(50);
+    expect(send).toHaveBeenCalledTimes(1);
+
+    // After the throttle window closes, the trailing emit fires.
+    await wait(300);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it("trailing emit reflects state at flush time, not schedule time", async () => {
+    const send = mock((_e: RealtimeEvent) => {});
+    const subId = "sub-trailing-state";
+    trackSubscriber(subId);
+    addSubscriber({
+      id: subId,
+      filter: { orgId: ctx.orgId, applicationId: ctx.defaultAppId, runId, isAdmin: true },
+      send,
+    });
+
+    // Leading edge — no ledger row yet → cost_so_far = 0
+    scheduleRunMetricBroadcast(runId);
+    await wait(50);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]![0]!.data.costSoFar).toBe(0);
+
+    // Insert a ledger row + schedule a trailing emit. The trailing
+    // emit must re-read the ledger and pick up the new total.
+    await db.insert(llmUsage).values({
+      source: "runner",
+      orgId: ctx.orgId,
+      runId,
+      inputTokens: 200,
+      outputTokens: 100,
+      costUsd: 0.01,
+    });
+    scheduleRunMetricBroadcast(runId);
+
+    await wait(350);
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(send.mock.calls[1]![0]!.data.costSoFar).toBeCloseTo(0.01, 5);
+  });
+
+  // ── tenant isolation ─────────────────────────────────────
+
+  it("does not deliver to subscribers in another org", async () => {
+    const sendOurs = mock((_e: RealtimeEvent) => {});
+    const sendOther = mock((_e: RealtimeEvent) => {});
+    trackSubscriber("sub-ours");
+    trackSubscriber("sub-other");
+
+    addSubscriber({
+      id: "sub-ours",
+      filter: { orgId: ctx.orgId, applicationId: ctx.defaultAppId, runId, isAdmin: true },
+      send: sendOurs,
+    });
+    addSubscriber({
+      id: "sub-other",
+      filter: { orgId: "intruder-org", applicationId: "intruder-app", isAdmin: true },
+      send: sendOther,
+    });
+
+    scheduleRunMetricBroadcast(runId);
+    await wait(50);
+
+    expect(sendOurs).toHaveBeenCalledTimes(1);
+    expect(sendOther).not.toHaveBeenCalled();
+  });
+
+  // ── lifecycle ────────────────────────────────────────────
+
+  it("clearRunMetricBroadcastState cancels pending trailing emits", async () => {
+    const send = mock((_e: RealtimeEvent) => {});
+    const subId = "sub-clear";
+    trackSubscriber(subId);
+    addSubscriber({
+      id: subId,
+      filter: { orgId: ctx.orgId, applicationId: ctx.defaultAppId, runId, isAdmin: true },
+      send,
+    });
+
+    scheduleRunMetricBroadcast(runId); // leading fires
+    scheduleRunMetricBroadcast(runId); // schedules trailing
+    await wait(50);
+    expect(send).toHaveBeenCalledTimes(1);
+
+    clearRunMetricBroadcastState(runId);
+    await wait(300);
+    expect(send).toHaveBeenCalledTimes(1); // trailing was cancelled
+  });
+
+  // ── degradation ──────────────────────────────────────────
+
+  it("scheduling for a non-existent run does not throw", async () => {
+    // No subscribers needed — the broadcaster reads the run row,
+    // sees null, and silently no-ops without firing NOTIFY.
+    expect(() => scheduleRunMetricBroadcast("non-existent-run")).not.toThrow();
+    await wait(50);
+  });
+});

--- a/apps/api/test/integration/services/run-metric-broadcaster.test.ts
+++ b/apps/api/test/integration/services/run-metric-broadcaster.test.ts
@@ -30,7 +30,8 @@ import {
   initRealtime,
   type RealtimeEvent,
 } from "../../../src/services/realtime.ts";
-import { llmUsage } from "@appstrate/db/schema";
+import { llmUsage, runs } from "@appstrate/db/schema";
+import { eq } from "drizzle-orm";
 
 const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
@@ -224,6 +225,72 @@ describe("run-metric-broadcaster (integration)", () => {
     // sees null, and silently no-ops without firing NOTIFY.
     expect(() => scheduleRunMetricBroadcast("non-existent-run")).not.toThrow();
     await wait(50);
+  });
+
+  // ── runs.cost persistence (refresh-mid-run hardening) ──────
+
+  it("persists cost_so_far on the run row so a refresh sees the latest value", async () => {
+    // Seed a ledger row so the broadcaster has a non-zero SUM.
+    await db.insert(llmUsage).values({
+      source: "runner",
+      orgId: ctx.orgId,
+      runId,
+      inputTokens: 200,
+      outputTokens: 50,
+      costUsd: 0.0123,
+    });
+
+    scheduleRunMetricBroadcast(runId);
+    await wait(50);
+
+    const [row] = await db
+      .select({ cost: runs.cost })
+      .from(runs)
+      .where(eq(runs.id, runId))
+      .limit(1);
+    expect(row?.cost).toBeCloseTo(0.0123, 5);
+  });
+
+  it("monotonic guard — a regressed cost_so_far does not overwrite a higher persisted value", async () => {
+    // Pre-seed runs.cost with a higher value than the next computed SUM
+    // (simulates finalize landing before the throttled trailing emit).
+    await db.update(runs).set({ cost: 0.05 }).where(eq(runs.id, runId));
+
+    // Ledger has a smaller cumulative cost.
+    await db.insert(llmUsage).values({
+      source: "runner",
+      orgId: ctx.orgId,
+      runId,
+      inputTokens: 10,
+      outputTokens: 5,
+      costUsd: 0.001,
+    });
+
+    scheduleRunMetricBroadcast(runId);
+    await wait(50);
+
+    const [row] = await db
+      .select({ cost: runs.cost })
+      .from(runs)
+      .where(eq(runs.id, runId))
+      .limit(1);
+    // The higher pre-existing value must survive — broadcaster never regresses.
+    expect(row?.cost).toBeCloseTo(0.05, 5);
+  });
+
+  it("zero cost_so_far is a no-op — runs.cost stays null", async () => {
+    // No ledger rows → cost_so_far = 0. The guarded UPDATE skips the
+    // write so the column stays null until the first non-zero metric
+    // (mirrors the existing finalize semantics where cost=0 → null).
+    scheduleRunMetricBroadcast(runId);
+    await wait(50);
+
+    const [row] = await db
+      .select({ cost: runs.cost })
+      .from(runs)
+      .where(eq(runs.id, runId))
+      .limit(1);
+    expect(row?.cost).toBeNull();
   });
 
   it("a vanished run drops its throttle entry to bound the in-memory map", async () => {

--- a/apps/api/test/integration/services/run-metric-streaming.test.ts
+++ b/apps/api/test/integration/services/run-metric-streaming.test.ts
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * End-to-end integration: ingesting an `appstrate.metric` event drives
+ * a `run_metric` SSE delivery to a matching subscriber.
+ *
+ * Combines `PersistingEventSink` (the ingestion hot path) with the
+ * realtime LISTEN service to verify the whole pipeline:
+ *
+ *   PersistingEventSink.persist(metric)
+ *     → upsert llm_usage
+ *     → scheduleRunMetricBroadcast
+ *     → pg_notify('run_metric', ...)
+ *     → realtime LISTEN handler
+ *     → subscriber.send → SSE frame
+ *
+ * The unit tests cover each step in isolation; this test guards the
+ * boundary contracts between them.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach, mock } from "bun:test";
+import { truncateAll } from "../../helpers/db.ts";
+import { createTestContext, type TestContext } from "../../helpers/auth.ts";
+import { seedAgent, seedRun } from "../../helpers/seed.ts";
+import { installPackage } from "../../../src/services/application-packages.ts";
+import { PersistingEventSink } from "../../../src/services/run-launcher/appstrate-event-sink.ts";
+import {
+  addSubscriber,
+  removeSubscriber,
+  initRealtime,
+  type RealtimeEvent,
+} from "../../../src/services/realtime.ts";
+import { _resetRunMetricBroadcasterForTests } from "../../../src/services/run-metric-broadcaster.ts";
+import type { RunEvent } from "@appstrate/afps-runtime/types";
+
+const wait = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+describe("run_metric end-to-end (event sink → SSE)", () => {
+  let ctx: TestContext;
+  const agentId = "@testorg/streaming-agent";
+  let runId: string;
+  const subscriberIds: string[] = [];
+
+  beforeAll(async () => {
+    await initRealtime();
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+    _resetRunMetricBroadcasterForTests();
+    ctx = await createTestContext();
+    await seedAgent({ id: agentId, orgId: ctx.orgId, createdBy: ctx.user.id });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, agentId);
+    const run = await seedRun({
+      packageId: agentId,
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      userId: ctx.user.id,
+      status: "running",
+    });
+    runId = run.id;
+  });
+
+  afterEach(() => {
+    for (const id of subscriberIds) removeSubscriber(id);
+    subscriberIds.length = 0;
+    _resetRunMetricBroadcasterForTests();
+  });
+
+  function metricEvent(usage: Record<string, number>, cost: number): RunEvent {
+    return {
+      type: "appstrate.metric",
+      timestamp: Date.now(),
+      runId,
+      usage,
+      cost,
+    } as RunEvent;
+  }
+
+  it("a single metric event arrives at a subscribed run-scoped SSE", async () => {
+    const send = mock((_e: RealtimeEvent) => {});
+    const id = "stream-sub-1";
+    subscriberIds.push(id);
+    addSubscriber({
+      id,
+      filter: { orgId: ctx.orgId, applicationId: ctx.defaultAppId, runId, isAdmin: true },
+      send,
+    });
+
+    const sink = new PersistingEventSink({
+      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      runId,
+      writeLedger: true,
+    });
+
+    await sink.handle(metricEvent({ input_tokens: 100, output_tokens: 50 }, 0.005));
+    await wait(80);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const frame = send.mock.calls[0]![0]!;
+    expect(frame.event).toBe("run_metric");
+    expect(frame.data).toMatchObject({
+      runId,
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      packageId: agentId,
+      tokenUsage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(frame.data.costSoFar).toBeCloseTo(0.005, 5);
+  });
+
+  it("subsequent metric events deliver running totals (cost monotonically increases)", async () => {
+    const send = mock((_e: RealtimeEvent) => {});
+    const id = "stream-sub-running";
+    subscriberIds.push(id);
+    addSubscriber({
+      id,
+      filter: { orgId: ctx.orgId, applicationId: ctx.defaultAppId, runId, isAdmin: true },
+      send,
+    });
+
+    const sink = new PersistingEventSink({
+      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      runId,
+      writeLedger: true,
+    });
+
+    // Three events with monotonically increasing cumulative totals.
+    // The throttle window is 250 ms — wait between emits so each one
+    // fires (no coalescing of trailing).
+    await sink.handle(metricEvent({ input_tokens: 100, output_tokens: 0 }, 0.001));
+    await wait(80);
+    await wait(300);
+    await sink.handle(metricEvent({ input_tokens: 200, output_tokens: 50 }, 0.005));
+    await wait(80);
+    await wait(300);
+    await sink.handle(metricEvent({ input_tokens: 350, output_tokens: 120 }, 0.012));
+    await wait(80);
+
+    expect(send).toHaveBeenCalledTimes(3);
+    expect(send.mock.calls[0]![0]!.data.costSoFar).toBeCloseTo(0.001, 5);
+    expect(send.mock.calls[1]![0]!.data.costSoFar).toBeCloseTo(0.005, 5);
+    expect(send.mock.calls[2]![0]!.data.costSoFar).toBeCloseTo(0.012, 5);
+  });
+
+  it("a regressed-cost metric event does not regress costSoFar (monotonic-max upsert)", async () => {
+    const send = mock((_e: RealtimeEvent) => {});
+    const id = "stream-sub-mono";
+    subscriberIds.push(id);
+    addSubscriber({
+      id,
+      filter: { orgId: ctx.orgId, applicationId: ctx.defaultAppId, runId, isAdmin: true },
+      send,
+    });
+
+    const sink = new PersistingEventSink({
+      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      runId,
+      writeLedger: true,
+    });
+
+    await sink.handle(metricEvent({ input_tokens: 200, output_tokens: 50 }, 0.01));
+    await wait(80);
+    await wait(300);
+    await sink.handle(metricEvent({ input_tokens: 50, output_tokens: 10 }, 0.003));
+    await wait(80);
+
+    expect(send).toHaveBeenCalledTimes(2);
+    // Both broadcasts must report the higher cost — the second event
+    // tried to regress but the upsert kept the higher value.
+    expect(send.mock.calls[0]![0]!.data.costSoFar).toBeCloseTo(0.01, 5);
+    expect(send.mock.calls[1]![0]!.data.costSoFar).toBeCloseTo(0.01, 5);
+  });
+
+  it("does not deliver metric events to subscribers in a different org", async () => {
+    const sendOurs = mock((_e: RealtimeEvent) => {});
+    const sendOther = mock((_e: RealtimeEvent) => {});
+    subscriberIds.push("ours", "other");
+
+    addSubscriber({
+      id: "ours",
+      filter: { orgId: ctx.orgId, applicationId: ctx.defaultAppId, runId, isAdmin: true },
+      send: sendOurs,
+    });
+    addSubscriber({
+      id: "other",
+      filter: { orgId: "alien-org", applicationId: "alien-app", isAdmin: true },
+      send: sendOther,
+    });
+
+    const sink = new PersistingEventSink({
+      scope: { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      runId,
+      writeLedger: true,
+    });
+    await sink.handle(metricEvent({ input_tokens: 1, output_tokens: 1 }, 0.0001));
+    await wait(80);
+
+    expect(sendOurs).toHaveBeenCalledTimes(1);
+    expect(sendOther).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/test/integration/services/run-watchdog.test.ts
+++ b/apps/api/test/integration/services/run-watchdog.test.ts
@@ -23,7 +23,7 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 import { eq } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
-import { runs, runLogs } from "@appstrate/db/schema";
+import { runs, runLogs, llmUsage } from "@appstrate/db/schema";
 import { encrypt } from "@appstrate/connect";
 import { getTestApp } from "../../helpers/app.ts";
 import { truncateAll } from "../../helpers/db.ts";
@@ -187,5 +187,47 @@ describe("run watchdog — unified stall detection", () => {
     const stillRunning = rows.filter((r) => ids.includes(r.id) && r.status === "running");
     expect(failed.length).toBe(2);
     expect(stillRunning.length).toBe(1);
+  });
+
+  // Regression coverage for #391 — "users perceive that failed/timed-
+  // out runs are not counted". Verifies the existing convergence:
+  // metric events that arrived BEFORE the container crashed have
+  // already written `llm_usage` rows; the watchdog's call to
+  // `finalizeRun` reads `computeRunCost` from that ledger and
+  // persists `runs.cost` on the failed terminal status, so the
+  // afterRun (cloud billing) hook fires with the right value even
+  // when the container never posted /finalize itself.
+  it("captures cost for a crashed run whose metric event landed before the crash", async () => {
+    const stale = new Date(Date.now() - 3600_000);
+    const runId = await seedRun(ctx, "@test/watchdog-agent", {
+      status: "running",
+      lastHeartbeatAt: stale,
+    });
+
+    // Simulate a metric event having landed before the container
+    // crashed: a runner-source `llm_usage` row exists with a non-zero
+    // cost. The watchdog must finalize the run AND surface that cost
+    // on the terminal `runs.cost` column for the billing hook.
+    await db.insert(llmUsage).values({
+      source: "runner",
+      orgId: ctx.orgId,
+      runId,
+      inputTokens: 1500,
+      outputTokens: 800,
+      costUsd: 0.0234,
+    });
+
+    const finalizedCount = await runWatchdogTick({
+      intervalSeconds: 30,
+      stallThresholdSeconds: 60,
+      maxFinalizesPerTick: 100,
+    });
+
+    expect(finalizedCount).toBe(1);
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    // Cost MUST survive the terminal status — it's the input cloud
+    // billing reads off the run row to charge the org.
+    expect(row?.cost).toBeCloseTo(0.0234, 5);
   });
 });

--- a/apps/web/src/components/run-info-tab.tsx
+++ b/apps/web/src/components/run-info-tab.tsx
@@ -9,7 +9,11 @@ import { EmptyState } from "./page-states";
 import { ProviderStatusRow } from "./provider-status-row";
 import { RunTrigger } from "./run-trigger";
 import { useProviders } from "../hooks/use-providers";
-import type { EnrichedRun, RunProviderSnapshot } from "@appstrate/shared-types";
+import {
+  ACTIVE_RUN_STATUSES,
+  type EnrichedRun,
+  type RunProviderSnapshot,
+} from "@appstrate/shared-types";
 
 interface RunInfoTabProps {
   run: EnrichedRun;
@@ -141,9 +145,22 @@ export function RunInfoTab({ run }: RunInfoTabProps) {
         </div>
       </SectionCard>
 
-      {/* Usage */}
+      {/* Usage — `cost` and `tokenUsage` reflect the running totals
+          while the run is in progress (patched into the React Query
+          cache by `useRunRealtime` `onMetric` events) and the
+          authoritative finalize-time values once the run terminates. */}
       {hasUsage ? (
-        <SectionCard title={t("exec.infoUsage")}>
+        <SectionCard
+          title={t("exec.infoUsage")}
+          headerRight={
+            run.status && ACTIVE_RUN_STATUSES.has(run.status) ? (
+              <span className="bg-primary/15 text-primary inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase">
+                <span className="bg-primary size-1.5 animate-pulse rounded-full" aria-hidden />
+                {t("exec.usageLive")}
+              </span>
+            ) : null
+          }
+        >
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {run.cost != null && (
               <InfoCard label={t("exec.usageCost")} value={`$${run.cost.toFixed(4)}`} />

--- a/apps/web/src/hooks/use-realtime.ts
+++ b/apps/web/src/hooks/use-realtime.ts
@@ -4,15 +4,32 @@ import { useEffect, useRef } from "react";
 import { getCurrentOrgId } from "./use-org";
 import { getCurrentApplicationId } from "./use-current-application";
 
+/** Live metric payload broadcast on the `run_metric` SSE event. */
+export interface RunMetricEvent {
+  runId: string;
+  orgId: string;
+  applicationId: string;
+  packageId: string;
+  tokenUsage: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  } | null;
+  costSoFar: number;
+}
+
 interface RunRealtimeHandlers {
   onStatusChange?: (payload: Record<string, unknown>) => void;
   onNewLog?: (log: Record<string, unknown>) => void;
+  onMetric?: (metric: RunMetricEvent) => void;
 }
 
 /**
- * Subscribe to run status changes and/or log inserts for a single run via
- * a single SSE connection. Pass any subset of handlers — the connection
- * dispatches by event type and skips channels with no listener attached.
+ * Subscribe to run status changes, log inserts, and/or live metric updates
+ * for a single run via a single SSE connection. Pass any subset of handlers
+ * — the connection dispatches by event type and skips channels with no
+ * listener attached.
  */
 export function useRunRealtime(runId: string | null | undefined, handlers: RunRealtimeHandlers) {
   const handlersRef = useRef(handlers);
@@ -44,6 +61,15 @@ export function useRunRealtime(runId: string | null | undefined, handlers: RunRe
       try {
         const data = JSON.parse(e.data);
         handlersRef.current.onNewLog?.(data);
+      } catch {
+        // Ignore malformed SSE payloads
+      }
+    });
+
+    es.addEventListener("run_metric", (e) => {
+      try {
+        const data = JSON.parse(e.data) as RunMetricEvent;
+        handlersRef.current.onMetric?.(data);
       } catch {
         // Ignore malformed SSE payloads
       }

--- a/apps/web/src/locales/en/agents.json
+++ b/apps/web/src/locales/en/agents.json
@@ -125,6 +125,7 @@
   "exec.usageOutputTokens": "Output tokens",
   "exec.usageCacheCreation": "Cache creation tokens",
   "exec.usageCacheRead": "Cache read tokens",
+  "exec.usageLive": "Live",
   "import.title": "Import package",
   "import.dropText": "Drop an AFPS, AFPS-bundle, or ZIP file here",
   "import.dropHint": "or click to browse",

--- a/apps/web/src/locales/fr/agents.json
+++ b/apps/web/src/locales/fr/agents.json
@@ -125,6 +125,7 @@
   "exec.usageOutputTokens": "Tokens de sortie",
   "exec.usageCacheCreation": "Tokens de création de cache",
   "exec.usageCacheRead": "Tokens de lecture de cache",
+  "exec.usageLive": "En direct",
   "import.title": "Importer un package",
   "import.dropText": "Glissez un fichier AFPS, AFPS-bundle ou ZIP ici",
   "import.dropHint": "ou cliquez pour parcourir",

--- a/apps/web/src/pages/run-detail.tsx
+++ b/apps/web/src/pages/run-detail.tsx
@@ -11,7 +11,7 @@ import { usePackageDetail } from "../hooks/use-packages";
 import { useRun, useRunLogs } from "../hooks/use-runs";
 import { useRunAgent, useCancelRun } from "../hooks/use-mutations";
 import { Spinner } from "../components/spinner";
-import { useRunRealtime } from "../hooks/use-realtime";
+import { useRunRealtime, type RunMetricEvent } from "../hooks/use-realtime";
 import { useCurrentOrgId } from "../hooks/use-org";
 import { useCurrentApplicationId } from "../hooks/use-current-application";
 import { LogViewer } from "../components/log-viewer";
@@ -22,7 +22,12 @@ import { LoadingState, ErrorState } from "../components/page-states";
 import { RunInfoTab } from "../components/run-info-tab";
 import { RunRow } from "../components/run-row";
 import { useMarkRead } from "../hooks/use-notifications";
-import { ACTIVE_RUN_STATUSES, type RunLog, type EnrichedRun } from "@appstrate/shared-types";
+import {
+  ACTIVE_RUN_STATUSES,
+  type Run,
+  type RunLog,
+  type EnrichedRun,
+} from "@appstrate/shared-types";
 import { formatDateField } from "../lib/markdown";
 import { JsonView } from "../components/json-view";
 import { Markdown } from "../components/markdown";
@@ -103,11 +108,11 @@ export function RunDetailPage() {
   const [userSubTab, setUserSubTab] = useState<"report" | "data" | null>(null);
   const resultSubTab = userSubTab ?? autoSubTab;
 
-  // Per-run SSE for log inserts only. Status patches come from
-  // `useGlobalRunSync` (mounted in MainLayout), which writes directly into
-  // the same `["run", orgId, applicationId, runId]` cache key. Terminal-status
-  // refetch is also already triggered globally via
-  // `invalidateRunAndNotificationQueries`.
+  // Per-run SSE for log inserts + live metric updates. Status patches
+  // come from `useGlobalRunSync` (mounted in MainLayout), which writes
+  // directly into the same `["run", orgId, applicationId, runId]`
+  // cache key. Terminal-status refetch is also already triggered
+  // globally via `invalidateRunAndNotificationQueries`.
   useRunRealtime(isRunning ? runId : null, {
     onNewLog: useCallback(
       (newLog: Record<string, unknown>) => {
@@ -116,6 +121,26 @@ export function RunDetailPage() {
           if (!prev) return [log];
           if (prev.some((l) => l.id === log.id)) return prev;
           return [...prev, log];
+        });
+      },
+      [qc, orgId, applicationId, runId],
+    ),
+    onMetric: useCallback(
+      (metric: RunMetricEvent) => {
+        // Patch the cached run row with the running token usage + cost
+        // so the Info tab reflects live progress without polling.
+        // `runs.cost` is the cached aggregate written at finalize on
+        // the server; mid-run we render the broadcaster's
+        // `cost_so_far` instead. The next terminal-status invalidation
+        // refetches the canonical row so this in-cache shadow is
+        // bounded by the run's lifetime.
+        qc.setQueryData<Run>(["run", orgId, applicationId, runId], (prev) => {
+          if (!prev) return prev;
+          return {
+            ...prev,
+            tokenUsage: metric.tokenUsage ?? prev.tokenUsage,
+            cost: metric.costSoFar,
+          } as Run;
         });
       },
       [qc, orgId, applicationId, runId],

--- a/apps/web/src/pages/run-detail.tsx
+++ b/apps/web/src/pages/run-detail.tsx
@@ -235,31 +235,30 @@ export function RunDetailPage() {
           </TabsList>
         </Tabs>
         <div className="flex items-center gap-2">
-          {/* Live token + cost readout — only while the run is active. The
-              `onMetric` SSE handler patches `run.tokenUsage` and `run.cost`
-              in place; this pill re-renders at the throttled cadence (250 ms
-              window) without polling. Shown for every running run, including
-              remote-origin ones (which still stream metrics even though the
-              Cancel button is hidden for them). */}
-          {isRunning &&
-            (() => {
-              const liveUsage = run.tokenUsage as {
-                input_tokens?: number;
-                output_tokens?: number;
-              } | null;
-              const totalTokens = (liveUsage?.input_tokens ?? 0) + (liveUsage?.output_tokens ?? 0);
-              if (totalTokens === 0 && run.cost == null) return null;
-              return (
-                <div className="text-muted-foreground bg-muted/50 flex items-center gap-2 rounded-md px-2.5 py-1 text-xs tabular-nums">
+          {/* Token + cost readout — shown at all times (pending, running,
+              terminal). While the run is active the pulse dot animates and
+              `onMetric` SSE patches `run.tokenUsage` + `run.cost` in place
+              at the throttled 250 ms cadence; once finalized, the same
+              fields hold the authoritative aggregate written by
+              `finalizeRun`. Defaults to zeros for runs that never produced
+              tokens (the readout is structural, not conditional on data). */}
+          {(() => {
+            const liveUsage = run.tokenUsage as {
+              input_tokens?: number;
+              output_tokens?: number;
+            } | null;
+            const totalTokens = (liveUsage?.input_tokens ?? 0) + (liveUsage?.output_tokens ?? 0);
+            return (
+              <div className="text-muted-foreground bg-muted/50 flex items-center gap-2 rounded-md px-2.5 py-1 text-xs tabular-nums">
+                {isRunning && (
                   <span className="bg-primary size-1.5 animate-pulse rounded-full" aria-hidden />
-                  {totalTokens > 0 && <span>{totalTokens.toLocaleString()} tokens</span>}
-                  {totalTokens > 0 && run.cost != null && <span aria-hidden>·</span>}
-                  {run.cost != null && (
-                    <span className="text-foreground font-medium">${run.cost.toFixed(4)}</span>
-                  )}
-                </div>
-              );
-            })()}
+                )}
+                <span>{totalTokens.toLocaleString()} tokens</span>
+                <span aria-hidden>·</span>
+                <span className="text-foreground font-medium">${(run.cost ?? 0).toFixed(4)}</span>
+              </div>
+            );
+          })()}
           {!isRunning && !isInline && agent && (
             <Button variant="outline" size="sm" onClick={() => setInputOpen(true)}>
               <Play className="size-3.5" />

--- a/apps/web/src/pages/run-detail.tsx
+++ b/apps/web/src/pages/run-detail.tsx
@@ -235,6 +235,31 @@ export function RunDetailPage() {
           </TabsList>
         </Tabs>
         <div className="flex items-center gap-2">
+          {/* Live token + cost readout — only while the run is active. The
+              `onMetric` SSE handler patches `run.tokenUsage` and `run.cost`
+              in place; this pill re-renders at the throttled cadence (250 ms
+              window) without polling. Shown for every running run, including
+              remote-origin ones (which still stream metrics even though the
+              Cancel button is hidden for them). */}
+          {isRunning &&
+            (() => {
+              const liveUsage = run.tokenUsage as {
+                input_tokens?: number;
+                output_tokens?: number;
+              } | null;
+              const totalTokens = (liveUsage?.input_tokens ?? 0) + (liveUsage?.output_tokens ?? 0);
+              if (totalTokens === 0 && run.cost == null) return null;
+              return (
+                <div className="text-muted-foreground bg-muted/50 flex items-center gap-2 rounded-md px-2.5 py-1 text-xs tabular-nums">
+                  <span className="bg-primary size-1.5 animate-pulse rounded-full" aria-hidden />
+                  {totalTokens > 0 && <span>{totalTokens.toLocaleString()} tokens</span>}
+                  {totalTokens > 0 && run.cost != null && <span aria-hidden>·</span>}
+                  {run.cost != null && (
+                    <span className="text-foreground font-medium">${run.cost.toFixed(4)}</span>
+                  )}
+                </div>
+              );
+            })()}
           {!isRunning && !isInline && agent && (
             <Button variant="outline" size="sm" onClick={() => setInputOpen(true)}>
               <Play className="size-3.5" />

--- a/packages/db/src/notify.ts
+++ b/packages/db/src/notify.ts
@@ -4,6 +4,54 @@ import { sql as drizzleSql } from "drizzle-orm";
 import type { Db } from "./client.ts";
 
 /**
+ * Wire payload for `run_metric` PG NOTIFY broadcasts.
+ *
+ * Fired application-side (not from a trigger) after persisting an
+ * `appstrate.metric` event so the running cumulative cost can be
+ * computed from the unified `llm_usage` ledger and bundled with the
+ * notification — a trigger would only see one row at a time and
+ * couldn't sum across the run.
+ *
+ * Snake-case keys mirror the existing `run_update` / `run_log_insert`
+ * channels so the realtime subscriber's snake-to-camel mapper handles
+ * all three identically.
+ */
+export interface RunMetricNotifyPayload {
+  /** The run id (matches `subscriber.filter.runId`). */
+  run_id: string;
+  /** Owning org (cross-tenant isolation gate). */
+  org_id: string;
+  /** Owning application (cross-app isolation gate). */
+  application_id: string;
+  /** Agent id, used by the per-agent runs SSE stream filter. */
+  package_id: string;
+  /** Cumulative token usage as last reported by the runner. */
+  token_usage: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  } | null;
+  /** Running aggregate of `llm_usage.cost_usd` for this run, in USD. */
+  cost_so_far: number;
+}
+
+/**
+ * Broadcast a metric update on the `run_metric` PG NOTIFY channel.
+ *
+ * Fire-and-forget: errors are intentionally surfaced to the caller so
+ * the ingestion path can log + drop them — a missing notification must
+ * never fail the persistence write that came before it.
+ *
+ * The payload is JSON-encoded inline; postgres truncates NOTIFY
+ * payloads at 8 KB but ours is bounded by the four `token_usage`
+ * integers + a float, well under that ceiling.
+ */
+export async function notifyRunMetric(db: Db, payload: RunMetricNotifyPayload): Promise<void> {
+  await db.execute(drizzleSql`SELECT pg_notify('run_metric', ${JSON.stringify(payload)})`);
+}
+
+/**
  * Install NOTIFY trigger functions and triggers on runs and run_logs tables.
  * Safe to call multiple times (uses CREATE OR REPLACE).
  */

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -472,6 +472,27 @@ export function installSessionBridge(
           totalUsage.cacheRead += u.cacheRead ?? 0;
           totalUsage.cacheWrite += u.cacheWrite ?? 0;
           totalUsage.cost += u.cost?.total ?? 0;
+
+          // Mid-run cumulative snapshot — fires after every assistant
+          // turn so the platform can stream live cost to the UI. The
+          // server upserts on the partial unique index with monotonic
+          // semantics (latest cost wins), so a later `agent_end` emit
+          // with the same totals is a no-op rather than a duplicate.
+          // Only fire when we actually accumulated tokens this turn —
+          // a no-op turn (e.g. tool-only step with no LLM round-trip)
+          // would emit an identical payload and waste a NOTIFY.
+          fire({
+            type: "appstrate.metric",
+            timestamp: Date.now(),
+            runId,
+            usage: {
+              input_tokens: totalUsage.input,
+              output_tokens: totalUsage.output,
+              cache_creation_input_tokens: totalUsage.cacheWrite,
+              cache_read_input_tokens: totalUsage.cacheRead,
+            },
+            cost: totalUsage.cost,
+          });
         }
 
         // SDK error (e.g. LLM API unreachable, auth failures)

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -478,21 +478,25 @@ export function installSessionBridge(
           // server upserts on the partial unique index with monotonic
           // semantics (latest cost wins), so a later `agent_end` emit
           // with the same totals is a no-op rather than a duplicate.
-          // Only fire when we actually accumulated tokens this turn —
-          // a no-op turn (e.g. tool-only step with no LLM round-trip)
-          // would emit an identical payload and waste a NOTIFY.
-          fire({
-            type: "appstrate.metric",
-            timestamp: Date.now(),
-            runId,
-            usage: {
-              input_tokens: totalUsage.input,
-              output_tokens: totalUsage.output,
-              cache_creation_input_tokens: totalUsage.cacheWrite,
-              cache_read_input_tokens: totalUsage.cacheRead,
-            },
-            cost: totalUsage.cost,
-          });
+          // Skip the snapshot when the turn produced zero new tokens
+          // (e.g. an empty-usage object or a tool-only step) — the
+          // payload would be identical to the previous one and waste
+          // a NOTIFY round-trip.
+          const hadTokens = (u.input ?? 0) > 0 || (u.output ?? 0) > 0;
+          if (hadTokens) {
+            fire({
+              type: "appstrate.metric",
+              timestamp: Date.now(),
+              runId,
+              usage: {
+                input_tokens: totalUsage.input,
+                output_tokens: totalUsage.output,
+                cache_creation_input_tokens: totalUsage.cacheWrite,
+                cache_read_input_tokens: totalUsage.cacheRead,
+              },
+              cost: totalUsage.cost,
+            });
+          }
         }
 
         // SDK error (e.g. LLM API unreachable, auth failures)

--- a/packages/runner-pi/test/session-bridge.test.ts
+++ b/packages/runner-pi/test/session-bridge.test.ts
@@ -486,7 +486,12 @@ describe("installSessionBridge — agent_end + usage accumulation", () => {
 
     session.emit({ type: "agent_end" });
 
-    const metric = sink.events.find((e) => e.type === "appstrate.metric") as unknown as {
+    // Each `message_end` with usage now emits a streaming
+    // `appstrate.metric` snapshot (cumulative running total) plus
+    // the final emit at `agent_end` — three total. The
+    // platform-side upsert with monotonic-max semantics means the
+    // last (largest) value wins.
+    const metricEvents = sink.events.filter((e) => e.type === "appstrate.metric") as unknown as {
       usage: {
         input_tokens: number;
         output_tokens: number;
@@ -494,12 +499,64 @@ describe("installSessionBridge — agent_end + usage accumulation", () => {
         cache_read_input_tokens: number;
       };
       cost: number;
-    };
-    expect(metric.usage.input_tokens).toBe(15);
-    expect(metric.usage.output_tokens).toBe(35);
-    expect(metric.usage.cache_creation_input_tokens).toBe(5);
-    expect(metric.usage.cache_read_input_tokens).toBe(1);
-    expect(metric.cost).toBeCloseTo(0.003, 5);
+    }[];
+    expect(metricEvents).toHaveLength(3);
+
+    // First message_end snapshot — running totals after turn 1.
+    expect(metricEvents[0]!.usage.input_tokens).toBe(10);
+    expect(metricEvents[0]!.cost).toBeCloseTo(0.001, 5);
+
+    // Second message_end snapshot — running totals after turn 2.
+    expect(metricEvents[1]!.usage.input_tokens).toBe(15);
+    expect(metricEvents[1]!.usage.output_tokens).toBe(35);
+    expect(metricEvents[1]!.cost).toBeCloseTo(0.003, 5);
+
+    // agent_end final snapshot — same totals as the last message_end
+    // (no further usage was added between them).
+    const final = metricEvents[2]!;
+    expect(final.usage.input_tokens).toBe(15);
+    expect(final.usage.output_tokens).toBe(35);
+    expect(final.usage.cache_creation_input_tokens).toBe(5);
+    expect(final.usage.cache_read_input_tokens).toBe(1);
+    expect(final.cost).toBeCloseTo(0.003, 5);
+  });
+
+  it("emits a streaming metric snapshot on each message_end with usage", () => {
+    const sink = createInternalCapture();
+    const session = createFakeSession();
+    installSessionBridge(session, sink, RUN_ID);
+
+    // Turn 1
+    session.pushMessage({
+      role: "assistant",
+      usage: { input: 100, output: 50, cost: { total: 0.005 } },
+      content: [{ type: "text", text: "first" }],
+    });
+    session.emit({ type: "message_end" });
+
+    // No further turns yet — the streaming snapshot from message_end
+    // must already exist and reflect turn-1 totals.
+    const streamed = sink.events.filter((e) => e.type === "appstrate.metric");
+    expect(streamed).toHaveLength(1);
+    expect((streamed[0] as unknown as { cost: number }).cost).toBeCloseTo(0.005, 5);
+  });
+
+  it("does not emit a metric on a message_end with no usage payload", () => {
+    const sink = createInternalCapture();
+    const session = createFakeSession();
+    installSessionBridge(session, sink, RUN_ID);
+
+    // No-op turn — assistant message without `usage` (e.g. tool-only).
+    session.pushMessage({
+      role: "assistant",
+      content: [{ type: "text", text: "tool turn" }],
+    });
+    session.emit({ type: "message_end" });
+
+    // No streaming snapshot — would just be a duplicate of the prior
+    // state and waste a NOTIFY.
+    const streamed = sink.events.filter((e) => e.type === "appstrate.metric");
+    expect(streamed).toHaveLength(0);
   });
 
   it("tolerates missing usage.cost on individual messages", () => {


### PR DESCRIPTION
## Summary

Closes #391 — runs now stream `tokenUsage` and a running `cost_so_far` to the UI as the agent emits `appstrate.metric` events. Failed/timed-out runs surface partial cost for the same reason.

- **Pi runner** emits an `appstrate.metric` snapshot after each assistant `message_end` (cumulative running totals), in addition to the existing `agent_end` emit.
- **Server-side metric ingestion** persists the upsert-ledger row with **monotonic-max semantics** (`onConflictDoUpdate ... setWhere EXCLUDED.cost_usd >= llm_usage.cost_usd`). Streaming totals replace earlier rows; reordered/smaller emits and the finalize fallback can never regress the recorded bill.
- **`run_metric` PG NOTIFY channel** broadcast by a per-run leading + trailing throttle (250 ms, in-memory Map cleared on finalize). Payload: `runId / orgId / applicationId / packageId / tokenUsage / costSoFar`. `costSoFar` is computed at flush time via `SUM(llm_usage.cost_usd)`.
- **Realtime SSE relay** of `run_metric` with the same orgId/applicationId/runId/packageId filters as `run_update` and `run_log_insert`.
- **Run detail UI** subscribes to `run_metric` events, patches `cost` + `tokenUsage` directly into the React Query cache, and renders a "Live" badge on the Usage section while the run is active.

## Billing for crashed runs

The existing watchdog → `finalizeRun` → `afterRun` flow already covers the issue's billing concern:
- Each `appstrate.metric` event writes a `llm_usage` row independently of finalize.
- The watchdog finalizes any run with an open sink past the heartbeat threshold and routes it through `finalizeRun`.
- `computeRunCost(runId)` aggregates from `llm_usage`, so the `afterRun` hook receives the right cost even for runs that never POST `/finalize`.

A regression test (`run-watchdog.test.ts: captures cost for a crashed run...`) locks this down. **No code change to the billing path** — the issue's Option A (per-row billing) was deferred per the open-question tag in the original ticket.

## Throttling — state of the art

Leading + trailing per run, 250 ms window. Matches the streaming-UI pattern (Slack, Linear, GitHub Actions): emit fast on the first event for low latency, coalesce bursts on the trailing edge to bound subscriber load. The trailing tick re-runs the read path so the broadcast reflects the latest persisted state at flush time, not at schedule time. In-memory throttle state is cleared from `finalizeRun` (both CAS winner and idempotent no-op branches) — bounded by the run's lifetime.

## Test plan

All `bun run check` tasks pass (typecheck, lint, format:check, verify:openapi, detect:breaking, build:system-packages:check). Test coverage:

- [x] **`run-metric-broadcaster.test.ts`** (new, 6 tests) — leading/trailing edges, payload shape from real DB rows, cross-tenant isolation, `clearRunMetricBroadcastState` cancels timers, non-existent run is a no-op.
- [x] **`run-metric-streaming.test.ts`** (new, 4 tests) — end-to-end ingest → upsert → NOTIFY → SSE delivery, monotonic running cost, cross-org isolation.
- [x] **`realtime.test.ts`** (extended, 4 new tests) — `run_metric` channel routes on orgId, applicationId, runId, packageId; cross-org isolation.
- [x] **`appstrate-event-sink.test.ts`** (extended, 2 new tests + 1 hardened) — monotonic-max upsert under regressed and streaming totals; concurrent writers converge on the maximum.
- [x] **`run-watchdog.test.ts`** (extended, 1 new test) — regression coverage for #391: crashed run whose metric landed before the crash surfaces `runs.cost` on the terminal failed status.
- [x] **`session-bridge.test.ts`** (extended, 2 new tests + 1 updated) — streaming `appstrate.metric` per `message_end`, skips no-op turns, multi-turn cumulative correctness.

Aggregate: 750 unit + 489 integration service + 86 integration routes + 124 runner-pi tests green. No regressions across the watchdog, run ingestion, or realtime test suites.

## Files changed

| Concern | File |
|---|---|
| Notify helper + payload type | `packages/db/src/notify.ts` |
| Throttled broadcaster | `apps/api/src/services/run-metric-broadcaster.ts` (new) |
| Metric persistence + NOTIFY hook | `apps/api/src/services/run-launcher/appstrate-event-sink.ts` |
| Throttle state cleanup at finalize | `apps/api/src/services/run-event-ingestion.ts` |
| LISTEN run_metric + dispatch | `apps/api/src/services/realtime.ts` |
| SSE payload pass-through doc | `apps/api/src/routes/realtime.ts` |
| Per-message metric emission | `packages/runner-pi/src/pi-runner.ts` |
| `onMetric` SSE handler | `apps/web/src/hooks/use-realtime.ts` |
| Cache patch on metric events | `apps/web/src/pages/run-detail.tsx` |
| Live badge + comment | `apps/web/src/components/run-info-tab.tsx` |
| FR + EN locale strings | `apps/web/src/locales/{en,fr}/agents.json` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)