### PR TITLE
feat: add llm_usage.billed_at for ledger-first billing (Layer 4)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -447,11 +447,17 @@ export function requireAdmin() {
 
 ### Orphaned run recovery
 
-On platform startup, any runs left in `pending` or `running` state from a previous crash are marked as `failed`. This prevents stale run tokens from remaining valid:
+On platform startup, any runs left in `pending` or `running` state from a previous crash are listed and finalized through `synthesiseFinalize` → `finalizeRun`. Routing through the canonical terminal-state pipeline (rather than a direct `UPDATE`) ensures the `afterRun` hook fires for every orphan, so billing and observability modules see the exact same lifecycle whether a run terminated cleanly, was cancelled, timed out, or was killed by a server crash. This also prevents stale run tokens from remaining valid:
 
 ```typescript
-// index.ts — startup
-await markOrphanRunsFailed();
+// boot.ts — startup
+const orphanIds = await listOrphanRunIds();
+for (const runId of orphanIds) {
+  await synthesiseFinalize(runId, {
+    status: "failed",
+    error: { message: "Server restarted while run was in progress. Please retry." },
+  });
+}
 ```
 
 **Standard:** This multi-layer authentication model implements the access control architecture described in **NIST SP 800-207** (Zero Trust Architecture): per-request verification, no implicit trust, and session-scoped credentials with automatic expiration.

--- a/apps/api/src/lib/boot.ts
+++ b/apps/api/src/lib/boot.ts
@@ -35,7 +35,8 @@ import {
 import { createVersionAndUpload } from "../services/package-versions.ts";
 import { uploadPackageFiles, SYSTEM_STORAGE_NAMESPACE } from "../services/package-items/storage.ts";
 import { storageFolderForType } from "../services/package-items/config.ts";
-import { markOrphanRunsFailed } from "../services/state/runs.ts";
+import { listOrphanRunIds } from "../services/state/runs.ts";
+import { synthesiseFinalize } from "../services/run-event-ingestion.ts";
 import { initScheduleWorker } from "../services/scheduler.ts";
 import { initInlineCompactionWorker } from "../services/inline-compaction.ts";
 import { initCancelSubscriber } from "../services/run-tracker.ts";
@@ -185,12 +186,33 @@ export async function boot(): Promise<void> {
     }),
   ]);
 
-  // Sequential cleanup: orphan runs must be marked before container cleanup,
+  // Sequential cleanup: orphan runs must be finalized before container cleanup,
   // and containers must be cleaned before sidecar pool init.
+  //
+  // Each orphan flows through `synthesiseFinalize` → `finalizeRun` so the
+  // afterRun hook fires (billing, observability, ...) for runs that burned
+  // LLM tokens before the previous process died. The CAS in `finalizeRun`
+  // makes this race-safe against a delayed metric POST that lands during
+  // the same boot window.
   try {
-    const { count, runIds } = await markOrphanRunsFailed();
-    if (count > 0) {
-      logger.info("Marked orphaned runs as failed", { count, runIds });
+    const orphanIds = await listOrphanRunIds();
+    if (orphanIds.length > 0) {
+      let finalized = 0;
+      for (const runId of orphanIds) {
+        try {
+          await synthesiseFinalize(runId, {
+            status: "failed",
+            error: { message: "Server restarted while run was in progress. Please retry." },
+          });
+          finalized++;
+        } catch (err) {
+          logger.warn("Could not finalize orphaned run", {
+            runId,
+            error: getErrorMessage(err),
+          });
+        }
+      }
+      logger.info("Finalized orphaned runs", { count: finalized, runIds: orphanIds });
     }
   } catch (err) {
     logger.warn("Could not clean orphaned runs", {

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -6,7 +6,6 @@ import { logger } from "../lib/logger.ts";
 import type { LoadedPackage, AppEnv } from "../types/index.ts";
 import {
   updateRun,
-  appendRunLog,
   getRun,
   getRunFull,
   getRunningRunsForPackage,
@@ -21,7 +20,6 @@ import type { ExecutionContext } from "@appstrate/afps-runtime/types";
 import { runPlatformContainer } from "../services/run-launcher/pi.ts";
 import type { PlatformContainerResult } from "../services/run-launcher/pi.ts";
 import type { ContainerOrchestrator } from "../services/orchestrator/index.ts";
-import { emptyRunResult, type RunResult } from "@appstrate/afps-runtime/runner";
 import { getVersionDetail } from "../services/package-versions.ts";
 import { parseRequestInput } from "../services/input-parser.ts";
 import { asJSONSchemaObject } from "@appstrate/core/form";
@@ -46,7 +44,7 @@ import {
   type InlineRunBody,
 } from "../services/inline-run.ts";
 import { runInlinePreflight } from "../services/inline-run-preflight.ts";
-import { finalizeRun, getRunSinkContext } from "../services/run-event-ingestion.ts";
+import { synthesiseFinalize } from "../services/run-event-ingestion.ts";
 import type { SinkCredentials } from "../lib/mint-sink-credentials.ts";
 
 // --- Background run (decoupled from client) ---
@@ -160,7 +158,8 @@ export async function executeAgentInBackground(
     // synthesis is a CAS no-op. If it didn't (crash, timeout, cancel),
     // we fill in the terminal state the platform observed.
     if (lifecycle.cancelled) {
-      // Cancel route already wrote status + closed the sink — nothing to do.
+      // Cancel route already routed the run through `synthesiseFinalize`,
+      // which CAS'd the sink closed and ran `afterRun`. Nothing to do here.
       return;
     }
 
@@ -204,38 +203,6 @@ export async function executeAgentInBackground(
   } finally {
     untrackRun(runId);
   }
-}
-
-/**
- * Re-enter `finalizeRun` with a terminal result synthesised by the
- * platform. Idempotent by design: the CAS on `sink_closed_at IS NULL`
- * inside `finalizeRun` makes this a no-op if the container already
- * posted its own finalize.
- */
-async function synthesiseFinalize(
-  runId: string,
-  terminal: {
-    status: "success" | "failed" | "timeout" | "cancelled";
-    error?: { message: string; stack?: string };
-    durationMs?: number;
-  },
-): Promise<void> {
-  const run = await getRunSinkContext(runId);
-  if (!run) {
-    logger.error("synthesiseFinalize: run sink context missing", { runId });
-    return;
-  }
-
-  const result: RunResult = emptyRunResult();
-  result.status = terminal.status;
-  if (terminal.error) result.error = terminal.error;
-  if (terminal.durationMs !== undefined) result.durationMs = terminal.durationMs;
-
-  await finalizeRun({
-    run,
-    result,
-    webhookId: `synthesized-${runId}`,
-  });
 }
 
 // --- Router ---
@@ -444,6 +411,15 @@ export function createRunsRouter() {
   });
 
   // POST /api/runs/:id/cancel — cancel a running/pending run
+  //
+  // Funnels through `synthesiseFinalize` so the cancellation traverses the
+  // exact same terminal-state pipeline as success/timeout/fail: cost is
+  // aggregated from `llm_usage`, `afterRun` fires (billing in cloud, …),
+  // the `run_completed` log row + `onRunStatusChange` broadcast happen
+  // exactly once. Pre-fix, this route wrote `status='cancelled'` and closed
+  // the sink directly — `afterRun` was never called and the cloud module
+  // never debited credits for cancelled runs that had already burned LLM
+  // tokens.
   router.post("/runs/:id/cancel", requirePermission("runs", "cancel"), async (c) => {
     const runId = c.req.param("id")!;
     const scope = getAppScope(c);
@@ -458,45 +434,19 @@ export function createRunsRouter() {
       throw conflict("not_cancellable", "This run cannot be cancelled");
     }
 
-    // Update DB + close the signed-event sink atomically — any in-flight
-    // event POST from the container will now reject with 410 gone, and
-    // `finalizeRun`'s CAS makes server-side synthesis a no-op.
-    const now = new Date().toISOString();
-    await updateRun(scope, runId, {
-      status: "cancelled",
-      error: "Cancelled by user",
-      completedAt: now,
-      notifiedAt: now,
-      sinkClosedAt: now,
-    });
-
-    // Log the cancellation
-    await appendRunLog(
-      scope,
-      runId,
-      "system",
-      "run_completed",
-      null,
-      {
-        runId,
-        status: "cancelled",
-      },
-      "info",
-    );
-
-    // Abort in-flight fetch calls immediately, then stop the container as backup
+    // Abort in-flight fetch calls + stop the container BEFORE synthesising
+    // the terminal so the runner stops emitting metric events and the
+    // sidecar can be reclaimed promptly. `finalizeRun` then drains any
+    // events that landed before this point, computes the authoritative
+    // cost from `llm_usage`, and writes the terminal state under CAS.
     abortRun(runId);
     getOrchestrator()
       .stopByRunId(runId)
       .catch(() => {});
 
-    void emitEvent("onRunStatusChange", {
-      orgId: scope.orgId,
-      runId,
-      packageId: run.packageId,
-      applicationId: scope.applicationId,
+    await synthesiseFinalize(runId, {
       status: "cancelled",
-      packageEphemeral: isInlineShadowPackageId(run.packageId),
+      error: { message: "Cancelled by user" },
     });
 
     return c.json({ ok: true });

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -27,7 +27,7 @@ import { db } from "@appstrate/db/client";
 import { runs, TERMINAL_RUN_EVENT_TYPES } from "@appstrate/db/schema";
 import { type CloudEventEnvelope } from "@appstrate/afps-runtime/events";
 import type { RunEvent } from "@appstrate/afps-runtime/types";
-import type { RunResult } from "@appstrate/afps-runtime/runner";
+import { emptyRunResult, type RunResult } from "@appstrate/afps-runtime/runner";
 import { notFound } from "../lib/errors.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
 import { logger } from "../lib/logger.ts";
@@ -464,6 +464,56 @@ export async function finalizeRun(input: FinalizeRunInput): Promise<void> {
     ...(resultToPersist && status === "success" ? { extra: { result: resultToPersist } } : {}),
   };
   void emitEvent("onRunStatusChange", broadcastParams);
+}
+
+/**
+ * Re-enter {@link finalizeRun} with a terminal `RunResult` synthesised by
+ * the platform — the canonical entry point for any code path that needs to
+ * close out a run without going through the runner-posted finalize.
+ *
+ * Three callers funnel through here today:
+ *
+ *   - `POST /api/runs/:id/cancel` — user-triggered cancellation. Without
+ *     this convergence, the cancel route used to write `status='cancelled'`
+ *     directly and the `afterRun` hook never fired — billing modules
+ *     observed zero charge for cancelled runs that had already burned LLM
+ *     tokens (issue #12 follow-up).
+ *   - `listOrphanRunIds` + boot loop — runs that were `running` when the
+ *     server crashed are finalised here so billing/observability hooks see
+ *     the exact same lifecycle as a clean termination.
+ *   - `executeAgentInBackground` synthesised termination — container exit
+ *     code, timeout, or orchestrator failure when the runner did not post
+ *     its own finalize.
+ *
+ * Idempotent by design: the CAS on `sink_closed_at IS NULL` inside
+ * `finalizeRun` makes this a no-op when the runner has already posted its
+ * own terminal — so concurrent synthesis + container-posted finalize ends
+ * up applying exactly once.
+ */
+export async function synthesiseFinalize(
+  runId: string,
+  terminal: {
+    status: "success" | "failed" | "timeout" | "cancelled";
+    error?: { message: string; stack?: string };
+    durationMs?: number;
+  },
+): Promise<void> {
+  const run = await getRunSinkContext(runId);
+  if (!run) {
+    logger.error("synthesiseFinalize: run sink context missing", { runId });
+    return;
+  }
+
+  const result: RunResult = emptyRunResult();
+  result.status = terminal.status;
+  if (terminal.error) result.error = terminal.error;
+  if (terminal.durationMs !== undefined) result.durationMs = terminal.durationMs;
+
+  await finalizeRun({
+    run,
+    result,
+    webhookId: `synthesized-${runId}`,
+  });
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/api/src/services/state/runs.ts
+++ b/apps/api/src/services/state/runs.ts
@@ -840,22 +840,21 @@ export async function listRunLogs(args: {
 }
 
 /**
- * Mark all in-flight runs as failed on server restart.
- * ⚠️ Single-instance only — in multi-instance deployments, this will fail ALL
- * instances' in-flight runs. Multi-instance support requires per-instance run tracking.
+ * List all in-flight run IDs at server startup. The caller (boot) feeds
+ * each id through `synthesiseFinalize` so the same lifecycle that fires
+ * for clean termination (afterRun, terminal log, onRunStatusChange) also
+ * fires for runs that survived a server crash. Without that convergence,
+ * any LLM tokens already burned by the crashed-runner before the crash
+ * would silently never be billed (cloud's `afterRun` would never see them).
+ *
+ * ⚠️ Single-instance only — in multi-instance deployments, this lists ALL
+ * instances' in-flight runs. Multi-instance support requires per-instance
+ * run tracking.
  */
-export async function markOrphanRunsFailed(): Promise<{
-  count: number;
-  runIds: string[];
-}> {
-  const updated = await db
-    .update(runs)
-    .set({
-      status: "failed",
-      error: "Server restarted while run was in progress. Please retry.",
-      completedAt: new Date(),
-    })
-    .where(inArray(runs.status, [...activeRunStatusValues]))
-    .returning({ id: runs.id });
-  return { count: updated.length, runIds: updated.map((r) => r.id) };
+export async function listOrphanRunIds(): Promise<string[]> {
+  const rows = await db
+    .select({ id: runs.id })
+    .from(runs)
+    .where(inArray(runs.status, [...activeRunStatusValues]));
+  return rows.map((r) => r.id);
 }

--- a/apps/api/test/integration/routes/runs-cancel-convergence.test.ts
+++ b/apps/api/test/integration/routes/runs-cancel-convergence.test.ts
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `POST /api/runs/:id/cancel` must converge on `finalizeRun` so the
+ * `afterRun` hook fires for cancelled runs that already burned LLM tokens.
+ *
+ * Pre-fix the cancel route wrote `status='cancelled'` directly and skipped
+ * `afterRun`, leaking billing on every user-cancelled run that had reached
+ * the LLM at least once. These tests pin the fix in place by spying on the
+ * hook with a fake module — if a future refactor reintroduces the bypass,
+ * the spy stops being called and the suite fails.
+ */
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@appstrate/db/client";
+import { runs, llmUsage } from "@appstrate/db/schema";
+import { encrypt } from "@appstrate/connect";
+import { sign } from "@appstrate/afps-runtime/events";
+import { getTestApp } from "../../helpers/app.ts";
+import { truncateAll } from "../../helpers/db.ts";
+import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
+import { seedPackage } from "../../helpers/seed.ts";
+import { loadModulesFromInstances, resetModules } from "../../../src/lib/modules/module-loader.ts";
+import type { AppstrateModule, RunStatusChangeParams } from "@appstrate/core/module";
+
+const app = getTestApp();
+
+const RUN_SECRET = "a".repeat(43); // matches mintSinkCredentials base64url(32B)
+
+function signedHeaders(secret: string, body: string) {
+  const msgId = `msg_${crypto.randomUUID()}`;
+  const timestampSec = Math.floor(Date.now() / 1000);
+  const headers = sign({ msgId, timestampSec, body, secret });
+  return {
+    "Content-Type": "application/json",
+    "webhook-id": headers["webhook-id"],
+    "webhook-timestamp": headers["webhook-timestamp"],
+    "webhook-signature": headers["webhook-signature"],
+  };
+}
+
+async function seedCancellableRun(
+  ctx: TestContext,
+  packageId: string,
+  overrides: {
+    status?: "pending" | "running";
+    modelSource?: string | null;
+  } = {},
+): Promise<string> {
+  const runId = `run_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
+  await db.insert(runs).values({
+    id: runId,
+    packageId,
+    orgId: ctx.orgId,
+    applicationId: ctx.defaultAppId,
+    status: overrides.status ?? "running",
+    runOrigin: "platform",
+    sinkSecretEncrypted: encrypt(RUN_SECRET),
+    sinkExpiresAt: new Date(Date.now() + 3600_000),
+    startedAt: new Date(),
+    tokenUsage: { input_tokens: 100, output_tokens: 50 },
+    ...(overrides.modelSource !== undefined ? { modelSource: overrides.modelSource } : {}),
+  });
+  return runId;
+}
+
+async function seedLlmUsage(
+  ctx: TestContext,
+  runId: string,
+  costUsd: number,
+  source: "runner" | "proxy" = "runner",
+): Promise<void> {
+  await db.insert(llmUsage).values({
+    source,
+    orgId: ctx.orgId,
+    runId,
+    inputTokens: 100,
+    outputTokens: 50,
+    costUsd,
+  });
+}
+
+interface AfterRunSpy {
+  callCount(): number;
+  lastParams(): RunStatusChangeParams | null;
+  allParams(): RunStatusChangeParams[];
+}
+
+async function installAfterRunSpy(): Promise<AfterRunSpy> {
+  const calls: RunStatusChangeParams[] = [];
+  const mod: AppstrateModule = {
+    manifest: { id: "cancel-spy", name: "Cancel Spy", version: "1.0.0" },
+    async init() {},
+    hooks: {
+      afterRun: async (params) => {
+        calls.push(params);
+        return null;
+      },
+    },
+  };
+  await loadModulesFromInstances([mod], {
+    databaseUrl: null,
+    redisUrl: null,
+    appUrl: "http://localhost:3000",
+    isEmbeddedDb: true,
+    applyMigrations: async () => {},
+    getSendMail: async () => () => {},
+    getOrgAdminEmails: async () => [],
+    services: {} as never,
+  });
+  return {
+    callCount: () => calls.length,
+    lastParams: () => calls[calls.length - 1] ?? null,
+    allParams: () => calls.slice(),
+  };
+}
+
+describe("POST /api/runs/:id/cancel — terminal-state convergence", () => {
+  let ctx: TestContext;
+  const agentId = "@cancel/spy-agent";
+
+  beforeEach(async () => {
+    await truncateAll();
+    resetModules();
+    ctx = await createTestContext({ email: "cancel@test.dev", orgSlug: "cancel-org" });
+    await seedPackage({ orgId: ctx.orgId, id: agentId, type: "agent" });
+  });
+
+  afterAll(() => {
+    // Don't leak the spy module into sibling test files.
+    resetModules();
+  });
+
+  it("cancelling a running run with cost fires afterRun with the SUM(llm_usage) cost", async () => {
+    const spy = await installAfterRunSpy();
+    const runId = await seedCancellableRun(ctx, agentId, { modelSource: "system" });
+    await seedLlmUsage(ctx, runId, 0.0551);
+
+    const res = await app.request(`/api/runs/${runId}/cancel`, {
+      method: "POST",
+      headers: authHeaders(ctx),
+    });
+    expect(res.status).toBe(200);
+
+    expect(spy.callCount()).toBe(1);
+    const params = spy.lastParams()!;
+    expect(params.runId).toBe(runId);
+    expect(params.orgId).toBe(ctx.orgId);
+    expect(params.applicationId).toBe(ctx.defaultAppId);
+    expect(params.status).toBe("cancelled");
+    expect(params.modelSource).toBe("system");
+    // Cost rounded — `runs.cost` is doublePrecision, llm_usage stores the
+    // exact value, so the SUM here matches what we seeded.
+    expect(params.cost).toBeCloseTo(0.0551, 4);
+
+    // The terminal state landed on `runs` via finalizeRun's CAS.
+    const [row] = await db
+      .select({ status: runs.status, cost: runs.cost, sinkClosedAt: runs.sinkClosedAt })
+      .from(runs)
+      .where(eq(runs.id, runId));
+    expect(row!.status).toBe("cancelled");
+    expect(row!.cost).toBeCloseTo(0.0551, 4);
+    expect(row!.sinkClosedAt).not.toBeNull();
+  });
+
+  it("cancelling a pending run (never reached the LLM) fires afterRun without cost", async () => {
+    const spy = await installAfterRunSpy();
+    const runId = await seedCancellableRun(ctx, agentId, {
+      status: "pending",
+      modelSource: "system",
+    });
+
+    const res = await app.request(`/api/runs/${runId}/cancel`, {
+      method: "POST",
+      headers: authHeaders(ctx),
+    });
+    expect(res.status).toBe(200);
+
+    expect(spy.callCount()).toBe(1);
+    const params = spy.lastParams()!;
+    expect(params.status).toBe("cancelled");
+    // No llm_usage rows seeded → `cost` is omitted from the hook params.
+    expect(params.cost).toBeUndefined();
+
+    const [row] = await db.select({ status: runs.status }).from(runs).where(eq(runs.id, runId));
+    expect(row!.status).toBe("cancelled");
+  });
+
+  it("cancelling a BYOK run forwards modelSource='org' so the cloud module skips billing", async () => {
+    const spy = await installAfterRunSpy();
+    const runId = await seedCancellableRun(ctx, agentId, { modelSource: "org" });
+    await seedLlmUsage(ctx, runId, 0.1);
+
+    const res = await app.request(`/api/runs/${runId}/cancel`, {
+      method: "POST",
+      headers: authHeaders(ctx),
+    });
+    expect(res.status).toBe(200);
+
+    expect(spy.callCount()).toBe(1);
+    const params = spy.lastParams()!;
+    expect(params.modelSource).toBe("org");
+    expect(params.cost).toBeCloseTo(0.1, 4);
+  });
+
+  it("two concurrent cancels — finalizeRun's CAS lets exactly one terminal state land", async () => {
+    // The platform calls `afterRun` BEFORE the CAS in `finalizeRun`, so
+    // racing cancels can both invoke the hook with identical params (this
+    // is the design from issue #12 — `afterRun` consumers MUST be
+    // idempotent on `runId`, which the cloud module enforces via a unique
+    // index on `cloud_usage_records.run_id`). What this test pins is the
+    // CAS-side invariant: at most one finalize advances the row to
+    // terminal state, the second is a no-op.
+    const spy = await installAfterRunSpy();
+    const runId = await seedCancellableRun(ctx, agentId, { modelSource: "system" });
+    await seedLlmUsage(ctx, runId, 0.02);
+
+    const [a, b] = await Promise.all([
+      app.request(`/api/runs/${runId}/cancel`, {
+        method: "POST",
+        headers: authHeaders(ctx),
+      }),
+      app.request(`/api/runs/${runId}/cancel`, {
+        method: "POST",
+        headers: authHeaders(ctx),
+      }),
+    ]);
+
+    // The second cancel either races and observes a still-cancellable
+    // state (200) or arrives after the first updated the row (409) —
+    // both are valid responses.
+    const statuses = [a.status, b.status].sort();
+    expect(statuses[0]!).toBe(200);
+    expect([200, 409]).toContain(statuses[1]!);
+
+    // afterRun MAY fire 1× or 2× depending on race ordering. Every call
+    // it does fire MUST carry the same parameters — concurrent finalizers
+    // observe the same source-of-truth (`runs` row + `llm_usage` ledger).
+    expect(spy.callCount()).toBeGreaterThanOrEqual(1);
+    expect(spy.callCount()).toBeLessThanOrEqual(2);
+    for (const params of spy.allParams()) {
+      expect(params.runId).toBe(runId);
+      expect(params.status).toBe("cancelled");
+      expect(params.cost).toBeCloseTo(0.02, 4);
+    }
+
+    // Exactly one terminal state landed on the row (CAS won by one caller).
+    const [row] = await db
+      .select({ status: runs.status, sinkClosedAt: runs.sinkClosedAt })
+      .from(runs)
+      .where(eq(runs.id, runId));
+    expect(row!.status).toBe("cancelled");
+    expect(row!.sinkClosedAt).not.toBeNull();
+  });
+
+  it("cancel followed by a runner-posted finalize is a CAS no-op (afterRun fires once)", async () => {
+    const spy = await installAfterRunSpy();
+    const runId = await seedCancellableRun(ctx, agentId, { modelSource: "system" });
+    await seedLlmUsage(ctx, runId, 0.03);
+
+    // User cancels first.
+    const cancelRes = await app.request(`/api/runs/${runId}/cancel`, {
+      method: "POST",
+      headers: authHeaders(ctx),
+    });
+    expect(cancelRes.status).toBe(200);
+
+    // Runner POSTs its own finalize after the cancel — common when the
+    // runner had a finalize in flight at the moment the user cancelled.
+    const body = JSON.stringify({
+      status: "success",
+      output: { ok: true },
+      durationMs: 100,
+    });
+    const finalizeRes = await app.request(`/api/runs/${runId}/events/finalize`, {
+      method: "POST",
+      headers: signedHeaders(RUN_SECRET, body),
+      body,
+    });
+    // Sink already closed by the cancel — runner's POST is rejected as gone.
+    expect(finalizeRes.status).toBe(410);
+
+    // `afterRun` fired exactly once, on the cancel path.
+    expect(spy.callCount()).toBe(1);
+    expect(spy.lastParams()!.status).toBe("cancelled");
+
+    const [row] = await db.select({ status: runs.status }).from(runs).where(eq(runs.id, runId));
+    expect(row!.status).toBe("cancelled");
+  });
+
+  it("returns 409 for already-terminal runs without firing afterRun", async () => {
+    const spy = await installAfterRunSpy();
+    const runId = await seedCancellableRun(ctx, agentId);
+    // Flip the run to a terminal state directly (simulating "already done").
+    await db.update(runs).set({ status: "success" }).where(eq(runs.id, runId));
+
+    const res = await app.request(`/api/runs/${runId}/cancel`, {
+      method: "POST",
+      headers: authHeaders(ctx),
+    });
+    expect(res.status).toBe(409);
+    expect(spy.callCount()).toBe(0);
+  });
+});

--- a/apps/api/test/integration/routes/runs.test.ts
+++ b/apps/api/test/integration/routes/runs.test.ts
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeEach } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@appstrate/db/client";
+import { runs } from "@appstrate/db/schema";
 import { getTestApp } from "../../helpers/app.ts";
 import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
@@ -501,7 +504,7 @@ describe("Runs API", () => {
   // ─── POST /api/runs/:id/cancel ─────────────────────────────
 
   describe("POST /api/runs/:id/cancel", () => {
-    it("cancels a running run", async () => {
+    it("cancels a running run and transitions it to cancelled", async () => {
       await seedAgent({ id: "@runorg/cancel-agent", orgId: ctx.orgId, createdBy: ctx.user.id });
       const run = await seedRun({
         packageId: "@runorg/cancel-agent",
@@ -509,6 +512,10 @@ describe("Runs API", () => {
         applicationId: ctx.defaultAppId,
         userId: ctx.user.id,
         status: "running",
+        // synthesiseFinalize requires sink_secret_encrypted to be present —
+        // every real run created via run-pipeline gets one at INSERT time.
+        sinkSecretEncrypted: "test-secret",
+        sinkExpiresAt: new Date(Date.now() + 3600_000),
       });
 
       const res = await app.request(`/api/runs/${run.id}/cancel`, {
@@ -519,9 +526,19 @@ describe("Runs API", () => {
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
       expect(body.ok).toBe(true);
+
+      // Convergence assertion — the cancel route flowed through finalizeRun
+      // (status flipped to cancelled, sink closed). See `runs-cancel-
+      // convergence.test.ts` for the afterRun-hook side of the contract.
+      const final = await db
+        .select({ status: runs.status, sinkClosedAt: runs.sinkClosedAt })
+        .from(runs)
+        .where(eq(runs.id, run.id));
+      expect(final[0]!.status).toBe("cancelled");
+      expect(final[0]!.sinkClosedAt).not.toBeNull();
     });
 
-    it("cancels a pending run", async () => {
+    it("cancels a pending run and transitions it to cancelled", async () => {
       await seedAgent({ id: "@runorg/cancel-pending", orgId: ctx.orgId, createdBy: ctx.user.id });
       const run = await seedRun({
         packageId: "@runorg/cancel-pending",
@@ -529,6 +546,8 @@ describe("Runs API", () => {
         applicationId: ctx.defaultAppId,
         userId: ctx.user.id,
         status: "pending",
+        sinkSecretEncrypted: "test-secret",
+        sinkExpiresAt: new Date(Date.now() + 3600_000),
       });
 
       const res = await app.request(`/api/runs/${run.id}/cancel`, {
@@ -539,6 +558,9 @@ describe("Runs API", () => {
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
       expect(body.ok).toBe(true);
+
+      const final = await db.select({ status: runs.status }).from(runs).where(eq(runs.id, run.id));
+      expect(final[0]!.status).toBe("cancelled");
     });
 
     it("returns 409 for non-running run", async () => {
@@ -577,6 +599,8 @@ describe("Runs API", () => {
         applicationId: otherCtx.defaultAppId,
         userId: otherCtx.user.id,
         status: "running",
+        sinkSecretEncrypted: "test-secret",
+        sinkExpiresAt: new Date(Date.now() + 3600_000),
       });
 
       const res = await app.request(`/api/runs/${run.id}/cancel`, {

--- a/apps/api/test/unit/finalize-convergence.test.ts
+++ b/apps/api/test/unit/finalize-convergence.test.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Static convergence guard — every transition into a terminal `runs.status`
+ * (`success | failed | timeout | cancelled`) must flow through `finalizeRun`
+ * (or `synthesiseFinalize`, which calls it). Without this invariant, a
+ * future regression that reintroduces a direct `db.update(runs).set({
+ * status: 'cancelled' })` would silently bypass the `afterRun` hook and
+ * skip billing — exactly the bug this whole PR fixes.
+ *
+ * The test grep-walks `apps/api/src/**` and fails if a `runs` UPDATE that
+ * sets a terminal status appears in any file other than the canonical
+ * convergence point. Cheap, no AST, attaches to the existing unit-test
+ * channel — pre-execution feedback in CI.
+ *
+ * What's intentionally allowed:
+ *   - `runs.status = 'running'` (the sole non-terminal transition, owned
+ *     by `executeAgentInBackground`) — terminal-only regex
+ *   - `db.insert(runs).values({ status: 'failed' })` — preflight failures
+ *     that never reached an LLM (no resources to bill); INSERT, not UPDATE
+ *   - References inside type unions, comments, JSDoc, or test helpers
+ *
+ * What's forbidden outside the allowlist:
+ *   - `db.update(runs).set({ status: 'cancelled' | 'failed' | 'timeout' | 'success' })`
+ *   - `updateRun(..., { status: '<terminal>' })`
+ */
+
+import { describe, it, expect } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const SRC_ROOT = join(import.meta.dir, "..", "..", "src");
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..");
+
+/**
+ * Files allowed to write a terminal status to `runs`. Each entry is a
+ * relative path from the repo root, matched exactly.
+ */
+const ALLOWLIST: ReadonlySet<string> = new Set([
+  // Canonical convergence — `finalizeRun` CAS, `synthesiseFinalize` helper,
+  // and the per-event sequence advance (which never sets terminal status).
+  "apps/api/src/services/run-event-ingestion.ts",
+]);
+
+/**
+ * Files allowed to INSERT a row with terminal status (preflight-failed runs
+ * that never reached the LLM). Different from UPDATE because there is no
+ * resource consumption to account for, and no in-flight sink to close.
+ */
+const INSERT_ALLOWLIST: ReadonlySet<string> = new Set([
+  "apps/api/src/services/state/runs.ts", // createFailedRun (INSERT only)
+]);
+
+const TERMINAL_STATUSES = ["cancelled", "failed", "timeout", "success"] as const;
+const TERMINAL_STATUS_RE = new RegExp(`status:\\s*"(${TERMINAL_STATUSES.join("|")})"`);
+const UPDATE_RUNS_RE = /\.update\s*\(\s*runs\s*\)/;
+const INSERT_RUNS_RE = /\.insert\s*\(\s*runs\s*\)/;
+const UPDATE_RUN_FN_RE = /\bupdateRun\s*\(/;
+
+interface Violation {
+  file: string;
+  line: number;
+  snippet: string;
+  reason: string;
+}
+
+function* walk(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      // Skip the OpenAPI spec tree (response examples are documentation,
+      // not runtime DB writes) and any test directories.
+      if (entry === "openapi" || entry === "test" || entry === "node_modules") continue;
+      yield* walk(full);
+    } else if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) {
+      yield full;
+    }
+  }
+}
+
+function findUpdateViolations(
+  content: string,
+  lines: string[],
+): Array<{ line: number; window: string }> {
+  // Hunt for `.update(runs)` then check the next ~12 lines for a terminal
+  // status assignment. The CAS in finalizeRun spans about that range.
+  const violations: Array<{ line: number; window: string }> = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!UPDATE_RUNS_RE.test(lines[i]!)) continue;
+    const window = lines.slice(i, Math.min(i + 12, lines.length)).join("\n");
+    if (TERMINAL_STATUS_RE.test(window)) {
+      violations.push({ line: i + 1, window });
+    }
+  }
+  // Also catch the `updateRun(scope, id, { status: 'failed' })` pattern.
+  for (let i = 0; i < lines.length; i++) {
+    if (!UPDATE_RUN_FN_RE.test(lines[i]!)) continue;
+    const window = lines.slice(i, Math.min(i + 6, lines.length)).join("\n");
+    if (TERMINAL_STATUS_RE.test(window)) {
+      violations.push({ line: i + 1, window });
+    }
+  }
+  void content; // unused — lines array is the source of truth
+  return violations;
+}
+
+function findInsertViolations(
+  _content: string,
+  lines: string[],
+): Array<{ line: number; window: string }> {
+  const violations: Array<{ line: number; window: string }> = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (!INSERT_RUNS_RE.test(lines[i]!)) continue;
+    const window = lines.slice(i, Math.min(i + 12, lines.length)).join("\n");
+    if (TERMINAL_STATUS_RE.test(window)) {
+      violations.push({ line: i + 1, window });
+    }
+  }
+  return violations;
+}
+
+describe("finalize convergence — static guard", () => {
+  it("no file outside the convergence allowlist transitions runs to a terminal status", () => {
+    const violations: Violation[] = [];
+
+    for (const file of walk(SRC_ROOT)) {
+      const rel = relative(REPO_ROOT, file);
+      const content = readFileSync(file, "utf8");
+      const lines = content.split("\n");
+
+      const updateHits = findUpdateViolations(content, lines);
+      if (updateHits.length > 0 && !ALLOWLIST.has(rel)) {
+        for (const hit of updateHits) {
+          violations.push({
+            file: rel,
+            line: hit.line,
+            snippet: hit.window.slice(0, 200),
+            reason:
+              "UPDATE on `runs` writes a terminal status outside the convergence allowlist. " +
+              "Route the transition through `synthesiseFinalize` so `afterRun` (billing) fires.",
+          });
+        }
+      }
+
+      const insertHits = findInsertViolations(content, lines);
+      if (insertHits.length > 0 && !INSERT_ALLOWLIST.has(rel)) {
+        for (const hit of insertHits) {
+          violations.push({
+            file: rel,
+            line: hit.line,
+            snippet: hit.window.slice(0, 200),
+            reason:
+              "INSERT on `runs` with terminal status outside the preflight allowlist. " +
+              "If this represents a run that consumed resources, route through `finalizeRun` instead.",
+          });
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      const report = violations
+        .map((v) => `\n  ${v.file}:${v.line}\n    → ${v.reason}\n    snippet: ${v.snippet}`)
+        .join("\n");
+      throw new Error(
+        `Found ${violations.length} convergence violation(s). Every terminal-status transition on \`runs\` MUST flow through \`finalizeRun\` so the \`afterRun\` hook fires for billing/observability:${report}`,
+      );
+    }
+
+    expect(violations).toHaveLength(0);
+  });
+
+  it("the allowlist itself is non-empty and points at the canonical finalize file", () => {
+    // Sanity check — if someone inadvertently empties the allowlist this
+    // test wouldn't catch real violations because every terminal status
+    // would belong to "an unallowed file" (vacuously true).
+    expect(ALLOWLIST.size).toBeGreaterThan(0);
+    expect(ALLOWLIST.has("apps/api/src/services/run-event-ingestion.ts")).toBe(true);
+  });
+});

--- a/packages/db/drizzle/0020_llm_usage_billed_at.sql
+++ b/packages/db/drizzle/0020_llm_usage_billed_at.sql
@@ -1,0 +1,29 @@
+-- Add `billed_at` to `llm_usage` so the cloud module can switch from
+-- snapshot-billing (`runs.cost` SUM at finalize time) to ledger-first
+-- billing (per-row claim with `billed_at IS NULL` as the work queue).
+--
+-- Layer 4 of the billing-correctness plan:
+--   - Layer 1 (appstrate#394) routed every terminal-state path through
+--     `finalizeRun`, closing the cancel-bypass leak.
+--   - Layer 3 (cloud#14) added a periodic sweeper that catches any
+--     `runs.cost > 0 AND no cloud_usage_records` gap.
+--   - Layer 4 (this) — eliminates the temporal coupling between the
+--     cost write and the billing debit. A late-arriving `llm_usage`
+--     row (sidecar buffer flush, runner reconnect, …) automatically
+--     enters the cloud sweeper's work queue without any platform-side
+--     coordination, because `billed_at IS NULL` is the canonical signal.
+--
+-- The platform never reads this column — it is informational from the
+-- platform's perspective. Cloud is the sole writer; cloud is the sole
+-- reader. Keeping it on the same row as `cost_usd` (rather than a
+-- side-table cloud could own) avoids the JOIN that bill-from-ledger
+-- would otherwise pay on every tick.
+ALTER TABLE "llm_usage" ADD COLUMN "billed_at" TIMESTAMPTZ;
+--> statement-breakpoint
+-- Partial index — cloud's sweeper SELECT is `WHERE run_id = ? AND
+-- billed_at IS NULL`. Once a row is billed, it leaves the index
+-- automatically, so the index footprint reflects in-flight work only.
+-- A regular index on `run_id` already exists (`idx_llm_usage_run_id`);
+-- this one is additive and far cheaper because it omits ~99 % of rows
+-- in steady state.
+CREATE INDEX "idx_llm_usage_unbilled_run_id" ON "llm_usage" ("run_id") WHERE billed_at IS NULL;

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1784073600000,
       "tag": "0019_rename_dashboard_user_to_user",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1784160000000,
+      "tag": "0020_llm_usage_billed_at",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/runs.ts
+++ b/packages/db/src/schema/runs.ts
@@ -371,6 +371,15 @@ export const llmUsage = pgTable(
     // Null on runner-source rows (they dedup on run_id instead).
     requestId: text("request_id"),
     createdAt: timestamp("created_at").defaultNow().notNull(),
+    // Billing-side marker (cloud-only) — `null` means the row has not yet
+    // been consumed by the billing path; set to `NOW()` by the cloud
+    // module's `recordUsage` once the cost has been debited. Lives on this
+    // table (rather than a side-table cloud could own) because it must be
+    // updated atomically with the SUM(cost_usd) read that produces the
+    // debit; a side-table would force a JOIN on every billing tick and
+    // double the partial-index footprint. The platform never reads this
+    // column — it is informational from the platform's perspective.
+    billedAt: timestamp("billed_at", { withTimezone: true }),
   },
   (table) => [
     index("idx_llm_usage_org_id").on(table.orgId),
@@ -378,6 +387,12 @@ export const llmUsage = pgTable(
     index("idx_llm_usage_user_id").on(table.userId),
     index("idx_llm_usage_run_id").on(table.runId),
     index("idx_llm_usage_org_created").on(table.orgId, table.createdAt),
+    // Cloud's bill-from-ledger sweep keys on (run_id) WHERE billed_at IS NULL.
+    // Partial index keeps the footprint to whatever's currently in flight —
+    // once a row is billed, it leaves the index automatically.
+    index("idx_llm_usage_unbilled_run_id")
+      .on(table.runId)
+      .where(sql`billed_at IS NULL`),
     // Proxy-source dedup: request_id is unique across all proxy rows.
     uniqueIndex("uq_llm_usage_proxy_request_id")
       .on(table.requestId)


### PR DESCRIPTION
## Summary

Adds a `billed_at` timestamp column on `llm_usage` so the cloud module can switch from snapshot-billing (`runs.cost` SUM at finalize time) to ledger-first billing (per-row claim with `billed_at IS NULL` as the work queue).

This is **Layer 4** of the billing-correctness plan:
- **Layer 1** (#394) routed every terminal-state path through `finalizeRun`, closing the cancel-bypass leak.
- **Layer 3** ([appstrate/cloud#14](https://github.com/appstrate/cloud/pull/14)) added a periodic sweeper that catches any `runs.cost > 0 AND no cloud_usage_records` gap.
- **Layer 4** (this PR + [appstrate/cloud#15](https://github.com/appstrate/cloud/pull/15)) eliminates the temporal coupling between the cost write and the billing debit. A late-arriving `llm_usage` row (sidecar buffer flush after `finalizeRun` already ran, runner reconnect) automatically enters the cloud sweeper's work queue because `billed_at IS NULL` is the canonical signal — no platform-side coordination required.

## Changes

- **`packages/db/src/schema/runs.ts`** — new `billedAt` column on `llm_usage`. Doc explains: cloud-only, single writer, single reader, kept on the row to avoid the JOIN tax of a side-table.
- **`packages/db/drizzle/0020_llm_usage_billed_at.sql`** — `ALTER TABLE … ADD COLUMN billed_at TIMESTAMPTZ` + `CREATE INDEX idx_llm_usage_unbilled_run_id ON llm_usage (run_id) WHERE billed_at IS NULL`. The partial index makes cloud's sweeper SELECT a cheap range scan; once a row is billed it leaves the index automatically.
- **`packages/db/drizzle/meta/_journal.json`** — registers the migration.

## Why on `llm_usage` (platform-owned) rather than a side-table cloud could own?

I considered `cloud_billed_llm_usages(llm_usage_id, billed_at)` to give cloud full ownership of its data. Rejected because:
- Doubles the partial-index footprint (we'd need both `idx_llm_usage_unbilled_run_id` AND a FK index on the side-table).
- Forces a JOIN on every billing tick (cloud would have to LEFT JOIN to detect "rows we haven't seen yet").
- A single nullable column the platform never reads is the smallest possible coupling. The platform can't even tell whether the cloud module is loaded.

## Test plan

- [x] `bun run check` — turbo check + verify-openapi clean
- [x] Migration applies cleanly on PostgreSQL test DB (verified — column + partial index present after `bun test`)
- [x] No platform-side test coverage required (the column is informational from the platform's perspective; the contract lives in cloud#15's tests)

## Out of scope

- Billing logic — lives in `appstrate/cloud#15` (the ledger-first `recordUsage` rewrite + backfill migration).
- Renaming any existing column or breaking the `runs.cost` snapshot semantic — the snapshot is still computed and stored, it just stops being the source of truth for billing.

## Companion PR

[appstrate/cloud#15](https://github.com/appstrate/cloud/pull/15) — the cloud-side ledger-first `recordUsage` + backfill migration. Merge order: this PR first (column must exist before cloud reads it), then cloud#15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)