### PR TITLE
fix(docker): glob `*.ts` instead of listing sidecar/runtime-pi sources by hand

### DIFF
--- a/runtime-pi/Dockerfile
+++ b/runtime-pi/Dockerfile
@@ -170,12 +170,12 @@ RUN mkdir -p node_modules/@mariozechner \
         node_modules/@mariozechner/pi-ai \
         node_modules/@mariozechner/pi-coding-agent
 
-# Bootstrap sources.
-COPY --chown=pi:pi runtime-pi/extensions/          ./extensions/
-COPY --chown=pi:pi runtime-pi/mcp/                 ./mcp/
-COPY --chown=pi:pi runtime-pi/extension-wrapper.ts ./extension-wrapper.ts
-COPY --chown=pi:pi runtime-pi/env.ts               ./env.ts
-COPY --chown=pi:pi runtime-pi/entrypoint.ts        ./entrypoint.ts
+# Bootstrap sources. Glob is single-level (no recursion into `sidecar/`
+# or `test/`), so adding a new `.ts` file at `runtime-pi/*.ts` is picked
+# up automatically — no Dockerfile edit required.
+COPY --chown=pi:pi runtime-pi/extensions/ ./extensions/
+COPY --chown=pi:pi runtime-pi/mcp/        ./mcp/
+COPY --chown=pi:pi runtime-pi/*.ts        ./
 
 # Agent workspace. AFPS tools ship pre-bundled with their deps inlined
 # (AFPS §3.4, via `@appstrate/core/tool-bundler`), so nothing under

--- a/runtime-pi/sidecar/Dockerfile
+++ b/runtime-pi/sidecar/Dockerfile
@@ -65,20 +65,10 @@ COPY packages/afps-runtime/src   packages/afps-runtime/src
 COPY packages/mcp-transport/src  packages/mcp-transport/src
 COPY packages/core/src           packages/core/src
 
-# Sidecar sources.
-COPY runtime-pi/sidecar/server.ts           \
-     runtime-pi/sidecar/app.ts              \
-     runtime-pi/sidecar/helpers.ts          \
-     runtime-pi/sidecar/forward-proxy.ts    \
-     runtime-pi/sidecar/ssrf.ts             \
-     runtime-pi/sidecar/mcp.ts              \
-     runtime-pi/sidecar/mcp-host.ts         \
-     runtime-pi/sidecar/blob-store.ts       \
-     runtime-pi/sidecar/credential-proxy.ts \
-     runtime-pi/sidecar/roots.ts            \
-     runtime-pi/sidecar/logger.ts           \
-     runtime-pi/sidecar/upstream-meta.ts    \
-     runtime-pi/sidecar/
+# Sidecar sources. Glob is single-level (no recursion into `test/`),
+# so adding a new `.ts` file at `runtime-pi/sidecar/*.ts` is picked up
+# automatically — no Dockerfile edit required.
+COPY runtime-pi/sidecar/*.ts runtime-pi/sidecar/
 
 WORKDIR /build/runtime-pi/sidecar
 RUN bun build --compile --minify server.ts --outfile sidecar


### PR DESCRIPTION
## Summary

Both `runtime-pi/Dockerfile` and `runtime-pi/sidecar/Dockerfile` enumerated their `.ts` source files explicitly via long `COPY runtime-pi/sidecar/server.ts \ runtime-pi/sidecar/app.ts \ ...` lists. When a new file is added to either directory, missing it from the Dockerfile list silently breaks the build.

This actually happened: `runtime-pi/sidecar/token-budget.ts` (added by #390) was not added to the Dockerfile, and the build failed with:
```
error: Could not resolve: "./token-budget.ts"
    at /build/runtime-pi/sidecar/app.ts:20:8
```

Fix: replace the explicit lists with single-level globs (`COPY runtime-pi/sidecar/*.ts runtime-pi/sidecar/`). The glob:
- picks up future `.ts` additions automatically — no Dockerfile edit needed
- does NOT recurse into subdirectories (`test/`, and for `runtime-pi/`, `sidecar/`) — so test files and the separate sidecar image are not pulled in

The other 5 Dockerfiles in the monorepo (`appstrate/`, `cloud/`, `portal/`, `registry/`, `website/`) copy whole directories (`COPY apps/` etc.) and are not affected.

## Test plan

- [x] `docker build -f runtime-pi/sidecar/Dockerfile .` succeeds — bundles the same 387 modules as before
- [x] `docker build -f runtime-pi/Dockerfile .` succeeds — produces an identical runtime tree
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)