### PR TITLE
docs(module-codex): track helper rename PROVIDERS → MODEL_PROVIDERS

### DIFF
--- a/packages/module-codex/README.md
+++ b/packages/module-codex/README.md
@@ -33,4 +33,4 @@ The helper's source lives in a separate private repo (`appstrate/connect-helper`
 
 ## Authoring follow-on OAuth providers
 
-This module is the canonical example. Copy the shape: declare a `ModelProviderDefinition` with `authMode: "oauth2"`, provide `hooks` if the access token needs to be decoded for an identity claim, and pin any wire-format quirks in `oauthWireFormat`. The client-side helper (`@appstrate/connect-helper`) registers each provider by canonical `providerId` in its own `PROVIDERS` table — extending it requires a coordinated bump.
+This module is the canonical example. Copy the shape: declare a `ModelProviderDefinition` with `authMode: "oauth2"`, provide `hooks` if the access token needs to be decoded for an identity claim, and pin any wire-format quirks in `oauthWireFormat`. The client-side helper (`@appstrate/connect-helper`) registers each provider by canonical `providerId` in its own `MODEL_PROVIDERS` table — extending it requires a coordinated bump.


### PR DESCRIPTION
## Summary

- Update `packages/module-codex/README.md` cross-reference: `connect-helper` renamed its internal registry from `PROVIDERS` to `MODEL_PROVIDERS` to match the platform vocabulary
- Companion to https://github.com/appstrate/connect-helper/pull/2 (closes appstrate/connect-helper#1)
- One-line doc update; no code change

## Test plan

- [x] `bun run check` — 19/19 turbo tasks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)