### PR TITLE
fix(ci): include core-providers + module-codex in e2e MODULES

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,10 +132,20 @@ jobs:
           BETTER_AUTH_SECRET: e2e-ci-secret-that-is-at-least-32-characters
           CONNECTION_ENCRYPTION_KEY: Y2FzgQmlgIRocYT1VUWM+73fQ5zOTPB8sHJxTh1x4qI=
           UPLOAD_SIGNING_SECRET: e2e-ci-upload-signing-secret
-          # E2E suite seeds webhooks (cascade deletion, cross-app/org isolation,
-          # UI org switching). The webhooks module is opt-in via MODULES
-          # since PR #72 — without this the webhook routes 404 and 12 specs fail.
-          MODULES: webhooks
+          # E2E suite needs the full default module set:
+          #  - webhooks: cascade deletion, cross-app/org isolation, UI org switching
+          #    (opt-in since PR #72; without it webhook routes 404 and 12 specs fail)
+          #  - core-providers: registers the anthropic/openai/openai-compatible
+          #    api-key model providers. SYSTEM_PROVIDER_KEYS rows are only
+          #    accepted at run time if their api shape resolves against the
+          #    registry, so without this module upload-flow.api 400s on every
+          #    POST /agents/:scope/:name/run.
+          #  - @appstrate/module-codex: registers `codex` so the pairing-lifecycle
+          #    e2e (`providerId: "codex"`) passes `isOAuthModelProvider()` and
+          #    mint returns 200 instead of 400.
+          # oidc is kept in lockstep with .env.example / packages/env defaults so
+          # the suite stays representative of a default self-host install.
+          MODULES: oidc,webhooks,core-providers,@appstrate/module-codex
           # Default system model so run-acceptance passes in specs that POST
           # /agents/:id/run (e.g. upload-flow). The run pipeline only needs a
           # resolvable model at acceptance time — the dummy apiKey is never


### PR DESCRIPTION
## Summary

3 E2E tests started failing on `main` after PR #397 merged. Root cause: the Test workflow pinned `MODULES: webhooks` (back when only webhooks was opt-in), but PR #397 made model providers module-contributed — so anything that resolves against the runtime provider registry now needs the relevant module loaded.

### Tests that started failing

| Test | Failure | Module needed |
|------|---------|---------------|
| `pairing-lifecycle.api: mint → consume → list → revoke` | mint returns **400** (refines `isOAuthModelProvider("codex")` → false) | `@appstrate/module-codex` |
| `upload-flow.api: POST /uploads → PUT → run consumes the blob` | run POST returns **400** | `core-providers` (registers `anthropic-messages` shape) |
| `upload-flow.api: reusing an upload:// URI twice fails with 409` | run POST returns **400** before getting to the dedup check | `core-providers` |

### Fix

Update `.github/workflows/test.yml` to set `MODULES` to the same value as the env default (`packages/env/src/index.ts`):

```
MODULES: oidc,webhooks,core-providers,@appstrate/module-codex
```

This matches `.env.example`, so the CI suite now reflects a default self-host install.

## Test plan

- [x] Inspect previous CI failure logs (3 runs since PR #397 merge: 25771533361, 25770981205)
- [x] Confirm root cause: `isOAuthModelProvider("codex")` and provider-registry resolution for `anthropic-messages`
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)