### PR TITLE
refactor: drop legacy (apiShape, baseUrl) credential form (#409)

### DIFF
--- a/apps/web/src/components/credential-form-modal.tsx
+++ b/apps/web/src/components/credential-form-modal.tsx
@@ -11,6 +11,11 @@
  * `MODULES` env var with zero client churn — their entries appear or
  * disappear in the picker automatically.
  *
+ * The form posts the canonical `{ label, providerId, apiKey, baseUrlOverride? }`
+ * shape. The `baseUrlOverride` field is only surfaced for providers that
+ * declare `baseUrlOverridable: true` (today: `openai-compatible`, exposed
+ * via the picker's "Custom" entry as the self-hosted escape hatch).
+ *
  * Edit mode is API-key-only — OAuth rows are immutable (label included)
  * and use the dedicated "reconnect" affordance, which re-enters the
  * modal with the same provider preselected to re-pair.
@@ -39,20 +44,20 @@ import {
   type ProviderRegistryEntry,
 } from "../hooks/use-model-provider-credentials";
 import type { ModelProviderCredentialInfo, TestResult } from "@appstrate/shared-types";
-import {
-  CUSTOM_ID,
-  PI_ADAPTER_TYPES,
-  getProviderById,
-  resolveProviderId,
-} from "@/lib/provider-registry-helpers";
+import { getProviderById, resolveProviderId } from "@/lib/provider-registry-helpers";
 import { PROVIDER_ICONS } from "./icons";
 import { OAuthPairingBody } from "./oauth-pairing-body";
 
+/**
+ * Canonical payload shape submitted to `POST /api/model-provider-credentials`.
+ * `baseUrlOverride` is only meaningful for providers with `baseUrlOverridable: true`
+ * (today: `openai-compatible`).
+ */
 export interface CredentialFormData {
   label: string;
-  apiShape: string;
-  baseUrl: string;
+  providerId: string;
   apiKey?: string;
+  baseUrlOverride?: string | null;
 }
 
 interface CredentialFormModalProps {
@@ -67,9 +72,8 @@ interface CredentialFormModalProps {
 
 interface CredentialFormFields {
   label: string;
-  apiShape: string;
-  baseUrl: string;
   apiKey: string;
+  baseUrlOverride: string;
 }
 
 function detectProviderFromCredential(
@@ -96,7 +100,7 @@ interface PickerOption {
 
 function buildOptions(registry: readonly ProviderRegistryEntry[]): PickerOption[] {
   return registry
-    .filter((p) => p.providerId !== "openrouter" && p.providerId !== "openai-compatible")
+    .filter((p) => p.providerId !== "openrouter")
     .map((p) => ({
       id: p.authMode === "oauth2" ? `oauth:${p.providerId}` : p.providerId,
       label: p.displayName,
@@ -131,7 +135,10 @@ function CredentialFormBody({
   const isEditing = !!credential;
   const selectedOption = options.find((o) => o.id === selectedId);
   const isOAuthSelected = selectedOption?.authMode === "oauth2";
-  const isCustom = selectedId === CUSTOM_ID;
+  const selectedProvider = selectedOption
+    ? getProviderById(selectedOption.providerId, registry)
+    : undefined;
+  const needsBaseUrlOverride = !!selectedProvider?.baseUrlOverridable;
 
   const {
     register,
@@ -144,27 +151,37 @@ function CredentialFormBody({
   } = useAppForm<CredentialFormFields>({
     defaultValues: {
       label: credential?.label ?? "",
-      apiShape: credential?.apiShape ?? "",
-      baseUrl: credential?.baseUrl ?? "",
       apiKey: "",
+      baseUrlOverride: credential?.baseUrl ?? "",
     },
   });
 
-  const [apiShape, baseUrl, apiKey, label] = useWatch({
+  const [baseUrlOverride, apiKey, label] = useWatch({
     control,
-    name: ["apiShape", "baseUrl", "apiKey", "label"],
+    name: ["baseUrlOverride", "apiKey", "label"],
   });
 
   const testMutation = useTestModelProviderCredentialInline();
   const [testResult, setTestResult] = useState<TestResult | null>(null);
-  const canTest = !!apiShape.trim() && !!baseUrl.trim() && (!!apiKey.trim() || !!credential);
+  // Inline-test endpoint still takes (apiShape, baseUrl) — these are
+  // computed from the chosen provider's registry entry (+ override).
+  const testApiShape = selectedProvider?.apiShape ?? "";
+  const testBaseUrl = needsBaseUrlOverride
+    ? baseUrlOverride.trim()
+    : (selectedProvider?.defaultBaseUrl ?? "");
+  const canTest =
+    !!selectedProvider &&
+    !isOAuthSelected &&
+    !!testApiShape &&
+    !!testBaseUrl &&
+    (!!apiKey.trim() || !!credential);
 
   const handleTest = () => {
     setTestResult(null);
     testMutation.mutate(
       {
-        apiShape: apiShape.trim(),
-        baseUrl: baseUrl.trim(),
+        apiShape: testApiShape,
+        baseUrl: testBaseUrl,
         ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
         ...(credential ? { existingKeyId: credential.id } : {}),
       },
@@ -184,28 +201,30 @@ function CredentialFormBody({
   const handleProviderChange = (id: string) => {
     setSelectedId(id);
     clearErrors();
-    if (id === CUSTOM_ID) {
-      setValue("apiShape", "");
-      setValue("baseUrl", "");
-      setValue("label", "");
+    const option = options.find((o) => o.id === id);
+    if (!option || option.authMode === "oauth2") {
+      setValue("baseUrlOverride", "");
       return;
     }
-    const option = options.find((o) => o.id === id);
-    if (!option || option.authMode === "oauth2") return;
     const provider = getProviderById(option.providerId, registry);
     if (provider) {
-      setValue("apiShape", provider.apiShape);
-      setValue("baseUrl", provider.defaultBaseUrl);
+      // Pre-seed the override field with the default base URL so users
+      // see the value they're customising. Non-overridable providers
+      // never read this field.
+      setValue("baseUrlOverride", provider.baseUrlOverridable ? provider.defaultBaseUrl : "");
       if (!label.trim()) setValue("label", provider.displayName);
     }
   };
 
   const onFormSubmit = handleSubmit((data) => {
+    if (!selectedProvider) return;
     onSubmit({
       label: data.label.trim(),
-      apiShape: data.apiShape.trim(),
-      baseUrl: data.baseUrl.trim(),
+      providerId: selectedProvider.providerId,
       ...(data.apiKey.trim() ? { apiKey: data.apiKey.trim() } : {}),
+      ...(needsBaseUrlOverride && data.baseUrlOverride.trim()
+        ? { baseUrlOverride: data.baseUrlOverride.trim() }
+        : {}),
     });
   });
 
@@ -274,7 +293,7 @@ function CredentialFormBody({
           <Button type="button" variant="outline" onClick={onClose}>
             {t("btn.cancel")}
           </Button>
-          <Button type="submit" form="pk-form" disabled={isPending}>
+          <Button type="submit" form="pk-form" disabled={isPending || !selectedProvider}>
             {isPending ? <Spinner /> : t("btn.save")}
           </Button>
         </>
@@ -287,10 +306,7 @@ function CredentialFormBody({
             <SelectTrigger id="pk-provider">
               <SelectValue placeholder={t("models.form.providerPlaceholder")} />
             </SelectTrigger>
-            <SelectContent>
-              {renderOptions(options, t)}
-              <SelectItem value={CUSTOM_ID}>{t("models.form.custom")}</SelectItem>
-            </SelectContent>
+            <SelectContent>{renderOptions(options, t)}</SelectContent>
           </Select>
         </div>
 
@@ -311,66 +327,36 @@ function CredentialFormBody({
           )}
         </div>
 
-        {isCustom && (
-          <>
-            <div className="space-y-2">
-              <Label htmlFor="pk-api">{t("models.form.api")}</Label>
-              <Select
-                value={apiShape}
-                onValueChange={(v) => {
-                  setValue("apiShape", v);
-                  clearErrors("apiShape");
-                }}
-                disabled={isEditing}
-              >
-                <SelectTrigger
-                  id="pk-api"
-                  className={cn(showError("apiShape") && "border-destructive")}
-                >
-                  <SelectValue placeholder={t("models.form.apiPlaceholder")} />
-                </SelectTrigger>
-                <SelectContent>
-                  {PI_ADAPTER_TYPES.map((apiType) => (
-                    <SelectItem key={apiType.value} value={apiType.value}>
-                      {apiType.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {showError("apiShape") && errors.apiShape?.message && (
-                <div className="text-destructive text-sm">{errors.apiShape.message}</div>
-              )}
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="pk-baseUrl">{t("credentials.form.baseUrl")}</Label>
-              <Input
-                id="pk-baseUrl"
-                type="url"
-                disabled={isEditing}
-                {...register("baseUrl", {
-                  validate: (v) => {
-                    if (!isCustom) return undefined;
-                    if (!v.trim()) return t("validation.required", { ns: "common" });
-                    try {
-                      new URL(v.trim());
-                    } catch {
-                      return t("validation.required", { ns: "common" });
-                    }
-                    return undefined;
-                  },
-                })}
-                placeholder="https://api.openai.com/v1"
-                aria-invalid={showError("baseUrl") ? true : undefined}
-                className={cn(showError("baseUrl") && "border-destructive")}
-              />
-              {showError("baseUrl") && errors.baseUrl?.message && (
-                <div className="text-destructive text-sm">{errors.baseUrl.message}</div>
-              )}
-            </div>
-          </>
+        {needsBaseUrlOverride && (
+          <div className="space-y-2">
+            <Label htmlFor="pk-baseUrl">{t("credentials.form.baseUrl")}</Label>
+            <Input
+              id="pk-baseUrl"
+              type="url"
+              disabled={isEditing}
+              {...register("baseUrlOverride", {
+                validate: (v) => {
+                  if (!needsBaseUrlOverride) return undefined;
+                  if (!v.trim()) return t("validation.required", { ns: "common" });
+                  try {
+                    new URL(v.trim());
+                  } catch {
+                    return t("validation.required", { ns: "common" });
+                  }
+                  return undefined;
+                },
+              })}
+              placeholder="https://api.openai.com/v1"
+              aria-invalid={showError("baseUrlOverride") ? true : undefined}
+              className={cn(showError("baseUrlOverride") && "border-destructive")}
+            />
+            {showError("baseUrlOverride") && errors.baseUrlOverride?.message && (
+              <div className="text-destructive text-sm">{errors.baseUrlOverride.message}</div>
+            )}
+          </div>
         )}
 
-        {!!selectedId && (
+        {!!selectedProvider && (
           <div className="space-y-2">
             <Label htmlFor="pk-apiKey">{t("credentials.form.apiKey")}</Label>
             <Input

--- a/apps/web/src/pages/org-settings/models.tsx
+++ b/apps/web/src/pages/org-settings/models.tsx
@@ -405,7 +405,6 @@ export function OrgSettingsModelsPage() {
   const createPkMutation = useCreateModelProviderCredential();
   const updatePkMutation = useUpdateModelProviderCredential();
   const deletePkMutation = useDeleteModelProviderCredential();
-  const registryQuery = useProvidersRegistry();
 
   if (!isAdmin) return <Navigate to="/org-settings/general" replace />;
 
@@ -496,24 +495,12 @@ export function OrgSettingsModelsPage() {
             );
           } else {
             const uniqueLabel = deduplicateLabel(data.label, credentials ?? []);
-            // Form still emits (apiShape, baseUrl) for UX presets; map to the
-            // canonical (providerId, baseUrlOverride) the API expects. The
-            // registry exposes the same matching server-side; any future
-            // registry-aware form can drop this translation.
-            const matchedProvider = registryQuery.data?.find(
-              (p) =>
-                p.authMode === "api_key" &&
-                p.apiShape === data.apiShape &&
-                p.defaultBaseUrl.replace(/\/+$/, "") === data.baseUrl.replace(/\/+$/, ""),
-            );
-            const providerId = matchedProvider?.providerId ?? "openai-compatible";
-            const baseUrlOverride = matchedProvider ? null : data.baseUrl;
             createPkMutation.mutate(
               {
                 label: uniqueLabel,
-                providerId,
+                providerId: data.providerId,
                 apiKey: data.apiKey ?? "",
-                ...(baseUrlOverride ? { baseUrlOverride } : {}),
+                ...(data.baseUrlOverride ? { baseUrlOverride: data.baseUrlOverride } : {}),
               },
               { onSuccess: () => setPkModalOpen(false) },
             );


### PR DESCRIPTION
## Summary

The credential form modal now posts the canonical `{ label, providerId, apiKey, baseUrlOverride? }` shape instead of the legacy `(apiShape, baseUrl)` pair. The provider picker is the source of truth — `providerId` is selected directly, and `baseUrlOverride` is only surfaced when the chosen provider declares `baseUrlOverridable: true` (today: `openai-compatible`).

The backend `createSchema` already only accepts the canonical shape and `resolveProviderIdFromApiKeyForm` was previously removed — this PR completes the migration on the frontend.

Closes #409.

## Backend changes

- No code changes required — `createSchema` already accepts only `{ label, providerId, apiKey, baseUrlOverride? }`
- `resolveProviderIdFromApiKeyForm` was already removed
- Verified the legacy union arm is gone from `apps/api/src/routes/model-provider-credentials.ts`
- `POST /api/model-provider-credentials/test` intentionally keeps its `(apiShape, baseUrl)` shape (per the issue's acceptance criteria — it tests configs before any credential exists)

## Frontend changes

- `apps/web/src/components/model-provider-credential-form-modal.tsx`: form fields are now `label`, `providerId` (via `<Select>`), `apiKey`, and an `baseUrlOverride` input that only renders for providers with `baseUrlOverridable: true`
- `openai-compatible` is now a first-class entry in the provider picker (replaces the old "Custom" sentinel) — its base URL is editable via the `baseUrlOverride` field
- The provider <Select> options are sourced from `useProvidersRegistry()` (the existing registry-driven hook), filtered to skip `openrouter`
- Inline test endpoint still works: the form derives `(apiShape, baseUrl)` for the test payload from the selected provider's registry entry plus the override
- `apps/web/src/pages/org-settings/models.tsx`: drops the registry-translation glue that mapped legacy form fields back to `(providerId, baseUrlOverride)` — the form now emits the canonical shape directly

## Manual test plan

Static checks (passed locally):
- `bun run check` — typecheck, lint, format, OpenAPI validation: all green
- `bun test apps/api/test/integration/routes/model-provider-credentials.test.ts` — 16/16 pass
- `bun run test:unit` — 782/782 pass

Browser verification (please run before merge):
- [ ] Open Settings → Models → Model Provider Keys → "Add key"
- [ ] Provider <Select> lists OpenAI, Anthropic, OpenAI-compatible, plus any OAuth providers — verify icons and OAuth badges render
- [ ] Pick OpenAI: Base URL field is **not** shown; label auto-fills; API key field is required
- [ ] Pick OpenAI-compatible: Base URL field **is** shown and pre-seeded with `https://api.openai.com/v1` (editable)
- [ ] Pick an OAuth provider: form swaps to the pairing-token body (existing behavior)
- [ ] Test button: with a valid OpenAI API key, click "Test" — should return "OK" with latency
- [ ] Save with OpenAI: verify the row appears in the list with the correct provider icon
- [ ] Save with OpenAI-compatible + custom base URL: verify the row appears and the base URL is persisted
- [ ] Edit an existing key: provider picker is disabled; label and API key are editable
- [ ] Verify the network request to `POST /api/model-provider-credentials` posts `{ label, providerId, apiKey, baseUrlOverride? }` only (no `apiShape`/`baseUrl`)