### PR TITLE
refactor: align pairing/import/connect naming (#410)

### DIFF
--- a/apps/api/src/lib/auth-pipeline.ts
+++ b/apps/api/src/lib/auth-pipeline.ts
@@ -306,13 +306,21 @@ export function skipAuth(path: string, publicPaths: Set<string>, headers?: Heade
   // HMAC signature at the route layer — not via JWT / API key / cookie.
   if (REMOTE_RUN_EVENT_PATH_PATTERN.test(path)) return true;
   if (publicPaths.has(path)) return true; // module-contributed public paths
-  // OAuth model-provider import is bearer-only: `Authorization: Bearer appp_…`
+  // OAuth model-provider pair-redeem is bearer-only: `Authorization: Bearer appp_…`
   // is the ONLY accepted auth shape. The route handler atomically consumes
   // the matching `model_provider_pairings` row; the row's userId/orgId/
   // providerId become the request context, replacing the cookie/API-key
   // chain entirely. Requests without the bearer reach the route handler
   // and 401 there.
-  if (path === "/api/model-providers-oauth/import" && headers) {
+  //
+  // The canonical path is `/pair/redeem`; `/import` is a deprecation alias
+  // kept indefinitely for `@appstrate/connect-helper` versions already in
+  // the wild via `npx`. Both share the same auth-bypass rule.
+  if (
+    (path === "/api/model-providers-oauth/pair/redeem" ||
+      path === "/api/model-providers-oauth/import") &&
+    headers
+  ) {
     const auth = headers.get("authorization") ?? headers.get("Authorization");
     if (auth?.startsWith("Bearer appp_")) return true;
   }

--- a/apps/api/src/openapi/paths/model-providers-oauth.ts
+++ b/apps/api/src/openapi/paths/model-providers-oauth.ts
@@ -7,7 +7,7 @@ export const modelProvidersOAuthPaths = {
       tags: ["Model Provider Credentials"],
       summary: "Mint a one-shot pairing token for the connect helper",
       description:
-        "Creates a single-use pairing token surfaced in the dashboard as a `npx @appstrate/connect-helper <token>` command. The user runs the command on their machine; the helper completes the loopback OAuth dance against the provider's authorization server, then POSTs the resulting credentials back to `/api/model-providers-oauth/import` using this token as Bearer credentials. The plaintext token is returned exactly once — only its SHA-256 hash is persisted. Org-scoped: only `X-Org-Id` is required (no `X-Application-Id` — the resulting credential lives in `model_provider_credentials`, which has no app affinity).",
+        "Creates a single-use pairing token surfaced in the dashboard as a `npx @appstrate/connect-helper <token>` command. The user runs the command on their machine; the helper completes the loopback OAuth dance against the provider's authorization server, then POSTs the resulting credentials back to `/api/model-providers-oauth/pair/redeem` using this token as Bearer credentials. (The legacy `/api/model-providers-oauth/import` path remains accepted as a deprecation alias for helper versions already in the wild via `npx`.) The plaintext token is returned exactly once — only its SHA-256 hash is persisted. Org-scoped: only `X-Org-Id` is required (no `X-Application-Id` — the resulting credential lives in `model_provider_credentials`, which has no app affinity).",
       parameters: [{ $ref: "#/components/parameters/XOrgId" }],
       requestBody: {
         required: true,
@@ -45,7 +45,7 @@ export const modelProvidersOAuthPaths = {
                   token: {
                     type: "string",
                     description:
-                      "Plaintext pairing token (`appp_<header>.<secret>`). Returned ONCE — never exposed by GET /pairing/:id. Carry as `Authorization: Bearer <token>` on POST /import.",
+                      "Plaintext pairing token (`appp_<header>.<secret>`). Returned ONCE — never exposed by GET /pairing/:id. Carry as `Authorization: Bearer <token>` on POST /pair/redeem (or the legacy /import alias).",
                   },
                   command: {
                     type: "string",
@@ -147,13 +147,13 @@ export const modelProvidersOAuthPaths = {
       },
     },
   },
-  "/api/model-providers-oauth/import": {
+  "/api/model-providers-oauth/pair/redeem": {
     post: {
-      operationId: "importOAuthModelProviderConnection",
+      operationId: "redeemOAuthModelProviderPairing",
       tags: ["Model Provider Credentials"],
-      summary: "Import an OAuth model provider token bundle from the connect helper",
+      summary: "Redeem a pairing token: post the OAuth credential bundle back to the platform",
       description:
-        "Bearer-only — authenticated by the pairing token previously minted via `POST /api/model-providers-oauth/pairing` (carry as `Authorization: Bearer appp_<token>`). The pairing's `userId` / `orgId` / `providerId` are pinned at mint time and override anything the request body claims, so a tampered helper cannot redirect the import to a different org or provider. Cookie/API-key requests 401. Server-side this re-derives identity slots defensively via the provider's `extractTokenIdentity` hook before persisting into `model_provider_credentials`.",
+        "Canonical pairing-redeem route used by `@appstrate/connect-helper`. Bearer-only — authenticated by the pairing token previously minted via `POST /api/model-providers-oauth/pairing` (carry as `Authorization: Bearer appp_<token>`). The pairing's `userId` / `orgId` / `providerId` are pinned at mint time and override anything the request body claims, so a tampered helper cannot redirect the redeem to a different org or provider. Cookie/API-key requests 401. Server-side this re-derives identity slots defensively via the provider's `extractTokenIdentity` hook before persisting into `model_provider_credentials`.",
       requestBody: {
         required: true,
         content: {
@@ -197,6 +197,87 @@ export const modelProvidersOAuthPaths = {
       responses: {
         "200": {
           description: "Connection persisted; matching provider key created.",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["credentialId", "providerId", "availableModelIds"],
+                properties: {
+                  credentialId: { type: "string", format: "uuid" },
+                  providerId: { type: "string" },
+                  email: { type: "string", format: "email" },
+                  availableModelIds: { type: "array", items: { type: "string" } },
+                },
+              },
+            },
+          },
+        },
+        "400": { $ref: "#/components/responses/ValidationError" },
+        "401": { $ref: "#/components/responses/Unauthorized" },
+        "403": {
+          description: "Forbidden — caller lacks `model-provider-credentials:write`.",
+          content: {
+            "application/problem+json": {
+              schema: { $ref: "#/components/schemas/ProblemDetail" },
+            },
+          },
+        },
+        "404": { $ref: "#/components/responses/NotFound" },
+      },
+    },
+  },
+  "/api/model-providers-oauth/import": {
+    post: {
+      operationId: "importOAuthModelProviderConnection",
+      tags: ["Model Provider Credentials"],
+      summary: "[Deprecated] Legacy alias of POST /api/model-providers-oauth/pair/redeem",
+      description:
+        '**Deprecated.** Use `POST /api/model-providers-oauth/pair/redeem` instead. This path is kept indefinitely as a backward-compatibility alias for `@appstrate/connect-helper` versions already in the wild via `npx @appstrate/connect-helper@latest <token>` — behaviour is identical to the canonical route. Responses carry `Deprecation: true` and a `Link: <…/pair/redeem>; rel="successor-version"` header. Same auth contract: `Authorization: Bearer appp_<token>` only.',
+      deprecated: true,
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["providerId", "label", "accessToken", "refreshToken"],
+              properties: {
+                providerId: {
+                  type: "string",
+                  pattern: "^[a-z0-9-]+$",
+                  description:
+                    "Canonical provider id. Must match the pairing's pinned providerId AND resolve to a registered OAuth provider. Unknown ids → 404; mismatched → 400.",
+                },
+                label: { type: "string", minLength: 1, maxLength: 120 },
+                accessToken: { type: "string", minLength: 1 },
+                refreshToken: { type: "string", minLength: 1 },
+                expiresAt: {
+                  type: ["integer", "null"],
+                  description: "Unix milliseconds since epoch — when the access token expires.",
+                },
+                email: {
+                  type: "string",
+                  format: "email",
+                  maxLength: 320,
+                  description:
+                    "Account email — either forwarded from the OAuth response body or re-derived server-side by the provider's `extractTokenIdentity` hook.",
+                },
+                accountId: {
+                  type: "string",
+                  minLength: 1,
+                  maxLength: 120,
+                  description:
+                    "Abstract account/tenant identifier — the well-known `accountId` slot from the provider's identity surface. When the CLI forwards it, the platform persists this value verbatim; otherwise the provider's `extractTokenIdentity` hook fills it in server-side.",
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "200": {
+          description:
+            'Connection persisted; matching provider key created. Carries `Deprecation: true` and `Link: <…/pair/redeem>; rel="successor-version"`.',
           content: {
             "application/json": {
               schema: {

--- a/apps/api/src/routes/model-providers-oauth.ts
+++ b/apps/api/src/routes/model-providers-oauth.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { z } from "zod";
 import { getEnv } from "@appstrate/env";
 import type { AppEnv } from "../types/index.ts";
@@ -18,6 +18,7 @@ import {
 import { invalidRequest, notFound, parseBody, unauthorized } from "../lib/errors.ts";
 import { recordAuditFromContext } from "../services/audit.ts";
 import { getClientIp } from "../lib/client-ip.ts";
+import { logger } from "../lib/logger.ts";
 
 /**
  * Body shape posted by `npx @appstrate/connect-helper <token>` after it
@@ -62,72 +63,103 @@ const importBody = z.object({
   accountId: z.string().min(1).max(120).optional(),
 });
 
+/**
+ * Pair-redeem handler — shared between the canonical
+ * `POST /api/model-providers-oauth/pair/redeem` route and the legacy
+ * `POST /api/model-providers-oauth/import` alias kept for back-compat with
+ * the `@appstrate/connect-helper` versions already in the wild via `npx`.
+ *
+ * Auth is exclusively `Authorization: Bearer appp_<token>`. The platform
+ * minted the token via POST /pairing (session-auth + RBAC); the helper
+ * POSTs the credentials back here with it as Bearer credentials. We
+ * `consumePairing()` atomically (single-use) — the resulting row's
+ * userId / orgId / providerId override anything the body claims, so a
+ * tampered helper cannot redirect the redeem to a different org or
+ * provider than the user authorized in the dashboard.
+ *
+ * No cookie / API-key path: the dashboard never POSTs to this route,
+ * it only mints pairings + polls their status. `auth-pipeline.ts` lets
+ * requests with `Bearer appp_` skip the cookie/API-key chain; any other
+ * shape lands here and we 401.
+ */
+async function handlePairRedeem(c: Context<AppEnv>) {
+  const authHeader = c.req.header("authorization") ?? c.req.header("Authorization");
+  if (!authHeader?.startsWith("Bearer appp_")) {
+    throw unauthorized(
+      "POST /api/model-providers-oauth/pair/redeem requires a pairing-token bearer (Authorization: Bearer appp_…)",
+    );
+  }
+
+  const token = authHeader.slice(7);
+  const fromIp = getClientIp(c);
+  const consumed = await consumePairing(token, fromIp === "unknown" ? undefined : fromIp);
+
+  const body = await c.req.json();
+  const input = parseBody(importBody, body);
+
+  // Body's providerId MUST match what the pairing was minted for —
+  // otherwise the helper could divert the redeem to a different
+  // provider than the user authorized in the dashboard.
+  if (input.providerId !== consumed.providerId) {
+    throw invalidRequest(
+      `providerId in body (${input.providerId}) does not match pairing (${consumed.providerId})`,
+      "providerId",
+    );
+  }
+
+  const result = await importOAuthModelProviderConnection({
+    ...input,
+    orgId: consumed.orgId,
+    userId: consumed.userId,
+  });
+
+  // Link the new credential back to the pairing row so the dashboard's
+  // GET /pairing/:id poll surfaces it without a separate list call.
+  await linkPairingCredential(consumed.id, result.credentialId);
+
+  await recordAuditFromContext(c, {
+    action: "oauth_model_provider.imported",
+    resourceType: "oauth_model_provider",
+    resourceId: result.credentialId,
+    after: {
+      providerId: result.providerId,
+      credentialId: result.credentialId,
+      availableModelIds: result.availableModelIds,
+      pairingId: consumed.id,
+      // No raw token / email — audit log MUST NOT carry secrets
+    },
+  });
+
+  return c.json(result);
+}
+
 export function createModelProvidersOAuthRouter() {
   const router = new Hono<AppEnv>();
 
-  // POST /api/model-providers-oauth/import
-  //
-  // Auth is exclusively `Authorization: Bearer appp_<token>`. The platform
-  // minted the token via POST /pairing (session-auth + RBAC); the helper
-  // POSTs the credentials back here with it as Bearer credentials. We
-  // `consumePairing()` atomically (single-use) — the resulting row's
-  // userId / orgId / providerId override anything the body claims, so a
-  // tampered helper cannot redirect the import to a different org or
-  // provider than the user authorized in the dashboard.
-  //
-  // No cookie / API-key path: the dashboard never POSTs to this route,
-  // it only mints pairings + polls their status. `auth-pipeline.ts` lets
-  // requests with `Bearer appp_` skip the cookie/API-key chain; any other
-  // shape lands here and we 401.
+  // POST /api/model-providers-oauth/pair/redeem — canonical pairing-redeem
+  // route. `pair` is the canonical noun (mirrors the `model_provider_pairings`
+  // table and the `/pairing` lifecycle endpoints); `redeem` is the verb the
+  // helper performs (consume the one-shot bearer + post credentials back).
+  router.post("/pair/redeem", handlePairRedeem);
+
+  // POST /api/model-providers-oauth/import — legacy alias kept indefinitely
+  // for backward compatibility with `@appstrate/connect-helper` versions
+  // already in the wild via `npx @appstrate/connect-helper@latest <token>`.
+  // Behaviour is identical to the canonical path; the only difference is a
+  // `Deprecation: true` response header + a `logger.warn` so operators can
+  // track adoption of the new path before retiring the alias.
   router.post("/import", async (c) => {
-    const authHeader = c.req.header("authorization") ?? c.req.header("Authorization");
-    if (!authHeader?.startsWith("Bearer appp_")) {
-      throw unauthorized(
-        "POST /api/model-providers-oauth/import requires a pairing-token bearer (Authorization: Bearer appp_…)",
-      );
-    }
-
-    const token = authHeader.slice(7);
-    const fromIp = getClientIp(c);
-    const consumed = await consumePairing(token, fromIp === "unknown" ? undefined : fromIp);
-
-    const body = await c.req.json();
-    const input = parseBody(importBody, body);
-
-    // Body's providerId MUST match what the pairing was minted for —
-    // otherwise the helper could divert the import to a different
-    // provider than the user authorized in the dashboard.
-    if (input.providerId !== consumed.providerId) {
-      throw invalidRequest(
-        `providerId in body (${input.providerId}) does not match pairing (${consumed.providerId})`,
-        "providerId",
-      );
-    }
-
-    const result = await importOAuthModelProviderConnection({
-      ...input,
-      orgId: consumed.orgId,
-      userId: consumed.userId,
-    });
-
-    // Link the new credential back to the pairing row so the dashboard's
-    // GET /pairing/:id poll surfaces it without a separate list call.
-    await linkPairingCredential(consumed.id, result.credentialId);
-
-    await recordAuditFromContext(c, {
-      action: "oauth_model_provider.imported",
-      resourceType: "oauth_model_provider",
-      resourceId: result.credentialId,
-      after: {
-        providerId: result.providerId,
-        credentialId: result.credentialId,
-        availableModelIds: result.availableModelIds,
-        pairingId: consumed.id,
-        // No raw token / email — audit log MUST NOT carry secrets
+    logger.warn(
+      "Deprecated route hit: POST /api/model-providers-oauth/import — clients should migrate to POST /api/model-providers-oauth/pair/redeem",
+      {
+        requestId: c.get("requestId"),
+        path: "/api/model-providers-oauth/import",
+        successor: "/api/model-providers-oauth/pair/redeem",
       },
-    });
-
-    return c.json(result);
+    );
+    c.header("Deprecation", "true");
+    c.header("Link", '</api/model-providers-oauth/pair/redeem>; rel="successor-version"');
+    return handlePairRedeem(c);
   });
 
   // ────────────────────────────────────────────────────────────────────────

--- a/apps/api/test/integration/routes/model-providers-oauth-pair-redeem.test.ts
+++ b/apps/api/test/integration/routes/model-providers-oauth-pair-redeem.test.ts
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Canonical pair-redeem route — `POST /api/model-providers-oauth/pair/redeem`.
+ *
+ * Same handler as the legacy `/import` alias (see
+ * `model-providers-oauth-import-pairing-bearer.test.ts` for the full
+ * single-use / cross-org / cross-provider invariants). This file covers
+ * the canonical-path-specific contract:
+ *   - The canonical path successfully redeems a fresh pairing token.
+ *   - The legacy `/import` alias remains accepted and emits a
+ *     `Deprecation: true` response header + a `Link: <…/pair/redeem>; rel="successor-version"`.
+ *   - The canonical path does NOT emit the deprecation header.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { getTestApp } from "../../helpers/app.ts";
+import { truncateAll } from "../../helpers/db.ts";
+import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
+
+const app = getTestApp();
+
+async function mintPairing(ctx: TestContext, providerId = "test-oauth") {
+  const res = await app.request("/api/model-providers-oauth/pairing", {
+    method: "POST",
+    headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+    body: JSON.stringify({ providerId }),
+  });
+  expect(res.status).toBe(200);
+  return (await res.json()) as {
+    id: string;
+    token: string;
+    command: string;
+    expiresAt: string;
+  };
+}
+
+function bearerHeaders(token: string): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${token}`,
+  };
+}
+
+const VALID_BODY = (providerId = "test-oauth") => ({
+  providerId,
+  label: "Test connection",
+  accessToken: "fake-access-token",
+  refreshToken: "fake-refresh-token",
+  expiresAt: Date.now() + 3600_000,
+  accountId: "11111111-2222-4333-8444-555555555555",
+});
+
+describe("POST /api/model-providers-oauth/pair/redeem — canonical route", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext();
+  });
+
+  it("redeems credentials when authenticated by a fresh pairing token", async () => {
+    const pairing = await mintPairing(ctx, "test-oauth");
+    const res = await app.request("/api/model-providers-oauth/pair/redeem", {
+      method: "POST",
+      headers: bearerHeaders(pairing.token),
+      body: JSON.stringify(VALID_BODY("test-oauth")),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { providerId: string; credentialId: string };
+    expect(body.providerId).toBe("test-oauth");
+    expect(body.credentialId).toBeTruthy();
+  });
+
+  it("does NOT emit Deprecation / Link successor-version response headers", async () => {
+    const pairing = await mintPairing(ctx, "test-oauth");
+    const res = await app.request("/api/model-providers-oauth/pair/redeem", {
+      method: "POST",
+      headers: bearerHeaders(pairing.token),
+      body: JSON.stringify(VALID_BODY("test-oauth")),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Deprecation")).toBeNull();
+    // Allow other Link headers from the framework, but not our successor-version one
+    const link = res.headers.get("Link");
+    expect(link === null || !link.includes("successor-version")).toBe(true);
+  });
+
+  it("rejects missing bearer with 401 (same contract as the alias)", async () => {
+    const res = await app.request("/api/model-providers-oauth/pair/redeem", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(VALID_BODY("test-oauth")),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects malformed bearer with 410 (single error code, no enumeration)", async () => {
+    const res = await app.request("/api/model-providers-oauth/pair/redeem", {
+      method: "POST",
+      headers: bearerHeaders("appp_garbage.notreallyatoken"),
+      body: JSON.stringify(VALID_BODY("test-oauth")),
+    });
+    expect(res.status).toBe(410);
+  });
+});
+
+describe("POST /api/model-providers-oauth/import — legacy alias", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext();
+  });
+
+  it("still works (back-compat for connect-helper versions already in the wild)", async () => {
+    const pairing = await mintPairing(ctx, "test-oauth");
+    const res = await app.request("/api/model-providers-oauth/import", {
+      method: "POST",
+      headers: bearerHeaders(pairing.token),
+      body: JSON.stringify(VALID_BODY("test-oauth")),
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("emits Deprecation: true and a Link: successor-version response header", async () => {
+    const pairing = await mintPairing(ctx, "test-oauth");
+    const res = await app.request("/api/model-providers-oauth/import", {
+      method: "POST",
+      headers: bearerHeaders(pairing.token),
+      body: JSON.stringify(VALID_BODY("test-oauth")),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Deprecation")).toBe("true");
+    const link = res.headers.get("Link") ?? "";
+    expect(link).toContain("/api/model-providers-oauth/pair/redeem");
+    expect(link).toContain('rel="successor-version"');
+  });
+
+  it("treats the canonical and legacy paths as the same single-use pairing (cross-path replay 410s)", async () => {
+    const pairing = await mintPairing(ctx, "test-oauth");
+
+    // Consume via legacy path …
+    const r1 = await app.request("/api/model-providers-oauth/import", {
+      method: "POST",
+      headers: bearerHeaders(pairing.token),
+      body: JSON.stringify(VALID_BODY("test-oauth")),
+    });
+    expect(r1.status).toBe(200);
+
+    // … then a replay on the canonical path must fail (same DB row).
+    const r2 = await app.request("/api/model-providers-oauth/pair/redeem", {
+      method: "POST",
+      headers: bearerHeaders(pairing.token),
+      body: JSON.stringify(VALID_BODY("test-oauth")),
+    });
+    expect(r2.status).toBe(410);
+  });
+});

--- a/scripts/verify-openapi.ts
+++ b/scripts/verify-openapi.ts
@@ -165,7 +165,8 @@ const expectedEndpoints = [
   "DELETE /api/model-provider-credentials/{id}",
   "POST /api/model-provider-credentials/{id}/test",
   // OAuth Model Providers (subscription billing)
-  "POST /api/model-providers-oauth/import",
+  "POST /api/model-providers-oauth/pair/redeem",
+  "POST /api/model-providers-oauth/import", // legacy alias kept for back-compat
   "POST /api/model-providers-oauth/pairing",
   "GET /api/model-providers-oauth/pairing/{id}",
   "DELETE /api/model-providers-oauth/pairing/{id}",


### PR DESCRIPTION
## Summary

- Adopt **`POST /api/model-providers-oauth/pair/redeem`** as the canonical pairing-redeem route, aligning the backend verb with the `model_provider_pairings` table and the existing `/pairing` lifecycle endpoints.
- Keep **`POST /api/model-providers-oauth/import`** indefinitely as a deprecation alias for `@appstrate/connect-helper` versions already in the wild via `npx`.
- Frontend UX wording (`connect`/`connecter`) and the DB-side noun (`pairing`) are unchanged — both were already on the canonical verb for their layer.

## Decision (canonical split)

| Verb | Scope | Status |
| ---- | ----- | ------ |
| `pairing` | Backend rendez-vous + token + `model_provider_pairings` row | unchanged |
| `pair/redeem` | Backend route the helper hits | **new canonical** |
| `import` | Backend route the helper hits | **legacy alias (deprecated)** |
| `connect` / `connecter` | Frontend UX wording | unchanged |

## Deprecation alias contract

The legacy `/import` path is **not** a 301 — it actually handles the request. Behaviour is identical to the canonical route except:

- Response carries `Deprecation: true`
- Response carries `Link: </api/model-providers-oauth/pair/redeem>; rel="successor-version"`
- A `logger.warn` is emitted with the request id + successor path, so operators can track adoption before retiring the alias

`auth-pipeline.ts` bypasses auth (cookie / API-key) for both paths whenever the request carries `Authorization: Bearer appp_…`, so the helper does not need to change anything to keep working.

## OpenAPI

- `/pair/redeem` is the primary entry (full schemas, descriptions)
- `/import` carries `deprecated: true` and a back-pointer in its description
- `verify-openapi` endpoint-coverage list updated with both paths

## Test plan

- [x] `bun run check` — turbo (tsc + eslint + prettier) + `verify:openapi` (272 endpoints) + `detect:breaking` (`/pair/redeem` flagged as non-breaking)
- [x] `bun test apps/api/test/integration/routes/model-providers-oauth-*` — 26 pass, 0 fail
  - Existing `/import` invariants still hold (single-use, cross-org / cross-provider rejection, malformed bearer 410, cookie-only 401)
  - New canonical route: 200 happy path, no deprecation headers, 401 on missing bearer, 410 on malformed bearer
  - New legacy alias contract: still 200s, **emits** `Deprecation: true` + `Link: successor-version`
  - Cross-path single-use: a pairing consumed via `/import` cannot be replayed on `/pair/redeem` (same DB row)

## Follow-up

- `@appstrate/connect-helper` bump targeting `/pair/redeem` will land in a separate PR in the helper repo (the helper is a separate repo per the issue — out of scope here). Existing helper versions on `npm` continue to work via the deprecation alias.

Closes #410