### PR TITLE
fix(ci): rename SYSTEM_PROVIDER_KEYS `api` → `apiShape` in e2e env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
           # /agents/:id/run (e.g. upload-flow). The run pipeline only needs a
           # resolvable model at acceptance time — the dummy apiKey is never
           # called because RUN_ADAPTER=process doesn't actually hit the LLM.
-          SYSTEM_PROVIDER_KEYS: '[{"id":"e2e","label":"E2E","api":"anthropic-messages","baseUrl":"https://example.invalid","apiKey":"e2e-dummy","models":[{"modelId":"claude-sonnet-4-5","label":"E2E Default","isDefault":true}]}]'
+          SYSTEM_PROVIDER_KEYS: '[{"id":"e2e","label":"E2E","apiShape":"anthropic-messages","baseUrl":"https://example.invalid","apiKey":"e2e-dummy","models":[{"modelId":"claude-sonnet-4-5","label":"E2E Default","isDefault":true}]}]'
 
       - name: Upload test report
         if: failure()


### PR DESCRIPTION
## Summary

PR #397 (commit `48368e92`) renamed the Zod field `api` → `apiShape` in `apps/api/src/services/model-registry.ts` (`rawModelProviderKeySchema`), but the e2e workflow's `SYSTEM_PROVIDER_KEYS` JSON kept the legacy key. `safeParse()` rejects every entry, only logs an error (`model-registry.ts:97`), `systemModels` stays empty, `resolveModel()` returns null, and `env-builder.ts:133` throws `ModelNotConfiguredError` → `run-pipeline.ts:243` returns 400.

Two specs hit this on every CI run since #397 merged:
- `upload-flow.api.spec.ts:82` — POST /uploads → PUT → run
- `upload-flow.api.spec.ts:145` — URI reuse 409 path (first run 400s)

PR #415 (previous CI fix) misdiagnosed this as a missing `core-providers` module. `core-providers` populates `getModelProvider(providerId)` — a different code path from `getSystemModels()`, which backs the run-acceptance model resolver. #415 is harmless but doesn't address the real cause; this PR does.

## Follow-up (separate PR)

`initSystemModelProviderKeys()` currently logs invalid entries via `logger.error` and continues. A field rename can therefore ship a green test suite while every production deploy 400s on run. Replacing the silent failure with a fail-fast at boot would catch the next instance of this class of bug.

## Test plan

- [ ] CI passes — Test workflow E2E job goes green
- [ ] No other workflows affected (only `.github/workflows/test.yml` changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)