### PR TITLE
fix(queue): give BullMQ Worker its own duplicated Redis connection

### DIFF
--- a/apps/api/src/infra/queue/bullmq-queue.ts
+++ b/apps/api/src/infra/queue/bullmq-queue.ts
@@ -6,6 +6,7 @@
 
 import { Queue, Worker, UnrecoverableError } from "bullmq";
 import type { ConnectionOptions } from "bullmq";
+import type Redis from "ioredis";
 import { getRedisConnection } from "../../lib/redis.ts";
 import { logger } from "../../lib/logger.ts";
 import type {
@@ -21,6 +22,13 @@ import { PermanentJobError } from "./interface.ts";
 export class BullMQQueue<T> implements JobQueue<T> {
   private queue: Queue<Record<string, unknown>, unknown, string>;
   private worker: Worker<Record<string, unknown>, unknown, string> | null = null;
+  // Owned by THIS queue instance — `worker.close()` disconnects it cleanly
+  // without touching the shared publisher. Sharing the global connection
+  // with the Worker's blocking client leaked an unhandled
+  // "Connection is closed" rejection on shutdown (ioredis flushes the
+  // command queue when the socket closes mid-BRPOP), failing bun:test
+  // files that exercise a full init→shutdown lifecycle.
+  private workerConnection: Redis | null = null;
 
   constructor(
     private readonly name: string,
@@ -70,6 +78,15 @@ export class BullMQQueue<T> implements JobQueue<T> {
   process(handler: JobHandler<T>, opts?: WorkerOptions): void {
     if (this.worker) return;
 
+    this.workerConnection = getRedisConnection().duplicate();
+    // Swallow "Connection is closed" rejections that fire when worker.close()
+    // tears down the blocking client mid-BRPOP. Without this, the unhandled
+    // rejection escapes BullMQ's run loop in some shutdown timings.
+    this.workerConnection.on("error", (err) => {
+      if (err.message === "Connection is closed.") return;
+      logger.error(`${this.name} worker connection error`, { error: err.message });
+    });
+
     this.worker = new Worker<Record<string, unknown>, unknown, string>(
       this.name,
       async (bullJob) => {
@@ -89,7 +106,7 @@ export class BullMQQueue<T> implements JobQueue<T> {
         }
       },
       {
-        connection: getRedisConnection() as unknown as ConnectionOptions,
+        connection: this.workerConnection as unknown as ConnectionOptions,
         ...(opts?.concurrency ? { concurrency: opts.concurrency } : {}),
         ...(opts?.limiter ? { limiter: opts.limiter } : {}),
         ...(opts?.backoffStrategy
@@ -114,6 +131,13 @@ export class BullMQQueue<T> implements JobQueue<T> {
   async shutdown(): Promise<void> {
     await this.worker?.close();
     await this.queue.close();
+    // Ensure the worker's duplicate connection is fully released — BullMQ's
+    // worker.close() drains commands but leaves the ioredis socket open in
+    // some paths, holding the test process alive past file end.
+    if (this.workerConnection && this.workerConnection.status !== "end") {
+      await this.workerConnection.quit().catch(() => {});
+    }
     this.worker = null;
+    this.workerConnection = null;
   }
 }


### PR DESCRIPTION
## Summary

`BullMQQueue` was wiring its Worker against the shared `getRedisConnection()` publisher (`bullmq-queue.ts:92`). `worker.close()` disconnected that shared socket while a BRPOP was in flight; ioredis flushed the pending command with `new Error("Connection is closed")` and the rejection escaped BullMQ's run loop as an unhandled rejection — `bun:test` marks the file as failed.

First test to hit this is `apps/api/test/integration/services/model-providers-pairing-cleanup-worker.test.ts` (introduced by #397). The test itself passes; the file fails on `# Unhandled error between tests`. Integration tests passed on run [25771906264](https://github.com/appstrate/appstrate/actions/runs/25771906264) and failed on run [25772493808](https://github.com/appstrate/appstrate/actions/runs/25772493808) with identical test code → flaky by shutdown timing.

## Changes

- Worker gets `getRedisConnection().duplicate()` (BullMQ-owned, isolated).
- Swallow the specific `Connection is closed.` error on that duplicate.
- `shutdown()` explicitly `quit()`s the duplicate after `worker.close()`.

The Queue keeps the shared publisher (non-blocking ops, no blocking client). The scheduler queue and refresh-worker queue use the same `BullMQQueue` wrapper and benefit from the same fix — they don't currently hit this path because they have no integration test exercising full init→shutdown, but the leak was latent.

## Test plan

- [ ] CI Integration job goes green on this branch.
- [ ] Re-run CI a couple of times to confirm the flake is gone.
- [ ] Local: `cd apps/api && bun test test/integration/services/model-providers-pairing-cleanup-worker.test.ts` runs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)