### PR TITLE
fix(docker): copy module-codex/package.json in runtime-pi + sidecar

### DIFF
--- a/runtime-pi/Dockerfile
+++ b/runtime-pi/Dockerfile
@@ -34,6 +34,7 @@ COPY packages/db/package.json            packages/db/
 COPY packages/emails/package.json        packages/emails/
 COPY packages/env/package.json           packages/env/
 COPY packages/mcp-transport/package.json packages/mcp-transport/
+COPY packages/module-codex/package.json  packages/module-codex/
 COPY packages/runner-pi/package.json     packages/runner-pi/
 COPY packages/shared-types/package.json  packages/shared-types/
 COPY packages/ui/package.json            packages/ui/

--- a/runtime-pi/sidecar/Dockerfile
+++ b/runtime-pi/sidecar/Dockerfile
@@ -32,6 +32,7 @@ COPY packages/db/package.json            packages/db/
 COPY packages/emails/package.json        packages/emails/
 COPY packages/env/package.json           packages/env/
 COPY packages/mcp-transport/package.json packages/mcp-transport/
+COPY packages/module-codex/package.json  packages/module-codex/
 COPY packages/runner-pi/package.json     packages/runner-pi/
 COPY packages/shared-types/package.json  packages/shared-types/
 COPY packages/ui/package.json            packages/ui/


### PR DESCRIPTION
## Summary
- PR #422 fixed the main `Dockerfile`'s deps stage, but left the **same** workspace-graph walk broken in `runtime-pi/Dockerfile` and `runtime-pi/sidecar/Dockerfile`
- Both run `bun install --frozen-lockfile --filter=…`, which still walks the full lockfile graph and dies on the missing `@appstrate/module-codex` manifest
- Caught by the v1.0.0-beta.12 release (pi job failed, sidecar cancelled — release.yml ↓)

## Test plan
- [x] `docker build --target deps -f runtime-pi/Dockerfile .` succeeds
- [x] `docker build --target builder -f runtime-pi/sidecar/Dockerfile .` succeeds
- [ ] CI release.yml green on the next tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)