### PR TITLE
fix(runs): backstop rate-limit failures + cap provider_call fan-out

### DIFF
--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -22,9 +22,9 @@
  * design.
  */
 
-import { and, eq, sql } from "drizzle-orm";
+import { and, desc, eq, sql } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
-import { runs, TERMINAL_RUN_EVENT_TYPES } from "@appstrate/db/schema";
+import { runs, runLogs, TERMINAL_RUN_EVENT_TYPES } from "@appstrate/db/schema";
 import { type CloudEventEnvelope } from "@appstrate/afps-runtime/events";
 import type { RunEvent } from "@appstrate/afps-runtime/types";
 import { emptyRunResult, type RunResult } from "@appstrate/afps-runtime/runner";
@@ -241,6 +241,23 @@ export async function finalizeRun(input: FinalizeRunInput): Promise<void> {
       status = "failed";
       errorMessage = `Output validation failed: ${validation.errors.join("; ")}`;
       outputValidationErrors = validation.errors;
+    }
+  }
+
+  // Adapter-error backstop. The Pi SDK keeps the agent loop alive after
+  // an `appstrate.error` (e.g. OpenAI 429 TPM rate-limit exhausting the
+  // SDK's internal retries) so `runner.run()` resolves without throwing.
+  // The result then lacks an explicit `status` / `error`, defaults to
+  // `success`, and `output` is null because the LLM never produced one.
+  // The `runHadZeroTokens` heuristic below does NOT trigger when partial
+  // tokens were produced before the fatal adapter error. Without this
+  // check, a run that hit an unrecoverable upstream error is reported as
+  // `success` with `result: null`.
+  if (status === "success" && (result.output === null || result.output === undefined)) {
+    const lastAdapterError = await findLastAdapterError(run.id);
+    if (lastAdapterError !== null) {
+      status = "failed";
+      errorMessage = lastAdapterError;
     }
   }
 
@@ -551,6 +568,30 @@ async function runHadZeroTokens(runId: string, result: RunResult): Promise<boole
   if (!row?.tokenUsage) return true;
   const usage = row.tokenUsage as Partial<TokenUsage>;
   return (usage.input_tokens ?? 0) === 0 && (usage.output_tokens ?? 0) === 0;
+}
+
+/**
+ * Last `adapter_error` row written by the {@link PersistingEventSink} for
+ * this run, or `null` when none was recorded. `appstrate.error` events
+ * fired by the Pi SDK on fatal upstream failures (rate-limit exhaustion,
+ * auth failures, malformed responses) land in `run_logs` as
+ * `type='system', event='adapter_error'`. When the runner then resolves
+ * without throwing — which is the SDK's current behaviour for
+ * `stopReason=error` — finalize is the last chance to translate that
+ * trail into a `failed` status. Indexed via `idx_run_logs_lookup`
+ * (run_id, id).
+ */
+async function findLastAdapterError(runId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ message: runLogs.message })
+    .from(runLogs)
+    .where(
+      and(eq(runLogs.runId, runId), eq(runLogs.type, "system"), eq(runLogs.event, "adapter_error")),
+    )
+    .orderBy(desc(runLogs.id))
+    .limit(1);
+  if (!row) return null;
+  return typeof row.message === "string" && row.message.length > 0 ? row.message : null;
 }
 
 function llmUnreachableMessage(run: RunSinkContext): string {

--- a/apps/api/test/integration/routes/runs-events-ingestion.test.ts
+++ b/apps/api/test/integration/routes/runs-events-ingestion.test.ts
@@ -525,6 +525,108 @@ describe("POST /api/runs/:runId/events/finalize — complete result persistence"
   });
 
   // ---------------------------------------------------------------------
+  // Adapter-error backstop (issue #427). When the Pi SDK exhausts its
+  // internal retries on a fatal upstream error (OpenAI 429 TPM, auth
+  // failure, malformed response, …) it emits `appstrate.error` events
+  // but `runner.run()` resolves without throwing. The finalize body
+  // then lacks `status` / `error`, and previously the run was reported
+  // as `success` with `result: null`. Finalize must instead consult
+  // the `adapter_error` trail in `run_logs` and translate it into a
+  // `failed` status with the last error message.
+  // ---------------------------------------------------------------------
+  it("flips success → failed when run_logs contains adapter_error rows and output is null", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/final-agent");
+
+    // Pre-seed the adapter_error trail the way `PersistingEventSink`
+    // would have on real `appstrate.error` ingestion. The shape mirrors
+    // `appstrate-event-sink.ts:appstrate.error` write.
+    await db.insert(runLogs).values([
+      {
+        runId,
+        orgId: ctx.orgId,
+        type: "system",
+        event: "adapter_error",
+        message: "Rate limit reached for gpt-5.4 (gpt-5.4-long-context)",
+        level: "error",
+      },
+      {
+        runId,
+        orgId: ctx.orgId,
+        type: "system",
+        event: "adapter_error",
+        message:
+          "Rate limit reached for gpt-5.4: TPM Limit 400000, Used 248785, Requested 312683. Please try again in 24.22s.",
+        level: "error",
+      },
+    ]);
+
+    // Runner reports success with non-zero tokens (partial output was
+    // produced before the fatal adapter error) but no `output` field —
+    // exactly the shape `runner.run()` resolves with when the Pi SDK
+    // abandons its retries.
+    const res = await postFinalize(runId, {
+      status: "success",
+      durationMs: 100,
+      usage: { input_tokens: 5_000, output_tokens: 1_423 },
+      // No `output` — the LLM never produced a final answer.
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    // Last (most recent) adapter_error wins.
+    expect(row?.error).toMatch(/TPM Limit 400000/);
+  });
+
+  it("preserves success when output is null but no adapter_error rows exist", async () => {
+    // Negative regression: an agent that legitimately has no output
+    // schema and emits no `appstrate.error` must still resolve as
+    // `success`. This pins the backstop's specificity.
+    const runId = await seedRunWithSink(ctx, "@test/final-agent");
+
+    const res = await postFinalize(runId, {
+      status: "success",
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+      // No `output`, no adapter_error pre-seed.
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("success");
+    expect(row?.error).toBeNull();
+  });
+
+  it("preserves success when output is present even if adapter_error rows exist", async () => {
+    // Negative regression: a recovered run (LLM retried successfully
+    // after a transient adapter error) ships a real `output`. The
+    // backstop must NOT punish recovered runs — it only fires on the
+    // "no final output AND adapter trail" combination.
+    const runId = await seedRunWithSink(ctx, "@test/final-agent");
+
+    await db.insert(runLogs).values({
+      runId,
+      orgId: ctx.orgId,
+      type: "system",
+      event: "adapter_error",
+      message: "transient: 429 (retried)",
+      level: "error",
+    });
+
+    const res = await postFinalize(runId, {
+      status: "success",
+      output: { answer: "all good" },
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("success");
+    expect(row?.error).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------
   // Authoritative cost in the finalize body — closes the second race
   // window. The runtime emits `appstrate.metric` as fire-and-forget
   // POST and `process.exit(0)` immediately after finalize returns; if

--- a/bun.lock
+++ b/bun.lock
@@ -2422,6 +2422,10 @@
 
     "@apidevtools/swagger-parser/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
 
+    "@appstrate/api/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@appstrate/ui/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@appstrate/ui/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "@appstrate/web/typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
@@ -2518,6 +2522,8 @@
 
     "ajv-formats/ajv": ["@redocly/ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-F+LMD2IDIXuHxgpLJh3nkLj9+tSaEzoUWd+7fONGq5pe2169FUDjpEkOfEpoGLz1sbZni/69p07OsecNfAOpqA=="],
 
+    "appstrate/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "babel-plugin-macros/cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
     "better-auth/jose": ["jose@6.2.2", "", {}, "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="],
@@ -2592,6 +2598,10 @@
 
     "wrap-ansi/string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
 
+    "@appstrate/api/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "@appstrate/ui/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "@aws-crypto/crc32/@aws-sdk/types/@smithy/types": ["@smithy/types@4.13.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g=="],
 
     "@aws-crypto/crc32c/@aws-sdk/types/@smithy/types": ["@smithy/types@4.13.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g=="],
@@ -2657,6 +2667,8 @@
     "@redocly/config/json-schema-to-ts/ts-algebra": ["ts-algebra@1.2.2", "", {}, "sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA=="],
 
     "@rjsf/validator-ajv8/ajv-formats/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
+
+    "appstrate/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "babel-plugin-macros/cosmiconfig/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 

--- a/runtime-pi/sidecar/README.md
+++ b/runtime-pi/sidecar/README.md
@@ -54,10 +54,11 @@ Byte caps protect the sidecar from OOM but do not reflect the true cost of a too
 
 The sidecar layers two token-aware checks on top of the byte caps (see `token-budget.ts`):
 
-| Knob                                    | Default        | Purpose                                                                                                                                                                                                                 |
-| --------------------------------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `SIDECAR_INLINE_TOOL_OUTPUT_TOKENS`     | 8 000 tokens   | Per-call inline cap. Tool outputs above this spill to the `BlobStore` regardless of size — keeps the agent's context cost per call bounded.                                                                             |
-| `SIDECAR_RUN_TOOL_OUTPUT_BUDGET_TOKENS` | 200 000 tokens | Cumulative ceiling per run. As the agent's tool outputs accumulate, the inline path tightens; once the ceiling is breached, every text response spills. Operators on 1 M-context Sonnet 4.6 deployments can raise this. |
+| Knob                                    | Default        | Purpose                                                                                                                                                                                                                                                                                                                      |
+| --------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SIDECAR_INLINE_TOOL_OUTPUT_TOKENS`     | 8 000 tokens   | Per-call inline cap. Tool outputs above this spill to the `BlobStore` regardless of size — keeps the agent's context cost per call bounded.                                                                                                                                                                                  |
+| `SIDECAR_RUN_TOOL_OUTPUT_BUDGET_TOKENS` | 100 000 tokens | Cumulative ceiling per run. As the agent's tool outputs accumulate, the inline path tightens; once the ceiling is breached, every text response spills. Tightened from 200 K after issue #427 — keeps a default-context run well under upstream TPM windows. Operators on 1 M-context Sonnet 4.6 deployments can raise this. |
+| `SIDECAR_PROVIDER_CALL_CONCURRENCY`     | 3              | Maximum number of concurrent `provider_call` MCP invocations a single run can issue. Caps fan-out so the next LLM turn cannot be stuffed with N parallel-fetched payloads at once (issue #427).                                                                                                                              |
 
 Token estimation uses the Anthropic-recommended **3.5 chars/token** heuristic — deterministic, allocation-free, suitable for the hot path of every `provider_call`. The official `@anthropic-ai/tokenizer` is no longer accurate for Claude 3+ models, and a real tokenizer (tiktoken / `count_tokens` API) would add 5-50 ms per call to the credential-injection round-trip.
 
@@ -70,7 +71,7 @@ Each text-path tool result carries an `appstrate://token-budget` `_meta` payload
     "appstrate://token-budget": {
       "estimatedTokens": 1234,
       "consumedTokens": 5000,
-      "runBudgetTokens": 200000,
+      "runBudgetTokens": 100000,
       "inlineCapTokens": 8000,
       "decision": "inline",
       "reason": "under_inline_cap",

--- a/runtime-pi/sidecar/app.ts
+++ b/runtime-pi/sidecar/app.ts
@@ -3,6 +3,11 @@
 import { timingSafeEqual } from "node:crypto";
 import { Hono, type Context } from "hono";
 import { mountMcp } from "./mcp.ts";
+import {
+  DEFAULT_PROVIDER_CALL_CONCURRENCY,
+  Semaphore,
+  readPositiveConcurrencyEnv,
+} from "./semaphore.ts";
 import { BlobStore } from "./blob-store.ts";
 import {
   LLM_PROXY_TIMEOUT_MS,
@@ -498,9 +503,19 @@ export function createApp(deps: AppDeps): Hono {
     DEFAULT_RUN_OUTPUT_BUDGET_TOKENS,
   );
   const tokenBudget = new TokenBudget({ inlineCapTokens, runBudgetTokens });
+  // Fan-out cap on `provider_call`. Defaults to
+  // {@link DEFAULT_PROVIDER_CALL_CONCURRENCY}; operators raise it for
+  // bandwidth-bound workloads via `SIDECAR_PROVIDER_CALL_CONCURRENCY`.
+  const providerCallSemaphore = new Semaphore(
+    readPositiveConcurrencyEnv(
+      "SIDECAR_PROVIDER_CALL_CONCURRENCY",
+      DEFAULT_PROVIDER_CALL_CONCURRENCY,
+    ),
+  );
   mountMcp(app, {
     blobStore,
     tokenBudget,
+    providerCallSemaphore,
     proxyDeps: {
       config,
       cookieJar,

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -52,6 +52,7 @@ import {
   ErrorCode,
   McpError,
   type AppstrateToolDefinition,
+  type CallToolResult,
   type ReadResourceResult,
   type Resource,
 } from "@appstrate/mcp-transport";
@@ -64,6 +65,7 @@ import {
   PROVIDER_ID_RE,
 } from "./helpers.ts";
 import { TokenBudget } from "./token-budget.ts";
+import { Semaphore } from "./semaphore.ts";
 import { logger } from "./logger.ts";
 
 /**
@@ -282,7 +284,7 @@ interface TokenBudgetMeta {
  * {@link TokenBudget} is wired (tests / embedders).
  */
 function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] {
-  const { blobStore, proxyDeps, tokenBudget } = options;
+  const { blobStore, proxyDeps, tokenBudget, providerCallSemaphore } = options;
   const { config, fetchFn } = proxyDeps;
   const providerCall: AppstrateToolDefinition = {
     descriptor: {
@@ -355,6 +357,29 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
       },
     },
     handler: async (rawArgs) => {
+      // Run-scoped fan-out cap. Without this, an agent that issues N
+      // parallel `provider_call`s funnels their full payloads into the
+      // next LLM turn, blowing past upstream model TPM windows
+      // (issue #427). The permit is held only for the duration of the
+      // upstream HTTP hop; pre-flight validation errors return inside
+      // the try/finally so the permit is always released.
+      const release = providerCallSemaphore ? await providerCallSemaphore.acquire() : null;
+      try {
+        return await providerCallInner(rawArgs);
+      } finally {
+        release?.();
+      }
+    },
+  };
+
+  /**
+   * Inner handler for `provider_call` — extracted so the
+   * concurrency-limiting wrapper above can stay shallow and the
+   * pre-flight validation / upstream HTTP body can keep its existing
+   * control flow without nested closures.
+   */
+  async function providerCallInner(rawArgs: unknown): Promise<CallToolResult> {
+    {
       const args = rawArgs as {
         providerId: string;
         target: string;
@@ -518,8 +543,8 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
         // `provider_call` — the runtime parser requires it.
         attachUpstreamMeta: true,
       });
-    },
-  };
+    }
+  }
 
   const runHistory: AppstrateToolDefinition = {
     descriptor: {
@@ -1117,6 +1142,18 @@ export interface MountMcpOptions {
    * unconditionally via `createApp` (see `app.ts`).
    */
   tokenBudget?: TokenBudget;
+  /**
+   * Run-scoped fan-out limiter for `provider_call`. Caps the number of
+   * concurrent upstream HTTP hops a single run can issue at once.
+   * Without a cap, an agent that fetches N items in parallel (8 Gmail
+   * messages, 20 ClickUp tasks, …) can feed the next LLM turn an
+   * over-sized JSON dump and blow past the upstream model's TPM
+   * window. See issue #427 for the reference incident.
+   *
+   * Optional only so tests / embedders can omit it; production wires a
+   * `Semaphore` unconditionally via `createApp` (see `app.ts`).
+   */
+  providerCallSemaphore?: Semaphore;
 }
 
 export function mountMcp(app: Hono, options: MountMcpOptions): void {

--- a/runtime-pi/sidecar/semaphore.ts
+++ b/runtime-pi/sidecar/semaphore.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tiny single-process concurrency limiter.
+ *
+ * Used by the sidecar to cap the number of in-flight `provider_call`
+ * MCP tool invocations a single run can fan out. Without a cap, an
+ * agent that fetches N items in parallel (8 Gmail messages, 20 ClickUp
+ * tasks, …) can stuff the next LLM turn with hundreds of KB of JSON in
+ * one shot and blow past the upstream model's TPM window. See
+ * issue #427 for the reference incident.
+ *
+ * Bun runs the sidecar on a single-threaded event loop so we don't
+ * need real mutexes — `acquire()` resolves immediately when the
+ * permit budget has room, otherwise it parks the caller on a FIFO
+ * waiter queue. The returned `release` is idempotent (calling it
+ * twice from the same caller doesn't refund two permits) so callers
+ * can safely place it in a `try { … } finally { release(); }`.
+ */
+export class Semaphore {
+  readonly maxConcurrent: number;
+  private active = 0;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(maxConcurrent: number) {
+    if (!Number.isFinite(maxConcurrent) || !Number.isInteger(maxConcurrent) || maxConcurrent <= 0) {
+      throw new Error(
+        `Semaphore: maxConcurrent must be a positive integer, got ${String(maxConcurrent)}.`,
+      );
+    }
+    this.maxConcurrent = maxConcurrent;
+  }
+
+  /** Number of permits currently held. Test-only observability. */
+  get inFlight(): number {
+    return this.active;
+  }
+
+  /** Waiters parked because all permits are held. Test-only observability. */
+  get queued(): number {
+    return this.waiters.length;
+  }
+
+  /**
+   * Acquire a permit. Resolves with a single-shot `release` function —
+   * subsequent calls on the same handle are no-ops, so a `finally`-based
+   * cleanup never accidentally over-releases.
+   */
+  async acquire(): Promise<() => void> {
+    if (this.active < this.maxConcurrent) {
+      this.active++;
+      return this.makeRelease();
+    }
+    await new Promise<void>((resolve) => this.waiters.push(resolve));
+    this.active++;
+    return this.makeRelease();
+  }
+
+  private makeRelease(): () => void {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      this.active--;
+      const next = this.waiters.shift();
+      if (next) next();
+    };
+  }
+}
+
+/**
+ * Default cap on simultaneous `provider_call` MCP invocations per run.
+ * Three matches the typical browsing concurrency a single LLM turn can
+ * usefully exploit while leaving headroom under most providers' per-IP
+ * rate limits. Operators can override via
+ * `SIDECAR_PROVIDER_CALL_CONCURRENCY`.
+ */
+export const DEFAULT_PROVIDER_CALL_CONCURRENCY = 3;
+
+/**
+ * Read a positive-integer concurrency cap from an env var, falling
+ * back to `defaultValue` when unset/empty. Mirrors the
+ * `readPositive*Env` helpers in `helpers.ts` and `token-budget.ts`
+ * so misconfiguration fails loud at sidecar boot.
+ */
+export function readPositiveConcurrencyEnv(name: string, defaultValue: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return defaultValue;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer, got ${JSON.stringify(raw)}.`);
+  }
+  return parsed;
+}

--- a/runtime-pi/sidecar/test/mcp.test.ts
+++ b/runtime-pi/sidecar/test/mcp.test.ts
@@ -1008,3 +1008,82 @@ describe("StreamableHTTPClientTransport interop (smoke test)", () => {
     expect(typeof Client).toBe("function");
   });
 });
+
+describe("POST /mcp — provider_call concurrency cap (issue #427)", () => {
+  // Regression: without a fan-out cap, an agent that issues N parallel
+  // `provider_call`s funnels their full payloads into the next LLM turn
+  // and blows past the upstream model's TPM window. The sidecar caps
+  // simultaneous upstream hops via `SIDECAR_PROVIDER_CALL_CONCURRENCY`
+  // (default 3). This test sets the cap to 2 and verifies that the 3rd
+  // and 4th calls park until earlier permits release.
+
+  it("limits concurrent upstream hops to SIDECAR_PROVIDER_CALL_CONCURRENCY", async () => {
+    process.env.SIDECAR_PROVIDER_CALL_CONCURRENCY = "2";
+    try {
+      let active = 0;
+      let peak = 0;
+      // Each upstream fetch parks until the test releases it. We track
+      // the peak simultaneous in-flight count: if the cap holds, peak
+      // never exceeds 2 across 4 parallel `provider_call` invocations.
+      const gates: Array<() => void> = [];
+      const fetchFn = mock(async () => {
+        active++;
+        if (active > peak) peak = active;
+        await new Promise<void>((resolve) => gates.push(resolve));
+        active--;
+        return new Response('{"ok":true}', {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+      const app = createApp(makeDeps({ fetchFn }));
+
+      const issue = (id: number) =>
+        rpc(app, {
+          method: "tools/call",
+          params: {
+            name: "provider_call",
+            arguments: {
+              providerId: "test-provider",
+              target: `https://api.example.com/items/${id}`,
+              method: "GET",
+            },
+          },
+        });
+
+      const calls = Promise.all([issue(1), issue(2), issue(3), issue(4)]);
+
+      // Yield the event loop enough times for the semaphore queue to
+      // settle. We need the first 2 calls to have reached `fetchFn` —
+      // 50 microtask turns is generous for the JSON-RPC + MCP plumbing.
+      for (let i = 0; i < 50; i++) await Promise.resolve();
+      expect(active).toBeLessThanOrEqual(2);
+      expect(peak).toBeLessThanOrEqual(2);
+      expect(gates.length).toBe(2);
+
+      // Release one permit — exactly one more upstream call should
+      // immediately start. Peak must still be capped at 2.
+      gates.shift()!();
+      for (let i = 0; i < 50; i++) await Promise.resolve();
+      expect(peak).toBeLessThanOrEqual(2);
+
+      // Release the rest so the test can wind down.
+      while (gates.length > 0) {
+        gates.shift()!();
+        for (let i = 0; i < 20; i++) await Promise.resolve();
+      }
+
+      const results = await calls;
+      // All four calls eventually succeed.
+      expect(results).toHaveLength(4);
+      for (const r of results) {
+        const result = r.json.result as { isError?: boolean };
+        expect(result.isError).toBeUndefined();
+      }
+      // Cap held throughout the whole test, not just at the start.
+      expect(peak).toBeLessThanOrEqual(2);
+    } finally {
+      delete process.env.SIDECAR_PROVIDER_CALL_CONCURRENCY;
+    }
+  });
+});

--- a/runtime-pi/sidecar/test/semaphore.test.ts
+++ b/runtime-pi/sidecar/test/semaphore.test.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the sidecar's `provider_call` concurrency limiter.
+ *
+ * The limiter exists to cap the number of in-flight upstream HTTP hops
+ * a single run can issue at once. Without it, an agent fanning out N
+ * parallel `provider_call`s can stuff the next LLM turn with hundreds
+ * of KB of accumulated JSON and blow past the upstream model's TPM
+ * window (issue #427). These tests pin the contract:
+ *
+ *   - capacity enforcement (≤ maxConcurrent simultaneous holders);
+ *   - FIFO release order;
+ *   - idempotent release;
+ *   - env-var parsing fails loud on misconfiguration.
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  DEFAULT_PROVIDER_CALL_CONCURRENCY,
+  Semaphore,
+  readPositiveConcurrencyEnv,
+} from "../semaphore.ts";
+
+describe("Semaphore", () => {
+  it("rejects non-positive caps at construction time", () => {
+    expect(() => new Semaphore(0)).toThrow(/positive integer/);
+    expect(() => new Semaphore(-1)).toThrow(/positive integer/);
+    expect(() => new Semaphore(1.5)).toThrow(/positive integer/);
+    expect(() => new Semaphore(Number.POSITIVE_INFINITY)).toThrow(/positive integer/);
+  });
+
+  it("admits up to maxConcurrent permits immediately", async () => {
+    const sem = new Semaphore(3);
+    const a = await sem.acquire();
+    const b = await sem.acquire();
+    const c = await sem.acquire();
+    expect(sem.inFlight).toBe(3);
+    expect(sem.queued).toBe(0);
+    a();
+    b();
+    c();
+  });
+
+  it("parks the 4th acquirer until a permit is released", async () => {
+    const sem = new Semaphore(3);
+    const a = await sem.acquire();
+    await sem.acquire();
+    await sem.acquire();
+    expect(sem.inFlight).toBe(3);
+
+    let pendingResolved = false;
+    const pending = sem.acquire().then((release) => {
+      pendingResolved = true;
+      return release;
+    });
+
+    // Yield twice to give the pending promise a chance to settle. If
+    // the queue were broken, this would slip through.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(pendingResolved).toBe(false);
+    expect(sem.queued).toBe(1);
+
+    a();
+    const release4 = await pending;
+    expect(pendingResolved).toBe(true);
+    expect(sem.inFlight).toBe(3);
+    release4();
+  });
+
+  it("releases waiters in FIFO order", async () => {
+    const sem = new Semaphore(1);
+    const release1 = await sem.acquire();
+
+    const order: number[] = [];
+    const w1 = sem.acquire().then((r) => {
+      order.push(1);
+      return r;
+    });
+    const w2 = sem.acquire().then((r) => {
+      order.push(2);
+      return r;
+    });
+    const w3 = sem.acquire().then((r) => {
+      order.push(3);
+      return r;
+    });
+
+    release1();
+    const r1 = await w1;
+    r1();
+    const r2 = await w2;
+    r2();
+    const r3 = await w3;
+    r3();
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  it("release is idempotent — double-call doesn't refund two permits", async () => {
+    const sem = new Semaphore(1);
+    const r = await sem.acquire();
+    r();
+    r(); // second call must be a no-op
+
+    // If the second call leaked a permit, this would be 0 after acquire.
+    const r2 = await sem.acquire();
+    expect(sem.inFlight).toBe(1);
+    r2();
+  });
+});
+
+describe("readPositiveConcurrencyEnv", () => {
+  const ENV = "SIDECAR_PROVIDER_CALL_CONCURRENCY_TEST";
+
+  it("returns default when env var is unset", () => {
+    delete process.env[ENV];
+    expect(readPositiveConcurrencyEnv(ENV, 7)).toBe(7);
+  });
+
+  it("returns default when env var is empty", () => {
+    process.env[ENV] = "";
+    expect(readPositiveConcurrencyEnv(ENV, 9)).toBe(9);
+    delete process.env[ENV];
+  });
+
+  it("parses a positive integer override", () => {
+    process.env[ENV] = "12";
+    expect(readPositiveConcurrencyEnv(ENV, 1)).toBe(12);
+    delete process.env[ENV];
+  });
+
+  it("fails loud on zero / negative / non-integer / non-numeric input", () => {
+    for (const bad of ["0", "-1", "1.5", "abc", "NaN"]) {
+      process.env[ENV] = bad;
+      expect(() => readPositiveConcurrencyEnv(ENV, 1)).toThrow(/positive integer/);
+    }
+    delete process.env[ENV];
+  });
+
+  it("DEFAULT_PROVIDER_CALL_CONCURRENCY is a sane positive integer", () => {
+    expect(Number.isInteger(DEFAULT_PROVIDER_CALL_CONCURRENCY)).toBe(true);
+    expect(DEFAULT_PROVIDER_CALL_CONCURRENCY).toBeGreaterThan(0);
+    // Three is a reasonable browse-bandwidth cap; pin the order of
+    // magnitude so a future tweak doesn't accidentally remove the cap.
+    expect(DEFAULT_PROVIDER_CALL_CONCURRENCY).toBeLessThanOrEqual(10);
+  });
+});

--- a/runtime-pi/sidecar/token-budget.ts
+++ b/runtime-pi/sidecar/token-budget.ts
@@ -80,16 +80,26 @@ const CHARS_PER_TOKEN = 3.5;
 export const DEFAULT_INLINE_OUTPUT_TOKENS = 8_000;
 
 /**
- * Default cumulative budget per run. 200 K tokens — the full default
+ * Default cumulative budget per run. 100 K tokens — half the default
  * Claude / Opus context window. The platform reserves additional space
  * for the system prompt, agent instructions, and conversation
  * history; this budget covers tool outputs only.
  *
- * Operators on 1 M-token Sonnet 4.6 deployments will likely raise this
- * via `SIDECAR_RUN_TOOL_OUTPUT_BUDGET_TOKENS`; OSS / dev defaults
- * stay conservative.
+ * Tightened from 200 K after issue #427: an agent fanning out 8
+ * parallel `provider_call`s could pack ~525 KB of JSON (~150 K tokens)
+ * of tool output into a single LLM turn and blow past the upstream
+ * model's TPM window before any retry / Retry-After negotiation
+ * could land. Keeping the ceiling well below typical model context
+ * windows leaves headroom for system prompt + conversation history
+ * while preserving the spill-to-blob escape hatch for anything
+ * heavier.
+ *
+ * Operators on 1 M-token Sonnet 4.6 deployments (or anyone whose
+ * upstream model TPM accommodates more) raise this via
+ * `SIDECAR_RUN_TOOL_OUTPUT_BUDGET_TOKENS`; OSS / dev defaults stay
+ * conservative.
  */
-export const DEFAULT_RUN_OUTPUT_BUDGET_TOKENS = 200_000;
+export const DEFAULT_RUN_OUTPUT_BUDGET_TOKENS = 100_000;
 
 /**
  * Pluggable token estimator. Receives a text payload, returns a


### PR DESCRIPTION
Closes #427.

## Summary

Three independent, surgical fixes for the rate-limit incident in #427 where an agent fanning out 8 parallel Gmail fetches built a 312 K-token LLM request, hit OpenAI's TPM ceiling, exhausted the Pi SDK's internal retries, and was then reported as `status=success` with `result=null`.

- **#3 from the issue — adapter-error backstop in `finalizeRun`.** `apps/api/src/services/run-event-ingestion.ts` now consults the `adapter_error` trail in `run_logs` before defaulting to `success`. When the runner resolves without an explicit status/error AND `result.output` is null/undefined AND the run has recorded `appstrate.error` events, the run is flipped to `failed` with the last adapter error as the user-facing message. This closes the gap the `runHadZeroTokens` heuristic missed (it doesn't fire when partial tokens were produced before the fatal error).

- **#4 from the issue — provider_call concurrency cap.** The sidecar (`runtime-pi/sidecar/mcp.ts` + new `semaphore.ts`) now caps simultaneous upstream HTTP hops at **3** (override via `SIDECAR_PROVIDER_CALL_CONCURRENCY`). Without a cap, an agent that issues N parallel `provider_call`s funnels their full payloads into the next LLM turn and pushes one request past the upstream model's TPM window.

- **#5 from the issue — tightened token budget default.** `DEFAULT_RUN_OUTPUT_BUDGET_TOKENS` drops 200 K → 100 K in `runtime-pi/sidecar/token-budget.ts`. The previous ceiling was the full default Claude context window; cutting it in half leaves room for system prompt + conversation history while preserving the spill-to-blob escape hatch for anything heavier.

## Out of scope (intentional)

- **#1 platform-side TPM bucket** and **#2 `Retry-After` honouring** — both flagged "gros impact / moyen" in the issue. They require platform-side architectural work (Redis token bucket per `(orgId, modelLabel)`, SDK retry-header negotiation) better suited to follow-up PRs. The three fixes in this PR are independent and address the symptom that surfaced the incident: correct run status reporting + reduced ammunition for hitting the rate limit in the first place.

## Test plan

- [x] 3 new finalize integration tests (`apps/api/test/integration/routes/runs-events-ingestion.test.ts`):
  - flips success → failed when run_logs contains adapter_error rows and output is null
  - preserves success when output is null but no adapter_error rows exist (no false positive)
  - preserves success when output is present even if adapter_error rows exist (recovered run, no false positive)
- [x] 10 new semaphore unit tests (`runtime-pi/sidecar/test/semaphore.test.ts`): capacity, FIFO release, idempotent release, env-var parsing
- [x] 1 new MCP integration test (`runtime-pi/sidecar/test/mcp.test.ts`) pinning the concurrency cap end-to-end via a controlled `fetchFn` and gated upstream responses
- [x] All 358 sidecar tests pass
- [x] All 782 API unit tests pass
- [x] All 103 finalize-adjacent integration tests pass (`runs-events-ingestion`, `appstrate-event-sink`, `runs-cancel-convergence`, `runs`, `run-watchdog`, `finalize-convergence`)
- [x] `bun run check` — turbo typecheck + lint + format + OpenAPI validation + breaking-change detector all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)