### PR TITLE
fix(sidecar): honor multipart body shape in provider_call

### DIFF
--- a/runtime-pi/sidecar/credential-proxy.ts
+++ b/runtime-pi/sidecar/credential-proxy.ts
@@ -59,7 +59,17 @@ export type ProviderRequestBody =
   | { kind: "none" }
   | { kind: "buffered"; bytes: ArrayBuffer; text?: string }
   | { kind: "streaming"; stream: ReadableStream }
-  | { kind: "formData"; build: (activeCreds: Record<string, string>) => FormData };
+  | {
+      kind: "formData";
+      build: (activeCreds: Record<string, string>) => FormData;
+      /**
+       * Field-part templates that will undergo `{{var}}` substitution
+       * when `substituteBody: true`. Used by the pre-flight check to
+       * fail-closed on unresolved placeholders — mirrors the buffered
+       * text path. Empty/omitted means no substitution will happen.
+       */
+      fieldTemplates?: string[];
+    };
 
 export interface ProviderCallArgs {
   providerId: string;
@@ -196,7 +206,9 @@ export async function executeProviderCall(
     }
   }
 
-  // 6. Pre-check body placeholder resolution (buffered + substitute path only).
+  // 6. Pre-check body placeholder resolution (buffered text + multipart
+  //    field-parts under substituteBody). Streaming + binary buffered
+  //    bodies are pass-through.
   if (substituteBody && body.kind === "buffered" && body.text !== undefined) {
     const testBody = substituteVars(body.text, creds.credentials);
     const unresolvedInBody = findUnresolvedPlaceholders(testBody);
@@ -205,6 +217,21 @@ export async function executeProviderCall(
         ok: false,
         status: 400,
         error: `Unresolved placeholders in body: {{${unresolvedInBody.join()}}}`,
+      };
+    }
+  }
+  if (substituteBody && body.kind === "formData" && body.fieldTemplates?.length) {
+    const unresolved = new Set<string>();
+    for (const template of body.fieldTemplates) {
+      for (const v of findUnresolvedPlaceholders(substituteVars(template, creds.credentials))) {
+        unresolved.add(v);
+      }
+    }
+    if (unresolved.size) {
+      return {
+        ok: false,
+        status: 400,
+        error: `Unresolved placeholders in body: {{${[...unresolved].join()}}}`,
       };
     }
   }

--- a/runtime-pi/sidecar/credential-proxy.ts
+++ b/runtime-pi/sidecar/credential-proxy.ts
@@ -45,13 +45,21 @@ import { logger } from "./logger.ts";
 
 /**
  * Body modes the proxy core accepts. The HTTP handler can produce
- * any of the three; the MCP handler only ever produces "buffered"
- * (since JSON-RPC carries body as a string).
+ * "none" / "buffered" / "streaming"; the MCP handler produces
+ * "buffered" for text + binary uploads, and "formData" for the
+ * `{ multipart: [...] }` body shape.
+ *
+ * The `formData` variant carries a builder closure rather than a
+ * pre-baked `FormData` so the per-attempt body can be regenerated with
+ * the current credentials — `substituteBody: true` on a string field
+ * part must see the refreshed token after a 401-retry, identical to
+ * the buffered text path.
  */
 export type ProviderRequestBody =
   | { kind: "none" }
   | { kind: "buffered"; bytes: ArrayBuffer; text?: string }
-  | { kind: "streaming"; stream: ReadableStream };
+  | { kind: "streaming"; stream: ReadableStream }
+  | { kind: "formData"; build: (activeCreds: Record<string, string>) => FormData };
 
 export interface ProviderCallArgs {
   providerId: string;
@@ -204,9 +212,10 @@ export async function executeProviderCall(
   /** Build the request body with credential substitution applied. */
   const buildBody = (
     activeCreds: Record<string, string>,
-  ): ArrayBuffer | string | ReadableStream | undefined => {
+  ): ArrayBuffer | string | ReadableStream | FormData | undefined => {
     if (body.kind === "none") return undefined;
     if (body.kind === "streaming") return body.stream;
+    if (body.kind === "formData") return body.build(activeCreds);
     if (substituteBody && body.text !== undefined) {
       return substituteVars(body.text, activeCreds);
     }
@@ -232,6 +241,21 @@ export async function executeProviderCall(
       resolvedHeaders["cookie"] = existing
         ? `${existing}; ${storedCookies.join("; ")}`
         : storedCookies.join("; ");
+    }
+
+    // For the FormData body shape, drop any caller-supplied
+    // multipart Content-Type so Bun's fetch generates the right
+    // `boundary=…` token itself — supplying a stale boundary would
+    // produce a wire-broken request.
+    if (body.kind === "formData") {
+      for (const key of Object.keys(resolvedHeaders)) {
+        if (
+          key.toLowerCase() === "content-type" &&
+          /^multipart\//i.test(resolvedHeaders[key] ?? "")
+        ) {
+          delete resolvedHeaders[key];
+        }
+      }
     }
 
     const init: RequestInit & Record<string, unknown> = {

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -63,6 +63,7 @@ import {
   MAX_REQUEST_BODY_SIZE,
   MAX_RESPONSE_SIZE,
   PROVIDER_ID_RE,
+  substituteVars,
 } from "./helpers.ts";
 import { TokenBudget } from "./token-budget.ts";
 import { Semaphore } from "./semaphore.ts";
@@ -268,6 +269,200 @@ interface TokenBudgetMeta {
 }
 
 /**
+ * Runtime shape of a single `provider_call.body.multipart[]` entry.
+ * Mirrors the JSON Schema on the tool descriptor — kept as an explicit
+ * TS type so the handler can narrow without `as` casts. Two variants:
+ *
+ *   - Field part: `{ name, value }` — a `multipart/form-data` form
+ *     field whose value is a string. `{{var}}` placeholders inside the
+ *     `value` are substituted when `substituteBody: true`.
+ *   - File part: `{ name, filename, bytes: <base64>, encoding, contentType? }`
+ *     — a binary file part. `bytes` is base64-decoded into a `Blob`
+ *     before being appended to the `FormData`. `{{var}}` substitution
+ *     is intentionally NOT applied to binary parts (would corrupt the
+ *     payload). `contentType` defaults to `application/octet-stream`.
+ */
+type MultipartPartArg =
+  | { name: string; value: string }
+  | {
+      name: string;
+      filename: string;
+      bytes: string;
+      encoding: "base64";
+      contentType?: string;
+    };
+
+interface MultipartValidationOk {
+  ok: true;
+  /** Decoded file parts paired with their declared metadata. */
+  files: Array<{ name: string; filename: string; contentType: string; bytes: Uint8Array }>;
+  /** Field parts — string templates that may need {{var}} substitution. */
+  fields: Array<{ name: string; value: string }>;
+  /** Sum of base64-decoded bytes across all file parts (for cap enforcement). */
+  decodedBytes: number;
+}
+
+interface MultipartValidationErr {
+  ok: false;
+  result: CallToolResult;
+}
+
+/**
+ * Validate + decode every entry in `provider_call.body.multipart[]`.
+ * Returns either the fully-decoded parts ready for `FormData` assembly,
+ * or a structured `CallToolResult` describing the first failure (mirrors
+ * the `{ fromBytes }` error shapes — invalid base64, oversize payload).
+ */
+function validateMultipartParts(
+  parts: MultipartPartArg[],
+): MultipartValidationOk | MultipartValidationErr {
+  const files: MultipartValidationOk["files"] = [];
+  const fields: MultipartValidationOk["fields"] = [];
+  let decodedBytes = 0;
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i]!;
+    if ("value" in part) {
+      if (typeof part.name !== "string" || part.name.length === 0) {
+        return {
+          ok: false,
+          result: {
+            content: [
+              {
+                type: "text",
+                text: `provider_call: body.multipart[${i}].name must be a non-empty string.`,
+              },
+            ],
+            isError: true,
+            _meta: PROVIDER_CALL_PREFLIGHT_META,
+          },
+        };
+      }
+      if (typeof part.value !== "string") {
+        return {
+          ok: false,
+          result: {
+            content: [
+              {
+                type: "text",
+                text: `provider_call: body.multipart[${i}].value must be a string. Use the file-part shape ({ name, filename, bytes, encoding }) for binary data.`,
+              },
+            ],
+            isError: true,
+            _meta: PROVIDER_CALL_PREFLIGHT_META,
+          },
+        };
+      }
+      fields.push({ name: part.name, value: part.value });
+      continue;
+    }
+    // File part: { name, filename, bytes, encoding, contentType? }
+    if (part.encoding !== "base64") {
+      return {
+        ok: false,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: `provider_call: body.multipart[${i}].encoding must be "base64" (only standard base64 file parts are supported).`,
+            },
+          ],
+          isError: true,
+          _meta: PROVIDER_CALL_PREFLIGHT_META,
+        },
+      };
+    }
+    if (typeof part.name !== "string" || part.name.length === 0) {
+      return {
+        ok: false,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: `provider_call: body.multipart[${i}].name must be a non-empty string.`,
+            },
+          ],
+          isError: true,
+          _meta: PROVIDER_CALL_PREFLIGHT_META,
+        },
+      };
+    }
+    if (typeof part.filename !== "string" || part.filename.length === 0) {
+      return {
+        ok: false,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: `provider_call: body.multipart[${i}].filename must be a non-empty string.`,
+            },
+          ],
+          isError: true,
+          _meta: PROVIDER_CALL_PREFLIGHT_META,
+        },
+      };
+    }
+    const decoded = decodeStrictBase64(part.bytes);
+    if (decoded === "invalid") {
+      return {
+        ok: false,
+        result: {
+          content: [
+            {
+              type: "text",
+              text: `provider_call: body.multipart[${i}].bytes is not standard base64 (RFC 4648 §4, alphabet \`+/\`, no whitespace).`,
+            },
+          ],
+          isError: true,
+          _meta: PROVIDER_CALL_PREFLIGHT_META,
+        },
+      };
+    }
+    decodedBytes += decoded.byteLength;
+    if (decodedBytes > MAX_REQUEST_BODY_SIZE) {
+      return {
+        ok: false,
+        result: {
+          content: [
+            {
+              type: "text",
+              text:
+                `provider_call: body.multipart sum of decoded file bytes is ${decodedBytes} bytes ` +
+                `(at index ${i}), which exceeds the per-request limit of ${MAX_REQUEST_BODY_SIZE} ` +
+                `bytes. Operators can raise the cap with SIDECAR_MAX_REQUEST_BODY_BYTES (and ` +
+                `SIDECAR_MAX_MCP_ENVELOPE_BYTES, since base64 inflation must still fit the ` +
+                `JSON-RPC envelope).`,
+            },
+          ],
+          structuredContent: {
+            error: {
+              code: "PAYLOAD_TOO_LARGE",
+              scope: "request_body",
+              limit: MAX_REQUEST_BODY_SIZE,
+              actual: decodedBytes,
+              envVar: "SIDECAR_MAX_REQUEST_BODY_BYTES",
+            },
+          },
+          isError: true,
+          _meta: PROVIDER_CALL_PREFLIGHT_META,
+        },
+      };
+    }
+    files.push({
+      name: part.name,
+      filename: part.filename,
+      contentType:
+        typeof part.contentType === "string" && part.contentType.length > 0
+          ? part.contentType
+          : "application/octet-stream",
+      bytes: decoded,
+    });
+  }
+
+  return { ok: true, files, fields, decodedBytes };
+}
+
+/**
  * Build the `provider_call`, `run_history`, and `recall_memory` MCP
  * tool definitions. All three tools are implemented in-process —
  * `provider_call` calls {@link executeProviderCall} directly via
@@ -331,9 +526,19 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
           },
           body: {
             description:
-              "Request body. Use a string for text/JSON endpoints, or " +
-              "`{ fromBytes: <base64>, encoding: 'base64' }` for binary uploads. " +
-              "Standard base64 (RFC 4648 §4) only — no URL-safe alphabet, no whitespace.",
+              "Request body. Three shapes:\n" +
+              "  - string: text/JSON endpoints.\n" +
+              "  - { fromBytes: <base64>, encoding: 'base64' }: binary uploads. " +
+              "Standard base64 (RFC 4648 §4) only — no URL-safe alphabet, no whitespace.\n" +
+              "  - { multipart: [...] }: multipart/form-data uploads. The sidecar " +
+              "builds a `FormData` from the supplied parts and lets `fetch()` set the " +
+              "`Content-Type: multipart/form-data; boundary=…` header itself — any " +
+              "caller-supplied multipart Content-Type is stripped (the boundary token " +
+              "must match the body bytes). Each part is either " +
+              "`{ name, value }` (a string field) or " +
+              "`{ name, filename, bytes: <base64>, encoding: 'base64', contentType? }` " +
+              "(a file part). Decoded byte sizes summed across all parts must fit " +
+              "SIDECAR_MAX_REQUEST_BODY_BYTES.",
             oneOf: [
               { type: "string" },
               {
@@ -343,6 +548,42 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
                 properties: {
                   fromBytes: { type: "string" },
                   encoding: { const: "base64" },
+                },
+              },
+              {
+                type: "object",
+                additionalProperties: false,
+                required: ["multipart"],
+                properties: {
+                  multipart: {
+                    type: "array",
+                    minItems: 1,
+                    items: {
+                      oneOf: [
+                        {
+                          type: "object",
+                          additionalProperties: false,
+                          required: ["name", "value"],
+                          properties: {
+                            name: { type: "string", minLength: 1 },
+                            value: { type: "string" },
+                          },
+                        },
+                        {
+                          type: "object",
+                          additionalProperties: false,
+                          required: ["name", "filename", "bytes", "encoding"],
+                          properties: {
+                            name: { type: "string", minLength: 1 },
+                            filename: { type: "string", minLength: 1 },
+                            bytes: { type: "string" },
+                            encoding: { const: "base64" },
+                            contentType: { type: "string" },
+                          },
+                        },
+                      ],
+                    },
+                  },
                 },
               },
             ],
@@ -385,7 +626,10 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
         target: string;
         method?: string;
         headers?: Record<string, string>;
-        body?: string | { fromBytes: string; encoding: "base64" };
+        body?:
+          | string
+          | { fromBytes: string; encoding: "base64" }
+          | { multipart: MultipartPartArg[] };
         substituteBody?: boolean;
       };
 
@@ -427,16 +671,49 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
         };
       }
 
-      // Resolve the request body to raw bytes. Two shapes supported:
+      // Resolve the request body to raw bytes. Three shapes supported:
       //  - string: TextEncoder → bytes (text/JSON endpoints)
       //  - { fromBytes, encoding: "base64" }: base64 → bytes (binary
       //    uploads — runtime resolvers materialise workspace files into
       //    this shape before MCP because JSON-RPC has no native byte
       //    type and forwarding bytes as a string corrupts non-UTF-8
       //    payloads).
+      //  - { multipart: [...] }: structured multipart/form-data. The
+      //    sidecar builds a `FormData` and lets `fetch()` set the
+      //    Content-Type so the boundary token matches the body bytes.
       let buffered: ArrayBuffer | undefined;
       let bodyText: string | undefined;
-      if (typeof args.body === "string") {
+      let multipartBody: { build: (activeCreds: Record<string, string>) => FormData } | undefined;
+      if (args.body && typeof args.body === "object" && "multipart" in args.body) {
+        const validation = validateMultipartParts(args.body.multipart);
+        if (!validation.ok) {
+          return validation.result;
+        }
+        const { files, fields } = validation;
+        const wantsSubstitution = !!args.substituteBody;
+        multipartBody = {
+          build: (activeCreds: Record<string, string>): FormData => {
+            const fd = new FormData();
+            // Field parts honour {{var}} substitution when opted in;
+            // binary parts intentionally pass through (substituting into
+            // bytes would corrupt the payload).
+            for (const f of fields) {
+              const value = wantsSubstitution ? substituteVars(f.value, activeCreds) : f.value;
+              fd.append(f.name, value);
+            }
+            for (const file of files) {
+              // Slice into a fresh ArrayBuffer so the Blob owns a copy
+              // independent of the Uint8Array's backing buffer.
+              const ab = file.bytes.buffer.slice(
+                file.bytes.byteOffset,
+                file.bytes.byteOffset + file.bytes.byteLength,
+              ) as ArrayBuffer;
+              fd.append(file.name, new Blob([ab], { type: file.contentType }), file.filename);
+            }
+            return fd;
+          },
+        };
+      } else if (typeof args.body === "string") {
         buffered = new TextEncoder().encode(args.body).buffer;
         bodyText = args.body;
       } else if (args.body && typeof args.body === "object" && "fromBytes" in args.body) {
@@ -508,13 +785,15 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
           targetUrl: args.target,
           method,
           callerHeaders,
-          body: buffered
-            ? {
-                kind: "buffered",
-                bytes: buffered,
-                ...(bodyText !== undefined && args.substituteBody ? { text: bodyText } : {}),
-              }
-            : { kind: "none" },
+          body: multipartBody
+            ? { kind: "formData" as const, build: multipartBody.build }
+            : buffered
+              ? {
+                  kind: "buffered" as const,
+                  bytes: buffered,
+                  ...(bodyText !== undefined && args.substituteBody ? { text: bodyText } : {}),
+                }
+              : { kind: "none" as const },
           substituteBody: !!args.substituteBody,
           proxyUrl: config.proxyUrl,
         },

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -269,6 +269,18 @@ interface TokenBudgetMeta {
 }
 
 /**
+ * Per-part metadata caps. Each is caller-supplied and ends up in MIME
+ * part headers (`Content-Disposition: name="…"; filename="…"` /
+ * `Content-Type: …`); none are counted by `MAX_REQUEST_BODY_SIZE`
+ * (which sums decoded file bytes). Without these, a 10 MB `filename`
+ * string would pass every existing check.
+ */
+const MAX_MULTIPART_PARTS = 256;
+const MAX_MULTIPART_NAME_LENGTH = 256;
+const MAX_MULTIPART_FILENAME_LENGTH = 1024;
+const MAX_MULTIPART_CONTENT_TYPE_LENGTH = 256;
+
+/**
  * Runtime shape of a single `provider_call.body.multipart[]` entry.
  * Mirrors the JSON Schema on the tool descriptor — kept as an explicit
  * TS type so the handler can narrow without `as` casts. Two variants:
@@ -307,146 +319,122 @@ interface MultipartValidationErr {
   result: CallToolResult;
 }
 
+/** Build a preflight error `CallToolResult` for multipart validation. */
+function multipartError(
+  text: string,
+  structuredContent?: CallToolResult["structuredContent"],
+): MultipartValidationErr {
+  return {
+    ok: false,
+    result: {
+      content: [{ type: "text", text }],
+      ...(structuredContent ? { structuredContent } : {}),
+      isError: true,
+      _meta: PROVIDER_CALL_PREFLIGHT_META,
+    },
+  };
+}
+
 /**
  * Validate + decode every entry in `provider_call.body.multipart[]`.
  * Returns either the fully-decoded parts ready for `FormData` assembly,
  * or a structured `CallToolResult` describing the first failure (mirrors
  * the `{ fromBytes }` error shapes — invalid base64, oversize payload).
+ *
+ * `parts` is typed as `unknown` because the MCP SDK does NOT validate
+ * `tools/call` arguments against the descriptor's `inputSchema` — a
+ * caller could pass a non-array (string/object/null) and the loop would
+ * either no-op or emit a confusing per-char error. The first check
+ * here is the runtime guard.
  */
-function validateMultipartParts(
-  parts: MultipartPartArg[],
-): MultipartValidationOk | MultipartValidationErr {
+function validateMultipartParts(parts: unknown): MultipartValidationOk | MultipartValidationErr {
+  if (!Array.isArray(parts)) {
+    return multipartError("provider_call: body.multipart must be an array of parts.");
+  }
+  if (parts.length === 0) {
+    return multipartError("provider_call: body.multipart must contain at least one part.");
+  }
+  if (parts.length > MAX_MULTIPART_PARTS) {
+    return multipartError(
+      `provider_call: body.multipart has ${parts.length} parts, which exceeds the per-request limit of ${MAX_MULTIPART_PARTS}.`,
+    );
+  }
+
   const files: MultipartValidationOk["files"] = [];
   const fields: MultipartValidationOk["fields"] = [];
   let decodedBytes = 0;
 
   for (let i = 0; i < parts.length; i++) {
-    const part = parts[i]!;
+    const part = parts[i] as MultipartPartArg | undefined;
+    if (!part || typeof part !== "object") {
+      return multipartError(`provider_call: body.multipart[${i}] must be an object.`);
+    }
+    if (typeof (part as { name?: unknown }).name !== "string" || part.name.length === 0) {
+      return multipartError(`provider_call: body.multipart[${i}].name must be a non-empty string.`);
+    }
+    if (part.name.length > MAX_MULTIPART_NAME_LENGTH) {
+      return multipartError(
+        `provider_call: body.multipart[${i}].name length ${part.name.length} exceeds the per-part limit of ${MAX_MULTIPART_NAME_LENGTH}.`,
+      );
+    }
     if ("value" in part) {
-      if (typeof part.name !== "string" || part.name.length === 0) {
-        return {
-          ok: false,
-          result: {
-            content: [
-              {
-                type: "text",
-                text: `provider_call: body.multipart[${i}].name must be a non-empty string.`,
-              },
-            ],
-            isError: true,
-            _meta: PROVIDER_CALL_PREFLIGHT_META,
-          },
-        };
-      }
       if (typeof part.value !== "string") {
-        return {
-          ok: false,
-          result: {
-            content: [
-              {
-                type: "text",
-                text: `provider_call: body.multipart[${i}].value must be a string. Use the file-part shape ({ name, filename, bytes, encoding }) for binary data.`,
-              },
-            ],
-            isError: true,
-            _meta: PROVIDER_CALL_PREFLIGHT_META,
-          },
-        };
+        return multipartError(
+          `provider_call: body.multipart[${i}].value must be a string. Use the file-part shape ({ name, filename, bytes, encoding }) for binary data.`,
+        );
       }
       fields.push({ name: part.name, value: part.value });
       continue;
     }
     // File part: { name, filename, bytes, encoding, contentType? }
     if (part.encoding !== "base64") {
-      return {
-        ok: false,
-        result: {
-          content: [
-            {
-              type: "text",
-              text: `provider_call: body.multipart[${i}].encoding must be "base64" (only standard base64 file parts are supported).`,
-            },
-          ],
-          isError: true,
-          _meta: PROVIDER_CALL_PREFLIGHT_META,
-        },
-      };
-    }
-    if (typeof part.name !== "string" || part.name.length === 0) {
-      return {
-        ok: false,
-        result: {
-          content: [
-            {
-              type: "text",
-              text: `provider_call: body.multipart[${i}].name must be a non-empty string.`,
-            },
-          ],
-          isError: true,
-          _meta: PROVIDER_CALL_PREFLIGHT_META,
-        },
-      };
+      return multipartError(
+        `provider_call: body.multipart[${i}].encoding must be "base64" (only standard base64 file parts are supported).`,
+      );
     }
     if (typeof part.filename !== "string" || part.filename.length === 0) {
-      return {
-        ok: false,
-        result: {
-          content: [
-            {
-              type: "text",
-              text: `provider_call: body.multipart[${i}].filename must be a non-empty string.`,
-            },
-          ],
-          isError: true,
-          _meta: PROVIDER_CALL_PREFLIGHT_META,
-        },
-      };
+      return multipartError(
+        `provider_call: body.multipart[${i}].filename must be a non-empty string.`,
+      );
+    }
+    if (part.filename.length > MAX_MULTIPART_FILENAME_LENGTH) {
+      return multipartError(
+        `provider_call: body.multipart[${i}].filename length ${part.filename.length} exceeds the per-part limit of ${MAX_MULTIPART_FILENAME_LENGTH}.`,
+      );
+    }
+    if (
+      part.contentType !== undefined &&
+      (typeof part.contentType !== "string" ||
+        part.contentType.length > MAX_MULTIPART_CONTENT_TYPE_LENGTH)
+    ) {
+      return multipartError(
+        `provider_call: body.multipart[${i}].contentType must be a string of at most ${MAX_MULTIPART_CONTENT_TYPE_LENGTH} characters.`,
+      );
     }
     const decoded = decodeStrictBase64(part.bytes);
     if (decoded === "invalid") {
-      return {
-        ok: false,
-        result: {
-          content: [
-            {
-              type: "text",
-              text: `provider_call: body.multipart[${i}].bytes is not standard base64 (RFC 4648 §4, alphabet \`+/\`, no whitespace).`,
-            },
-          ],
-          isError: true,
-          _meta: PROVIDER_CALL_PREFLIGHT_META,
-        },
-      };
+      return multipartError(
+        `provider_call: body.multipart[${i}].bytes is not standard base64 (RFC 4648 §4, alphabet \`+/\`, no whitespace).`,
+      );
     }
     decodedBytes += decoded.byteLength;
     if (decodedBytes > MAX_REQUEST_BODY_SIZE) {
-      return {
-        ok: false,
-        result: {
-          content: [
-            {
-              type: "text",
-              text:
-                `provider_call: body.multipart sum of decoded file bytes is ${decodedBytes} bytes ` +
-                `(at index ${i}), which exceeds the per-request limit of ${MAX_REQUEST_BODY_SIZE} ` +
-                `bytes. Operators can raise the cap with SIDECAR_MAX_REQUEST_BODY_BYTES (and ` +
-                `SIDECAR_MAX_MCP_ENVELOPE_BYTES, since base64 inflation must still fit the ` +
-                `JSON-RPC envelope).`,
-            },
-          ],
-          structuredContent: {
-            error: {
-              code: "PAYLOAD_TOO_LARGE",
-              scope: "request_body",
-              limit: MAX_REQUEST_BODY_SIZE,
-              actual: decodedBytes,
-              envVar: "SIDECAR_MAX_REQUEST_BODY_BYTES",
-            },
+      return multipartError(
+        `provider_call: body.multipart sum of decoded file bytes is ${decodedBytes} bytes ` +
+          `(at index ${i}), which exceeds the per-request limit of ${MAX_REQUEST_BODY_SIZE} ` +
+          `bytes. Operators can raise the cap with SIDECAR_MAX_REQUEST_BODY_BYTES (and ` +
+          `SIDECAR_MAX_MCP_ENVELOPE_BYTES, since base64 inflation must still fit the ` +
+          `JSON-RPC envelope).`,
+        {
+          error: {
+            code: "PAYLOAD_TOO_LARGE",
+            scope: "request_body",
+            limit: MAX_REQUEST_BODY_SIZE,
+            actual: decodedBytes,
+            envVar: "SIDECAR_MAX_REQUEST_BODY_BYTES",
           },
-          isError: true,
-          _meta: PROVIDER_CALL_PREFLIGHT_META,
         },
-      };
+      );
     }
     files.push({
       name: part.name,
@@ -558,6 +546,7 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
                   multipart: {
                     type: "array",
                     minItems: 1,
+                    maxItems: MAX_MULTIPART_PARTS,
                     items: {
                       oneOf: [
                         {
@@ -565,7 +554,11 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
                           additionalProperties: false,
                           required: ["name", "value"],
                           properties: {
-                            name: { type: "string", minLength: 1 },
+                            name: {
+                              type: "string",
+                              minLength: 1,
+                              maxLength: MAX_MULTIPART_NAME_LENGTH,
+                            },
                             value: { type: "string" },
                           },
                         },
@@ -574,11 +567,22 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
                           additionalProperties: false,
                           required: ["name", "filename", "bytes", "encoding"],
                           properties: {
-                            name: { type: "string", minLength: 1 },
-                            filename: { type: "string", minLength: 1 },
+                            name: {
+                              type: "string",
+                              minLength: 1,
+                              maxLength: MAX_MULTIPART_NAME_LENGTH,
+                            },
+                            filename: {
+                              type: "string",
+                              minLength: 1,
+                              maxLength: MAX_MULTIPART_FILENAME_LENGTH,
+                            },
                             bytes: { type: "string" },
                             encoding: { const: "base64" },
-                            contentType: { type: "string" },
+                            contentType: {
+                              type: "string",
+                              maxLength: MAX_MULTIPART_CONTENT_TYPE_LENGTH,
+                            },
                           },
                         },
                       ],
@@ -683,7 +687,12 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
       //    Content-Type so the boundary token matches the body bytes.
       let buffered: ArrayBuffer | undefined;
       let bodyText: string | undefined;
-      let multipartBody: { build: (activeCreds: Record<string, string>) => FormData } | undefined;
+      let multipartBody:
+        | {
+            build: (activeCreds: Record<string, string>) => FormData;
+            fieldTemplates: string[];
+          }
+        | undefined;
       if (args.body && typeof args.body === "object" && "multipart" in args.body) {
         const validation = validateMultipartParts(args.body.multipart);
         if (!validation.ok) {
@@ -692,6 +701,7 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
         const { files, fields } = validation;
         const wantsSubstitution = !!args.substituteBody;
         multipartBody = {
+          fieldTemplates: wantsSubstitution ? fields.map((f) => f.value) : [],
           build: (activeCreds: Record<string, string>): FormData => {
             const fd = new FormData();
             // Field parts honour {{var}} substitution when opted in;
@@ -786,7 +796,11 @@ function buildSidecarTools(options: MountMcpOptions): AppstrateToolDefinition[] 
           method,
           callerHeaders,
           body: multipartBody
-            ? { kind: "formData" as const, build: multipartBody.build }
+            ? {
+                kind: "formData" as const,
+                build: multipartBody.build,
+                fieldTemplates: multipartBody.fieldTemplates,
+              }
             : buffered
               ? {
                   kind: "buffered" as const,

--- a/runtime-pi/sidecar/test/multipart.test.ts
+++ b/runtime-pi/sidecar/test/multipart.test.ts
@@ -288,6 +288,146 @@ describe("POST /mcp — provider_call multipart/form-data", () => {
     expect(capturedContentType!.includes("AAAAAA")).toBe(false);
   });
 
+  it("does NOT strip caller-supplied non-multipart Content-Type headers", async () => {
+    // The strip filter must be scoped to `multipart/*` — a caller that
+    // accidentally sets `Content-Type: application/json` alongside a
+    // multipart body should still have that header pass through (the
+    // FormData body will then override it on the Request, but the
+    // filter regex must not match).
+    let capturedContentType: string | null = null;
+    const fetchFn = mock(async (_url: string, init?: RequestInit) => {
+      // Read directly off the init.headers map — this lets us observe
+      // whether the sidecar's strip filter touched it, independent of
+      // whatever fetch() does at Request construction time.
+      const rawHeaders = init?.headers as Record<string, string> | undefined;
+      capturedContentType = rawHeaders?.["Content-Type"] ?? rawHeaders?.["content-type"] ?? null;
+      return new Response("{}", { status: 200 });
+    });
+    const app = createApp(makeMultipartDeps({ fetchFn: fetchFn as unknown as typeof fetch }));
+
+    await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "@appstrate/test",
+          target: "https://api.example.com/sink",
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: { multipart: [{ name: "f", value: "v" }] },
+        },
+      },
+    });
+    // Non-multipart Content-Type survived the strip filter.
+    expect(capturedContentType).not.toBeNull();
+    expect(capturedContentType!).toBe("application/json");
+  });
+
+  it("fail-closes on unresolved {{placeholders}} in field-part values under substituteBody", async () => {
+    // Mirror of the buffered text path: a typo in a `{{var}}` template
+    // (`access_tokn` vs `access_token`) must surface as a 400-style
+    // preflight error rather than silently shipping the literal
+    // `{{access_tokn}}` to the upstream third party.
+    const fetchFn = mock(async () => new Response("{}", { status: 200 }));
+    const app = createApp(makeMultipartDeps({ fetchFn: fetchFn as unknown as typeof fetch }));
+
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "@appstrate/test",
+          target: "https://api.example.com/sink",
+          method: "POST",
+          substituteBody: true,
+          body: {
+            multipart: [{ name: "token", value: "Bearer {{access_tokn}}" }],
+          },
+        },
+      },
+    });
+    const result = res.json.result as { content: Array<{ text: string }>; isError?: boolean };
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("Unresolved placeholders in body");
+    expect(result.content[0]!.text).toContain("access_tokn");
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("rejects a non-array body.multipart with a clear runtime guard", async () => {
+    // The MCP SDK does NOT validate tools/call arguments against the
+    // descriptor's inputSchema, so a caller can pass `multipart: "x"`.
+    // The handler must reject it with a structured error instead of
+    // iterating a string char-by-char.
+    const app = createApp(makeMultipartDeps());
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "@appstrate/test",
+          target: "https://api.example.com/sink",
+          method: "POST",
+          body: { multipart: "oops" as unknown as object[] },
+        },
+      },
+    });
+    const result = res.json.result as { content: Array<{ text: string }>; isError?: boolean };
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("must be an array");
+  });
+
+  it("rejects body.multipart with more than MAX_MULTIPART_PARTS entries", async () => {
+    // Without this cap, a caller could supply 100k single-byte parts
+    // that fit every other check (envelope cap, decoded-bytes cap) but
+    // allocate 100k Blobs + FormData entries.
+    const tooMany = Array.from({ length: 257 }, (_, i) => ({ name: `f${i}`, value: "v" }));
+    const app = createApp(makeMultipartDeps());
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "@appstrate/test",
+          target: "https://api.example.com/sink",
+          method: "POST",
+          body: { multipart: tooMany },
+        },
+      },
+    });
+    const result = res.json.result as { content: Array<{ text: string }>; isError?: boolean };
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("exceeds the per-request limit of 256");
+  });
+
+  it("rejects a part with an oversize filename", async () => {
+    const app = createApp(makeMultipartDeps());
+    const huge = "x".repeat(1025);
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "@appstrate/test",
+          target: "https://api.example.com/sink",
+          method: "POST",
+          body: {
+            multipart: [
+              {
+                name: "f",
+                filename: huge,
+                bytes: Buffer.from("x").toString("base64"),
+                encoding: "base64",
+              },
+            ],
+          },
+        },
+      },
+    });
+    const result = res.json.result as { content: Array<{ text: string }>; isError?: boolean };
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("filename length");
+  });
+
   it("returns 413 with structured PAYLOAD_TOO_LARGE when summed file bytes exceed the cap", async () => {
     // Two parts that together overflow MAX_REQUEST_BODY_SIZE even
     // though each individually fits — verifies the cap is the SUM, not

--- a/runtime-pi/sidecar/test/multipart.test.ts
+++ b/runtime-pi/sidecar/test/multipart.test.ts
@@ -1,0 +1,388 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for the `{ multipart: [...] }` body shape of `provider_call`.
+ *
+ * The MCP handler validates parts via the structured Zod-like guard in
+ * `mcp.ts`, builds a standard `FormData` (so Bun's `fetch()` controls
+ * the `Content-Type: multipart/form-data; boundary=…` header), strips
+ * any caller-supplied `Content-Type: multipart/...` header, and lets
+ * `executeProviderCall` regenerate the body per attempt for the
+ * 401-retry path. These tests pin the wire-format guarantees:
+ *
+ *   - Upstream sees `multipart/form-data` with a well-formed boundary.
+ *   - All parts round-trip via `Request#formData()`.
+ *   - Binary file parts match byte-for-byte.
+ *   - `{{var}}` substitution applies to string field parts only when
+ *     `substituteBody: true`, never to binary part bytes.
+ *   - 413 + structured PAYLOAD_TOO_LARGE error when the sum of decoded
+ *     file bytes exceeds SIDECAR_MAX_REQUEST_BODY_BYTES.
+ *   - `tools/list` advertises the multipart shape.
+ */
+
+import { describe, it, expect, mock } from "bun:test";
+import { createApp, type AppDeps } from "../app.ts";
+import { MAX_REQUEST_BODY_SIZE } from "../helpers.ts";
+import type { CredentialsResponse } from "../helpers.ts";
+
+function makeMultipartDeps(overrides?: Partial<AppDeps>): AppDeps {
+  return {
+    config: { platformApiUrl: "http://mock:3000", runToken: "tok", proxyUrl: "" },
+    fetchCredentials: mock(
+      async (): Promise<CredentialsResponse> => ({
+        credentials: { access_token: "tok-abc" },
+        authorizedUris: ["https://api.example.com/**"],
+        allowAllUris: false,
+        credentialHeaderName: "Authorization",
+        credentialHeaderPrefix: "Bearer",
+        credentialFieldName: "access_token",
+      }),
+    ),
+    cookieJar: new Map(),
+    fetchFn: mock(
+      async () =>
+        new Response('{"ok":true}', {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ),
+    isReady: () => true,
+    ...overrides,
+  };
+}
+
+async function rpc(
+  app: ReturnType<typeof createApp>,
+  body: { method: string; params?: unknown },
+): Promise<{ status: number; json: Record<string, unknown> }> {
+  const res = await app.request("/mcp", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      Host: "localhost",
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, ...body }),
+  });
+  return { status: res.status, json: JSON.parse(await res.text()) };
+}
+
+describe("POST /mcp — provider_call multipart/form-data", () => {
+  it("builds a FormData and lets fetch() pick a multipart Content-Type with boundary", async () => {
+    let capturedContentType: string | null = null;
+    const capturedFields: Record<string, string> = {};
+    let capturedFile: { name: string; size: number; bytes: Uint8Array; type: string } | null = null;
+
+    const fetchFn = mock(async (_url: string, init?: RequestInit) => {
+      // Parse the multipart body upstream-side. Constructing a Request
+      // around the same body lets us call `.formData()` and verify the
+      // boundary token in the Content-Type matches the wire bytes.
+      // When the body is a FormData, fetch() synthesises the
+      // Content-Type header on the Request itself rather than mutating
+      // `init.headers` — so we read it from the Request after
+      // construction.
+      const req = new Request("https://api.example.com/sink", {
+        method: "POST",
+        headers: new Headers(init?.headers as HeadersInit | undefined),
+        body: init?.body as BodyInit,
+      });
+      capturedContentType = req.headers.get("content-type");
+      const fd = await req.formData();
+      for (const [k, v] of fd.entries()) {
+        if (typeof v === "string") {
+          capturedFields[k] = v;
+        } else {
+          const ab = await v.arrayBuffer();
+          capturedFile = {
+            name: k,
+            size: ab.byteLength,
+            bytes: new Uint8Array(ab),
+            type: v.type,
+          };
+        }
+      }
+      return new Response('{"ok":true}', {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    const app = createApp(makeMultipartDeps({ fetchFn: fetchFn as unknown as typeof fetch }));
+
+    // A non-UTF-8 payload — the canary for "body was JSON-stringified
+    // instead of multipart-encoded".
+    const fileBytes = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const base64 = Buffer.from(fileBytes).toString("base64");
+
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "@appstrate/test",
+          target: "https://api.example.com/sink",
+          method: "POST",
+          body: {
+            multipart: [
+              { name: "title", value: "hello world" },
+              { name: "tag", value: "alpha" },
+              {
+                name: "image",
+                filename: "logo.png",
+                bytes: base64,
+                encoding: "base64",
+                contentType: "image/png",
+              },
+            ],
+          },
+        },
+      },
+    });
+    expect(res.status).toBe(200);
+    const result = res.json.result as { isError?: boolean };
+    expect(result.isError).toBeFalsy();
+
+    expect(capturedContentType).not.toBeNull();
+    expect(capturedContentType!).toMatch(/^multipart\/form-data;\s*boundary=/i);
+    expect(capturedFields).toEqual({ title: "hello world", tag: "alpha" });
+    expect(capturedFile).not.toBeNull();
+    expect(capturedFile!.name).toBe("image");
+    expect(capturedFile!.type).toBe("image/png");
+    expect(capturedFile!.size).toBe(fileBytes.byteLength);
+    expect(capturedFile!.bytes).toEqual(fileBytes);
+  });
+
+  it("substitutes {{vars}} in string field parts when substituteBody: true (never in file bytes)", async () => {
+    const capturedFields: Record<string, string> = {};
+    let capturedFileBytes: Uint8Array | null = null;
+    const fetchFn = mock(async (_url: string, init?: RequestInit) => {
+      const reqHeaders = new Headers(init?.headers as HeadersInit | undefined);
+      const req = new Request("https://api.example.com/sink", {
+        method: "POST",
+        headers: reqHeaders,
+        body: init?.body as BodyInit,
+      });
+      const fd = await req.formData();
+      for (const [k, v] of fd.entries()) {
+        if (typeof v === "string") {
+          capturedFields[k] = v;
+        } else {
+          capturedFileBytes = new Uint8Array(await v.arrayBuffer());
+        }
+      }
+      return new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } });
+    });
+    const app = createApp(makeMultipartDeps({ fetchFn: fetchFn as unknown as typeof fetch }));
+
+    // The literal `{{access_token}}` placeholder inside the binary
+    // payload must NOT be substituted — that would corrupt the file
+    // content and silently leak a credential into a binary upload.
+    const bytesWithPlaceholder = new TextEncoder().encode("BINARY:{{access_token}}:END");
+    const base64 = Buffer.from(bytesWithPlaceholder).toString("base64");
+
+    await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "@appstrate/test",
+          target: "https://api.example.com/sink",
+          method: "POST",
+          substituteBody: true,
+          body: {
+            multipart: [
+              { name: "token", value: "Bearer {{access_token}}" },
+              { name: "untouched", value: "no-placeholder" },
+              {
+                name: "blob",
+                filename: "data.bin",
+                bytes: base64,
+                encoding: "base64",
+                contentType: "application/octet-stream",
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(capturedFields.token).toBe("Bearer tok-abc");
+    expect(capturedFields.untouched).toBe("no-placeholder");
+    expect(capturedFileBytes).not.toBeNull();
+    // Binary part must come through verbatim — placeholder text intact.
+    expect(new TextDecoder().decode(capturedFileBytes!)).toBe("BINARY:{{access_token}}:END");
+  });
+
+  it("does NOT substitute field-part values when substituteBody is omitted", async () => {
+    const capturedFields: Record<string, string> = {};
+    const fetchFn = mock(async (_url: string, init?: RequestInit) => {
+      const req = new Request("https://api.example.com/sink", {
+        method: "POST",
+        headers: new Headers(init?.headers as HeadersInit | undefined),
+        body: init?.body as BodyInit,
+      });
+      const fd = await req.formData();
+      for (const [k, v] of fd.entries()) {
+        if (typeof v === "string") capturedFields[k] = v;
+      }
+      return new Response("{}", { status: 200 });
+    });
+    const app = createApp(makeMultipartDeps({ fetchFn: fetchFn as unknown as typeof fetch }));
+
+    await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "@appstrate/test",
+          target: "https://api.example.com/sink",
+          method: "POST",
+          body: {
+            multipart: [{ name: "token", value: "Bearer {{access_token}}" }],
+          },
+        },
+      },
+    });
+    // Off by default — placeholder must reach upstream untouched.
+    expect(capturedFields.token).toBe("Bearer {{access_token}}");
+  });
+
+  it("strips caller-supplied Content-Type: multipart/... so fetch() controls the boundary", async () => {
+    let capturedContentType: string | null = null;
+    const fetchFn = mock(async (_url: string, init?: RequestInit) => {
+      // Re-derive Content-Type via a Request so we observe what
+      // fetch() actually puts on the wire (FormData triggers the
+      // boundary to be set on the Request, not on init.headers).
+      const req = new Request("https://api.example.com/sink", {
+        method: "POST",
+        headers: new Headers(init?.headers as HeadersInit | undefined),
+        body: init?.body as BodyInit,
+      });
+      capturedContentType = req.headers.get("content-type");
+      return new Response("{}", { status: 200 });
+    });
+    const app = createApp(makeMultipartDeps({ fetchFn: fetchFn as unknown as typeof fetch }));
+
+    await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "@appstrate/test",
+          target: "https://api.example.com/sink",
+          method: "POST",
+          headers: {
+            // Stale boundary token — if the sidecar forwards this
+            // header verbatim, Bun emits a body with a different
+            // boundary and the upstream parser breaks. The sidecar
+            // must drop this so fetch() picks its own.
+            "Content-Type": "multipart/form-data; boundary=AAAAAA",
+          },
+          body: {
+            multipart: [{ name: "f", value: "v" }],
+          },
+        },
+      },
+    });
+    expect(capturedContentType).not.toBeNull();
+    expect(capturedContentType!).toMatch(/^multipart\/form-data;\s*boundary=/i);
+    expect(capturedContentType!.includes("AAAAAA")).toBe(false);
+  });
+
+  it("returns 413 with structured PAYLOAD_TOO_LARGE when summed file bytes exceed the cap", async () => {
+    // Two parts that together overflow MAX_REQUEST_BODY_SIZE even
+    // though each individually fits — verifies the cap is the SUM, not
+    // the per-part max.
+    const half = Buffer.alloc(Math.ceil(MAX_REQUEST_BODY_SIZE / 2) + 1024, 0x41);
+    const b64 = half.toString("base64");
+    const app = createApp(makeMultipartDeps());
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "@appstrate/test",
+          target: "https://api.example.com/sink",
+          method: "POST",
+          body: {
+            multipart: [
+              { name: "a", filename: "a.bin", bytes: b64, encoding: "base64" },
+              { name: "b", filename: "b.bin", bytes: b64, encoding: "base64" },
+            ],
+          },
+        },
+      },
+    });
+    const result = res.json.result as {
+      content: Array<{ text: string }>;
+      structuredContent?: {
+        error?: { code?: string; scope?: string; limit?: number; envVar?: string };
+      };
+      isError?: boolean;
+    };
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("exceeds the per-request limit");
+    expect(result.structuredContent?.error?.code).toBe("PAYLOAD_TOO_LARGE");
+    expect(result.structuredContent?.error?.scope).toBe("request_body");
+    expect(result.structuredContent?.error?.limit).toBe(MAX_REQUEST_BODY_SIZE);
+    expect(result.structuredContent?.error?.envVar).toBe("SIDECAR_MAX_REQUEST_BODY_BYTES");
+  });
+
+  it("rejects a file part with invalid base64", async () => {
+    const app = createApp(makeMultipartDeps());
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "@appstrate/test",
+          target: "https://api.example.com/sink",
+          method: "POST",
+          body: {
+            multipart: [
+              { name: "f", filename: "f.bin", bytes: "not-base64!!!", encoding: "base64" },
+            ],
+          },
+        },
+      },
+    });
+    const result = res.json.result as { content: Array<{ text: string }>; isError?: boolean };
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("not standard base64");
+  });
+
+  it("advertises the multipart shape in tools/list", async () => {
+    const app = createApp(makeMultipartDeps());
+    const res = await rpc(app, { method: "tools/list" });
+    const result = res.json.result as {
+      tools: Array<{
+        name: string;
+        inputSchema: { properties: { body?: { oneOf?: unknown[]; description?: string } } };
+      }>;
+    };
+    const proxy = result.tools.find((t) => t.name === "provider_call")!;
+    expect(proxy.inputSchema.properties.body?.oneOf?.length).toBe(3);
+    expect(proxy.inputSchema.properties.body?.description).toContain("multipart");
+  });
+
+  it("dispatches a multipart JSON-RPC call without crashing the MCP transport", async () => {
+    // Lightweight smoke-test: tool call returns 200 + non-error result,
+    // confirming the descriptor + handler are wired end-to-end through
+    // the SDK's stateless transport.
+    const app = createApp(makeMultipartDeps());
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "provider_call",
+        arguments: {
+          providerId: "@appstrate/test",
+          target: "https://api.example.com/sink",
+          method: "POST",
+          body: { multipart: [{ name: "k", value: "v" }] },
+        },
+      },
+    });
+    expect(res.status).toBe(200);
+    const result = res.json.result as { isError?: boolean };
+    expect(result.isError).toBeFalsy();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `multipart` body variant to the `provider_call` MCP tool schema (oneOf: string | { fromBytes } | { multipart: [...] }).
- Build `FormData` at the sidecar boundary; let Bun's `fetch()` set the boundary token in `Content-Type: multipart/form-data; boundary=…`.
- Strip caller-supplied `Content-Type: multipart/...` headers so the boundary in the header matches the bytes on the wire.
- Enforce `SIDECAR_MAX_REQUEST_BODY_BYTES` across the **sum** of decoded file-part bytes (mirrors the structured 413 contract used by the `{ fromBytes }` path: `{ code: "PAYLOAD_TOO_LARGE", scope, limit, actual, envVar }`).
- Substitute `{{vars}}` in string-valued field parts only when `substituteBody: true`; binary parts always pass through verbatim.
- Body builder is a closure (`build(activeCreds)`), so the 401-retry path can re-render the FormData with the refreshed token — identical to the buffered text path.

## Out of scope / follow-ups

- The AFPS spec's TS types do not yet declare the `multipart` shape on `ProviderCallBody`. Declared locally in the sidecar handler (runtime contract); a follow-up will lift it into `@afps-spec/schema` so runtime resolvers can construct it with full IDE help.

## Test plan

- [x] Multipart round-trip: upstream sees `multipart/form-data; boundary=…` Content-Type, all field parts and file parts decode via `Request#formData()`.
- [x] Binary file part: raw bytes (PNG header) match after upload.
- [x] Variable substitution scoped to field strings when `substituteBody: true`; binary bytes containing literal `{{access_token}}` text pass through untouched.
- [x] No substitution by default (placeholder reaches upstream as literal text).
- [x] Caller-supplied `Content-Type: multipart/form-data; boundary=AAAAAA` is stripped — `fetch()` picks a fresh boundary.
- [x] 413 + structured `PAYLOAD_TOO_LARGE` when sum of decoded part bytes exceeds `SIDECAR_MAX_REQUEST_BODY_BYTES`.
- [x] Invalid base64 in a file part surfaces the same error message shape as the `{ fromBytes }` path.
- [x] `tools/list` advertises the new variant (3-way `oneOf` on `body`).
- [x] End-to-end JSON-RPC dispatch through the SDK stateless transport.

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)