### PR TITLE
feat(runner-pi): enable Pi auto-compaction driven by model catalog

### DIFF
--- a/apps/api/src/services/org-models.ts
+++ b/apps/api/src/services/org-models.ts
@@ -397,9 +397,46 @@ function resolveCatalogDefaults(providerId: string, modelId: string): CatalogDef
   };
 }
 
+/**
+ * Focused cascade for the three numeric/cost capability fields a runner
+ * needs to size compaction, budget responses, and price LLM calls. Keeps
+ * the env-driven (`SYSTEM_PROVIDER_KEYS`) and DB-driven (`org_models`)
+ * builders aligned on the exact same `explicit > catalog > null` chain.
+ *
+ * Honors `catalogProviderId` via {@link resolveCatalogDefaults} so OAuth
+ * wrappers (codex → openai, claude-code → anthropic) hit the right
+ * pricing file. Each field resolves independently — setting one explicit
+ * override does not shadow another field's catalog fallback.
+ */
+export function resolveCapabilities(
+  providerId: string,
+  modelId: string,
+  explicit: {
+    contextWindow: number | null;
+    maxTokens: number | null;
+    cost: ModelCost | null;
+  },
+): {
+  contextWindow: number | null;
+  maxTokens: number | null;
+  cost: ModelCost | null;
+} {
+  const catalog = resolveCatalogDefaults(providerId, modelId);
+  return {
+    contextWindow: explicit.contextWindow ?? catalog.contextWindow ?? null,
+    maxTokens: explicit.maxTokens ?? catalog.maxTokens ?? null,
+    cost: explicit.cost ?? catalog.cost ?? null,
+  };
+}
+
 /** Build a `ResolvedModel` from a system `ModelDefinition` (env-driven). */
 function buildSystemResolvedModel(def: ModelDefinition): ResolvedModel {
   const defaults = resolveCatalogDefaults(def.providerId, def.modelId);
+  const capabilities = resolveCapabilities(def.providerId, def.modelId, {
+    contextWindow: def.contextWindow ?? null,
+    maxTokens: def.maxTokens ?? null,
+    cost: def.cost ?? null,
+  });
   return {
     providerId: def.providerId,
     apiShape: def.apiShape,
@@ -408,10 +445,10 @@ function buildSystemResolvedModel(def: ModelDefinition): ResolvedModel {
     apiKey: def.apiKey,
     label: def.label ?? defaults.label ?? def.modelId,
     input: def.input ?? defaults.input ?? null,
-    contextWindow: def.contextWindow ?? defaults.contextWindow ?? null,
-    maxTokens: def.maxTokens ?? defaults.maxTokens ?? null,
+    contextWindow: capabilities.contextWindow,
+    maxTokens: capabilities.maxTokens,
     reasoning: def.reasoning ?? defaults.reasoning ?? null,
-    cost: def.cost ?? defaults.cost ?? null,
+    cost: capabilities.cost,
     isSystemModel: true,
   };
 }
@@ -422,11 +459,17 @@ function buildSystemResolvedModel(def: ModelDefinition): ResolvedModel {
  * service resolves them from the registry by `providerId` (with the per-row
  * `baseUrlOverride` honored when `baseUrlOverridable: true`). Every catalog-
  * derivable column on `org_models` is an optional override that defers to
- * {@link resolveCatalogDefaults} on null — so a weekly catalog refresh
- * propagates to existing rows.
+ * the catalog on null — so a weekly catalog refresh propagates to existing
+ * rows. Numeric/cost capability fields go through {@link resolveCapabilities}
+ * so the env-driven and DB-driven paths share the exact same cascade.
  */
 function buildDbResolvedModel(row: DbOrgModelRow, creds: DbModelCredentials): ResolvedModel {
   const defaults = resolveCatalogDefaults(creds.providerId, row.modelId);
+  const capabilities = resolveCapabilities(creds.providerId, row.modelId, {
+    contextWindow: row.contextWindow,
+    maxTokens: row.maxTokens,
+    cost: (row.cost as ModelCost | null) ?? null,
+  });
   return {
     providerId: creds.providerId,
     apiShape: creds.apiShape,
@@ -435,10 +478,10 @@ function buildDbResolvedModel(row: DbOrgModelRow, creds: DbModelCredentials): Re
     apiKey: creds.apiKey,
     label: row.label ?? defaults.label ?? row.modelId,
     input: (row.input as string[] | null) ?? defaults.input ?? null,
-    contextWindow: row.contextWindow ?? defaults.contextWindow ?? null,
-    maxTokens: row.maxTokens ?? defaults.maxTokens ?? null,
+    contextWindow: capabilities.contextWindow,
+    maxTokens: capabilities.maxTokens,
     reasoning: row.reasoning ?? defaults.reasoning ?? null,
-    cost: (row.cost as ModelCost | null) ?? defaults.cost ?? null,
+    cost: capabilities.cost,
     isSystemModel: false,
     accountId: creds.accountId,
     credentialId: row.credentialId,

--- a/apps/api/test/unit/services/org-models-resolve-capabilities.test.ts
+++ b/apps/api/test/unit/services/org-models-resolve-capabilities.test.ts
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `resolveCapabilities` — the focused 3-field cascade
+ * (`explicit > catalog > null`) that feeds both the env-driven
+ * (`SYSTEM_PROVIDER_KEYS`) and DB-driven (`org_models`) builders.
+ * Closes appstrate#445.
+ *
+ * Pure-function tests — no DB, no HTTP. The catalog is the on-disk
+ * LiteLLM-vendored snapshot in `apps/api/src/data/pricing/*.json` so
+ * `gpt-4o` (openai) is a stable fixture, and a hand-registered
+ * test provider validates the `catalogProviderId` alias path.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { resolveCapabilities } from "../../../src/services/org-models.ts";
+import {
+  registerModelProvider,
+  resetModelProviders,
+} from "../../../src/services/model-providers/registry.ts";
+import { seedTestModelProviders } from "../../helpers/model-providers.ts";
+
+// `gpt-4o` ships in the vendored snapshot at $2.5 / $10 per M, 128k
+// context, 16k max tokens. Asserting the canonical numbers keeps the
+// test honest against a stale catalog (a regenerate that drops the
+// entry fails loudly here, not in production).
+const GPT_4O = {
+  contextWindow: 128_000,
+  maxTokensMin: 4_096, // Sanity floor — actual is 16_384 on the current snapshot.
+  costInput: 2.5,
+  costOutput: 10,
+};
+
+describe("resolveCapabilities — cascade per field", () => {
+  beforeAll(() => {
+    // The function reads from the model-provider registry via
+    // `resolveCatalogDefaults`. Seed it to the canonical test baseline
+    // (core-providers + synthetic test-oauth) so `openai` resolves.
+    seedTestModelProviders();
+  });
+  afterAll(() => {
+    // Re-seed for the next file in the same `bun test` process.
+    seedTestModelProviders();
+  });
+
+  describe("contextWindow", () => {
+    it("returns explicit when set (ignores catalog)", () => {
+      const res = resolveCapabilities("openai", "gpt-4o", {
+        contextWindow: 999,
+        maxTokens: null,
+        cost: null,
+      });
+      expect(res.contextWindow).toBe(999);
+    });
+
+    it("falls through to catalog when explicit is null", () => {
+      const res = resolveCapabilities("openai", "gpt-4o", {
+        contextWindow: null,
+        maxTokens: null,
+        cost: null,
+      });
+      expect(res.contextWindow).toBe(GPT_4O.contextWindow);
+    });
+
+    it("returns null on catalog miss (unknown model)", () => {
+      const res = resolveCapabilities("openai", "ft:gpt-4o:my-org:custom:xyz", {
+        contextWindow: null,
+        maxTokens: null,
+        cost: null,
+      });
+      expect(res.contextWindow).toBeNull();
+    });
+
+    it("returns null on catalog miss (unknown provider)", () => {
+      const res = resolveCapabilities("unmapped-provider-id", "gpt-4o", {
+        contextWindow: null,
+        maxTokens: null,
+        cost: null,
+      });
+      expect(res.contextWindow).toBeNull();
+    });
+  });
+
+  describe("maxTokens", () => {
+    it("returns explicit when set (ignores catalog)", () => {
+      const res = resolveCapabilities("openai", "gpt-4o", {
+        contextWindow: null,
+        maxTokens: 7,
+        cost: null,
+      });
+      expect(res.maxTokens).toBe(7);
+    });
+
+    it("falls through to catalog when explicit is null", () => {
+      const res = resolveCapabilities("openai", "gpt-4o", {
+        contextWindow: null,
+        maxTokens: null,
+        cost: null,
+      });
+      expect(res.maxTokens).not.toBeNull();
+      expect(res.maxTokens!).toBeGreaterThanOrEqual(GPT_4O.maxTokensMin);
+    });
+
+    it("returns null on catalog miss", () => {
+      const res = resolveCapabilities("openai", "ft:gpt-4o:my-org:custom:xyz", {
+        contextWindow: null,
+        maxTokens: null,
+        cost: null,
+      });
+      expect(res.maxTokens).toBeNull();
+    });
+  });
+
+  describe("cost", () => {
+    it("returns explicit when set (ignores catalog)", () => {
+      const override = { input: 1.25, output: 5, cacheRead: 0, cacheWrite: 0 };
+      const res = resolveCapabilities("openai", "gpt-4o", {
+        contextWindow: null,
+        maxTokens: null,
+        cost: override,
+      });
+      expect(res.cost).toEqual(override);
+    });
+
+    it("falls through to catalog when explicit is null", () => {
+      const res = resolveCapabilities("openai", "gpt-4o", {
+        contextWindow: null,
+        maxTokens: null,
+        cost: null,
+      });
+      expect(res.cost).not.toBeNull();
+      expect(res.cost!.input).toBeCloseTo(GPT_4O.costInput, 4);
+      expect(res.cost!.output).toBeCloseTo(GPT_4O.costOutput, 4);
+    });
+
+    it("returns null on catalog miss", () => {
+      const res = resolveCapabilities("openai", "ft:gpt-4o:my-org:custom:xyz", {
+        contextWindow: null,
+        maxTokens: null,
+        cost: null,
+      });
+      expect(res.cost).toBeNull();
+    });
+  });
+
+  describe("catalogProviderId alias", () => {
+    // OAuth wrappers (codex → openai, claude-code → anthropic) declare
+    // `catalogProviderId` so they look up pricing in the right file.
+    // Hand-register a synthetic wrapper with `catalogProviderId: "openai"`
+    // — depending on `module-codex` from a core unit test would couple
+    // these to a module's load order.
+    const ALIAS_ID = "test-openai-wrapper-445";
+
+    beforeAll(() => {
+      registerModelProvider({
+        providerId: ALIAS_ID,
+        displayName: "Test wrapper (alias → openai)",
+        iconUrl: "",
+        authMode: "api_key",
+        catalogProviderId: "openai",
+        defaultBaseUrl: "https://api.openai.test/v1",
+        baseUrlOverridable: false,
+        apiShape: "openai-completions",
+        featuredModels: [],
+      });
+    });
+    afterAll(() => {
+      // Restore the canonical baseline so subsequent suites in the same
+      // `bun test` process don't see a leaked synthetic registration.
+      resetModelProviders();
+      seedTestModelProviders();
+    });
+
+    it("resolves catalog via catalogProviderId (codex → openai pattern)", () => {
+      const res = resolveCapabilities(ALIAS_ID, "gpt-4o", {
+        contextWindow: null,
+        maxTokens: null,
+        cost: null,
+      });
+      // The wrapper's own providerId has no catalog file — only the alias
+      // makes the lookup succeed.
+      expect(res.contextWindow).toBe(GPT_4O.contextWindow);
+      expect(res.cost).not.toBeNull();
+      expect(res.cost!.input).toBeCloseTo(GPT_4O.costInput, 4);
+    });
+  });
+
+  describe("field independence", () => {
+    it("setting contextWindow explicitly does not shadow cost catalog fallback", () => {
+      // Each field cascades on its own — pinning one explicit override
+      // must NOT prevent the other two from reading the catalog.
+      const res = resolveCapabilities("openai", "gpt-4o", {
+        contextWindow: 999,
+        maxTokens: null,
+        cost: null,
+      });
+      expect(res.contextWindow).toBe(999);
+      expect(res.maxTokens).not.toBeNull();
+      expect(res.cost).not.toBeNull();
+      expect(res.cost!.input).toBeCloseTo(GPT_4O.costInput, 4);
+    });
+
+    it("setting maxTokens explicitly does not shadow contextWindow catalog fallback", () => {
+      const res = resolveCapabilities("openai", "gpt-4o", {
+        contextWindow: null,
+        maxTokens: 7,
+        cost: null,
+      });
+      expect(res.maxTokens).toBe(7);
+      expect(res.contextWindow).toBe(GPT_4O.contextWindow);
+    });
+  });
+});

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -103,6 +103,58 @@ export interface PiRunnerOptions {
 }
 
 /**
+ * Default response budget when the model carries no `maxTokens`.
+ * 16384 covers the common "no thinking" Claude / GPT response shape;
+ * models with larger budgets (Claude Sonnet thinking @ 64k) override
+ * via `model.maxTokens` and `reserveTokens` follows.
+ */
+const DEFAULT_RESERVE_TOKENS = 16384;
+/**
+ * Floor on `keepRecentTokens`. Below ~20k the agent loses meaningful
+ * recent context (a few thousand tokens of recent tool calls + the last
+ * user message) and starts replaying earlier turns. 20k is small enough
+ * to fit even tiny context windows once `reserveTokens` is subtracted.
+ */
+const MIN_KEEP_RECENT_TOKENS = 20_000;
+/**
+ * Fallback context window when the model omits it. Matches the Claude
+ * family's standard 200k window — the most common runtime target.
+ */
+const DEFAULT_CONTEXT_WINDOW = 200_000;
+/** Fraction of the context window to keep verbatim after a compaction pass. */
+const KEEP_RECENT_FRACTION = 0.1;
+
+/**
+ * Derive Pi SDK compaction settings from a resolved model. Pure function
+ * so the env-driven (`SYSTEM_PROVIDER_KEYS`) and DB-driven (`org_models`)
+ * paths get identical compaction sizing for the same `(contextWindow,
+ * maxTokens)` pair.
+ *
+ * | Knob               | Mapping                                | Why                                                                                                                                                                              |
+ * |--------------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+ * | `reserveTokens`    | `model.maxTokens ?? 16384`             | Response budget. MUST be ≥ `max_tokens` or the first call post-compaction underflows and the upstream 400 ("prompt is too long") reappears. Critical for Claude Sonnet thinking mode (`maxTokens: 64000`). |
+ * | `keepRecentTokens` | `max(20000, 10% × contextWindow)`      | Preserves the ratio across model sizes: 20k on Claude 200k, ~100k on GPT-4.1 1M, ~200k on Gemini 2M. The floor stops small windows from over-compacting away recent context.    |
+ *
+ * Operators can disable compaction entirely with
+ * `MODEL_COMPACTION_ENABLED=false` (mirrors the existing
+ * `MODEL_RETRY_ENABLED` pattern) — useful when stacking external
+ * compaction middleware. See appstrate#445.
+ */
+export function derivePiCompactionSettings(
+  model: { contextWindow?: number | null; maxTokens?: number | null },
+  env: Record<string, string | undefined> = process.env,
+): { enabled: false } | { enabled: true; reserveTokens: number; keepRecentTokens: number } {
+  if (env["MODEL_COMPACTION_ENABLED"] === "false") return { enabled: false };
+  const contextWindow = model.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+  const reserveTokens = model.maxTokens ?? DEFAULT_RESERVE_TOKENS;
+  const keepRecentTokens = Math.max(
+    MIN_KEEP_RECENT_TOKENS,
+    Math.floor(contextWindow * KEEP_RECENT_FRACTION),
+  );
+  return { enabled: true, reserveTokens, keepRecentTokens };
+}
+
+/**
  * Convert a Pi `MODEL_API` string into the provider key the Pi SDK's
  * {@link AuthStorage} uses to look up API keys.
  */
@@ -244,7 +296,7 @@ export class PiRunner implements Runner {
       resourceLoader,
       sessionManager: SessionManager.inMemory(),
       settingsManager: SettingsManager.inMemory({
-        compaction: { enabled: false },
+        compaction: derivePiCompactionSettings(model, process.env),
         // Pi SDK's built-in retry (Retry-After honoring + jitter, max 2
         // attempts) covers transient 429/5xx upstream. Operators can
         // opt out by setting `MODEL_RETRY_ENABLED=false` on the runtime

--- a/packages/runner-pi/test/pi-runner-compaction.test.ts
+++ b/packages/runner-pi/test/pi-runner-compaction.test.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for {@link derivePiCompactionSettings} — the pure mapping
+ * from a resolved model's `(contextWindow, maxTokens)` to the Pi SDK's
+ * `CompactionSettings`. Closes appstrate#445.
+ *
+ * Why we extracted this out of `executeSession`: the in-line call inside
+ * the Pi SDK boot is impossible to unit-test (it would need a full
+ * `createAgentSession` mock, which the `ScriptedPiRunner` helper bypasses
+ * by overriding `executeSession` entirely). The pure function lets us
+ * assert the contract directly without faking the SDK.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { derivePiCompactionSettings } from "../src/pi-runner.ts";
+
+describe("derivePiCompactionSettings — reserveTokens", () => {
+  it("uses model.maxTokens when populated", () => {
+    const result = derivePiCompactionSettings({ contextWindow: 200_000, maxTokens: 64_000 }, {});
+    if (result.enabled === false) throw new Error("compaction should be enabled");
+    // Claude Sonnet 4.5 in thinking mode declares maxTokens=64000 —
+    // reserveTokens MUST track this or the first post-compaction call
+    // underflows and we see the same upstream 400.
+    expect(result.reserveTokens).toBe(64_000);
+  });
+
+  it("falls back to 16384 when model.maxTokens is null", () => {
+    const result = derivePiCompactionSettings({ contextWindow: 200_000, maxTokens: null }, {});
+    if (result.enabled === false) throw new Error("compaction should be enabled");
+    expect(result.reserveTokens).toBe(16_384);
+  });
+
+  it("falls back to 16384 when model.maxTokens is undefined", () => {
+    const result = derivePiCompactionSettings({ contextWindow: 200_000 }, {});
+    if (result.enabled === false) throw new Error("compaction should be enabled");
+    expect(result.reserveTokens).toBe(16_384);
+  });
+});
+
+describe("derivePiCompactionSettings — keepRecentTokens", () => {
+  it("Claude 200k window → 20000 (floor wins, 10% == floor)", () => {
+    // 10% × 200k = 20k, exactly at the floor.
+    const result = derivePiCompactionSettings({ contextWindow: 200_000, maxTokens: 16_384 }, {});
+    if (result.enabled === false) throw new Error("compaction should be enabled");
+    expect(result.keepRecentTokens).toBe(20_000);
+  });
+
+  it("GPT-4.1 1M window → 100000 (10% × 1M)", () => {
+    const result = derivePiCompactionSettings({ contextWindow: 1_000_000, maxTokens: 32_000 }, {});
+    if (result.enabled === false) throw new Error("compaction should be enabled");
+    expect(result.keepRecentTokens).toBe(100_000);
+  });
+
+  it("Gemini 2M window → 200000 (10% × 2M)", () => {
+    const result = derivePiCompactionSettings({ contextWindow: 2_000_000, maxTokens: 8_192 }, {});
+    if (result.enabled === false) throw new Error("compaction should be enabled");
+    expect(result.keepRecentTokens).toBe(200_000);
+  });
+
+  it("100k window → 20000 (floor wins over 10% = 10k)", () => {
+    // Floor protects small-window models from over-compaction: 10% would
+    // strip recent context below a useful tail.
+    const result = derivePiCompactionSettings({ contextWindow: 100_000, maxTokens: 4_096 }, {});
+    if (result.enabled === false) throw new Error("compaction should be enabled");
+    expect(result.keepRecentTokens).toBe(20_000);
+  });
+
+  it("null contextWindow → defaults to 200k path (keepRecentTokens=20000)", () => {
+    const result = derivePiCompactionSettings({ contextWindow: null, maxTokens: 16_384 }, {});
+    if (result.enabled === false) throw new Error("compaction should be enabled");
+    expect(result.keepRecentTokens).toBe(20_000);
+  });
+
+  it("undefined contextWindow → defaults to 200k path (keepRecentTokens=20000)", () => {
+    const result = derivePiCompactionSettings({ maxTokens: 16_384 }, {});
+    if (result.enabled === false) throw new Error("compaction should be enabled");
+    expect(result.keepRecentTokens).toBe(20_000);
+  });
+});
+
+describe("derivePiCompactionSettings — MODEL_COMPACTION_ENABLED opt-out", () => {
+  it("returns { enabled: false } when MODEL_COMPACTION_ENABLED=false", () => {
+    // Mirrors the existing MODEL_RETRY_ENABLED escape hatch — operators
+    // stacking external compaction middleware can disable Pi's pass.
+    const result = derivePiCompactionSettings(
+      { contextWindow: 200_000, maxTokens: 64_000 },
+      { MODEL_COMPACTION_ENABLED: "false" },
+    );
+    expect(result).toEqual({ enabled: false });
+  });
+
+  it("ignores other values of MODEL_COMPACTION_ENABLED (only 'false' opts out)", () => {
+    // Strict string match — anything but exactly "false" keeps compaction
+    // on. Matches the retry flag's behaviour.
+    const result = derivePiCompactionSettings(
+      { contextWindow: 200_000, maxTokens: 16_384 },
+      { MODEL_COMPACTION_ENABLED: "true" },
+    );
+    if (result.enabled === false) throw new Error("compaction should be enabled");
+    expect(result.reserveTokens).toBe(16_384);
+  });
+
+  it("defaults to enabled when MODEL_COMPACTION_ENABLED is undefined", () => {
+    const result = derivePiCompactionSettings({ contextWindow: 200_000, maxTokens: 16_384 }, {});
+    if (result.enabled === false) throw new Error("compaction should be enabled");
+    expect(result.reserveTokens).toBe(16_384);
+    expect(result.keepRecentTokens).toBe(20_000);
+  });
+});
+
+describe("derivePiCompactionSettings — full result shape", () => {
+  it("returns both reserveTokens and keepRecentTokens for Claude Sonnet thinking", () => {
+    // The original failure mode in appstrate#445: Claude Sonnet 4.5
+    // thinking sets maxTokens=64000 on a 200k window. Without
+    // reserveTokens tracking maxTokens, compaction reserves only the
+    // SDK default (4k or whatever) and the next call underflows.
+    const result = derivePiCompactionSettings({ contextWindow: 200_000, maxTokens: 64_000 }, {});
+    expect(result).toEqual({
+      enabled: true,
+      reserveTokens: 64_000,
+      keepRecentTokens: 20_000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #445.

- Generalize the catalog cascade in `apps/api/src/services/org-models.ts`: new `resolveCapabilities(providerId, modelId, explicit)` helper covers `contextWindow` + `maxTokens` + `cost` uniformly with the `explicit > LiteLLM-vendored catalog > null` precedence. Wired into both `buildSystemResolvedModel` (env-driven `SYSTEM_PROVIDER_KEYS`) and `buildDbResolvedModel` (DB-driven `org_models`) so they cannot drift. Honors `catalogProviderId` for OAuth wrappers (codex → openai, claude-code → anthropic).
- Enable Pi auto-compaction in `packages/runner-pi/src/pi-runner.ts`, parameterized from the resolved model via a new pure `derivePiCompactionSettings(model, env)`:
  - `reserveTokens = model.maxTokens ?? 16384` — must be ≥ the response budget or the first call post-compaction underflows and the upstream `prompt is too long` 400 reappears. Critical for Claude Sonnet thinking mode (`maxTokens: 64000`).
  - `keepRecentTokens = max(20000, floor(0.1 × contextWindow))` — preserves the ratio: 20k on 200k window, 100k on 1M, 200k on 2M. The 20k floor protects small-window models from over-compaction.
- `MODEL_COMPACTION_ENABLED=false` opt-out for operators stacking external middleware (mirrors `MODEL_RETRY_ENABLED`).

## Test plan

- [x] `bun test packages/runner-pi/test/pi-runner-compaction.test.ts` — 13 tests covering `reserveTokens` derivation, `keepRecentTokens` ratio + floor, env opt-out, full result shape
- [x] `bun test packages/runner-pi/test` — 154 tests pass, no regression
- [x] `bun test apps/api/test/unit/services/org-models-resolve-capabilities.test.ts` — 13 tests covering per-field cascade (explicit / catalog / miss), `catalogProviderId` alias path, field independence
- [x] `bun test apps/api/test/unit` — 804 tests pass
- [x] `bun test apps/api/test/integration/services/org-models-pricing-catalog.test.ts` — 4 tests pass (existing coverage of the cascade through `loadModel` end-to-end)
- [x] `bun run check` — typecheck + lint + format + verify:openapi + detect:breaking all green
- [ ] Manual sanity post-merge: long run on Claude Sonnet 4.5 + GPT-4.1 1M no longer hits `prompt is too long`

🤖 Generated with [Claude Code](https://claude.com/claude-code)