### PR TITLE
fix: report honest boot duration in runtime-ready event

### DIFF
--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -214,11 +214,6 @@ export async function runCommand(opts: RunCommandOptions): Promise<void> {
 }
 
 async function runCommandLocal(opts: RunCommandOptions): Promise<void> {
-  // Captured at command entry so the "runtime ready in {N}ms" signal
-  // reflects the user-perceived warm-up cost (profile resolution, model
-  // download, bundle prep, sink setup) — not just PiRunner construction.
-  const commandStartedAt = Date.now();
-
   // ─── 1. Resolve provider mode + profile state ──────────────────────
   const mode: ProviderMode = parseProviderMode(opts.providers);
   const target = parseRunTarget(opts.bundle);
@@ -609,12 +604,21 @@ async function runCommandLocal(opts: RunCommandOptions): Promise<void> {
     // it to the platform, flipping the remote run from pending to
     // running on the first ingested sequence. Identical signal shape
     // to the one runtime-pi emits inside the Docker container.
+    //
+    // `performance.now()` is measured from `performance.timeOrigin` (the
+    // wall-clock instant the CLI process started), so the reported
+    // duration covers Bun startup + ESM import evaluation + the warm-up
+    // work below (profile resolution, model download, bundle prep, sink
+    // setup) — i.e. the full user-perceived gap. A top-level
+    // `Date.now()` captured at function entry would miss the import
+    // phase entirely because ES module imports are evaluated before any
+    // top-level statement runs.
     const emittedRunId = reportSession?.runId ?? runId;
     const extensionsCount = prepared.extensionFactories.length + providerFactories.length;
     await emitRuntimeReady(sink, emittedRunId, {
       bundleLoaded: true,
       extensions: extensionsCount,
-      bootDurationMs: Date.now() - commandStartedAt,
+      bootDurationMs: performance.now(),
     }).catch((err) => {
       // Do not fail the run because the heartbeat failed — the sink's
       // own retry loop has already done what it could. A warning to

--- a/runtime-pi/entrypoint.ts
+++ b/runtime-pi/entrypoint.ts
@@ -107,11 +107,6 @@ function buildInContainerBundle(prompt: string): Bundle {
   };
 }
 
-// Captured as early as possible so the "runtime ready in {N}ms" signal
-// reflects the full bootloader cost (bundle extract, providers wiring,
-// dynamic tool imports) — not just the post-init slice.
-const BOOT_STARTED_AT = Date.now();
-
 // --- 0. Env validation + sink bootstrap ---
 // Every runtime-pi invocation MUST come from a platform run that has
 // already minted sink credentials + inserted a pending run row. We
@@ -448,10 +443,19 @@ const runnerBundle: Bundle = bundle ?? buildInContainerBundle(systemPrompt);
 // imports are all done. It also gives the dashboard a first log line
 // immediately on cold starts (Docker pull can take seconds) instead of
 // a silent gap between `pending` and the first tool call.
+//
+// `performance.now()` is measured from `performance.timeOrigin` (the
+// wall-clock instant the process started), so it folds in Bun startup
+// + ESM import evaluation (the heavy module loading at the top of this
+// file) on top of the post-import boot work. An earlier `Date.now()`
+// timer declared as a top-level const missed all of that — ES modules
+// evaluate every `import` before any top-level statement runs, so the
+// timer started only after the slow part was already done and reported
+// an artificially low duration vs. the user-perceived gap.
 await emitRuntimeReady(bridgedSink, AGENT_RUN_ID, {
   bundleLoaded: bundle !== null,
   extensions: extensionFactories.length,
-  bootDurationMs: Date.now() - BOOT_STARTED_AT,
+  bootDurationMs: performance.now(),
 });
 
 // --- 6a. Liveness keep-alive ---


### PR DESCRIPTION
## Summary

- The `runtime ready in {N}ms` signal (emitted by both `runtime-pi/entrypoint.ts` and `apps/cli/src/commands/run.ts`) was reporting an artificially low number compared to the wall-clock gap between container/process launch and that first log line.
- Root cause: `const BOOT_STARTED_AT = Date.now();` (runtime-pi) and `const commandStartedAt = Date.now();` (CLI) were declared as top-level statements **after** the `import` block. In ES modules, every `import` is evaluated **before** any top-level statement runs — so the timer started only after the heavy module loading (`@mariozechner/pi-coding-agent`, `@appstrate/afps-runtime/*`, `@appstrate/mcp-transport`, …) was already done. Bun startup + ESM evaluation — typically the slowest leg of the boot — was excluded entirely.
- Fix: replace both `Date.now() - <captured>` expressions with `performance.now()`, which is measured from `performance.timeOrigin` (the wall-clock instant the process started). This folds in Bun startup + ESM import evaluation on top of the post-init work, giving an honest duration that matches the user-perceived "container launched -> first log line" gap.
- No type or contract changes: `RuntimeReadyPayload.bootDurationMs: number` already accepts the fractional ms `performance.now()` returns, and `emitRuntimeReady` already does `Math.round(payload.bootDurationMs)` for the human-readable string. The helper itself (`packages/runner-pi/src/runtime-ready.ts`) was not touched — the bug was purely at the call sites.

## Test plan

- [x] `bun run check` from repo root — passes (19/19 turbo tasks: typecheck + lint + format + verify-openapi + detect-breaking + build-system-packages). Only pre-existing lint warning in `packages/ui/src/schema-form/file-widget.tsx`, unrelated.
- [x] Targeted unit tests `bun test packages/runner-pi/test/runtime-ready.test.ts` — 6/6 pass (the helper's contract is unchanged; tests use hardcoded `bootDurationMs` values).
- [ ] Manual smoke: launch a run and confirm the reported `bootDurationMs` is now in the same ballpark as the wall-clock gap (was ~40ms, expected hundreds of ms once Bun startup + ESM evaluation are included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)