### PR TITLE
fix(test): drop obsolete runs.cost=null assertion racing the broadcaster

### DIFF
--- a/apps/api/src/services/run-launcher/appstrate-event-sink.ts
+++ b/apps/api/src/services/run-launcher/appstrate-event-sink.ts
@@ -37,11 +37,16 @@
  *     appstrate.error    → run_logs (system/adapter_error) + lastAdapterError
  *     appstrate.metric   → runs.tokenUsage snapshot (running total)
  *                         + llm_usage ledger row (source="runner")
+ *                         + schedules a throttled `run_metric` broadcast
+ *                           which also persists `cost_so_far` onto the
+ *                           run row (monotonic-max guarded)
  *
- * `runs.cost` is NEVER written here — it is the cached aggregate written
- * exactly once by `finalizeRun`. These sinks are the single writer of
- * the `llm_usage` runner rows and the single reader/writer of
- * `runs.tokenUsage`.
+ * These sinks are the single writer of the `llm_usage` runner rows and
+ * the single reader/writer of `runs.tokenUsage`. `runs.cost` is cached
+ * aggregate of `llm_usage` and is refreshed on two paths: the throttled
+ * broadcaster (during streaming, via {@link scheduleRunMetricBroadcast})
+ * and `finalizeRun` (terminal write). Both writers use a monotonic guard
+ * so the recorded value never regresses.
  */
 
 import { createReducerSink, type ReducerSinkHandle } from "@appstrate/afps-runtime/sinks";

--- a/apps/api/test/integration/services/appstrate-event-sink.test.ts
+++ b/apps/api/test/integration/services/appstrate-event-sink.test.ts
@@ -22,6 +22,7 @@ import {
   AggregatingEventSink,
   PersistingEventSink,
 } from "../../../src/services/run-launcher/appstrate-event-sink.ts";
+import { _resetRunMetricBroadcasterForTests } from "../../../src/services/run-metric-broadcaster.ts";
 import type { RunEvent } from "@appstrate/afps-runtime/types";
 import { reduceEvents, emptyRunResult } from "@appstrate/afps-runtime/runner";
 import { db } from "@appstrate/db/client";
@@ -231,6 +232,12 @@ describe("PersistingEventSink", () => {
 
   beforeEach(async () => {
     await truncateAll();
+    // The broadcaster's throttle map is module-scoped — wipe it between
+    // tests so a fire-and-forget broadcast scheduled by one test cannot
+    // race a later test's reads of runs.cost. The broadcaster's own
+    // behavior (including the runs.cost write) is covered by its
+    // dedicated test suite (run-metric-broadcaster.test.ts).
+    _resetRunMetricBroadcasterForTests();
     ctx = await createTestContext();
     await seedAgent({ id: agentId, orgId: ctx.orgId, createdBy: ctx.user.id });
     await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, agentId);
@@ -273,8 +280,12 @@ describe("PersistingEventSink", () => {
       output_tokens: 125,
     });
 
-    // runs.cost MUST NOT be touched by the sink — only finalizeRun writes it.
-    expect(runRow?.cost).toBeNull();
+    // runs.cost is intentionally NOT asserted here — the sink schedules a
+    // fire-and-forget run_metric broadcast that also refreshes runs.cost
+    // (monotonic-max guarded) so a mid-run UI refresh sees the latest
+    // value rather than null until finalize. That write race is covered
+    // end-to-end by run-metric-broadcaster.test.ts; this test focuses on
+    // the synchronous ledger + tokenUsage write-through.
   });
 
   it("concurrent metric writes for the same run land at most one runner row (max wins)", async () => {

--- a/packages/db/src/schema/runs.ts
+++ b/packages/db/src/schema/runs.ts
@@ -328,9 +328,13 @@ export const packagePersistence = pgTable(
  *                events carry the run's monotonic `sequence`; dedup on
  *                `(run_id, source, sequence)`.
  *
- * `runs.cost` is the cached SUM of this table for that run, written once
- * at `finalizeRun`. Never write to `runs.cost` from anywhere else — this
- * table is the single source of truth for run cost. (`credential_proxy_usage`
+ * `runs.cost` is the cached SUM of this table for that run. It is
+ * refreshed on two paths: the throttled `run_metric` broadcaster
+ * (during streaming, so a mid-run refresh sees the latest value) and
+ * `finalizeRun` (terminal write). Both writers use a monotonic guard
+ * (`UPDATE … WHERE cost IS NULL OR cost < new`) so the value never
+ * regresses. This table remains the single source of truth — `runs.cost`
+ * is only a cache of `SUM(llm_usage.cost_usd)`. (`credential_proxy_usage`
  * is an audit log, not a cost ledger — see its header comment.)
  *
  * A call is attributable to exactly one principal: either an API key


### PR DESCRIPTION
## Summary

CI on `main` has been failing intermittently since PR #393 (`a8d499b7` — *feat: stream live token usage & cost during run execution*) with:

```
Received: 0.003
  at apps/api/test/integration/services/appstrate-event-sink.test.ts:277
(fail) PersistingEventSink > appstrate.metric → single runner ledger row + tokenUsage snapshot when writeLedger is on
```

Affected runs (non-exhaustive): [25897992337](https://github.com/appstrate/appstrate/actions/runs/25897992337), [25897229722](https://github.com/appstrate/appstrate/actions/runs/25897229722), [25894584121](https://github.com/appstrate/appstrate/actions/runs/25894584121).

### Root cause

PR #393 added `run-metric-broadcaster.ts`, which writes `runs.cost = cost_so_far` (monotonic-max guarded) on every metric event so a mid-run UI refresh sees the latest value instead of `null` until finalize. The sink calls `scheduleRunMetricBroadcast(runId)` after every `appstrate.metric`, which fires `void fireBroadcast(runId)` — a detached, leading-edge broadcast.

In the test, `await sink.handle(...)` returns before the detached broadcast resolves. The intermediate `await db.select()` calls let the broadcast complete its `UPDATE runs SET cost = …` mid-test, so by the time the test reads `runRow.cost` and asserts `toBeNull()`, the value is `0.003`.

The invariant the assertion encoded (*"runs.cost is written exactly once, by finalizeRun"*) was retired by #393 — the broadcaster is a second, intentional, monotonic-safe writer. The runner ledger remains the source of truth.

### Fix

1. **Drop the obsolete `expect(runRow?.cost).toBeNull()` assertion.** The broadcaster's `runs.cost` write is already covered end-to-end by `run-metric-broadcaster.test.ts` (3 dedicated cases: writes, monotonic guard, zero no-op). This test focuses on the synchronous ledger + tokenUsage write-through.
2. **Call `_resetRunMetricBroadcasterForTests()` in the `PersistingEventSink` `beforeEach`** — the broadcaster's throttle map is module-scoped and can otherwise leak state between tests.
3. **Update stale comments** in `appstrate-event-sink.ts` and `packages/db/src/schema/runs.ts` that still claimed `finalizeRun` was the sole writer of `runs.cost`.

No production behavior change.

## Test plan

- [x] `bun test apps/api/test/integration/services/appstrate-event-sink.test.ts` — 23 pass / 0 fail
- [x] `bun test apps/api/test/integration/services/run-metric-broadcaster.test.ts apps/api/test/integration/services/run-metric-streaming.test.ts` — 14 pass / 0 fail
- [x] `tsc --noEmit` on `apps/api` and `packages/db` — clean
- [x] `eslint` + `prettier --check` on touched files — clean
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)