### PR TITLE
fix(runtime-pi): copy module-claude-code manifest in Dockerfile

### DIFF
--- a/runtime-pi/Dockerfile
+++ b/runtime-pi/Dockerfile
@@ -33,8 +33,9 @@ COPY packages/core/package.json          packages/core/
 COPY packages/db/package.json            packages/db/
 COPY packages/emails/package.json        packages/emails/
 COPY packages/env/package.json           packages/env/
-COPY packages/mcp-transport/package.json packages/mcp-transport/
-COPY packages/module-codex/package.json  packages/module-codex/
+COPY packages/mcp-transport/package.json     packages/mcp-transport/
+COPY packages/module-claude-code/package.json packages/module-claude-code/
+COPY packages/module-codex/package.json      packages/module-codex/
 COPY packages/runner-pi/package.json     packages/runner-pi/
 COPY packages/shared-types/package.json  packages/shared-types/
 COPY packages/ui/package.json            packages/ui/

--- a/runtime-pi/sidecar/Dockerfile
+++ b/runtime-pi/sidecar/Dockerfile
@@ -31,8 +31,9 @@ COPY packages/core/package.json          packages/core/
 COPY packages/db/package.json            packages/db/
 COPY packages/emails/package.json        packages/emails/
 COPY packages/env/package.json           packages/env/
-COPY packages/mcp-transport/package.json packages/mcp-transport/
-COPY packages/module-codex/package.json  packages/module-codex/
+COPY packages/mcp-transport/package.json     packages/mcp-transport/
+COPY packages/module-claude-code/package.json packages/module-claude-code/
+COPY packages/module-codex/package.json      packages/module-codex/
 COPY packages/runner-pi/package.json     packages/runner-pi/
 COPY packages/shared-types/package.json  packages/shared-types/
 COPY packages/ui/package.json            packages/ui/


### PR DESCRIPTION
## Summary

- Add missing `COPY packages/module-claude-code/package.json` step to both `runtime-pi/Dockerfile` and `runtime-pi/sidecar/Dockerfile`.
- Unblocks image builds: `bun install --frozen-lockfile` walks the entire lockfile graph (the `--filter` flag prunes the install but not the resolution), and `apps/api` declares `@appstrate/module-claude-code: workspace:*`, so the workspace manifest must be present in the build context.

## Root cause

`packages/module-claude-code/` was moved from a separate private repo into the appstrate workspace, but the runtime-pi and sidecar Dockerfiles weren't updated to copy the new workspace manifest. Build fails with:

\`\`\`
error: Workspace dependency "@appstrate/module-claude-code" not found
Searched in "./*"
\`\`\`

## Test plan

- [ ] \`docker build --platform linux/amd64 -t appstrate-pi -f runtime-pi/Dockerfile .\` succeeds.
- [ ] \`docker build --platform linux/amd64 -t appstrate-sidecar -f runtime-pi/sidecar/Dockerfile .\` succeeds.

Only the manifest is copied — neither the runtime nor the sidecar imports module-claude-code at runtime; it's loaded by \`apps/api\` at boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)