### PR TITLE
fix(sidecar): bypass upstream proxy when target is the platform host

### DIFF
--- a/runtime-pi/sidecar/forward-proxy.ts
+++ b/runtime-pi/sidecar/forward-proxy.ts
@@ -36,8 +36,24 @@ export function createForwardProxy(deps: ForwardProxyDeps): ForwardProxyResult {
   const SOCKET_IDLE_TIMEOUT_MS = 120_000; // 2 min idle → destroy tunnel
   const MAX_CONNECT_HEADER_SIZE = 16_384; // 16 KB — CONNECT response headers should be tiny
 
-  function getUpstreamProxy(): { host: string; port: number; auth: string | null } | null {
+  function getUpstreamProxy(
+    targetHost?: string,
+  ): { host: string; port: number; auth: string | null } | null {
     if (!config.proxyUrl) return null;
+    // Bypass the upstream proxy when the target is the platform host.
+    // Same rationale as isAllowedHost() below: platform traffic is internal,
+    // trusted by construction (HMAC-signed run events scoped to a single
+    // run). Residential / datacenter egress proxies (Decodo, Bright Data,
+    // Smartproxy, …) typically refuse RFC1918 or docker-bridge hostnames
+    // as "restricted targets" with a 403 — which would crash the agent at
+    // bootstrap, since `emitRuntimeReady` POSTs to the platform sink as
+    // its very first action. Keeping platform traffic off the upstream
+    // proxy preserves the proxy's purpose (mask outbound IP for tracked
+    // upstreams) without breaking internal comms.
+    if (targetHost) {
+      const platformHost = getPlatformHost();
+      if (platformHost && targetHost.toLowerCase() === platformHost) return null;
+    }
     try {
       const url = new URL(config.proxyUrl);
       // HTTPS upstream proxies are not supported — the forward proxy connects via plain TCP.
@@ -144,8 +160,6 @@ export function createForwardProxy(deps: ForwardProxyDeps): ForwardProxyResult {
       return;
     }
 
-    const upstream = getUpstreamProxy();
-
     let parsed: URL;
     try {
       parsed = new URL(targetUrl);
@@ -162,6 +176,10 @@ export function createForwardProxy(deps: ForwardProxyDeps): ForwardProxyResult {
       res.end("Blocked: internal network");
       return;
     }
+
+    // Resolve the upstream proxy with the target hostname — internal platform
+    // traffic bypasses the upstream proxy (see getUpstreamProxy docstring).
+    const upstream = getUpstreamProxy(parsed.hostname);
 
     const cleaned = forwardHeaders(req.headers);
 
@@ -253,7 +271,9 @@ export function createForwardProxy(deps: ForwardProxyDeps): ForwardProxyResult {
       return;
     }
 
-    const upstream = getUpstreamProxy();
+    // Resolve the upstream proxy with the target hostname — internal platform
+    // traffic bypasses the upstream proxy (see getUpstreamProxy docstring).
+    const upstream = getUpstreamProxy(host);
 
     if (upstream) {
       // Chain through authenticated upstream proxy

--- a/runtime-pi/sidecar/test/forward-proxy.test.ts
+++ b/runtime-pi/sidecar/test/forward-proxy.test.ts
@@ -54,6 +54,50 @@ function startEchoServer(): Promise<{ port: number; server: HttpServer }> {
   });
 }
 
+/**
+ * Start a fake upstream HTTP proxy that captures the target hosts it was
+ * asked to forward to and replies with a distinguishable response (header
+ * `X-Via-Upstream: true`). Use to prove that the forward proxy did — or did
+ * not — chain through the upstream for a given target.
+ *
+ * On CONNECT, replies `403 Forbidden` so the inner forward proxy surfaces
+ * an "upstream rejected" status to its caller; if the bypass worked the
+ * caller gets `200 Connection Established` directly from the target host.
+ */
+function startFakeUpstream(): Promise<{
+  port: number;
+  server: HttpServer;
+  receivedHttpHosts: string[];
+  receivedConnectTargets: string[];
+}> {
+  const receivedHttpHosts: string[] = [];
+  const receivedConnectTargets: string[] = [];
+  return new Promise((resolve) => {
+    const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+      let host = "";
+      try {
+        host = new URL(req.url ?? "").hostname;
+      } catch {
+        /* ignore */
+      }
+      receivedHttpHosts.push(host);
+      res.writeHead(200, { "Content-Type": "application/json", "X-Via-Upstream": "true" });
+      res.end(JSON.stringify({ proxied: true, host }));
+    });
+    server.on("connect", (req, clientSocket) => {
+      receivedConnectTargets.push(req.url ?? "");
+      clientSocket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
+      clientSocket.destroy();
+    });
+    servers.push(server);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      const port = typeof addr === "object" ? addr!.port : 0;
+      resolve({ port, server, receivedHttpHosts, receivedConnectTargets });
+    });
+  });
+}
+
 function makeProxy(overrides?: Parameters<typeof createForwardProxy>[0]): ForwardProxyResult {
   const result = createForwardProxy({
     config: { platformApiUrl: "http://mock:3000", runToken: "tok", proxyUrl: "" },
@@ -433,6 +477,119 @@ describe("platform host exemption", () => {
 
     const res = await connectViaProxy(port, "169.254.169.254:80");
     expect(res.statusCode).toBe(403);
+  });
+});
+
+// --- Upstream proxy bypass for platform host ---
+//
+// A residential / datacenter egress proxy configured via `config.proxyUrl`
+// (Decodo, Bright Data, …) typically refuses RFC1918 / docker-bridge
+// hostnames as "restricted targets" with a 403. Platform sink traffic must
+// keep flowing even when such a proxy is wired up, otherwise the agent
+// crashes at bootstrap (the very first POST to the sink would fail).
+
+describe("upstream proxy bypass for platform host", () => {
+  it("HTTP: platform host is reached directly, not via upstream proxy", async () => {
+    const echo = await startEchoServer();
+    const upstream = await startFakeUpstream();
+    const proxy = makeProxy({
+      config: {
+        platformApiUrl: `http://127.0.0.1:${echo.port}`,
+        runToken: "tok",
+        proxyUrl: `http://127.0.0.1:${upstream.port}`,
+      },
+      isBlockedHostFn: () => false,
+    });
+    await proxy.ready;
+    const { port } = proxy.address();
+
+    const res = await httpViaProxy(port, `http://127.0.0.1:${echo.port}/sink/events`);
+    expect(res.status).toBe(200);
+    // X-Via-Upstream is only set by the fake upstream → its absence proves bypass.
+    expect(res.headers["x-via-upstream"]).toBeUndefined();
+    const body = JSON.parse(res.body);
+    expect(body.url).toBe("/sink/events"); // came from echo directly
+    expect(upstream.receivedHttpHosts).toHaveLength(0);
+  });
+
+  it("HTTP: non-platform host is routed through the upstream proxy", async () => {
+    const target = await startEchoServer();
+    const upstream = await startFakeUpstream();
+    const proxy = makeProxy({
+      config: {
+        // Platform points elsewhere — the target below is NOT the platform.
+        platformApiUrl: "http://platform-host:3000",
+        runToken: "tok",
+        proxyUrl: `http://127.0.0.1:${upstream.port}`,
+      },
+      isBlockedHostFn: () => false,
+    });
+    await proxy.ready;
+    const { port } = proxy.address();
+
+    const res = await httpViaProxy(port, `http://127.0.0.1:${target.port}/external`);
+    expect(res.status).toBe(200);
+    expect(res.headers["x-via-upstream"]).toBe("true");
+    expect(upstream.receivedHttpHosts).toContain("127.0.0.1");
+  });
+
+  it("HTTP: platform-host bypass is case-insensitive", async () => {
+    const echo = await startEchoServer();
+    const upstream = await startFakeUpstream();
+    const proxy = makeProxy({
+      config: {
+        // Mixed case platform host — comparison should lower-case both sides.
+        platformApiUrl: `http://127.0.0.1:${echo.port}`,
+        runToken: "tok",
+        proxyUrl: `http://127.0.0.1:${upstream.port}`,
+      },
+      isBlockedHostFn: () => false,
+    });
+    await proxy.ready;
+    const { port } = proxy.address();
+
+    const res = await httpViaProxy(port, `http://127.0.0.1:${echo.port}/x`);
+    expect(res.status).toBe(200);
+    expect(upstream.receivedHttpHosts).toHaveLength(0);
+  });
+
+  it("CONNECT: platform host is tunneled directly, not chained through upstream proxy", async () => {
+    const echo = await startEchoServer();
+    const upstream = await startFakeUpstream();
+    const proxy = makeProxy({
+      config: {
+        platformApiUrl: `http://127.0.0.1:${echo.port}`,
+        runToken: "tok",
+        proxyUrl: `http://127.0.0.1:${upstream.port}`,
+      },
+      isBlockedHostFn: () => false,
+    });
+    await proxy.ready;
+    const { port } = proxy.address();
+
+    const res = await connectViaProxy(port, `127.0.0.1:${echo.port}`);
+    expect(res.statusCode).toBe(200); // direct TCP tunnel succeeded
+    expect(upstream.receivedConnectTargets).toHaveLength(0);
+  });
+
+  it("CONNECT: non-platform host is chained through the upstream proxy", async () => {
+    const echo = await startEchoServer();
+    const upstream = await startFakeUpstream();
+    const proxy = makeProxy({
+      config: {
+        platformApiUrl: "http://platform-host:3000",
+        runToken: "tok",
+        proxyUrl: `http://127.0.0.1:${upstream.port}`,
+      },
+      isBlockedHostFn: () => false,
+    });
+    await proxy.ready;
+    const { port } = proxy.address();
+
+    const res = await connectViaProxy(port, `127.0.0.1:${echo.port}`);
+    // Fake upstream rejects CONNECT with 403 → forward proxy surfaces "Upstream Rejected".
+    expect(res.statusCode).toBe(403);
+    expect(upstream.receivedConnectTargets).toContain(`127.0.0.1:${echo.port}`);
   });
 });
 


### PR DESCRIPTION
## Problem

When an org or agent configures a residential / datacenter egress proxy (Decodo, Bright Data, Smartproxy, …) via `config.proxyUrl`, the sidecar's forward proxy currently routes **all** outbound traffic through it — including the agent's POSTs back to the platform sink (`emitRuntimeReady`, run events, finalize).

Residential proxies typically refuse RFC1918 / docker-bridge hostnames (`host.docker.internal`, the platform container's bridge hostname) as `"restricted targets"` with a 403. Result: the very first `POST /api/runs/{id}/events/runtime-ready` from the agent fails, the agent exits with code 1, and the run fails before doing any actual work.

Repro: any agent that has both
- A custom upstream proxy attached (org or agent override)
- Its `forwardProxyUrl` pointed at the sidecar (current default for the Pi runner)

…will crash at bootstrap, regardless of the providers it depends on.

## Solution

Mirror the existing `isAllowedHost()` platform-host exemption used for SSRF: `getUpstreamProxy()` now takes the target hostname and returns `null` when it matches the configured platform host. The result:

- Internal sink/finalize traffic to the platform goes direct (still subject to `isAllowedHost`).
- External `provider_call` traffic continues to be chained through the upstream proxy exactly as before.

The bypass:
- Applies to both **HTTP forwarding** and **CONNECT** tunnels (both code paths in `forward-proxy.ts`).
- Is **case-insensitive** on the hostname comparison.
- **Re-reads `config.platformApiUrl` on every request** — same hot-reload contract as `getPlatformHost()`, so pool sidecars reconfigured via `POST /configure` pick up the right host.

Single-source-of-truth: the platform host is already known to the sidecar via `getPlatformHost()`. No new env var, no new config field, no new operator-tunable.

## Diff summary

- `runtime-pi/sidecar/forward-proxy.ts` — `getUpstreamProxy()` now accepts an optional `targetHost` and short-circuits to `null` when it matches `getPlatformHost()`. Both call sites updated to pass the parsed hostname.
- `runtime-pi/sidecar/test/forward-proxy.test.ts` — 5 new tests (`describe("upstream proxy bypass for platform host")`) covering HTTP and CONNECT paths, with a `startFakeUpstream()` helper that captures the targets the upstream is asked to forward and surfaces its participation via an `X-Via-Upstream` header (HTTP) and a 403 on CONNECT.

## Test plan

- [x] `bun test runtime-pi/sidecar/test/forward-proxy.test.ts` — 28 pass, 0 fail.
- [x] Validated against a real Decodo Canada sticky-session proxy + a LinkedIn-Voyager provider: with this patch, the agent boots, the sink ACK comes back from `host.docker.internal:3000` direct, and external `provider_call`s to `linkedin.com/**` still flow through Decodo as expected.