### PR TITLE
fix(bootstrap): auto-install minisign on fresh hosts (#470)

### DIFF
--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -414,16 +414,22 @@ jobs:
           echo "::endgroup::"
           echo "✓ tampered-checksums path OK"
 
-          # ── Scenario 4: minisign missing from PATH (fail closed) ─────
-          echo "::group::minisign missing"
-          # Strip /usr/bin (where minisign lives on Ubuntu) but keep enough
-          # for curl + sh builtins + sha256sum (all in /usr/bin, so we also
-          # need to shadow minisign by pointing PATH elsewhere and relying
-          # on an explicit denylist). Simpler: create a PATH with only the
-          # minimum required tools, symlinked explicitly.
+          # ── Scenario 4: minisign auto-install fallback paths (issue #470) ─
+          # The happy auto-install path (apt-get/apk/brew available +
+          # minisign absent → install and proceed) is exercised end-to-end
+          # by `fresh-install-distros` on real distro images. Here we lock
+          # the two "fall back to the legacy fail-closed hint" branches —
+          # the ones the unit-style PATH sandbox can actually reproduce.
+
+          # ── 4a: no recognised package manager → legacy hint ──────────
+          # PATH stripped of every known PM (apt-get/apk/dnf/pacman/zypper
+          # /brew). detect_minisign_installer must return 1 and the script
+          # must surface the original "install minisign manually" message,
+          # not silently fail somewhere later in the verify chain.
+          echo "::group::minisign missing — no package manager"
           NOBIN="$GITHUB_WORKSPACE/no-minisign-path"
           mkdir -p "$NOBIN"
-          for b in curl bash grep sed tr head cat mkdir mktemp rm install chmod cd cp ln sha256sum sudo uname tee printf; do
+          for b in curl bash grep sed tr head cat mkdir mktemp rm install chmod cd cp ln sha256sum sudo uname tee printf id; do
             if command -v "$b" >/dev/null 2>&1; then
               ln -sf "$(command -v "$b")" "$NOBIN/$b" 2>/dev/null || true
             fi
@@ -435,12 +441,50 @@ jobs:
           set -e
           echo "$NOMINI_OUT"
           if [ "$rc" -eq 0 ]; then
-            echo "::error::bootstrap proceeded without minisign available"; exit 1
+            echo "::error::bootstrap proceeded without minisign + no PM available"; exit 1
           fi
           echo "$NOMINI_OUT" | grep -q "minisign is required" \
             || { echo "::error::bootstrap did not emit the minisign-missing hint"; exit 1; }
+          # Auto-install must NOT have fired (no recognised installer).
+          echo "$NOMINI_OUT" | grep -q "Installing minisign via" \
+            && { echo "::error::bootstrap tried to auto-install with no PM detected"; exit 1; }
           echo "::endgroup::"
-          echo "✓ missing-minisign path OK"
+          echo "✓ 4a: no-PM → legacy hint"
+
+          # ── 4b: APPSTRATE_NO_INSTALL_MINISIGN=1 opt-out (apt available) ─
+          # Operators who manage the dependency themselves opt out via env
+          # var. Even with apt-get on PATH, the script must skip the
+          # auto-install attempt and surface the legacy hint instead.
+          echo "::group::minisign missing — APPSTRATE_NO_INSTALL_MINISIGN=1"
+          OPTOUT_BIN="$GITHUB_WORKSPACE/no-minisign-with-apt"
+          mkdir -p "$OPTOUT_BIN"
+          for b in curl bash grep sed tr head cat mkdir mktemp rm install chmod cd cp ln sha256sum sudo uname tee printf id apt-get; do
+            if command -v "$b" >/dev/null 2>&1; then
+              ln -sf "$(command -v "$b")" "$OPTOUT_BIN/$b" 2>/dev/null || true
+            fi
+          done
+          # Shadow `minisign` to /bin/false to force the missing-minisign
+          # branch even though the host has it (the dry-run installs
+          # minisign at the top of the job — see "Install minisign" step).
+          ln -sf /bin/false "$OPTOUT_BIN/minisign"
+          set +e
+          OPTOUT_OUT=$(PATH="$OPTOUT_BIN" \
+            APPSTRATE_BIN_DIR="$GITHUB_WORKSPACE/bin-optout" \
+            APPSTRATE_NO_INSTALL_MINISIGN=1 \
+            bash /tmp/bootstrap.sh 2>&1)
+          rc=$?
+          set -e
+          echo "$OPTOUT_OUT"
+          if [ "$rc" -eq 0 ]; then
+            echo "::error::opt-out bootstrap proceeded with broken minisign"; exit 1
+          fi
+          echo "$OPTOUT_OUT" | grep -q "minisign is required" \
+            || { echo "::error::opt-out did not surface the legacy hint"; exit 1; }
+          echo "$OPTOUT_OUT" | grep -q "Installing minisign via" \
+            && { echo "::error::APPSTRATE_NO_INSTALL_MINISIGN=1 still tried to auto-install"; exit 1; }
+          echo "::endgroup::"
+          echo "✓ 4b: opt-out → legacy hint"
+          echo "✓ missing-minisign fallback paths OK"
 
           # ── Scenario 5: APPSTRATE_SKIP_VERIFY=1 + CI=true (warns + proceeds) ─
           # Skip is gated on CI=true to prevent social-engineered bypass on
@@ -767,3 +811,146 @@ jobs:
             || { echo "::error::rc modified despite BIN_DIR already on PATH"; exit 1; }
           echo "::endgroup::"
           echo "✓ already-on-PATH skip OK"
+
+  # End-to-end exercise of the bootstrap on a *real* fresh distro image
+  # (issue #470). Stages a fake signed release on the host, runs Python
+  # http.server, then `docker run --network host` per-distro with only
+  # `curl` (+ ca-certs/bash where needed) pre-installed — minisign is
+  # deliberately absent, so the auto-installer must drive it home.
+  #
+  # This is the test that would have caught #470 — the existing
+  # PATH-sandbox scenarios test "fail closed when no PM", but no job
+  # exercised the "apt-get available + minisign missing" happy path
+  # that the homepage one-liner hits on a fresh Ubuntu.
+  fresh-install-distros:
+    runs-on: ubuntu-latest
+    needs: [static, workflow-lint]
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-24.04
+            image: ubuntu:24.04
+            prep: apt-get update -qq && apt-get install -y -qq curl ca-certificates bash
+          - name: debian-bookworm
+            image: debian:bookworm-slim
+            prep: apt-get update -qq && apt-get install -y -qq curl ca-certificates bash
+          - name: alpine-3
+            image: alpine:3
+            prep: apk add --no-cache curl ca-certificates bash
+          - name: fedora-latest
+            image: fedora:latest
+            prep: dnf install -y -q curl ca-certificates bash >/dev/null
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install minisign on runner (for signing the fake release)
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq minisign
+
+      - name: Stage fake signed release + rewrite bootstrap.sh
+        run: |
+          set -euo pipefail
+
+          ROOT="$GITHUB_WORKSPACE/served-${{ matrix.name }}"
+          mkdir -p "$ROOT/release"
+
+          cat > "$ROOT/release/appstrate-linux-x64" <<'CLI'
+          #!/usr/bin/env bash
+          echo "FAKE_CLI_RAN subcommand=$1 argv=$*"
+          exit 0
+          CLI
+          chmod +x "$ROOT/release/appstrate-linux-x64"
+
+          # Also stage the arm64 asset — the matrix runs on ubuntu-latest
+          # (x64) but future self-hosted arm runners would otherwise miss.
+          cp "$ROOT/release/appstrate-linux-x64" "$ROOT/release/appstrate-linux-arm64"
+
+          (cd "$ROOT/release" && sha256sum appstrate-linux-x64 appstrate-linux-arm64 > checksums.txt)
+
+          umask 077
+          minisign -G -W -f -p /tmp/dry-${{ matrix.name }}.pub -s /tmp/dry-${{ matrix.name }}.key
+          minisign -S -s /tmp/dry-${{ matrix.name }}.key -t "fresh-install dry-run" \
+            -m "$ROOT/release/checksums.txt"
+
+          PUBKEY=$(grep -v '^untrusted' /tmp/dry-${{ matrix.name }}.pub | head -1 | tr -d '\n')
+
+          # shellcheck disable=SC2016  # `${VERSION}` is literal in the sed pattern
+          sed \
+            -e "s|__APPSTRATE_VERSION__|v1.0.0-dry|g" \
+            -e 's|https://github.com/appstrate/appstrate/releases/latest/download|http://localhost:8767/release|' \
+            -e 's|https://github.com/appstrate/appstrate/releases/download/${VERSION}|http://localhost:8767/release|' \
+            -e "s|APPSTRATE_MINISIGN_PUBKEY=\"[^\"]*\"|APPSTRATE_MINISIGN_PUBKEY=\"${PUBKEY}\"|" \
+            scripts/bootstrap.sh > /tmp/bootstrap-${{ matrix.name }}.sh
+          bash -n /tmp/bootstrap-${{ matrix.name }}.sh
+          echo "ROOT=$ROOT" >> "$GITHUB_ENV"
+
+      - name: Serve fake release from host (Python http.server)
+        run: |
+          set -euo pipefail
+          cd "$ROOT"
+          # Bind to 0.0.0.0 explicitly so `--network host` containers can
+          # reach it via 127.0.0.1 (Linux host-networking shares the
+          # runner's loopback). Port 8767 — distinct from the dry-run
+          # job's 8766 to avoid clashing if both run concurrently.
+          python3 -m http.server 8767 --bind 0.0.0.0 >/tmp/httpd.log 2>&1 &
+          echo $! > /tmp/httpd-${{ matrix.name }}.pid
+          # Brief wait for the port to come up; fail loudly if it doesn't.
+          for _ in 1 2 3 4 5; do
+            curl -fsS "http://127.0.0.1:8767/release/checksums.txt" >/dev/null && break
+            sleep 1
+          done
+          curl -fsS "http://127.0.0.1:8767/release/checksums.txt" >/dev/null
+
+      - name: Run bootstrap inside ${{ matrix.image }} (fresh distro, no minisign)
+        run: |
+          set -euo pipefail
+
+          # Use APPSTRATE_NO_LAUNCH=1 so the bootstrap stops AFTER verifying
+          # + dropping the binary, without exec'ing the fake CLI. That keeps
+          # the script's exit code meaningful and lets us inspect post-run
+          # state (binary on disk, minisign on PATH) from the host.
+          #
+          # `--network host` so the container can reach the host's Python
+          # server at 127.0.0.1:8767. Linux runners only — fine for
+          # ubuntu-latest.
+          OUT=$(docker run --rm \
+            --network host \
+            --workdir /tmp \
+            -e APPSTRATE_NO_LAUNCH=1 \
+            -e APPSTRATE_BIN_DIR=/tmp/appstrate-bin \
+            -v "/tmp/bootstrap-${{ matrix.name }}.sh:/tmp/bootstrap.sh:ro" \
+            "${{ matrix.image }}" \
+            sh -c '
+              set -e
+              ${{ matrix.prep }}
+              # Sanity: minisign must NOT be present before bootstrap runs.
+              if command -v minisign >/dev/null 2>&1; then
+                echo "TEST_SETUP_BROKEN: minisign already on PATH inside container" >&2
+                exit 99
+              fi
+              bash /tmp/bootstrap.sh
+              echo "POST_BOOTSTRAP_MINISIGN=$(command -v minisign || echo MISSING)"
+              echo "POST_BOOTSTRAP_BINARY=$(ls -la /tmp/appstrate-bin/appstrate 2>/dev/null || echo MISSING)"
+            ' 2>&1)
+          rc=$?
+          echo "$OUT"
+          test "$rc" -eq 0 \
+            || { echo "::error::bootstrap exited $rc on ${{ matrix.name }}"; exit 1; }
+          echo "$OUT" | grep -q "Installing minisign via" \
+            || { echo "::error::bootstrap did not announce the auto-install on ${{ matrix.name }}"; exit 1; }
+          echo "$OUT" | grep -q "Integrity + provenance verified" \
+            || { echo "::error::verification chain did not complete on ${{ matrix.name }}"; exit 1; }
+          echo "$OUT" | grep -q "POST_BOOTSTRAP_MINISIGN=/" \
+            || { echo "::error::minisign not on PATH after bootstrap on ${{ matrix.name }}"; exit 1; }
+          echo "$OUT" | grep -q "POST_BOOTSTRAP_BINARY=.* /tmp/appstrate-bin/appstrate" \
+            || { echo "::error::appstrate binary not dropped on ${{ matrix.name }}"; exit 1; }
+          echo "✓ ${{ matrix.name }}: minisign auto-install + verify + drop OK"
+
+      - name: Stop the http server
+        if: always()
+        run: |
+          if [ -f "/tmp/httpd-${{ matrix.name }}.pid" ]; then
+            kill "$(cat /tmp/httpd-${{ matrix.name }}.pid)" 2>/dev/null || true
+          fi
+          rm -f /tmp/dry-${{ matrix.name }}.key

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -458,15 +458,15 @@ jobs:
           echo "::group::minisign missing — APPSTRATE_NO_INSTALL_MINISIGN=1"
           OPTOUT_BIN="$GITHUB_WORKSPACE/no-minisign-with-apt"
           mkdir -p "$OPTOUT_BIN"
+          # apt-get IS available here (so `detect_minisign_installer` would
+          # otherwise return "apt"), but `minisign` is NOT — leaving the
+          # have_minisign check false. The opt-out env var must prevent the
+          # auto-install from firing even though a PM is detectable.
           for b in curl bash grep sed tr head cat mkdir mktemp rm install chmod cd cp ln sha256sum sudo uname tee printf id apt-get; do
             if command -v "$b" >/dev/null 2>&1; then
               ln -sf "$(command -v "$b")" "$OPTOUT_BIN/$b" 2>/dev/null || true
             fi
           done
-          # Shadow `minisign` to /bin/false to force the missing-minisign
-          # branch even though the host has it (the dry-run installs
-          # minisign at the top of the job — see "Install minisign" step).
-          ln -sf /bin/false "$OPTOUT_BIN/minisign"
           set +e
           OPTOUT_OUT=$(PATH="$OPTOUT_BIN" \
             APPSTRATE_BIN_DIR="$GITHUB_WORKSPACE/bin-optout" \
@@ -914,6 +914,11 @@ jobs:
           # `--network host` so the container can reach the host's Python
           # server at 127.0.0.1:8767. Linux runners only — fine for
           # ubuntu-latest.
+          #
+          # `set +e` wrap is load-bearing: the workflow runs under `bash -e`
+          # so a non-zero docker exit would kill the step before $OUT could
+          # be echoed, leaving no diagnostic. Capture rc explicitly instead.
+          set +e
           OUT=$(docker run --rm \
             --network host \
             --workdir /tmp \
@@ -934,6 +939,7 @@ jobs:
               echo "POST_BOOTSTRAP_BINARY=$(ls -la /tmp/appstrate-bin/appstrate 2>/dev/null || echo MISSING)"
             ' 2>&1)
           rc=$?
+          set -e
           echo "$OUT"
           test "$rc" -eq 0 \
             || { echo "::error::bootstrap exited $rc on ${{ matrix.name }}"; exit 1; }

--- a/.github/workflows/test-install.yml
+++ b/.github/workflows/test-install.yml
@@ -960,3 +960,132 @@ jobs:
             kill "$(cat /tmp/httpd-${{ matrix.name }}.pid)" 2>/dev/null || true
           fi
           rm -f /tmp/dry-${{ matrix.name }}.key
+
+  # Same end-to-end exercise as `fresh-install-distros` but on a real
+  # macos-latest runner (Apple Silicon). We can't use Docker on macOS
+  # GHA runners — the bootstrap runs natively on the host. To simulate
+  # "fresh macOS without minisign" we `brew uninstall minisign` (the
+  # runner image ships it for the linux signing step elsewhere), then
+  # run the bootstrap and assert the brew auto-install fires.
+  #
+  # macos-latest minutes are 10× linux's. Only matrix-entry, no parallel
+  # fan-out — gates exactly the macOS code path that the linux matrix
+  # cannot reach.
+  fresh-install-macos:
+    runs-on: macos-latest
+    needs: [static, workflow-lint]
+    timeout-minutes: 15
+    env:
+      # Skip `brew update`'s formula-tap refresh — adds 30-60s on a
+      # cold runner and isn't needed for an installed-formula reinstall.
+      HOMEBREW_NO_AUTO_UPDATE: "1"
+      HOMEBREW_NO_INSTALL_CLEANUP: "1"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Ensure minisign present on runner (for signing the fake release)
+        run: |
+          set -euo pipefail
+          if ! command -v minisign >/dev/null 2>&1; then
+            brew install minisign
+          fi
+          # Resolve the canonical path now; brew might be in /opt/homebrew/bin
+          # (Apple Silicon) or /usr/local/bin (Intel runners — legacy).
+          command -v minisign
+
+      - name: Stage fake signed release + rewrite bootstrap.sh
+        run: |
+          set -euo pipefail
+          ROOT="$GITHUB_WORKSPACE/served-macos"
+          mkdir -p "$ROOT/release"
+
+          # macos-latest is Apple Silicon → uname -m=arm64 → darwin-arm64
+          # is the asset the bootstrap will request. Stage x64 too for
+          # forward compatibility with future Intel-runner pinning.
+          cat > "$ROOT/release/appstrate-darwin-arm64" <<'CLI'
+          #!/usr/bin/env bash
+          echo "FAKE_CLI_RAN subcommand=$1 argv=$*"
+          exit 0
+          CLI
+          chmod +x "$ROOT/release/appstrate-darwin-arm64"
+          cp "$ROOT/release/appstrate-darwin-arm64" "$ROOT/release/appstrate-darwin-x64"
+
+          # macOS ships BSD `shasum`, not GNU `sha256sum` — use shasum to
+          # produce a manifest the bootstrap's `shasum -a 256 -c` branch
+          # will accept (same `<hash>  <file>` format).
+          (cd "$ROOT/release" && shasum -a 256 appstrate-darwin-arm64 appstrate-darwin-x64 > checksums.txt)
+
+          umask 077
+          minisign -G -W -f -p /tmp/dry-macos.pub -s /tmp/dry-macos.key
+          minisign -S -s /tmp/dry-macos.key -t "macos dry-run" \
+            -m "$ROOT/release/checksums.txt"
+
+          PUBKEY=$(grep -v '^untrusted' /tmp/dry-macos.pub | head -1 | tr -d '\n')
+
+          # macOS sed needs `-i ''` for in-place edits, but we're piping
+          # to a fresh file so the GNU/BSD difference doesn't bite here.
+          # shellcheck disable=SC2016  # `${VERSION}` is literal in the sed pattern
+          sed \
+            -e "s|__APPSTRATE_VERSION__|v1.0.0-dry|g" \
+            -e 's|https://github.com/appstrate/appstrate/releases/latest/download|http://localhost:8768/release|' \
+            -e 's|https://github.com/appstrate/appstrate/releases/download/${VERSION}|http://localhost:8768/release|' \
+            -e "s|APPSTRATE_MINISIGN_PUBKEY=\"[^\"]*\"|APPSTRATE_MINISIGN_PUBKEY=\"${PUBKEY}\"|" \
+            scripts/bootstrap.sh > /tmp/bootstrap-macos.sh
+          bash -n /tmp/bootstrap-macos.sh
+          echo "ROOT=$ROOT" >> "$GITHUB_ENV"
+
+      - name: Serve fake release from runner (Python http.server)
+        run: |
+          set -euo pipefail
+          cd "$ROOT"
+          python3 -m http.server 8768 --bind 0.0.0.0 >/tmp/httpd.log 2>&1 &
+          echo $! > /tmp/httpd-macos.pid
+          for _ in 1 2 3 4 5; do
+            curl -fsS "http://127.0.0.1:8768/release/checksums.txt" >/dev/null && break
+            sleep 1
+          done
+          curl -fsS "http://127.0.0.1:8768/release/checksums.txt" >/dev/null
+
+      - name: Uninstall minisign (simulate fresh macOS without it)
+        run: |
+          set -euo pipefail
+          # `brew uninstall` fully removes the keg + symlink, so the
+          # subsequent `brew install minisign` from try_install_minisign
+          # is a true install (not a no-op re-link). Without this the
+          # auto-install would print "already installed" and exit 0 while
+          # leaving nothing on PATH — exactly the silent-pass we want
+          # to guard against.
+          brew uninstall minisign
+          if command -v minisign >/dev/null 2>&1; then
+            echo "::error::brew uninstall left minisign on PATH ($(command -v minisign))"
+            exit 1
+          fi
+
+      - name: Run bootstrap on macOS (should auto-install minisign via brew)
+        run: |
+          set +e
+          OUT=$(APPSTRATE_NO_LAUNCH=1 \
+            APPSTRATE_BIN_DIR=/tmp/appstrate-bin \
+            bash /tmp/bootstrap-macos.sh 2>&1)
+          rc=$?
+          set -e
+          echo "$OUT"
+          test "$rc" -eq 0 \
+            || { echo "::error::bootstrap exited $rc on macOS"; exit 1; }
+          echo "$OUT" | grep -q "Installing minisign via brew" \
+            || { echo "::error::macOS did not announce the brew auto-install"; exit 1; }
+          echo "$OUT" | grep -q "Integrity + provenance verified" \
+            || { echo "::error::macOS verification chain did not complete"; exit 1; }
+          command -v minisign >/dev/null 2>&1 \
+            || { echo "::error::minisign not on PATH after macOS bootstrap"; exit 1; }
+          test -x /tmp/appstrate-bin/appstrate \
+            || { echo "::error::appstrate binary not dropped on macOS"; exit 1; }
+          echo "✓ macOS: brew auto-install + verify + drop OK"
+
+      - name: Stop the http server
+        if: always()
+        run: |
+          if [ -f "/tmp/httpd-macos.pid" ]; then
+            kill "$(cat /tmp/httpd-macos.pid)" 2>/dev/null || true
+          fi
+          rm -f /tmp/dry-macos.key

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -512,10 +512,15 @@ _appstrate_bootstrap() {
         err "  → Duplicate or malformed entries — do NOT execute."
         exit 1
       fi
+      # `--quiet` is GNU-only — BusyBox's sha256sum (Alpine) rejects it
+      # with "unrecognized option". Drop the flag and silence the "OK"
+      # confirmation line via `>/dev/null` instead, which is portable
+      # across GNU coreutils, BusyBox, and macOS BSD shasum. Exit code
+      # is what drives the gate; the suppressed line is just noise.
       if have_sha256sum; then
-        sha256sum -c --quiet checksums.local.txt
+        sha256sum -c checksums.local.txt >/dev/null
       elif have_shasum; then
-        shasum -a 256 -c --quiet checksums.local.txt
+        shasum -a 256 -c checksums.local.txt >/dev/null
       else
         err "Neither sha256sum nor shasum is available on this system."
         exit 1

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -151,13 +151,22 @@ _appstrate_bootstrap() {
   # incantation against the wrong manager is worse than failing closed).
   detect_minisign_installer() {
     if [ "$OS" = "darwin" ]; then
-      command -v brew >/dev/null 2>&1 && { printf 'brew'; return; }
+      if command -v brew >/dev/null 2>&1; then
+        printf 'brew'
+        return 0
+      fi
     else
-      command -v apt-get >/dev/null 2>&1 && { printf 'apt'; return; }
-      command -v apk >/dev/null 2>&1 && { printf 'apk'; return; }
-      command -v dnf >/dev/null 2>&1 && { printf 'dnf'; return; }
-      command -v pacman >/dev/null 2>&1 && { printf 'pacman'; return; }
-      command -v zypper >/dev/null 2>&1 && { printf 'zypper'; return; }
+      # `bin:name` pairs — bin we probe with `command -v`, name we emit.
+      # apt-get is the only case where the two differ (we surface it as
+      # "apt" because that's how the user knows it). Other distros: same.
+      for _mgr in apt-get:apt apk:apk dnf:dnf pacman:pacman zypper:zypper; do
+        _bin="${_mgr%:*}"
+        _name="${_mgr#*:}"
+        if command -v "$_bin" >/dev/null 2>&1; then
+          printf '%s' "$_name"
+          return 0
+        fi
+      done
     fi
     return 1
   }

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -37,6 +37,11 @@
 #                                 PATH. Equivalent to uv's UV_NO_MODIFY_PATH.
 #   APPSTRATE_SKIP_VERIFY=1       Skip signature + checksum verification (CI
 #                                 debug only — do NOT set on user machines).
+#   APPSTRATE_NO_INSTALL_MINISIGN=1
+#                                 Do not attempt to auto-install `minisign` via
+#                                 the host package manager when it's missing.
+#                                 The script falls back to the original
+#                                 instructions-then-exit behaviour.
 
 set -euo pipefail
 
@@ -122,6 +127,97 @@ _appstrate_bootstrap() {
   have_sha256sum() { command -v sha256sum >/dev/null 2>&1; }
   have_shasum() { command -v shasum >/dev/null 2>&1; }
   have_minisign() { command -v minisign >/dev/null 2>&1; }
+
+  # ─── minisign auto-install (issue #470) ─────────────────────────────────────
+  #
+  # The one-liner one-step UX promise ("paste this, get a running Appstrate")
+  # breaks on every Debian-family box without minisign pre-installed: the
+  # verification gate is non-negotiable, so the script otherwise dies asking
+  # the user to apt-install a package and re-run. Detect the host package
+  # manager, install minisign ourselves, and proceed — same trust assumption
+  # as the `curl … | bash` step (user trusts get.appstrate.dev over TLS).
+  #
+  # Auto-install fires in three contexts without a prompt:
+  #   1. `--yes` arg present (advertised one-liner on the homepage)
+  #   2. CI=true|1|yes (any CI runner — non-interactive by definition)
+  #   3. No TTY available for a prompt (piped from another script, systemd…)
+  # In an interactive TTY without any of the above, a y/N prompt fires
+  # (defaults to Y — declining mirrors the legacy hint-and-exit behaviour).
+  #
+  # APPSTRATE_NO_INSTALL_MINISIGN=1 opts out entirely.
+
+  # Pick the first available package manager. We don't auto-install on
+  # distros we haven't validated (the install command differs and the wrong
+  # incantation against the wrong manager is worse than failing closed).
+  detect_minisign_installer() {
+    if [ "$OS" = "darwin" ]; then
+      command -v brew >/dev/null 2>&1 && { printf 'brew'; return; }
+    else
+      command -v apt-get >/dev/null 2>&1 && { printf 'apt'; return; }
+      command -v apk >/dev/null 2>&1 && { printf 'apk'; return; }
+      command -v dnf >/dev/null 2>&1 && { printf 'dnf'; return; }
+      command -v pacman >/dev/null 2>&1 && { printf 'pacman'; return; }
+      command -v zypper >/dev/null 2>&1 && { printf 'zypper'; return; }
+    fi
+    return 1
+  }
+
+  # Build the install command for `$1` (manager name). Prepends `sudo` only
+  # when not already root AND `sudo` is on PATH — keeps containerised installs
+  # (root, no sudo binary) working without a spurious "sudo: not found" trap.
+  minisign_install_cmd() {
+    _mgr="$1"
+    _sudo=""
+    if [ "$(id -u 2>/dev/null || echo 0)" != "0" ] && command -v sudo >/dev/null 2>&1; then
+      _sudo="sudo"
+    fi
+    case "$_mgr" in
+      brew) printf 'brew install minisign' ;;
+      apt) printf '%s DEBIAN_FRONTEND=noninteractive apt-get install -y minisign' "$_sudo" ;;
+      apk) printf '%s apk add --no-cache minisign' "$_sudo" ;;
+      dnf) printf '%s dnf install -y minisign' "$_sudo" ;;
+      pacman) printf '%s pacman -S --noconfirm minisign' "$_sudo" ;;
+      zypper) printf '%s zypper install -y minisign' "$_sudo" ;;
+      *) return 1 ;;
+    esac
+  }
+
+  # apt-get install fails on a stale package cache (very common on fresh
+  # Ubuntu images — `/var/lib/apt/lists` is empty). Refresh once before
+  # the install attempt; ignore failures (the install step will surface a
+  # real error if the index actually can't be fetched).
+  apt_refresh_if_needed() {
+    _sudo=""
+    if [ "$(id -u 2>/dev/null || echo 0)" != "0" ] && command -v sudo >/dev/null 2>&1; then
+      _sudo="sudo"
+    fi
+    # `-qq` keeps the refresh quiet; the bootstrap is the only voice the
+    # user should hear in the happy path.
+    $_sudo apt-get update -qq >/dev/null 2>&1 || true
+  }
+
+  # Returns 0 if minisign got installed, non-zero otherwise. Caller decides
+  # how to react — we don't `exit` from here so the surrounding flow keeps
+  # owning the error UX.
+  try_install_minisign() {
+    _mgr="$(detect_minisign_installer)" || return 1
+    _cmd="$(minisign_install_cmd "$_mgr")" || return 1
+    log "Installing minisign via $_mgr (required for signature verification)"
+    log "  \$ $_cmd"
+    # apt needs a fresh package index on stock cloud-init / Docker images.
+    if [ "$_mgr" = "apt" ]; then apt_refresh_if_needed; fi
+    # `sh -c` rather than direct exec so the sudo prefix expands correctly
+    # and we never have to special-case the leading-empty-string case.
+    if ! sh -c "$_cmd"; then
+      err "Failed to install minisign via $_mgr."
+      return 1
+    fi
+    if ! have_minisign; then
+      err "minisign install reported success but the binary is still not on PATH."
+      return 1
+    fi
+    return 0
+  }
 
   # ─── Dual-install pre-check (issue #249, phase 4) ───────────────────────────
   #
@@ -293,15 +389,75 @@ _appstrate_bootstrap() {
     # took < 5s; installing minisign via the OS package manager costs
     # roughly the same.
     if ! have_minisign; then
-      err "minisign is required to verify the Appstrate CLI download."
-      err "  → macOS:   brew install minisign"
-      err "  → Debian:  sudo apt install minisign"
-      err "  → Alpine:  apk add minisign"
-      err "  → Other:   https://jedisct1.github.io/minisign/"
-      err ""
-      err "To override (NOT recommended, only for CI debug), re-run with"
-      err "  APPSTRATE_SKIP_VERIFY=1 curl -fsSL https://get.appstrate.dev | bash"
-      exit 1
+      # Decide between auto-install vs. prompt vs. fail-with-hint. We treat
+      # the same four signals that drive the launch decision below as
+      # "unattended": --yes arg, APPSTRATE_AUTO_INSTALL=1, CI=true|1|yes,
+      # and "no TTY on stdout". This keeps `curl … | bash -s -- --yes`
+      # truly one-step and prevents the prompt from firing in Dockerfile
+      # RUN, cron, or systemd contexts where there's nobody to answer.
+      _ms_wants_auto=0
+      case " $* " in *" --yes "*) _ms_wants_auto=1 ;; esac
+      if [ "${APPSTRATE_AUTO_INSTALL:-0}" = "1" ]; then _ms_wants_auto=1; fi
+      case "${CI:-}" in true | 1 | yes) _ms_wants_auto=1 ;; esac
+      if [ ! -t 1 ]; then _ms_wants_auto=1; fi
+
+      if [ "${APPSTRATE_NO_INSTALL_MINISIGN:-0}" = "1" ]; then
+        _ms_installer=""
+      else
+        _ms_installer="$(detect_minisign_installer || true)"
+      fi
+
+      _ms_should_install=0
+      if [ -n "$_ms_installer" ]; then
+        if [ "$_ms_wants_auto" = "1" ]; then
+          _ms_should_install=1
+        else
+          # Interactive prompt — fall back to /dev/tty if stdin is the
+          # curl pipe (same trick as the dual-install gate above).
+          _ms_tty=""
+          if [ -t 0 ]; then
+            _ms_tty="stdin"
+          elif [ -r /dev/tty ]; then
+            _ms_tty="/dev/tty"
+          fi
+          if [ -n "$_ms_tty" ]; then
+            warn "minisign is required to verify the Appstrate CLI download."
+            printf '\nInstall it now via %s? [Y/n] ' "$_ms_installer"
+            _ms_answer=""
+            if [ "$_ms_tty" = "/dev/tty" ]; then
+              IFS= read -r _ms_answer </dev/tty || _ms_answer=""
+            else
+              IFS= read -r _ms_answer || _ms_answer=""
+            fi
+            case "$_ms_answer" in
+              "" | y | Y | yes | YES) _ms_should_install=1 ;;
+              *) _ms_should_install=0 ;;
+            esac
+          fi
+        fi
+      fi
+
+      if [ "$_ms_should_install" = "1" ]; then
+        if ! try_install_minisign; then
+          err ""
+          err "Could not auto-install minisign. Install it manually and re-run:"
+          err "  → macOS:   brew install minisign"
+          err "  → Debian:  sudo apt install minisign"
+          err "  → Alpine:  apk add minisign"
+          err "  → Other:   https://jedisct1.github.io/minisign/"
+          exit 1
+        fi
+      else
+        err "minisign is required to verify the Appstrate CLI download."
+        err "  → macOS:   brew install minisign"
+        err "  → Debian:  sudo apt install minisign"
+        err "  → Alpine:  apk add minisign"
+        err "  → Other:   https://jedisct1.github.io/minisign/"
+        err ""
+        err "To override (NOT recommended, only for CI debug), re-run with"
+        err "  APPSTRATE_SKIP_VERIFY=1 curl -fsSL https://get.appstrate.dev | bash"
+        exit 1
+      fi
     fi
 
     log "Fetching release checksums + signature"


### PR DESCRIPTION
## Summary

The advertised one-liner `curl -fsSL https://get.appstrate.dev | bash` dies on every fresh Ubuntu/Debian host (and any system without `minisign` pre-installed): the bootstrap requires `minisign` for signature verification, but neither installed it nor offered to. The user had to read the error, switch context to `apt`, then re-run — defeating the purpose of a one-step installer.

This change detects the host package manager and installs `minisign` itself before the verification gate, preserving the trust chain (no `APPSTRATE_SKIP_VERIFY=1` workaround) while honouring the one-liner UX promise on a fresh install.

## Behaviour

- **Unattended (`--yes`, `APPSTRATE_AUTO_INSTALL=1`, `CI=true|1|yes`, no TTY)** → installs silently. Same signals already used elsewhere in the script for the launch decision, so behaviour stays predictable.
- **Interactive TTY** → `[Y/n]` prompt (defaults to Y; declining mirrors the legacy hint-and-exit).
- **Unrecognised distro** → falls back to the original instructions-then-exit message — never picks the wrong install command on a host we haven't validated.
- **Opt-out** → `APPSTRATE_NO_INSTALL_MINISIGN=1` for operators who want to manage the dependency themselves.

Supported package managers: `apt-get`, `apk`, `brew`, `dnf`, `pacman`, `zypper`. `sudo` is only prepended when not running as root *and* `sudo` is on PATH (containerised installs as root work without a spurious \"sudo: not found\"). For `apt`, the package index is refreshed first (stock cloud-init / Docker images ship empty `/var/lib/apt/lists`).

Same trust assumption as the `curl … | bash` step itself: the user has already chosen to trust `get.appstrate.dev` over TLS.

Fixes #470

## Test plan

- [x] `shellcheck scripts/bootstrap.sh` passes
- [x] `bash -n scripts/bootstrap.sh` parses
- [x] Unit-tested the `minisign_install_cmd` builder for all 6 managers + the unknown-manager refusal path
- [ ] Smoke-test the one-liner on a fresh Ubuntu 24.04 box without `minisign` pre-installed (the original repro from #470)
- [ ] Smoke-test on macOS without `minisign` (brew available) — confirms the prompt path
- [ ] Smoke-test in a Docker `RUN` step (no TTY) — confirms the auto path fires without `--yes`
- [ ] Confirm `APPSTRATE_NO_INSTALL_MINISIGN=1` falls back to the legacy hint-and-exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)