### PR TITLE
fix(sidecar): capture Set-Cookie from intermediate redirect hops (#473)

### DIFF
--- a/runtime-pi/sidecar/credential-proxy.ts
+++ b/runtime-pi/sidecar/credential-proxy.ts
@@ -61,6 +61,27 @@ function mergeSetCookieIntoJar(
   cookieJar.set(providerId, [...byName.values()]);
 }
 
+/** Parse a `Cookie:` header value into name→pair entries, deduped by name. */
+function parseCookieHeader(value: string | null): Map<string, string> {
+  const byName = new Map<string, string>();
+  if (!value) return byName;
+  for (const part of value.split(";")) {
+    const trimmed = part.trim();
+    if (trimmed) byName.set(trimmed.split("=")[0]!, trimmed);
+  }
+  return byName;
+}
+
+interface RedirectFollowOptions {
+  url: string;
+  init: RequestInit;
+  fetchFn: typeof fetch;
+  cookieJar: Map<string, string[]>;
+  providerId: string;
+  /** Lowercased name of the credential header server-injected by the proxy. */
+  injectedCredentialHeader: string | null;
+}
+
 /**
  * Manually follow 3xx redirects so we can capture `Set-Cookie` from
  * **every** hop into the per-provider jar — Bun's native fetch only
@@ -73,15 +94,20 @@ function mergeSetCookieIntoJar(
  * this, the credential proxy could leak the Bearer token to any origin
  * a redirect points at. Streaming bodies skip this path entirely
  * (caller falls back to native fetch — bodies can't be replayed).
+ *
+ * Caller-supplied cookies are preserved across hops (Bun's native
+ * follower propagates the request `Cookie` header all the way). The
+ * jar wins on name conflict so server-rotated values replace stale
+ * caller-supplied ones.
  */
 async function fetchFollowingRedirectsCapturingCookies(
-  url: string,
-  init: RequestInit,
-  fetchFn: typeof fetch,
-  cookieJar: Map<string, string[]>,
-  providerId: string,
-  injectedCredentialHeader: string | null,
+  opts: RedirectFollowOptions,
 ): Promise<Response> {
+  const { url, init, fetchFn, cookieJar, providerId, injectedCredentialHeader } = opts;
+  const callerCookies = parseCookieHeader(
+    new Headers(init.headers as HeadersInit | undefined).get("cookie"),
+  );
+
   let currentUrl = url;
   let currentInit: RequestInit = { ...init, redirect: "manual" };
 
@@ -101,8 +127,10 @@ async function fetchFollowingRedirectsCapturingCookies(
 
     const headers = new Headers(currentInit.headers as HeadersInit | undefined);
     headers.delete("cookie");
-    const stored = cookieJar.get(providerId);
-    if (stored?.length) headers.set("cookie", stored.join("; "));
+    // Compose Cookie from caller-supplied + jar (jar wins on dup name).
+    const merged = new Map(callerCookies);
+    for (const ck of cookieJar.get(providerId) ?? []) merged.set(ck.split("=")[0]!, ck);
+    if (merged.size) headers.set("cookie", [...merged.values()].join("; "));
     if (dropBody) {
       headers.delete("content-length");
       headers.delete("content-type");
@@ -380,14 +408,14 @@ export async function executeProviderCall(
       init.duplex = "half";
       return fetchFn(resolvedUrl, init);
     }
-    return fetchFollowingRedirectsCapturingCookies(
-      resolvedUrl,
+    return fetchFollowingRedirectsCapturingCookies({
+      url: resolvedUrl,
       init,
       fetchFn,
       cookieJar,
       providerId,
-      activeCreds.credentialHeaderName?.toLowerCase() ?? null,
-    );
+      injectedCredentialHeader: activeCreds.credentialHeaderName?.toLowerCase() ?? null,
+    });
   };
 
   // 7. First outbound request. Network/timeout errors surface as a

--- a/runtime-pi/sidecar/credential-proxy.ts
+++ b/runtime-pi/sidecar/credential-proxy.ts
@@ -119,9 +119,14 @@ async function fetchFollowingRedirectsCapturingCookies(
     const location = response.headers.get("location");
     if (!location) return response;
 
-    // 301/302/303 → method becomes GET, body + content-{length,type} dropped.
-    // 307/308     → method + body preserved verbatim.
-    const dropBody = response.status === 301 || response.status === 302 || response.status === 303;
+    // Per WHATWG fetch (HTTP-redirect fetch step 11) + RFC 9110 §15.4:
+    //   - 301/302 downgrade POST → GET (other methods preserved)
+    //   - 303     downgrade everything-except-GET/HEAD → GET (HEAD preserved)
+    //   - 307/308 preserve method + body verbatim
+    const method = (currentInit.method ?? "GET").toUpperCase();
+    const dropBody =
+      ((response.status === 301 || response.status === 302) && method === "POST") ||
+      (response.status === 303 && method !== "GET" && method !== "HEAD");
     const nextUrl = new URL(location, currentUrl).toString();
     const crossOrigin = new URL(nextUrl).origin !== new URL(currentUrl).origin;
 

--- a/runtime-pi/sidecar/credential-proxy.ts
+++ b/runtime-pi/sidecar/credential-proxy.ts
@@ -43,55 +43,36 @@ import {
 import { getErrorMessage } from "@appstrate/core/errors";
 import { logger } from "./logger.ts";
 
-/**
- * Max redirect hops we will follow manually. Matches Bun's native
- * `fetch` default. Beyond this we surface a clear error instead of
- * letting the chain loop silently.
- */
 const MAX_REDIRECTS = 10;
 
-/**
- * Merge a list of `Set-Cookie` header values into the per-provider
- * jar. Attributes (Path, Expires, Domain, SameSite, …) are stripped —
- * the jar is per-provider-per-run, so finer-grained scoping is not
- * needed for the proxied call model. Cookies are deduped by name, so
- * a rotated value from upstream replaces the prior one.
- */
+/** Dedup by cookie name; strip attributes (Path, Expires, Domain, SameSite, …). */
 function mergeSetCookieIntoJar(
   setCookieHeaders: string[],
   cookieJar: Map<string, string[]>,
   providerId: string,
 ): void {
   if (!setCookieHeaders.length) return;
-  const cookieValues = setCookieHeaders.map((h) => h.split(";")[0]!.trim());
-  const existing = cookieJar.get(providerId) ?? [];
   const byName = new Map<string, string>();
-  for (const ck of existing) byName.set(ck.split("=")[0]!, ck);
-  for (const ck of cookieValues) byName.set(ck.split("=")[0]!, ck);
+  for (const ck of cookieJar.get(providerId) ?? []) byName.set(ck.split("=")[0]!, ck);
+  for (const h of setCookieHeaders) {
+    const ck = h.split(";")[0]!.trim();
+    byName.set(ck.split("=")[0]!, ck);
+  }
   cookieJar.set(providerId, [...byName.values()]);
 }
 
 /**
- * Manually follow 3xx redirects, capturing `Set-Cookie` headers from
- * **every** hop into the per-provider jar and re-injecting the growing
- * jar as `Cookie` on each next hop.
+ * Manually follow 3xx redirects so we can capture `Set-Cookie` from
+ * **every** hop into the per-provider jar — Bun's native fetch only
+ * surfaces the final hop's `Set-Cookie`, which breaks multi-step
+ * OAuth/CAS flows where the session cookie lands on an intermediate
+ * 302 (see #473).
  *
- * Why this exists: Bun's native `fetch` follows redirects automatically
- * but `Response.headers.getSetCookie()` on the final response only
- * surfaces the **last hop's** `Set-Cookie` headers — cookies set by
- * intermediate hops are silently dropped. That breaks multi-step
- * login flows (CAS + OAuth/OIDC, enterprise SSO chains) where the
- * session cookie is set on a non-final 302.
- *
- * Streaming request bodies use the native `fetch` redirect follower
- * instead (their bodies can't be replayed across 307/308 hops) — for
- * those, last-hop-only cookie capture remains the unavoidable
- * behaviour.
- *
- * RFC 9110 redirect semantics:
- *   - 301/302/303 → method becomes GET, body + Content-Length /
- *                    Content-Type dropped
- *   - 307/308     → method + body preserved verbatim
+ * On cross-origin hops we strip `Authorization` and the provider's
+ * injected credential header to match WHATWG fetch behaviour — without
+ * this, the credential proxy could leak the Bearer token to any origin
+ * a redirect points at. Streaming bodies skip this path entirely
+ * (caller falls back to native fetch — bodies can't be replayed).
  */
 async function fetchFollowingRedirectsCapturingCookies(
   url: string,
@@ -99,6 +80,7 @@ async function fetchFollowingRedirectsCapturingCookies(
   fetchFn: typeof fetch,
   cookieJar: Map<string, string[]>,
   providerId: string,
+  injectedCredentialHeader: string | null,
 ): Promise<Response> {
   let currentUrl = url;
   let currentInit: RequestInit = { ...init, redirect: "manual" };
@@ -111,7 +93,12 @@ async function fetchFollowingRedirectsCapturingCookies(
     const location = response.headers.get("location");
     if (!location) return response;
 
+    // 301/302/303 → method becomes GET, body + content-{length,type} dropped.
+    // 307/308     → method + body preserved verbatim.
     const dropBody = response.status === 301 || response.status === 302 || response.status === 303;
+    const nextUrl = new URL(location, currentUrl).toString();
+    const crossOrigin = new URL(nextUrl).origin !== new URL(currentUrl).origin;
+
     const headers = new Headers(currentInit.headers as HeadersInit | undefined);
     headers.delete("cookie");
     const stored = cookieJar.get(providerId);
@@ -120,6 +107,10 @@ async function fetchFollowingRedirectsCapturingCookies(
       headers.delete("content-length");
       headers.delete("content-type");
     }
+    if (crossOrigin) {
+      headers.delete("authorization");
+      if (injectedCredentialHeader) headers.delete(injectedCredentialHeader);
+    }
 
     currentInit = {
       ...currentInit,
@@ -127,7 +118,7 @@ async function fetchFollowingRedirectsCapturingCookies(
       body: dropBody ? undefined : currentInit.body,
       headers,
     };
-    currentUrl = new URL(location, currentUrl).toString();
+    currentUrl = nextUrl;
   }
 
   throw new Error(`Too many redirects (>${MAX_REDIRECTS}) starting at ${url}`);
@@ -383,12 +374,10 @@ export async function executeProviderCall(
       proxy: args.proxyUrl || undefined,
     };
     if (init.body instanceof ReadableStream) {
-      // Required by fetch when sending a streaming request body.
+      // Streaming bodies can't be replayed across hops — fall back to
+      // native fetch (intermediate-hop Set-Cookie lost, step 8 captures
+      // the final hop only).
       init.duplex = "half";
-      // Streaming bodies cannot be replayed across redirect hops, so
-      // we let the native fetch follower handle 3xx — intermediate-hop
-      // Set-Cookie headers are unavoidably lost on this path. Step 8
-      // captures the final hop's cookies for the streaming case.
       return fetchFn(resolvedUrl, init);
     }
     return fetchFollowingRedirectsCapturingCookies(
@@ -397,6 +386,7 @@ export async function executeProviderCall(
       fetchFn,
       cookieJar,
       providerId,
+      activeCreds.credentialHeaderName?.toLowerCase() ?? null,
     );
   };
 
@@ -439,13 +429,9 @@ export async function executeProviderCall(
     }
   }
 
-  // 8. Capture Set-Cookie headers from the terminal response into the
-  //    per-provider jar. For buffered/formData/none bodies the manual
-  //    redirect follower has already merged every hop (including this
-  //    terminal one) — calling merge again is a no-op since it dedups
-  //    by name. For streaming bodies (native fetch redirect follower)
-  //    this is the only capture point; intermediate-hop cookies are
-  //    unavoidably lost.
+  // 8. Terminal-hop Set-Cookie capture. No-op for buffered (the
+  //    follower already merged every hop); load-bearing for streaming
+  //    (final hop only — bodies can't be replayed).
   mergeSetCookieIntoJar(upstream.headers.getSetCookie(), cookieJar, providerId);
 
   // 9. Log persistent auth failures locally (once per provider per

--- a/runtime-pi/sidecar/credential-proxy.ts
+++ b/runtime-pi/sidecar/credential-proxy.ts
@@ -44,6 +44,96 @@ import { getErrorMessage } from "@appstrate/core/errors";
 import { logger } from "./logger.ts";
 
 /**
+ * Max redirect hops we will follow manually. Matches Bun's native
+ * `fetch` default. Beyond this we surface a clear error instead of
+ * letting the chain loop silently.
+ */
+const MAX_REDIRECTS = 10;
+
+/**
+ * Merge a list of `Set-Cookie` header values into the per-provider
+ * jar. Attributes (Path, Expires, Domain, SameSite, …) are stripped —
+ * the jar is per-provider-per-run, so finer-grained scoping is not
+ * needed for the proxied call model. Cookies are deduped by name, so
+ * a rotated value from upstream replaces the prior one.
+ */
+function mergeSetCookieIntoJar(
+  setCookieHeaders: string[],
+  cookieJar: Map<string, string[]>,
+  providerId: string,
+): void {
+  if (!setCookieHeaders.length) return;
+  const cookieValues = setCookieHeaders.map((h) => h.split(";")[0]!.trim());
+  const existing = cookieJar.get(providerId) ?? [];
+  const byName = new Map<string, string>();
+  for (const ck of existing) byName.set(ck.split("=")[0]!, ck);
+  for (const ck of cookieValues) byName.set(ck.split("=")[0]!, ck);
+  cookieJar.set(providerId, [...byName.values()]);
+}
+
+/**
+ * Manually follow 3xx redirects, capturing `Set-Cookie` headers from
+ * **every** hop into the per-provider jar and re-injecting the growing
+ * jar as `Cookie` on each next hop.
+ *
+ * Why this exists: Bun's native `fetch` follows redirects automatically
+ * but `Response.headers.getSetCookie()` on the final response only
+ * surfaces the **last hop's** `Set-Cookie` headers — cookies set by
+ * intermediate hops are silently dropped. That breaks multi-step
+ * login flows (CAS + OAuth/OIDC, enterprise SSO chains) where the
+ * session cookie is set on a non-final 302.
+ *
+ * Streaming request bodies use the native `fetch` redirect follower
+ * instead (their bodies can't be replayed across 307/308 hops) — for
+ * those, last-hop-only cookie capture remains the unavoidable
+ * behaviour.
+ *
+ * RFC 9110 redirect semantics:
+ *   - 301/302/303 → method becomes GET, body + Content-Length /
+ *                    Content-Type dropped
+ *   - 307/308     → method + body preserved verbatim
+ */
+async function fetchFollowingRedirectsCapturingCookies(
+  url: string,
+  init: RequestInit,
+  fetchFn: typeof fetch,
+  cookieJar: Map<string, string[]>,
+  providerId: string,
+): Promise<Response> {
+  let currentUrl = url;
+  let currentInit: RequestInit = { ...init, redirect: "manual" };
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    const response = await fetchFn(currentUrl, currentInit);
+    mergeSetCookieIntoJar(response.headers.getSetCookie(), cookieJar, providerId);
+
+    if (response.status < 300 || response.status >= 400) return response;
+    const location = response.headers.get("location");
+    if (!location) return response;
+
+    const dropBody = response.status === 301 || response.status === 302 || response.status === 303;
+    const headers = new Headers(currentInit.headers as HeadersInit | undefined);
+    headers.delete("cookie");
+    const stored = cookieJar.get(providerId);
+    if (stored?.length) headers.set("cookie", stored.join("; "));
+    if (dropBody) {
+      headers.delete("content-length");
+      headers.delete("content-type");
+    }
+
+    currentInit = {
+      ...currentInit,
+      method: dropBody ? "GET" : currentInit.method,
+      body: dropBody ? undefined : currentInit.body,
+      headers,
+    };
+    currentUrl = new URL(location, currentUrl).toString();
+  }
+
+  throw new Error(`Too many redirects (>${MAX_REDIRECTS}) starting at ${url}`);
+}
+
+/**
  * Body modes the proxy core accepts. The HTTP handler can produce
  * "none" / "buffered" / "streaming"; the MCP handler produces
  * "buffered" for text + binary uploads, and "formData" for the
@@ -295,8 +385,19 @@ export async function executeProviderCall(
     if (init.body instanceof ReadableStream) {
       // Required by fetch when sending a streaming request body.
       init.duplex = "half";
+      // Streaming bodies cannot be replayed across redirect hops, so
+      // we let the native fetch follower handle 3xx — intermediate-hop
+      // Set-Cookie headers are unavoidably lost on this path. Step 8
+      // captures the final hop's cookies for the streaming case.
+      return fetchFn(resolvedUrl, init);
     }
-    return fetchFn(resolvedUrl, init);
+    return fetchFollowingRedirectsCapturingCookies(
+      resolvedUrl,
+      init,
+      fetchFn,
+      cookieJar,
+      providerId,
+    );
   };
 
   // 7. First outbound request. Network/timeout errors surface as a
@@ -338,18 +439,14 @@ export async function executeProviderCall(
     }
   }
 
-  // 8. Capture Set-Cookie headers into the per-provider jar. We strip
-  //    attributes (Path, Expires, …) and merge by name so cookies
-  //    rotated by upstream replace the prior value.
-  const setCookieHeaders = upstream.headers.getSetCookie();
-  if (setCookieHeaders.length) {
-    const cookieValues = setCookieHeaders.map((h) => h.split(";")[0]!.trim());
-    const existing = cookieJar.get(providerId) ?? [];
-    const byName = new Map<string, string>();
-    for (const ck of existing) byName.set(ck.split("=")[0]!, ck);
-    for (const ck of cookieValues) byName.set(ck.split("=")[0]!, ck);
-    cookieJar.set(providerId, [...byName.values()]);
-  }
+  // 8. Capture Set-Cookie headers from the terminal response into the
+  //    per-provider jar. For buffered/formData/none bodies the manual
+  //    redirect follower has already merged every hop (including this
+  //    terminal one) — calling merge again is a no-op since it dedups
+  //    by name. For streaming bodies (native fetch redirect follower)
+  //    this is the only capture point; intermediate-hop cookies are
+  //    unavoidably lost.
+  mergeSetCookieIntoJar(upstream.headers.getSetCookie(), cookieJar, providerId);
 
   // 9. Log persistent auth failures locally (once per provider per
   //    run, only if the retry above did NOT fix it). The Set also

--- a/runtime-pi/sidecar/test/credential-proxy.test.ts
+++ b/runtime-pi/sidecar/test/credential-proxy.test.ts
@@ -225,3 +225,226 @@ describe("executeProviderCall — 401 retry path", () => {
     expect(refreshCredentials).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("executeProviderCall — multi-hop redirect cookie capture (#473)", () => {
+  /**
+   * Bug repro: in multi-step OAuth/CAS flows the session cookie is
+   * often dropped on an intermediate 302. With Bun's native
+   * `redirect: "follow"` only the final hop's Set-Cookie is exposed,
+   * so the jar misses the mid-hop session cookie. After the fix we
+   * follow redirects manually and merge cookies from every hop.
+   */
+  it("captures Set-Cookie from intermediate hops", async () => {
+    let calls = 0;
+    const fetchFn = mock(async (url: string | URL) => {
+      calls += 1;
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/login")) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://api.example.com/callback", "set-cookie": "step1=A" },
+        });
+      }
+      if (u.endsWith("/callback")) {
+        // Intermediate hop — its cookie is the one that used to be lost.
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://api.example.com/home", "set-cookie": "session=XYZ" },
+        });
+      }
+      return new Response("ok", {
+        status: 200,
+        headers: { "set-cookie": "last=Z" },
+      });
+    });
+    const deps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
+    const result = await executeProviderCall(
+      {
+        providerId: "kijiji",
+        targetUrl: "https://api.example.com/login",
+        method: "GET",
+        callerHeaders: {},
+        body: { kind: "none" },
+      },
+      deps,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.response.status).toBe(200);
+    expect(calls).toBe(3);
+    const jar = deps.cookieJar.get("kijiji");
+    // Pre-fix: ["step1=A", "last=Z"] — session=XYZ is missing.
+    // Post-fix: all three cookies merged into the jar.
+    expect(jar).toContain("step1=A");
+    expect(jar).toContain("session=XYZ");
+    expect(jar).toContain("last=Z");
+  });
+
+  it("re-injects the growing jar as Cookie header on each next hop", async () => {
+    const cookieHeadersSeen: (string | null)[] = [];
+    const fetchFn = mock(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      const headers = new Headers(init?.headers);
+      cookieHeadersSeen.push(headers.get("cookie"));
+      if (u.endsWith("/a")) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://api.example.com/b", "set-cookie": "first=1" },
+        });
+      }
+      if (u.endsWith("/b")) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://api.example.com/c", "set-cookie": "second=2" },
+        });
+      }
+      return new Response("ok", { status: 200 });
+    });
+    const deps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
+    await executeProviderCall(
+      {
+        providerId: "demo",
+        targetUrl: "https://api.example.com/a",
+        method: "GET",
+        callerHeaders: {},
+        body: { kind: "none" },
+      },
+      deps,
+    );
+    expect(cookieHeadersSeen.length).toBe(3);
+    expect(cookieHeadersSeen[0]).toBeNull();
+    expect(cookieHeadersSeen[1]).toBe("first=1");
+    // Both cookies sent on the third hop (jar grew across hops).
+    expect(cookieHeadersSeen[2]).toContain("first=1");
+    expect(cookieHeadersSeen[2]).toContain("second=2");
+  });
+
+  it("downgrades method to GET and drops body on 301/302/303", async () => {
+    const observed: { method: string; body: unknown; contentType: string | null }[] = [];
+    const fetchFn = mock(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      const headers = new Headers(init?.headers);
+      observed.push({
+        method: init?.method ?? "GET",
+        body: init?.body,
+        contentType: headers.get("content-type"),
+      });
+      if (u.endsWith("/post")) {
+        return new Response(null, {
+          status: 303,
+          headers: { location: "https://api.example.com/result" },
+        });
+      }
+      return new Response("done", { status: 200 });
+    });
+    const deps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
+    const result = await executeProviderCall(
+      {
+        providerId: "demo",
+        targetUrl: "https://api.example.com/post",
+        method: "POST",
+        callerHeaders: { "content-type": "application/json" },
+        body: {
+          kind: "buffered",
+          bytes: new TextEncoder().encode('{"x":1}').buffer as ArrayBuffer,
+          text: '{"x":1}',
+        },
+      },
+      deps,
+    );
+    expect(result.ok).toBe(true);
+    expect(observed[0]!.method).toBe("POST");
+    expect(observed[1]!.method).toBe("GET");
+    expect(observed[1]!.body).toBeUndefined();
+    expect(observed[1]!.contentType).toBeNull();
+  });
+
+  it("preserves method and body on 307/308", async () => {
+    const observed: { method: string; body: unknown }[] = [];
+    const fetchFn = mock(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      observed.push({ method: init?.method ?? "GET", body: init?.body });
+      if (u.endsWith("/post")) {
+        return new Response(null, {
+          status: 307,
+          headers: { location: "https://api.example.com/result" },
+        });
+      }
+      return new Response("done", { status: 200 });
+    });
+    const deps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
+    const result = await executeProviderCall(
+      {
+        providerId: "demo",
+        targetUrl: "https://api.example.com/post",
+        method: "POST",
+        callerHeaders: { "content-type": "application/json" },
+        body: {
+          kind: "buffered",
+          bytes: new TextEncoder().encode('{"x":1}').buffer as ArrayBuffer,
+          text: '{"x":1}',
+        },
+      },
+      deps,
+    );
+    expect(result.ok).toBe(true);
+    expect(observed[0]!.method).toBe("POST");
+    expect(observed[1]!.method).toBe("POST");
+    expect(observed[1]!.body).toBeDefined();
+  });
+
+  it("throws on redirect chains exceeding MAX_REDIRECTS", async () => {
+    const fetchFn = mock(
+      async () =>
+        new Response(null, {
+          status: 302,
+          headers: { location: "https://api.example.com/loop" },
+        }),
+    );
+    const deps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
+    const result = await executeProviderCall(
+      {
+        providerId: "demo",
+        targetUrl: "https://api.example.com/loop",
+        method: "GET",
+        callerHeaders: {},
+        body: { kind: "none" },
+      },
+      deps,
+    );
+    // Surfaces as a structured upstream failure (wrapped by wrapFetchError).
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(502);
+  });
+
+  it("streaming bodies still use native fetch and only capture final-hop cookies", async () => {
+    const fetchFn = mock(
+      async () =>
+        new Response("ok", {
+          status: 200,
+          headers: { "set-cookie": "final=F" },
+        }),
+    );
+    const deps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
+    const stream = new ReadableStream({
+      start(c) {
+        c.enqueue(new Uint8Array([1, 2, 3]));
+        c.close();
+      },
+    });
+    const result = await executeProviderCall(
+      {
+        providerId: "demo",
+        targetUrl: "https://api.example.com/upload",
+        method: "POST",
+        callerHeaders: {},
+        body: { kind: "streaming", stream },
+      },
+      deps,
+    );
+    expect(result.ok).toBe(true);
+    // Native fetch called once with redirect: "follow" (default).
+    const init = fetchFn.mock.calls[0]![1] as RequestInit;
+    expect(init.redirect).not.toBe("manual");
+    expect(deps.cookieJar.get("demo")).toEqual(["final=F"]);
+  });
+});

--- a/runtime-pi/sidecar/test/credential-proxy.test.ts
+++ b/runtime-pi/sidecar/test/credential-proxy.test.ts
@@ -392,7 +392,10 @@ describe("executeProviderCall — multi-hop redirect cookie capture (#473)", () 
     expect(observed[1]!.body).toBeDefined();
   });
 
-  it("throws on redirect chains exceeding MAX_REDIRECTS", async () => {
+  it("caps redirect chains at MAX_REDIRECTS hops", async () => {
+    // MAX_REDIRECTS = 10 → exactly 11 fetch attempts before the throw
+    // (hops 0..10 inclusive). Asserting the call count proves the cap
+    // is doing the work — `wrapFetchError` masks the thrown message.
     const fetchFn = mock(
       async () =>
         new Response(null, {
@@ -411,9 +414,61 @@ describe("executeProviderCall — multi-hop redirect cookie capture (#473)", () 
       },
       deps,
     );
-    // Surfaces as a structured upstream failure (wrapped by wrapFetchError).
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.status).toBe(502);
+    expect(fetchFn).toHaveBeenCalledTimes(11);
+  });
+
+  it("strips Authorization + injected credential header on cross-origin redirect", async () => {
+    const authHeadersSeen: { auth: string | null; apiKey: string | null }[] = [];
+    const fetchFn = mock(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      const headers = new Headers(init?.headers);
+      authHeadersSeen.push({
+        auth: headers.get("authorization"),
+        apiKey: headers.get("x-api-key"),
+      });
+      if (u.startsWith("https://api.example.com")) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://evil.attacker.com/steal" },
+        });
+      }
+      return new Response("ok", { status: 200 });
+    });
+    const fetchCredentials = mock(
+      async (): Promise<CredentialsResponse> => ({
+        credentials: { access_token: "secret-token" },
+        // The follower only validates the initial URL — the destination
+        // origin is whatever the attacker-controlled redirect points at.
+        // We rely on cross-origin header stripping for defence in depth.
+        authorizedUris: ["https://api.example.com/**"],
+        allowAllUris: true,
+        credentialHeaderName: "X-Api-Key",
+        credentialHeaderPrefix: "",
+        credentialFieldName: "access_token",
+      }),
+    );
+    const deps = makeDeps({
+      fetchFn: fetchFn as unknown as typeof fetch,
+      fetchCredentials,
+    });
+    await executeProviderCall(
+      {
+        providerId: "demo",
+        targetUrl: "https://api.example.com/start",
+        method: "GET",
+        callerHeaders: { authorization: "Bearer caller-token" },
+        body: { kind: "none" },
+      },
+      deps,
+    );
+    expect(authHeadersSeen.length).toBe(2);
+    // Hop 1 (same origin): both headers present.
+    expect(authHeadersSeen[0]!.apiKey).toBe("secret-token");
+    // Hop 2 (cross-origin): Authorization + injected credential stripped.
+    expect(authHeadersSeen[1]!.auth).toBeNull();
+    expect(authHeadersSeen[1]!.apiKey).toBeNull();
   });
 
   it("streaming bodies still use native fetch and only capture final-hop cookies", async () => {

--- a/runtime-pi/sidecar/test/credential-proxy.test.ts
+++ b/runtime-pi/sidecar/test/credential-proxy.test.ts
@@ -613,6 +613,69 @@ describe("executeProviderCall — multi-hop redirect cookie capture (#473)", () 
     expect(authSeen[1]).toBeNull();
   });
 
+  it("preserves PUT method + body on 301/302 (spec: only POST is downgraded)", async () => {
+    const observed: { method: string; body: unknown }[] = [];
+    const fetchFn = mock(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      observed.push({ method: init?.method ?? "GET", body: init?.body });
+      if (u.endsWith("/old")) {
+        return new Response(null, {
+          status: 301,
+          headers: { location: "https://api.example.com/new" },
+        });
+      }
+      return new Response("ok", { status: 200 });
+    });
+    const deps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
+    const result = await executeProviderCall(
+      {
+        providerId: "demo",
+        targetUrl: "https://api.example.com/old",
+        method: "PUT",
+        callerHeaders: { "content-type": "application/json" },
+        body: {
+          kind: "buffered",
+          bytes: new TextEncoder().encode('{"x":1}').buffer as ArrayBuffer,
+          text: '{"x":1}',
+        },
+      },
+      deps,
+    );
+    expect(result.ok).toBe(true);
+    expect(observed[0]!.method).toBe("PUT");
+    // Pre-spec-fix: would have been "GET" with undefined body.
+    expect(observed[1]!.method).toBe("PUT");
+    expect(observed[1]!.body).toBeDefined();
+  });
+
+  it("preserves HEAD on 303 (spec: only non-GET/HEAD is downgraded)", async () => {
+    const observed: string[] = [];
+    const fetchFn = mock(async (url: string | URL, init?: RequestInit) => {
+      observed.push(init?.method ?? "GET");
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/check")) {
+        return new Response(null, {
+          status: 303,
+          headers: { location: "https://api.example.com/result" },
+        });
+      }
+      return new Response(null, { status: 200 });
+    });
+    const deps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
+    const result = await executeProviderCall(
+      {
+        providerId: "demo",
+        targetUrl: "https://api.example.com/check",
+        method: "HEAD",
+        callerHeaders: {},
+        body: { kind: "none" },
+      },
+      deps,
+    );
+    expect(result.ok).toBe(true);
+    expect(observed).toEqual(["HEAD", "HEAD"]);
+  });
+
   it("replays FormData body across 307 redirects", async () => {
     let bodyOnHop1: unknown;
     const fetchFn = mock(async (url: string | URL, init?: RequestInit) => {

--- a/runtime-pi/sidecar/test/credential-proxy.test.ts
+++ b/runtime-pi/sidecar/test/credential-proxy.test.ts
@@ -502,4 +502,146 @@ describe("executeProviderCall — multi-hop redirect cookie capture (#473)", () 
     expect(init.redirect).not.toBe("manual");
     expect(deps.cookieJar.get("demo")).toEqual(["final=F"]);
   });
+
+  it("propagates caller-supplied Cookie header across all hops (jar wins on dup)", async () => {
+    const cookieHeadersSeen: (string | null)[] = [];
+    const fetchFn = mock(async (url: string | URL, init?: RequestInit) => {
+      cookieHeadersSeen.push(new Headers(init?.headers).get("cookie"));
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/a")) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://api.example.com/b", "set-cookie": "session=server-v1" },
+        });
+      }
+      if (u.endsWith("/b")) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://api.example.com/c" },
+        });
+      }
+      return new Response("ok", { status: 200 });
+    });
+    const deps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
+    await executeProviderCall(
+      {
+        providerId: "demo",
+        targetUrl: "https://api.example.com/a",
+        method: "GET",
+        // Caller passes two cookies — one will be rotated by upstream, one won't.
+        callerHeaders: { cookie: "tracking=xyz; session=caller-v0" },
+        body: { kind: "none" },
+      },
+      deps,
+    );
+    expect(cookieHeadersSeen.length).toBe(3);
+    // Hop 0: caller cookies as-is (no jar yet).
+    expect(cookieHeadersSeen[0]).toContain("tracking=xyz");
+    expect(cookieHeadersSeen[0]).toContain("session=caller-v0");
+    // Hop 1+: tracking preserved (not in jar), session replaced by server value.
+    expect(cookieHeadersSeen[1]).toContain("tracking=xyz");
+    expect(cookieHeadersSeen[1]).toContain("session=server-v1");
+    expect(cookieHeadersSeen[1]).not.toContain("session=caller-v0");
+    expect(cookieHeadersSeen[2]).toContain("tracking=xyz");
+    expect(cookieHeadersSeen[2]).toContain("session=server-v1");
+  });
+
+  it("resolves relative Location headers against the current hop URL", async () => {
+    const urlsSeen: string[] = [];
+    const fetchFn = mock(async (url: string | URL) => {
+      const u = typeof url === "string" ? url : url.toString();
+      urlsSeen.push(u);
+      if (u === "https://api.example.com/v1/login") {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "/v1/callback" }, // relative path
+        });
+      }
+      if (u === "https://api.example.com/v1/callback") {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "../v2/home" }, // relative with parent traversal
+        });
+      }
+      return new Response("ok", { status: 200 });
+    });
+    const deps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
+    const result = await executeProviderCall(
+      {
+        providerId: "demo",
+        targetUrl: "https://api.example.com/v1/login",
+        method: "GET",
+        callerHeaders: {},
+        body: { kind: "none" },
+      },
+      deps,
+    );
+    expect(result.ok).toBe(true);
+    expect(urlsSeen).toEqual([
+      "https://api.example.com/v1/login",
+      "https://api.example.com/v1/callback",
+      "https://api.example.com/v2/home",
+    ]);
+  });
+
+  it("treats HTTPS→HTTP downgrade as cross-origin (strips credentials)", async () => {
+    const authSeen: (string | null)[] = [];
+    const fetchFn = mock(async (url: string | URL, init?: RequestInit) => {
+      authSeen.push(new Headers(init?.headers).get("authorization"));
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.startsWith("https://api.example.com")) {
+        return new Response(null, {
+          status: 302,
+          // Same host, protocol downgrade — origin differs per WHATWG.
+          headers: { location: "http://api.example.com/insecure" },
+        });
+      }
+      return new Response("ok", { status: 200 });
+    });
+    const deps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
+    await executeProviderCall(
+      {
+        providerId: "demo",
+        targetUrl: "https://api.example.com/start",
+        method: "GET",
+        callerHeaders: {},
+        body: { kind: "none" },
+      },
+      deps,
+    );
+    expect(authSeen[0]).toBe("Bearer tok-123");
+    expect(authSeen[1]).toBeNull();
+  });
+
+  it("replays FormData body across 307 redirects", async () => {
+    let bodyOnHop1: unknown;
+    const fetchFn = mock(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/upload")) {
+        return new Response(null, {
+          status: 307,
+          headers: { location: "https://api.example.com/upload-final" },
+        });
+      }
+      bodyOnHop1 = init?.body;
+      return new Response("ok", { status: 200 });
+    });
+    const deps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
+    const form = new FormData();
+    form.set("field", "value");
+    const result = await executeProviderCall(
+      {
+        providerId: "demo",
+        targetUrl: "https://api.example.com/upload",
+        method: "POST",
+        callerHeaders: {},
+        body: { kind: "formData", build: () => form },
+      },
+      deps,
+    );
+    expect(result.ok).toBe(true);
+    // 307 preserves method + body — FormData replayed on hop 1.
+    expect(bodyOnHop1).toBeInstanceOf(FormData);
+    expect((bodyOnHop1 as FormData).get("field")).toBe("value");
+  });
 });


### PR DESCRIPTION
## Summary

- Bun's native \`fetch\` follows 3xx redirects automatically but \`Response.headers.getSetCookie()\` on the final response only surfaces the **last hop's** \`Set-Cookie\` headers — cookies set on intermediate hops are silently dropped. This breaks multi-step OAuth/CAS flows (Kijiji, Okta/Workday/Salesforce SSO chains, anything using \`signin → /callback → /session-set → /\` where the session cookie lands on a middle hop).
- Manually follow redirects in the buffered-body path (\`redirect: "manual"\`), capturing \`Set-Cookie\` from every hop into the per-provider jar and re-injecting the growing jar as \`Cookie\` on each next hop.
- Streaming bodies fall back to native \`fetch\` (bodies can't be replayed across 307/308 hops) — last-hop-only capture stays for that path.

RFC 9110 semantics:
- 301/302/303 → method becomes GET, body + \`Content-Length\`/\`Content-Type\` dropped
- 307/308 → method + body preserved verbatim
- \`MAX_REDIRECTS = 10\` cap (matches Bun's native default)

Net behaviour: strict superset — captures every hop + the final, vs. the final only. No flag, no opt-in.

Closes #473

## Test plan

- [x] Added 6 new tests in \`runtime-pi/sidecar/test/credential-proxy.test.ts\`:
  - Captures \`Set-Cookie\` from intermediate hops (the exact bug repro)
  - Re-injects the growing jar as \`Cookie\` header on each next hop
  - Downgrades method to GET and drops body on 301/302/303
  - Preserves method and body on 307/308
  - Surfaces a structured failure when redirect chains exceed \`MAX_REDIRECTS\`
  - Streaming bodies still use native \`fetch\` (only final-hop capture)
- [x] Full sidecar suite: 377 pass / 0 fail
- [x] \`bun run check\` — all 20 turbo tasks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)