### PR TITLE
fix(runs): thread tx executor through writeRunnerLedgerRow

### DIFF
--- a/apps/api/src/services/run-launcher/appstrate-event-sink.ts
+++ b/apps/api/src/services/run-launcher/appstrate-event-sink.ts
@@ -222,7 +222,7 @@ export async function persistRunEvent(
       // is best-effort by its own contract (see writeRunnerLedgerRow's
       // try/catch) so it never aborts the surrounding transaction.
       if (opts.writeLedger) {
-        await writeRunnerLedgerRow(scope, runId, { cost, usage });
+        await writeRunnerLedgerRow(scope, runId, { cost, usage }, executor);
         // Best-effort live broadcast — never blocks the ingestion hot
         // path nor fails it. The broadcaster throttles per-run to
         // avoid flooding SSE subscribers under bursty metric emission
@@ -339,13 +339,14 @@ export async function writeRunnerLedgerRow(
     cost: number | null;
     usage: TokenUsage | null;
   },
+  executor: Db = db,
 ): Promise<void> {
   // Skip degenerate events with neither usage nor cost — nothing to bill
   // or audit.
   if (row.cost === null && !row.usage) return;
 
   try {
-    await db
+    await executor
       .insert(llmUsage)
       .values({
         source: "runner",


### PR DESCRIPTION
## Summary

Fixes the CI E2E job timeout that has dogged every push to \`main\` since #462 (\`99be60e3\`). After the regression landed, every push triggers the 15min job ceiling because the API server freezes once the suite hits the upload-flow tests that trigger real runs — every subsequent test (including unrelated UI tests) hits the 30s Playwright timeout.

## Root cause

#462 wrapped the CAS on \`runs.last_event_sequence\` + \`persistRunEvent\` dispatch in a \`db.transaction(async (tx) => …)\` so a transient \`run_logs\` INSERT failure rolls the sequence advance back. \`persistRunEvent\` threads \`tx\` to \`appendRunLog\` / \`updateRun\` correctly, but the \`appstrate.metric\` branch calls \`writeRunnerLedgerRow\` **without** the executor:

\`\`\`ts
// apps/api/src/services/run-launcher/appstrate-event-sink.ts:225
if (opts.writeLedger) {
  await writeRunnerLedgerRow(scope, runId, { cost, usage });   // ← uses module-level \`db\`, not \`executor\`
  scheduleRunMetricBroadcast(runId);
}
\`\`\`

\`writeRunnerLedgerRow\` does \`await db.insert(llmUsage)…\`. On PGlite (single connection — Tier 0 / E2E CI), the connection is held by the outer transaction; the inner \`db.insert\` queues for the same connection and **deadlocks**. The handler for \`POST /api/runs/:id/events\` never returns, and every subsequent DB-touching request queues behind the deadlocked connection. The API server freezes on all routes.

Why the \`Integration tests\` job stays green on the same SHAs: it spins up real PostgreSQL via \`test/setup/docker-compose.test.yml\`, so the pool has multiple connections and the issue is silent. Only the E2E job (PGlite + in-memory queue + \`RUN_ADAPTER=process\`) reproduces it.

## Fix

Threading \`executor\` through to \`writeRunnerLedgerRow\` — same pattern already used for \`appendRunLog\` and \`updateRun\` in this file:

\`\`\`diff
        if (opts.writeLedger) {
-         await writeRunnerLedgerRow(scope, runId, { cost, usage });
+         await writeRunnerLedgerRow(scope, runId, { cost, usage }, executor);
        }
…
  export async function writeRunnerLedgerRow(
    scope: AppScope,
    runId: string,
    row: { cost: number | null; usage: TokenUsage | null },
+   executor: Db = db,
  ): Promise<void> {
    if (row.cost === null && !row.usage) return;
    try {
-     await db
+     await executor
        .insert(llmUsage)
\`\`\`

## Test plan

- [x] **Repro on \`main\` (pre-fix)**: \`DATABASE_URL='' REDIS_URL='' RUN_ADAPTER=process MODULES=oidc,webhooks,core-providers,@appstrate/module-codex,@appstrate/module-claude-code bun apps/api/src/index.ts\` + \`cd e2e && npx playwright test --workers=2\` → server freezes around test 65/66, every subsequent test hits 30s timeout, \`curl /health\` → 000.
- [x] **Same setup, this branch**: \`85 passed (9.7s)\`. \`curl /health\` → 200 throughout.
- [x] \`bun run check\` is unaffected (signature-compatible default param).
- [ ] CI \`Test\` workflow on this PR — the E2E job's \`if:\` is \`contains(github.event.pull_request.labels.*.name, 'e2e') || github.ref == 'refs/heads/main'\`, so the PR needs the \`e2e\` label to actually exercise the regression pre-merge. Same for \`integration\` if we want both arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)