### PR TITLE
chore(core): bump to 2.20.0

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to `@appstrate/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.20.0] — 2026-05-16
+
+### Added
+
+- `@appstrate/core/sidecar-types` — `TokenBudget` gains
+  `contextWindowTokens` + `reserveTokens` fields, enabling a pre-flight
+  context-window guard for parallel tool-call outputs. A
+  `provider_call` output that would push `consumed + estimated` past
+  `contextWindow − reserve` now spills with reason
+  `exceeds_context_window`, even when it fits under the per-call inline
+  cap and the run-budget ceiling. Fixes a class of parallel-fan-out
+  failures where a batch of individually-safe outputs blew past the
+  model's context window before turn-boundary auto-compaction could
+  fire (e.g. Claude Haiku 4.5 + Gmail parallel fetch).
+
+- `@appstrate/core/sidecar-types` — `RuntimeReady` event surface
+  formalised for the platform's `runtime-ready` event-pipeline
+  contract, alongside the parallel agent/sidecar boot reorganisation
+  in `runtime-pi`. No new top-level export — the contract lives on the
+  existing `sidecar-types` surface that runtime-pi consumes.
+
+### Changed
+
+- `@appstrate/core/module` + `@appstrate/core/platform-types` — minor
+  shape refinements around the `pricing catalog` + `providerId`
+  hardening landed in #439 (Portkey migration epic, net −1860 LoC).
+  Module init context types align with the new pricing-catalog read
+  path. No public API renames; existing module authors are unaffected
+  unless they used the previously-internal `apiShape`/`baseUrl` model
+  fields, which were dropped in the same PR (see migration `0022`).
+
 ## [2.18.0] — 2026-04-27
 
 ### Changed

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Bump `@appstrate/core` to **2.20.0** ahead of the `v1.0.0-beta.14` server release.

### Commits in `packages/core/src/` since `core@2.19.0`

- 2d4213b0 fix(sidecar,runner): pre-flight context-window guard for parallel tool calls (#464) (#465)
- 6d03e89d feat(runtime): parallel agent/sidecar boot + remove sidecar pool (#455)
- 8da61195 feat: pricing catalog + picker UX + providerId hardening (closes #437) (#439)

2 features → minor bump.

### CHANGELOG.md

Added `[2.20.0]` entry describing the new `TokenBudget` fields (`contextWindowTokens`, `reserveTokens`), the `RuntimeReady` event surface refinement, and the pricing-catalog / providerId-hardening shape refinements in `module.ts` + `platform-types.ts`.

### Schemas

Regenerated `packages/core/schema/` — no diff.

### Downstream

After this lands and `core@2.20.0` is published:
- `cloud/` lockfile bump (Phase 1d)
- `registry/` lockfile bump (Phase 1d)
- then `v1.0.0-beta.14` tags

## Test plan

- [x] `bun run check` (TypeScript + ESLint + Prettier + OpenAPI) ✓
- [x] `bun run generate:schemas` → no diff ✓
- [ ] CI green
- [ ] Squash-merge → `git reset --hard origin/main` → tag `core@2.20.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)