### PR TITLE
fix(bootstrap): recover from Homebrew unlinked-keg state (#479)

### DIFF
--- a/apps/api/test/unit/scripts-bootstrap.test.ts
+++ b/apps/api/test/unit/scripts-bootstrap.test.ts
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Unit tests for the bash functions in scripts/bootstrap.sh.
+//
+// The script wraps all of its body in `_appstrate_bootstrap` and invokes it
+// at the very bottom — a guard against partial `curl … | bash` execution.
+// To exercise nested helpers in isolation, we set
+// `APPSTRATE_BOOTSTRAP_SOURCE_ONLY=1` before sourcing: the wrapper still
+// runs, defines every nested function (bash promotes nested function bodies
+// to global scope as soon as the enclosing function executes), and then
+// returns before any network/install side effects.
+//
+// Per-test we manufacture a temp `PATH` with fake package-manager shims
+// (e.g. `brew`) whose behaviour we control byte-for-byte. This lets us
+// reproduce the unlinked-keg scenario from issue #479 deterministically on
+// any host — no Homebrew install required.
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { resolve } from "node:path";
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+const SCRIPT = resolve(import.meta.dir, "../../../../scripts/bootstrap.sh");
+
+interface ShellResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+async function runShell(body: string, binDir: string): Promise<ShellResult> {
+  // `set +e` after sourcing — bootstrap.sh runs `set -euo pipefail`, which
+  // would abort the test shell on the first non-zero return inside a
+  // helper. Tests assert on exit codes explicitly, so we relax that here.
+  const script = `
+APPSTRATE_BOOTSTRAP_SOURCE_ONLY=1 source "${SCRIPT}"
+set +e
+${body}
+`;
+  // PATH composition: the per-test bin dir comes first (fake package
+  // manager shims win lookup), followed by /usr/bin:/bin for system
+  // utilities the script itself relies on at source time (uname, tr,
+  // mktemp, dirname, basename). Notably absent: /opt/homebrew/bin,
+  // /usr/local/bin — so a dev mac with brew installed doesn't leak a
+  // real brew into "no manager available" assertions.
+  const path = `${binDir}:/usr/bin:/bin`;
+  // Absolute path to bash so the launch itself doesn't depend on PATH.
+  const proc = Bun.spawn(["/bin/bash", "-c", script], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env, PATH: path },
+  });
+  const exitCode = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  return { exitCode, stdout, stderr };
+}
+
+function writeExecutable(path: string, body: string): void {
+  writeFileSync(path, body);
+  chmodSync(path, 0o755);
+}
+
+describe("scripts/bootstrap.sh", () => {
+  let tmpBin: string;
+
+  beforeEach(() => {
+    tmpBin = mkdtempSync(`${tmpdir()}/bootstrap-test-`);
+  });
+
+  afterEach(() => {
+    rmSync(tmpBin, { recursive: true, force: true });
+  });
+
+  describe("try_install_minisign (issue #479 — Homebrew unlinked-keg recovery)", () => {
+    it("recovers from unlinked-keg state by calling `brew link`", async () => {
+      // Fake brew mimics the bug from #479: `install` exits 0 with the
+      // "already installed but not linked" warning, leaving minisign off
+      // PATH. `link` materialises the binary, mirroring symlink restore.
+      writeExecutable(
+        `${tmpBin}/brew`,
+        `#!/bin/bash
+case "$1" in
+  install)
+    echo "Warning: minisign 0.12 is already installed, it's just not linked." >&2
+    exit 0
+    ;;
+  link)
+    cat > "${tmpBin}/minisign" <<'INNER'
+#!/bin/bash
+exit 0
+INNER
+    chmod +x "${tmpBin}/minisign"
+    exit 0
+    ;;
+esac
+exit 1
+`,
+      );
+
+      const res = await runShell(`OS=darwin try_install_minisign && echo OK || echo FAIL`, tmpBin);
+
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout).toContain("brew link minisign");
+      expect(res.stdout).toContain("OK");
+      expect(res.stdout).not.toContain("FAIL");
+    });
+
+    it("succeeds without invoking `brew link` on the happy path", async () => {
+      // Brew install materialises minisign directly — no recovery needed.
+      writeExecutable(
+        `${tmpBin}/brew`,
+        `#!/bin/bash
+if [ "$1" = "install" ]; then
+  cat > "${tmpBin}/minisign" <<'INNER'
+#!/bin/bash
+exit 0
+INNER
+  chmod +x "${tmpBin}/minisign"
+  exit 0
+fi
+echo "fake brew: unexpected subcommand $1" >&2
+exit 1
+`,
+      );
+
+      const res = await runShell(`OS=darwin try_install_minisign && echo OK || echo FAIL`, tmpBin);
+
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout).toContain("OK");
+      // The recovery path must stay dormant when install already worked.
+      expect(res.stdout).not.toContain("brew link minisign");
+    });
+
+    it("surfaces a clear error when `brew install` exits non-zero", async () => {
+      writeExecutable(
+        `${tmpBin}/brew`,
+        `#!/bin/bash
+echo "Error: simulated brew failure" >&2
+exit 1
+`,
+      );
+
+      const res = await runShell(`OS=darwin try_install_minisign && echo OK || echo FAIL`, tmpBin);
+
+      expect(res.stdout).toContain("FAIL");
+      expect(res.stderr).toContain("Failed to install minisign");
+    });
+
+    it("falls back to the legacy error when even `brew link` cannot restore the binary", async () => {
+      // Pathological case: install reports unlinked, link also fails. The
+      // recovery attempt should fire (logged) but the final guard should
+      // still surface the misleading-success diagnostic.
+      writeExecutable(
+        `${tmpBin}/brew`,
+        `#!/bin/bash
+case "$1" in
+  install)
+    echo "Warning: minisign 0.12 is already installed, it's just not linked." >&2
+    exit 0
+    ;;
+  link)
+    echo "Error: simulated link failure" >&2
+    exit 1
+    ;;
+esac
+exit 1
+`,
+      );
+
+      const res = await runShell(`OS=darwin try_install_minisign && echo OK || echo FAIL`, tmpBin);
+
+      expect(res.stdout).toContain("FAIL");
+      expect(res.stdout).toContain("brew link minisign");
+      expect(res.stderr).toContain("install reported success but the binary is still not on PATH");
+    });
+
+    it("returns failure when no supported package manager is on PATH", async () => {
+      // OS=darwin so detection only probes for `brew`. On a Linux CI box,
+      // `/usr/bin/apt-get` would otherwise match (we always include
+      // /usr/bin:/bin so the script's own setup helpers — uname, tr — can
+      // resolve). brew is never preinstalled at /usr/bin, so this stays
+      // deterministic on macOS and Linux alike.
+      const res = await runShell(`OS=darwin try_install_minisign && echo OK || echo FAIL`, tmpBin);
+
+      expect(res.stdout).toContain("FAIL");
+    });
+  });
+
+  describe("detect_minisign_installer", () => {
+    it("returns 'brew' on darwin when brew is on PATH", async () => {
+      writeExecutable(`${tmpBin}/brew`, `#!/bin/bash\nexit 0\n`);
+
+      const res = await runShell(`OS=darwin detect_minisign_installer`, tmpBin);
+
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout.trim()).toBe("brew");
+    });
+
+    it("returns 'apt' on linux when apt-get is on PATH", async () => {
+      writeExecutable(`${tmpBin}/apt-get`, `#!/bin/bash\nexit 0\n`);
+
+      const res = await runShell(`OS=linux detect_minisign_installer`, tmpBin);
+
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout.trim()).toBe("apt");
+    });
+
+    it("returns non-zero when no supported manager is available", async () => {
+      // OS=darwin keeps detection scoped to `brew` — never present at
+      // /usr/bin on either macOS or Linux. OS=linux would false-positive
+      // on Ubuntu CI where /usr/bin/apt-get exists.
+      const res = await runShell(
+        `OS=darwin detect_minisign_installer && echo OK || echo FAIL`,
+        tmpBin,
+      );
+
+      expect(res.stdout).toContain("FAIL");
+    });
+  });
+
+  describe("minisign_install_cmd", () => {
+    it("emits the bare brew command (no sudo on macOS)", async () => {
+      const res = await runShell(`minisign_install_cmd brew`, tmpBin);
+
+      expect(res.exitCode).toBe(0);
+      expect(res.stdout.trim()).toBe("brew install minisign");
+    });
+
+    it("returns non-zero for an unknown manager", async () => {
+      const res = await runShell(
+        `minisign_install_cmd unknown-mgr && echo OK || echo FAIL`,
+        tmpBin,
+      );
+
+      expect(res.stdout).toContain("FAIL");
+    });
+  });
+});

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -221,6 +221,15 @@ _appstrate_bootstrap() {
       err "Failed to install minisign via $_mgr."
       return 1
     fi
+    # Homebrew edge case (#479): `brew install` on an already-installed-but-
+    # unlinked keg exits 0 with a "not linked" warning on stderr, leaving the
+    # binary off PATH. The keg is already on disk — just re-create the
+    # symlinks. `brew link` (no flags) is the documented remediation;
+    # minisign isn't keg-only, so no --force, and we don't overwrite.
+    if [ "$_mgr" = "brew" ] && ! have_minisign; then
+      log "  \$ brew link minisign"
+      brew link minisign >/dev/null 2>&1 || true
+    fi
     if ! have_minisign; then
       err "minisign install reported success but the binary is still not on PATH."
       return 1
@@ -271,6 +280,16 @@ _appstrate_bootstrap() {
     fi
     printf '%s/%s' "$_real_dir" "$_base"
   }
+
+  # Test-only escape hatch: when set, return before any side-effecting work
+  # (network, install, dual-install probe). Bash nested-function bodies are
+  # only registered globally once the enclosing function runs at least
+  # once, so callers source this script with APPSTRATE_BOOTSTRAP_SOURCE_ONLY=1
+  # to make the helpers above (`try_install_minisign`, `have_minisign`, …)
+  # visible to a test harness without triggering the install flow.
+  if [ "${APPSTRATE_BOOTSTRAP_SOURCE_ONLY:-0}" = "1" ]; then
+    return 0
+  fi
 
   EXISTING_APPSTRATE="$(command -v appstrate 2>/dev/null || true)"
   if [ -n "$EXISTING_APPSTRATE" ] && [ "${APPSTRATE_FORCE_DUAL:-0}" != "1" ]; then


### PR DESCRIPTION
## Summary

Closes #479.

- `try_install_minisign` now auto-heals the Homebrew unlinked-keg edge case by calling `brew link minisign` when `brew install` exits 0 but the binary is still off PATH. Scoped to `_mgr = "brew"` — zero impact on apt/apk/dnf/pacman/zypper. Falls back to the existing diagnostic if `brew link` also fails (no regression).
- Adds `APPSTRATE_BOOTSTRAP_SOURCE_ONLY=1` — a test-only escape hatch that early-returns from `_appstrate_bootstrap` after every nested helper is defined but before any side-effecting work. Lets a harness `source` the script and call individual functions in isolation.
- New unit suite `apps/api/test/unit/scripts-bootstrap.test.ts` (10 tests, no DB/Docker) exercises `try_install_minisign`, `detect_minisign_installer`, and `minisign_install_cmd` against fake `brew` shims that reproduce the #479 unlinked-keg case byte-for-byte. Runs in ~3s on macOS and Linux alike.

## Test plan

- [x] `bun test apps/api/test/unit/scripts-bootstrap.test.ts` → 10 pass / 0 fail
- [x] `bash -n scripts/bootstrap.sh` (syntax check)
- [x] `bunx prettier --check apps/api/test/unit/scripts-bootstrap.test.ts`
- [ ] Manual repro on macOS: `brew unlink minisign && curl -fsSL https://get.appstrate.dev | bash` — should log `$ brew link minisign` and proceed with install instead of bailing with the misleading "re-run brew install" message.

## Validation

Homebrew docs confirm the behaviour: [`brew install` on an already-installed-but-unlinked formula exits 0](https://discourse.brew.sh/t/what-exit-code-is-brew-install-supposed-to-return-when-formula-is-already-installed/1607) with [a "not linked" warning on stderr](https://github.com/Homebrew/brew/issues/2676), and `brew link <formula>` is [the documented remediation](https://docs.brew.sh/Manpage). `--force` is only needed for keg-only formulae — minisign isn't keg-only, so a bare `brew link minisign` is sufficient (the issue's repro confirms this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)