### PR TITLE
refactor(connect): single-source the delivery.http resolver (#1)

### DIFF
--- a/packages/afps-runtime/src/resolvers/http-delivery.ts
+++ b/packages/afps-runtime/src/resolvers/http-delivery.ts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 Appstrate
+
+/**
+ * Canonical `delivery.http` credential-injection resolver, shared by the
+ * platform (`@appstrate/connect` re-exports these) and the portable
+ * `appstrate run` CLI ({@link ./integration-api-call.ts}).
+ *
+ * afps-runtime is the dependency-free bottom layer, so the single copy lives
+ * here and `@appstrate/connect` (which already depends on this package)
+ * imports + re-exports it — there is no longer a hand-maintained mirror.
+ *
+ * The resolver is credential-source agnostic: it takes the auth type, the
+ * decrypted credential fields, and the manifest's `delivery.http` block, and
+ * returns the header name + rendered value the proxy injects (or `null` when
+ * nothing should be injected).
+ */
+
+/** Subset of `auths.{key}.delivery.http` the resolver consumes (structural). */
+export interface HttpDeliveryConfig {
+  headerName?: string;
+  headerPrefix?: string;
+  valueFrom?: string | { template: string; encoding?: "base64" };
+  allowServerOverride?: boolean;
+}
+
+/**
+ * Plan returned by {@link resolveHttpDelivery}. The proxy uses this to decide
+ * whether to inject a header and what value to set; `allowServerOverride`
+ * mirrors the manifest setting (default `false` → the proxy strips any
+ * caller-supplied header of the same name before injection).
+ */
+export interface HttpDeliveryPlan {
+  headerName: string;
+  headerPrefix: string;
+  /** Rendered, post-encoding value ready to be sent as the header value. */
+  value: string;
+  /** Mirrors manifest; default `false` means the proxy MUST strip caller overrides. */
+  allowServerOverride: boolean;
+}
+
+/**
+ * Camel-cased manifest aliases → snake_case credential storage keys.
+ * Bidirectional: {@link readCredentialField} looks up both forms transparently
+ * so a manifest author can write `from: "accessToken"` regardless of how the
+ * field was stored.
+ *
+ * Source: proposal §4.1.3 (fields exposed implicitly by auth type).
+ */
+export const ALIAS_MAP: Readonly<Record<string, string>> = {
+  accessToken: "access_token",
+  refreshToken: "refresh_token",
+  idToken: "id_token",
+  tokenType: "token_type",
+  expiresAt: "expires_at",
+  accessTokenSecret: "access_token_secret",
+  consumerKey: "consumer_key",
+  consumerSecret: "consumer_secret",
+  accountEmail: "account_email",
+  accountId: "account_id",
+  apiKey: "api_key",
+  credentialsJson: "credentials_json",
+};
+
+/** Reverse map — snake_case → camelCase. Built once. */
+const REVERSE_ALIAS_MAP: Readonly<Record<string, string>> = Object.fromEntries(
+  Object.entries(ALIAS_MAP).map(([camel, snake]) => [snake, camel]),
+);
+
+/**
+ * Read a credential field by its **manifest-side** name (camelCase OR
+ * snake_case). Returns `undefined` if neither form is set.
+ */
+export function readCredentialField(
+  fields: Readonly<Record<string, string>>,
+  name: string,
+): string | undefined {
+  if (fields[name] !== undefined) return fields[name];
+  const alias = ALIAS_MAP[name] ?? REVERSE_ALIAS_MAP[name];
+  if (alias && fields[alias] !== undefined) return fields[alias];
+  return undefined;
+}
+
+const AUTH_TYPE_HTTP_DEFAULTS: Readonly<
+  Record<string, { headerName: string; headerPrefix: string; valueFrom: string }>
+> = {
+  oauth2: { headerName: "Authorization", headerPrefix: "Bearer ", valueFrom: "accessToken" },
+  oauth1: { headerName: "Authorization", headerPrefix: "", valueFrom: "accessToken" },
+  api_key: { headerName: "X-Api-Key", headerPrefix: "", valueFrom: "apiKey" },
+  basic: { headerName: "Authorization", headerPrefix: "Basic ", valueFrom: "" },
+  custom: { headerName: "", headerPrefix: "", valueFrom: "" },
+};
+
+function renderTemplate(
+  template: string,
+  fields: Readonly<Record<string, string>>,
+  encoding: "base64" | undefined,
+): string {
+  const rendered = template.replace(/\{\{\s*(\w+)\s*\}\}/g, (_match, key: string) => {
+    return readCredentialField(fields, key) ?? "";
+  });
+  if (encoding === "base64") return Buffer.from(rendered, "utf8").toString("base64");
+  return rendered;
+}
+
+/**
+ * Resolve a `delivery.http` plan for a single auth. Returns `null` when no
+ * header can be injected (e.g. `custom` auth without explicit `delivery.http`)
+ * — callers treat that as "the proxy injects nothing for this auth".
+ *
+ * Defaults are derived from the auth type per proposal §4.1.4 — `oauth2` sends
+ * `Authorization: Bearer <accessToken>`, `api_key` sends `X-Api-Key: <apiKey>`,
+ * etc. Explicit manifest values always win.
+ */
+export function resolveHttpDelivery(
+  authType: string,
+  fields: Readonly<Record<string, string>>,
+  http: HttpDeliveryConfig | undefined,
+): HttpDeliveryPlan | null {
+  const defaults = AUTH_TYPE_HTTP_DEFAULTS[authType] ?? {
+    headerName: "",
+    headerPrefix: "",
+    valueFrom: "",
+  };
+  const headerName = http?.headerName ?? defaults.headerName;
+  if (!headerName) return null;
+
+  const headerPrefix = http?.headerPrefix ?? defaults.headerPrefix;
+
+  let value: string;
+  const valueFrom = http?.valueFrom ?? defaults.valueFrom;
+  if (typeof valueFrom === "string") {
+    // basic / custom with no explicit valueFrom — value is empty; the proxy
+    // builds the value itself (e.g. basic auth base64s username:password).
+    value = valueFrom.length === 0 ? "" : (readCredentialField(fields, valueFrom) ?? "");
+  } else {
+    value = renderTemplate(valueFrom.template, fields, valueFrom.encoding);
+  }
+
+  if (value.length === 0 && authType === "basic" && !http?.valueFrom) {
+    const username = readCredentialField(fields, "username") ?? "";
+    const password = readCredentialField(fields, "password") ?? "";
+    value = Buffer.from(`${username}:${password}`, "utf8").toString("base64");
+  }
+
+  return {
+    headerName,
+    headerPrefix,
+    value,
+    allowServerOverride: http?.allowServerOverride === true,
+  };
+}

--- a/packages/afps-runtime/src/resolvers/index.ts
+++ b/packages/afps-runtime/src/resolvers/index.ts
@@ -41,6 +41,16 @@ export {
 export { BundledSkillResolver, BundledSkillResolutionError } from "./bundled-skill-resolver.ts";
 export { resolvePackageRef, readPackageText, readPackageBytes } from "./bundle-adapter.ts";
 
+// Canonical `delivery.http` credential-injection resolver (shared with
+// `@appstrate/connect`, which re-exports these).
+export {
+  ALIAS_MAP,
+  readCredentialField,
+  resolveHttpDelivery,
+  type HttpDeliveryConfig,
+  type HttpDeliveryPlan,
+} from "./http-delivery.ts";
+
 // Reusable credential-injecting HTTP-call core — tool factory + helpers.
 export {
   ABSOLUTE_MAX_RESPONSE_SIZE,
@@ -80,7 +90,6 @@ export {
   type IntegrationApiCallResolver,
   type IntegrationRef,
   type ApiCallIntegrationMeta,
-  type HttpDeliveryConfig,
   type LocalIntegrationCredentialsFile,
   type LocalIntegrationResolverOptions,
   type RemoteAppstrateIntegrationResolverOptions,

--- a/packages/afps-runtime/src/resolvers/integration-api-call.ts
+++ b/packages/afps-runtime/src/resolvers/integration-api-call.ts
@@ -40,6 +40,7 @@ import {
   type ApiCallFn,
   type ApiCallMeta,
 } from "./http-call-core.ts";
+import { resolveHttpDelivery, type HttpDeliveryConfig } from "./http-delivery.ts";
 import { resolvePackageRef } from "./bundle-adapter.ts";
 
 // ─────────────────────────────────────────────
@@ -80,14 +81,6 @@ export interface ApiCallIntegrationMeta {
   allowAllUris: boolean;
   /** `auths.{key}.delivery.http`, when declared. Drives header injection in local mode. */
   http?: HttpDeliveryConfig;
-}
-
-/** Subset of `auths.{key}.delivery.http` the local resolver consumes. */
-export interface HttpDeliveryConfig {
-  headerName?: string;
-  headerPrefix?: string;
-  valueFrom?: string | { template: string; encoding?: "base64" };
-  allowServerOverride?: boolean;
 }
 
 /**
@@ -369,7 +362,7 @@ function injectCredential(
   }
 
   // 2. Manifest `delivery.http` plan (auth-type defaults).
-  const plan = resolveLocalHttpDelivery(meta.authType, fields, meta.http);
+  const plan = resolveHttpDelivery(meta.authType, fields, meta.http);
   if (!plan || !plan.headerName) return;
   // `allowServerOverride: false` (default) → strip a caller-supplied header
   // of the same name before injecting (defence-in-depth, mirrors the sidecar).
@@ -379,90 +372,6 @@ function injectCredential(
     }
   }
   headers[plan.headerName] = `${plan.headerPrefix}${plan.value}`;
-}
-
-/**
- * Auth-type → header injection defaults. Portable mirror of
- * `@appstrate/connect`'s `AUTH_TYPE_HTTP_DEFAULTS` (afps-runtime cannot
- * depend on the platform's connect package).
- */
-const AUTH_TYPE_HTTP_DEFAULTS: Readonly<
-  Record<string, { headerName: string; headerPrefix: string; valueFrom: string }>
-> = {
-  oauth2: { headerName: "Authorization", headerPrefix: "Bearer ", valueFrom: "access_token" },
-  oauth1: { headerName: "Authorization", headerPrefix: "", valueFrom: "access_token" },
-  api_key: { headerName: "X-Api-Key", headerPrefix: "", valueFrom: "api_key" },
-  basic: { headerName: "Authorization", headerPrefix: "Basic ", valueFrom: "" },
-  custom: { headerName: "", headerPrefix: "", valueFrom: "" },
-};
-
-/** camelCase manifest alias → snake_case storage key (mirrors connect's ALIAS_MAP). */
-const ALIAS_MAP: Readonly<Record<string, string>> = {
-  accessToken: "access_token",
-  refreshToken: "refresh_token",
-  apiKey: "api_key",
-};
-const REVERSE_ALIAS_MAP: Readonly<Record<string, string>> = Object.fromEntries(
-  Object.entries(ALIAS_MAP).map(([camel, snake]) => [snake, camel]),
-);
-
-function readCredentialField(fields: Record<string, string>, name: string): string | undefined {
-  if (fields[name] !== undefined) return fields[name];
-  const alias = ALIAS_MAP[name] ?? REVERSE_ALIAS_MAP[name];
-  if (alias && fields[alias] !== undefined) return fields[alias];
-  return undefined;
-}
-
-interface LocalHttpDeliveryPlan {
-  headerName: string;
-  headerPrefix: string;
-  value: string;
-  allowServerOverride: boolean;
-}
-
-/**
- * Portable equivalent of `@appstrate/connect`'s `resolveHttpDelivery`.
- * Resolves a `delivery.http` plan for one auth, applying auth-type defaults.
- * Returns `null` when no header can be injected.
- */
-function resolveLocalHttpDelivery(
-  authType: string,
-  fields: Record<string, string>,
-  http: HttpDeliveryConfig | undefined,
-): LocalHttpDeliveryPlan | null {
-  const defaults = AUTH_TYPE_HTTP_DEFAULTS[authType] ?? {
-    headerName: "",
-    headerPrefix: "",
-    valueFrom: "",
-  };
-  const headerName = http?.headerName ?? defaults.headerName;
-  if (!headerName) return null;
-  const headerPrefix = http?.headerPrefix ?? defaults.headerPrefix;
-
-  let value: string;
-  const valueFrom = http?.valueFrom ?? defaults.valueFrom;
-  if (typeof valueFrom === "string") {
-    value = valueFrom.length === 0 ? "" : (readCredentialField(fields, valueFrom) ?? "");
-  } else {
-    const rendered = valueFrom.template.replace(/\{\{\s*(\w+)\s*\}\}/g, (_m, key: string) => {
-      return readCredentialField(fields, key) ?? "";
-    });
-    value =
-      valueFrom.encoding === "base64" ? Buffer.from(rendered, "utf8").toString("base64") : rendered;
-  }
-
-  if (value.length === 0 && authType === "basic" && !http?.valueFrom) {
-    const username = readCredentialField(fields, "username") ?? "";
-    const password = readCredentialField(fields, "password") ?? "";
-    value = Buffer.from(`${username}:${password}`, "utf8").toString("base64");
-  }
-
-  return {
-    headerName,
-    headerPrefix,
-    value,
-    allowServerOverride: http?.allowServerOverride === true,
-  };
 }
 
 // ─────────────────────────────────────────────

--- a/packages/connect/src/integration-credentials.ts
+++ b/packages/connect/src/integration-credentials.ts
@@ -7,35 +7,20 @@
  * spawn/credentials resolvers and the sidecar's MITM listener.
  */
 
-import type { IntegrationManifest } from "@appstrate/core/integration";
 import type { ProxyCredentialsPayload } from "./proxy-primitives.ts";
 
-/**
- * Camel-cased manifest aliases → snake_case credential storage keys.
- * Bidirectional: the resolver looks up both forms transparently.
- *
- * Source: proposal §4.1.3 (Fields exposed implicitly by auth type) +
- * legacy `DecryptedCredentials` shape used by `credentials.ts`.
- */
-export const ALIAS_MAP: Readonly<Record<string, string>> = {
-  accessToken: "access_token",
-  refreshToken: "refresh_token",
-  idToken: "id_token",
-  tokenType: "token_type",
-  expiresAt: "expires_at",
-  accessTokenSecret: "access_token_secret",
-  consumerKey: "consumer_key",
-  consumerSecret: "consumer_secret",
-  accountEmail: "account_email",
-  accountId: "account_id",
-  apiKey: "api_key",
-  credentialsJson: "credentials_json",
-};
-
-/** Reverse map — snake_case → camelCase. Built once. */
-const REVERSE_ALIAS_MAP: Readonly<Record<string, string>> = Object.fromEntries(
-  Object.entries(ALIAS_MAP).map(([camel, snake]) => [snake, camel]),
-);
+// The `delivery.http` resolver + alias-aware field reader live once in
+// @appstrate/afps-runtime (the dependency-free bottom layer this package
+// already depends on); re-export them so existing `@appstrate/connect`
+// consumers keep their import path.
+export {
+  ALIAS_MAP,
+  readCredentialField,
+  resolveHttpDelivery,
+  type HttpDeliveryConfig,
+  type HttpDeliveryPlan,
+} from "@appstrate/afps-runtime/resolvers";
+import type { HttpDeliveryPlan } from "@appstrate/afps-runtime/resolvers";
 
 /** Per-auth resolved credentials (a single entry in the multi-auth payload). */
 export interface ResolvedAuthCredentials {
@@ -84,45 +69,6 @@ export function projectToStringMap(raw: Record<string, unknown>): Record<string,
 }
 
 /**
- * Read a credential field by its **manifest-side** name (camelCase OR
- * snake_case). Returns `undefined` if neither form is set.
- *
- * Used by every `delivery.*.from` / `valueFrom` resolution so authors
- * can write `from: "accessToken"` regardless of how the field is
- * stored.
- */
-export function readCredentialField(
-  fields: Readonly<Record<string, string>>,
-  name: string,
-): string | undefined {
-  if (fields[name] !== undefined) return fields[name];
-  // Manifest used camelCase, storage used snake_case (or vice versa).
-  const alias = ALIAS_MAP[name] ?? REVERSE_ALIAS_MAP[name];
-  if (alias && fields[alias] !== undefined) return fields[alias];
-  return undefined;
-}
-
-// ─────────────────────────────────────────────
-// Delivery — HTTP
-// ─────────────────────────────────────────────
-
-/**
- * Plan returned by {@link resolveHttpDelivery}. The proxy uses this to
- * decide whether to inject a header and what value to set; the
- * `allowServerOverride` flag mirrors the manifest setting (default
- * false → proxy strips any caller-supplied header of the same name
- * before injection).
- */
-export interface HttpDeliveryPlan {
-  headerName: string;
-  headerPrefix: string;
-  /** Rendered, post-encoding value ready to be sent as the header value. */
-  value: string;
-  /** Mirrors manifest; default `false` means the proxy MUST strip caller overrides. */
-  allowServerOverride: boolean;
-}
-
-/**
  * Wire payload returned by both `/internal/integration-credentials/{scope}/{name}`
  * endpoints (GET read-current + POST refresh). Single source of truth shared by
  * the platform resolver (producer) and the sidecar `MitmCredentialSource`
@@ -133,73 +79,6 @@ export interface IntegrationCredentialsWire {
   auths: ReadonlyArray<ResolvedAuthCredentials>;
   deliveryPlans: Readonly<Record<string, HttpDeliveryPlan>>;
   expiresAtEpochMs: Readonly<Record<string, number | null>>;
-}
-
-const AUTH_TYPE_HTTP_DEFAULTS: Readonly<
-  Record<string, { headerName: string; headerPrefix: string; valueFrom: string }>
-> = {
-  oauth2: { headerName: "Authorization", headerPrefix: "Bearer ", valueFrom: "accessToken" },
-  oauth1: { headerName: "Authorization", headerPrefix: "", valueFrom: "accessToken" },
-  api_key: { headerName: "X-Api-Key", headerPrefix: "", valueFrom: "apiKey" },
-  basic: { headerName: "Authorization", headerPrefix: "Basic ", valueFrom: "" },
-  custom: { headerName: "", headerPrefix: "", valueFrom: "" },
-};
-
-/**
- * Resolve a `delivery.http` plan for a single auth. Returns `null`
- * when no header can be injected (e.g. `custom` auth without explicit
- * `delivery.http`) — callers should treat that as "the proxy does not
- * inject anything for this auth on this URL".
- *
- * Defaults are derived from the auth type per proposal §4.1.4 — `oauth2`
- * sends `Authorization: Bearer <accessToken>`, `api_key` sends
- * `X-Api-Key: <apiKey>` etc. Explicit manifest values always win.
- */
-export function resolveHttpDelivery(
-  authType: string,
-  fields: Readonly<Record<string, string>>,
-  http: NonNullable<NonNullable<IntegrationManifest["auths"]>[string]["delivery"]["http"]>,
-): HttpDeliveryPlan | null {
-  const defaults = AUTH_TYPE_HTTP_DEFAULTS[authType] ?? {
-    headerName: "",
-    headerPrefix: "",
-    valueFrom: "",
-  };
-  const headerName = http.headerName ?? defaults.headerName;
-  if (!headerName) return null;
-
-  const headerPrefix = http.headerPrefix ?? defaults.headerPrefix;
-
-  let value: string;
-  const valueFrom = http.valueFrom ?? defaults.valueFrom;
-  if (typeof valueFrom === "string") {
-    if (valueFrom.length === 0) {
-      // basic / custom with no explicit valueFrom — value is empty.
-      // The proxy is then responsible for building the value itself
-      // (e.g. basic auth concatenates username:password and base64s it).
-      value = "";
-    } else {
-      value = readCredentialField(fields, valueFrom) ?? "";
-    }
-  } else {
-    value = renderTemplate(valueFrom.template, fields, valueFrom.encoding);
-  }
-
-  if (value.length === 0 && (authType === "basic" || authType === "custom") && !http.valueFrom) {
-    // Default-shape basic auth: compute `base64(username:password)`.
-    if (authType === "basic") {
-      const username = readCredentialField(fields, "username") ?? "";
-      const password = readCredentialField(fields, "password") ?? "";
-      value = Buffer.from(`${username}:${password}`, "utf8").toString("base64");
-    }
-  }
-
-  return {
-    headerName,
-    headerPrefix,
-    value,
-    allowServerOverride: http.allowServerOverride === true,
-  };
 }
 
 /**
@@ -240,18 +119,4 @@ export function buildProxyCredentialsPayload(opts: {
       : {}),
     credentialFieldName: PROXY_INJECTED_FIELD,
   };
-}
-
-function renderTemplate(
-  template: string,
-  fields: Readonly<Record<string, string>>,
-  encoding: "base64" | undefined,
-): string {
-  const rendered = template.replace(/\{\{\s*(\w+)\s*\}\}/g, (_match, key: string) => {
-    const value = readCredentialField(fields, key);
-    if (value !== undefined) return value;
-    return "";
-  });
-  if (encoding === "base64") return Buffer.from(rendered, "utf8").toString("base64");
-  return rendered;
 }


### PR DESCRIPTION
The remaining finding from the simplification analysis (#1), deferred out of #492 because it changes behaviour at a published-package boundary and warranted its own credential-path validation.

## Problem
`resolveHttpDelivery` + `readCredentialField` + `ALIAS_MAP` + `AUTH_TYPE_HTTP_DEFAULTS` lived **twice**: in `@appstrate/connect` (platform) and a hand-maintained "portable mirror" in `@appstrate/afps-runtime` (the standalone `appstrate run` CLI). They had **already drifted** — connect's defaults keyed in camelCase with a 12-entry `ALIAS_MAP`, afps-runtime's in snake_case with a 3-entry one — each papered over by its own alias map. Exactly the silent-drift surface the audit targets.

## Fix
afps-runtime is the dependency-free bottom layer, and `@appstrate/connect` already depends on it (it re-exports `matchesAuthorizedUriSpec` from `@appstrate/afps-runtime/resolvers`). So the canonical copy now lives in **`packages/afps-runtime/src/resolvers/http-delivery.ts`**, and connect **re-exports** it — no more mirror, dependency arrow stays acyclic.

**Casing decision:** standardised on connect's **camelCase defaults + 12-entry `ALIAS_MAP`** (the superset). Because `readCredentialField` resolves either casing via the alias map, this strictly *widens* alias coverage for the CLI and is byte-identical for the platform — no behaviour change on the platform side, only more-permissive (never less) field resolution for the CLI.

- **new `http-delivery.ts`** — `resolveHttpDelivery`, `readCredentialField`, `ALIAS_MAP`, `HttpDeliveryConfig`, `HttpDeliveryPlan`; exported from the resolvers barrel.
- **afps-runtime `integration-api-call.ts`** — drop `resolveLocalHttpDelivery` + the duplicated defaults/alias-map/reader; call the canonical resolver.
- **connect `integration-credentials.ts`** — drop its own definitions, re-export the canonical ones so every `@appstrate/connect` importer (spawn-resolver, credentials-resolver, credential-proxy, sidecar connect-login, MITM planner) keeps its import path unchanged.

Net **−241 / +176** (the logic now lives once); the larger removal is the eliminated second copy.

## Validation
- `bun run check` — 20/20 (tsc + eslint + prettier + openapi), 0 errors.
- `bun test` — **1159 pass, 0 fail** across afps-runtime, connect, sidecar, and the **DB-backed credential-proxy injection** suite — all of which exercise `resolveHttpDelivery` on the real injection path.

> Stacked on #492. Together with #492 this closes the full simplification analysis (10 findings: 8 done across the two PRs, 1 dropped as a verified false positive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)