### PR TITLE
refactor(integrations): PR #481 review pass 4 — proxy redirect leaks, ssrf, upsert races

### DIFF
--- a/apps/api/src/services/integration-connection-resolver.ts
+++ b/apps/api/src/services/integration-connection-resolver.ts
@@ -482,9 +482,9 @@ async function loadAccessibleConnections(
   integrationIds: string[],
 ): Promise<ConnectionRow[]> {
   if (integrationIds.length === 0) return [];
-  // Own (any application — XOR check is on owner) OR shared-with-org
-  // matching this application. Both branches scoped to integrations the
-  // agent actually requires to avoid loading the world.
+  // Own OR shared-with-org, both scoped to THIS application (the
+  // applicationId predicate is applied outside the OR) and to the
+  // integrations the agent actually requires, to avoid loading the world.
   const rows = await db
     .select()
     .from(integrationConnections)

--- a/apps/api/src/services/integration-credentials-resolver.ts
+++ b/apps/api/src/services/integration-credentials-resolver.ts
@@ -27,6 +27,7 @@ import {
   type IntegrationCredentialsWire,
 } from "@appstrate/connect";
 import type { IntegrationManifest } from "@appstrate/core/integration";
+import { expandScopesGranted } from "@appstrate/core/integration";
 import { OAUTH_REFRESH_LEAD_MS } from "@appstrate/core/sidecar-types";
 
 import { logger } from "../lib/logger.ts";
@@ -182,7 +183,12 @@ export async function resolveLiveIntegrationCredentials(
             integrationPackageId: integrationId,
             authKey,
           });
-          const missing = required.filter((s) => !granted.includes(s));
+          // Expand the granted set through the manifest `implies` hierarchy
+          // before diffing — a parent grant (e.g. GitHub `repo`) covers the
+          // children it implies (`public_repo`), so a raw membership check
+          // would falsely flag the connection as below the required floor.
+          const expandedGranted = expandScopesGranted(granted, manifest, authKey);
+          const missing = required.filter((s) => !expandedGranted.includes(s));
           if (missing.length > 0) {
             await markIntegrationConnectionNeedsReconnection(connection.id);
             logger.warn("Integration scope shrink dropped below required floor", {

--- a/apps/api/src/services/integration-org-defaults-service.ts
+++ b/apps/api/src/services/integration-org-defaults-service.ts
@@ -106,29 +106,12 @@ export async function upsertOrgDefault(
   });
 
   const now = new Date();
-  const [existing] = await db
-    .select({ id: integrationOrgDefaults.id })
-    .from(integrationOrgDefaults)
-    .where(
-      and(
-        eq(integrationOrgDefaults.applicationId, scope.applicationId),
-        eq(integrationOrgDefaults.integrationPackageId, integrationPackageId),
-      ),
-    )
-    .limit(1);
-
-  if (existing) {
-    await db
-      .update(integrationOrgDefaults)
-      .set({
-        connectionId: input.connectionId,
-        enforce: input.enforce,
-        createdBy: input.createdBy,
-        updatedAt: now,
-      })
-      .where(eq(integrationOrgDefaults.id, existing.id));
-  } else {
-    await db.insert(integrationOrgDefaults).values({
+  // Atomic upsert on the (application, integration) unique index — avoids the
+  // check-then-insert race where two concurrent first-writers both miss the
+  // SELECT and the loser's INSERT throws a raw unique-violation (500).
+  await db
+    .insert(integrationOrgDefaults)
+    .values({
       applicationId: scope.applicationId,
       integrationPackageId,
       connectionId: input.connectionId,
@@ -136,8 +119,16 @@ export async function upsertOrgDefault(
       createdBy: input.createdBy,
       createdAt: now,
       updatedAt: now,
+    })
+    .onConflictDoUpdate({
+      target: [integrationOrgDefaults.applicationId, integrationOrgDefaults.integrationPackageId],
+      set: {
+        connectionId: input.connectionId,
+        enforce: input.enforce,
+        createdBy: input.createdBy,
+        updatedAt: now,
+      },
     });
-  }
 
   return {
     integrationPackageId,

--- a/apps/api/src/services/integration-pins-service.ts
+++ b/apps/api/src/services/integration-pins-service.ts
@@ -458,9 +458,10 @@ export async function updateConnectionMetadata(
         .limit(1),
     ]);
     if (pins.length > 0) {
+      // Existence check only (`.limit(1)`), so don't claim a count.
       throw conflict(
         "connection_pinned",
-        `Connection cannot be unshared while it is pinned to ${pins.length} agent(s). Remove the pin(s) first.`,
+        "Connection cannot be unshared while it is pinned to one or more agents. Remove the pin(s) first.",
       );
     }
     if (orgDefaults.length > 0) {

--- a/packages/connect/src/connect/login-engine.ts
+++ b/packages/connect/src/connect/login-engine.ts
@@ -14,7 +14,9 @@
  * This is a manifest-author-driven HTTP request → an SSRF / exfil / DoS
  * surface. It is bounded by construction:
  *   - the request URL must match the integration's `authorizedUris` allowlist
- *     (unless `allowAllUris`);
+ *     (the author's explicit trust boundary); when `allowAllUris` waives the
+ *     allowlist, the SSRF blocklist (loopback/RFC1918/link-local/metadata)
+ *     applies instead so there is never an unbounded in-process fetch;
  *   - per-request timeout; capped response body;
  *   - regex patterns are length-capped (schema) and run against a size-capped
  *     body (true ReDoS needs RE2 — documented residual; the body cap bounds
@@ -33,6 +35,7 @@ import {
   matchesAuthorizedUriSpec,
 } from "../proxy-primitives.ts";
 import { decodeJwtPayload } from "@appstrate/core/jwt";
+import { isBlockedUrl } from "@appstrate/core/ssrf";
 
 export interface LoginLimits {
   stepTimeoutMs: number;
@@ -274,8 +277,20 @@ export async function runLogin(config: LoginConfig, ctx: LoginContext): Promise<
     );
   }
 
-  // URL allowlist (defence beyond the SSRF blocklist).
-  if (!ctx.allowAllUris) {
+  // URL gate. This engine runs in the platform process (not the
+  // credential-isolating sidecar), so the request URL is a manifest-authored
+  // SSRF surface. Two mutually-exclusive controls:
+  //   - allowlist present (`!allowAllUris`): the `authorizedUris` patterns are
+  //     the author's explicit, auditable trust boundary — honor them verbatim
+  //     (a self-hosted integration may legitimately scope to a LAN host).
+  //   - `allowAllUris` (no allowlist): there is no author-declared boundary, so
+  //     fall back to the SSRF blocklist to refuse loopback/RFC1918/link-local/
+  //     cloud-metadata targets the platform could otherwise be steered to.
+  if (ctx.allowAllUris) {
+    if (isBlockedUrl(url)) {
+      throw new LoginError("step 0: url targets a blocked/internal address", 0, "url_not_allowed");
+    }
+  } else {
     const allowed = (ctx.authorizedUris ?? []).some((spec) => matchesAuthorizedUriSpec(spec, url));
     if (!allowed) {
       throw new LoginError("step 0: url not in authorizedUris allowlist", 0, "url_not_allowed");

--- a/packages/connect/src/encryption.ts
+++ b/packages/connect/src/encryption.ts
@@ -234,21 +234,30 @@ export function encryptCredentialEnvelope(envelope: {
  * the entire blob as injectables, exactly as before.
  */
 export function decryptCredentialEnvelope(ciphertext: string): CredentialEnvelope {
-  const decoded = decryptCredentials<Record<string, unknown>>(ciphertext) ?? {};
+  const decoded = decryptCredentials<unknown>(ciphertext) ?? {};
   if (
-    decoded &&
-    typeof decoded === "object" &&
+    isPlainObject(decoded) &&
     decoded["v"] === STRUCTURED_ENVELOPE_VERSION &&
-    typeof decoded["outputs"] === "object" &&
-    decoded["outputs"] !== null
+    isPlainObject(decoded["outputs"])
   ) {
     const inputs = decoded["inputs"];
     return {
-      outputs: decoded["outputs"] as Record<string, unknown>,
-      inputs:
-        typeof inputs === "object" && inputs !== null ? (inputs as Record<string, unknown>) : {},
+      outputs: decoded["outputs"],
+      inputs: isPlainObject(inputs) ? inputs : {},
     };
   }
   // v1 flat blob — the whole map is injectable, nothing is a bootstrap secret.
-  return { outputs: decoded, inputs: {} };
+  // Guard against a hand-crafted blob that decrypts to a non-object (array /
+  // primitive): such a value carries no injectable fields, so treat it as empty.
+  return { outputs: isPlainObject(decoded) ? decoded : {}, inputs: {} };
+}
+
+/**
+ * Narrow to a non-null, non-array plain object. `typeof [] === "object"` and
+ * `typeof null === "object"`, so the bare `typeof` test both crypto-envelope
+ * detection and credential projection used to lean on would let an array
+ * through and mislabel it as a credential map.
+ */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
 }

--- a/packages/connect/src/integration-mitm-planner.ts
+++ b/packages/connect/src/integration-mitm-planner.ts
@@ -162,11 +162,12 @@ export function planMitmAction(
   const stripped: string[] = [...universalStrip];
 
   if (plan) {
-    // The manifest's headerName is in scope of `allowServerOverride`.
-    // The universal pair stays stripped regardless — the spec is firm
-    // that the proxy must never forward a server-supplied Authorization
-    // header, even if the server claims override is allowed for its
-    // own configured header (confused-deputy boundary).
+    // By default the proxy strips a server-supplied header matching the
+    // injection target (confused-deputy boundary — integration code must not
+    // pre-empt the injected credential). The ONE exception is an explicit
+    // `allowServerOverride` on an Authorization-typed auth: the manifest author
+    // opted in, so the integration's own Authorization value is allowed to
+    // survive and we drop it from the universal strip list below.
     if (plan.allowServerOverride && looseEquals(plan.headerName, "Authorization")) {
       // Override allowed for Authorization → drop it from the strip list so
       // the caller's own value survives.

--- a/packages/connect/src/token-utils.ts
+++ b/packages/connect/src/token-utils.ts
@@ -138,16 +138,27 @@ export function parseTokenResponse(
   requestedScopes?: string[],
   fallbackRefreshToken?: string,
 ): ParsedTokenResponse {
-  const accessToken = tokenData.access_token as string;
-  if (!accessToken) {
-    throw new Error("No access_token in token response");
+  if (typeof tokenData.access_token !== "string" || !tokenData.access_token) {
+    throw new Error("No (string) access_token in token response");
   }
+  const accessToken = tokenData.access_token;
 
-  const refreshToken = (tokenData.refresh_token as string | undefined) ?? fallbackRefreshToken;
+  const refreshToken =
+    typeof tokenData.refresh_token === "string" ? tokenData.refresh_token : fallbackRefreshToken;
 
+  // Some IdPs (Azure AD v1, certain Keycloak configs) serialize `expires_in`
+  // as a JSON string ("3600"). Coerce so the proactive lead-window refresh
+  // still fires — a strict `typeof === "number"` check would drop it and
+  // leave `expiresAt: null` (token treated as never-expiring).
   let expiresAt: string | null = null;
-  if (typeof tokenData.expires_in === "number") {
-    expiresAt = new Date(Date.now() + tokenData.expires_in * 1000).toISOString();
+  const expiresIn =
+    typeof tokenData.expires_in === "number"
+      ? tokenData.expires_in
+      : typeof tokenData.expires_in === "string"
+        ? Number(tokenData.expires_in)
+        : NaN;
+  if (Number.isFinite(expiresIn)) {
+    expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
   }
 
   const scopeStr = typeof tokenData.scope === "string" ? tokenData.scope : "";

--- a/packages/connect/test/connect/login-engine.test.ts
+++ b/packages/connect/test/connect/login-engine.test.ts
@@ -81,6 +81,28 @@ describe("runLogin — declarative login", () => {
     expect(JSON.stringify(res.outputs)).not.toContain("s3cr3t");
   });
 
+  it("SSRF blocklist applies even under allowAllUris (runs in-process)", async () => {
+    const { impl, calls } = fakeFetch([{ status: 200, body: "{}" }]);
+    const config: LoginConfig = {
+      steps: [
+        {
+          request: { method: "GET", url: "http://169.254.169.254/latest/meta-data/" },
+          extract: { access_token: { from: "header", path: "x-token" } },
+          output: ["access_token"],
+        },
+      ],
+    };
+    const run = runLogin(config, {
+      inputs: {},
+      authorizedUris: [],
+      allowAllUris: true, // waives the allowlist — must NOT waive the blocklist
+      fetchImpl: impl,
+    });
+    await expect(run).rejects.toMatchObject({ reason: "url_not_allowed" });
+    // Fail-closed: the request never went out.
+    expect(calls.length).toBe(0);
+  });
+
   it("extracts a JWT claim (petitspas-like personId)", async () => {
     const jwt = `${b64url({ alg: "none" })}.${b64url({ AUTH: [{ personId: "P-42" }] })}.`;
     const { impl } = fakeFetch([{ status: 200, body: JSON.stringify({ access_token: jwt }) }]);

--- a/packages/connect/test/token-utils.test.ts
+++ b/packages/connect/test/token-utils.test.ts
@@ -47,7 +47,19 @@ describe("parseTokenResponse", () => {
   });
 
   it("throws when access_token is missing", () => {
-    expect(() => parseTokenResponse({})).toThrow("No access_token");
+    expect(() => parseTokenResponse({})).toThrow("No (string) access_token");
+  });
+
+  it("throws when access_token is a non-string", () => {
+    expect(() => parseTokenResponse({ access_token: 12345 })).toThrow("No (string) access_token");
+  });
+
+  it("coerces a string expires_in (Azure AD v1 / Keycloak)", () => {
+    const before = Date.now();
+    const result = parseTokenResponse({ ...baseToken, expires_in: "3600" });
+    expect(result.expiresAt).not.toBeNull();
+    const ms = new Date(result.expiresAt!).getTime();
+    expect(ms).toBeGreaterThanOrEqual(before + 3600 * 1000 - 1000);
   });
 
   it("computes expiresAt from expires_in", () => {

--- a/packages/core/src/ssrf.ts
+++ b/packages/core/src/ssrf.ts
@@ -25,6 +25,11 @@ export function isBlockedHost(hostname: string): boolean {
     h = new URL(urlStr).hostname.toLowerCase();
     // Bun keeps brackets on IPv6 hostnames — strip them for uniform checks
     h = h.replace(/^\[|\]$/g, "");
+    // A trailing dot is a valid FQDN form that DNS resolves identically
+    // (`metadata.google.internal.`, `localhost.`, `127.0.0.1.`) but would
+    // slip past the exact-string host matches and the dotted-IP regex
+    // below. Normalize it away so the blocklist can't be bypassed.
+    h = h.replace(/\.$/, "");
   } catch {
     return true; // Unparseable hostname = blocked
   }

--- a/packages/core/test/ssrf.test.ts
+++ b/packages/core/test/ssrf.test.ts
@@ -78,6 +78,17 @@ describe("isBlockedHost", () => {
     expect(isBlockedHost("::ffff:0808:0808")).toBe(false); // 8.8.8.8
   });
 
+  it("blocks trailing-dot FQDN bypass", () => {
+    // A trailing dot resolves identically in DNS but used to slip past the
+    // exact-string and dotted-IP checks (#481 audit H3).
+    expect(isBlockedHost("localhost.")).toBe(true);
+    expect(isBlockedHost("metadata.google.internal.")).toBe(true);
+    expect(isBlockedHost("host.docker.internal.")).toBe(true);
+    expect(isBlockedHost("127.0.0.1.")).toBe(true);
+    expect(isBlockedHost("169.254.169.254.")).toBe(true);
+    expect(isBlockedUrl("http://metadata.google.internal./computeMetadata/v1/")).toBe(true);
+  });
+
   it("blocks unparseable hostname", () => {
     expect(isBlockedHost("")).toBe(true);
   });

--- a/runtime-pi/sidecar/credential-proxy.ts
+++ b/runtime-pi/sidecar/credential-proxy.ts
@@ -251,6 +251,11 @@ async function fetchFollowingRedirectsCapturingCookies(
     if (stripCred) {
       headers.delete("authorization");
       if (injectedCredentialHeader) headers.delete(injectedCredentialHeader);
+      // Cookies are credentials too. The jar/caller cookies were composed
+      // above unconditionally (to follow intra-allowlist multi-host flows);
+      // strip them on an out-of-boundary cross-origin hop so an
+      // upstream-controlled redirect can't exfiltrate the session jar.
+      headers.delete("cookie");
     }
 
     currentInit = {
@@ -527,13 +532,18 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
       proxy: args.proxyUrl || undefined,
     };
     if (init.body instanceof ReadableStream) {
-      // Streaming bodies can't be replayed across hops — fall back to
-      // native fetch (intermediate-hop Set-Cookie lost, step 8 captures
-      // the final hop only). Per-hop SSRF/allowlist validation is NOT
-      // applied on this path: bytes have already flown before the
-      // sidecar can see the 30x. The initial-URL allowlist check at
-      // step 4 bounds the surface.
+      // Streaming bodies can't be replayed across hops, so the manual
+      // redirect follower (which re-issues each hop) can't run here.
+      // `redirect: "manual"` is mandatory, NOT a default: native
+      // `redirect: "follow"` would carry the injected credential header
+      // (and any cookie jar) into an upstream-controlled cross-origin
+      // redirect — WHATWG fetch strips `Authorization` cross-origin but
+      // NOT custom headers like `X-Api-Key`, the usual injection target.
+      // Returning the 30x unfollowed keeps the credential on the initial
+      // (allowlist-checked) origin only; the caller re-issues against the
+      // surfaced `finalUrl` if it wants to follow.
       init.duplex = "half";
+      init.redirect = "manual";
       const response = await fetchFn(resolvedUrl, init);
       return { response, finalUrl: response.url || resolvedUrl };
     }

--- a/runtime-pi/sidecar/test/credential-proxy.test.ts
+++ b/runtime-pi/sidecar/test/credential-proxy.test.ts
@@ -497,9 +497,11 @@ describe("executeApiCall — multi-hop redirect cookie capture (#473)", () => {
       deps,
     );
     expect(result.ok).toBe(true);
-    // Native fetch called once with redirect: "follow" (default).
+    // Streaming bodies can't be replayed across hops, so the path pins
+    // `redirect: "manual"` — native "follow" would leak the injected
+    // credential header into a cross-origin redirect (see #481 audit H1).
     const init = fetchFn.mock.calls[0]![1] as RequestInit;
-    expect(init.redirect).not.toBe("manual");
+    expect(init.redirect).toBe("manual");
     expect(deps.cookieJar.get("demo")).toEqual(["final=F"]);
   });
 
@@ -1067,12 +1069,11 @@ describe("executeApiCall — finalUrl exposure (#471)", () => {
     if (result.ok) expect(result.finalUrl).toBe("https://api.example.com/b");
   });
 
-  it("returns response.url on the streaming path (Bun native follow)", async () => {
-    // Streaming bodies use Bun's native redirect: "follow" which
-    // populates Response.url. The sidecar must surface it as finalUrl.
+  it("returns response.url on the streaming path", async () => {
+    // The streaming path uses `redirect: "manual"`; when the upstream
+    // responds without a redirect, `Response.url` carries the resolved
+    // URL. The sidecar must surface it as finalUrl.
     const fetchFn = mock(async (_url: string | URL, _init?: RequestInit) => {
-      // Simulate Bun's behaviour after following a redirect: the
-      // Response carries the post-follow URL.
       const res = new Response("uploaded", { status: 200 });
       Object.defineProperty(res, "url", {
         value: "https://api.example.com/uploaded?key=final",


### PR DESCRIPTION
4th deep-review pass of the integration core (PR #481), security/correctness lens. 5 parallel opus reviewers; every finding verified in source before fixing; regression tests added. Re-reviewed for over-engineering — see "Trimmed" below.

## 🔴 HIGH — credential exfiltration via redirects
- **Streaming proxy path** (`credential-proxy.ts`) now pins `redirect:"manual"`. Native `follow` carried the injected credential header (e.g. `X-Api-Key`) into an upstream-controlled **cross-origin** redirect — WHATWG fetch strips `Authorization` cross-origin but **not** custom headers. The buffered path already defended this; the streaming path didn't.
- **Cookie jar** now stripped on out-of-boundary cross-origin hops (was leaking the per-integration session jar).
- **SSRF trailing-dot bypass** (`ssrf.ts`): `metadata.google.internal.`, `169.254.169.254.` resolved identically in DNS but slipped past the exact-host and dotted-IP checks. *(Pre-existing core, newly exposed by the epic's `allowAllUris` consumers.)*

## 🟠 HIGH — login-engine in-process SSRF
`login-engine.ts` runs in the platform process. The SSRF blocklist now **backstops the `allowAllUris` case** (no author allowlist); an explicit `authorizedUris` boundary is still honored verbatim (correct for scoped/self-hosted hosts).

## 🟡 MEDIUM
- `expires_in` as a JSON string (`"3600"` — Azure AD v1 / Keycloak) now coerced → proactive refresh fires instead of treating the token as never-expiring.
- `org-default` upsert → idiomatic `onConflictDoUpdate` (simpler **and** race-safe; net −17 lines).
- v2 credential-envelope detection hardened against array/type confusion.

## 🟢 LOW
Non-string `access_token` guarded (drops an unsafe `as` cast) · scope-shrink diff now expands the manifest `implies` hierarchy via the canonical `expandScopesGranted` (no false `needsReconnection` when a parent grant covers a required child) · corrected a misleading pin-count message + two stale comments.

## Trimmed after fresh-eyes review (removed as unnecessary / over-engineered)
- **Pin upsert race-fix** — would have added a `try/catch` + helper to two functions to convert a *rare, benign* 500 (the unique index already prevents any duplicate). Drizzle can't target the pins' `coalesce(user_id,'')` expression index, so no clean fix exists; not worth the shim. Left as the original check-then-insert.
- **`loadKeyring` key-length recheck** — redundant; `@appstrate/env` already enforces 32 bytes at boot and fail-fasts before `loadKeyring` runs.

## Validation
`bun run check` 20/20 · touched suites green. Also fixed 7 pre-existing `connect-e2e` failures (stale `server:{type:"api_call"}` fixtures from task #296 → `apiCall` block) — those fixtures live in the untracked `local-test-packages/` dir, so the fix is local and not part of this diff.

## Deferred (with rationale)
**Token-refresh cross-instance race (A2)** intentionally **not** here. CAS write-back is low-value (benign valid-vs-valid clobber; the rotating-refresh-token case fails at the exchange with `invalid_grant` *before* the write). The correct fix is a distributed single-flight lock — a separately-testable infra change. Happy to do it as a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)