### PR TITLE
fix(runner-pi): declare the @appstrate/core workspace dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -306,6 +306,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@appstrate/afps-runtime": "workspace:*",
+        "@appstrate/core": "workspace:*",
         "@appstrate/mcp-transport": "workspace:*",
         "ajv": "^8.20.0",
       },

--- a/packages/runner-pi/package.json
+++ b/packages/runner-pi/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "@appstrate/afps-runtime": "workspace:*",
+    "@appstrate/core": "workspace:*",
     "@appstrate/mcp-transport": "workspace:*",
     "ajv": "^8.20.0"
   },


### PR DESCRIPTION
## Problem
`docker build -f ./runtime-pi/Dockerfile .` fails in the `deps` stage:

```
error: Could not resolve: "@appstrate/core/runtime-tool-defs"
  at /build/packages/runner-pi/src/runtime-tools/runtime-tool-extensions.ts:31
```

## Cause
`packages/runner-pi/src` imports `@appstrate/core` (notably `@appstrate/core/runtime-tool-defs`, added when the runtime tools became MCP tool definitions), but `runner-pi/package.json` only declared `@appstrate/afps-runtime` + `@appstrate/mcp-transport`. A **phantom dependency**: root-level workspace hoisting resolves it in local dev, so `bun build` and `bun run check` pass locally — but the Dockerfile's `deps` stage installs/resolves per workspace package and the missing declaration surfaces. The published `core@2.20.0` predates the `./runtime-tool-defs` subpath export too, so there's no npm fallback.

## Fix
Declare `"@appstrate/core": "workspace:*"` in `runner-pi/package.json` (+ lockfile). One line; links the local core in every resolution context.

Unrelated to the PR #481 review work — surfaced while building the image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)