### PR TITLE
fix(integrations): validate connection credentials against manifest schema

### DIFF
--- a/apps/api/src/services/connect/fields-strategy.ts
+++ b/apps/api/src/services/connect/fields-strategy.ts
@@ -9,12 +9,16 @@
  * unchanged.
  */
 
+import type { JSONSchemaObject } from "@appstrate/core/form";
+
 import {
   extractIdentity,
   readIntegrationAuth,
   saveIntegrationConnection,
   type IntegrationConnectionSummary,
 } from "../integration-connections.ts";
+import { validateConnectionCredentials } from "../schema.ts";
+import { invalidRequest } from "../../lib/errors.ts";
 import type {
   ConnectContext,
   ConnectCompleteInput,
@@ -28,12 +32,30 @@ export class FieldsStrategy implements IntegrationConnectStrategy {
     input: ConnectCompleteInput,
   ): Promise<IntegrationConnectionSummary> {
     const credentials = assertFieldsInput(input, "FieldsStrategy");
-    const { manifest } = await readIntegrationAuth(
+    const { manifest, auth } = await readIntegrationAuth(
       ctx.scope,
       ctx.integrationPackageId,
       ctx.authKey,
     );
     requireNonEmptyCredentials(credentials);
+
+    // Validate the pasted bag against the auth's declared credentials.schema.
+    // Rejects missing required fields AND wrong-cased keys (e.g. `apiKey` for a
+    // manifest declaring `api_key`), which would otherwise persist a connection
+    // that looks healthy but whose `delivery.http` injection silently no-ops at
+    // runtime (the field lookup misses → empty value → header never injected).
+    const credsResult = validateConnectionCredentials(
+      auth.credentials?.schema as JSONSchemaObject | undefined,
+      credentials,
+    );
+    if (!credsResult.valid) {
+      throw invalidRequest(
+        `Credentials do not match the integration's declared schema: ${credsResult.errors
+          .map((e) => `${e.field} ${e.message}`)
+          .join("; ")}`,
+        "credentials",
+      );
+    }
 
     const { accountId, identityClaims } = extractIdentity(manifest, ctx.authKey, credentials);
     return saveIntegrationConnection(ctx.scope, {

--- a/apps/api/src/services/integration-spawn-resolver.ts
+++ b/apps/api/src/services/integration-spawn-resolver.ts
@@ -509,6 +509,30 @@ async function resolveDeliveries(
         authType: auth.type,
       });
     } else {
+      // A plan with a header name but an empty value is a silent-no-op trap:
+      // the MITM planner drops empty-value injections, so the credential header
+      // is never injected and upstream calls go out unauthenticated while the
+      // run still "succeeds". This happens when `delivery.http.valueFrom` names
+      // a credential field that is absent on the stored connection — typically a
+      // key-casing mismatch (e.g. `apiKey` stored vs `api_key` declared). Surface
+      // it loudly instead of letting it pass unnoticed. (`basic` builds its value
+      // from username:password, so an empty value there is the same defect.)
+      if (plan.headerName.length > 0 && plan.value.length === 0) {
+        logger.warn(
+          "delivery.http resolved an empty credential value — header will NOT be injected " +
+            "(credential field missing/empty on the connection; check for a key-casing mismatch " +
+            "against the manifest's credentials.schema)",
+          {
+            integrationId,
+            authKey: row.authKey,
+            authType: auth.type,
+            connectionId: row.id,
+            headerName: plan.headerName,
+            valueFrom: typeof httpDecl.valueFrom === "string" ? httpDecl.valueFrom : "<template>",
+            storedFieldKeys: Object.keys(fields),
+          },
+        );
+      }
       httpDeliveryAuths[row.authKey] = {
         ...plan,
         authType: auth.type,

--- a/apps/api/src/services/schema.ts
+++ b/apps/api/src/services/schema.ts
@@ -135,6 +135,45 @@ function runValidate(
 // surface unchanged.
 export const validateConfig = validateConfigCore;
 
+/**
+ * Validate a submitted credential bag against an integration auth's
+ * `credentials.schema` (AFPS §4.1.3).
+ *
+ * Beyond catching missing required fields, this catches wrong-cased or
+ * misspelled keys (e.g. `apiKey` when the manifest declares `api_key`):
+ * the manifest schema names the exact field keys, so an unexpected key
+ * leaves the required field absent and fails validation. Without this gate
+ * such a bag persists a healthy-looking connection whose `delivery.http`
+ * injection silently resolves to an empty value at runtime (the credential
+ * header is never injected, yet the run still "succeeds").
+ *
+ * No-op when the auth declares no schema properties — there is nothing to
+ * validate against, and forcing field shape on an undeclared schema would
+ * reject legitimately loose `custom` auths.
+ */
+export function validateConnectionCredentials(
+  schema: JSONSchemaObject | undefined,
+  credentials: Record<string, string>,
+): ValidationResult {
+  if (!schema?.properties || Object.keys(schema.properties).length === 0) {
+    return { valid: true, errors: [], data: credentials };
+  }
+  const required = Array.isArray(schema.required) ? schema.required : [];
+  // Mirror the input path: AJV coerceTypes lets "" satisfy `required`, so
+  // strip empty/null values for required keys before validating.
+  const effectiveData = stripEmptyRequired(credentials, required);
+  const validate = ajv.compile(schema);
+  if (validate(effectiveData)) return { valid: true, errors: [], data: credentials };
+  const errors = (validate.errors || []).map((e) => ({
+    field:
+      e.instancePath.replace(/^\//, "") ||
+      (e.params as { missingProperty?: string })?.missingProperty ||
+      "unknown",
+    message: e.message || "Validation failed",
+  }));
+  return { valid: false, errors };
+}
+
 export function validateInput(
   input: Record<string, unknown> | undefined,
   schema: JSONSchemaObject,

--- a/apps/api/test/integration/routes/integrations.test.ts
+++ b/apps/api/test/integration/routes/integrations.test.ts
@@ -288,6 +288,58 @@ describe("api_key connection flow", () => {
   });
 });
 
+describe("api_key credentials schema validation (delivery.http silent-no-op guard)", () => {
+  let ctx: TestContext;
+
+  // A manifest whose api_key auth declares `required: ["api_key"]` — the shape
+  // the silent-no-op bug needs to be caught (key-casing mismatch leaves the
+  // required field absent, so `delivery.http` injection resolves to "").
+  function strictManifest(name = "@myorg/strict"): IntegrationManifest {
+    const m = gmailManifest(name);
+    m.auths!.api!.credentials = {
+      schema: {
+        type: "object",
+        required: ["api_key"],
+        properties: { api_key: { type: "string" } },
+      },
+    };
+    return m;
+  }
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "myorg" });
+    await seedIntegration(ctx.orgId, strictManifest("@myorg/strict"));
+  });
+
+  it("rejects a wrong-cased credential key that misses the required field (400)", async () => {
+    const res = await app.request("/api/integrations/@myorg/strict/auths/api/connect/fields", {
+      method: "POST",
+      headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+      // `apiKey` (camelCase) instead of the declared `api_key` (snake_case):
+      // would otherwise persist a healthy-looking connection whose injection
+      // silently no-ops at runtime.
+      body: JSON.stringify({ credentials: { apiKey: "AKIA-SECRET" } }),
+    });
+    expect(res.status).toBe(400);
+    // Nothing persisted.
+    const rows = await db
+      .select()
+      .from(integrationConnections)
+      .where(eq(integrationConnections.integrationPackageId, "@myorg/strict"));
+    expect(rows).toHaveLength(0);
+  });
+
+  it("accepts the correctly-cased credential key (200)", async () => {
+    const res = await app.request("/api/integrations/@myorg/strict/auths/api/connect/fields", {
+      method: "POST",
+      headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+      body: JSON.stringify({ credentials: { api_key: "AKIA-SECRET" } }),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
 describe("OAuth client CRUD", () => {
   let ctx: TestContext;
   beforeEach(async () => {


### PR DESCRIPTION
## Problem

A `delivery.http` credential injection **silently no-ops** when the stored credential field name doesn't match the manifest's `credentials.schema` — e.g. `apiKey` (camelCase) stored vs `api_key` (snake_case) declared.

The connect path only validated that the credential bag was non-empty (`z.record(string,string)` + `requireNonEmptyCredentials`). It never checked the bag against the auth's declared `credentials.schema`. So a mis-keyed credential:

1. Persisted a connection that looks **healthy** (`needs_reconnection=false`).
2. At runtime, `resolveHttpDelivery`'s `valueFrom: "api_key"` lookup missed → `value: ""`.
3. The MITM planner drops empty-value injections (`renderInjection` returns `null`) → **the header is never injected**.
4. The run still **succeeds** because the upstream call goes out (just unauthenticated).

Surfaced by an agent run (`run_2915901e…`) that exercised `@appstrate/bun-toolkit`'s `fetch_echo` and reported its injected `X-Toolkit-Token` never reached upstream. Root cause: the stored connection's credential field was `apiKey`, while the manifest declares `api_key`.

## Changes

**1. Connect-time validation gate**
- `validateConnectionCredentials()` (`schema.ts`) compiles the auth's `credentials.schema` via AJV and validates the submitted bag (reusing the existing `stripEmptyRequired` so AJV's `coerceTypes` doesn't let `""` satisfy `required`). No-op when the auth declares no schema properties (keeps loose `custom` auths working).
- `FieldsStrategy.complete()` calls it and rejects with **400** on missing required fields or wrong-cased keys, before persisting. No more healthy-looking-but-broken connections.

**2. Non-silent runtime failure (defense-in-depth)**
- The spawn resolver now emits an audit-level `logger.warn` when `delivery.http` resolves a header name with an **empty value** — naming the integration, connection, expected `valueFrom`, and the actually-stored field keys. Makes existing mis-keyed connections diagnosable instead of failing quietly.

## Tests
New `api_key credentials schema validation` block in `integrations.test.ts`:
- Wrong-cased key (`apiKey` for a manifest declaring `api_key`) → 400, nothing persisted.
- Correctly-cased key → 200.

All 25 tests in the file pass; typecheck/prettier/eslint clean.

## Note
Pre-existing bad connections (created before this gate) are **not** mutated — the runtime warn now flags them, and reconnecting via the UI (which sends the correct manifest keys) fixes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)