### PR TITLE
feat(core)!: remove oauth1 auth type + connect authoring guide (Phase 7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ storage/
 docs/*
 !docs/adr/
 !docs/cli/
+!docs/guides/
 !docs/migrations/
 flows/*
 

--- a/apps/api/src/openapi/baseline.json
+++ b/apps/api/src/openapi/baseline.json
@@ -3839,7 +3839,7 @@
                           },
                           "type": {
                             "type": "string",
-                            "enum": ["oauth2", "oauth1", "api_key", "basic", "custom"]
+                            "enum": ["oauth2", "api_key", "basic", "custom"]
                           },
                           "required": {
                             "type": "boolean"

--- a/apps/api/src/openapi/paths/integrations.ts
+++ b/apps/api/src/openapi/paths/integrations.ts
@@ -156,7 +156,7 @@ const authStatusSchema = {
   required: ["authKey", "type", "required", "scopes", "audience", "connections", "hasOAuthClient"],
   properties: {
     authKey: { type: "string" },
-    type: { type: "string", enum: ["oauth2", "oauth1", "api_key", "basic", "custom"] },
+    type: { type: "string", enum: ["oauth2", "api_key", "basic", "custom"] },
     required: { type: "boolean" },
     scopes: { type: "array", items: { type: "string" } },
     audience: { type: ["string", "null"] },

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -385,7 +385,7 @@ export function createIntegrationsRouter() {
       const body = parseBody(connectFieldsSchema, await c.req.json());
       try {
         const { auth } = await readIntegrationAuth(scope, packageId, authKey);
-        if (auth.type === "oauth2" || auth.type === "oauth1") {
+        if (auth.type === "oauth2") {
           throw invalidRequest(
             `Auth '${authKey}' is type '${auth.type}' — use the OAuth flow, not the fields flow`,
           );

--- a/apps/api/src/services/connect/registry.ts
+++ b/apps/api/src/services/connect/registry.ts
@@ -9,8 +9,6 @@
  *   - `custom` + `connect.tool`         → OrchestratedStrategy (code, needs executor)
  *   - `api_key` / `basic` / bare custom → FieldsStrategy (paste-the-bag)
  *
- * `oauth1` has no working connect path (removed in Phase 7).
- *
  * `connect.tool` (Orchestrated) requires a {@link ConnectToolExecutor} — the
  * connect-run substrate that actually runs the untrusted login tool. Callers
  * that can supply one (the connect-run / sidecar boot path) pass it; the plain

--- a/apps/api/test/unit/services/connect-registry.test.ts
+++ b/apps/api/test/unit/services/connect-registry.test.ts
@@ -61,14 +61,15 @@ describe("resolveStrategy", () => {
     expect(() => resolveStrategy(a)).toThrow(/connect-run substrate/);
   });
 
-  it("throws for an auth type without a connect strategy (oauth1)", () => {
-    expect(() => resolveStrategy(auth("oauth1"))).toThrow();
+  it("throws for an unknown auth type without a connect strategy", () => {
+    const a = { type: "unsupported" } as unknown as AuthDef;
+    expect(() => resolveStrategy(a)).toThrow(/no connect strategy/);
   });
 });
 
 describe("FieldsStrategy.complete", () => {
   it("refuses a wrong-kind input rather than persisting", async () => {
-    // Defence-in-depth: the route guards oauth/oauth1 too, but the strategy
+    // Defence-in-depth: the route guards oauth2 too, but the strategy
     // rejects a non-fields input before any DB access.
     const s = new FieldsStrategy();
     await expect(

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -737,7 +737,6 @@
   "integration.auth.noOauthClient": "No OAuth client registered — an administrator must configure the clientId/secret before connecting.",
   "integration.auth.noClientHint": "No OAuth client configured — set it up in the \"Access\" tab before connecting an account.",
   "integration.auth.type.oauth2": "OAuth",
-  "integration.auth.type.oauth1": "OAuth 1.0",
   "integration.auth.type.api_key": "API key",
   "integration.auth.type.basic": "Username & password",
   "integration.auth.type.custom": "Custom credentials",

--- a/apps/web/src/locales/fr/settings.json
+++ b/apps/web/src/locales/fr/settings.json
@@ -737,7 +737,6 @@
   "integration.auth.noOauthClient": "Aucun client OAuth enregistré — un administrateur doit configurer le clientId/secret avant la connexion.",
   "integration.auth.noClientHint": "Aucun client OAuth configuré — configurez-le dans l'onglet « Accès » avant de connecter un compte.",
   "integration.auth.type.oauth2": "OAuth",
-  "integration.auth.type.oauth1": "OAuth 1.0",
   "integration.auth.type.api_key": "Clé API",
   "integration.auth.type.basic": "Identifiant + mot de passe",
   "integration.auth.type.custom": "Identifiants personnalisés",

--- a/docs/guides/writing-an-integration-with-connect.md
+++ b/docs/guides/writing-an-integration-with-connect.md
@@ -1,0 +1,142 @@
+# Writing an integration with `connect`
+
+How an integration author declares **credential acquisition** in `manifest.auths.{key}`.
+A single abstraction (`ConnectStrategy`) covers every shape; the platform picks the
+strategy purely from the manifest. This guide maps each declaration to the strategy it
+selects and shows the minimal manifest for each.
+
+> Source of truth: `apps/api/src/services/connect/registry.ts` (`resolveStrategy`) and the
+> `auths.{key}` schema in `packages/core/src/integration.ts`.
+
+## Strategy selection at a glance
+
+| `auth.type`         | `connect` | `connect.runAt` | Strategy     | Flow                                                |
+| ------------------- | --------- | --------------- | ------------ | --------------------------------------------------- |
+| `oauth2`            | —         | —               | OAuth2       | OAuth 2.0 + PKCE, auto-refresh                      |
+| `api_key` / `basic` | —         | —               | Fields       | paste-the-bag (user submits the credential)         |
+| `custom`            | _absent_  | —               | Fields       | paste-the-bag, free-form schema                     |
+| `custom`            | `steps`   | —               | Login        | one declarative login request                       |
+| `custom`            | `tool`    | `run-start`     | LoginSecret  | store the secret, mint the session at each run      |
+| `custom`            | `tool`    | `link`          | Orchestrated | run the login tool once in an ephemeral connect-run |
+
+`oauth1` is **not** a valid auth type — it was removed (no working connect path, signing
+never implemented).
+
+---
+
+## 1. OAuth 2.0 (`oauth2`)
+
+For IdPs that support the authorization-code + PKCE flow. `authorizationUrl` and `tokenUrl`
+are **required** (no discovery). Declare the scope catalog via `availableScopes` so the
+runtime can infer the least-privilege scope union from agents' tool selection.
+
+```jsonc
+"auths": {
+  "oauth": {
+    "type": "oauth2",
+    "authorizationUrl": "https://example.com/oauth/authorize",
+    "tokenUrl": "https://example.com/oauth/token",
+    "availableScopes": [
+      { "value": "read", "label": "Read access" },
+      { "value": "write", "label": "Write access" }
+    ]
+  }
+}
+```
+
+Token refresh is automatic (proactive near expiry + on a mid-run `401`). Nothing else to wire.
+
+## 2. Paste-the-bag (`api_key` / `basic` / bare `custom`)
+
+The user submits the credential through the dashboard fields modal. `custom` lets you define
+an arbitrary credential schema; `api_key` / `basic` use the canonical fields (`api_key`,
+`username` / `password`).
+
+```jsonc
+"auths": {
+  "token": { "type": "api_key" }
+}
+```
+
+Use `delivery.http` to control how the credential is injected on outbound calls (header name,
+prefix, source field). See the `@appstrate/connect` README for the per-type defaults.
+
+## 3. Declarative login (`custom` + `connect.steps`)
+
+For services where a **single** stateless HTTP request exchanges a user-supplied secret
+(password, API token) for a session credential — no redirect chain, no impersonation. Exactly
+**one** step. Extract the credential from the response with `extract`.
+
+```jsonc
+"auths": {
+  "session": {
+    "type": "custom",
+    "connect": {
+      "steps": [
+        {
+          "request": { "method": "POST", "url": "https://example.com/login" },
+          "extract": { "session_token": { "from": "body", "jsonPath": "$.token" } }
+        }
+      ],
+      "limits": { "timeoutMs": 10000 }
+    }
+  }
+}
+```
+
+Anything stateful (cookie jars, multi-step CAS, CSRF token scraping, redirect following)
+does **not** belong here — use an orchestrated `tool` (§4/§5).
+
+## 4. Orchestrated, per-run (`custom` + `connect.tool` + `runAt: "run-start"`)
+
+The integration ships an MCP tool (named by `connect.tool`) that performs the login in code.
+With `runAt: "run-start"`, the dashboard **only stores the user's login secret**; the session
+is minted fresh inside each agent run's sidecar by the connect-login primitive. Set
+`persistLoginSecret: true` so the tool can re-bootstrap an expired session without re-prompting.
+
+```jsonc
+"auths": {
+  "login": {
+    "type": "custom",
+    "connect": {
+      "tool": "login",
+      "runAt": "run-start",
+      "persistLoginSecret": true,
+      "reauthOn": [401],
+      "outputs": ["JSESSIONID"]
+    }
+  }
+}
+```
+
+`reauthOn` lists the upstream status codes (typically `[401]`) on which the MITM proxy signals
+the sandbox to re-run the login tool mid-run. `outputs` is the authoritative set of injectable
+values the tool produces.
+
+## 5. Orchestrated, at link (`custom` + `connect.tool` + `runAt: "link"`)
+
+Same orchestrated tool, but the login runs **once** in an ephemeral connect-run when the user
+clicks "Connect" (e.g. capturing a durable cookie). The platform launches a stripped sidecar,
+runs the untrusted tool, captures the credential bundle, and tears down.
+
+```jsonc
+"auths": {
+  "login": {
+    "type": "custom",
+    "connect": { "tool": "login", "runAt": "link", "outputs": ["session_cookie"] }
+  }
+}
+```
+
+Choose `link` when the credential is durable and acquired once; choose `run-start` when each
+run needs a fresh session from a stored secret.
+
+---
+
+## Security notes
+
+- The login secret travels in the run's `inputs` plane and is substituted **proxy-side** by the
+  sidecar's MITM — the integration's tool code never reads it, and it is never logged.
+- `connect` is only valid on `type: "custom"`; declare **exactly one** of `steps` or `tool`.
+- Declarative `steps` are bounded by `limits` (timeout, body size); the orchestrated `tool`
+  runs in the sandboxed runner with the per-run CA and MITM envelope.

--- a/packages/afps-runtime/src/resolvers/http-delivery.ts
+++ b/packages/afps-runtime/src/resolvers/http-delivery.ts
@@ -54,7 +54,6 @@ const AUTH_TYPE_HTTP_DEFAULTS: Readonly<
   Record<string, { headerName: string; headerPrefix: string; valueFrom: string }>
 > = {
   oauth2: { headerName: "Authorization", headerPrefix: "Bearer ", valueFrom: "access_token" },
-  oauth1: { headerName: "Authorization", headerPrefix: "", valueFrom: "access_token" },
   api_key: { headerName: "X-Api-Key", headerPrefix: "", valueFrom: "api_key" },
   basic: { headerName: "Authorization", headerPrefix: "Basic ", valueFrom: "" },
   custom: { headerName: "", headerPrefix: "", valueFrom: "" },

--- a/packages/afps-runtime/src/resolvers/integration-api-call.ts
+++ b/packages/afps-runtime/src/resolvers/integration-api-call.ts
@@ -74,7 +74,7 @@ export interface ApiCallIntegrationMeta {
   namespace: string;
   /** Auth key supplying credentials (`apiCall.authKey` or the single auth). */
   authKey: string;
-  /** Auth type (`oauth2` | `oauth1` | `api_key` | `basic` | `custom`). */
+  /** Auth type (`oauth2` | `api_key` | `basic` | `custom`). */
   authType: string;
   /** URL allowlist enforced by the tool before dispatch. */
   authorizedUris: string[];

--- a/packages/connect/README.md
+++ b/packages/connect/README.md
@@ -25,7 +25,6 @@ See `src/index.ts` for the authoritative export surface.
 - **api_key** — Single key stored in header
 - **basic** — Username/password Base64
 - **custom** — Multi-field credential schema rendered as dynamic form
-- **oauth1** — recognized as a manifest auth-type value, but this package ships **no** OAuth 1.0a / HMAC-SHA1 signing implementation
 
 ## OAuth error classification
 

--- a/packages/connect/src/integration-credentials.ts
+++ b/packages/connect/src/integration-credentials.ts
@@ -23,7 +23,7 @@ import type { HttpDeliveryPlan } from "@appstrate/afps-runtime/resolvers";
 export interface ResolvedAuthCredentials {
   /** Auth key as declared in `auths.{key}` of the manifest. */
   authKey: string;
-  /** Auth type (`oauth2`, `oauth1`, `api_key`, `basic`, `custom`). */
+  /** Auth type (`oauth2`, `api_key`, `basic`, `custom`). */
   authType: string;
   /**
    * Credential fields, keyed by their canonical **storage** name (snake_case)

--- a/packages/connect/src/integration-mitm-planner.ts
+++ b/packages/connect/src/integration-mitm-planner.ts
@@ -94,8 +94,8 @@ export interface MitmAction {
   /** Header to add to the outbound request. `null` when no auth matched. */
   injectedHeader: { name: string; value: string } | null;
   /**
-   * Whether to attempt a 401-retry path. Always `true` for `oauth2` /
-   * `oauth1` matches (refresh-capable). `false` for `api_key` / `basic` /
+   * Whether to attempt a 401-retry path. Always `true` for `oauth2`
+   * matches (refresh-capable). `false` for `api_key` / `basic` /
    * `custom` — no refresh path exists, so retrying would loop.
    */
   retry401: boolean;
@@ -199,7 +199,7 @@ export function planMitmAction(
     matchedAuth: matched,
     strippedHeaderNames: dedupeCaseInsensitive(stripped),
     injectedHeader,
-    retry401: matched.authType === "oauth2" || matched.authType === "oauth1",
+    retry401: matched.authType === "oauth2",
   };
 }
 

--- a/packages/connect/test/integration-mitm-planner.test.ts
+++ b/packages/connect/test/integration-mitm-planner.test.ts
@@ -255,16 +255,6 @@ describe("planMitmAction — retry401 per auth type", () => {
     expect(planMitmAction(ctx, payload(a)).retry401).toBe(true);
   });
 
-  it("oauth1 → retry401: true", () => {
-    const a = auth("twitter", { authType: "oauth1" });
-    const ctx: MitmRequestContext = {
-      url: "https://api.twitter.com/x",
-      headerNames: [],
-      deliveryPlans: { twitter: PLAIN_BEARER },
-    };
-    expect(planMitmAction(ctx, payload(a)).retry401).toBe(true);
-  });
-
   for (const t of ["api_key", "basic", "custom"]) {
     it(`${t} → retry401: false`, () => {
       const a: ResolvedAuthCredentials = {

--- a/packages/core/schema/integration.schema.json
+++ b/packages/core/schema/integration.schema.json
@@ -237,7 +237,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["oauth2", "oauth1", "api_key", "basic", "custom"]
+            "enum": ["oauth2", "api_key", "basic", "custom"]
           },
           "required": { "type": "boolean" },
           "authorizationUrl": { "type": "string" },

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -277,7 +277,7 @@ const deliverySchema = z
     message: "delivery must declare at least one of: http, env, files",
   });
 
-const authTypeEnum = z.enum(["oauth2", "oauth1", "api_key", "basic", "custom"]);
+const authTypeEnum = z.enum(["oauth2", "api_key", "basic", "custom"]);
 
 const credentialsSchemaObject = z.object({
   schema: z.looseObject({}),
@@ -1092,7 +1092,7 @@ export function expandScopesGranted(
  * children) — the single source of truth for the insufficient-scopes diff
  * used by both the connection resolver and the agent-page picker.
  *
- * Scopes are an OAuth2 concept: api_key / basic / custom / oauth1 auths
+ * Scopes are an OAuth2 concept: api_key / basic / custom auths
  * grant access wholesale and carry no scope catalog, so an agent's declared
  * scopes can never be "missing" from such a connection. Diffing against one
  * would spuriously report every declared scope as missing (its `granted`

--- a/packages/core/src/sidecar-types.ts
+++ b/packages/core/src/sidecar-types.ts
@@ -133,7 +133,7 @@ export interface SidecarLaunchSpec {
  * proactive refresh scheduling).
  */
 export interface HttpDeliveryAuthSpec {
-  /** Auth type from the manifest (`oauth2` | `oauth1` | `api_key` | `basic` | `custom`). */
+  /** Auth type from the manifest (`oauth2` | `api_key` | `basic` | `custom`). */
   authType: string;
   /** Header name to inject (e.g. `Authorization`). */
   headerName: string;

--- a/runtime-pi/sidecar/README.md
+++ b/runtime-pi/sidecar/README.md
@@ -166,4 +166,4 @@ Cancellation honours `ctx.signal` between chunks; on abort, the resolver issues 
 - The resolver-side contract — file resolution, `responseMode` logic, `byteLength` thresholds — is documented next to the code in [`packages/afps-runtime/src/resolvers/http-call-core.ts`](../../packages/afps-runtime/src/resolvers/http-call-core.ts).
 - The `api_upload` adapter contracts, chunker semantics, and per-protocol error surfaces are documented next to the code in [`runtime-pi/mcp/api-upload-resolver.ts`](../mcp/api-upload-resolver.ts) and [`runtime-pi/mcp/upload-adapters/`](../mcp/upload-adapters/).
 - Sidecar lifecycle, network isolation, parallel container startup, and credential reporting paths are documented in the platform-level [`CLAUDE.md`](../../CLAUDE.md) under "Sidecar Protocol".
-- Provider auth modes (`oauth2` / `oauth1` / `api_key` / `basic` / `custom`) and the `credentialHeaderName` / `credentialHeaderPrefix` injection contract live in `@appstrate/connect`.
+- Integration auth modes (`oauth2` / `api_key` / `basic` / `custom`) and the `credentialHeaderName` / `credentialHeaderPrefix` injection contract live in `@appstrate/connect`.


### PR DESCRIPTION
## Phase 7 — retrait OAuth1 (breaking) + cleanup + guide auteur

Closes the final follow-up of the connect-acquisition epic. OAuth1 was a
**declarable-but-unconnectable** auth type: `resolveStrategy` threw for it (no
connect path) and the HMAC-SHA1 signing was never implemented. 0 shipped-manifest
usage, 0 prod data → clean removal, not a deprecation. No migration.

### Breaking change — `oauth1` removed from the integration auth-type enum
A manifest declaring `auths.{key}.type: "oauth1"` no longer validates. This is
**intentional and accepted** (the type never had a working connect path). The
OpenAPI breaking-change baseline was refreshed to record it as intentional.

`manifestVersion` is **not** bumped: it mirrors MCPB's `1.x` and isn't
appstrate-controlled; removing an enum value doesn't change the MCPB contract.

### Surface removed (appstrate only)
- `authTypeEnum` (`packages/core/src/integration.ts`) + `integration.schema.json` enum
- `AUTH_TYPE_HTTP_DEFAULTS` oauth1 delivery default (`afps-runtime/http-delivery.ts`)
- mitm-planner `retry401` oauth1 branch + comments (`@appstrate/connect`)
- route fields-flow guard (`routes/integrations.ts`) + strategy-registry docstring
- OpenAPI auth-type enum + refreshed `baseline.json`
- en/fr i18n auth-type label
- tests referencing oauth1 (connect-registry, mitm-planner) — rewritten/removed
- `@appstrate/connect` + sidecar README auth-mode lists

### Out of scope (deliberate)
`afps-spec` keeps `oauth1` in its **legacy provider** schema (`provider.schema.json`,
§7.3) — the provider type was already removed from the platform and afps-spec is a
CC-BY spec versioned/published independently. Per the execution plan §7.1, this PR
is appstrate-only.

### Docs
- New author guide: `docs/guides/writing-an-integration-with-connect.md` — maps each
  manifest auth declaration to the connect strategy it selects (OAuth2, Fields,
  declarative Login, orchestrated run-start / link) with a minimal manifest for each.

### Verification
- `bun run check` 20/20 (tsc + eslint + prettier + verify-openapi)
- `detect:breaking` passes against the refreshed baseline
- `grep -ri oauth1` finds no live path in `apps/`, `packages/`, `runtime-pi/`, `scripts/`
- Tests: core 466, connect 144, api-unit 778, connect/integration DB-backed 31 — all green

Note: the spec-status updates (`CONNECT_ACQUISITION_SPEC.md` → Validé) live in the
separate private `docs/` repo and are handled there, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)