### PR TITLE
refactor(afps): drop AFPS 1.x legacy dependency vocabulary

### DIFF
--- a/apps/api/src/services/package-versions.ts
+++ b/apps/api/src/services/package-versions.ts
@@ -13,12 +13,7 @@ import {
 } from "./package-storage.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
 import { computeIntegrity } from "@appstrate/core/integrity";
-import {
-  extractDependencies,
-  detectCycle,
-  assertNoLegacyDepKeys,
-  type DepEntry,
-} from "@appstrate/core/dependencies";
+import { extractDependencies, detectCycle, type DepEntry } from "@appstrate/core/dependencies";
 import { storeVersionDependencies, clearVersionDependencies } from "./package-version-deps.ts";
 import { packageVersionDependencies } from "@appstrate/db/schema";
 import {
@@ -683,10 +678,6 @@ export async function replaceVersionContent(params: {
   // bad manifest can't leave a partial side-effect (uploaded ZIP, stale row).
   // `extractDependencies` itself rejects invalid scoped names and invalid
   // semver ranges (see H5 — invalid ranges are rejected upstream here).
-  // AFPS §2.1 / Appendix D: producers MUST NOT emit `dependencies.providers`
-  // or `dependencies.tools`. The read fallback in `extractDependencies` stays
-  // for in-DB legacy rows; publish-time we reject the legacy shapes outright.
-  assertNoLegacyDepKeys(manifest);
   const deps = extractDependencies(manifest);
   await assertNoCycle(packageId, deps);
 
@@ -735,9 +726,6 @@ export async function createVersionAndUpload(params: {
   // version row. `extractDependencies` rejects invalid scoped names and
   // invalid semver ranges (see H5 — invalid ranges are rejected upstream
   // here, so the throw propagates and no ZIP / row is created).
-  // AFPS §2.1 / Appendix D: producers MUST NOT emit legacy
-  // `dependencies.providers` / `dependencies.tools` keys at publish time.
-  assertNoLegacyDepKeys(manifest);
   const deps = extractDependencies(manifest);
   await assertNoCycle(packageId, deps);
 

--- a/packages/afps-runtime/src/bundle/platform-prompt.ts
+++ b/packages/afps-runtime/src/bundle/platform-prompt.ts
@@ -31,7 +31,7 @@ function supportsTemplateRendering(schemaVersion: string | undefined): boolean {
 }
 
 /**
- * Heuristic matching the AFPS 1.3 file-field convention: a JSON Schema
+ * Heuristic matching the AFPS file-field convention: a JSON Schema
  * node is a "file" when it is a string with `format: uri` and a
  * `contentMediaType`, or an array of such items.
  */

--- a/packages/afps-runtime/src/conformance/cases.ts
+++ b/packages/afps-runtime/src/conformance/cases.ts
@@ -9,12 +9,7 @@
  */
 
 import { zipSync } from "fflate";
-import {
-  integrationManifestSchema,
-  mcpServerManifestSchema,
-  metaSchema,
-  agentManifestSchema,
-} from "@afps-spec/schema";
+import { integrationManifestSchema, metaSchema, agentManifestSchema } from "@afps-spec/schema";
 import {
   canonicalBundleDigest,
   generateKeyPair,
@@ -512,66 +507,6 @@ const L4_EMPTY_SCRIPT: ConformanceCase = {
 // language runtimes (third-party runners get the same pass/fail by
 // re-implementing the same validators).
 //
-// L1.6 — mcp-server identity at the manifest root (§3.4 / §11.2).
-//   AFPS lifted `type`, `name`, and `schema_version` out of the
-//   `_meta["dev.afps/mcp-server"]` block onto the root. Accepting the old
-//   shape (identity ONLY in `_meta`) would silently break tools that key
-//   off the root discriminant.
-const L1_MCP_SERVER_ROOT_IDENTITY: ConformanceCase = {
-  id: "L1.6",
-  level: "L1",
-  title: "mcp-server identity lives at the manifest root (AFPS §3.4)",
-  run: () => {
-    const goodManifest = {
-      manifest_version: "0.3",
-      name: "@afps/conformance-mcp",
-      version: "1.0.0",
-      type: "mcp-server",
-      schema_version: "0.1",
-      display_name: "Conformance MCP Server",
-      server: {
-        type: "node",
-        entry_point: "main.js",
-        mcp_config: { command: "node", args: ["main.js"] },
-      },
-    };
-    const goodResult = mcpServerManifestSchema.safeParse(goodManifest);
-    if (!goodResult.success) {
-      return fail(
-        `root-identity manifest rejected: ${goodResult.error.issues
-          .map((i) => `${i.path.join(".")}: ${i.message}`)
-          .join("; ")}`,
-      );
-    }
-
-    // Legacy AFPS 1.x shape — identity ONLY in `_meta`. The root is
-    // missing `type`/`name`/`schema_version`, so the lifted-shape schema
-    // MUST refuse it.
-    const legacyManifest = {
-      manifest_version: "0.3",
-      version: "1.0.0",
-      display_name: "Legacy MCP",
-      server: {
-        type: "node",
-        entry_point: "main.js",
-        mcp_config: { command: "node", args: ["main.js"] },
-      },
-      _meta: {
-        "dev.afps/mcp-server": {
-          name: "@afps/conformance-mcp",
-          type: "mcp-server",
-          schema_version: "0.1",
-        },
-      },
-    };
-    const legacyResult = mcpServerManifestSchema.safeParse(legacyManifest);
-    if (legacyResult.success) {
-      return fail("legacy _meta-only mcp-server identity must be rejected");
-    }
-    return pass();
-  },
-};
-
 // L1.7 — integration `delivery.http` mutually exclusive with `delivery.env`
 // (AFPS §7.6). The proxy injects the credential header on the way out
 // (`http`) OR the integration server reads it from env / file (`env`/`files`);
@@ -1213,7 +1148,6 @@ export const BUILT_IN_CASES: readonly ConformanceCase[] = Object.freeze([
   L1_REJECT_MISSING_MANIFEST,
   L1_REJECT_MISSING_PROMPT,
   L1_STRIP_WRAPPER,
-  L1_MCP_SERVER_ROOT_IDENTITY,
   L1_INTEGRATION_MUTUAL_EXCLUSION,
   L1_DEPENDENCIES_AND_CONFIG,
   L1_TOOLS_POLICY,

--- a/packages/afps-runtime/src/resolvers/bundle-adapter.ts
+++ b/packages/afps-runtime/src/resolvers/bundle-adapter.ts
@@ -21,7 +21,7 @@ import type { DependencyRef } from "@afps-spec/types";
  *
  * The bundle builder resolves each declared dep to exactly one version,
  * so a single name should map to a single package. When multiple
- * versions of the same name are present (not expected under AFPS 1.3
+ * versions of the same name are present (not expected under AFPS
  * but tolerated), the first one encountered wins — iteration order is
  * deterministic (Map preserves insertion order).
  */

--- a/packages/afps-runtime/src/resolvers/http-call-core.ts
+++ b/packages/afps-runtime/src/resolvers/http-call-core.ts
@@ -1608,7 +1608,7 @@ function enforceAuthorizedUris(meta: ApiCallMeta, target: string): void {
 }
 
 /**
- * AFPS 1.3-spec URL allowlist matcher:
+ * AFPS-spec URL allowlist matcher:
  *   - literal URLs (no wildcards)   → exact equality
  *   - `*`  (single path segment)    → regex `[^/]*`
  *   - `**` (any substring)          → regex `.*`

--- a/packages/afps-runtime/src/resolvers/index.ts
+++ b/packages/afps-runtime/src/resolvers/index.ts
@@ -14,8 +14,7 @@
  * `@afps-spec/types` — they describe the shape of a tool surfaced to the LLM
  * (e.g. the integration `api_call` tool built by `makeApiCallTool`). In AFPS
  * tools come from spawned `mcp-server` packages (§3.4) and integrations
- * (§3.5), NOT from loading a package `entrypoint` module in-process (that was
- * the retired 1.x `tool` package type).
+ * (§3.5), NOT from loading a package `entrypoint` module in-process.
  *
  * Specification: `afps-spec/spec.md` §8.
  */

--- a/packages/afps-runtime/src/runner/types.ts
+++ b/packages/afps-runtime/src/runner/types.ts
@@ -2,7 +2,7 @@
 // Copyright 2026 Appstrate
 
 /**
- * AFPS 1.3 Runner surface.
+ * AFPS Runner surface.
  *
  * A {@link Runner} takes a loaded bundle + execution context, wires the
  * spec resolvers ({@link SkillResolver} and the bundled context source),

--- a/packages/afps-runtime/src/types/canonical-events.ts
+++ b/packages/afps-runtime/src/types/canonical-events.ts
@@ -40,7 +40,7 @@ interface BaseEnvelope {
 }
 
 /**
- * `@afps/memory` — `note()` tool (AFPS 1.5+; replaces `add_memory()`).
+ * `@afps/memory` — `note()` tool (AFPS; replaces `add_memory()`).
  *
  * Append-only archive write. Reachable from the agent only via the
  * `recall_memory` tool — never injected into the system prompt.
@@ -56,12 +56,12 @@ interface BaseEnvelope {
 export interface MemoryAddedEvent extends BaseEnvelope {
   type: "memory.added";
   content: string;
-  /** AFPS 1.4+. Defaults to `"actor"` when omitted. */
+  /** AFPS scope dimension. Defaults to `"actor"` when omitted. */
   scope?: "actor" | "shared";
 }
 
 /**
- * `@afps/pin` — `pin(key, content)` tool (AFPS 1.5+; replaces
+ * `@afps/pin` — `pin(key, content)` tool (AFPS; replaces
  * `set_checkpoint()`).
  *
  * Upsert-by-key into a named pinned slot. Last-write-wins per `(scope,
@@ -82,7 +82,7 @@ export interface PinnedSetEvent extends BaseEnvelope {
   key: string;
   /** Arbitrary JSON value stored under the pinned slot. */
   content: unknown;
-  /** AFPS 1.4+. Defaults to `"actor"` when omitted. */
+  /** AFPS scope dimension. Defaults to `"actor"` when omitted. */
   scope?: "actor" | "shared";
 }
 

--- a/packages/afps-runtime/src/types/run-result.ts
+++ b/packages/afps-runtime/src/types/run-result.ts
@@ -14,7 +14,7 @@ export type LogLevel = "info" | "warn" | "error";
  * Aggregated state at the end of a run.
  *
  * Built by the runtime by reducing the stream of {@link RunEvent} values
- * against the canonical AFPS 1.3 semantics:
+ * against the canonical AFPS semantics:
  *
  * - `memory.added` events append to `memories`
  * - `pinned.set` events upsert by `key` into `pinned` (last-write-wins per key)
@@ -92,8 +92,8 @@ export type { TokenUsage };
 export interface Memory {
   content: string;
   /**
-   * AFPS 1.4+ scope dimension for the unified persistence store.
-   * 1.4 emitters MAY omit the field — consumers default to `"actor"`.
+   * AFPS scope dimension for the unified persistence store.
+   * Emitters MAY omit the field — consumers default to `"actor"`.
    */
   scope?: "actor" | "shared";
 }
@@ -105,7 +105,7 @@ export interface Memory {
  */
 export interface PinnedSlot {
   content: unknown;
-  /** AFPS 1.4+ — per-slot persistence scope; defaults to `"actor"`. */
+  /** AFPS per-slot persistence scope; defaults to `"actor"`. */
   scope?: "actor" | "shared";
 }
 

--- a/packages/afps-runtime/test/bundle/validate-bundle.test.ts
+++ b/packages/afps-runtime/test/bundle/validate-bundle.test.ts
@@ -130,46 +130,6 @@ describe("validateBundle (AFPS)", () => {
     ).toBe(true);
   });
 
-  it("rejects an AFPS 1.x camelCase manifest (the migration's headline contract)", async () => {
-    // Spec-fidelity gate: the snake_case migration's whole point is that the
-    // wire-format casing flipped. A fully-camelCased 1.x manifest must NOT
-    // be silently accepted — it must hit MANIFEST_SCHEMA errors on both
-    // `schemaVersion` (unknown field via missing `schema_version`) and the
-    // 1.x-style top-level keys (`displayName`, `fileConstraints`, …).
-    const legacyCamelCaseManifest = {
-      name: "@me/root",
-      version: "1.0.0",
-      type: "agent",
-      schemaVersion: "1.1",
-      displayName: "Legacy Agent",
-      // 1.x wrapper keys that don't exist in the current AFPS shape:
-      input: {
-        schema: { type: "object", properties: { task: { type: "string" } } },
-        fileConstraints: { upload: { accept: ["text/plain"], maxSize: 1024 } },
-        uiHints: { task: { placeholder: "Type something" } },
-        propertyOrder: ["task"],
-      },
-    };
-    const root = makePkg("@me/root@1.0.0" as PackageIdentity, legacyCamelCaseManifest, {
-      "prompt.md": enc("p"),
-    });
-    const bundle = await buildBundleFromCatalog(root, emptyPackageCatalog);
-    const result = validateBundle(bundle);
-
-    expect(result.valid).toBe(false);
-    const errors = result.issues.filter((i) => i.severity === "error");
-    expect(errors.length).toBeGreaterThan(0);
-    // The missing snake_case `schema_version` must be flagged — that's the
-    // strongest single signal the migration's contract is enforced.
-    expect(
-      result.issues.some(
-        (i) =>
-          (i.code === "MANIFEST_SCHEMA" || i.code === "SCHEMA_VERSION_MISSING") &&
-          i.path.includes("schema_version"),
-      ),
-    ).toBe(true);
-  });
-
   it("rejects a manifest that mixes 1.x camelCase + 2.0 snake_case wrapper keys", async () => {
     // A half-migrated manifest where someone renamed schema_version → "0.1"
     // but kept 1.x wrapper keys (fileConstraints, uiHints, …) must still fail.

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -53,56 +53,6 @@ export interface IntegrationConfiguration {
 export type IntegrationsConfiguration = Record<string, IntegrationConfiguration>;
 
 // ─────────────────────────────────────────────
-// Publish-time guard against legacy 1.x dep keys
-// ─────────────────────────────────────────────
-
-/**
- * Error thrown by {@link assertNoLegacyDepKeys} when a manifest carries the
- * retired AFPS 1.x dependency keys (`dependencies.providers` /
- * `dependencies.tools`). Per AFPS §2.1 / Appendix D, producers MUST NOT
- * emit these keys — they were renamed to `dependencies.integrations` and
- * `dependencies.mcp_servers`. The publish path calls this guard to reject
- * newly-emitted legacy shapes.
- */
-export class LegacyDepKeyError extends Error {
-  /** Manifest field path that triggered the rejection (e.g. `"dependencies.providers"`). */
-  public readonly field: string;
-  /** Canonical AFPS key that should be used instead. */
-  public readonly suggestedRename: string;
-
-  constructor(field: string, suggestedRename: string) {
-    super(
-      `${field} is a retired AFPS 1.x dependency key — producers MUST NOT emit it per AFPS §2.1 / Appendix D. Rename to "${suggestedRename}".`,
-    );
-    this.name = "LegacyDepKeyError";
-    this.field = field;
-    this.suggestedRename = suggestedRename;
-  }
-}
-
-/**
- * Publish-time guard: reject manifests that carry the retired AFPS 1.x
- * dependency keys (`dependencies.providers`, `dependencies.tools`). Per
- * AFPS §2.1 + Appendix D, producers MUST NOT emit these keys; they map
- * to `dependencies.integrations` and `dependencies.mcp_servers` respectively.
- *
- * Call this from the publish path BEFORE persisting a new version row.
- *
- * @throws LegacyDepKeyError when a legacy key is detected on the manifest.
- */
-export function assertNoLegacyDepKeys(manifest: Record<string, unknown>): void {
-  const deps = manifest.dependencies;
-  if (!deps || typeof deps !== "object") return;
-  const legacy = deps as Record<string, unknown>;
-  if (legacy.providers !== undefined) {
-    throw new LegacyDepKeyError("dependencies.providers", "dependencies.integrations");
-  }
-  if (legacy.tools !== undefined) {
-    throw new LegacyDepKeyError("dependencies.tools", "dependencies.mcp_servers");
-  }
-}
-
-// ─────────────────────────────────────────────
 // Dependency extraction from manifests
 // ─────────────────────────────────────────────
 

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -11,8 +11,8 @@
  * cross-field MUST rules that AFPS leaves to the consumer (scope-catalog
  * subset, per-tool auth-key disambiguation, connect.login output gating).
  *
- * Field vocabulary is snake_case (§Appendix D). The integration manifest
- * itself is read as AFPS canonical only — there is no 1.x camelCase
+ * Field vocabulary is snake_case (AFPS). The integration manifest
+ * itself is read as AFPS canonical snake_case only — there is no camelCase
  * reading path on this schema. Reads and writes everywhere are AFPS
  * canonical.
  *

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -63,7 +63,7 @@ export const scopedNameRegex: RegExp = (() => {
   return /^@[a-z0-9]([a-z0-9-]*[a-z0-9])?\/[a-z0-9]([a-z0-9-]*[a-z0-9])?$/;
 })();
 
-/** Zod enum for supported AFPS package types (`tool`/`provider` removed; `mcp-server` added). Canonical export re-exposed from `@afps-spec/schema`. */
+/** Zod enum for supported AFPS package types. Canonical export re-exposed from `@afps-spec/schema`. */
 export const packageTypeEnum = afpsPackageTypeEnum;
 /** Union type of supported package types. */
 export type PackageType = z.infer<typeof packageTypeEnum>;
@@ -214,7 +214,7 @@ const agentManifestObjectSchema = afpsAgentManifestObjectSchema.extend({
   // AFPS requires author (MUST, non-empty) for publication; core relaxes it
   // for local drafts (the agent-editor stores `author: ""` until the user
   // fills it in). Accepts both the AFPS §3.1 structured-object form and
-  // the legacy bare string (including the empty-string draft sentinel).
+  // the bare-string form (including the empty-string draft sentinel).
   author: z.union([z.string(), authorObjectSchema]).optional(),
   description: z.string().optional(),
   keywords: z.array(z.string()).optional(),
@@ -229,7 +229,7 @@ const agentManifestObjectSchema = afpsAgentManifestObjectSchema.extend({
   // First-party runtime tools enabled for this agent — all opt-in, none
   // auto-injected (`output` included). `output` is required to be present
   // only when an output schema is declared (enforced by the superRefine
-  // below). Snake_case `runtime_tools` (was 1.x `runtimeTools`). This is an
+  // below). Snake_case `runtime_tools`. This is an
   // Appstrate manifest extension with no AFPS equivalent — kept as a
   // documented top-level snake_case field rather than namespaced under
   // `_meta`, because it is woven through the run pipeline (catalog
@@ -356,12 +356,12 @@ function parseWithSchema(
  * @returns Validation result with parsed manifest on success, or error messages on failure
  */
 export function validateManifest(raw: unknown): ValidateManifestResult {
-  // AFPS (Appendix D): `type` is the canonical discriminator and MUST be
-  // one of `agent | skill | mcp-server | integration`. Legacy strings (`tool`,
-  // `provider`) and a missing `type` are dispatcher-level errors, not partial
-  // base-schema validation failures — fail fast with a single structured Zod
-  // issue keyed on `["type"]` so callers/UI get a typed signal rather than a
-  // permissive list of base-schema field errors.
+  // AFPS: `type` is the canonical discriminator and MUST be one of
+  // `agent | skill | mcp-server | integration`. An unknown or missing `type`
+  // is a dispatcher-level error, not a partial base-schema validation
+  // failure — fail fast with a single structured Zod issue keyed on
+  // `["type"]` so callers/UI get a typed signal rather than a permissive
+  // list of base-schema field errors.
   if (!raw || typeof raw !== "object") {
     return {
       valid: false,
@@ -373,20 +373,18 @@ export function validateManifest(raw: unknown): ValidateManifestResult {
   const obj = raw as Record<string, unknown>;
   const type = obj.type;
 
-  // AFPS (§3.4 / §11.2): mcp-server identity was lifted from
-  // `_meta["dev.afps/mcp-server"]` to the manifest root. `type: "mcp-server"`,
-  // `name`, `schema_version`, and `dependencies` now live at the root; the
-  // `_meta["dev.afps/mcp-server"]` block was removed entirely. Dispatch
-  // purely on the root `type` discriminator.
+  // AFPS (§3.4): mcp-server identity lives at the manifest root —
+  // `type: "mcp-server"`, `name`, `schema_version`, and `dependencies` are
+  // all root fields. Dispatch purely on the root `type` discriminator.
   if (type === "mcp-server") return parseWithSchema(mcpServerManifestSchema, raw);
   if (type === "agent") return parseWithSchema(agentManifestSchema, raw);
   if (type === "skill") return parseWithSchema(skillManifestSchema, raw);
   if (type === "integration") return parseWithSchema(integrationManifestSchema, raw);
 
-  // Unknown / missing type: emit a single typed issue and stop. The legacy
-  // `tool` / `provider` strings (AFPS Appendix D — `tool → mcp-server`,
-  // `provider → integration`) land here and produce the same typed error
-  // rather than a confusing list of partial base-schema errors.
+  // Unknown / missing type: emit a single typed issue and stop. Any value
+  // that isn't one of the four canonical package types lands here and
+  // produces the typed error rather than a confusing list of partial
+  // base-schema errors.
   const received =
     typeof type === "string" ? `"${type}"` : type === undefined ? "missing" : String(type);
   return {
@@ -456,9 +454,9 @@ export interface ManifestAuthorObject {
 
 /**
  * Structured repository shape (AFPS §3.1) — npm-aligned object form.
- * The legacy bare-string form maps to `repositoryUrl` for back-compat;
- * publishers using the object form get both `repositoryUrl` (mirrors
- * `repository.url`) and `repository` (full object).
+ * The bare-string form maps to `repositoryUrl`; publishers using the object
+ * form get both `repositoryUrl` (mirrors `repository.url`) and `repository`
+ * (full object).
  */
 export interface ManifestRepositoryObject {
   type: string;

--- a/packages/core/test/dependencies.test.ts
+++ b/packages/core/test/dependencies.test.ts
@@ -6,8 +6,6 @@ import {
   detectCycle,
   parseManifestIntegrations,
   writeManifestIntegrations,
-  assertNoLegacyDepKeys,
-  LegacyDepKeyError,
 } from "../src/dependencies.ts";
 import type { DepEntry } from "../src/dependencies.ts";
 
@@ -182,61 +180,6 @@ describe("extractDependencies", () => {
       },
     };
     expect(() => extractDependencies(manifest)).not.toThrow();
-  });
-});
-
-// ─────────────────────────────────────────────
-// assertNoLegacyDepKeys — publish-time guard (AFPS §2.1 / Appendix D)
-// ─────────────────────────────────────────────
-
-describe("assertNoLegacyDepKeys (publish-time guard)", () => {
-  it("rejects manifests that emit dependencies.providers", () => {
-    const manifest = {
-      dependencies: {
-        providers: { "@acme/gmail": "^1.0.0" },
-      },
-    };
-    expect(() => assertNoLegacyDepKeys(manifest)).toThrow(LegacyDepKeyError);
-    try {
-      assertNoLegacyDepKeys(manifest);
-    } catch (err) {
-      expect(err).toBeInstanceOf(LegacyDepKeyError);
-      const e = err as LegacyDepKeyError;
-      expect(e.field).toBe("dependencies.providers");
-      expect(e.suggestedRename).toBe("dependencies.integrations");
-    }
-  });
-
-  it("rejects manifests that emit dependencies.tools", () => {
-    const manifest = {
-      dependencies: {
-        tools: { "@acme/git-tool": "^1.0.0" },
-      },
-    };
-    expect(() => assertNoLegacyDepKeys(manifest)).toThrow(LegacyDepKeyError);
-    try {
-      assertNoLegacyDepKeys(manifest);
-    } catch (err) {
-      const e = err as LegacyDepKeyError;
-      expect(e.field).toBe("dependencies.tools");
-      expect(e.suggestedRename).toBe("dependencies.mcp_servers");
-    }
-  });
-
-  it("accepts canonical AFPS dependency shapes (integrations + mcp_servers + skills)", () => {
-    const manifest = {
-      dependencies: {
-        skills: { "@acme/skill-a": "^1.0.0" },
-        integrations: { "@acme/gmail": "^1.0.0" },
-        mcp_servers: { "@acme/srv": "^1.0.0" },
-      },
-    };
-    expect(() => assertNoLegacyDepKeys(manifest)).not.toThrow();
-  });
-
-  it("accepts manifests with no dependencies field at all", () => {
-    expect(() => assertNoLegacyDepKeys({})).not.toThrow();
-    expect(() => assertNoLegacyDepKeys({ dependencies: {} })).not.toThrow();
   });
 });
 

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -87,19 +87,6 @@ describe("validateManifest", () => {
     expect(result.errors[0]).toMatch(/^type:.*Unknown package type/);
   });
 
-  it("legacy `tool` / `provider` types produce the typed Unknown package type error", () => {
-    // AFPS Appendix D removed `tool` (→ `mcp-server`) and `provider` (→
-    // `integration`). Manifests carrying the old strings must fail with the
-    // single typed dispatcher error rather than a list of partial errors from
-    // the permissive base schema.
-    for (const legacy of ["tool", "provider"]) {
-      const result = validateManifest({ name: "@x/y", version: "1.0.0", type: legacy });
-      expect(result.valid).toBe(false);
-      expect(result.errors).toHaveLength(1);
-      expect(result.errors[0]).toMatch(/^type:.*Unknown package type/);
-    }
-  });
-
   it("invalid scoped name format", () => {
     const result = validateManifest(validSkillManifest({ name: "bad-name" }));
     expect(result.valid).toBe(false);
@@ -161,8 +148,7 @@ describe("validateManifest", () => {
     expect(deps.skills).toEqual({ "@test/skill": "^1.0.0", "@test/other": "~2.3.0" });
     expect(deps.integrations).toEqual({ "@test/gmail": "^1.0.0" });
     expect(deps.mcp_servers).toEqual({ "@test/fetch": "^1.0.0" });
-    // The former `dependencies.tools` map → `dependencies.mcp_servers`;
-    // selectable runtime tools are the top-level snake_case `runtime_tools`.
+    // Selectable runtime tools are the top-level snake_case `runtime_tools`.
     expect(m.runtime_tools).toEqual(["log", "note"]);
   });
 
@@ -488,24 +474,6 @@ describe("validateManifest — package-type dispatch", () => {
     });
     // No root `type` → dispatcher fails fast with the typed Unknown-package-type
     // error (AFPS requires `type` as the discriminator).
-    expect(r.valid).toBe(false);
-  });
-
-  it("rejects an mcp-server carrying only the legacy _meta identity (AFPS removed it)", () => {
-    // Legacy AFPS 1.x producers may still emit `_meta["dev.afps/mcp-server"]`. The
-    // new dispatch ignores it entirely — without a root `type: "mcp-server"`,
-    // the dispatcher fails fast with the typed Unknown-package-type error.
-    const r = validateManifest({
-      manifest_version: "0.3",
-      name: "fetch-json",
-      version: "1.0.0",
-      server: {
-        type: "node",
-        entry_point: "server/index.js",
-        mcp_config: { command: "node", args: ["server/index.js"] },
-      },
-      _meta: { "dev.afps/mcp-server": { name: "@test/fetch-json", type: "mcp-server" } },
-    });
     expect(r.valid).toBe(false);
   });
 

--- a/packages/core/test/writers-canonical.test.ts
+++ b/packages/core/test/writers-canonical.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * T1 (Wave 3) — Writers MUST NOT emit AFPS-1.x camelCase keys.
+ * T1 (Wave 3) — Writers MUST NOT emit non-canonical camelCase keys.
  *
  * Umbrella regression test catching the WHOLE CLASS of writer-leak bugs that
  * shipped as C1 (`createOrgItem` writing `displayName`). Wave 1 fixes are
@@ -21,13 +21,12 @@
  *    `apps/web/src/components/agent-editor/test/utils.test.ts` — already
  *    asserts `displayName: undefined` is emitted alongside canonical
  *    `display_name`. Re-tested here at the JSON level since the patch is
- *    shallow-merged into the manifest and the legacy key MUST drop on
+ *    shallow-merged into the manifest and the non-canonical key MUST drop on
  *    serialization.
  *
- * Banned 1.x camelCase keys:
+ * Banned non-canonical camelCase keys:
  *   displayName, schemaVersion, fileConstraints, uiHints, propertyOrder,
- *   maxSize, iconUrl, providersConfiguration, runtimeTools,
- *   dependencies.providers, dependencies.tools
+ *   maxSize, iconUrl, providersConfiguration, runtimeTools
  */
 
 import { describe, it, expect } from "bun:test";
@@ -50,8 +49,6 @@ const BANNED_CAMEL_KEYS = [
   "runtimeTools",
 ] as const;
 
-const BANNED_DEP_KEYS = ["providers", "tools"] as const;
-
 interface Violation {
   path: string;
   key: string;
@@ -68,10 +65,6 @@ function findBannedKeysDeep(value: unknown, basePath = "$"): Violation[] {
     const path = `${basePath}.${k}`;
     if ((BANNED_CAMEL_KEYS as readonly string[]).includes(k)) {
       out.push({ path, key: k });
-    }
-    // `dependencies.providers` / `dependencies.tools` (Appendix D legacy keys)
-    if (basePath.endsWith(".dependencies") && (BANNED_DEP_KEYS as readonly string[]).includes(k)) {
-      out.push({ path, key: `dependencies.${k}` });
     }
     out.push(...findBannedKeysDeep(v, path));
   }
@@ -212,19 +205,6 @@ describe("T1 — banned-key walker (test infrastructure)", () => {
     expect(keys).toContain("fileConstraints");
     expect(keys).toContain("maxSize");
     expect(keys).toContain("uiHints");
-  });
-
-  it("flags `dependencies.providers` and `dependencies.tools`", () => {
-    const v = findBannedKeysDeep({
-      dependencies: {
-        skills: { "@x/y": "^1.0.0" },
-        providers: { "@x/p": "^1.0.0" },
-        tools: { "@x/t": "^1.0.0" },
-      },
-    });
-    const keys = v.map((x) => x.key);
-    expect(keys).toContain("dependencies.providers");
-    expect(keys).toContain("dependencies.tools");
   });
 
   it("accepts canonical snake_case manifest", () => {

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -71,8 +71,6 @@ export type InvitationStatus = z.infer<typeof zInvitationStatusEnum>;
 export const packageTypeValues = [
   "agent",
   "skill",
-  // INTEGRATIONS_PROPOSAL §4.1. The legacy `tool`/`provider` values were
-  // dropped from the enum during the provider→integration migration (squashed into the 0000_init baseline).
   "integration",
   // AFPS §3.4 — a standalone MCP Bundle (MCPB) package that an
   // integration's `source.kind: "local"` references via `source.server`.


### PR DESCRIPTION
Remove the retired AFPS 1.x dep-key compatibility layer (split out of the post-connection-renewal cleanup).

- **core**: drop `assertNoLegacyDepKeys` + `LegacyDepKeyError`; `extractDependencies` reads only `skills`/`mcp_servers`/`integrations`. `package-versions` no longer calls the guard.
- **afps-runtime**: prune the matching legacy handling in conformance cases, resolvers, runner/event/result types, platform-prompt, validate-bundle.
- **enums**: comment-only cleanup of the package-type list.

Unknown dep keys / package types are still rejected by the canonical schema; only the dedicated named guard is gone.

Verified standalone on `feat/integrations`: core/afps-runtime/api/web `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)