### PR TITLE
fix(integrations): stop X-Integration-Id leaking upstream + dedup helpers

### DIFF
--- a/apps/api/src/routes/credential-proxy.ts
+++ b/apps/api/src/routes/credential-proxy.ts
@@ -395,6 +395,7 @@ export function createCredentialProxyRouter() {
 
 const PROXY_CONTROL_HEADERS = new Set([
   "x-integration",
+  "x-integration-id",
   "x-target",
   "x-session-id",
   "x-substitute-body",

--- a/packages/connect/src/utils.ts
+++ b/packages/connect/src/utils.ts
@@ -4,9 +4,13 @@
  * Shared utilities for the connect package.
  */
 
+import { getErrorMessage } from "@appstrate/core/errors";
+
 /**
  * Extract a human-readable error message from an unknown error value.
+ * Thin alias over `@appstrate/core`'s `getErrorMessage` (kept for the
+ * connect-package call sites).
  */
 export function extractErrorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  return getErrorMessage(err);
 }

--- a/packages/core/src/schema-validation.ts
+++ b/packages/core/src/schema-validation.ts
@@ -16,6 +16,7 @@
 
 import { createAjv } from "./ajv.ts";
 import type { JSONSchemaObject } from "./form.ts";
+import { isPlainObject } from "./safe-json.ts";
 
 const ajv = createAjv({ coerceTypes: true });
 
@@ -104,8 +105,4 @@ export function deepMergeConfig(
     }
   }
   return out;
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -171,6 +171,7 @@ function validateMcpHostHeader(req: Request): Response | undefined {
  */
 const API_CALL_FORBIDDEN_HEADERS = new Set<string>([
   "x-integration",
+  "x-integration-id",
   "x-target",
   "x-substitute-body",
   "x-stream-response",


### PR DESCRIPTION
Audit tier 1 (mechanical / safe-now). From the feat/integrations cleanliness audit.

- **Header leak (fix)**: credential-proxy + sidecar `api_call` read the routing header as `X-Integration-Id` but the strip sets only listed `x-integration` → the header was forwarded to the third-party provider. Added `x-integration-id` to `PROXY_CONTROL_HEADERS` + `API_CALL_FORBIDDEN_HEADERS`.
- **DRY**: `connect/utils.extractErrorMessage` → delegate to `@appstrate/core` `getErrorMessage` (was byte-identical); `core/schema-validation` uses the exported `isPlainObject` from `safe-json` instead of a private duplicate.

Deferred from this tier (with reason): deleting dead core exports (`PACKAGE_TYPES`, `AvailableScope`, etc.) — `@appstrate/core` is published and registry/portal consumers aren't verifiable locally; removing exports risks breaking them. The ~12 redundant `try/catch→internalError` sites — judgment-heavy (some translate errors), low value.

Verified: core/connect/api `tsc` clean; 250 core+connect tests, 23 credential-proxy tests, 43 sidecar api_call tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)