### PR TITLE
fix(api): org-settings membership gate, AJV validator cache, guard post-finalize side-data

### DIFF
--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -495,9 +495,16 @@ router.put("/:orgId/members/:userId", async (c) => {
   return c.json({ userId: targetUserId, role: data.role });
 });
 
-// GET /api/orgs/:orgId/settings — get org settings
+// GET /api/orgs/:orgId/settings — get org settings (any member)
 router.get("/:orgId/settings", async (c) => {
+  const user = c.get("user");
   const orgId = c.req.param("orgId");
+
+  // Membership gate — without it any cookie-session user could read an
+  // arbitrary org's settings by passing its id (apiKeyOrgScopeGuard only
+  // pins API keys, not sessions). Mirrors the PUT handler below.
+  const member = await getOrgMember(orgId, user.id);
+  if (!member) throw forbidden("Not a member of this organization");
 
   const settings = await getOrgSettings(orgId);
   return c.json(settings);

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -445,58 +445,70 @@ export async function finalizeRun(input: FinalizeRunInput): Promise<void> {
     actorFromIds(actorRow?.userId ?? null, actorRow?.endUserId ?? null),
   );
 
-  if (result.memories?.length) {
-    // Split memories by declared scope and write each non-empty bucket
-    // to the unified store. The store IS the store — exceptions
-    // propagate so finalize fails loudly on persistence faults.
-    const sharedContent: string[] = [];
-    const actorContent: string[] = [];
-    for (const m of result.memories) {
-      if (m.scope === "shared") sharedContent.push(m.content);
-      else actorContent.push(m.content);
+  // Post-CAS best-effort: the run is already terminal in `runs`. Memory and
+  // pinned-slot persistence is agent-authored side-data — a transient store
+  // fault here must NOT strand the status-change broadcast below (the only
+  // signal that updates the UI / fires webhooks) nor 500 the runner for a run
+  // that is already committed terminal. Log + swallow, like the run-log writes
+  // further down. (Persistence faults are surfaced via the error log for ops.)
+  try {
+    if (result.memories?.length) {
+      // Split memories by declared scope and write each non-empty bucket.
+      const sharedContent: string[] = [];
+      const actorContent: string[] = [];
+      for (const m of result.memories) {
+        if (m.scope === "shared") sharedContent.push(m.content);
+        else actorContent.push(m.content);
+      }
+
+      if (actorContent.length > 0) {
+        await addUnifiedMemories(
+          run.packageId,
+          run.applicationId,
+          run.orgId,
+          persistenceScope,
+          actorContent,
+          run.id,
+        );
+      }
+      if (sharedContent.length > 0) {
+        await addUnifiedMemories(
+          run.packageId,
+          run.applicationId,
+          run.orgId,
+          { type: "shared" },
+          sharedContent,
+          run.id,
+        );
+      }
     }
 
-    if (actorContent.length > 0) {
-      await addUnifiedMemories(
-        run.packageId,
-        run.applicationId,
-        run.orgId,
-        persistenceScope,
-        actorContent,
-        run.id,
-      );
+    // Unified-persistence pinned-slot write — the single store for every
+    // named pinned slot the agent wrote via `pin({ key, content })`,
+    // including the carry-over `"checkpoint"` slot. Honors the AFPS
+    // scope when the runtime stamped one onto each slot; falls back to
+    // the run's actor scope.
+    if (result.pinned) {
+      for (const [key, slot] of Object.entries(result.pinned)) {
+        const slotScope = slot.scope === "shared" ? { type: "shared" as const } : persistenceScope;
+        await upsertPinned(
+          run.packageId,
+          run.applicationId,
+          run.orgId,
+          slotScope,
+          key,
+          slot.content,
+          run.id,
+        );
+      }
     }
-    if (sharedContent.length > 0) {
-      await addUnifiedMemories(
-        run.packageId,
-        run.applicationId,
-        run.orgId,
-        { type: "shared" },
-        sharedContent,
-        run.id,
-      );
-    }
+  } catch (err) {
+    logger.error("finalize: memory/pinned persistence failed (run already terminal)", {
+      runId: run.id,
+      err: getErrorMessage(err),
+    });
   }
 
-  // Unified-persistence pinned-slot write — the single store for every
-  // named pinned slot the agent wrote via `pin({ key, content })`,
-  // including the carry-over `"checkpoint"` slot. Honors the AFPS
-  // scope when the runtime stamped one onto each slot; falls back to
-  // the run's actor scope.
-  if (result.pinned) {
-    for (const [key, slot] of Object.entries(result.pinned)) {
-      const slotScope = slot.scope === "shared" ? { type: "shared" as const } : persistenceScope;
-      await upsertPinned(
-        run.packageId,
-        run.applicationId,
-        run.orgId,
-        slotScope,
-        key,
-        slot.content,
-        run.id,
-      );
-    }
-  }
   // Post-CAS best-effort: the run is already terminal in `runs`. A
   // transient log INSERT failure here is logged and swallowed — the UI
   // shows the run as complete from the row-level state regardless.

--- a/apps/api/src/services/schema.ts
+++ b/apps/api/src/services/schema.ts
@@ -15,6 +15,25 @@ import { validateConfig as validateConfigCore } from "@appstrate/core/schema-val
 // rely on server-only concerns (file-field stripping, output overload).
 const ajv = createAjv({ coerceTypes: true });
 
+// Compiled-validator cache. `validateInput`/`validateOutput`/
+// `validateConnectionCredentials` run on hot paths (per run, per connect)
+// and rebuild a fresh `effectiveSchema` object each call, so AJV's own
+// by-reference cache never hits — compilation (the expensive step) ran every
+// time. Key by the schema's canonical JSON so structurally-equal schemas
+// share one compiled validator. Bounded to cap memory in a long-lived process.
+const validatorCache = new Map<string, ReturnType<typeof ajv.compile>>();
+const MAX_CACHED_VALIDATORS = 500;
+function compileCached(schema: object): ReturnType<typeof ajv.compile> {
+  const key = JSON.stringify(schema);
+  let validate = validatorCache.get(key);
+  if (!validate) {
+    validate = ajv.compile(schema);
+    if (validatorCache.size >= MAX_CACHED_VALIDATORS) validatorCache.clear();
+    validatorCache.set(key, validate);
+  }
+  return validate;
+}
+
 // AJV with coerceTypes coerces null → "" for strings, which incorrectly passes
 // `required` checks. Strip empty/null values so AJV sees them as missing.
 function stripEmptyRequired(
@@ -104,8 +123,8 @@ function runValidate(
     };
   }
 
-  // 3. Compile + validate
-  const validate = ajv.compile(effectiveSchema);
+  // 3. Compile (cached) + validate
+  const validate = compileCached(effectiveSchema);
   const valid = validate(effectiveData);
 
   // 4. Per-kind error mapping
@@ -164,7 +183,7 @@ export function validateConnectionCredentials(
   // Mirror the input path: AJV coerceTypes lets "" satisfy `required`, so
   // strip empty/null values for required keys before validating.
   const effectiveData = stripEmptyRequired(credentials, required);
-  const validate = ajv.compile(schema);
+  const validate = compileCached(schema);
   if (validate(effectiveData)) return { valid: true, errors: [], data: credentials };
   const errors = (validate.errors || []).map((e) => ({
     field:


### PR DESCRIPTION
Audit tier 2 (robustness) — batch 1, the clear/low-risk fixes.

1. **Tenant read (fix)**: `GET /api/orgs/:orgId/settings` had **no membership check** — any cookie-session user could read an arbitrary org's settings by id (`apiKeyOrgScopeGuard` only pins API keys, not sessions). Added a `getOrgMember` gate mirroring the PUT handler. Low-sensitivity data, but a cross-tenant read inconsistent with every sibling.
2. **Perf**: cache compiled AJV validators (keyed by canonical schema JSON, bounded at 500). `validateInput`/`validateOutput`/`validateConnectionCredentials` rebuild a fresh `effectiveSchema` object per call, so AJV's by-reference cache never hit — it recompiled on every run/connect (hot path).
3. **Correctness**: memory + pinned-slot persistence in `finalizeRun` ran **un-guarded after** the run row is committed terminal — a transient store fault stranded the `onRunStatusChange` broadcast (UI/webhooks never update) and 500'd the runner for an already-finished run. Made best-effort (log+swallow) like the adjacent run-log writes, so the broadcast is always reached.

Verified: api `tsc` clean; schema + organizations + run-event-ingestion tests pass (43).

**Deferred to dedicated PRs** (higher-risk, merit focused review): `actorFilter()` adoption across the integration services (tenant-critical predicate refactor), the `beforeSignup`/`afterSignup` hook→event contract change, and the org concurrency-cap TOCTOU (needs an atomic reservation design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)