### PR TITLE
fix(sidecar): wipe per-run CA private key on teardown + race-free leaf serials

### DIFF
--- a/runtime-pi/sidecar/integration-cert-minter.ts
+++ b/runtime-pi/sidecar/integration-cert-minter.ts
@@ -32,7 +32,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 import { tmpdir } from "node:os";
-import { randomUUID } from "node:crypto";
+import { randomUUID, randomBytes } from "node:crypto";
 import {
   runOpenssl as runOpensslExec,
   readPem as readPemExec,
@@ -79,6 +79,13 @@ export interface CertMinter {
   readonly cacheSize: number;
   /** Drop every cached cert. Tests use this; production rarely needs it. */
   resetCache(): void;
+  /**
+   * Wipe the on-disk session workdir — including the staged CA **private
+   * key** (`ca.key`). MUST be called at run teardown: on the process adapter
+   * `os.tmpdir()` is not tmpfs, so without this the per-run CA signing key
+   * (a forgeable trust anchor for that run's MITM CA) survives on the host.
+   */
+  dispose(): Promise<void>;
 }
 
 export class CertMintError extends Error {
@@ -181,6 +188,14 @@ export function createCertMinter(options: CertMinterOptions): CertMinter {
     resetCache() {
       cache.clear();
     },
+    async dispose() {
+      cache.clear();
+      staged = null;
+      // rm -rf the whole session workdir (ca.crt + ca.key + any leaf
+      // remnants). Best-effort: a failed unlink is logged-by-caller, never
+      // throws teardown.
+      await fs.rm(sessionDir, { recursive: true, force: true }).catch(() => {});
+    },
   };
 
   return minter;
@@ -208,7 +223,12 @@ async function mintLeaf(
   const csrPath = path.join(sessionDir, `leaf-${id}.csr`);
   const extPath = path.join(sessionDir, `leaf-${id}.ext`);
   const certPath = path.join(sessionDir, `leaf-${id}.crt`);
-  const serialPath = path.join(sessionDir, "ca.srl");
+  // Random 128-bit serial per leaf instead of `-CAcreateserial`/`ca.srl`.
+  // The shared serial file is a read-modify-write that races when the MITM
+  // listener mints leaves for distinct SNI hosts concurrently — two mints
+  // could read the same serial and emit colliding-serial certs under one CA,
+  // or corrupt `ca.srl`. A random serial removes the shared state entirely.
+  const serial = `0x${randomBytes(16).toString("hex")}`;
 
   try {
     await runOpenssl(spawn, opensslBin, ["genrsa", "-out", keyPath, "2048"]);
@@ -244,9 +264,8 @@ async function mintLeaf(
       input.caCertPath,
       "-CAkey",
       input.caKeyPath,
-      "-CAcreateserial",
-      "-CAserial",
-      serialPath,
+      "-set_serial",
+      serial,
       "-days",
       String(input.days),
       "-sha256",

--- a/runtime-pi/sidecar/integrations-boot.ts
+++ b/runtime-pi/sidecar/integrations-boot.ts
@@ -1359,6 +1359,10 @@ export async function bootIntegrations(
         } catch {
           // ignore — best-effort
         }
+        // Wipe the minter's on-disk session workdir (the staged CA *private
+        // key*). On the process adapter os.tmpdir() is not tmpfs, so without
+        // this the per-run CA signing key survives on the host.
+        await runCa.minter.dispose();
       }
     },
   };
@@ -1418,6 +1422,7 @@ export async function runConnectOnce(
   const clients: AppstrateMcpClient[] = [];
   const mitmListeners: MitmListenerHandle[] = [];
   let runCaCertHostPath: string | null = null;
+  let runCaMinter: CertMinter | null = null;
 
   try {
     // Per-run CA — connect-login ALWAYS needs the MITM (the login secret is
@@ -1425,6 +1430,7 @@ export async function runConnectOnce(
     // `bootIntegrations` we let a CA failure throw rather than degrade.
     const ca = await prepareRunCa(runId, "afps-ca-connect-");
     runCaCertHostPath = ca.certHostPath;
+    runCaMinter = ca.minter;
 
     // Hoist the single credentials source for this connect-run (mirrors
     // `bootIntegrations`). connect-login ALWAYS needs the MITM, so the source
@@ -1514,6 +1520,7 @@ export async function runConnectOnce(
         // ignore — listener already torn down
       }
     }
+    if (runCaMinter) await runCaMinter.dispose();
     if (runCaCertHostPath) {
       try {
         await rm(runCaCertHostPath, { force: true });


### PR DESCRIPTION
Audit tier 3 (sidecar security) — the two well-bounded cert-minter fixes.

- **CA private key left on disk**: the minter stages the per-run CA private key at `<workdir>/afps-mint-*/ca.key`; teardown only unlinked the public cert PEM, never the session dir. On the **process adapter** (`os.tmpdir()` ≠ tmpfs) the per-run CA signing key — a forgeable trust anchor for that run's MITM CA — survived on the host. Added `CertMinter.dispose()` (rm -rf session dir, clears cache) and wired it into `bootIntegrations.shutdown` + the connect-run `finally`.
- **Leaf serial race**: leaves were signed with `-CAcreateserial`/`ca.srl` (shared read-modify-write). Concurrent cross-SNI mints could read the same serial → colliding-serial leaves under one CA, or corrupt `ca.srl`. Switched to a random 128-bit `-set_serial` per leaf — no shared state, no race.

Verified: cert-minter + mitm tests pass (19). No new tsc errors (pre-existing `fetch.preconnect`/lib-mismatch baseline noise unaffected).

**Deferred to dedicated PRs** (security-*design* changes, not rushed): SSRF `isBlockedHost` DNS-resolution + connect-time IP pinning (sync→async signature change on the published `afps-shared` package, ripples to all proxy callers); and the `/mcp` `runToken` gate (wired-but-dead on the docker path — needs a deliberate finish-the-auth vs delete-the-dead-path decision; the per-run Docker network is the real boundary today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)