### PR TITLE
refactor(integrations): use actorFilter() for connection owner predicates

### DIFF
--- a/apps/api/src/services/integration-connections.ts
+++ b/apps/api/src/services/integration-connections.ts
@@ -37,7 +37,7 @@ import {
 import { logger } from "../lib/logger.ts";
 import { notFound, conflict, invalidRequest } from "../lib/errors.ts";
 import type { AppScope } from "../lib/scope.ts";
-import { actorInsert } from "../lib/actor.ts";
+import { actorInsert, actorFilter } from "../lib/actor.ts";
 import type { Actor } from "@appstrate/connect";
 import {
   resolveIntegrationToolCatalog,
@@ -176,10 +176,7 @@ async function loadActorConnection(
   authKey: string,
   context: { applicationId: string; actor: Actor; connectionId?: string },
 ): Promise<ActorConnectionRow | null> {
-  const ownerPredicate =
-    context.actor.type === "user"
-      ? eq(integrationConnections.userId, context.actor.id)
-      : eq(integrationConnections.endUserId, context.actor.id);
+  const ownerPredicate = actorFilter(context.actor, integrationConnections);
   const rows = await db
     .select({
       id: integrationConnections.id,
@@ -240,10 +237,7 @@ async function loadAccessibleConnectionById(
   connectionId: string,
   context: { applicationId: string; actor: Actor },
 ): Promise<ResolvedConnectionRow | null> {
-  const ownerPredicate =
-    context.actor.type === "user"
-      ? eq(integrationConnections.userId, context.actor.id)
-      : eq(integrationConnections.endUserId, context.actor.id);
+  const ownerPredicate = actorFilter(context.actor, integrationConnections);
   const [row] = await db
     .select({
       id: integrationConnections.id,
@@ -790,10 +784,7 @@ export async function persistCredentialBundle(
 
   if (target.kind === "update-owned") {
     await assertAppBelongsToOrg(target.scope);
-    const { userId, endUserId } = actorInsert(target.actor);
-    const ownerPredicate = userId
-      ? eq(integrationConnections.userId, userId)
-      : eq(integrationConnections.endUserId, endUserId!);
+    const ownerPredicate = actorFilter(target.actor, integrationConnections);
     const ownerScope = and(
       eq(integrationConnections.id, target.connectionId),
       eq(integrationConnections.applicationId, target.scope.applicationId),
@@ -894,10 +885,7 @@ export async function listIntegrationConnections(
   actor: Actor,
 ): Promise<IntegrationConnectionSummary[]> {
   await assertAppBelongsToOrg(scope);
-  const { userId, endUserId } = actorInsert(actor);
-  const ownerPredicate = userId
-    ? eq(integrationConnections.userId, userId)
-    : eq(integrationConnections.endUserId, endUserId!);
+  const ownerPredicate = actorFilter(actor, integrationConnections);
   const rows = await db
     .select()
     .from(integrationConnections)
@@ -920,10 +908,7 @@ export async function deleteIntegrationConnection(
   connectionId: string,
   actor: Actor,
 ): Promise<void> {
-  const { userId, endUserId } = actorInsert(actor);
-  const ownerPredicate = userId
-    ? eq(integrationConnections.userId, userId)
-    : eq(integrationConnections.endUserId, endUserId!);
+  const ownerPredicate = actorFilter(actor, integrationConnections);
   const deleted = await db
     .delete(integrationConnections)
     .where(

--- a/apps/api/src/services/me-connections.ts
+++ b/apps/api/src/services/me-connections.ts
@@ -18,7 +18,7 @@ import {
   packages,
   applications,
 } from "@appstrate/db/schema";
-import type { Actor } from "../lib/actor.ts";
+import { actorFilter, type Actor } from "../lib/actor.ts";
 import type { MeConnectionEntry, MeConnectionSourceGroup } from "@appstrate/shared-types";
 import { asRecord } from "@appstrate/core/safe-json";
 import { toISORequired } from "../lib/date-helpers.ts";
@@ -31,10 +31,7 @@ import { getPackageDisplayName } from "../lib/package-helpers.ts";
 async function listAllActorIntegrationConnections(
   actor: Actor,
 ): Promise<MeConnectionSourceGroup[]> {
-  const ownerPredicate =
-    actor.type === "user"
-      ? eq(integrationConnections.userId, actor.id)
-      : eq(integrationConnections.endUserId, actor.id);
+  const ownerPredicate = actorFilter(actor, integrationConnections);
 
   const rows = await db
     .select({


### PR DESCRIPTION
Audit tier 2 — `actorFilter()` adoption (the #1 cross-cutting DRY finding).

The "filter connection rows by actor (user vs end_user)" SQL predicate was hand-rolled **6×** across `integration-connections.ts` (`loadActorConnection`, `loadAccessibleConnectionById`, `persistCredentialBundle` update-owned, `listIntegrationConnections`, `deleteIntegrationConnection`) and `me-connections.ts`, in two spellings. Replaced all with the existing `actorFilter(actor, cols)` helper.

Pure DRY / future-footgun removal — **each replacement verified to emit the identical WHERE clause** (`end_user → eq(endUserId)`, else `eq(userId)`). No behaviour change.

Verified: api `tsc` clean; 42 tenant-isolation tests (identity-guard, connection load/list/delete, me-connections) pass.

Left as-is (would need riskier refactor, not pure dedup): `integration-pins-service` builds an object-shaped `{userId?,endUserId?}` filter under a colliding local name `actorFilter`; the connection resolver's actor match is in-memory, not SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)