### PR TITLE
refactor(modules): callAllHooks() for broadcast signup hooks

### DIFF
--- a/apps/api/src/lib/boot.ts
+++ b/apps/api/src/lib/boot.ts
@@ -13,6 +13,7 @@ import {
   getModules,
   getModuleContributions,
   getModuleModelProviders,
+  callAllHooks,
 } from "./modules/module-loader.ts";
 import { getModuleRegistry, buildModuleInitContext } from "./modules/registry.ts";
 import { registerEmailOverrides } from "@appstrate/emails";
@@ -112,27 +113,14 @@ export async function boot(): Promise<void> {
       registerEmailOverrides(mod.emailOverrides);
     }
   }
-  // Broadcast `beforeSignup` to EVERY loaded module (not first-match-wins
-  // like other hooks). The cloud module's free-tier gate AND the OIDC
-  // module's per-client signup policy both need to run on every signup;
-  // first throw aborts the user creation. Iteration is inline (rather
-  // than going through `callHook`) because the semantics differ from the
-  // generic first-match-wins path in `module-loader.ts`.
-  setBeforeSignupHook(async (email, ctx) => {
-    for (const mod of getModules().values()) {
-      const hook = mod.hooks?.beforeSignup;
-      if (hook) await hook(email, ctx);
-    }
-  });
-  // Broadcast `afterSignup` to every loaded module too — OIDC uses it to
-  // auto-join the newly created user to the org pinned by the in-flight
-  // OAuth client so the onward /authorize redirect completes cleanly.
-  setAfterSignupHook(async (user, ctx) => {
-    for (const mod of getModules().values()) {
-      const hook = mod.hooks?.afterSignup;
-      if (hook) await hook(user, ctx);
-    }
-  });
+  // `beforeSignup` / `afterSignup` broadcast to EVERY loaded module (not
+  // first-match-wins like the other hooks) via `callAllHooks`: the cloud
+  // free-tier gate AND the OIDC per-client signup policy both run on every
+  // signup, and a throwing `beforeSignup` aborts user creation. OIDC's
+  // `afterSignup` auto-joins the new user to the org pinned by the in-flight
+  // OAuth client so the onward /authorize redirect completes.
+  setBeforeSignupHook((email, ctx) => callAllHooks("beforeSignup", email, ctx));
+  setAfterSignupHook((user, ctx) => callAllHooks("afterSignup", user, ctx));
   // Self-hosting bootstrap side effects (issue #228). Fires only when
   // `createBootstrapOrg` actually inserted the org row. Mirrors the post-
   // create sequence in `routes/organizations.ts` so the bootstrap owner

--- a/apps/api/src/lib/modules/module-loader.ts
+++ b/apps/api/src/lib/modules/module-loader.ts
@@ -638,6 +638,24 @@ export async function callHook<K extends keyof ModuleHooks>(
   return undefined;
 }
 
+/**
+ * Broadcast a hook to EVERY loaded module (vs {@link callHook}'s
+ * first-match-wins). For the rare hooks whose semantics are "every module
+ * participates" — currently `beforeSignup` / `afterSignup`, where the cloud
+ * free-tier gate AND the OIDC per-client signup policy both must run on each
+ * signup. Errors PROPAGATE (unlike {@link emitEvent}): a throwing
+ * `beforeSignup` aborts user creation, which is the gate's whole purpose.
+ */
+export async function callAllHooks<K extends keyof ModuleHooks>(
+  name: K,
+  ...args: Parameters<ModuleHooks[K]>
+): Promise<void> {
+  for (const mod of _modules.values()) {
+    const hook = (mod.hooks as Record<string, AnyHandler> | undefined)?.[name];
+    if (hook) await hook(...args);
+  }
+}
+
 /** Check if any loaded module provides a given hook. */
 export function hasHook(name: keyof ModuleHooks): boolean {
   for (const mod of _modules.values()) {


### PR DESCRIPTION
Audit tier 2 — module dispatch cleanup.

`beforeSignup`/`afterSignup` broadcast to every module (not first-match like the other hooks), so `boot.ts` hand-rolled two near-identical `for (mod of getModules())` loops, bypassing the module-loader. Added a `callAllHooks(name, ...)` broadcast dispatcher next to `callHook` (errors **propagate** — a throwing `beforeSignup` must abort signup) and replaced the two inline loops with it.

**Kept `beforeSignup`/`afterSignup` in `ModuleHooks`** (not moved to `ModuleEvents`): the **cloud** module implements them under `hooks`, so relocating the contract would be a cross-repo breaking change. This removes the duplication without touching the published `@appstrate/core/module` contract.

Verified: api `tsc` clean; module-loader + auth-bootstrap + zero-footprint + OIDC signup-guard tests pass (65 + 41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)