### PR TITLE
refactor(runtime-pi): drop dead agent-side MCP runToken bearer

### DIFF
--- a/runtime-pi/entrypoint.ts
+++ b/runtime-pi/entrypoint.ts
@@ -394,8 +394,11 @@ if (sidecarUrl) {
     // worst-case cold container pulls (#406 acceptance criteria: 20–45s
     // boots are routine). Operators on slow registries can widen via
     // `APPSTRATE_MCP_CONNECT_DEADLINE_MS`.
+    // The sidecar's /mcp endpoint gates inbound requests by the per-run
+    // Docker network + Host-header check (`validateMcpHostHeader`); it does
+    // NOT verify a bearer token, so the agent connects unauthenticated. (An
+    // earlier RUN_TOKEN-as-bearer path was wired but never validated — dropped.)
     mcpClient = await createMcpHttpClient(`${sidecarUrl.replace(/\/$/, "")}/mcp`, {
-      ...(env.runToken ? { bearerToken: env.runToken } : {}),
       clientInfo: { name: "appstrate-runtime-pi", version: "1.0" },
       retry: {
         deadlineMs: env.mcpConnectDeadlineMs,

--- a/runtime-pi/env.ts
+++ b/runtime-pi/env.ts
@@ -62,13 +62,6 @@ export interface RuntimeEnv {
    */
   traceparent?: string;
   /**
-   * Per-run Bearer token for the MCP HTTP transport. When unset, the
-   * MCP client connects unauthenticated — relies on Docker network
-   * isolation only. Reuses the platform's existing `RUN_TOKEN` env to
-   * avoid minting a separate secret.
-   */
-  runToken?: string;
-  /**
    * Wall-clock budget for the initial MCP handshake against the sidecar
    * (in milliseconds). Wraps both the connect retry loop and the final
    * attempt. Operators on slow registries can widen this when cold
@@ -304,6 +297,5 @@ export function parseRuntimeEnv(source: NodeJS.ProcessEnv = process.env): Runtim
     mcpConnectDeadlineMs,
     outputSchemaRaw: source.OUTPUT_SCHEMA || undefined,
     traceparent: source.TRACEPARENT || undefined,
-    runToken: source.RUN_TOKEN || undefined,
   };
 }


### PR DESCRIPTION
Audit tier 3 — remove the wired-but-dead `/mcp` bearer path (you chose delete-over-finish).

The agent container passed `RUN_TOKEN` as a `bearerToken` to the sidecar `/mcp` transport, but the sidecar **never validates it** — `validateMcpHostHeader` gates `/mcp` by the per-run Docker network + Host header only. The bearer was always sent-and-ignored. Removed the agent-side `runToken` env field + the `bearerToken` wiring and documented that `/mcp` auth is network + Host bound.

**Untouched**: the sidecar's own `process.env.RUN_TOKEN` (server.ts), which authenticates the sidecar's **outbound** calls to platform internal endpoints (bundle fetch, credential source, token refresh) — live + essential, separate from the agent-side path removed here.

Verified: runtime-pi `tsc` clean (env/entrypoint); 602 runtime-pi tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)