### PR TITLE
feat(web): add integrations tab to the package library

### DIFF
--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -82,6 +82,7 @@
   "library.title": "Package Library",
   "library.tab.agents": "Agents",
   "library.tab.skills": "Skills",
+  "library.tab.integrations": "Integrations",
   "library.column.package": "Package",
   "library.system": "System",
   "library.systemAlwaysActive": "System package, always active",

--- a/apps/web/src/locales/fr/common.json
+++ b/apps/web/src/locales/fr/common.json
@@ -82,6 +82,7 @@
   "library.title": "Bibliothèque de packages",
   "library.tab.agents": "Agents",
   "library.tab.skills": "Skills",
+  "library.tab.integrations": "Intégrations",
   "library.column.package": "Package",
   "library.system": "Système",
   "library.systemAlwaysActive": "Package système, toujours actif",

--- a/apps/web/src/pages/library-page.tsx
+++ b/apps/web/src/pages/library-page.tsx
@@ -21,17 +21,19 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { Badge } from "@/components/ui/badge";
 
-const TABS = ["agents", "skills"] as const;
+const TABS = ["agents", "skills", "integrations"] as const;
 type Tab = (typeof TABS)[number];
 
 const TYPE_MAP: Record<Tab, string> = {
   agents: "agent",
   skills: "skill",
+  integrations: "integration",
 };
 
 const DETAIL_PATH_MAP: Record<string, string> = {
   agent: "/agents",
   skill: "/skills",
+  integration: "/integrations",
 };
 
 export function LibraryPage() {
@@ -82,13 +84,17 @@ function LibraryMatrix({
 }) {
   const { t } = useTranslation();
   const toggle = useTogglePackageInstall();
+  // Agents/skills treat a "system" package as globally available (locked on,
+  // can't toggle). Integrations are different: they must be activated per
+  // application even when system-sourced, so their system rows stay toggleable.
+  const lockSystem = type !== "integration";
 
   if (pkgs.length === 0) {
     return <EmptyState message={t("library.empty")} icon={Package} />;
   }
 
   const handleToggle = (pkg: LibraryPackageItem, applicationId: string, installed: boolean) => {
-    if (pkg.source === "system") return;
+    if (lockSystem && pkg.source === "system") return;
     toggle.mutate(
       { applicationId, packageId: pkg.id, installed },
       {
@@ -140,13 +146,13 @@ function LibraryMatrix({
             </TableCell>
             {applications.map((app) => {
               const installed = pkg.installed_in.includes(app.id);
-              const isSystem = pkg.source === "system";
+              const locked = lockSystem && pkg.source === "system";
               return (
                 <TableCell key={app.id} className="text-center">
                   <Checkbox
-                    checked={isSystem || installed}
-                    disabled={isSystem}
-                    title={isSystem ? t("library.systemAlwaysActive") : undefined}
+                    checked={locked || installed}
+                    disabled={locked}
+                    title={locked ? t("library.systemAlwaysActive") : undefined}
                     onCheckedChange={() => handleToggle(pkg, app.id, installed)}
                   />
                 </TableCell>


### PR DESCRIPTION
## Pourquoi

La Bibliothèque de packages n'exposait que **Agents + Skills**, alors que l'API library renvoie déjà les **4 types** avec leur état d'installation par application. Les **intégrations s'activent par application** (même table `application_packages` que le bouton « Activer ») — c'est exactement la fonction de cette page (« rendre dispo par workspace ») — donc elles ont leur place dans la matrice.

## Ce que ça fait

- **3ᵉ onglet « Intégrations »** dans la matrice (cases par app = activer/désactiver dans cette app). Le nom de la ligne renvoie vers `/integrations/:id` pour la config riche (OAuth, connexions).
- **Nuance système** : la matrice verrouille les lignes `system` pour agents/skills (système = dispo partout), **mais les intégrations restent cochables même système** — elles doivent être activées par app. Vérifié : le toggle générique par-app (`installPackage`/`uninstallPackage`) accepte les packages système, gère le type integration, et cible **n'importe quelle** app — contrairement à `/integrations/:id/activate` qui n'agit que sur l'app courante.
- i18n `library.tab.integrations` (fr/en).

## Notes pour la review

- **Audit** : le toggle générique journalise comme un install de package, pas `integration.activated`. Si tu veux l'audit exact via la matrice, il faudrait ajouter un paramètre `applicationId` à `/activate` (aujourd'hui app-courante seulement). Non bloquant.
- **Volume** : l'onglet liste toutes les intégrations disponibles (dont les ~64 système). Un filtre/recherche serait un + UX (hors scope ici).
- Désactiver est **non-destructif** : retire la ligne `application_packages`, les connexions (`integration_connections`, par-acteur) restent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)