### PR TITLE
fix(sidecar): warn when serverless integration exposes 0 tools

### DIFF
--- a/runtime-pi/sidecar/integrations-boot.ts
+++ b/runtime-pi/sidecar/integrations-boot.ts
@@ -857,6 +857,49 @@ export function pushUnavailableToolBreadcrumb(
 }
 
 /**
+ * Breadcrumb for the serverless (`sourceKind: "none"`) branch, where the
+ * in-process `api_call` server is the integration's entire surface.
+ *
+ * When `toolCount === 0` the integration is effectively non-functional: the
+ * config (`integrations_configuration[id].tools`) didn't list `"api_call"`, so
+ * the resolver filtered everything and nothing is callable. The agent silently
+ * falls back to read/bash and the run looks healthy until it fails its job.
+ * Emit a `warn` with an actionable message instead of a success-toned "ready"
+ * breadcrumb, so the misconfiguration is self-diagnosing. Keep the
+ * `ready (N tools)` wording only for `N > 0`.
+ */
+export function pushServerlessReadyBreadcrumb(
+  spec: IntegrationSpawnSpec,
+  toolCount: number,
+  durationMs: number,
+  breadcrumbs: IntegrationBootBreadcrumb[],
+): void {
+  if (toolCount === 0) {
+    breadcrumbs.push({
+      message: `${spec.integrationId}: api_call exposed 0 tools — nothing callable. Check integrations_configuration["${spec.integrationId}"].tools (a serverless integration must list "api_call").`,
+      level: "warn",
+      data: {
+        integrationId: spec.integrationId,
+        kind: "serverless",
+        durationMs,
+        toolCount: 0,
+      },
+    });
+    return;
+  }
+  breadcrumbs.push({
+    message: `${spec.integrationId}: api_call ready (${durationMs}ms, ${toolCount} tool${toolCount === 1 ? "" : "s"})`,
+    level: "info",
+    data: {
+      integrationId: spec.integrationId,
+      kind: "serverless",
+      durationMs,
+      toolCount,
+    },
+  });
+}
+
+/**
  * Spawn each integration sequentially, register the surviving ones on a
  * shared {@link McpHost}, and return the materialised tool list. Per-integration
  * failures are captured in `result.failed` so a single broken integration
@@ -1113,16 +1156,7 @@ export async function bootIntegrations(
           // serverless integration — no `source.server`, so `vendored` is N/A.
         });
         const ms = Math.round(performance.now() - specStart);
-        breadcrumbs.push({
-          message: `${spec.integrationId}: api_call ready (${ms}ms, ${apiCallToolCount} tool${apiCallToolCount === 1 ? "" : "s"})`,
-          level: "info",
-          data: {
-            integrationId: spec.integrationId,
-            kind: "serverless",
-            durationMs: ms,
-            toolCount: apiCallToolCount,
-          },
-        });
+        pushServerlessReadyBreadcrumb(spec, apiCallToolCount, ms, breadcrumbs);
         continue;
       }
       const server = spec.manifest.server;

--- a/runtime-pi/sidecar/test/integrations-boot-serverless-breadcrumb.test.ts
+++ b/runtime-pi/sidecar/test/integrations-boot-serverless-breadcrumb.test.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for `pushServerlessReadyBreadcrumb` — the serverless (`sourceKind:
+ * "none"`) branch breadcrumb.
+ *
+ * A serverless integration whose config didn't list `"api_call"` exposes zero
+ * tools and is effectively non-functional. It must surface as a `warn` with an
+ * actionable message rather than the success-toned `api_call ready` breadcrumb,
+ * which is indistinguishable in tone from the healthy `(N tools)` case.
+ */
+
+import { describe, it, expect } from "bun:test";
+import type { IntegrationBootBreadcrumb } from "@appstrate/core/sidecar-types";
+import type { IntegrationSpawnSpec } from "@appstrate/core/sidecar-types";
+import { pushServerlessReadyBreadcrumb } from "../integrations-boot.ts";
+
+function serverlessSpec(): IntegrationSpawnSpec {
+  return {
+    integrationId: "@tractr/google-drive",
+    namespace: "google_drive",
+    sourceKind: "none",
+    manifest: { name: "@tractr/google-drive", version: "1.0.0" },
+    spawnEnv: {},
+  } as IntegrationSpawnSpec;
+}
+
+describe("pushServerlessReadyBreadcrumb", () => {
+  it("warns when 0 tools were exposed", () => {
+    const breadcrumbs: IntegrationBootBreadcrumb[] = [];
+    pushServerlessReadyBreadcrumb(serverlessSpec(), 0, 12, breadcrumbs);
+
+    expect(breadcrumbs).toHaveLength(1);
+    expect(breadcrumbs[0]!.level).toBe("warn");
+    expect(breadcrumbs[0]!.message).toContain("api_call exposed 0 tools");
+    expect(breadcrumbs[0]!.message).toContain(
+      'integrations_configuration["@tractr/google-drive"].tools',
+    );
+    expect(breadcrumbs[0]!.data).toMatchObject({
+      integrationId: "@tractr/google-drive",
+      kind: "serverless",
+      durationMs: 12,
+      toolCount: 0,
+    });
+  });
+
+  it("never uses the success-toned 'ready' wording for 0 tools", () => {
+    const breadcrumbs: IntegrationBootBreadcrumb[] = [];
+    pushServerlessReadyBreadcrumb(serverlessSpec(), 0, 5, breadcrumbs);
+
+    expect(breadcrumbs[0]!.message).not.toContain("ready");
+  });
+
+  it("emits an info 'ready' breadcrumb for a single tool (singular)", () => {
+    const breadcrumbs: IntegrationBootBreadcrumb[] = [];
+    pushServerlessReadyBreadcrumb(serverlessSpec(), 1, 8, breadcrumbs);
+
+    expect(breadcrumbs).toHaveLength(1);
+    expect(breadcrumbs[0]!.level).toBe("info");
+    expect(breadcrumbs[0]!.message).toBe("@tractr/google-drive: api_call ready (8ms, 1 tool)");
+    expect(breadcrumbs[0]!.data).toMatchObject({
+      integrationId: "@tractr/google-drive",
+      kind: "serverless",
+      durationMs: 8,
+      toolCount: 1,
+    });
+  });
+
+  it("emits an info 'ready' breadcrumb for multiple tools (plural)", () => {
+    const breadcrumbs: IntegrationBootBreadcrumb[] = [];
+    pushServerlessReadyBreadcrumb(serverlessSpec(), 2, 3, breadcrumbs);
+
+    expect(breadcrumbs).toHaveLength(1);
+    expect(breadcrumbs[0]!.level).toBe("info");
+    expect(breadcrumbs[0]!.message).toBe("@tractr/google-drive: api_call ready (3ms, 2 tools)");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #545. A serverless (`source.kind: "none"`) integration whose config did not list `"api_call"` registers **zero tools** and is effectively non-functional — the agent silently falls back to `read`/`bash` and the run looks healthy until it fails its job. The boot breadcrumb previously logged `api_call ready (0 tools)` at `info`, indistinguishable in tone from the healthy `(N tools)` case, which actively misled diagnosis.

## Change

- Extract the serverless-branch breadcrumb into an exported `pushServerlessReadyBreadcrumb` helper (mirroring the existing `pushUnavailableToolBreadcrumb` no-silent-degradation guard).
- When `toolCount === 0`: emit `level: "warn"` with an actionable message naming `integrations_configuration["<id>"].tools` and noting a serverless integration must list `"api_call"`.
- Keep the `info` `api_call ready (Nms, N tool(s))` wording only for `N > 0` (singular/plural preserved).

This turns a silent misconfiguration into a visible, self-diagnosing warning. No runtime behavior change — only the log level and message for the 0-tools case.

## Tests

New `runtime-pi/sidecar/test/integrations-boot-serverless-breadcrumb.test.ts` (4 cases): warns on 0 tools with actionable message + data, never uses success-toned "ready" for 0 tools, info `ready` for 1 tool (singular) and 2 tools (plural). Sibling `integrations-boot-unavailable-tools.test.ts` still green.

Full pre-push `check` (24 turbo tasks: typecheck, lint, format, verify:openapi, detect:breaking, …) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)