### PR TITLE
fix(core): support integrations_configuration tools wildcard "*" via @afps-spec/schema 0.6.0 (#547)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "appstrate",
       "dependencies": {
-        "@afps-spec/schema": "^0.4.0",
+        "@afps-spec/schema": "^0.6.0",
         "@appstrate/connect": "workspace:*",
         "@appstrate/core": "workspace:*",
         "@appstrate/mcp-transport": "workspace:*",
@@ -186,7 +186,7 @@
         "afps": "./bin/afps.ts",
       },
       "dependencies": {
-        "@afps-spec/schema": "^0.4.0",
+        "@afps-spec/schema": "^0.6.0",
         "@afps-spec/types": "^0.1.0",
         "@appstrate/afps-shared": "workspace:*",
         "fflate": "^0.8.2",
@@ -238,7 +238,7 @@
       "name": "@appstrate/core",
       "version": "2.21.0",
       "dependencies": {
-        "@afps-spec/schema": "^0.4.0",
+        "@afps-spec/schema": "^0.6.0",
         "@appstrate/afps-shared": "^0.1.0",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -412,7 +412,7 @@
     "zod": "4.4.3",
   },
   "packages": {
-    "@afps-spec/schema": ["@afps-spec/schema@0.4.0", "", { "dependencies": { "ajv": "^8.17.1", "semver": "^7.7.4", "zod": "^4.4.3" } }, "sha512-Gb8g/okiYZkwNhPoHOw83EnUfWHZKm1UOGFbpTN6kUArWofyESn4JIrG3WVJDtc4T5wLM8P66hBNJP4dzZ8LoA=="],
+    "@afps-spec/schema": ["@afps-spec/schema@0.6.0", "", { "dependencies": { "ajv": "^8.17.1", "semver": "^7.7.4", "zod": "^4.4.3" } }, "sha512-ycGMEm6h4E+Fe4/H709O9jnww2jnWawn2WT7ijQlqcm6U/nWkocEx/wnjWAo1Orrbka+TiTQDLUoqKjCqZNEvw=="],
 
     "@afps-spec/types": ["@afps-spec/types@0.1.0", "", {}, "sha512-0fK0vqhtzr+fRPnze2HPr+Krrx8pZwiOsUDjFswwz/Mr/VfnvWN+xinwzajX17NfFwA8W5a+vY90xO7HL7M9Xg=="],
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "*.{ts,tsx,json,md,yml,yaml}": "prettier --write"
   },
   "dependencies": {
-    "@afps-spec/schema": "^0.4.0",
+    "@afps-spec/schema": "^0.6.0",
     "@appstrate/connect": "workspace:*",
     "@appstrate/core": "workspace:*",
     "@appstrate/mcp-transport": "workspace:*",

--- a/packages/afps-runtime/package.json
+++ b/packages/afps-runtime/package.json
@@ -66,7 +66,7 @@
     "fixtures:build": "bun run scripts/build-fixtures.ts"
   },
   "dependencies": {
-    "@afps-spec/schema": "^0.4.0",
+    "@afps-spec/schema": "^0.6.0",
     "@afps-spec/types": "^0.1.0",
     "@appstrate/afps-shared": "workspace:*",
     "file-type": "^22.0.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -79,7 +79,7 @@
     "./credential-template": "./src/credential-template.ts"
   },
   "dependencies": {
-    "@afps-spec/schema": "^0.4.0",
+    "@afps-spec/schema": "^0.6.0",
     "@appstrate/afps-shared": "^0.1.0",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/packages/core/schema/agent.schema.json
+++ b/packages/core/schema/agent.schema.json
@@ -240,10 +240,18 @@
         "type": "object",
         "properties": {
           "tools": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+            "anyOf": [
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "string",
+                "const": "*"
+              }
+            ]
           },
           "scopes": {
             "type": "array",

--- a/packages/core/schema/integration.schema.json
+++ b/packages/core/schema/integration.schema.json
@@ -821,12 +821,12 @@
         "type": "string"
       }
     },
+    "allow_undeclared_tools": {
+      "type": "boolean"
+    },
     "setup_guide": {
       "type": "object",
       "properties": {
-        "callback_url_hint": {
-          "type": "string"
-        },
         "steps": {
           "type": "array",
           "items": {

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -226,6 +226,10 @@ const agentManifestObjectSchema = afpsAgentManifestObjectSchema.extend({
   // maps + §4.4 per-integration config, including the rule that every
   // `integrations_configuration` key matches a declared integration dep).
   // We do not override those fields here to avoid drifting from the spec.
+  // The §4.4 `tools` wildcard (`string[] | "*"`, issue #547) is supported by
+  // the canonical schema as of @afps-spec/schema@0.5.0; no local widening is
+  // needed — the inherited shape already matches the Appstrate runtime
+  // contract (`dependencies.ts` `ToolsWildcard` / `isToolsWildcard`).
   // First-party runtime tools enabled for this agent — all opt-in, none
   // auto-injected (`output` included). `output` is required to be present
   // only when an output schema is declared (enforced by the superRefine

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -149,13 +149,29 @@ describe("integrationManifestSchema — oauth2 discovery + manual", () => {
     expect(integrationManifestSchema.safeParse(m).success).toBe(true);
   });
 
-  it("rejects oauth2 with neither issuer nor endpoints", () => {
-    const m = baseManifest();
+  it("rejects oauth2 with neither issuer nor endpoints on a non-remote source", () => {
+    // §7.3 issuer-or-endpoints rule applies to non-remote sources. Use a local
+    // source so the rule is in force (a remote source waives it — see below).
+    const m = baseManifest({
+      source: { kind: "local", server: { name: "@official/gmail-server", version: "^1.0.0" } },
+    });
     const auths = m.auths as Record<string, Record<string, unknown>>;
     delete auths.oauth!.issuer;
     delete auths.oauth!.authorization_endpoint;
     delete auths.oauth!.token_endpoint;
     expect(integrationManifestSchema.safeParse(m).success).toBe(false);
+  });
+
+  it("accepts oauth2 with neither issuer nor endpoints on a remote source (§7.3 waiver, 0.6.0)", () => {
+    // A remote MCP server discovers its authorization server at connect time
+    // from `source.remote.url` (RFC 9728 → RFC 8414), so its oauth2 auth MAY
+    // omit both issuer and explicit endpoints. baseManifest() is a remote source.
+    const m = baseManifest();
+    const auths = m.auths as Record<string, Record<string, unknown>>;
+    delete auths.oauth!.issuer;
+    delete auths.oauth!.authorization_endpoint;
+    delete auths.oauth!.token_endpoint;
+    expect(integrationManifestSchema.safeParse(m).success).toBe(true);
   });
 
   it("accepts RFC 8414 fields: resource, code_challenge_methods_supported, authorization_params", () => {

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -219,6 +219,53 @@ describe("validateManifest", () => {
     expect(result.valid).toBe(true);
   });
 
+  it("accepts the tools wildcard '*' in integrations_configuration (issue #547)", () => {
+    const result = validateManifest(
+      validAgentManifest({
+        dependencies: {
+          integrations: { "@test/gmail-mcp": "^1.0.0" },
+        },
+        integrations_configuration: {
+          "@test/gmail-mcp": { tools: "*", auth_key: "primary" },
+        },
+      }),
+    );
+    expect(result.valid).toBe(true);
+    const cfg = (
+      result.manifest as { integrations_configuration?: Record<string, { tools?: unknown }> }
+    ).integrations_configuration;
+    expect(cfg?.["@test/gmail-mcp"]?.tools).toBe("*");
+  });
+
+  it("accepts an explicit tools array in integrations_configuration", () => {
+    const result = validateManifest(
+      validAgentManifest({
+        dependencies: {
+          integrations: { "@test/gmail-mcp": "^1.0.0" },
+        },
+        integrations_configuration: {
+          "@test/gmail-mcp": { tools: ["send_email", "list_threads"] },
+        },
+      }),
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects a non-wildcard string for integrations_configuration tools", () => {
+    const result = validateManifest(
+      validAgentManifest({
+        dependencies: {
+          integrations: { "@test/gmail-mcp": "^1.0.0" },
+        },
+        integrations_configuration: {
+          "@test/gmail-mcp": { tools: "all" as unknown as string[] },
+        },
+      }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e) => e.includes("tools"))).toBe(true);
+  });
+
   it("accepts skill + mcp_server dependency values as bare semver strings (§4.1)", () => {
     const result = validateManifest(
       validAgentManifest({


### PR DESCRIPTION
## Summary

Fixes #547. Importing an agent that uses the documented `integrations_configuration.<id>.tools: "*"` wildcard failed with `400 invalid_manifest`, even though the **runtime fully supports** it and the published `appstrate` skill documents `"*"` as valid.

## Root cause

`integrations_configuration` is inherited from `@afps-spec/schema`. The pin was `^0.4.0`, whose `tools` is `z.array(z.string())` — no wildcard branch. The 400 is a **Zod** failure surfaced by `validateManifest`; the committed `agent.schema.json` is *generated* from that Zod source, so the JSON file was a downstream symptom, not the cause.

The runtime already supports the wildcard:
- `dependencies.ts` → `TOOLS_WILDCARD = "*"`, `isToolsWildcard()`
- `integration-spawn-resolver.ts` → wildcard ⇒ `toolAllowlist = undefined` (every upstream tool passes through)
- `validateAgentIntegrationScopes` accepts `"*"` when the integration declares `allow_undeclared_tools: true`

## Approach: canonical, not a local override

The wildcard is **canonical AFPS** (spec.md §4.4 / §7.8 — `tools: string[] | "*"`). It already landed in the canonical Zod schema in **@afps-spec/schema@0.5.0**, but was never published (npm `latest` was pinned at `0.4.0`). So rather than locally widening the inherited shape in appstrate (drift from spec), the fix is to consume the canonical schema.

Published **@afps-spec/schema@0.6.0** (adds a 0.6.0 CHANGELOG entry; CI publish via `afps-schema@0.6.0` tag) and bumped the dependency here.

## Changes

- Bump `@afps-spec/schema` `^0.4.0` → `^0.6.0` (root, `packages/core`, `packages/afps-runtime`).
- `validation.ts`: keep **verbatim inheritance** of `integrations_configuration` (no local override); the inherited shape now carries the wildcard. Documented inline.
- Regenerated JSON schemas (`bun run generate:schemas`):
  - `agent.schema.json` → `tools` is now `anyOf [ string[], const "*" ]`.
  - `integration.schema.json` → gains `allow_undeclared_tools` (0.5.0) and drops the legacy `setup_guide.callback_url_hint` (0.5.0 "drop legacy 1.x vocabulary"). **`auths.<key>.callback_url_hint` is unchanged** — appstrate's `integration-detail.tsx` reads that path, unaffected.
  - 0.6.0 also waives the §7.3 oauth2 issuer-or-endpoints rule for `remote` sources (additive relaxation; non-remote unchanged).
- Tests:
  - `validation.test.ts` — wildcard accept, explicit-array accept, non-wildcard-string reject.
  - `integration.test.ts` — §7.3 oauth2 test now asserts rejection only on **non-remote** sources, plus a positive case for the remote waiver.

## Verification

- `bun test packages/core/test/` → 595 pass, 0 fail
- `packages/afps-runtime` → 559 pass, 0 fail
- core + afps-runtime `tsc --noEmit` clean; eslint + prettier clean
- Pre-push `bun run check` (24 turbo tasks across api/web/core/all incl. `detect:breaking`, `verify:openapi`, `conformance:check`) passed — 0 breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)