### PR TITLE
fix(tests,auth): green resolver suite + silence two benign Better Auth warnings

### DIFF
--- a/apps/api/src/modules/oidc/auth/plugins.ts
+++ b/apps/api/src/modules/oidc/auth/plugins.ts
@@ -209,6 +209,11 @@ export function oidcBetterAuthPlugins(opts: OidcBetterAuthPluginsOptions = {}): 
     oauthProvider({
       loginPage: "/api/oauth/login",
       consentPage: "/api/oauth/consent",
+      // basePath is `/api/auth` (not `/`), so BA advises ensuring the
+      // discovery doc at `/.well-known/oauth-authorization-server/api/auth`
+      // is served — which this plugin itself serves. The warning is purely
+      // advisory for the non-root basePath; clear it via the documented flag.
+      silenceWarnings: { oauthAuthServerConfig: true },
       // Snapshot the full vocabulary at plugin construction time —
       // `betterAuthPlugins()` runs after `loadModules()` populates the
       // module registry, so module-contributed scopes are included in

--- a/apps/api/test/unit/services/integration-connection-resolver.test.ts
+++ b/apps/api/test/unit/services/integration-connection-resolver.test.ts
@@ -139,6 +139,8 @@ describe("resolveConnections — admin pin (cascade layer 1)", () => {
     expect(result.resolved[INTEG]).toEqual({
       connectionId: c.id,
       source: "admin_pin",
+      label: null,
+      accountId: "acc_x",
     });
   });
 
@@ -205,6 +207,8 @@ describe("resolveConnections — run override (cascade layer 2)", () => {
     expect(result.resolved[INTEG]).toEqual({
       connectionId: c.id,
       source: "run_override",
+      label: null,
+      accountId: "acc_x",
     });
   });
 
@@ -257,6 +261,8 @@ describe("resolveConnections — member pin (cascade layer 4)", () => {
     expect(result.resolved[INTEG]).toEqual({
       connectionId: c.id,
       source: "member_pin",
+      label: null,
+      accountId: "acc_x",
     });
   });
 
@@ -345,6 +351,8 @@ describe("resolveConnections — fallback (cascade layer 5)", () => {
     expect(result.resolved[INTEG]).toEqual({
       connectionId: c.id,
       source: "fallback_auto",
+      label: null,
+      accountId: "acc_x",
     });
   });
 
@@ -588,6 +596,8 @@ describe("resolveConnections — org default", () => {
     expect(result.resolved[INTEG]).toEqual({
       connectionId: def.id,
       source: "org_default_enforced",
+      label: null,
+      accountId: "acc_x",
     });
   });
 
@@ -627,7 +637,12 @@ describe("resolveConnections — org default", () => {
       actorUserId: USER_ID,
     });
     expect(result.errors).toEqual([]);
-    expect(result.resolved[INTEG]).toEqual({ connectionId: def.id, source: "org_default" });
+    expect(result.resolved[INTEG]).toEqual({
+      connectionId: def.id,
+      source: "org_default",
+      label: null,
+      accountId: "acc_x",
+    });
   });
 
   it("member pin beats the SOFT default (explicit preference wins)", () => {
@@ -654,7 +669,12 @@ describe("resolveConnections — org default", () => {
       actorUserId: USER_ID,
     });
     expect(result.errors).toEqual([]);
-    expect(result.resolved[INTEG]).toEqual({ connectionId: onlyOne.id, source: "fallback_auto" });
+    expect(result.resolved[INTEG]).toEqual({
+      connectionId: onlyOne.id,
+      source: "fallback_auto",
+      label: null,
+      accountId: "acc_x",
+    });
   });
 
   it("a scope-deficient org default surfaces insufficient_scopes (checkHealth still runs)", () => {

--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -582,6 +582,30 @@ function buildAuth(
     // Better Auth the active secret (not the legacy single-value var).
     secret: env.BETTER_AUTH_SECRETS[env.BETTER_AUTH_ACTIVE_KID] ?? env.BETTER_AUTH_SECRET,
 
+    // Route Better Auth's internal logs through our structured pino logger
+    // instead of its default console writer (repo rule: no console.*). Only
+    // warn/error reach this sink (BA's default level), so the volume matches
+    // the prior console output — it's just redirected and JSON-structured.
+    //
+    // Suppress one construction-time false positive: the google/github social
+    // providers below are registered with empty placeholder creds ON PURPOSE
+    // so the per-app OIDC social override (`enterSocialOverride`) has a live
+    // provider factory to flow tenant creds through at request time. BA's
+    // `!clientId` guard runs once at construction and can't see that
+    // request-time override, so "Social provider … is missing clientId or
+    // clientSecret" is noise here, not an actionable warning.
+    logger: {
+      log: (level, message, ...args) => {
+        if (
+          level === "warn" &&
+          /^Social provider \w+ is missing clientId or clientSecret$/.test(message)
+        ) {
+          return;
+        }
+        logger[level](message, args.length > 0 ? { args } : undefined);
+      },
+    },
+
     plugins: [...basePlugins, ...extraPlugins],
 
     emailAndPassword: {


### PR DESCRIPTION
## Why

After #558 merged into `feat/integrations`, the API suite sat at **2180 pass / 7 fail** with two `WARN [Better Auth]` lines in test output. All three issues are unrelated to #558 — pre-existing drift from the integrations WIP. This PR brings the suite to **2187 pass / 0 fail, zero Better Auth warnings**.

## Changes

### 1. Resolver unit tests (7 failures) — tests were stale, code was right
`resolveConnections()` now carries `label` + `accountId` on the resolved snapshot (`integration-connection-resolver.ts:419`) so the UI picker can render the label + account badge. Seven unit tests still asserted the old exact `{ connectionId, source }` shape via `toEqual`. Updated them to pin the full snapshot.

### 2. `Social provider … is missing clientId or clientSecret` (warn) — false positive
The google/github providers are registered with **empty placeholder creds on purpose** so the per-app OIDC social override (`enterSocialOverride`) has a live provider factory to flow tenant creds through at request time. BA's `!clientId` guard runs at construction and can't see that request-time override.

Fix: route BA's internal logger through our pino logger (repo rule: no `console.*`) and drop that one message. Only warn/error reach the sink (BA default level) — volume unchanged, just redirected + JSON-structured.

- Caveat: the filter is text-coupled to BA's message wording. A BA upgrade rewording it makes the filter silently stop matching → the warning **reappears** (fails open — noise returns, nothing real is ever hidden).

### 3. `ensure '/.well-known/oauth-authorization-server/api/auth' exists` (warn)
Advisory for the non-root basePath (`/api/auth`); the discovery doc is served by the `oauthProvider` plugin itself. Cleared via the plugin's own documented `silenceWarnings.oauthAuthServerConfig` flag.

## Verification

- `bun run check` → 24/24 (tsc + eslint + prettier + openapi)
- `bun test apps/api/test` → 2187 pass / 0 fail, no `WARN [Better Auth]` lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)