### PR TITLE
fix(runtime-pi): bring runtime-pi + sidecar into the typecheck gate (#560)

### DIFF
--- a/runtime-pi/mcp/api-upload-resolver.ts
+++ b/runtime-pi/mcp/api-upload-resolver.ts
@@ -250,7 +250,11 @@ export class McpApiUploadResolver {
     let chunkIndex = 0;
     try {
       const stream = openFileStream(absPath);
-      const reader = stream.getReader();
+      // `getReader()` resolves to the `node:stream/web` reader declaration,
+      // while `chunkBytes` declares the global one — structurally identical
+      // (same `ReadableStreamDefaultReader<Uint8Array>`), so bridge the two
+      // lib variants with a cast, matching this file's `openFileStream` cast.
+      const reader = stream.getReader() as ReadableStreamDefaultReader<Uint8Array>;
       try {
         const iter = chunkBytes(reader, partSizeBytes, totalBytes);
         for await (const chunk of iter) {

--- a/runtime-pi/package.json
+++ b/runtime-pi/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "test": "bun test test/"
   },
   "dependencies": {

--- a/runtime-pi/sidecar/integration-credentials-source.ts
+++ b/runtime-pi/sidecar/integration-credentials-source.ts
@@ -203,6 +203,14 @@ export interface IntegrationCredentialsSource extends MitmCredentialSource {
    * connect.tool re-login retry path.
    */
   shouldReauth(authKey: string, status: number): boolean;
+  /**
+   * Override the base's optional
+   * {@link MitmCredentialSource.refreshOnUnauthorized} as REQUIRED — this
+   * factory always wires it (routes to the registered re-login handler, else
+   * the platform refresh POST). Callers holding the concrete source type can
+   * invoke it without a presence check.
+   */
+  refreshOnUnauthorized(authKey: string): Promise<boolean>;
 }
 
 /**

--- a/runtime-pi/sidecar/integrations-boot.ts
+++ b/runtime-pi/sidecar/integrations-boot.ts
@@ -438,20 +438,27 @@ export async function connectRemoteHttpIntegration(
     return { name: plan.headerName, value: `${plan.headerPrefix}${plan.value}` };
   };
 
-  const customFetch: typeof fetch = async (input, init) => {
-    const send = async (): Promise<Response> => {
-      const headers = new Headers(init?.headers);
-      const h = readHeader();
-      if (h) headers.set(h.name, h.value);
-      return fetch(input, { ...init, headers });
-    };
-    let res = await send();
-    if (res.status === 401 && source.refreshOnUnauthorized) {
-      const refreshed = await source.refreshOnUnauthorized(authKey).catch(() => false);
-      if (refreshed) res = await send();
-    }
-    return res;
-  };
+  // `typeof fetch` (Bun) carries a static `preconnect` member alongside the
+  // call signature. The MCP transport's `fetch?: typeof fetch` option demands
+  // the full shape, so forward the real `preconnect` rather than casting it
+  // away — the override stays a faithful drop-in for `fetch`.
+  const customFetch: typeof fetch = Object.assign(
+    async (input: Parameters<typeof fetch>[0], init: Parameters<typeof fetch>[1]) => {
+      const send = async (): Promise<Response> => {
+        const headers = new Headers(init?.headers);
+        const h = readHeader();
+        if (h) headers.set(h.name, h.value);
+        return fetch(input, { ...init, headers });
+      };
+      let res = await send();
+      if (res.status === 401 && source.refreshOnUnauthorized) {
+        const refreshed = await source.refreshOnUnauthorized(authKey).catch(() => false);
+        if (refreshed) res = await send();
+      }
+      return res;
+    },
+    { preconnect: fetch.preconnect },
+  );
 
   const clientInfo = {
     name: "appstrate-sidecar-remote-integration",

--- a/runtime-pi/sidecar/package.json
+++ b/runtime-pi/sidecar/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "test": "bun test"
   },
   "dependencies": {

--- a/runtime-pi/sidecar/test/app.test.ts
+++ b/runtime-pi/sidecar/test/app.test.ts
@@ -217,7 +217,7 @@ describe("ALL /llm/* — basic routing", () => {
 
   it("forwards path and query string to baseUrl", async () => {
     const fetchFn = mock(
-      async () =>
+      async (_url: string, _init?: RequestInit) =>
         new Response('{"id":"msg_1"}', {
           status: 200,
           headers: { "Content-Type": "application/json" },
@@ -232,7 +232,7 @@ describe("ALL /llm/* — basic routing", () => {
       body: '{"model":"claude-sonnet-4-5"}',
     });
     expect(res.status).toBe(200);
-    const url = (fetchFn.mock.calls[0] as [string])[0];
+    const url = fetchFn.mock.calls[0]![0];
     expect(url).toBe("https://api.anthropic.com/v1/messages?stream=true");
   });
 
@@ -267,7 +267,9 @@ describe("ALL /llm/* — basic routing", () => {
 
 describe("ALL /llm/* — placeholder replacement", () => {
   it("replaces placeholder in x-api-key header", async () => {
-    const fetchFn = mock(async () => new Response("ok", { status: 200 }));
+    const fetchFn = mock(
+      async (_url: string, _init?: RequestInit) => new Response("ok", { status: 200 }),
+    );
     const deps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
     deps.config.llm = LLM_CONFIG;
     const app = createApp(deps);
@@ -275,13 +277,15 @@ describe("ALL /llm/* — placeholder replacement", () => {
       method: "POST",
       headers: { "x-api-key": "sk-placeholder" },
     });
-    const opts = (fetchFn.mock.calls[0] as [string, RequestInit])[1];
+    const opts = fetchFn.mock.calls[0]![1]!;
     const headers = opts.headers as Record<string, string>;
     expect(headers["x-api-key"]).toBe("real-sk-ant-key");
   });
 
   it("replaces placeholder embedded in Authorization Bearer header", async () => {
-    const fetchFn = mock(async () => new Response("ok", { status: 200 }));
+    const fetchFn = mock(
+      async (_url: string, _init?: RequestInit) => new Response("ok", { status: 200 }),
+    );
     const deps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
     deps.config.llm = {
       authMode: "api_key",
@@ -294,13 +298,15 @@ describe("ALL /llm/* — placeholder replacement", () => {
       method: "POST",
       headers: { Authorization: "Bearer sk-ant-oat01-placeholder" },
     });
-    const opts = (fetchFn.mock.calls[0] as [string, RequestInit])[1];
+    const opts = fetchFn.mock.calls[0]![1]!;
     const headers = opts.headers as Record<string, string>;
     expect(headers["authorization"]).toBe("Bearer sk-ant-oat01-real-token");
   });
 
   it("preserves headers that do not contain the placeholder", async () => {
-    const fetchFn = mock(async () => new Response("ok", { status: 200 }));
+    const fetchFn = mock(
+      async (_url: string, _init?: RequestInit) => new Response("ok", { status: 200 }),
+    );
     const deps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
     deps.config.llm = LLM_CONFIG;
     const app = createApp(deps);
@@ -312,7 +318,7 @@ describe("ALL /llm/* — placeholder replacement", () => {
         "X-Custom": "untouched",
       },
     });
-    const opts = (fetchFn.mock.calls[0] as [string, RequestInit])[1];
+    const opts = fetchFn.mock.calls[0]![1]!;
     const headers = opts.headers as Record<string, string>;
     expect(headers["x-api-key"]).toBe("real-sk-ant-key");
     expect(headers["content-type"]).toBe("application/json");

--- a/runtime-pi/sidecar/test/credential-proxy.test.ts
+++ b/runtime-pi/sidecar/test/credential-proxy.test.ts
@@ -96,7 +96,7 @@ describe("executeApiCall — structured failures", () => {
 describe("executeApiCall — happy path", () => {
   it("forwards credentials, captures cookies, and returns the upstream response", async () => {
     const fetchFn = mock(
-      async () =>
+      async (_url: string | URL, _init?: RequestInit) =>
         new Response('{"data":42}', {
           status: 200,
           headers: {
@@ -473,7 +473,7 @@ describe("executeApiCall — multi-hop redirect cookie capture (#473)", () => {
 
   it("streaming bodies still use native fetch and only capture final-hop cookies", async () => {
     const fetchFn = mock(
-      async () =>
+      async (_url: string | URL, _init?: RequestInit) =>
         new Response("ok", {
           status: 200,
           headers: { "set-cookie": "final=F" },

--- a/runtime-pi/sidecar/test/fixtures/bun-toolkit/server.ts
+++ b/runtime-pi/sidecar/test/fixtures/bun-toolkit/server.ts
@@ -175,7 +175,14 @@ async function callTool(name: string, args: Record<string, unknown>): Promise<un
       return ok({ algorithm, hex: hasher.digest("hex") });
     }
     case "password_hash": {
-      const algorithm = typeof args.algorithm === "string" ? args.algorithm : "argon2id";
+      const requested = typeof args.algorithm === "string" ? args.algorithm : "argon2id";
+      const algorithm: "argon2id" | "argon2i" | "argon2d" | "bcrypt" =
+        requested === "bcrypt" ||
+        requested === "argon2i" ||
+        requested === "argon2d" ||
+        requested === "argon2id"
+          ? requested
+          : "argon2id";
       const hash = await Bun.password.hash(
         String(args.password),
         algorithm === "bcrypt" ? { algorithm: "bcrypt", cost: 10 } : { algorithm },

--- a/runtime-pi/sidecar/test/forward-proxy.test.ts
+++ b/runtime-pi/sidecar/test/forward-proxy.test.ts
@@ -98,7 +98,9 @@ function startFakeUpstream(): Promise<{
   });
 }
 
-function makeProxy(overrides?: Parameters<typeof createForwardProxy>[0]): ForwardProxyResult {
+function makeProxy(
+  overrides?: Partial<Parameters<typeof createForwardProxy>[0]>,
+): ForwardProxyResult {
   const result = createForwardProxy({
     config: { platformApiUrl: "http://mock:3000", runToken: "tok", proxyUrl: "" },
     listenPort: 0,

--- a/runtime-pi/sidecar/test/integration-credentials-source.test.ts
+++ b/runtime-pi/sidecar/test/integration-credentials-source.test.ts
@@ -116,7 +116,7 @@ describe("createIntegrationCredentialsSource", () => {
     });
 
     expect(source.current().auths[0]!.fields.apiKey).toBe("tok-1");
-    const ok = await source.refreshOnUnauthorized!("primary");
+    const ok = await source.refreshOnUnauthorized("primary");
     expect(ok).toBe(true);
     expect(calls.length).toBe(1);
     expect(calls[0]!.method).toBe("POST");
@@ -143,9 +143,9 @@ describe("createIntegrationCredentialsSource", () => {
       minRefreshIntervalMs: 60_000,
     });
 
-    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
     // Cooldown should suppress the second attempt without firing fetch.
-    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
     expect(calls).toBe(1);
   });
 
@@ -161,7 +161,7 @@ describe("createIntegrationCredentialsSource", () => {
       initialPayload: initial,
       fetchFn,
     });
-    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
     // Payload unchanged.
     expect(source.current().auths[0]!.fields.apiKey).toBe("tok-1");
   });
@@ -177,7 +177,7 @@ describe("createIntegrationCredentialsSource", () => {
       initialPayload: initial,
       fetchFn,
     });
-    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
   });
 
   it("coalesces concurrent refresh calls for the same authKey", async () => {
@@ -201,9 +201,9 @@ describe("createIntegrationCredentialsSource", () => {
     });
 
     // Three concurrent refresh calls — should fire ONE network call.
-    const p1 = source.refreshOnUnauthorized!("primary");
-    const p2 = source.refreshOnUnauthorized!("primary");
-    const p3 = source.refreshOnUnauthorized!("primary");
+    const p1 = source.refreshOnUnauthorized("primary");
+    const p2 = source.refreshOnUnauthorized("primary");
+    const p3 = source.refreshOnUnauthorized("primary");
     expect(calls).toBe(1);
     resolvePending!(new Response(JSON.stringify(makeWireJson("tok-2")), { status: 200 }));
     expect(await p1).toBe(true);
@@ -230,8 +230,8 @@ describe("createIntegrationCredentialsSource", () => {
       minRefreshIntervalMs: 0,
     });
 
-    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
-    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
     expect(calls).toBe(2);
   });
 });
@@ -369,7 +369,7 @@ describe("createIntegrationCredentialsSource — connect.tool re-login (P3)", ()
       [401],
     );
 
-    const ok = await source.refreshOnUnauthorized!("primary");
+    const ok = await source.refreshOnUnauthorized("primary");
     expect(ok).toBe(true);
     expect(handlerRan).toBe(1);
     // The platform refresh endpoint must NOT have been called.
@@ -392,7 +392,7 @@ describe("createIntegrationCredentialsSource — connect.tool re-login (P3)", ()
     // Handler registered for a DIFFERENT authKey — primary still uses POST.
     source.setReloginHandler("other", async () => true, [401]);
 
-    expect(await source.refreshOnUnauthorized!("primary")).toBe(true);
+    expect(await source.refreshOnUnauthorized("primary")).toBe(true);
     expect(postCalls).toBe(1);
     expect(source.current().auths[0]!.fields.apiKey).toBe("tok-2");
   });
@@ -422,8 +422,8 @@ describe("createIntegrationCredentialsSource — connect.tool re-login (P3)", ()
     );
 
     // In-flight dedup: two concurrent calls run the handler once.
-    const p1 = source.refreshOnUnauthorized!("primary");
-    const p2 = source.refreshOnUnauthorized!("primary");
+    const p1 = source.refreshOnUnauthorized("primary");
+    const p2 = source.refreshOnUnauthorized("primary");
     expect(handlerRan).toBe(1);
     resolvePending!(true);
     expect(await p1).toBe(true);
@@ -431,7 +431,7 @@ describe("createIntegrationCredentialsSource — connect.tool re-login (P3)", ()
 
     // Cooldown: a subsequent call within the interval is suppressed without
     // re-running the handler.
-    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
     expect(handlerRan).toBe(1);
   });
 
@@ -453,9 +453,9 @@ describe("createIntegrationCredentialsSource — connect.tool re-login (P3)", ()
       },
       [401],
     );
-    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
     // Cooldown armed → second attempt suppressed.
-    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
     expect(handlerRan).toBe(1);
   });
 });

--- a/runtime-pi/sidecar/test/integration-credentials-source.test.ts
+++ b/runtime-pi/sidecar/test/integration-credentials-source.test.ts
@@ -116,7 +116,7 @@ describe("createIntegrationCredentialsSource", () => {
     });
 
     expect(source.current().auths[0]!.fields.apiKey).toBe("tok-1");
-    const ok = await source.refreshOnUnauthorized("primary");
+    const ok = await source.refreshOnUnauthorized!("primary");
     expect(ok).toBe(true);
     expect(calls.length).toBe(1);
     expect(calls[0]!.method).toBe("POST");
@@ -143,9 +143,9 @@ describe("createIntegrationCredentialsSource", () => {
       minRefreshIntervalMs: 60_000,
     });
 
-    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
     // Cooldown should suppress the second attempt without firing fetch.
-    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
     expect(calls).toBe(1);
   });
 
@@ -161,7 +161,7 @@ describe("createIntegrationCredentialsSource", () => {
       initialPayload: initial,
       fetchFn,
     });
-    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
     // Payload unchanged.
     expect(source.current().auths[0]!.fields.apiKey).toBe("tok-1");
   });
@@ -177,7 +177,7 @@ describe("createIntegrationCredentialsSource", () => {
       initialPayload: initial,
       fetchFn,
     });
-    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
   });
 
   it("coalesces concurrent refresh calls for the same authKey", async () => {
@@ -201,9 +201,9 @@ describe("createIntegrationCredentialsSource", () => {
     });
 
     // Three concurrent refresh calls — should fire ONE network call.
-    const p1 = source.refreshOnUnauthorized("primary");
-    const p2 = source.refreshOnUnauthorized("primary");
-    const p3 = source.refreshOnUnauthorized("primary");
+    const p1 = source.refreshOnUnauthorized!("primary");
+    const p2 = source.refreshOnUnauthorized!("primary");
+    const p3 = source.refreshOnUnauthorized!("primary");
     expect(calls).toBe(1);
     resolvePending!(new Response(JSON.stringify(makeWireJson("tok-2")), { status: 200 }));
     expect(await p1).toBe(true);
@@ -230,8 +230,8 @@ describe("createIntegrationCredentialsSource", () => {
       minRefreshIntervalMs: 0,
     });
 
-    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
-    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
     expect(calls).toBe(2);
   });
 });
@@ -369,7 +369,7 @@ describe("createIntegrationCredentialsSource — connect.tool re-login (P3)", ()
       [401],
     );
 
-    const ok = await source.refreshOnUnauthorized("primary");
+    const ok = await source.refreshOnUnauthorized!("primary");
     expect(ok).toBe(true);
     expect(handlerRan).toBe(1);
     // The platform refresh endpoint must NOT have been called.
@@ -392,7 +392,7 @@ describe("createIntegrationCredentialsSource — connect.tool re-login (P3)", ()
     // Handler registered for a DIFFERENT authKey — primary still uses POST.
     source.setReloginHandler("other", async () => true, [401]);
 
-    expect(await source.refreshOnUnauthorized("primary")).toBe(true);
+    expect(await source.refreshOnUnauthorized!("primary")).toBe(true);
     expect(postCalls).toBe(1);
     expect(source.current().auths[0]!.fields.apiKey).toBe("tok-2");
   });
@@ -422,8 +422,8 @@ describe("createIntegrationCredentialsSource — connect.tool re-login (P3)", ()
     );
 
     // In-flight dedup: two concurrent calls run the handler once.
-    const p1 = source.refreshOnUnauthorized("primary");
-    const p2 = source.refreshOnUnauthorized("primary");
+    const p1 = source.refreshOnUnauthorized!("primary");
+    const p2 = source.refreshOnUnauthorized!("primary");
     expect(handlerRan).toBe(1);
     resolvePending!(true);
     expect(await p1).toBe(true);
@@ -431,7 +431,7 @@ describe("createIntegrationCredentialsSource — connect.tool re-login (P3)", ()
 
     // Cooldown: a subsequent call within the interval is suppressed without
     // re-running the handler.
-    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
     expect(handlerRan).toBe(1);
   });
 
@@ -453,9 +453,9 @@ describe("createIntegrationCredentialsSource — connect.tool re-login (P3)", ()
       },
       [401],
     );
-    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
     // Cooldown armed → second attempt suppressed.
-    expect(await source.refreshOnUnauthorized("primary")).toBe(false);
+    expect(await source.refreshOnUnauthorized!("primary")).toBe(false);
     expect(handlerRan).toBe(1);
   });
 });

--- a/runtime-pi/sidecar/test/integration-mitm-e2e.test.ts
+++ b/runtime-pi/sidecar/test/integration-mitm-e2e.test.ts
@@ -158,7 +158,9 @@ describe("MITM listener — subprocess end-to-end", () => {
         expect(parsed.body).toBe(`{"upstream":"ok"}`);
         // The smuggled `Bearer SHOULD-BE-STRIPPED` MUST NOT reach upstream;
         // the listener replaced it with the planner's fresh token.
-        expect(observedHeader).toBe("Bearer fresh-token");
+        // Cast: TS narrows a `let` assigned only inside a closure back to its
+        // initializer type (`null`); the stubFetch above mutates it at runtime.
+        expect(observedHeader as string | null).toBe("Bearer fresh-token");
         expect(observedBody).toBe(`{"hi":"world"}`);
       } finally {
         await listener.close();

--- a/runtime-pi/sidecar/test/integrations-boot-bun-toolkit-e2e.test.ts
+++ b/runtime-pi/sidecar/test/integrations-boot-bun-toolkit-e2e.test.ts
@@ -161,7 +161,7 @@ describe("@appstrate/bun-toolkit fixtures", () => {
         string,
         { type: string; delivery: { http: { in: string; name: string; value: string } } }
       >;
-      tools_policy: Record<string, { required_scopes?: string[] }>;
+      tools_policy: Record<string, { required_scopes?: Record<string, string[]> }>;
     };
     expect(m.source.kind).toBe("local");
     expect(m.source.server?.name).toBe(SERVER_ID);

--- a/runtime-pi/sidecar/test/integrations-boot-connect-login.test.ts
+++ b/runtime-pi/sidecar/test/integrations-boot-connect-login.test.ts
@@ -230,8 +230,11 @@ describe("runConnectLoginHook", () => {
       expect(source.shouldReauth("session", 403)).toBe(false);
 
       // Simulate the listener's reauth path: refreshOnUnauthorized routes to
-      // the registered re-login handler, which re-runs the login tool.
-      const ok = await source.refreshOnUnauthorized("session");
+      // the registered re-login handler, which re-runs the login tool. The
+      // factory always wires this hook (optional only on the base
+      // MitmCredentialSource contract), so narrow it before invoking.
+      expect(source.refreshOnUnauthorized).toBeDefined();
+      const ok = await source.refreshOnUnauthorized!("session");
       expect(ok).toBe(true);
       expect(rotating.loginCalls()).toBe(2);
       // The fresh session is now injectable — a retried request gets sess-2.
@@ -296,8 +299,11 @@ describe("runConnectLoginHook", () => {
       expect(source.deliveryPlans().session!.value).toBe("boot");
 
       // Re-login fails → false, and the previously-captured session is left
-      // untouched (the listener returns the original failed response).
-      const ok = await source.refreshOnUnauthorized("session");
+      // untouched (the listener returns the original failed response). The
+      // factory always wires this hook (optional only on the base
+      // MitmCredentialSource contract), so narrow it before invoking.
+      expect(source.refreshOnUnauthorized).toBeDefined();
+      const ok = await source.refreshOnUnauthorized!("session");
       expect(ok).toBe(false);
       expect(calls).toBe(2);
       expect(source.deliveryPlans().session!.value).toBe("boot");

--- a/runtime-pi/sidecar/test/integrations-boot-connect-login.test.ts
+++ b/runtime-pi/sidecar/test/integrations-boot-connect-login.test.ts
@@ -230,11 +230,8 @@ describe("runConnectLoginHook", () => {
       expect(source.shouldReauth("session", 403)).toBe(false);
 
       // Simulate the listener's reauth path: refreshOnUnauthorized routes to
-      // the registered re-login handler, which re-runs the login tool. The
-      // factory always wires this hook (optional only on the base
-      // MitmCredentialSource contract), so narrow it before invoking.
-      expect(source.refreshOnUnauthorized).toBeDefined();
-      const ok = await source.refreshOnUnauthorized!("session");
+      // the registered re-login handler, which re-runs the login tool.
+      const ok = await source.refreshOnUnauthorized("session");
       expect(ok).toBe(true);
       expect(rotating.loginCalls()).toBe(2);
       // The fresh session is now injectable — a retried request gets sess-2.
@@ -299,11 +296,8 @@ describe("runConnectLoginHook", () => {
       expect(source.deliveryPlans().session!.value).toBe("boot");
 
       // Re-login fails → false, and the previously-captured session is left
-      // untouched (the listener returns the original failed response). The
-      // factory always wires this hook (optional only on the base
-      // MitmCredentialSource contract), so narrow it before invoking.
-      expect(source.refreshOnUnauthorized).toBeDefined();
-      const ok = await source.refreshOnUnauthorized!("session");
+      // untouched (the listener returns the original failed response).
+      const ok = await source.refreshOnUnauthorized("session");
       expect(ok).toBe(false);
       expect(calls).toBe(2);
       expect(source.deliveryPlans().session!.value).toBe("boot");

--- a/runtime-pi/sidecar/test/integrations-boot-remote-http.test.ts
+++ b/runtime-pi/sidecar/test/integrations-boot-remote-http.test.ts
@@ -106,7 +106,9 @@ describe("connectRemoteHttpIntegration — credential injection", () => {
         await getFetch()(SERVER_URL, { method: "POST" });
       },
     );
-    expect(seen).toBe("Bearer TOKEN");
+    // Cast: TS narrows a `let` assigned only inside a closure back to its
+    // initializer type (`null`); the global fetch stub mutates it at runtime.
+    expect(seen as string | null).toBe("Bearer TOKEN");
   });
 
   it("force-refreshes once and retries on a 401", async () => {

--- a/runtime-pi/sidecar/test/mcp-host.test.ts
+++ b/runtime-pi/sidecar/test/mcp-host.test.ts
@@ -317,7 +317,7 @@ describe("McpHost — namespace normalisation", () => {
         client: fs.client,
       });
       const names = host.buildTools().map((t) => t.descriptor.name);
-      const ns = names[0]!.split("__")[0];
+      const ns = names[0]!.split("__")[0]!;
       expect(ns.length).toBeLessThanOrEqual(20);
     } finally {
       await fs.pair.close();
@@ -385,8 +385,8 @@ describe("McpHost — trusted (first-party) bypass of the poisoning sanitiser", 
   }
 
   const noteDescOf = (tool: AppstrateToolDefinition): string =>
-    (tool.descriptor.inputSchema as { properties: { note: { description: string } } }).properties
-      .note.description;
+    (tool.descriptor.inputSchema as unknown as { properties: { note: { description: string } } })
+      .properties.note.description;
 
   it("truncates an untrusted tool's rich docs but keeps the trusted one verbatim", async () => {
     const untrusted = await makeUpstream(fatSchemaTool());
@@ -665,8 +665,8 @@ describe("McpHost — intoNamespace (attachable api_call)", () => {
       const apicall = tools.find((t) => t.descriptor.name === "kijiji__api_call")!;
       const r1 = await search.handler({}, {} as never);
       const r2 = await apicall.handler({}, {} as never);
-      expect((r1.content as [{ text: string }])[0].text).toBe("notion-results");
-      expect((r2.content as [{ text: string }])[0].text).toBe("api_call-result");
+      expect((r1.content as unknown as [{ text: string }])[0].text).toBe("notion-results");
+      expect((r2.content as unknown as [{ text: string }])[0].text).toBe("api_call-result");
     } finally {
       await host.dispose();
     }

--- a/runtime-pi/sidecar/test/mcp.test.ts
+++ b/runtime-pi/sidecar/test/mcp.test.ts
@@ -33,13 +33,15 @@ function makeDeps(overrides?: Partial<AppDeps>): AppDeps {
       }),
     ),
     cookieJar: new Map(),
+    // Bun's `Mock` lacks the `preconnect` member that `typeof fetch`
+    // declares; the cast bridges that cross-lib friction.
     fetchFn: mock(
       async () =>
         new Response('{"ok":true}', {
           status: 200,
           headers: { "Content-Type": "application/json" },
         }),
-    ),
+    ) as unknown as typeof fetch,
     isReady: () => true,
     ...overrides,
   };
@@ -213,7 +215,7 @@ describe("POST /mcp — tools/call run_history", () => {
           headers: { "Content-Type": "application/json" },
         }),
     );
-    const app = createApp(makeDeps({ fetchFn }));
+    const app = createApp(makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }));
 
     const res = await rpc(app, {
       method: "tools/call",
@@ -227,7 +229,7 @@ describe("POST /mcp — tools/call run_history", () => {
     // Verifies the `limit` and `fields` arguments propagated as query
     // parameters into the underlying platform call.
     expect(fetchFn).toHaveBeenCalledTimes(1);
-    const calledUrl = fetchFn.mock.calls[0]![0] as string;
+    const calledUrl = (fetchFn.mock.calls[0] as unknown as [string])[0];
     expect(calledUrl).toContain("/internal/run-history");
     expect(calledUrl).toContain("limit=5");
     expect(calledUrl).toContain("fields=checkpoint");
@@ -243,7 +245,7 @@ describe("POST /mcp — tools/call recall_memory", () => {
           headers: { "Content-Type": "application/json" },
         }),
     );
-    const app = createApp(makeDeps({ fetchFn }));
+    const app = createApp(makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }));
 
     const res = await rpc(app, {
       method: "tools/call",
@@ -255,7 +257,7 @@ describe("POST /mcp — tools/call recall_memory", () => {
     expect(result.content[0]!.text).toBe('{"memories":[{"id":1,"content":"x"}]}');
 
     expect(fetchFn).toHaveBeenCalledTimes(1);
-    const calledUrl = fetchFn.mock.calls[0]![0] as string;
+    const calledUrl = (fetchFn.mock.calls[0] as unknown as [string])[0];
     expect(calledUrl).toContain("/internal/memories");
     expect(calledUrl).toContain("q=python");
     expect(calledUrl).toContain("limit=3");
@@ -263,13 +265,13 @@ describe("POST /mcp — tools/call recall_memory", () => {
 
   it("omits empty q from the upstream URL", async () => {
     const fetchFn = mock(async () => new Response('{"memories":[]}', { status: 200 }));
-    const app = createApp(makeDeps({ fetchFn }));
+    const app = createApp(makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }));
 
     await rpc(app, {
       method: "tools/call",
       params: { name: "recall_memory", arguments: { limit: 1 } },
     });
-    const calledUrl = fetchFn.mock.calls[0]![0] as string;
+    const calledUrl = (fetchFn.mock.calls[0] as unknown as [string])[0];
     expect(calledUrl).not.toContain("q=");
     expect(calledUrl).toContain("limit=1");
   });
@@ -330,7 +332,7 @@ describe("POST /mcp — per-request transport (stateless mode)", () => {
           headers: { "Content-Type": "application/json" },
         }),
     );
-    const app = createApp(makeDeps({ fetchFn }));
+    const app = createApp(makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }));
 
     const args = { limit: 1 };
 
@@ -468,7 +470,7 @@ describe("POST /mcp — bounded response read", () => {
           headers: { "Content-Type": "application/json" },
         }),
     );
-    const app = createApp(makeDeps({ fetchFn }));
+    const app = createApp(makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }));
     const res = await rpc(app, {
       method: "tools/call",
       params: { name: "run_history", arguments: { limit: 1 } },
@@ -549,7 +551,7 @@ describe("POST /mcp — api_call", () => {
           headers: { "Content-Type": "application/json" },
         }),
     );
-    const app = await makeApiCallApp({ fetchFn });
+    const app = await makeApiCallApp({ fetchFn: fetchFn as unknown as typeof fetch });
     const res = await rpc(app, {
       method: "tools/call",
       params: {
@@ -561,7 +563,7 @@ describe("POST /mcp — api_call", () => {
     const result = res.json.result as { content: Array<{ text: string }>; isError?: boolean };
     expect(result.isError).toBeUndefined();
     expect(result.content[0]!.text).toBe('{"messages":[]}');
-    const init = fetchFn.mock.calls[0]![1] as RequestInit;
+    const init = (fetchFn.mock.calls[0] as unknown as [string, RequestInit])[1];
     const headers = init.headers as Record<string, string>;
     expect(headers["Authorization"]).toBe("Bearer integ-tok-1");
   });

--- a/runtime-pi/sidecar/test/multipart.test.ts
+++ b/runtime-pi/sidecar/test/multipart.test.ts
@@ -44,13 +44,15 @@ function makeMultipartDeps(overrides?: Partial<AppDeps>): AppDeps {
     config: { platformApiUrl: "http://mock:3000", runToken: "tok", proxyUrl: "" },
     fetchCredentials: mock(async (): Promise<CredentialsResponse> => integrationCreds()),
     cookieJar: new Map(),
+    // bun:test `mock()` lacks the `preconnect` member of `typeof fetch`; cast
+    // through the same shim the per-test fetchFn overrides use.
     fetchFn: mock(
       async () =>
         new Response('{"ok":true}', {
           status: 200,
           headers: { "Content-Type": "application/json" },
         }),
-    ),
+    ) as unknown as typeof fetch,
     isReady: () => true,
     ...overrides,
   };
@@ -114,8 +116,8 @@ describe("POST /mcp — api_call multipart/form-data", () => {
       // construction.
       const req = new Request("https://api.example.com/sink", {
         method: "POST",
-        headers: new Headers(init?.headers as HeadersInit | undefined),
-        body: init?.body as BodyInit,
+        headers: new Headers(init?.headers),
+        body: init?.body,
       });
       capturedContentType = req.headers.get("content-type");
       const fd = await req.formData();
@@ -185,11 +187,11 @@ describe("POST /mcp — api_call multipart/form-data", () => {
     const capturedFields: Record<string, string> = {};
     let capturedFileBytes: Uint8Array | null = null;
     const fetchFn = mock(async (_url: string, init?: RequestInit) => {
-      const reqHeaders = new Headers(init?.headers as HeadersInit | undefined);
+      const reqHeaders = new Headers(init?.headers);
       const req = new Request("https://api.example.com/sink", {
         method: "POST",
         headers: reqHeaders,
-        body: init?.body as BodyInit,
+        body: init?.body,
       });
       const fd = await req.formData();
       for (const [k, v] of fd.entries()) {
@@ -246,8 +248,8 @@ describe("POST /mcp — api_call multipart/form-data", () => {
     const fetchFn = mock(async (_url: string, init?: RequestInit) => {
       const req = new Request("https://api.example.com/sink", {
         method: "POST",
-        headers: new Headers(init?.headers as HeadersInit | undefined),
-        body: init?.body as BodyInit,
+        headers: new Headers(init?.headers),
+        body: init?.body,
       });
       const fd = await req.formData();
       for (const [k, v] of fd.entries()) {
@@ -282,8 +284,8 @@ describe("POST /mcp — api_call multipart/form-data", () => {
       // boundary to be set on the Request, not on init.headers).
       const req = new Request("https://api.example.com/sink", {
         method: "POST",
-        headers: new Headers(init?.headers as HeadersInit | undefined),
-        body: init?.body as BodyInit,
+        headers: new Headers(init?.headers),
+        body: init?.body,
       });
       capturedContentType = req.headers.get("content-type");
       return new Response("{}", { status: 200 });

--- a/runtime-pi/sidecar/test/oauth-token-cache.test.ts
+++ b/runtime-pi/sidecar/test/oauth-token-cache.test.ts
@@ -41,7 +41,9 @@ interface CacheHarness {
   calls: () => Array<{ url: string; method: string }>;
 }
 
-function makeHarness(handler?: (url: string, init: RequestInit) => Response): CacheHarness {
+function makeHarness(
+  handler?: (url: string, init: RequestInit) => Response | Promise<Response>,
+): CacheHarness {
   const calls: Array<{ url: string; method: string }> = [];
   const fetchFn = mock(async (url: unknown, init?: RequestInit) => {
     const u = typeof url === "string" ? url : (url as URL).toString();

--- a/runtime-pi/sidecar/test/token-budget-integration.test.ts
+++ b/runtime-pi/sidecar/test/token-budget-integration.test.ts
@@ -50,7 +50,8 @@ function makeDeps(overrides?: Partial<AppDeps>): AppDeps {
       }),
     ),
     cookieJar: new Map(),
-    fetchFn: mock(async () => new Response("{}", { status: 200 })),
+    // bun:test Mock lacks fetch.preconnect — cross-lib friction with DOM `typeof fetch`.
+    fetchFn: mock(async () => new Response("{}", { status: 200 })) as unknown as typeof fetch,
     isReady: () => true,
     ...overrides,
   };
@@ -171,7 +172,10 @@ describe("token-aware spill — dense JSON (issue #390 primary)", () => {
         }),
     );
     const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 100_000 });
-    const app = await buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget });
+    const app = await buildTestApp({
+      deps: makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }),
+      tokenBudget,
+    });
 
     const res = await rpc(app, {
       method: "tools/call",
@@ -205,7 +209,10 @@ describe("token-aware spill — dense JSON (issue #390 primary)", () => {
         }),
     );
     const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 100_000 });
-    const app = await buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget });
+    const app = await buildTestApp({
+      deps: makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }),
+      tokenBudget,
+    });
 
     const res = await rpc(app, {
       method: "tools/call",
@@ -250,7 +257,10 @@ describe("token-aware spill — cumulative pressure (issue #390 secondary)", () 
     // Inline cap allows each call individually; run budget tight
     // enough to exhaust within 50 calls.
     const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 20_000 });
-    const app = await buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget });
+    const app = await buildTestApp({
+      deps: makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }),
+      tokenBudget,
+    });
 
     let inlineCount = 0;
     let spillCount = 0;
@@ -298,7 +308,10 @@ describe("token-aware spill — `_meta` accounting", () => {
         }),
     );
     const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 100_000 });
-    const app = await buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget });
+    const app = await buildTestApp({
+      deps: makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }),
+      tokenBudget,
+    });
 
     const res = await rpc(app, {
       method: "tools/call",
@@ -331,7 +344,10 @@ describe("token-aware spill — `_meta` accounting", () => {
         }),
     );
     const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 100_000 });
-    const app = await buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget });
+    const app = await buildTestApp({
+      deps: makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }),
+      tokenBudget,
+    });
 
     const consumed: number[] = [];
     for (let i = 0; i < 3; i++) {
@@ -369,7 +385,10 @@ describe("token-aware spill — `_meta` accounting", () => {
         }),
     );
     const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 100_000 });
-    const app = await buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget });
+    const app = await buildTestApp({
+      deps: makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }),
+      tokenBudget,
+    });
 
     const res = await rpc(app, {
       method: "tools/call",
@@ -395,7 +414,10 @@ describe("token-aware spill — applied to all platform tools", () => {
         }),
     );
     const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 100_000 });
-    const app = await buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget });
+    const app = await buildTestApp({
+      deps: makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }),
+      tokenBudget,
+    });
 
     const res = await rpc(app, {
       method: "tools/call",
@@ -418,7 +440,10 @@ describe("token-aware spill — applied to all platform tools", () => {
         }),
     );
     const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 100_000 });
-    const app = await buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget });
+    const app = await buildTestApp({
+      deps: makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }),
+      tokenBudget,
+    });
 
     const res = await rpc(app, {
       method: "tools/call",
@@ -444,7 +469,9 @@ describe("token-aware spill — backwards compatibility", () => {
         }),
     );
     // Build app with NO tokenBudget passed — exercise the legacy path.
-    const app = await buildTestApp({ deps: makeDeps({ fetchFn }) });
+    const app = await buildTestApp({
+      deps: makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }),
+    });
 
     const res = await rpc(app, {
       method: "tools/call",
@@ -470,7 +497,9 @@ describe("token-aware spill — backwards compatibility", () => {
           headers: { "Content-Type": "application/json" },
         }),
     );
-    const app = await buildTestApp({ deps: makeDeps({ fetchFn }) });
+    const app = await buildTestApp({
+      deps: makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }),
+    });
     const res = await rpc(app, {
       method: "tools/call",
       params: {
@@ -511,7 +540,7 @@ describe("token-aware spill — env-var configuration via createApp", () => {
       );
       // Build runtimeDeps explicitly so the env-var-driven TokenBudget is
       // shared with the in-process api_call host (mirrors server.ts).
-      const appDeps = makeDeps({ fetchFn });
+      const appDeps = makeDeps({ fetchFn: fetchFn as unknown as typeof fetch });
       const runtimeDeps = buildSidecarRuntimeDeps(appDeps);
       const host = await buildApiCallHost(
         [
@@ -581,7 +610,11 @@ describe("token-aware spill — fallback when blob store is full", () => {
         }),
     );
     const tokenBudget = new TokenBudget({ inlineCapTokens: 4_000, runBudgetTokens: 100_000 });
-    const app = await buildTestApp({ deps: makeDeps({ fetchFn }), tokenBudget, blobStore });
+    const app = await buildTestApp({
+      deps: makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }),
+      tokenBudget,
+      blobStore,
+    });
 
     const res = await rpc(app, {
       method: "tools/call",

--- a/runtime-pi/sidecar/tsconfig.json
+++ b/runtime-pi/sidecar/tsconfig.json
@@ -1,9 +1,9 @@
 {
-  "extends": "../tsconfig.base.json",
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "noEmit": true,
     "skipLibCheck": true
   },
   "include": ["**/*.ts"],
-  "exclude": ["node_modules", "sidecar"]
+  "exclude": ["node_modules"]
 }

--- a/runtime-pi/sidecar/turbo.json
+++ b/runtime-pi/sidecar/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "typecheck": {
+      "inputs": ["**/*.ts", "tsconfig.json", "package.json"]
+    }
+  }
+}

--- a/runtime-pi/test/extension-wrapper.test.ts
+++ b/runtime-pi/test/extension-wrapper.test.ts
@@ -87,7 +87,7 @@ describe("wrapExtensionFactory", () => {
     // Emits an error event
     const errorEmits = emitCalls.filter((c) => c.type === "error");
     expect(errorEmits).toHaveLength(1);
-    expect(errorEmits[0].message).toContain("something broke");
+    expect(errorEmits[0]!.message).toContain("something broke");
   });
 
   it("catches non-Error thrown values", async () => {

--- a/runtime-pi/test/mcp-api-upload-resolver.test.ts
+++ b/runtime-pi/test/mcp-api-upload-resolver.test.ts
@@ -60,20 +60,21 @@ function writeSyntheticFile(name: string, size: number) {
   return { workspace: ws, bytes };
 }
 
+/** The CallToolResult-ish shape every simulator returns. */
+interface SimResult {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+  isError?: boolean;
+}
+
 /**
  * Build an in-process MCP pair whose `api_call` handler is
  * driven by a per-test simulator. The simulator receives the same
  * args shape the sidecar would and returns the CallToolResult shape
  * (including `_meta`) that the resolver's wrapper expects.
  */
-async function makePair(
-  simulate: (args: Record<string, unknown>) => Promise<{
-    status: number;
-    headers: Record<string, string>;
-    body: string;
-    isError?: boolean;
-  }>,
-) {
+async function makePair(simulate: (args: Record<string, unknown>) => Promise<SimResult>) {
   const tool: AppstrateToolDefinition = {
     descriptor: {
       name: API_CALL_TOOL,
@@ -508,7 +509,7 @@ describe("McpApiUploadResolver — s3-multipart", () => {
   it("treats a 200 with <Error> body from CompleteMultipartUpload as failure", async () => {
     // S3 quirk: a 200 with an `<Error>` body is a failure. The
     // adapter must surface this to the agent.
-    const { pair, mcp } = await makePair(async (args) => {
+    const { pair, mcp } = await makePair(async (args): Promise<SimResult> => {
       const method = args.method as string;
       const target = args.target as string;
       if (method === "POST" && /\?uploads$/.test(target)) {
@@ -658,7 +659,7 @@ describe("McpApiUploadResolver — tus", () => {
   it("fails fast when the server reports a desynced offset", async () => {
     // Server returns offset=1 instead of the expected (4MiB-1)+1 → resolver must
     // refuse to continue.
-    const { pair, mcp } = await makePair(async (args) => {
+    const { pair, mcp } = await makePair(async (args): Promise<SimResult> => {
       const method = args.method as string;
       if (method === "POST") {
         return {
@@ -709,7 +710,7 @@ describe("McpApiUploadResolver — tus", () => {
     // confirmed by upstream — counting them would mislead the agent
     // about how many bytes actually landed).
     let chunkCount = 0;
-    const { pair, mcp } = await makePair(async (args) => {
+    const { pair, mcp } = await makePair(async (args): Promise<SimResult> => {
       const method = args.method as string;
       if (method === "POST") {
         return {
@@ -1227,8 +1228,11 @@ describe("McpApiUploadResolver — cancellation parity", () => {
       expect(result.ok).toBe(false);
       await deletes.wait(1);
       // The user signal was aborted, but the DELETE still landed —
-      // proving the resolver used a SEPARATE signal for cleanup.
-      expect(deleteSawAbortedSignal).toBe(true);
+      // proving the resolver used a SEPARATE signal for cleanup. The
+      // assignment happens inside the simulator callback (which TS can't
+      // prove ran), so it stays narrowed to the `null` initializer here;
+      // widen the read back to its declared union for the matcher.
+      expect(deleteSawAbortedSignal as boolean | null).toBe(true);
       expect(deletes.count).toBe(1);
     } finally {
       await pair.close();
@@ -1249,7 +1253,7 @@ describe("McpApiUploadResolver — s3-multipart ETag round-trip", () => {
     // pass the raw ETag through. AWS itself accepts both forms;
     // emitting the stricter form keeps every clone happy.
     let completeBody = "";
-    const { pair, mcp } = await makePair(async (args) => {
+    const { pair, mcp } = await makePair(async (args): Promise<SimResult> => {
       const method = args.method as string;
       const target = args.target as string;
       if (method === "POST" && /\?uploads$/.test(target)) {

--- a/runtime-pi/test/mcp-direct.test.ts
+++ b/runtime-pi/test/mcp-direct.test.ts
@@ -81,7 +81,12 @@ describe("buildMcpDirectFactories — runtime-injected tools", () => {
   it("registers run_history + recall_memory and no api_call", async () => {
     const { mcp, pair } = await makeMockServer();
     try {
-      const factories = await buildMcpDirectFactories({ mcp, runId: "run-1", emit: () => {} });
+      const factories = await buildMcpDirectFactories({
+        mcp,
+        runId: "run-1",
+        emit: () => {},
+        workspace: "/tmp",
+      });
       const captured: CapturedTool[] = [];
       const api = makeMockExtensionApi(captured);
       for (const f of factories) f(api);
@@ -97,7 +102,12 @@ describe("buildMcpDirectFactories — run_history dispatch", () => {
   it("forwards limit + fields to the MCP run_history tool", async () => {
     const { mcp, pair, calls } = await makeMockServer();
     try {
-      const factories = await buildMcpDirectFactories({ mcp, runId: "run-1", emit: () => {} });
+      const factories = await buildMcpDirectFactories({
+        mcp,
+        runId: "run-1",
+        emit: () => {},
+        workspace: "/tmp",
+      });
       const captured: CapturedTool[] = [];
       const api = makeMockExtensionApi(captured);
       for (const f of factories) f(api);
@@ -116,7 +126,12 @@ describe("buildMcpDirectFactories — recall_memory dispatch", () => {
   it("forwards q + limit to the MCP recall_memory tool", async () => {
     const { mcp, pair, calls } = await makeMockServer();
     try {
-      const factories = await buildMcpDirectFactories({ mcp, runId: "run-1", emit: () => {} });
+      const factories = await buildMcpDirectFactories({
+        mcp,
+        runId: "run-1",
+        emit: () => {},
+        workspace: "/tmp",
+      });
       const captured: CapturedTool[] = [];
       const api = makeMockExtensionApi(captured);
       for (const f of factories) f(api);
@@ -135,7 +150,12 @@ describe("buildMcpDirectFactories — integration tools", () => {
       { name: "github__api_call", description: "GitHub api_call" },
     ]);
     try {
-      const factories = await buildMcpDirectFactories({ mcp, runId: "run-1", emit: () => {} });
+      const factories = await buildMcpDirectFactories({
+        mcp,
+        runId: "run-1",
+        emit: () => {},
+        workspace: "/tmp",
+      });
       const captured: CapturedTool[] = [];
       const api = makeMockExtensionApi(captured);
       for (const f of factories) f(api);
@@ -188,6 +208,7 @@ describe("buildMcpDirectFactories — runtime-event trust boundary", () => {
       mcp,
       runId: "run-1",
       emit: (e) => emitted.push(e as { type: string }),
+      workspace: "/tmp",
     });
     const captured: CapturedTool[] = [];
     const api = makeMockExtensionApi(captured);
@@ -240,7 +261,7 @@ describe("buildMcpDirectFactories — failure modes", () => {
     const mcp = wrapClient(pair.client, { close: () => Promise.resolve() });
     try {
       await expect(
-        buildMcpDirectFactories({ mcp, runId: "run-1", emit: () => {} }),
+        buildMcpDirectFactories({ mcp, runId: "run-1", emit: () => {}, workspace: "/tmp" }),
       ).rejects.toThrow(/run_history/);
     } finally {
       await pair.close();

--- a/runtime-pi/turbo.json
+++ b/runtime-pi/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "typecheck": {
+      "inputs": ["**/*.ts", "!sidecar/**", "tsconfig.json", "package.json"]
+    }
+  }
+}


### PR DESCRIPTION
Closes #560.

## Problem

`appstrate-pi-runtime` and `appstrate-sidecar` had no `typecheck` script, so `bun run check` (turbo) never type-checked the Docker-image runtime code. A real `tsc` error in `entrypoint.ts` slipped through green in #558 and was only caught by a manual `tsc --noEmit`.

Closing the gap surfaced **~103 inherited errors** (no gate ever ran) — almost all in tests that drifted from current source signatures during the integrations WIP, plus **2 genuine source type bugs**.

## Source fixes (2)

- **`mcp/api-upload-resolver.ts`** — bridge the `node:stream/web` vs global `ReadableStreamDefaultReader` lib variants with a cast (same friction `openFileStream` already casts around). Structurally identical, runtime-safe.
- **`sidecar/integrations-boot.ts`** — `customFetch` is passed where the MCP transport wants `typeof fetch`, which (Bun) carries a static `preconnect`. Forward the **real** `fetch.preconnect` via `Object.assign` rather than casting it away, so the override stays a faithful drop-in for `fetch`.

## Test drift (101)

Updated mocks / deps / call-args to match current source types. Dominant causes:
- deps objects gained required fields (`workspace`, `ForwardProxyDeps.config`)
- Bun's `mock()` lacks `typeof fetch`'s `preconnect`
- `mock.calls` tuple typing under `noUncheckedIndexedAccess`
- discriminated result unions no longer overlapping old tuple casts

No assertions removed; no `any` / `@ts-ignore` / `@ts-expect-error`. One fixture (`bun-toolkit/server.ts`) narrows the password algorithm to `Bun.password.hash`'s literal union with an argon2id fallback — strictly safer.

## Gate wiring

- New `runtime-pi/sidecar/tsconfig.json`; scoped `runtime-pi/tsconfig.json` to exclude the nested sidecar package (it was recursing into it).
- `"typecheck": "tsc --noEmit"` on both `package.json` files.
- **Per-package `turbo.json`** overriding `typecheck.inputs` to the flat layout (`**/*.ts`) — the root task's `src/**` input glob would never invalidate the cache on these packages' source changes (they have no `src/`), silently re-greening a stale gate. This is the subtle part: without it the script exists but the gate is a no-op after the first cache write.

## Verification

- `bun run check` now runs **26 tasks** (was 24), all green.
- A planted type error in **either** package fails the gate via cache-miss (confirms inputs invalidate on source change).
- Edited test files pass at runtime: **246 tests, 0 fail**. The 3 Docker/binary-only e2e tests carry assertion-read casts only (no logic change), not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)