### PR TITLE
fix(runs): route agent egress through proxy on the no-sidecar path

### DIFF
--- a/apps/api/src/services/run-launcher/pi.ts
+++ b/apps/api/src/services/run-launcher/pi.ts
@@ -122,12 +122,16 @@ export async function runPlatformContainer(
       : deriveKeyPlaceholder(llmApiKey);
 
     // Skip the sidecar entirely when the run declares no integrations AND
-    // uses a static API key. The sidecar's sole purposes are integration
-    // MCP multiplexing (Phase 1.4) and LLM passthrough for OAuth; an
-    // API-key model with no integrations needs neither. Saves a
-    // subprocess spawn + MCP handshake + forward-proxy bind on every run.
+    // uses a static API key AND has no egress proxy. The sidecar's purposes
+    // are integration MCP multiplexing (Phase 1.4), LLM passthrough for
+    // OAuth, AND hosting the forward proxy that masks the agent's outbound
+    // IP. An API-key model with no integrations and no proxy needs none of
+    // these. When a proxy IS configured, the sidecar's forward-proxy bind
+    // is the ONLY path that routes agent egress through it — skipping the
+    // sidecar would silently drop the proxy and leak the host IP.
     const hasIntegrations = (plan.integrations?.length ?? 0) > 0;
-    const skipSidecar = !hasIntegrations && !!llmConfig.apiKey && !isOauthCredential;
+    const skipSidecar =
+      !hasIntegrations && !!llmConfig.apiKey && !isOauthCredential && !plan.proxyUrl;
 
     let sidecarLlm: LlmProxyConfig | undefined;
     if (isOauthCredential) {

--- a/apps/api/test/integration/services/run-launcher-no-sidecar.test.ts
+++ b/apps/api/test/integration/services/run-launcher-no-sidecar.test.ts
@@ -198,6 +198,34 @@ describe("run-launcher — sidecar skip decision", () => {
     expect(env.SIDECAR_URL).toBe("http://sidecar:8080");
   });
 
+  it("creates the sidecar when a proxy is configured (even with api-key + no integrations)", async () => {
+    const { orchestrator, counts } = createCountingFake();
+
+    await runPlatformContainer({
+      runId: "run_proxy",
+      context: buildContext("run_proxy"),
+      // No integrations + static API key would normally skip the sidecar,
+      // but a configured proxy forces it: the sidecar's forward proxy is
+      // the only path that routes agent egress through the proxy. Skipping
+      // it would silently drop the proxy and leak the host IP.
+      plan: buildRunPlan({ proxyUrl: "http://proxy.local:8080" }),
+      sinkCredentials: mintSinkCredentials({
+        runId: "run_proxy",
+        appUrl: "http://platform:3000",
+        ttlSeconds: 60,
+      }),
+      orchestrator,
+    });
+
+    expect(counts.createSidecarCalls).toBe(1);
+    expect(counts.createWorkloadCalls).toBe(1);
+    // With the sidecar wired, the agent egresses through its forward proxy.
+    const env = counts.capturedAgentEnv ?? {};
+    expect(env.SIDECAR_URL).toBe("http://sidecar:8080");
+    expect(env.HTTP_PROXY).toBe("http://sidecar:8081");
+    expect(env.HTTPS_PROXY).toBe("http://sidecar:8081");
+  });
+
   it("skip path passes the real api key through (no placeholder substitution without a sidecar)", async () => {
     const { orchestrator, counts } = createCountingFake();
 


### PR DESCRIPTION
## Problem

A proxy applied to an agent was silently ignored. Two runs of the same agent — one without a proxy, one with a working proxy — returned the **same outbound IP**.

## Root cause

Agent egress is routed through the proxy **only** by the sidecar's forward proxy (`HTTP_PROXY → sidecar:8081 → upstream proxyUrl`). The sidecar-skip fast path (`run-launcher/pi.ts`) fires when a run has no integrations and a static API-key model — but the condition ignored `plan.proxyUrl`:

```ts
const skipSidecar = !hasIntegrations && !!llmConfig.apiKey && !isOauthCredential;
```

So even with a proxy configured, the sidecar was skipped, the forward proxy never bound, no `HTTP_PROXY` reached the agent, and it egressed with the **host IP**. The resolution chain (`resolveProxy` → `plan.proxyUrl`) was correct end-to-end; the skip decision discarded the result.

## Fix

Gate the skip on `!plan.proxyUrl`. Any configured proxy now forces the sidecar.

## Why tests missed it

`run-launcher-no-sidecar.test.ts` never built a plan with `proxyUrl` set, so the proxy↔skip interaction was untested. Each unit was green (`resolveProxy`, `applySpecToSidecarEnv` sets `PROXY_URL`, `forward-proxy` works when it exists) — the seam between "proxy resolved" and "sidecar skipped" was the hole. Added an integration test asserting a proxy-configured api-key/no-integration run spawns the sidecar and sets `HTTP_PROXY` on the agent.

## Test

```
bun test apps/api/test/integration/services/run-launcher-no-sidecar.test.ts
# 4 pass / 0 fail
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)