### PR TITLE
fix(runtime-pi): stream input documents without the Bun.write(Response) spin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,44 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  runtime-e2e:
+    name: Runtime container e2e
+    # The runtime-pi document-provisioning spin only reproduces in the BUNDLED
+    # image, so `runtime-pi/test/provision-container.e2e.test.ts` needs the real
+    # `appstrate-pi` image built — which the fast `unit` job does not do (it
+    # would blow the 5-min budget), so that test SKIPS there. This job builds
+    # the image and runs it, giving the regression an actual gate. Same
+    # label-OR-main policy as the other heavy jobs (opt-in pre-merge via the
+    # `e2e` label, always post-merge on main).
+    if: contains(github.event.pull_request.labels.*.name, 'e2e') || github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: "1.3.11"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Build the agent runtime image the e2e launches. linux/amd64 is native on
+      # ubuntu-latest, so no QEMU. Tag `appstrate-pi:latest` — the test's default
+      # `PI_IMAGE`, and the trigger for its `hasImage()` gate.
+      - name: Build appstrate-pi image
+        run: docker build --platform linux/amd64 -t appstrate-pi:latest -f runtime-pi/Dockerfile .
+
+      # The root bunfig preload boots the test docker-compose stack
+      # unconditionally; start it so the preload is satisfied (the e2e itself
+      # uses only its own in-process mock sink, not the DB).
+      - name: Start test infrastructure
+        run: docker compose -f test/setup/docker-compose.test.yml up -d --wait
+
+      - name: Run runtime container e2e
+        run: bun test runtime-pi/test/provision-container.e2e.test.ts
+
   e2e:
     name: E2E tests
     if: contains(github.event.pull_request.labels.*.name, 'e2e') || github.ref == 'refs/heads/main'

--- a/runtime-pi/entrypoint.ts
+++ b/runtime-pi/entrypoint.ts
@@ -34,7 +34,6 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import { randomUUID } from "node:crypto";
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import type { Api, Model } from "@mariozechner/pi-ai";
 import {
@@ -61,7 +60,6 @@ import {
   type Bundle,
   type PackageIdentity,
 } from "@appstrate/afps-runtime/bundle";
-import { sign } from "@appstrate/afps-runtime/events";
 import { HttpSink, attachStdoutBridge } from "@appstrate/afps-runtime/sinks";
 import type { ExecutionContext, RunEvent } from "@appstrate/afps-runtime/types";
 import { emptyRunResult } from "@appstrate/afps-runtime/runner";
@@ -69,6 +67,7 @@ import { createMcpHttpClient, type AppstrateMcpClient } from "@appstrate/mcp-tra
 import { wrapExtensionFactory } from "./extension-wrapper.ts";
 import { parseRuntimeEnv, RuntimeEnvError } from "./env.ts";
 import { buildMcpDirectFactories } from "./mcp/direct.ts";
+import { provisionWorkspace, provisionDocuments, type ProvisionDeps } from "./provision.ts";
 
 /**
  * Synthesise a Bundle the runner can consume when no `.afps` ships
@@ -266,145 +265,6 @@ const exists = (p: string) =>
 
 const WORKSPACE = env.workspaceDir;
 
-// Generous retry budget: workspace provisioning is the first blocking network
-// call, and with a sidecar the forward proxy may still be binding. 6 attempts
-// with exponential backoff span ~8 s (0.5+1+2+2+2), well inside the boot gate.
-const PROVISION_MAX_ATTEMPTS = 6;
-
-/**
- * Signed GET against a run-scoped platform route, with the provisioning retry
- * budget. Re-signs each attempt (fresh timestamp). Returns the {@link Response}
- * as soon as it is `ok` OR carries a deterministic non-retryable status (4xx
- * other than 429 — the caller decides whether that status is fatal). Retries
- * 5xx, 429, and network errors with exponential backoff; throws only when the
- * budget is exhausted on transient failures.
- *
- * Auth mirrors the event sink: a Standard Webhooks HMAC over the (empty) GET
- * body keyed on the run secret. Outbound traffic reaches the platform exactly
- * as the sink does — through the sidecar forward proxy when attached, directly
- * over the egress network when not — so no extra wiring is needed.
- */
-async function signedGetWithRetry(url: string): Promise<Response> {
-  let lastError = "unknown error";
-  for (let attempt = 1; attempt <= PROVISION_MAX_ATTEMPTS; attempt++) {
-    try {
-      const headers: Record<string, string> = {
-        ...sign({
-          msgId: randomUUID(),
-          timestampSec: Math.floor(Date.now() / 1000),
-          body: "",
-          secret: env.sink.secret,
-        }),
-      };
-      const res = await fetch(url, { method: "GET", headers });
-      // Success, or a deterministic 4xx (404 missing, 401 bad signature, 410
-      // closed/expired sink) that retrying cannot fix — hand back either way.
-      if (res.ok || (res.status < 500 && res.status !== 429)) return res;
-      lastError = `HTTP ${res.status}`;
-    } catch (err) {
-      lastError = getErrorMessage(err);
-    }
-    if (attempt < PROVISION_MAX_ATTEMPTS) {
-      await new Promise((r) => setTimeout(r, Math.min(500 * 2 ** (attempt - 1), 2000)));
-    }
-  }
-  throw new Error(
-    `request to ${url} failed after ${PROVISION_MAX_ATTEMPTS} attempts: ${lastError}`,
-  );
-}
-
-/**
- * Self-provision the AFPS bundle by fetching it from the platform and writing
- * it into {@link WORKSPACE} as `agent-package.afps`.
- *
- * Replaces the old seed-into-the-run-volume delivery, whose correctness
- * depended on the run volume's driver: a tmpfs-backed `local` volume is not
- * shared between the short-lived seed helper and the agent container, so the
- * seeded AFPS bundle silently vanished and skills never materialised
- * (issue #549). Fetching makes the workspace volume pure agent-local scratch,
- * so its backing (disk or tmpfs) is once again a free performance choice.
- *
- * Any non-2xx is fatal — including `404`. The platform always uploads at least
- * the agent package (`buildAgentPackage` never returns an empty bundle), so a
- * missing object is never a legitimate "empty workspace": it means the upload
- * was lost, deleted early, or the request was misrouted. Continuing in that
- * state is exactly the silent-degradation regression #549 fixed, so we fail
- * loud instead.
- */
-async function provisionWorkspace(): Promise<void> {
-  const url = env.sink.url.replace(/\/events$/, "/workspace");
-  let res: Response;
-  try {
-    res = await signedGetWithRetry(url);
-  } catch (err) {
-    return await die(`Failed to provision workspace from platform: ${getErrorMessage(err)}`);
-  }
-  if (!res.ok) {
-    return await die(`Failed to provision workspace from platform: HTTP ${res.status}`);
-  }
-  // The bundle is the `agent-package.afps` bytes (itself a ZIP the Pi runtime
-  // reads). Stream it straight to the workspace root — no intermediate unzip.
-  await fs.mkdir(WORKSPACE, { recursive: true });
-  await Bun.write(path.join(WORKSPACE, "agent-package.afps"), res);
-}
-
-/**
- * Self-provision the run's input documents, streaming each to
- * `WORKSPACE/documents/<name>`.
- *
- * Documents are delivered out-of-band from the bundle: large and variable,
- * they are fetched individually and streamed straight to disk, so the agent
- * never buffers the whole payload — peak memory stays bounded regardless of
- * upload size. The manifest enumerates them; a 404 on the manifest means the
- * run carries no documents (the common case) and is NOT a fault. A 404 on a
- * document the manifest listed IS fatal, same reasoning as the bundle (#549).
- */
-async function provisionDocuments(): Promise<void> {
-  const manifestUrl = env.sink.url.replace(/\/events$/, "/documents");
-  let manifestRes: Response;
-  try {
-    manifestRes = await signedGetWithRetry(manifestUrl);
-  } catch (err) {
-    return await die(`Failed to fetch documents manifest: ${getErrorMessage(err)}`);
-  }
-  if (manifestRes.status === 404) return; // run carries no input documents
-  if (!manifestRes.ok) {
-    return await die(`Failed to fetch documents manifest: HTTP ${manifestRes.status}`);
-  }
-
-  const manifest = (await manifestRes.json()) as { documents?: { name?: unknown }[] };
-  const names = (manifest.documents ?? [])
-    .map((d) => d.name)
-    .filter((n): n is string => typeof n === "string" && n.length > 0);
-  if (names.length === 0) return;
-
-  const dir = path.join(WORKSPACE, "documents");
-  await fs.mkdir(dir, { recursive: true });
-
-  // Sequential: input-document sets are small (typically 1–few files), so
-  // streaming each in turn bounds open connections and peak memory without a
-  // concurrency primitive.
-  for (const name of names) {
-    // Defence-in-depth: the platform sanitises names to a single path segment,
-    // but never write outside `dir` on a malformed manifest.
-    if (path.basename(name) !== name || name === "." || name === "..") {
-      return await die(`Refusing unsafe document name: ${name}`);
-    }
-    let docRes: Response;
-    try {
-      docRes = await signedGetWithRetry(`${manifestUrl}/${encodeURIComponent(name)}`);
-    } catch (err) {
-      return await die(`Failed to fetch document ${name}: ${getErrorMessage(err)}`);
-    }
-    if (!docRes.ok || !docRes.body) {
-      return await die(`Failed to fetch document ${name}: HTTP ${docRes.status}`);
-    }
-    // Stream the response body straight to disk — never materialise the whole
-    // document in memory. Bun.write consumes a Response as a stream.
-    await Bun.write(path.join(dir, name), docRes);
-  }
-}
-
 /** Create a minimal valid git repo via filesystem (avoids 3 subprocess spawns). */
 async function initGitWorkspace(): Promise<void> {
   const gitDir = `${WORKSPACE}/.git`;
@@ -484,7 +344,13 @@ await progress(`runtime starting (${Math.round(performance.now())}ms cold start)
 // so overlapping their fetches shaves cold-start latency. On failure either
 // one calls `die()` (process.exit), so the first fault wins and the other is
 // abandoned with the process.
-await Promise.all([provisionWorkspace(), provisionDocuments()]);
+const provisionDeps: ProvisionDeps = {
+  sinkUrl: env.sink.url,
+  sinkSecret: env.sink.secret,
+  workspace: WORKSPACE,
+  die,
+};
+await Promise.all([provisionWorkspace(provisionDeps), provisionDocuments(provisionDeps)]);
 
 const packagePath = path.join(WORKSPACE, "agent-package.afps");
 const hasPackage = await exists(packagePath);

--- a/runtime-pi/provision.ts
+++ b/runtime-pi/provision.ts
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Agent-container workspace self-provisioning.
+ *
+ * Extracted from `entrypoint.ts` so the boot-critical fetch + stream-to-disk
+ * paths are unit-testable in isolation (the entrypoint itself is a top-level
+ * `await` script with module side effects + `process.exit`, so it can't be
+ * imported). Every external dependency — the sink URL/secret, the workspace
+ * path, the fatal-error escalation, and `fetch`/`sleep` — is injected via
+ * {@link ProvisionDeps}, so a test drives these against a local HTTP server
+ * with no globals or real backoff delays.
+ *
+ * Behaviour is identical to the inlined versions; see the per-function docs.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { randomUUID } from "node:crypto";
+import { sign } from "@appstrate/afps-runtime/events";
+import { getErrorMessage } from "@appstrate/core/errors";
+
+/**
+ * Generous retry budget: workspace provisioning is the first blocking network
+ * call, and with a sidecar the forward proxy may still be binding. 6 attempts
+ * with exponential backoff span ~8 s (0.5+1+2+2+2), well inside the boot gate.
+ */
+export const PROVISION_MAX_ATTEMPTS = 6;
+
+export interface ProvisionDeps {
+  /** The run-scoped event sink URL (`…/api/runs/:id/events`). The workspace
+   *  and documents routes are derived by swapping the `/events` suffix. */
+  sinkUrl: string;
+  /** Run secret used to HMAC-sign each GET (Standard Webhooks). */
+  sinkSecret: string;
+  /** Absolute workspace root the bundle + documents are written under. */
+  workspace: string;
+  /**
+   * Fatal-error escalation. In production this posts an `appstrate.error`
+   * event and `process.exit(1)`s (never returns); in tests it throws so the
+   * calling provision step halts and the assertion can inspect the message.
+   */
+  die: (message: string) => Promise<never>;
+  /** Injected for tests; defaults to the global `fetch`. */
+  fetchFn?: typeof fetch;
+  /** Injected for tests; defaults to {@link PROVISION_MAX_ATTEMPTS}. */
+  maxAttempts?: number;
+  /** Backoff sleeper; injected so tests skip the real exponential delay. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Signed GET against a run-scoped platform route, with the provisioning retry
+ * budget. Re-signs each attempt (fresh timestamp). Returns the {@link Response}
+ * as soon as it is `ok` OR carries a deterministic non-retryable status (4xx
+ * other than 429 — the caller decides whether that status is fatal). Retries
+ * 5xx, 429, and network errors with exponential backoff; throws only when the
+ * budget is exhausted on transient failures.
+ *
+ * Auth mirrors the event sink: a Standard Webhooks HMAC over the (empty) GET
+ * body keyed on the run secret. Outbound traffic reaches the platform exactly
+ * as the sink does — through the sidecar forward proxy when attached, directly
+ * over the egress network when not — so no extra wiring is needed.
+ */
+export async function signedGetWithRetry(url: string, deps: ProvisionDeps): Promise<Response> {
+  const fetchFn = deps.fetchFn ?? fetch;
+  const maxAttempts = deps.maxAttempts ?? PROVISION_MAX_ATTEMPTS;
+  const sleep = deps.sleep ?? defaultSleep;
+  let lastError = "unknown error";
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const headers: Record<string, string> = {
+        ...sign({
+          msgId: randomUUID(),
+          timestampSec: Math.floor(Date.now() / 1000),
+          body: "",
+          secret: deps.sinkSecret,
+        }),
+      };
+      const res = await fetchFn(url, { method: "GET", headers });
+      // Success, or a deterministic 4xx (404 missing, 401 bad signature, 410
+      // closed/expired sink) that retrying cannot fix — hand back either way.
+      if (res.ok || (res.status < 500 && res.status !== 429)) return res;
+      lastError = `HTTP ${res.status}`;
+    } catch (err) {
+      lastError = getErrorMessage(err);
+    }
+    if (attempt < maxAttempts) {
+      await sleep(Math.min(500 * 2 ** (attempt - 1), 2000));
+    }
+  }
+  throw new Error(`request to ${url} failed after ${maxAttempts} attempts: ${lastError}`);
+}
+
+/**
+ * Self-provision the AFPS bundle by fetching it from the platform and writing
+ * it into the workspace as `agent-package.afps`.
+ *
+ * Any non-2xx is fatal — including `404`. The platform always uploads at least
+ * the agent package (`buildAgentPackage` never returns an empty bundle), so a
+ * missing object is never a legitimate "empty workspace": it means the upload
+ * was lost, deleted early, or the request was misrouted. Continuing in that
+ * state is exactly the silent-degradation regression #549 fixed, so we fail
+ * loud instead.
+ */
+export async function provisionWorkspace(deps: ProvisionDeps): Promise<void> {
+  const url = deps.sinkUrl.replace(/\/events$/, "/workspace");
+  let res: Response;
+  try {
+    res = await signedGetWithRetry(url, deps);
+  } catch (err) {
+    return await deps.die(`Failed to provision workspace from platform: ${getErrorMessage(err)}`);
+  }
+  if (!res.ok) {
+    return await deps.die(`Failed to provision workspace from platform: HTTP ${res.status}`);
+  }
+  // The bundle is the `agent-package.afps` bytes (itself a ZIP the Pi runtime
+  // reads). Buffer-then-write: the bundle is small + bounded, and passing the
+  // fetch `Response` to `Bun.write` for streaming-consume busy-loops in the
+  // bundled runtime (see `provisionDocuments`).
+  await fs.mkdir(deps.workspace, { recursive: true });
+  const bytes = new Uint8Array(await res.arrayBuffer());
+  await Bun.write(path.join(deps.workspace, "agent-package.afps"), bytes);
+}
+
+/**
+ * Self-provision the run's input documents, streaming each to
+ * `workspace/documents/<name>`.
+ *
+ * Documents are delivered out-of-band from the bundle: large and variable,
+ * they are fetched individually and streamed straight to disk, so the agent
+ * never buffers the whole payload — peak memory stays bounded regardless of
+ * upload size. The manifest enumerates them; a 404 on the manifest means the
+ * run carries no documents (the common case) and is NOT a fault. A non-ok on a
+ * document the manifest listed IS fatal, same reasoning as the bundle (#549).
+ */
+export async function provisionDocuments(deps: ProvisionDeps): Promise<void> {
+  const manifestUrl = deps.sinkUrl.replace(/\/events$/, "/documents");
+  let manifestRes: Response;
+  try {
+    manifestRes = await signedGetWithRetry(manifestUrl, deps);
+  } catch (err) {
+    return await deps.die(`Failed to fetch documents manifest: ${getErrorMessage(err)}`);
+  }
+  if (manifestRes.status === 404) return; // run carries no input documents
+  if (!manifestRes.ok) {
+    return await deps.die(`Failed to fetch documents manifest: HTTP ${manifestRes.status}`);
+  }
+
+  const manifest = (await manifestRes.json()) as { documents?: { name?: unknown }[] };
+  const names = (manifest.documents ?? [])
+    .map((d) => d.name)
+    .filter((n): n is string => typeof n === "string" && n.length > 0);
+  if (names.length === 0) return;
+
+  const dir = path.join(deps.workspace, "documents");
+  await fs.mkdir(dir, { recursive: true });
+
+  // Sequential: input-document sets are small (typically 1–few files), so
+  // streaming each in turn bounds open connections and peak memory without a
+  // concurrency primitive.
+  for (const name of names) {
+    // Defence-in-depth: the platform sanitises names to a single path segment,
+    // but never write outside `dir` on a malformed manifest.
+    if (path.basename(name) !== name || name === "." || name === "..") {
+      return await deps.die(`Refusing unsafe document name: ${name}`);
+    }
+    let docRes: Response;
+    try {
+      docRes = await signedGetWithRetry(`${manifestUrl}/${encodeURIComponent(name)}`, deps);
+    } catch (err) {
+      return await deps.die(`Failed to fetch document ${name}: ${getErrorMessage(err)}`);
+    }
+    if (!docRes.ok || !docRes.body) {
+      return await deps.die(`Failed to fetch document ${name}: HTTP ${docRes.status}`);
+    }
+    // Stream the response body to disk chunk-by-chunk — peak memory stays
+    // bounded regardless of document size (WORKSPACE_MAX_DOCS_BYTES allows up
+    // to 256 MiB). We DO NOT use `Bun.write(path, docRes)` / `Bun.write(path,
+    // docRes.body)`: handing the fetch `Response`/stream to `Bun.write` for
+    // streaming-consume busy-loops at 100% CPU in the bundled runtime,
+    // starving the event loop so the sink heartbeat never fires and the run is
+    // killed at the 60s watchdog. Draining the reader explicitly into a
+    // FileSink avoids that code path while preserving O(1) memory.
+    const writer = Bun.file(path.join(dir, name)).writer();
+    const reader = docRes.body.getReader();
+    try {
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        writer.write(value);
+        // Apply backpressure so a fast upstream cannot queue unbounded chunks
+        // in the sink buffer — keeps peak memory flat for large documents.
+        await writer.flush();
+      }
+    } finally {
+      reader.releaseLock();
+      await writer.end();
+    }
+  }
+}

--- a/runtime-pi/provision.ts
+++ b/runtime-pi/provision.ts
@@ -195,6 +195,11 @@ export async function provisionDocuments(deps: ProvisionDeps): Promise<void> {
         // in the sink buffer — keeps peak memory flat for large documents.
         await writer.flush();
       }
+    } catch (err) {
+      // A mid-stream read/write failure is fatal, same as a non-ok fetch: route
+      // it through `die()` so the run gets an `appstrate.error` breadcrumb
+      // rather than crashing out as an unhandled rejection.
+      return await deps.die(`Failed to stream document ${name}: ${getErrorMessage(err)}`);
     } finally {
       reader.releaseLock();
       await writer.end();

--- a/runtime-pi/test/provision-container.e2e.test.ts
+++ b/runtime-pi/test/provision-container.e2e.test.ts
@@ -89,6 +89,11 @@ describe.skipIf(!RUN)("runtime-pi container provisions documents without spinnin
     const docBytes = new TextEncoder().encode("the answer is 42\n");
     server = Bun.serve({
       port: 0,
+      // Bind all interfaces: on Linux the container reaches the mock via the
+      // `host.docker.internal:host-gateway` IP, which a loopback-only bind
+      // would not answer (Docker Desktop's host-routing magic hides this on
+      // macOS, but CI runs on Linux).
+      hostname: "0.0.0.0",
       async fetch(req) {
         const u = new URL(req.url);
         const p = u.pathname;

--- a/runtime-pi/test/provision-container.e2e.test.ts
+++ b/runtime-pi/test/provision-container.e2e.test.ts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Container e2e — the ONLY layer that catches the document-provisioning spin.
+ *
+ * The original bug (`Bun.write(path, Response)` busy-looping at 100% CPU)
+ * reproduces only in the BUNDLED runtime (`dist/entrypoint.js`), so no
+ * source-level unit test can trigger it. This test runs the real
+ * `appstrate-pi` image against a document-bearing run, with a self-contained
+ * mock sink serving the AFPS bundle + one input document. The regression
+ * assertion is simple and direct: with a document present, the container must
+ * emit a boot event PAST provisioning ("workspace initialized") within the
+ * deadline. The buggy build never gets there — it spins in `provisionDocuments`
+ * and is silent after "runtime starting".
+ *
+ * Gated: skips when Docker or the `appstrate-pi` image is unavailable (local
+ * dev without a built image, CI without the runtime image). Build it with:
+ *   docker build --platform linux/amd64 -t appstrate-pi -f runtime-pi/Dockerfile .
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { zipArtifact } from "@appstrate/core/zip";
+import {
+  extractRootFromAfps,
+  buildBundleFromCatalog,
+  writeBundleToBuffer,
+  emptyPackageCatalog,
+} from "@appstrate/afps-runtime/bundle";
+
+const IMAGE = process.env.PI_IMAGE ?? "appstrate-pi:latest";
+const DEADLINE_MS = 60_000;
+
+function hasDocker(): boolean {
+  try {
+    return spawnSync("docker", ["info"], { stdio: "ignore" }).status === 0;
+  } catch {
+    return false;
+  }
+}
+function hasImage(): boolean {
+  try {
+    return spawnSync("docker", ["image", "inspect", IMAGE], { stdio: "ignore" }).status === 0;
+  } catch {
+    return false;
+  }
+}
+
+const RUN = hasDocker() && hasImage();
+if (!RUN) {
+  console.warn(
+    `[provision-container.e2e] skipped — docker=${hasDocker()} image(${IMAGE})=${hasImage()}`,
+  );
+}
+
+/**
+ * Minimal valid agent `.afps-bundle` (the multi-package archive with
+ * `bundle.json` that the platform's `/workspace` route serves and the runtime
+ * reads via `readBundleFromFile`). A raw single-package `.afps` is rejected
+ * with `BUNDLE_JSON_MISSING`.
+ */
+async function buildAgentBundle(): Promise<Uint8Array> {
+  const manifest = {
+    name: "@e2e/provision-probe",
+    version: "1.0.0",
+    type: "agent",
+    schema_version: "0.2",
+    display_name: "Provision Probe",
+    author: "e2e",
+  };
+  const afps = zipArtifact({
+    "manifest.json": new TextEncoder().encode(JSON.stringify(manifest)),
+    "prompt.md": new TextEncoder().encode("# probe\n\nStop immediately.\n"),
+  });
+  const root = extractRootFromAfps(afps);
+  const bundle = await buildBundleFromCatalog(root, emptyPackageCatalog, { depTypes: ["skills"] });
+  return writeBundleToBuffer(bundle);
+}
+
+describe.skipIf(!RUN)("runtime-pi container provisions documents without spinning", () => {
+  let server: ReturnType<typeof Bun.serve> | undefined;
+  let containerName: string | undefined;
+  const SECRET = "container-e2e-secret-0123456789";
+  const RID = "run_container_e2e";
+  const events: string[] = [];
+
+  beforeAll(async () => {
+    const bundle = await buildAgentBundle();
+    const docBytes = new TextEncoder().encode("the answer is 42\n");
+    server = Bun.serve({
+      port: 0,
+      async fetch(req) {
+        const u = new URL(req.url);
+        const p = u.pathname;
+        if (p.endsWith("/workspace")) {
+          return new Response(bundle, { headers: { "content-type": "application/octet-stream" } });
+        }
+        if (p.endsWith("/documents")) {
+          return Response.json({ documents: [{ name: "note.txt", size: docBytes.byteLength }] });
+        }
+        if (p.match(/\/documents\/[^/]+$/)) {
+          // Chunked stream — same shape as the platform's document route.
+          const stream = new ReadableStream<Uint8Array>({
+            start(c) {
+              c.enqueue(docBytes);
+              c.close();
+            },
+          });
+          return new Response(stream);
+        }
+        if (p.endsWith("/events") || p.endsWith("/events/finalize")) {
+          events.push(await req.text());
+          return new Response(null, { status: 204 });
+        }
+        // Model endpoint (reached only if provisioning succeeded) — fail fast.
+        return new Response("{}", { status: 503 });
+      },
+    });
+  });
+
+  afterAll(() => {
+    server?.stop(true);
+    if (containerName) spawnSync("docker", ["rm", "-f", containerName], { stdio: "ignore" });
+  });
+
+  it(
+    "emits a post-provisioning boot event with a document present",
+    async () => {
+      const port = server!.port;
+      const host = `http://host.docker.internal:${port}/api/runs/${RID}`;
+      containerName = `appstrate-e2e-provision-${Date.now()}`;
+      // Detached: the container runs independently of this test process, so no
+      // long-lived child keeps Bun alive. We poll the sink, then `rm -f`.
+      const run = spawnSync(
+        "docker",
+        [
+          "run",
+          "-d",
+          "--name",
+          containerName,
+          "--platform",
+          "linux/amd64",
+          // Linux portability — Docker Desktop adds this automatically, but CI
+          // engines need it explicit.
+          "--add-host",
+          "host.docker.internal:host-gateway",
+          "-e",
+          `AGENT_RUN_ID=${RID}`,
+          "-e",
+          `APPSTRATE_SINK_URL=${host}/events`,
+          "-e",
+          `APPSTRATE_SINK_FINALIZE_URL=${host}/events/finalize`,
+          "-e",
+          `APPSTRATE_SINK_SECRET=${SECRET}`,
+          "-e",
+          "MODEL_API=anthropic-messages",
+          "-e",
+          "MODEL_ID=claude-sonnet-4-6",
+          "-e",
+          `MODEL_BASE_URL=http://host.docker.internal:${port}/llm`,
+          "-e",
+          "MODEL_API_KEY=test",
+          "-e",
+          "AGENT_PROMPT=Stop immediately.",
+          IMAGE,
+        ],
+        { encoding: "utf8" },
+      );
+      expect(run.status, `docker run failed: ${run.stderr}`).toBe(0);
+
+      try {
+        const start = Date.now();
+        // Poll the collected sink events for the post-provisioning marker.
+        // The buggy build spins in provisionDocuments and never emits it.
+        for (;;) {
+          if (events.some((e) => e.includes("workspace initialized"))) break;
+          if (Date.now() - start > DEADLINE_MS) {
+            const logs = spawnSync("docker", ["logs", containerName], { encoding: "utf8" });
+            throw new Error(
+              `no post-provisioning event within ${DEADLINE_MS}ms — runtime likely spun in provisionDocuments.\nevents=${JSON.stringify(events).slice(0, 500)}\ncontainer logs:\n${(logs.stdout ?? "") + (logs.stderr ?? "")}`.slice(
+                0,
+                1500,
+              ),
+            );
+          }
+          await new Promise((r) => setTimeout(r, 500));
+        }
+        expect(events.some((e) => e.includes("workspace initialized"))).toBe(true);
+      } finally {
+        spawnSync("docker", ["rm", "-f", containerName], { stdio: "ignore" });
+      }
+    },
+    DEADLINE_MS + 15_000,
+  );
+});

--- a/runtime-pi/test/provision.test.ts
+++ b/runtime-pi/test/provision.test.ts
@@ -278,6 +278,31 @@ describe("provisionDocuments", () => {
     expect(messages[0]).toContain("x.txt");
   });
 
+  it("dies (does not crash) when a document body errors mid-stream", async () => {
+    const ws = await tempWorkspace();
+    const { die, messages } = makeDie();
+    // Inject the transport so the document body rejects on read deterministically
+    // (a server-side stream abort surfaces client-side as a clean EOF, not a
+    // read error — so it can't exercise the write-loop catch).
+    const fetchFn = (async (url: string | URL): Promise<Response> => {
+      if (String(url).endsWith("/documents")) {
+        return Response.json({ documents: [{ name: "partial.bin", size: 9 }] });
+      }
+      const body = new ReadableStream<Uint8Array>({
+        start(c) {
+          c.enqueue(new Uint8Array([1, 2, 3]));
+        },
+        pull(c) {
+          c.error(new Error("connection reset mid-stream"));
+        },
+      });
+      return new Response(body, { status: 200 });
+    }) as unknown as typeof fetch;
+
+    await expect(provisionDocuments(deps(ws, die, { fetchFn }))).rejects.toBeInstanceOf(DieError);
+    expect(messages[0]).toContain("stream document partial.bin");
+  });
+
   it("refuses a path-traversal document name without fetching it", async () => {
     config.documents = () => Response.json({ documents: [{ name: "../evil" }] });
     let docFetched = false;

--- a/runtime-pi/test/provision.test.ts
+++ b/runtime-pi/test/provision.test.ts
@@ -1,0 +1,331 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the agent-container workspace provisioning
+ * (`runtime-pi/provision.ts`) — the boot-critical path that fetches the AFPS
+ * bundle + input documents from the platform and writes them to disk.
+ *
+ * Drives the real `provisionWorkspace` / `provisionDocuments` against a local
+ * HTTP server that VERIFIES the Standard-Webhooks HMAC (so signing correctness
+ * is exercised, not mocked) and streams documents back chunked
+ * (`transfer-encoding: chunked`, no content-length) — the exact shape the
+ * platform's `/documents/:name` route serves. `die` is injected to throw, so
+ * fatal paths surface as rejections instead of `process.exit`.
+ *
+ * NOTE: the original production bug — `Bun.write(path, Response)` busy-looping
+ * — only reproduces in the BUNDLED runtime, so a source-level unit test cannot
+ * trigger it. These tests pin the contract (correct bytes, streaming, fatal
+ * paths) + completion-under-timeout; the bundled-only spin is covered by the
+ * container e2e.
+ */
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtemp, readFile, rm, access } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { verify } from "@appstrate/afps-runtime/events";
+import {
+  provisionWorkspace,
+  provisionDocuments,
+  signedGetWithRetry,
+  type ProvisionDeps,
+} from "../provision.ts";
+
+const SECRET = "test-run-secret-0123456789";
+
+/** Per-test server behaviour, reset in `beforeEach`. */
+interface ServerConfig {
+  requireSig: boolean;
+  lastSigOk: boolean | null;
+  /** Path-suffix → handler. Suffix matched against the URL pathname tail. */
+  workspace: (req: Request) => Response | Promise<Response>;
+  documents: (req: Request) => Response | Promise<Response>;
+  doc: (name: string, req: Request) => Response | Promise<Response>;
+}
+
+let server: ReturnType<typeof Bun.serve>;
+let base: string;
+let config: ServerConfig;
+
+/** A chunked `Response` (no content-length) emitting `bytes` in `chunkSize` slices. */
+function chunkedResponse(bytes: Uint8Array, chunkSize = 16): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (let i = 0; i < bytes.length; i += chunkSize) {
+        controller.enqueue(bytes.subarray(i, i + chunkSize));
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, { headers: { "content-type": "application/octet-stream" } });
+}
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const u = new URL(req.url);
+      // Verify the HMAC the runtime signed (empty GET body).
+      const sig = verify({
+        msgId: req.headers.get("webhook-id") ?? "",
+        timestampSec: Number(req.headers.get("webhook-timestamp") ?? "0"),
+        body: "",
+        secret: SECRET,
+        signatureHeader: req.headers.get("webhook-signature") ?? "",
+      });
+      config.lastSigOk = sig.ok;
+      if (config.requireSig && !sig.ok) {
+        return new Response("bad signature", { status: 401 });
+      }
+      if (u.pathname.endsWith("/workspace")) return config.workspace(req);
+      if (u.pathname.endsWith("/documents")) return config.documents(req);
+      const m = u.pathname.match(/\/documents\/([^/]+)$/);
+      if (m) return config.doc(decodeURIComponent(m[1]!), req);
+      return new Response("not found", { status: 404 });
+    },
+  });
+  base = `http://localhost:${server.port}`;
+});
+
+afterAll(() => server.stop(true));
+
+beforeEach(() => {
+  config = {
+    requireSig: false,
+    lastSigOk: null,
+    workspace: () => new Response("bundle-bytes", { status: 200 }),
+    documents: () => new Response("no docs", { status: 404 }),
+    doc: () => new Response("missing", { status: 404 }),
+  };
+});
+
+class DieError extends Error {}
+
+/** A `die` that throws (instead of `process.exit`) so tests can assert. */
+function makeDie(): { die: ProvisionDeps["die"]; messages: string[] } {
+  const messages: string[] = [];
+  const die = async (message: string): Promise<never> => {
+    messages.push(message);
+    throw new DieError(message);
+  };
+  return { die, messages };
+}
+
+let workspaces: string[] = [];
+async function tempWorkspace(): Promise<string> {
+  const dir = await mkdtemp(path.join(tmpdir(), "provision-test-"));
+  workspaces.push(dir);
+  return dir;
+}
+afterEach(async () => {
+  await Promise.all(workspaces.map((d) => rm(d, { recursive: true, force: true })));
+  workspaces = [];
+});
+
+function deps(
+  workspace: string,
+  die: ProvisionDeps["die"],
+  extra: Partial<ProvisionDeps> = {},
+): ProvisionDeps {
+  return {
+    sinkUrl: `${base}/api/runs/run_test/events`,
+    sinkSecret: SECRET,
+    workspace,
+    die,
+    // No real backoff + small budget so retry tests are fast.
+    sleep: async () => {},
+    maxAttempts: 3,
+    ...extra,
+  };
+}
+
+const exists = (p: string): Promise<boolean> =>
+  access(p).then(
+    () => true,
+    () => false,
+  );
+
+describe("provisionWorkspace", () => {
+  it("fetches the bundle with a valid signature and writes agent-package.afps", async () => {
+    config.requireSig = true;
+    config.workspace = () => new Response("AFPS-BUNDLE-BYTES", { status: 200 });
+    const ws = await tempWorkspace();
+    const { die } = makeDie();
+
+    await provisionWorkspace(deps(ws, die));
+
+    expect(config.lastSigOk).toBe(true); // signing is real, server verified it
+    const written = await readFile(path.join(ws, "agent-package.afps"), "utf8");
+    expect(written).toBe("AFPS-BUNDLE-BYTES");
+  });
+
+  it("dies on a 404 (the bundle is always uploaded — a miss is fatal, #549)", async () => {
+    config.workspace = () => new Response("gone", { status: 404 });
+    const ws = await tempWorkspace();
+    const { die, messages } = makeDie();
+
+    await expect(provisionWorkspace(deps(ws, die))).rejects.toBeInstanceOf(DieError);
+    expect(messages[0]).toContain("HTTP 404");
+  });
+
+  it("dies on a rejected signature (401)", async () => {
+    config.requireSig = true;
+    const ws = await tempWorkspace();
+    // Wrong secret → server returns 401, which signedGetWithRetry surfaces.
+    const { die, messages } = makeDie();
+    await expect(
+      provisionWorkspace(deps(ws, die, { sinkSecret: "wrong-secret" })),
+    ).rejects.toBeInstanceOf(DieError);
+    expect(messages[0]).toContain("HTTP 401");
+  });
+
+  it("retries a transient 503 then succeeds", async () => {
+    let calls = 0;
+    config.workspace = () => {
+      calls += 1;
+      return calls < 2
+        ? new Response("try later", { status: 503 })
+        : new Response("RECOVERED", { status: 200 });
+    };
+    const ws = await tempWorkspace();
+    const { die } = makeDie();
+
+    await provisionWorkspace(deps(ws, die));
+
+    expect(calls).toBe(2);
+    expect(await readFile(path.join(ws, "agent-package.afps"), "utf8")).toBe("RECOVERED");
+  });
+
+  it("dies after the retry budget is exhausted on persistent 5xx", async () => {
+    config.workspace = () => new Response("down", { status: 503 });
+    const ws = await tempWorkspace();
+    const { die, messages } = makeDie();
+
+    await expect(provisionWorkspace(deps(ws, die, { maxAttempts: 2 }))).rejects.toBeInstanceOf(
+      DieError,
+    );
+    expect(messages[0]).toContain("after 2 attempts");
+  });
+});
+
+describe("provisionDocuments", () => {
+  it("is a no-op when the manifest 404s (run carries no documents)", async () => {
+    config.documents = () => new Response("none", { status: 404 });
+    const ws = await tempWorkspace();
+    const { die, messages } = makeDie();
+
+    await provisionDocuments(deps(ws, die));
+
+    expect(messages).toHaveLength(0);
+    expect(await exists(path.join(ws, "documents"))).toBe(false);
+  });
+
+  it("is a no-op when the manifest is empty", async () => {
+    config.documents = () => Response.json({ documents: [] });
+    const ws = await tempWorkspace();
+    const { die, messages } = makeDie();
+
+    await provisionDocuments(deps(ws, die));
+    expect(messages).toHaveLength(0);
+  });
+
+  it("streams every manifest document to documents/<name> with exact bytes", async () => {
+    const files: Record<string, Uint8Array> = {
+      "a.txt": new TextEncoder().encode("hello alpha"),
+      "b.csv": new TextEncoder().encode("id,v\n1,2\n3,4\n"),
+    };
+    config.documents = () =>
+      Response.json({
+        documents: Object.entries(files).map(([name, b]) => ({ name, size: b.byteLength })),
+      });
+    config.doc = (name) => chunkedResponse(files[name]!);
+    const ws = await tempWorkspace();
+    const { die, messages } = makeDie();
+
+    await provisionDocuments(deps(ws, die));
+
+    expect(messages).toHaveLength(0);
+    for (const [name, bytes] of Object.entries(files)) {
+      const onDisk = await readFile(path.join(ws, "documents", name));
+      expect(Buffer.compare(onDisk, Buffer.from(bytes))).toBe(0);
+    }
+  });
+
+  it("streams a large multi-chunk document byte-exact (reader loop + backpressure)", async () => {
+    // 1 MiB of deterministic bytes, served in 16-byte chunks → exercises the
+    // chunk-by-chunk reader loop the fix relies on.
+    const big = new Uint8Array(1024 * 1024);
+    for (let i = 0; i < big.length; i++) big[i] = i % 251;
+    config.documents = () => Response.json({ documents: [{ name: "big.bin", size: big.length }] });
+    config.doc = () => chunkedResponse(big, 16);
+    const ws = await tempWorkspace();
+    const { die } = makeDie();
+
+    await provisionDocuments(deps(ws, die));
+
+    const onDisk = await readFile(path.join(ws, "documents", "big.bin"));
+    expect(onDisk.byteLength).toBe(big.byteLength);
+    expect(Buffer.compare(onDisk, Buffer.from(big))).toBe(0);
+  });
+
+  it("dies when a listed document fetch returns non-ok", async () => {
+    config.documents = () => Response.json({ documents: [{ name: "x.txt", size: 1 }] });
+    config.doc = () => new Response("gone", { status: 404 });
+    const ws = await tempWorkspace();
+    const { die, messages } = makeDie();
+
+    await expect(provisionDocuments(deps(ws, die))).rejects.toBeInstanceOf(DieError);
+    expect(messages[0]).toContain("x.txt");
+  });
+
+  it("refuses a path-traversal document name without fetching it", async () => {
+    config.documents = () => Response.json({ documents: [{ name: "../evil" }] });
+    let docFetched = false;
+    config.doc = () => {
+      docFetched = true;
+      return new Response("nope", { status: 200 });
+    };
+    const ws = await tempWorkspace();
+    const { die, messages } = makeDie();
+
+    await expect(provisionDocuments(deps(ws, die))).rejects.toBeInstanceOf(DieError);
+    expect(messages[0]).toContain("unsafe document name");
+    expect(docFetched).toBe(false);
+  });
+
+  it("dies if the manifest itself errors with a non-404 status", async () => {
+    config.documents = () => new Response("boom", { status: 500 });
+    const ws = await tempWorkspace();
+    const { die, messages } = makeDie();
+
+    await expect(provisionDocuments(deps(ws, die, { maxAttempts: 1 }))).rejects.toBeInstanceOf(
+      DieError,
+    );
+    expect(messages[0]).toContain("documents manifest");
+  });
+});
+
+describe("signedGetWithRetry", () => {
+  it("does not retry a deterministic 4xx (returns it immediately)", async () => {
+    let calls = 0;
+    config.documents = () => {
+      calls += 1;
+      return new Response("nope", { status: 403 });
+    };
+    const ws = await tempWorkspace();
+    const { die } = makeDie();
+    const res = await signedGetWithRetry(`${base}/api/runs/run_test/documents`, deps(ws, die));
+    expect(res.status).toBe(403);
+    expect(calls).toBe(1); // 403 is non-retryable
+  });
+
+  it("signs every request (server-side HMAC verify passes)", async () => {
+    config.requireSig = true;
+    config.documents = () => new Response("ok", { status: 200 });
+    const ws = await tempWorkspace();
+    const { die } = makeDie();
+    const res = await signedGetWithRetry(`${base}/api/runs/run_test/documents`, deps(ws, die));
+    expect(res.status).toBe(200);
+    expect(config.lastSigOk).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

Any run carrying **input documents** was killed at the 60s heartbeat watchdog. The agent container booted, emitted `runtime starting`, then went **100% CPU and silent** — the container stayed "healthy" while the run was marked `failed` ("no heartbeat for 60s").

Root cause: `provisionDocuments` streamed each document to disk with `await Bun.write(path, docRes)`, handing the fetch `Response` to Bun to stream-consume. In the **bundled** runtime (`dist/entrypoint.js`) that busy-loops at 100% CPU and never resolves, starving the event loop so `startSinkHeartbeat` never fires. (It does *not* reproduce unbundled — which is why no source test caught it, and why the platform-side document routes, already well tested, looked fine.)

## Fix

Drain the body reader into a `FileSink` explicitly instead of passing the `Response`/stream to `Bun.write`:
- O(1) peak memory — preserves the streaming-to-disk intent of #561 (per-run docs are capped at `WORKSPACE_MAX_DOCS_BYTES` = 256 MiB; buffering would reintroduce that blow-up).
- Avoids the spinning `Bun.write(Response)` code path entirely.

## Testability refactor

Extracted `provisionWorkspace` / `provisionDocuments` / `signedGetWithRetry` into a dependency-injected `runtime-pi/provision.ts`. `entrypoint.ts` is a top-level-`await` script with module side effects + `process.exit`, so it could never be imported/tested — which is exactly why this path shipped untested.

## Tests

- **`provision.test.ts`** — 14 unit tests against a local **HMAC-verifying** server (signing is exercised, not mocked): signed fetch + retry/backoff, 404/401/5xx, path-traversal refusal, and **multi-chunk streaming byte-exactness** (incl. a 1 MiB document).
- **`provision-container.e2e.test.ts`** — Docker-gated regression that runs the **real `appstrate-pi` image** against a document-bearing run and asserts it progresses **past provisioning**. This is the only layer that catches the bundle-specific spin.

### Verification
- Unit: `14 pass / 0 fail`; full runtime-pi suite `620 pass / 0 fail`; `tsc` + prettier clean.
- Container e2e: **passes on the fix**, **fails on the pre-fix image** (only `runtime starting` then silence) — proving the regression test has teeth.
- Real platform run (local instance, doc-bearing agent + skills): `success`, both documents read, structured output correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
