### PR TITLE
fix(orchestrator): self-heal stale egress network and stop leaking containers on failed launch

### DIFF
--- a/apps/api/src/lib/boot.ts
+++ b/apps/api/src/lib/boot.ts
@@ -6,6 +6,7 @@ import { packages, packageVersions } from "@appstrate/db/schema";
 import { expireOldInvitations } from "../services/invitations.ts";
 import { cleanupExpiredKeys } from "../services/api-keys.ts";
 import { cleanupExpiredUploads, startUploadGc } from "../services/uploads.ts";
+import { startOrphanReaper } from "../services/orphan-reaper.ts";
 import { createNotifyTriggers } from "@appstrate/db/notify";
 import { logger } from "./logger.ts";
 import {
@@ -330,6 +331,11 @@ export async function boot(): Promise<void> {
 
   // Kick off the recurring upload sweep once initial cleanup is scheduled.
   startUploadGc();
+
+  // Kick off the recurring orphan-container reaper. The boot-time
+  // `cleanupOrphans` above only runs once; a long-lived API needs a periodic
+  // sweep so failed-launch residue can't accumulate until the next restart.
+  startOrphanReaper();
 }
 
 /**

--- a/apps/api/src/lib/shutdown.ts
+++ b/apps/api/src/lib/shutdown.ts
@@ -17,6 +17,7 @@ import { shutdownPairingCleanupWorker } from "../services/model-providers/pairin
 import { stopRunWatchdog } from "../services/run-watchdog.ts";
 import { getOrchestrator } from "../services/orchestrator/index.ts";
 import { stopUploadGc } from "../services/uploads.ts";
+import { stopOrphanReaper } from "../services/orphan-reaper.ts";
 
 const SHUTDOWN_TIMEOUT_MS = 30_000;
 
@@ -30,6 +31,7 @@ export function createShutdownHandler(setShuttingDown: () => void): () => Promis
 
     logger.info("Shutdown initiated, stopping container orchestrator...");
     stopUploadGc();
+    stopOrphanReaper();
     await getOrchestrator().shutdown();
 
     // Unsubscribe from cancel channel before draining to avoid processing

--- a/apps/api/src/services/docker.ts
+++ b/apps/api/src/services/docker.ts
@@ -480,6 +480,46 @@ export async function removeNetwork(networkId: string): Promise<void> {
   await assertDockerOk(res, "remove network", [404]);
 }
 
+/** True if a Docker network with this ID currently exists on the daemon. */
+export async function networkExists(networkId: string): Promise<boolean> {
+  const res = await dockerFetch(`/networks/${networkId}`);
+  if (res.status === 404) return false;
+  return res.ok;
+}
+
+/** Resolve a Docker network ID by its exact name, or null if none matches. */
+export async function findNetworkByName(name: string): Promise<string | null> {
+  const filters = JSON.stringify({ name: [name] });
+  const res = await dockerFetch(`/networks?filters=${encodeURIComponent(filters)}`);
+  if (!res.ok) return null;
+  const networks = (await res.json()) as Array<{ Id: string; Name: string }>;
+  // Docker's `name` network filter is a substring match — pin to exact name.
+  return networks.find((n) => n.Name === name)?.Id ?? null;
+}
+
+/**
+ * Idempotently resolve a Docker network ID by exact name, creating it if
+ * absent. Tolerates the create race (a co-located instance / concurrent boot
+ * creating the same shared network): on a duplicate/error, re-resolve by name
+ * before giving up. Used for the shared `appstrate-egress` infra network,
+ * which can be reclaimed out from under a long-lived API.
+ */
+export async function ensureNetwork(
+  name: string,
+  options?: { internal?: boolean },
+): Promise<string> {
+  const existing = await findNetworkByName(name);
+  if (existing) return existing;
+  try {
+    return await createNetwork(name, options);
+  } catch (err) {
+    // Lost a create race (or hit CheckDuplicate) — re-resolve before failing.
+    const raced = await findNetworkByName(name);
+    if (raced) return raced;
+    throw err;
+  }
+}
+
 // --- Orphaned container cleanup ---
 
 export async function cleanupOrphanedContainers(): Promise<{
@@ -508,6 +548,32 @@ export async function cleanupOrphanedContainers(): Promise<{
   const networkCount = await cleanupOrphanedNetworks();
 
   return { containers: containers.length, networks: networkCount };
+}
+
+/**
+ * Runtime-safe periodic orphan sweep. Unlike {@link cleanupOrphanedContainers}
+ * (boot-only — it force-removes EVERY managed container and tears down the
+ * shared egress network, which is only safe when no runs are live), this
+ * removes only managed containers that are (a) not running/restarting and
+ * (b) older than `maxAgeSeconds`. It never touches a live run nor any network,
+ * so it is safe to call on a long-lived API. Reclaims the residue of launches
+ * that leaked between `createContainer` and the lifecycle cleanup. Returns the
+ * number of containers removed.
+ */
+export async function reapStaleManagedContainers(maxAgeSeconds: number): Promise<number> {
+  const filters = JSON.stringify({ label: ["appstrate.managed=true"] });
+  const res = await dockerFetch(`/containers/json?all=true&filters=${encodeURIComponent(filters)}`);
+  if (!res.ok) return 0;
+  // `/containers/json` reports `State` as a lowercase string ("created",
+  // "running", "exited", …) and `Created` as Unix seconds.
+  const containers = (await res.json()) as Array<{ Id: string; State: string; Created: number }>;
+  const cutoff = Math.floor(Date.now() / 1000) - maxAgeSeconds;
+  const stale = containers.filter(
+    (c) => c.State !== "running" && c.State !== "restarting" && c.Created < cutoff,
+  );
+  if (stale.length === 0) return 0;
+  const results = await Promise.allSettled(stale.map((c) => removeContainer(c.Id)));
+  return results.filter((r) => r.status === "fulfilled").length;
 }
 
 /**

--- a/apps/api/src/services/orchestrator/constants.ts
+++ b/apps/api/src/services/orchestrator/constants.ts
@@ -2,3 +2,16 @@
 
 export const SIDECAR_MEMORY_BYTES = 256 * 1024 * 1024;
 export const SIDECAR_NANO_CPUS = 500_000_000;
+
+/**
+ * Minimum age before the periodic orphan reaper will remove a non-running
+ * managed container. Generous on purpose: a healthy run is `running` for its
+ * whole life (and so never a candidate), so this only bounds the window
+ * between a terminal/`created` state and the lifecycle cleanup. An hour is far
+ * longer than any create→start or exit→remove gap, so the reaper can never
+ * race a launch that is merely slow.
+ */
+export const ORPHAN_REAP_MAX_AGE_SECONDS = 60 * 60;
+
+/** How often the runtime-safe orphan reaper sweeps. */
+export const ORPHAN_REAP_INTERVAL_MS = 30 * 60 * 1000;

--- a/apps/api/src/services/orchestrator/docker-orchestrator.ts
+++ b/apps/api/src/services/orchestrator/docker-orchestrator.ts
@@ -15,7 +15,11 @@ import * as docker from "../docker.ts";
 import { createNetworkWithPoolRetry } from "../docker-errors.ts";
 import { logger } from "../../lib/logger.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
-import { SIDECAR_MEMORY_BYTES, SIDECAR_NANO_CPUS } from "./constants.ts";
+import {
+  ORPHAN_REAP_MAX_AGE_SECONDS,
+  SIDECAR_MEMORY_BYTES,
+  SIDECAR_NANO_CPUS,
+} from "./constants.ts";
 
 class DockerWorkloadHandle implements WorkloadHandle {
   constructor(
@@ -44,13 +48,39 @@ export class DockerOrchestrator implements ContainerOrchestrator {
     // already masks the warm-image sidecar boot, so a pre-warmed pool buys
     // nothing extra on the user-visible latency.
     const env = getEnv();
-    const [, , , egressId] = await Promise.all([
+    await Promise.all([
       docker.ensureImage(env.PI_IMAGE),
       docker.ensureImage(env.SIDECAR_IMAGE),
       docker.detectPlatformNetwork(),
-      docker.createNetwork("appstrate-egress"),
+      // Populates `this.egressNetworkId`; resolves an existing network or
+      // creates one. Same path used per-run, so boot and steady state agree.
+      this.ensureEgressNetwork(),
     ]);
-    this.egressNetworkId = egressId;
+  }
+
+  /**
+   * Resolve the shared egress network's ID, re-validating the cached value
+   * against the live daemon and recreating the network on a miss.
+   *
+   * The egress network is shared infra reused across every run, cached once at
+   * boot. But it can be reclaimed out from under a long-lived API — a host
+   * `docker network prune`, a Docker daemon restart, or a co-located Appstrate
+   * instance's boot sweep (which removes `appstrate-egress` by name). A stale
+   * cache is silent and catastrophic: `createContainer` still succeeds (the
+   * dead network ID is only recorded on the container), but `startContainer`
+   * 404s with "network <id> not found", so EVERY run fails to launch until the
+   * API restarts. Re-validating here makes the orchestrator self-heal.
+   */
+  private async ensureEgressNetwork(): Promise<string> {
+    const cached = this.egressNetworkId;
+    if (cached && (await docker.networkExists(cached))) return cached;
+    const id = await docker.ensureNetwork("appstrate-egress");
+    this.egressNetworkId = id;
+    return id;
+  }
+
+  async reapStaleOrphans(): Promise<number> {
+    return docker.reapStaleManagedContainers(ORPHAN_REAP_MAX_AGE_SECONDS);
   }
 
   async shutdown(): Promise<void> {
@@ -126,33 +156,45 @@ export class DockerOrchestrator implements ContainerOrchestrator {
 
     // Create sidecar on egress network (primary) so it has DNS + internet.
     // Then connect to run network (internal) with "sidecar" alias for agent DNS.
+    // Re-validate the egress network ID rather than trusting the boot-time
+    // cache: if it went stale the `start` below would 404 on every run.
     const containerId = await docker.createContainer(runId, sidecarEnv, {
       image: env.SIDECAR_IMAGE,
       adapterName: "sidecar",
       memory: SIDECAR_MEMORY_BYTES,
       nanoCpus: SIDECAR_NANO_CPUS,
-      networkId: this.egressNetworkId!,
+      networkId: await this.ensureEgressNetwork(),
       extraHosts: platformNetwork ? [] : ["host.docker.internal:host-gateway"],
     });
 
-    // Connect to run network (agent reaches sidecar via "sidecar" DNS alias)
-    await docker.connectContainerToNetwork(boundary.id, containerId, ["sidecar"]);
+    // The container now exists but isn't started. Any failure before we return
+    // its handle (a connect error, a stale-network 404 at start) would strand
+    // it as a `created` orphan — the caller's cleanup keys off the handle we
+    // haven't returned yet. Remove it on the throw path so a failed launch
+    // never leaks a container.
+    try {
+      // Connect to run network (agent reaches sidecar via "sidecar" DNS alias)
+      await docker.connectContainerToNetwork(boundary.id, containerId, ["sidecar"]);
 
-    if (platformNetwork) {
-      await docker.connectContainerToNetwork(platformNetwork.networkId, containerId);
+      if (platformNetwork) {
+        await docker.connectContainerToNetwork(platformNetwork.networkId, containerId);
+      }
+
+      // #406 — parallel boot. Start the sidecar but DO NOT block on its
+      // `/health` here. The agent (started in parallel by pi.ts) drives
+      // a retrying MCP handshake against `sidecar:8080/mcp`, which absorbs:
+      //   - ECONNREFUSED while the sidecar is wiring its listener
+      //   - ENOTFOUND while the Docker bridge propagates the "sidecar" alias
+      // Sidecar exit detection still happens loudly: a non-blocking watcher
+      // races `waitForExit` against the run. If the sidecar dies before MCP
+      // connects, the watcher logs `exitCode` + buffered stderr/stdout, so
+      // operators see "sidecar exited 1 (npm not found)" rather than the
+      // agent's eventual "deadline exceeded" hand-wave.
+      await docker.startContainer(containerId);
+    } catch (err) {
+      await docker.removeContainer(containerId).catch(() => {});
+      throw err;
     }
-
-    // #406 — parallel boot. Start the sidecar but DO NOT block on its
-    // `/health` here. The agent (started in parallel by pi.ts) drives
-    // a retrying MCP handshake against `sidecar:8080/mcp`, which absorbs:
-    //   - ECONNREFUSED while the sidecar is wiring its listener
-    //   - ENOTFOUND while the Docker bridge propagates the "sidecar" alias
-    // Sidecar exit detection still happens loudly: a non-blocking watcher
-    // races `waitForExit` against the run. If the sidecar dies before MCP
-    // connects, the watcher logs `exitCode` + buffered stderr/stdout, so
-    // operators see "sidecar exited 1 (npm not found)" rather than the
-    // agent's eventual "deadline exceeded" hand-wave.
-    await docker.startContainer(containerId);
     this.watchSidecarExit(runId, containerId);
 
     return new DockerWorkloadHandle(containerId, runId, "sidecar");
@@ -230,7 +272,15 @@ export class DockerOrchestrator implements ContainerOrchestrator {
     });
 
     if (spec.files && spec.files.items.length > 0) {
-      await docker.injectFiles(containerId, spec.files.items, spec.files.targetDir);
+      // Injection runs against the created-but-not-started container; a throw
+      // here would leak a `created` orphan (the handle isn't returned yet, so
+      // the caller can't reap it). Remove it on the throw path.
+      try {
+        await docker.injectFiles(containerId, spec.files.items, spec.files.targetDir);
+      } catch (err) {
+        await docker.removeContainer(containerId).catch(() => {});
+        throw err;
+      }
     }
 
     return new DockerWorkloadHandle(containerId, spec.runId, spec.role);

--- a/apps/api/src/services/orchestrator/process-orchestrator.ts
+++ b/apps/api/src/services/orchestrator/process-orchestrator.ts
@@ -170,6 +170,12 @@ export class ProcessOrchestrator implements ContainerOrchestrator {
     return { workloads, isolationBoundaries };
   }
 
+  async reapStaleOrphans(): Promise<number> {
+    // The process adapter has no managed Docker containers to reap; boundary
+    // directories from dead runs are reclaimed by cleanupOrphans at boot.
+    return 0;
+  }
+
   async createIsolationBoundary(runId: string): Promise<IsolationBoundary> {
     const dir = join(DATA_DIR, runId);
     await mkdir(dir, { recursive: true });

--- a/apps/api/src/services/orphan-reaper.ts
+++ b/apps/api/src/services/orphan-reaper.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { getErrorMessage } from "@appstrate/core/errors";
+import { logger } from "../lib/logger.ts";
+import { getOrchestrator } from "./orchestrator/index.ts";
+import { ORPHAN_REAP_INTERVAL_MS } from "./orchestrator/constants.ts";
+
+let reapTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Start a background sweep that reaps stale, non-running managed containers on
+ * a fixed interval. Complements the boot-time orphan cleanup: a long-lived API
+ * never restarts, so without a periodic sweep the residue of failed launches
+ * accumulates until the next deploy. The orchestrator's `reapStaleOrphans` is
+ * runtime-safe (only removes terminated/stale containers, never a live run nor
+ * any network). Safe to call multiple times — a no-op after the first.
+ */
+export function startOrphanReaper(): void {
+  if (reapTimer) return;
+  reapTimer = setInterval(() => {
+    getOrchestrator()
+      .reapStaleOrphans()
+      .then((count) => {
+        if (count > 0) logger.info("Reaped stale orphan containers", { count });
+      })
+      .catch((err) => {
+        logger.warn("Periodic orphan reaper sweep failed", {
+          error: getErrorMessage(err),
+        });
+      });
+  }, ORPHAN_REAP_INTERVAL_MS);
+  // Don't hold the event loop open for this timer alone.
+  reapTimer.unref?.();
+}
+
+/** Stop the background sweep. Called from the shutdown handler. */
+export function stopOrphanReaper(): void {
+  if (reapTimer) {
+    clearInterval(reapTimer);
+    reapTimer = null;
+  }
+}

--- a/apps/api/src/services/run-launcher/pi.ts
+++ b/apps/api/src/services/run-launcher/pi.ts
@@ -228,25 +228,35 @@ export async function runPlatformContainer(
     // Sidecar + agent setup in parallel (identical to the legacy path —
     // the only behavioural change is WHERE the agent's events end up).
     // When `skipSidecar`, we only create the agent workload.
+    //
+    // Capture each handle the instant its create resolves (inside `.then`),
+    // NOT after the whole `Promise.all` settles. `Promise.all` rejects on the
+    // first failing branch but does NOT cancel its siblings — so a sidecar
+    // failure can leave a successfully-created agent container behind. With a
+    // post-await assignment the reject would throw straight to `finally` with
+    // both handles still `undefined`, stranding that container. Eager capture
+    // lets `finally` reap whatever was created.
     const [sidecar, agent] = await Promise.all([
-      skipSidecar ? Promise.resolve(undefined) : orch.createSidecar(runId, boundary, sidecarSpec),
-      orch.createWorkload(
-        {
-          runId,
-          role: "agent",
-          image: getEnv().PI_IMAGE,
-          env: containerEnv,
-          resources: { memoryBytes: 1536 * 1024 * 1024, nanoCpus: 2_000_000_000 },
-          files:
-            filesToInject.length > 0
-              ? { items: filesToInject, targetDir: "/workspace" }
-              : undefined,
-        },
-        boundary,
-      ),
+      skipSidecar
+        ? Promise.resolve(undefined)
+        : orch.createSidecar(runId, boundary, sidecarSpec).then((h) => (sidecarHandle = h)),
+      orch
+        .createWorkload(
+          {
+            runId,
+            role: "agent",
+            image: getEnv().PI_IMAGE,
+            env: containerEnv,
+            resources: { memoryBytes: 1536 * 1024 * 1024, nanoCpus: 2_000_000_000 },
+            files:
+              filesToInject.length > 0
+                ? { items: filesToInject, targetDir: "/workspace" }
+                : undefined,
+          },
+          boundary,
+        )
+        .then((h) => (agentHandle = h)),
     ]);
-    sidecarHandle = sidecar;
-    agentHandle = agent;
 
     return await waitForWorkload(orch, agent, sidecar, plan.timeout, signal);
   } finally {

--- a/apps/api/test/integration/services/docker-api.test.ts
+++ b/apps/api/test/integration/services/docker-api.test.ts
@@ -13,9 +13,13 @@ import {
   createNetwork,
   connectContainerToNetwork,
   removeNetwork,
+  networkExists,
+  findNetworkByName,
+  ensureNetwork,
   cleanupOrphanedContainers,
   cleanupOrphanedNetworks,
   cleanupOrphanedRunNetworks,
+  reapStaleManagedContainers,
   getContainerHostPort,
 } from "../../../src/services/docker.ts";
 
@@ -701,4 +705,93 @@ describe("Full lifecycle", () => {
     const res = await fetch(`${DOCKER_URL}/containers/${id}/json`);
     expect(res.status).toBe(404);
   }, 30_000);
+});
+
+// ─── ensureNetwork / networkExists / findNetworkByName ──────
+
+describe("ensureNetwork / networkExists / findNetworkByName", () => {
+  it(
+    "creates the network when absent, then resolves the same id idempotently",
+    async () => {
+      const name = `appstrate-test-egress-${uid()}`;
+      const id1 = trackNetwork(await ensureNetwork(name));
+
+      expect(await networkExists(id1)).toBe(true);
+      expect(await findNetworkByName(name)).toBe(id1);
+
+      // Second call must reuse the existing network — no duplicate, no throw.
+      const id2 = await ensureNetwork(name);
+      expect(id2).toBe(id1);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "networkExists / findNetworkByName report a removed network as gone",
+    async () => {
+      const name = `appstrate-test-egress-${uid()}`;
+      const id = await ensureNetwork(name);
+      expect(await networkExists(id)).toBe(true);
+
+      await removeNetwork(id);
+
+      // This mirrors the stale-egress-cache bug: a cached id whose network was
+      // reclaimed must read as absent so the orchestrator recreates it.
+      expect(await networkExists(id)).toBe(false);
+      expect(await findNetworkByName(name)).toBeNull();
+    },
+    TIMEOUT,
+  );
+});
+
+// ─── reapStaleManagedContainers ─────────────────────────────
+
+describe("reapStaleManagedContainers", () => {
+  it(
+    "removes a non-running managed container older than the cutoff",
+    async () => {
+      const id = await createRawContainer(["sleep", "60"]); // created, never started
+
+      // Negative maxAge → cutoff in the future → the just-created container
+      // counts as stale and gets reaped.
+      const removed = await reapStaleManagedContainers(-10);
+      expect(removed).toBeGreaterThanOrEqual(1);
+
+      const res = await fetch(`${DOCKER_URL}/containers/${id}/json`);
+      expect(res.status).toBe(404);
+      untrackContainer(id);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "never removes a running container, even past the cutoff",
+    async () => {
+      const id = await createRawContainer(["sleep", "60"]);
+      await startContainer(id);
+
+      await reapStaleManagedContainers(-10);
+
+      // The live run must survive the sweep — the State guard protects it.
+      const res = await fetch(`${DOCKER_URL}/containers/${id}/json`);
+      expect(res.status).toBe(200);
+
+      await stopContainer(id, 1);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "leaves a fresh container untouched within the age window",
+    async () => {
+      const id = await createRawContainer(["sleep", "60"]);
+
+      // 1h window → a container created moments ago is not yet stale.
+      await reapStaleManagedContainers(3600);
+
+      const res = await fetch(`${DOCKER_URL}/containers/${id}/json`);
+      expect(res.status).toBe(200);
+    },
+    TIMEOUT,
+  );
 });

--- a/apps/api/test/integration/services/platform-container-sink.test.ts
+++ b/apps/api/test/integration/services/platform-container-sink.test.ts
@@ -89,6 +89,9 @@ function createFakeOrchestrator(config: FakeOrchestratorConfig = {}): FakeOrches
     async cleanupOrphans(): Promise<CleanupReport> {
       return { workloads: 0, isolationBoundaries: 0 };
     },
+    async reapStaleOrphans(): Promise<number> {
+      return 0;
+    },
     async ensureImages() {},
     async createIsolationBoundary(runId: string): Promise<IsolationBoundary> {
       const boundary: IsolationBoundary = { id: `net_${runId}`, name: `appstrate-exec-${runId}` };

--- a/apps/api/test/integration/services/run-launcher-no-sidecar.test.ts
+++ b/apps/api/test/integration/services/run-launcher-no-sidecar.test.ts
@@ -50,6 +50,9 @@ function createCountingFake(): {
     async cleanupOrphans(): Promise<CleanupReport> {
       return { workloads: 0, isolationBoundaries: 0 };
     },
+    async reapStaleOrphans(): Promise<number> {
+      return 0;
+    },
     async ensureImages() {},
     async createIsolationBoundary(runId: string): Promise<IsolationBoundary> {
       return { id: `net_${runId}`, name: `appstrate-exec-${runId}` };

--- a/apps/api/test/integration/services/run-launcher-parallel-boot.test.ts
+++ b/apps/api/test/integration/services/run-launcher-parallel-boot.test.ts
@@ -70,6 +70,9 @@ function createTimingFake(config: TimingFakeConfig): {
     async cleanupOrphans(): Promise<CleanupReport> {
       return { workloads: 0, isolationBoundaries: 0 };
     },
+    async reapStaleOrphans(): Promise<number> {
+      return 0;
+    },
     async ensureImages() {},
     async createIsolationBoundary(runId: string): Promise<IsolationBoundary> {
       return { id: `net_${runId}`, name: `appstrate-exec-${runId}` };
@@ -270,5 +273,83 @@ describe("#406 parallel-boot — pi.ts vs slow sidecar", () => {
     // /health round-trips. Generous upper bound to keep the test
     // resilient on slow CI.
     expect(elapsed).toBeLessThan(2_000);
+  });
+});
+
+describe("partial-failure cleanup — created workloads must not leak", () => {
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it("removes the already-created agent workload when sidecar creation rejects", async () => {
+    const removed: WorkloadHandle[] = [];
+    let boundaryRemoved = false;
+    const agentHandle: WorkloadHandle = { id: "agent_leak", runId: "run_leak", role: "agent" };
+
+    // Mirrors the real stale-egress failure: the sidecar branch rejects (its
+    // own container is reaped internally by the orchestrator), while the agent
+    // branch resolves a handle. `Promise.all` rejects without cancelling the
+    // agent branch, so a successfully-created agent container exists. The
+    // launcher MUST reap it — pre-fix, the handle was assigned only AFTER the
+    // await, so `finally` saw `undefined` and stranded the container.
+    const orchestrator: ContainerOrchestrator = {
+      async initialize() {},
+      async shutdown() {},
+      async cleanupOrphans(): Promise<CleanupReport> {
+        return { workloads: 0, isolationBoundaries: 0 };
+      },
+      async reapStaleOrphans(): Promise<number> {
+        return 0;
+      },
+      async ensureImages() {},
+      async createIsolationBoundary(runId: string): Promise<IsolationBoundary> {
+        return { id: `net_${runId}`, name: `appstrate-exec-${runId}` };
+      },
+      async removeIsolationBoundary() {
+        boundaryRemoved = true;
+      },
+      async createSidecar(): Promise<WorkloadHandle> {
+        // Small delay so the agent's createWorkload resolves (and its handle
+        // is captured) before this rejects — exactly the real ordering, where
+        // the sidecar fails late at `startContainer`.
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        throw new Error("Docker start container failed: 404 network not found");
+      },
+      async createWorkload(spec: WorkloadSpec): Promise<WorkloadHandle> {
+        return { id: agentHandle.id, runId: spec.runId, role: spec.role };
+      },
+      async startWorkload() {},
+      async stopWorkload() {},
+      async removeWorkload(handle: WorkloadHandle) {
+        removed.push(handle);
+      },
+      async waitForExit(): Promise<number> {
+        return 0;
+      },
+      async *streamLogs(): AsyncGenerator<string> {},
+      async stopByRunId(): Promise<StopResult> {
+        return "stopped";
+      },
+      async resolvePlatformApiUrl(): Promise<string> {
+        return "http://platform:3000";
+      },
+    };
+
+    await expect(
+      runPlatformContainer({
+        runId: "run_leak",
+        context: buildContext("run_leak"),
+        plan: buildRunPlan(),
+        sinkCredentials: mintSinkCredentials({
+          runId: "run_leak",
+          appUrl: "http://platform:3000",
+          ttlSeconds: 60,
+        }),
+        orchestrator,
+      }),
+    ).rejects.toThrow();
+
+    expect(removed.map((h) => h.id)).toContain("agent_leak");
+    expect(boundaryRemoved).toBe(true);
   });
 });

--- a/packages/core/src/platform-types.ts
+++ b/packages/core/src/platform-types.ts
@@ -232,6 +232,14 @@ export interface ContainerOrchestrator {
   /** Clean up orphaned workloads/networks from a previous crash. */
   cleanupOrphans(): Promise<CleanupReport>;
 
+  /**
+   * Periodic, runtime-safe orphan sweep. Unlike {@link cleanupOrphans}
+   * (boot-only), this MUST be safe to call while runs are live: implementations
+   * remove only terminated/stale residue, never an active workload, and never
+   * shared infra. Returns the number reclaimed; a no-op returns 0.
+   */
+  reapStaleOrphans(): Promise<number>;
+
   /** Ensure images are locally available (pull if missing/outdated). No-op when not applicable. */
   ensureImages(images: string[]): Promise<void>;
 


### PR DESCRIPTION
## Symptom

On a long-lived self-hosted instance, **100% of runs were failing to launch** for ~10 days, and `created` agent+sidecar container pairs were piling up, never reaped. The API logs show one identical signature per run:

```
error: "Docker start container failed: 404 ... failed to set up container networking:
        network <id> not found"
msg:   "runPlatformContainer threw — synthesising failed terminal"
```

The failing network `<id>` was constant across days while the actual `appstrate-egress` network had a different id — a stale cache. Networks/volumes were reclaimed but the containers leaked, an asymmetry that pinned the bug precisely.

## Root cause — three combined issues

### 1. Stale egress network cache (the trigger — breaks 100% of runs)
`DockerOrchestrator` resolved the shared `appstrate-egress` id once at boot into `egressNetworkId` and never revalidated it. When the network is reclaimed out from under a long-lived API (host `docker network prune`, daemon restart, or a co-located instance's boot sweep that deletes `appstrate-egress` **by name**), the cache points at a dead id. `createContainer` still succeeds (the id is only recorded on the container), but `startContainer` 404s — so every run fails until the API restarts.

### 2. Container leak on partial launch failure (the symptom)
In `pi.ts`, `sidecarHandle`/`agentHandle` were assigned only **after** `await Promise.all([createSidecar, createWorkload])`. `Promise.all` rejects on the first failing branch but does not cancel its siblings, so a successfully-created container's handle was never captured — the `finally` cleanup (guarded on the handles) skipped it, stranding a `created` orphan. `boundary` is assigned *before* the await, so the network was still torn down → exactly the network-gone/container-leaked asymmetry observed.

### 3. No periodic orphan reaper
`cleanupOrphans()` only runs at boot, so a long-lived API never reclaims leaked residue until the next deploy.

## Fixes

| # | Change |
|---|--------|
| 1 | `ensureEgressNetwork()` revalidates the cached id against the daemon (`networkExists`) and recreates by name on a miss (`ensureNetwork` — idempotent + create-race tolerant). Used at boot **and** per sidecar/workload, so the orchestrator self-heals. |
| 2 | Capture each handle inside `.then` the instant its create resolves, so `finally` reaps whatever was created. Belt-and-braces: `createSidecar`/`createWorkload` remove their own container on the throw path before the handle is returned. |
| 3 | `reapStaleOrphans()` — runtime-safe (removes only **non-running** managed containers older than 1h, never a live run nor any network) — on a 30-min timer, started in boot, stopped on shutdown. |

## Tests
- **Regression** (`run-launcher-parallel-boot`): a rejecting `createSidecar` while `createWorkload` succeeds must reap the created agent (would fail pre-fix — handle never captured).
- **Docker integration** (`docker-api`): `ensureNetwork`/`networkExists`/`findNetworkByName` (create/idempotent/removed-network), and `reapStaleManagedContainers` (age cutoff + running-state guard).
- `bun run check` green (typecheck, prettier, lint, 0 breaking).

## Operational note
The affected instance was cleaned manually (10 orphan containers removed). After merge + redeploy, the orchestrator self-heals the egress network and the reaper prevents re-accumulation. No DB migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
