### PR TITLE
fix(docker): ship afps-shared semver in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,8 +91,13 @@ COPY --from=build /app/packages/core/package.json ./packages/core/
 COPY --from=build /app/packages/afps-runtime/src ./packages/afps-runtime/src
 COPY --from=build /app/packages/afps-runtime/package.json ./packages/afps-runtime/
 
-# AFPS shared (zero-dep leaf — companion-files, semver, integrity, credential-template, …)
+# AFPS shared (companion-files, semver, integrity, credential-template, …)
 # Required by @appstrate/core, @appstrate/afps-runtime, @appstrate/connect at runtime.
+# NOT a zero-dep leaf: it declares `semver`. Bun installs isolated per-package
+# node_modules, so afps-shared's `semver` lives in ITS OWN node_modules — which MUST
+# ship, or the runtime crash-loops with
+# `Cannot find package 'semver' from .../packages/afps-shared/src/semver-resolve.ts`.
+COPY --from=deps /app/packages/afps-shared/node_modules ./packages/afps-shared/node_modules
 COPY --from=build /app/packages/afps-shared/src ./packages/afps-shared/src
 COPY --from=build /app/packages/afps-shared/package.json ./packages/afps-shared/
 


### PR DESCRIPTION
## Summary
The beta.17 image crash-loops on boot: `Cannot find package 'semver' from .../packages/afps-shared/src/semver-resolve.ts`. `@appstrate/afps-shared` declares `semver ^7.7.1`, but bun installs isolated per-package node_modules and the runtime stage only copied afps-shared's `src` + `package.json` — not its node_modules. Mirror the core/db pattern.

Found deploying v1.0.0-beta.17 (#481) to production.

## Test
- `docker build` + verified `/app/packages/afps-shared/node_modules/semver` present and `@appstrate/afps-shared/semver-resolve` imports cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)