### PR TITLE
fix(integrations): gate runs on integration active-state + drop orphaned-auth connections

### DIFF
--- a/apps/api/src/services/agent-readiness.ts
+++ b/apps/api/src/services/agent-readiness.ts
@@ -10,9 +10,11 @@ import {
   resolveConnectionsForRun,
   translateResolutionError,
 } from "./integration-connection-resolver.ts";
+import { isIntegrationActive } from "./integration-connections.ts";
 import { validateConfig } from "./schema.ts";
 import { extractManifestSchemas } from "../lib/manifest-utils.ts";
 import { isPromptEmpty, findMissingDependencies } from "@appstrate/core/validation";
+import { parseManifestIntegrations } from "@appstrate/core/dependencies";
 import { deepMergeConfig } from "@appstrate/core/schema-validation";
 import type { ConnectionOverrides } from "@appstrate/core/integration";
 import { ApiError, type ValidationFieldError } from "../lib/errors.ts";
@@ -52,7 +54,7 @@ export interface AgentReadinessParams {
  *
  * Single source of truth for readiness checks — the throwing wrapper
  * `validateAgentReadiness` delegates to this. Fail-fast sequence:
- * prompt → skills → integration connections → config.
+ * prompt → skills → integration install/enable → integration connections → config.
  */
 export async function collectAgentReadinessErrors(
   params: AgentReadinessParams,
@@ -81,6 +83,28 @@ export async function collectAgentReadinessErrors(
       title: "Missing Skill",
       message: `Required skill '${skillId}' is not installed`,
     });
+  }
+
+  // Integration install/enable gate — runs regardless of actor (it is an
+  // app-level fact, not an actor-level one). Every integration the agent
+  // declares MUST be installed AND enabled on the application. Without this
+  // the run silently degrades: the runtime spawn resolver skips an inactive
+  // integration (`isIntegrationActive` false) and the agent launches without
+  // its tools. The connection resolver below does NOT catch this — it gates
+  // on whether an accessible connection exists, and a disabled/uninstalled
+  // integration can still have lingering connections that resolve cleanly.
+  // Checked before connections so an inactive integration fails fast with a
+  // clear cause rather than a downstream `not_connected`.
+  const declaredIntegrations = parseManifestIntegrations(manifest as Record<string, unknown>);
+  for (const entry of declaredIntegrations) {
+    if (!(await isIntegrationActive(entry.id, applicationId))) {
+      errors.push({
+        field: `integrations.${entry.id}`,
+        code: "integration_not_active",
+        title: "Integration Not Enabled",
+        message: `Integration '${entry.id}' is not installed or is disabled in this application.`,
+      });
+    }
   }
 
   // Resolver enumerates own + shared connections, applies

--- a/apps/api/src/services/integration-connection-resolver.ts
+++ b/apps/api/src/services/integration-connection-resolver.ts
@@ -165,24 +165,43 @@ export function resolveConnections(input: ResolveConnectionsInput): ConnectionRe
   const errors: ConnectionResolutionError[] = [];
 
   const { adminPins, memberPins } = indexPins(input.pins, input.actorUserId ?? null);
-  const connectionIndex = new Map<string, ConnectionRow>();
-  for (const c of input.accessibleConnections) connectionIndex.set(c.id, c);
 
   for (const req of input.requirements) {
     // Inert only when the agent picked neither tools nor scopes. apiCall
     // integrations expose no tools, so scope selection keeps them active.
     if (!req.hasSelectedTools && req.agentScopes.length === 0) continue;
 
+    // Orphaned-auth guard: drop this integration's connections whose `authKey`
+    // no longer exists in its CURRENT manifest. A version bump can rename the
+    // auth (e.g. `primary` → `session`); a row left on the old key can never
+    // produce a delivery plan (the spawn resolver matches connection→auth by
+    // authKey), so it must not be a candidate at any cascade layer — otherwise
+    // the run auto-picks a connection that silently fails at runtime, and the
+    // member picker offers a connection the integration page (which iterates
+    // manifest auths) doesn't show. Other integrations' rows pass through
+    // untouched. Empty manifest auths → no constraint (defensive).
+    const manifestAuthKeys = new Set(
+      Object.keys((req.manifest as { auths?: Record<string, unknown> }).auths ?? {}),
+    );
+    const liveConnections =
+      manifestAuthKeys.size === 0
+        ? input.accessibleConnections
+        : input.accessibleConnections.filter(
+            (c) => c.integrationId !== req.integrationId || manifestAuthKeys.has(c.authKey),
+          );
+    const liveIndex = new Map<string, ConnectionRow>();
+    for (const c of liveConnections) liveIndex.set(c.id, c);
+
     // AFPS §4.1 `auth_key`: when the agent dep pins an auth method,
     // restrict the candidate connection set to rows on that auth BEFORE
     // running the cascade. The chosen connection's authKey carries through
     // to credential injection downstream; pre-filtering here means every
     // cascade layer (pins / overrides / fallback) honours the pin uniformly.
-    const integrationCandidates = input.accessibleConnections.filter(
+    const integrationCandidates = liveConnections.filter(
       (c) => c.integrationId === req.integrationId,
     );
-    let filteredConnections = input.accessibleConnections;
-    let filteredIndex = connectionIndex;
+    let filteredConnections = liveConnections;
+    let filteredIndex = liveIndex;
     if (req.requiredAuthKey !== undefined) {
       const matchingOnAuth = integrationCandidates.filter((c) => c.authKey === req.requiredAuthKey);
       if (matchingOnAuth.length === 0 && integrationCandidates.length > 0) {

--- a/apps/api/src/services/integration-connections.ts
+++ b/apps/api/src/services/integration-connections.ts
@@ -318,7 +318,8 @@ export async function selectAccessibleConnection(
 /**
  * `true` when the integration is active in the app — i.e. recorded in
  * `application_packages` (activation installs the row, deactivation removes
- * it). Use {@link assertIntegrationActive} when the caller needs a
+ * it) AND not switched off (`enabled = true`). A disabled install counts as
+ * inactive. Use {@link assertIntegrationActive} when the caller needs a
  * structured 404 instead of a boolean.
  */
 export async function isIntegrationActive(
@@ -332,6 +333,12 @@ export async function isIntegrationActive(
       and(
         eq(applicationPackages.applicationId, applicationId),
         eq(applicationPackages.packageId, packageId),
+        // "Active" = installed AND enabled. A disabled install (enabled=false)
+        // must be treated as inactive everywhere: the runtime spawn resolver
+        // skips it and run readiness rejects the run — otherwise a declared
+        // integration that an operator switched off would silently degrade
+        // the run (tools missing) instead of failing fast.
+        eq(applicationPackages.enabled, true),
       ),
     )
     .limit(1);

--- a/apps/api/src/services/integration-pins-service.ts
+++ b/apps/api/src/services/integration-pins-service.ts
@@ -660,19 +660,31 @@ export async function resolveAgentIntegrationPick(args: {
   const orgDefaultConnectionId = orgDefault?.connection_id ?? null;
   const orgDefaultEnforced = orgDefault?.enforce ?? false;
 
-  const candidates: IntegrationCandidate[] = candidatesRaw.map((c) => ({
-    ...c,
-    missing_scopes: manifest
-      ? missingScopesForConnection({
-          manifest,
-          authKey: c.auth_key,
-          granted: c.scopes_granted,
-          agentTools,
-          agentScopes,
-        })
-      : [],
-    is_own: actor.type === "user" ? c.owner_user_id === actor.id : c.owner_end_user_id === actor.id,
-  }));
+  // Drop orphaned-auth connections: a row whose `auth_key` no longer exists in
+  // the integration's current manifest (e.g. a version bump renamed the auth,
+  // `primary` → `session`) can never be delivered — the spawn resolver matches
+  // a connection to its auth by `authKey`, so an orphaned one yields no
+  // delivery plan. Offering it in the picker desynced the agent dropdown (which
+  // listed it) from the integration page (which iterates manifest auths and so
+  // hid it), and let a member pick a connection that silently fails at runtime.
+  // When the manifest can't be fetched, fall back to no filtering.
+  const manifestAuthKeys = manifest ? new Set(Object.keys(manifest.auths ?? {})) : null;
+  const candidates: IntegrationCandidate[] = candidatesRaw
+    .filter((c) => manifestAuthKeys === null || manifestAuthKeys.has(c.auth_key))
+    .map((c) => ({
+      ...c,
+      missing_scopes: manifest
+        ? missingScopesForConnection({
+            manifest,
+            authKey: c.auth_key,
+            granted: c.scopes_granted,
+            agentTools,
+            agentScopes,
+          })
+        : [],
+      is_own:
+        actor.type === "user" ? c.owner_user_id === actor.id : c.owner_end_user_id === actor.id,
+    }));
 
   const resolved = resolution.resolved[integrationId] ?? null;
   const err = resolution.errors.find((e) => e.integrationId === integrationId) ?? null;

--- a/apps/api/test/integration/routes/runs-412-missing-connection.test.ts
+++ b/apps/api/test/integration/routes/runs-412-missing-connection.test.ts
@@ -35,7 +35,8 @@ import { db, truncateAll } from "../../helpers/db.ts";
 import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
 import { seedAgent, seedPackage } from "../../helpers/seed.ts";
 import { installPackage } from "../../../src/services/application-packages.ts";
-import { integrationConnections } from "@appstrate/db/schema";
+import { integrationConnections, applicationPackages } from "@appstrate/db/schema";
+import { and, eq } from "drizzle-orm";
 import { encryptCredentials } from "@appstrate/connect";
 import {
   localIntegrationManifest,
@@ -343,6 +344,77 @@ describe("POST /api/agents/:scope/:name/run — 412 missing_integration_connecti
     // The smuggled connection_id is the wire contract the reconnect modal
     // consumes — without it the OAuth callback INSERTs a duplicate row.
     expect(err!.connection_id).toBe(deadConnectionId);
+  });
+
+  it("returns 412 integration_not_active when a declared integration is installed but DISABLED, even with a live connection", async () => {
+    // The exact prod regression: a declared integration is switched off on the
+    // app (enabled=false) while a resolvable connection lingers. The connection
+    // gate alone would PASS (the connection resolves), so the run used to launch
+    // and silently degrade — the runtime spawn resolver skips the inactive
+    // integration and the agent runs without its tools. Readiness must reject.
+    await seedAgent({
+      id: AGENT,
+      orgId: ctx.orgId,
+      createdBy: ctx.user.id,
+      draftManifest: buildAgentManifest([INTEGRATION]),
+    });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, AGENT);
+    await seedIntegration(INTEGRATION);
+    // A live, resolvable connection exists — the connection gate would pass.
+    await seedConnection(INTEGRATION, ctx.user.id);
+    // Operator disables the integration on the application.
+    await db
+      .update(applicationPackages)
+      .set({ enabled: false })
+      .where(
+        and(
+          eq(applicationPackages.applicationId, ctx.defaultAppId),
+          eq(applicationPackages.packageId, INTEGRATION),
+        ),
+      );
+
+    const res = await app.request(`/api/agents/${AGENT}/run`, {
+      method: "POST",
+      headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(412);
+    const body = (await res.json()) as ProblemDetails;
+    expect(body.code).toBe("missing_integration_connection");
+    const err = body.errors!.find((e) => e.field === `integrations.${INTEGRATION}`);
+    expect(err).toBeDefined();
+    expect(err!.code).toBe("integration_not_active");
+  });
+
+  it("returns 412 integration_not_active when a declared integration is NOT installed on the app", async () => {
+    await seedAgent({
+      id: AGENT,
+      orgId: ctx.orgId,
+      createdBy: ctx.user.id,
+      draftManifest: buildAgentManifest([INTEGRATION]),
+    });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, AGENT);
+    // Seed the integration PACKAGE but do NOT install it on the application.
+    await seedPackage({
+      id: INTEGRATION,
+      orgId: ctx.orgId,
+      type: "integration",
+      source: "local",
+      draftManifest: buildIntegrationManifest(INTEGRATION),
+    });
+
+    const res = await app.request(`/api/agents/${AGENT}/run`, {
+      method: "POST",
+      headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(412);
+    const body = (await res.json()) as ProblemDetails;
+    const err = body.errors!.find((e) => e.field === `integrations.${INTEGRATION}`);
+    expect(err).toBeDefined();
+    expect(err!.code).toBe("integration_not_active");
   });
 
   it("happy path: returns NON-412 status when the actor has exactly one accessible connection", async () => {

--- a/apps/api/test/unit/services/integration-connection-resolver.test.ts
+++ b/apps/api/test/unit/services/integration-connection-resolver.test.ts
@@ -61,6 +61,22 @@ function oauth2Manifest(): IntegrationManifest {
           },
         },
       },
+      // A second declared auth shape. The cascade tests inject `pat`
+      // connections to exercise multi-auth resolution; both keys must exist
+      // in the manifest (a connection only exists for a declared auth — the
+      // orphaned-auth guard drops rows whose authKey the manifest dropped).
+      pat: {
+        type: "api_key",
+        authorized_uris: ["https://api.example.com/**"],
+        delivery: {
+          http: {
+            in: "header",
+            name: "Authorization",
+            prefix: "Bearer ",
+            value: "{$credential.api_key}",
+          },
+        },
+      },
     },
     tools: {},
   } as unknown as IntegrationManifest;
@@ -807,5 +823,36 @@ describe("resolveConnections — agent dep `auth_key` (AFPS §4.1)", () => {
     // as `pinned_connection_unavailable`.
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]!.code).toBe("pinned_connection_unavailable");
+  });
+});
+
+// ─────────────────── Orphaned-auth guard (version-bump auth rename) ─────────────
+describe("resolveConnections — orphaned-auth guard", () => {
+  it("drops a connection whose authKey is absent from the current manifest", () => {
+    // Simulates a version bump that renamed the auth (e.g. `primary` → the
+    // declared `oauth`/`pat`): the lingering `legacy_primary` row can never be
+    // delivered, so it must NOT be auto-picked — the run reports not_connected.
+    const orphan = conn({ authKey: "legacy_primary" });
+    const result = resolveConnections({
+      requirements: [req(oauth2Manifest())],
+      accessibleConnections: [orphan],
+      pins: [],
+    });
+    expect(result.resolved[INTEG]).toBeUndefined();
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.code).toBe("not_connected");
+  });
+
+  it("keeps declared-auth connections, dropping only the orphaned one", () => {
+    const live = conn({ authKey: "oauth" });
+    const orphan = conn({ authKey: "legacy_primary" });
+    const result = resolveConnections({
+      requirements: [req(oauth2Manifest())],
+      accessibleConnections: [live, orphan],
+      pins: [],
+    });
+    // Single live candidate → auto; the orphan never competes (no must_choose).
+    expect(result.errors).toEqual([]);
+    expect(result.resolved[INTEG]?.connectionId).toBe(live.id);
   });
 });


### PR DESCRIPTION
Two correctness fixes surfaced while deploying the martial v2 agents (provider→integration / AFPS 2.0). Both were real prod gaps; both are environment-independent (main == deployed beta.18 on the touched files).

## 1. Run launch ignored integration install/enabled state (`7e4db1248`)
Run readiness validated that an *accessible connection* existed for each declared integration but never checked whether the integration was **installed AND enabled** on the application. The runtime spawn resolver *does* skip an inactive integration (`isIntegrationActive` false), so a run declaring a disabled/uninstalled integration launched and silently degraded — agent ran without that integration's tools.

The connection gate couldn't catch this: it keys on whether a connection resolves, and a disabled/uninstalled integration can still have lingering connections that resolve cleanly (observed in prod: a not-installed `@appstrate/google-drive` with stale connections passed readiness while the runtime skipped it).

- `isIntegrationActive` now requires `application_packages.enabled = true`, not just row presence → a disabled install is inactive everywhere (runtime skip + readiness reject), consistent semantics.
- `agent-readiness` asserts every declared integration is active **before** the connection check, surfacing `integration_not_active` on the `integrations.*` field (folds into the existing 412 envelope the MissingConnectionsModal consumes). Runs regardless of actor — install/enable is an app-level fact.

## 2. Orphaned-auth connections still offered as candidates (`42f1dfab4`)
A connection's `auth_key` can be orphaned by a version bump that renames the integration's auth (`primary` → `session`). The lingering row matches no auth in the current manifest, so the spawn resolver can't build a delivery plan — yet it was still a candidate. This desynced two views: the agent connection picker listed the orphaned "Default" while the integration page (iterates manifest auths) showed nothing, and a member/run could pick a connection that silently fails at runtime.

Both candidate paths now exclude connections whose `auth_key` is absent from the integration's current manifest auths:
- `resolveConnections` — filters per-requirement before the cascade, so no layer (pin / override / fallback) selects an orphaned-auth row.
- `resolveAgentIntegrationPick` — same filter on the member picker's candidate list.

## Tests
- `tsc --noEmit` clean.
- `runs-412-missing-connection` (8): + disabled-with-live-connection, + not-installed.
- `integration-connection-resolver` (43): + orphaned-auth drop; fixtures updated (a connection only exists for a declared auth).
- pins-service / spawn-resolver / scope / bundle-import suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)