### PR TITLE
fix(integrations): honour member pins on inert integrations + align picker ok/ko with launch badge

### DIFF
--- a/apps/api/src/services/integration-connection-resolver.ts
+++ b/apps/api/src/services/integration-connection-resolver.ts
@@ -37,6 +37,7 @@ import {
 } from "@appstrate/core/dependencies";
 import {
   missingScopesForConnection,
+  manifestAuthKeySet,
   type IntegrationManifest,
   type ConnectionOverrides,
   type ConnectionResolutionError,
@@ -136,6 +137,15 @@ export interface ResolveConnectionsInput {
    * current actor (drives `ownedByActor` on `insufficient_scopes`).
    */
   actorEndUserId?: string | null;
+  /**
+   * Resolve integrations the agent declared but left INERT (no tools/scopes
+   * selected). The runtime never spawns these, so the run path leaves this
+   * `false` and skips them. The agent-page picker sets it `true`: an inert
+   * integration still has connections to manage and a pin cascade to honour,
+   * so the picker wants the same verdict (and `source`) the cascade produces —
+   * without re-deriving the precedence itself.
+   */
+  includeInert?: boolean;
 }
 
 // ─────────────────────────── Pure resolver (unit-tested) ──────────────────────
@@ -168,8 +178,11 @@ export function resolveConnections(input: ResolveConnectionsInput): ConnectionRe
 
   for (const req of input.requirements) {
     // Inert only when the agent picked neither tools nor scopes. apiCall
-    // integrations expose no tools, so scope selection keeps them active.
-    if (!req.hasSelectedTools && req.agentScopes.length === 0) continue;
+    // integrations expose no tools, so scope selection keeps them active. The
+    // runtime skips inert integrations (never spawned); the picker opts in via
+    // `includeInert` so it gets the same cascade verdict for connections it
+    // still manages.
+    if (!req.hasSelectedTools && req.agentScopes.length === 0 && !input.includeInert) continue;
 
     // Orphaned-auth guard: drop this integration's connections whose `authKey`
     // no longer exists in its CURRENT manifest. A version bump can rename the
@@ -179,15 +192,13 @@ export function resolveConnections(input: ResolveConnectionsInput): ConnectionRe
     // the run auto-picks a connection that silently fails at runtime, and the
     // member picker offers a connection the integration page (which iterates
     // manifest auths) doesn't show. Other integrations' rows pass through
-    // untouched. Empty manifest auths → no constraint (defensive).
-    const manifestAuthKeys = new Set(
-      Object.keys((req.manifest as { auths?: Record<string, unknown> }).auths ?? {}),
-    );
+    // untouched. `null` (manifest absent / zero auths) → no constraint.
+    const liveAuthKeys = manifestAuthKeySet(req.manifest);
     const liveConnections =
-      manifestAuthKeys.size === 0
+      liveAuthKeys === null
         ? input.accessibleConnections
         : input.accessibleConnections.filter(
-            (c) => c.integrationId !== req.integrationId || manifestAuthKeys.has(c.authKey),
+            (c) => c.integrationId !== req.integrationId || liveAuthKeys.has(c.authKey),
           );
     const liveIndex = new Map<string, ConnectionRow>();
     for (const c of liveConnections) liveIndex.set(c.id, c);
@@ -490,6 +501,8 @@ export interface ResolveConnectionsForRunInput {
   scope: AppScope;
   runOverrides?: ConnectionOverrides | null;
   scheduleOverrides?: ConnectionOverrides | null;
+  /** Resolve inert integrations too — see {@link ResolveConnectionsInput.includeInert}. */
+  includeInert?: boolean;
 }
 
 export async function resolveConnectionsForRun(
@@ -525,6 +538,7 @@ export async function resolveConnectionsForRun(
     scheduleOverrides: input.scheduleOverrides ?? null,
     actorUserId,
     actorEndUserId,
+    includeInert: input.includeInert ?? false,
   });
 }
 

--- a/apps/api/src/services/integration-pins-service.ts
+++ b/apps/api/src/services/integration-pins-service.ts
@@ -41,7 +41,11 @@ import type {
   IntegrationPickStatus,
   IntegrationPin,
 } from "@appstrate/shared-types";
-import { missingScopesForConnection } from "@appstrate/core/integration";
+import {
+  missingScopesForConnection,
+  manifestAuthKeySet,
+  type ConnectionResolutionSource,
+} from "@appstrate/core/integration";
 import { parseManifestIntegrations } from "@appstrate/core/dependencies";
 import { conflict, notFound, invalidRequest } from "../lib/errors.ts";
 import type { AppScope } from "../lib/scope.ts";
@@ -599,6 +603,19 @@ async function attachOwnerNames(rows: ConnectionRow[]): Promise<SharedConnection
 // ─────────────────────────── Agent-page picker resolution ─────────────────────
 
 /**
+ * Map a resolver `source` to the picker's status badge. A force layer (admin
+ * pin / enforced org default) reads as `admin_locked`; the actor's own member
+ * pin as `pinned`; every remaining source (override / soft default / fallback)
+ * is an unforced `auto`. Single definition so the `resolved` and the
+ * `insufficient_scopes` branches can't drift on this mapping.
+ */
+function pickStatusForSource(source: ConnectionResolutionSource): IntegrationPickStatus {
+  if (source === "admin_pin" || source === "org_default_enforced") return "admin_locked";
+  if (source === "member_pin") return "pinned";
+  return "auto";
+}
+
+/**
  * The single-source verdict for the agent-page connection picker: which
  * connection the next run would use for this (agent, integration, actor),
  * plus the candidate list and pin/blocked state the dropdown renders.
@@ -649,6 +666,11 @@ export async function resolveAgentIntegrationPick(args: {
         packageId: agentPackageId,
         actor,
         scope: { orgId: scope.orgId, applicationId: scope.applicationId },
+        // The picker manages connections for EVERY declared integration, incl.
+        // inert ones (auth_key but no tools/scopes). Opting in here makes the
+        // cascade honour their pins too — so we reuse its verdict + `source`
+        // rather than re-deriving the precedence in this service.
+        includeInert: true,
       }),
     ],
   );
@@ -661,16 +683,14 @@ export async function resolveAgentIntegrationPick(args: {
   const orgDefaultEnforced = orgDefault?.enforce ?? false;
 
   // Drop orphaned-auth connections: a row whose `auth_key` no longer exists in
-  // the integration's current manifest (e.g. a version bump renamed the auth,
-  // `primary` → `session`) can never be delivered — the spawn resolver matches
-  // a connection to its auth by `authKey`, so an orphaned one yields no
-  // delivery plan. Offering it in the picker desynced the agent dropdown (which
-  // listed it) from the integration page (which iterates manifest auths and so
-  // hid it), and let a member pick a connection that silently fails at runtime.
-  // When the manifest can't be fetched, fall back to no filtering.
-  const manifestAuthKeys = manifest ? new Set(Object.keys(manifest.auths ?? {})) : null;
+  // the integration's current manifest can never be delivered (the spawn
+  // resolver matches connection → auth by `authKey`). Shared `manifestAuthKeySet`
+  // keeps this guard — and its `null` = "no constraint" semantics — identical to
+  // the runtime resolver's, so the picker and the run path can't disagree about
+  // which connections are live.
+  const liveAuthKeys = manifestAuthKeySet(manifest);
   const candidates: IntegrationCandidate[] = candidatesRaw
-    .filter((c) => manifestAuthKeys === null || manifestAuthKeys.has(c.auth_key))
+    .filter((c) => liveAuthKeys === null || liveAuthKeys.has(c.auth_key))
     .map((c) => ({
       ...c,
       missing_scopes: manifest
@@ -696,12 +716,7 @@ export async function resolveAgentIntegrationPick(args: {
 
   if (resolved) {
     resolvedConnectionId = resolved.connectionId;
-    status =
-      resolved.source === "admin_pin" || resolved.source === "org_default_enforced"
-        ? "admin_locked"
-        : resolved.source === "member_pin"
-          ? "pinned"
-          : "auto";
+    status = pickStatusForSource(resolved.source);
     resolvedOwnedByActor = candidates.find((c) => c.id === resolved.connectionId)?.is_own ?? false;
   } else if (err) {
     switch (err.code) {
@@ -709,12 +724,7 @@ export async function resolveAgentIntegrationPick(args: {
         resolvedConnectionId = err.connectionId ?? null;
         resolvedMissingScopes = err.missingScopes ?? [];
         resolvedOwnedByActor = err.ownedByActor ?? false;
-        status =
-          err.source === "admin_pin" || err.source === "org_default_enforced"
-            ? "admin_locked"
-            : err.source === "member_pin"
-              ? "pinned"
-              : "auto";
+        status = err.source ? pickStatusForSource(err.source) : "auto";
         break;
       case "must_choose_connection":
         status = "must_choose";
@@ -730,8 +740,10 @@ export async function resolveAgentIntegrationPick(args: {
         status = "none";
     }
   } else {
-    // Integration is inert (agent picked no tools) — the picker still lists
-    // candidates; mirror the fallback branch so the trigger label is sane.
+    // No verdict at all — only reachable when the integration manifest couldn't
+    // be fetched (buildRequirement returned null, so the resolver never saw it,
+    // `includeInert` notwithstanding). The pin cascade can't run without the
+    // manifest; fall back to a sane label from the candidate count.
     status = candidates.length === 1 ? "auto" : candidates.length === 0 ? "none" : "must_choose";
     if (candidates.length === 1) resolvedConnectionId = candidates[0]!.id;
   }

--- a/apps/api/test/integration/routes/integrations-admin-pins.test.ts
+++ b/apps/api/test/integration/routes/integrations-admin-pins.test.ts
@@ -207,6 +207,75 @@ describe("/api/integrations/:packageId admin surface", () => {
       const res = await app.request(`/api/integrations/${INTEGRATION}/agent-resolution/${AGENT}`);
       expect(res.status).toBe(401);
     });
+
+    // Regression (#576 follow-up): an INERT integration entry (declared with an
+    // auth_key but no tools/scopes) is skipped by the run resolver, so
+    // resolveAgentIntegrationPick falls through to its inert branch. That branch
+    // must still honour the member pin — otherwise a PUT /me/integration-pins
+    // succeeds (200) but the verdict stays "must_choose" and the picker can
+    // never reflect the selection.
+    it("honours the member pin on an INERT integration (no tools/scopes)", async () => {
+      // Inert agent: declares the integration with an auth_key only — no tools,
+      // no scopes — so the run resolver treats it as inert and emits no verdict.
+      const INERT_AGENT = "@adminorg/agent-inert";
+      await seedAgent({
+        id: INERT_AGENT,
+        orgId: ctx.orgId,
+        createdBy: ctx.user.id,
+        draftManifest: {
+          name: INERT_AGENT,
+          version: "1.0.0",
+          type: "agent",
+          schema_version: "0.2",
+          display_name: "Inert Test Agent",
+          dependencies: { integrations: { [INTEGRATION]: "^1.0.0" } },
+          integrations_configuration: { [INTEGRATION]: { auth_key: "primary" } },
+        },
+      });
+      await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, INERT_AGENT);
+
+      // Two accessible connections → ambiguous → must_choose until pinned.
+      const connA = await seedPrivateConnectionFor(ctx.user.id);
+      const connB = await seedSharedConnection();
+
+      const beforeRes = await app.request(
+        `/api/integrations/${INTEGRATION}/agent-resolution/${INERT_AGENT}`,
+        { headers: authHeaders(ctx) },
+      );
+      const before = (await beforeRes.json()) as {
+        status: string;
+        resolved_connection_id: string | null;
+      };
+      expect(before.status).toBe("must_choose");
+      expect(before.resolved_connection_id).toBeNull();
+
+      // Member pins connection B via the same endpoint the picker calls.
+      const pinRes = await app.request("/api/me/integration-pins", {
+        method: "PUT",
+        headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agent_package_id: INERT_AGENT,
+          integration_package_id: INTEGRATION,
+          connection_id: connB,
+        }),
+      });
+      expect(pinRes.status).toBe(200);
+
+      const afterRes = await app.request(
+        `/api/integrations/${INTEGRATION}/agent-resolution/${INERT_AGENT}`,
+        { headers: authHeaders(ctx) },
+      );
+      const after = (await afterRes.json()) as {
+        status: string;
+        resolved_connection_id: string | null;
+        member_pinned_connection_id: string | null;
+      };
+      // The pin must now drive the verdict — not must_choose.
+      expect(after.status).toBe("pinned");
+      expect(after.resolved_connection_id).toBe(connB);
+      expect(after.member_pinned_connection_id).toBe(connB);
+      expect(connA).not.toBe(connB);
+    });
   });
 
   // ─── PUT /:packageId/pins/:agentPackageId (admin org pin) ─

--- a/apps/web/src/components/integration-connect/integration-connection-picker.tsx
+++ b/apps/web/src/components/integration-connect/integration-connection-picker.tsx
@@ -40,6 +40,7 @@ import { FieldsConnectModal } from "./fields-connect-modal";
 import { useIntegrationOAuthPopup } from "./use-integration-oauth-popup";
 import { connectionDisplayLabel } from "./connection-label";
 import { connectableAuthKeys } from "./connectable-auth-keys";
+import { isIntegrationEntryActive, resolutionBlocksRun } from "./integration-run-readiness";
 import { requiredScopesForAgent } from "@appstrate/core/integration";
 import { api } from "../../api";
 
@@ -274,9 +275,21 @@ export function IntegrationConnectionPicker({
   // Warning visuals when there's no usable connection OR the displayed one is
   // under-scoped (run would be blocked). In override mode "no pick" is a valid
   // inherit state, so only the under-scoped case warns.
-  const triggerWarn = overrideMode
-    ? underScoped
-    : status === "must_choose" || status === "stale" || underScoped;
+  //
+  // The trigger paints amber on exactly the states that gate a run — the SAME
+  // predicate (`resolutionBlocksRun`) the launch badge and the 412 modal use,
+  // so the picker can never disagree with the badge for a given integration.
+  //
+  // Gated on `entryActive`: an inert integration (agent selected no tool/scope)
+  // is never spawned at runtime, so it never gates Run — the launch badge skips
+  // it entirely (use-agent-integrations-readiness). A `must_choose` / `stale` /
+  // `none` on an inert entry is a manageable ambiguity, NOT a run-blocking
+  // error, so it stays neutral here too.
+  //
+  // Override mode (schedule editor) keeps its own rule: "no pick" = inherit is
+  // valid, so only the SELECTED override connection being under-scoped warns.
+  const entryActive = isIntegrationEntryActive({ tools: agentTools, scopes: agentScopes });
+  const triggerWarn = overrideMode ? underScoped : entryActive && resolutionBlocksRun(resolution);
   const TriggerIcon = triggerWarn ? AlertTriangle : displayConn ? Users : Plus;
 
   // Blocked for this member AND nothing to pick → dead end. Show a

--- a/apps/web/src/hooks/use-agent-integrations-readiness.ts
+++ b/apps/web/src/hooks/use-agent-integrations-readiness.ts
@@ -5,6 +5,7 @@ import type { AgentIntegrationEntry, IntegrationAgentResolution } from "@appstra
 import { api } from "../api";
 import { useCurrentOrgId } from "./use-org";
 import { useCurrentApplicationId } from "./use-current-application";
+import { agentResolutionQueryKey } from "./use-integrations";
 import {
   isIntegrationEntryActive,
   resolutionBlocksRun,
@@ -43,15 +44,9 @@ export function useAgentIntegrationsReadiness(
 
   const results = useQueries({
     queries: active.map((entry) => ({
-      // Mirror `useIntegrationAgentResolution`'s key verbatim to share its cache.
-      queryKey: [
-        "integrations",
-        orgId ?? undefined,
-        applicationId ?? undefined,
-        "agent-resolution",
-        entry.id,
-        agentPackageId,
-      ] as const,
+      // Shared key builder → same cache entry as `useIntegrationAgentResolution`,
+      // so the badge and the Connexions tab never fetch the verdict twice.
+      queryKey: agentResolutionQueryKey(orgId, applicationId, entry.id, agentPackageId),
       enabled: Boolean(orgId && applicationId && agentPackageId),
       queryFn: () =>
         api<IntegrationAgentResolution>(

--- a/apps/web/src/hooks/use-integrations.ts
+++ b/apps/web/src/hooks/use-integrations.ts
@@ -48,6 +48,21 @@ const KEY = (orgId: string | null | undefined, applicationId: string | null | un
   ["integrations", orgId ?? undefined, applicationId ?? undefined] as const;
 
 /**
+ * React Query key for a (integration, agent) resolution verdict. Exported so
+ * every consumer — the picker hook ({@link useIntegrationAgentResolution}) and
+ * the launch-badge readiness hook (`useAgentIntegrationsReadiness`) — builds it
+ * from ONE place and shares the cache. Hand-copying the key risked a silent
+ * cache split where the badge and the Connexions tab fetch the same verdict
+ * twice and disagree.
+ */
+export const agentResolutionQueryKey = (
+  orgId: string | null | undefined,
+  applicationId: string | null | undefined,
+  integrationId: string | undefined,
+  agentPackageId: string | undefined,
+) => [...KEY(orgId, applicationId), "agent-resolution", integrationId, agentPackageId] as const;
+
+/**
  * Shared request builder for `PATCH /integrations/{packageId}/connections/{id}`.
  *
  * Both the agent-context update (`useUpdateIntegrationConnection`) and the
@@ -130,12 +145,7 @@ export function useIntegrationAgentResolution(
   const orgId = useCurrentOrgId();
   const applicationId = useCurrentApplicationId();
   return useQuery({
-    queryKey: [
-      ...KEY(orgId, applicationId),
-      "agent-resolution",
-      integrationId,
-      agentPackageId,
-    ] as const,
+    queryKey: agentResolutionQueryKey(orgId, applicationId, integrationId, agentPackageId),
     enabled: Boolean(orgId && applicationId && integrationId && agentPackageId),
     queryFn: () =>
       api<IntegrationAgentResolution>(

--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -405,6 +405,26 @@ export function getDeclaredToolNames(manifest: IntegrationManifest): string[] {
 }
 
 /**
+ * The set of auth keys a manifest currently declares — the single source for
+ * the "orphaned-auth" guard. A connection whose `authKey` is not in this set
+ * can never produce a delivery plan (the spawn resolver matches connection →
+ * auth by key), so it must not be offered in the picker nor auto-picked at run
+ * time. Returns `null` when there is NO constraint to apply — either the
+ * manifest is absent/unfetchable, or it declares zero auths — so every caller
+ * treats `null` as "don't filter" and the empty-auths edge can't silently drop
+ * every candidate. Callers keep their own row shape; this owns the key set +
+ * null semantics so the two filter sites (runtime resolver + picker verdict)
+ * can't drift apart.
+ */
+export function manifestAuthKeySet(
+  manifest: IntegrationManifest | null | undefined,
+): Set<string> | null {
+  if (!manifest) return null;
+  const keys = Object.keys(manifest.auths ?? {});
+  return keys.length === 0 ? null : new Set(keys);
+}
+
+/**
  * Tool names referenced as a run-start `connect.tool` across all auths.
  * Auto-hidden from the agent surface — these are credential-acquisition
  * primitives the platform invokes at boot, not agent capabilities.


### PR DESCRIPTION
Closes #578.

## Problème

Deux bugs exposés une fois que PR #576 a rendu le picker de connexion pour **toute** intégration déclarée, y compris **inertes** (`auth_key` sans tools/scopes) :

1. **La sélection ne tient pas.** Le run-resolver saute les intégrations inertes (jamais spawnées), donc `resolveAgentIntegrationPick` tombait dans une branche qui **ignorait le member pin** — `PUT /me/integration-pins` répondait `200` mais le verdict restait `must_choose`, le dropdown bloqué sur « À choisir ».
2. **Détection ok/ko du picker désalignée avec le badge de lancement.** Le badge saute les inertes (`isIntegrationEntryActive`) et bloque sur `resolutionBlocksRun` ; le picker peignait en ambre sur les inertes, et seulement sur un **sous-ensemble** des états bloquants (`none`/`needs_reconnection` omis).

## Correctif

- **`includeInert`** sur `resolveConnections`/`resolveConnectionsForRun` (défaut `false` = runtime intact). Le picker passe `true` → réutilise la **vraie cascade** (et son `source`) au lieu de ré-implémenter la précédence. Supprime la cascade écrite à la main dans le pin service.
- Picker : warn gaté sur `entryActive` + piloté par le **même** `resolutionBlocksRun` que le badge → plus de divergence (inertes ET actives).

## DRY / robustesse

- `pickStatusForSource()` — mapping `source → status` unique (était dupliqué 2-3×).
- `agentResolutionQueryKey()` — clé partagée picker-hook + badge-hook (était copiée « verbatim » → risque cache-split silencieux).
- `manifestAuthKeySet()` dans `@appstrate/core` — garde orphaned-auth partagée resolver + picker. **Corrige un bug latent** : le pin service droppait tous les candidats sur un manifest à 0 auth, alors que le resolver traitait ça comme « pas de contrainte ». Sémantique `null` unifiée.

## Validation

- `tsc --noEmit` core + api + web ✅
- Tests : resolver unit + admin-pins (incl. nouveau test régression inert+pin → `pinned`) + me-pins + pins-service + run-readiness = **89** ✅ · runs **40** (runtime inchangé) ✅
- eslint + prettier ✅

## Hors scope

Source du drift (l'éditeur écrit `auth_key` sans `scopes`) toujours non corrigée — prévention racine séparée (déjà notée dans #576).

🤖 Generated with [Claude Code](https://claude.com/claude-code)