### PR TITLE
test(e2e): read snake_case credential wire fields in pairing lifecycle

### DIFF
--- a/e2e/tests/oauth-model-providers/pairing-lifecycle.api.spec.ts
+++ b/e2e/tests/oauth-model-providers/pairing-lifecycle.api.spec.ts
@@ -24,7 +24,7 @@
  *   6. GET  /model-provider-credentials → new row carries
  *                                 `authMode:"oauth2"`, `source:"custom"`,
  *                                 `providerId:"<provider>"`,
- *                                 `needsReconnection:false`
+ *                                 `needs_reconnection:false`
  *   7. POST /pair/redeem token replay → 410
  *   8. DELETE credential        → 204, gone from the list
  *   9. DELETE /pairing/<bogus>  → 204 idempotent (wrong-id is silent)
@@ -82,8 +82,8 @@ interface CredentialRow {
   authMode: "oauth2" | "api_key";
   source: "built-in" | "custom";
   providerId?: string;
-  needsReconnection?: boolean;
-  oauthEmail?: string | null;
+  needs_reconnection?: boolean;
+  oauth_email?: string | null;
 }
 
 for (const provider of PROVIDER_CASES) {
@@ -179,8 +179,8 @@ for (const provider of PROVIDER_CASES) {
         expect(row?.authMode).toBe("oauth2");
         expect(row?.source).toBe("custom");
         expect(row?.providerId).toBe(provider.id);
-        expect(row?.needsReconnection).toBe(false);
-        expect(row?.oauthEmail).toBe(SYNTHETIC_EMAIL);
+        expect(row?.needs_reconnection).toBe(false);
+        expect(row?.oauth_email).toBe(SYNTHETIC_EMAIL);
 
         // 7. Same bearer cannot be replayed — pairings are single-use.
         const replayBody: Record<string, unknown> = {


### PR DESCRIPTION
## Problem

CI **Test** job (E2E) fails on `pairing-lifecycle.api.spec.ts:182`:

```
expect(row?.needsReconnection).toBe(false)   // Expected: false, received: undefined
```

Failing since #585 for both `codex` and `claude-code` provider cases.

## Root cause

The casing audit in #585 renamed the `/model-provider-credentials` wire JSONB fields to snake_case (per the wire-casing policy):

- `oauthEmail` → `oauth_email`
- `needsReconnection` → `needs_reconnection`

`mapRow` in `apps/api/src/services/model-providers/credentials.ts` emits the snake_case fields. The web reads were updated, but this e2e spec still read the camelCase names → `undefined` at runtime → `toBe(false)` / `toBe(SYNTHETIC_EMAIL)` failed.

## Fix

Align the `CredentialRow` interface and the two assertions with the actual wire shape. No production code change — test-only.

## Verification

- Confirmed `mapRow` emits `needs_reconnection` / `oauth_email`.
- Swept `apps/web/src` + `e2e/` for stray camelCase reads — only i18n keys/comments remain (not wire reads).
- Prettier clean.
- E2E not run locally (needs Docker + live server); change is a mechanical field-name match against confirmed wire output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)