### PR TITLE
fix(api): return 404 for unknown/non-UUID modelId on run (#544)

### DIFF
--- a/apps/api/src/routes/runs-remote.ts
+++ b/apps/api/src/routes/runs-remote.ts
@@ -37,6 +37,7 @@ import { resolveRunnerContext } from "../lib/runner-context.ts";
 import { resolveRegistryAgent } from "../services/registry-run-resolver.ts";
 import { validateConfig, validateInput } from "../services/schema.ts";
 import { validateAgentReadiness } from "../services/agent-readiness.ts";
+import { assertExplicitModelExists } from "../services/org-models.ts";
 import { asJSONSchemaObject } from "@appstrate/core/form";
 import type { LoadedPackage } from "../types/index.ts";
 import type { AppEnv } from "../types/index.ts";
@@ -264,6 +265,11 @@ export function createRunsRemoteRouter() {
           preflight.resolvedDeps,
         );
       }
+
+      // Reject an explicit `modelId` override that references no real model
+      // (system key or org-model UUID) with a clean 404 — both the registry
+      // and inline branches forward the caller's value verbatim.
+      await assertExplicitModelExists(orgId, modelIdOverride);
 
       const runId = `run_${crypto.randomUUID()}`;
       const runner = await resolveRunnerContext(c);

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -24,6 +24,7 @@ import { requireAgent } from "../middleware/guards.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
 import { getOrchestrator } from "../services/orchestrator/index.ts";
 import { prepareAndExecuteRun, resolveRunPreflight } from "../services/run-pipeline.ts";
+import { assertExplicitModelExists } from "../services/org-models.ts";
 import { resolveRunnerContext } from "../lib/runner-context.ts";
 import { getActor } from "../lib/actor.ts";
 import { getAppScope } from "../lib/scope.ts";
@@ -83,6 +84,12 @@ export function createRunsRouter() {
         configOverride,
         connectionOverrides,
       } = inputResult;
+
+      // An explicit per-run `modelId` override must reference a real model
+      // (system key or org-model UUID). Reject unknown/malformed values with a
+      // clean 404 rather than letting them silently fall through to the org
+      // default downstream (or crash the uuid cast — see loadModel).
+      await assertExplicitModelExists(orgId, modelIdOverride);
 
       // Shared preflight: resolve config, validate readiness. Threading
       // `connectionOverrides` here is what makes the

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -19,6 +19,7 @@ import { invalidRequest, notFound, parseBody, validationFailed } from "../lib/er
 import { rateLimit } from "../middleware/rate-limit.ts";
 import { getActor } from "../lib/actor.ts";
 import { getAppScope } from "../lib/scope.ts";
+import { assertExplicitModelExists } from "../services/org-models.ts";
 import { asJSONSchemaObject, schemaHasFileFields } from "@appstrate/core/form";
 import { listScheduleRuns } from "../services/state/runs.ts";
 import { recordAuditFromContext } from "../services/audit.ts";
@@ -118,6 +119,11 @@ export function createSchedulesRouter() {
       }
 
       const scope = getAppScope(c);
+
+      // Reject a `model_id_override` that references no real model up front, so
+      // a bad id fails at schedule-create time instead of silently each tick.
+      await assertExplicitModelExists(scope.orgId, data.model_id_override);
+
       const schedule = await createSchedule(scope, agent.id, actor, {
         name: data.name,
         cronExpression: data.cron_expression,
@@ -169,6 +175,10 @@ export function createSchedulesRouter() {
     if (data.cron_expression && !isValidCron(data.cron_expression)) {
       throw invalidRequest("Invalid cron expression", "cron_expression");
     }
+
+    // Reject a `model_id_override` that references no real model (no-op when
+    // the field isn't part of this patch).
+    await assertExplicitModelExists(scope.orgId, data.model_id_override);
 
     // Translate snake_case wire fields to internal camelCase for the service.
     const schedule = await updateSchedule(scope, id, {

--- a/apps/api/src/services/inline-run.ts
+++ b/apps/api/src/services/inline-run.ts
@@ -22,6 +22,7 @@ import type { Actor } from "../lib/actor.ts";
 import { logger } from "../lib/logger.ts";
 import { runInlinePreflight, type InlineRunBody } from "./inline-run-preflight.ts";
 import { prepareAndExecuteRun } from "./run-pipeline.ts";
+import { assertExplicitModelExists } from "./org-models.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
 
 export type { InlineRunBody };
@@ -153,6 +154,11 @@ export async function triggerInlineRun(params: {
     proxyIdOverride,
     resolvedDeps,
   } = preflight;
+
+  // Reject an unknown/malformed explicit `modelId` with a clean 404 before we
+  // mint a shadow package — avoids both a leaked shadow row and the downstream
+  // uuid-cast crash.
+  await assertExplicitModelExists(orgId, modelIdOverride);
 
   // ----- 2. Insert shadow row (now that we know the manifest is valid). -----
   const createdBy = actor?.type === "user" ? actor.id : null;

--- a/apps/api/src/services/org-models.ts
+++ b/apps/api/src/services/org-models.ts
@@ -8,6 +8,7 @@ import { lookupCatalogModel } from "./pricing-catalog.ts";
 import type { CatalogModelEntry } from "@appstrate/shared-types";
 import type { ModelCost } from "@appstrate/core/module";
 import { logger } from "../lib/logger.ts";
+import { notFound } from "../lib/errors.ts";
 import { isBlockedUrl } from "@appstrate/core/ssrf";
 import { dedupeLabel } from "@appstrate/core/dedupe-label";
 import type { ModelMetadata, OrgModelInfo, TestResult } from "@appstrate/shared-types";
@@ -503,6 +504,30 @@ export async function resolveModel(
   return null;
 }
 
+/**
+ * True when a DB error is Postgres `22P02` (invalid_text_representation) — the
+ * class raised when a non-UUID string is compared against a `uuid` column.
+ * Matches on the SQLSTATE code with a message fallback, and walks the `cause`
+ * chain since Drizzle wraps the driver error in a `DrizzleQueryError`. Covers
+ * both the Tier-0 embedded driver (PGlite) and a real server (postgres.js).
+ */
+function isInvalidTextRepresentation(err: unknown): boolean {
+  let current: unknown = err;
+  for (let depth = 0; current != null && depth < 5; depth++) {
+    if (typeof current === "object") {
+      if ((current as { code?: unknown }).code === "22P02") return true;
+      const message = (current as { message?: unknown }).message;
+      if (typeof message === "string" && message.includes("invalid input syntax for type uuid")) {
+        return true;
+      }
+      current = (current as { cause?: unknown }).cause;
+    } else {
+      break;
+    }
+  }
+  return false;
+}
+
 export async function loadModel(orgId: string, modelDbId: string): Promise<ResolvedModel | null> {
   // Check system models first
   const system = getSystemModels();
@@ -511,22 +536,35 @@ export async function loadModel(orgId: string, modelDbId: string): Promise<Resol
     return buildSystemResolvedModel(systemDef);
   }
 
-  // Check DB
-  const [row] = await db
-    .select({
-      modelId: orgModels.modelId,
-      credentialId: orgModels.credentialId,
-      enabled: orgModels.enabled,
-      label: orgModels.label,
-      input: orgModels.input,
-      contextWindow: orgModels.contextWindow,
-      maxTokens: orgModels.maxTokens,
-      reasoning: orgModels.reasoning,
-      cost: orgModels.cost,
-    })
-    .from(orgModels)
-    .where(scopedWhere(orgModels, { orgId, extra: [eq(orgModels.id, modelDbId)] }))
-    .limit(1);
+  // Check DB. `orgModels.id` is a `uuid` column — a `modelDbId` that isn't a
+  // valid UUID (e.g. a human-readable model name like `gpt-5.5`) makes Postgres
+  // raise `invalid input syntax for type uuid` rather than returning no rows.
+  // Normalise that one cast failure into "not found" (null) so callers see a
+  // clean 4xx instead of a 500; rethrow any other error (e.g. a real DB outage)
+  // rather than masking it as a missing model. Same hazard handled in
+  // `llm-proxy/core.ts`.
+  let row: (DbOrgModelRow & { enabled: boolean }) | undefined;
+  try {
+    [row] = await db
+      .select({
+        modelId: orgModels.modelId,
+        credentialId: orgModels.credentialId,
+        enabled: orgModels.enabled,
+        label: orgModels.label,
+        input: orgModels.input,
+        contextWindow: orgModels.contextWindow,
+        maxTokens: orgModels.maxTokens,
+        reasoning: orgModels.reasoning,
+        cost: orgModels.cost,
+      })
+      .from(orgModels)
+      .where(scopedWhere(orgModels, { orgId, extra: [eq(orgModels.id, modelDbId)] }))
+      .limit(1);
+  } catch (err) {
+    // `22P02` = invalid_text_representation (the uuid cast failure).
+    if (isInvalidTextRepresentation(err)) return null;
+    throw err;
+  }
 
   if (!row || !row.enabled) return null;
 
@@ -534,6 +572,30 @@ export async function loadModel(orgId: string, modelDbId: string): Promise<Resol
   if (!creds) return null;
 
   return buildDbResolvedModel(row, creds);
+}
+
+/**
+ * Validate an explicit, caller-supplied `modelId` (run body / schedule row).
+ *
+ * `loadModel` resolves both system-model keys and org-model UUIDs, returning
+ * null for anything else (including non-UUID strings, which it now swallows
+ * rather than letting Postgres throw). A null here means the caller referenced
+ * a model that doesn't exist — surface a deterministic 404 with a helpful
+ * message instead of silently falling through to the org default (which is the
+ * intended graceful behaviour only for persisted agent-column pins resolved via
+ * {@link resolveModel}).
+ *
+ * No-op when `modelId` is null/undefined (no explicit override supplied).
+ */
+export async function assertExplicitModelExists(
+  orgId: string,
+  modelId: string | null | undefined,
+): Promise<void> {
+  if (!modelId) return;
+  const model = await loadModel(orgId, modelId);
+  if (!model) {
+    throw notFound(`Model '${modelId}' not found — expected a model UUID or a system model key`);
+  }
 }
 
 // --- Connection test ---

--- a/apps/api/test/integration/routes/runs.test.ts
+++ b/apps/api/test/integration/routes/runs.test.ts
@@ -196,6 +196,63 @@ describe("Runs API", () => {
     });
   });
 
+  // ─── POST /api/agents/:scope/:name/run — modelId override ──
+  //
+  // Regression for #544: an explicit, caller-supplied `modelId` that is not a
+  // real model reference must produce a clean 404, not an unhandled 500. A
+  // non-UUID value (e.g. a human-readable model name) used to reach the
+  // `org_models.id` uuid column and make Postgres raise
+  // `invalid input syntax for type uuid`, which bubbled up as a 500.
+  describe("POST /api/agents/:scope/:name/run — modelId override", () => {
+    async function seedNoInputAgent() {
+      await seedAgent({
+        id: "@runorg/model-agent",
+        orgId: ctx.orgId,
+        createdBy: ctx.user.id,
+        draftManifest: {
+          name: "@runorg/model-agent",
+          version: "0.1.0",
+          type: "agent",
+          description: "Agent without input schema",
+        },
+        draftContent: "Do the thing.",
+      });
+      await installPackage(
+        { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+        "@runorg/model-agent",
+      );
+    }
+
+    it("returns 404 (not 500) for a non-UUID modelId", async () => {
+      await seedNoInputAgent();
+
+      const res = await app.request("/api/agents/@runorg/model-agent/run", {
+        method: "POST",
+        headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+        body: JSON.stringify({ input: {}, modelId: "gpt-5.5" }),
+      });
+
+      expect(res.status).toBe(404);
+      const body = (await res.json()) as { detail?: string };
+      expect(body.detail).toContain("gpt-5.5");
+    });
+
+    it("returns 404 for a well-formed but unknown modelId UUID", async () => {
+      await seedNoInputAgent();
+
+      const res = await app.request("/api/agents/@runorg/model-agent/run", {
+        method: "POST",
+        headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+        body: JSON.stringify({
+          input: {},
+          modelId: "5af6e114-c264-479d-8c13-ed981b96e972",
+        }),
+      });
+
+      expect(res.status).toBe(404);
+    });
+  });
+
   // ─── GET /api/agents/:scope/:name/runs ─────────────────────
 
   describe("GET /api/agents/:scope/:name/runs", () => {

--- a/apps/api/test/integration/services/org-models-pricing-catalog.test.ts
+++ b/apps/api/test/integration/services/org-models-pricing-catalog.test.ts
@@ -119,4 +119,13 @@ describe("loadModel — vendored pricing catalog fallback (#437 phase 2)", () =>
     expect(resolved!.input).toContain("text");
     expect(resolved!.reasoning === false || resolved!.reasoning === null).toBe(true);
   });
+
+  // Regression for #544: `org_models.id` is a uuid column. A non-UUID id (e.g.
+  // a human-readable model name) used to make Postgres throw
+  // `invalid input syntax for type uuid`, surfacing as a 500. loadModel now
+  // swallows the cast failure and resolves null ("not found").
+  it("returns null (no throw) for a non-UUID modelDbId", async () => {
+    const resolved = await loadModel(ctx.orgId, "gpt-5.5");
+    expect(resolved).toBeNull();
+  });
 });


### PR DESCRIPTION
Closes #544.

## Problem
Starting a run with an explicit `modelId` that isn't a valid model reference (e.g. a human-readable name like `gpt-5.5`) returned **HTTP 500**. The value reached the `org_models.id` `uuid` column and Postgres raised `invalid input syntax for type uuid`, which bubbled up unhandled.

## Fix (two parts)

**1. Harden `loadModel` (`services/org-models.ts`)** — the actual 500 source.
Catch the `22P02` (`invalid_text_representation`) cast failure and resolve `null` ("not found") instead of letting it throw. Any *other* DB error is rethrown so a real outage isn't masked as "model missing". Walks the `cause` chain since Drizzle wraps the driver error in a `DrizzleQueryError`. This removes the 500 for **every** caller (run, scheduler, llm-proxy, …) — same hazard already handled in `llm-proxy/core.ts`.

**2. Clean 4xx for an explicit override** — new `assertExplicitModelExists()`.
`loadModel` returning null would otherwise *silently fall through to the org default* (intended graceful behaviour for persisted agent-column pins, via `resolveModel`). To give the caller the deterministic feedback the issue asks for, validate the **caller-supplied** `modelId` at the layers where "explicit" is known and throw `notFound` (404) with a helpful message when it resolves to nothing. Wired into:
- `POST /api/agents/:scope/:name/run` (`routes/runs.ts`)
- remote run route (`routes/runs-remote.ts`) — registry + inline branches
- inline run (`services/inline-run.ts`) — before the shadow package is minted
- schedule create + update (`routes/schedules.ts`) — fails at config time, not silently each tick

The graceful fallback for persisted pins is intentionally left untouched.

## Tests
- `routes/runs.test.ts`: run returns **404 (not 500)** for a non-UUID `modelId`, and for a well-formed-but-unknown UUID.
- `services/org-models-pricing-catalog.test.ts`: `loadModel` resolves `null` without throwing on a non-UUID id.

All affected suites green (Tier-0 / PGlite): runs, runs-remote, inline-run, schedules, llm-proxy, models. `tsc`, eslint, prettier clean on changed files.

## Decisions
- **404 over 400**: the body already passed Zod; this is a missing *reference*, not a malformed body.
- **Strictness scope**: an explicit override that doesn't resolve now hard-404s (including a deleted-but-well-formed UUID) — matches the issue's "treat non-matching as not found". `resolveModel`'s fallback for persisted agent-column pins is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)