### PR TITLE
fix(integrations): decouple runner egress from credential injection (#543)

### DIFF
--- a/apps/api/src/services/integration-spawn-resolver.ts
+++ b/apps/api/src/services/integration-spawn-resolver.ts
@@ -420,6 +420,10 @@ async function resolveOne(
     ...(deliveries.fileMounts && Object.keys(deliveries.fileMounts).length > 0
       ? { fileMounts: deliveries.fileMounts }
       : {}),
+    // Issue #543 — explicit egress signal for no-injection local runners.
+    // The sidecar mounts a plain CONNECT egress listener when this is set and
+    // no injection plan exists. Dropped for remote HTTP (no runner to route).
+    ...(deliveries.needsEgress && !isRemoteHttp ? { needsEgress: true } : {}),
     // Opt-in shared workspace mount declared on the referenced
     // mcp-server. Only emitted for local sources — remote and
     // serverless integrations have no runner container/process to
@@ -479,6 +483,14 @@ interface ResolvedDeliveries {
    * onto `IntegrationSpawnSpec.connectLogin`.
    */
   connectLogin?: NonNullable<IntegrationSpawnSpec["connectLogin"]>;
+  /**
+   * Issue #543 — `true` when this local-source runner needs a controlled
+   * egress route but no header injection (a `delivery.env` auth that declares
+   * an outbound surface). The sidecar mounts a plain CONNECT egress listener
+   * for it. Never set for `mtls` (reaches upstream directly) or non-local
+   * sources. `resolveOne` copies this onto `IntegrationSpawnSpec.needsEgress`.
+   */
+  needsEgress?: boolean;
 }
 
 /**
@@ -803,54 +815,36 @@ async function resolveDeliveries(
     }
   }
 
-  // ─── egress route for env-delivery local runners (no header injection) ───
+  // ─── egress signal for local runners (decoupled from injection, #543) ───
   // A local-source runner sits on the per-run network (`internal: true` in
-  // docker mode) with NO direct egress; its only route out is the
-  // per-integration MITM listener. A `delivery.http` integration gets that
-  // listener for free (its injection plan mounts one). A `delivery.env`
-  // integration (the server holds its own credentials and authenticates
-  // itself, e.g. a form/session login) resolves no injection plan, so without
-  // this it gets no listener — and no way out. Emit a forward-only
-  // `httpDeliveryAuths` entry (empty injection plan) purely to mount the
-  // listener, giving the runner its egress route. It injects NOTHING (empty
-  // headerName → the planner skips injection); the env credentials are
-  // delivered separately via `spawnEnv`. Mirrors the run-start connect.tool
-  // placeholder above.
+  // docker mode) with NO direct egress; its only route out is a
+  // per-integration listener the sidecar mounts and hands it as `HTTPS_PROXY`.
   //
-  // Note on scope: the MITM is NOT an `authorized_uris` allowlist — it forwards
-  // to any external host and only hard-blocks internal/cloud-metadata targets
-  // (SSRF floor, enforced at CONNECT in integration-mitm-listener.ts). In the
-  // delivery path `authorized_uris` scopes which auth's credential gets
-  // injected, not which hosts are reachable; we carry it through verbatim
-  // (harmless when empty or `allow_all_uris`, since this entry injects nothing).
+  // Egress and credential injection are orthogonal concerns. A `delivery.http`
+  // integration gets its egress route from the MITM listener its injection
+  // plan (`httpDeliveryAuths`) already mounts. A `delivery.env` integration
+  // (the server authenticates itself, e.g. a form/session login) resolves NO
+  // injection plan — so we raise an explicit `needsEgress` flag and the
+  // sidecar mounts a plain CONNECT egress listener for it (tunnel + SSRF
+  // floor, NO TLS termination, NO cert mint). The env credentials are
+  // delivered separately via `spawnEnv`.
   //
-  // Restricted to `delivery.env`, and NEVER `mtls`: the MITM terminates upstream
-  // TLS, so routing an mtls client-cert handshake through it would break it
-  // (same reason `mtls + delivery.http` is rejected at install) —
-  // `delivery.files`/mtls runners must reach upstream directly. Skipped when an
-  // http plan already mounted the listener, when nothing resolved, or when the
-  // integration declares no outbound surface.
+  // NEVER for `mtls`: routing a client-cert handshake through a proxy that
+  // terminates TLS would break it (same reason `mtls + delivery.http` is
+  // rejected at install) — `delivery.files`/mtls runners reach upstream
+  // directly. We set the flag for any non-mtls local runner that declares an
+  // outbound surface; when an http injection plan is ALSO present the sidecar
+  // picks the MITM listener (which already provides egress) — `needsEgress`
+  // is the fallback, decided MITM-first in `integrations-boot.ts`.
+  //
+  // Scope note: the egress listener is NOT an `authorized_uris` allowlist
+  // today — it forwards to any external host and only hard-blocks
+  // internal/cloud-metadata targets (SSRF floor). Turning `authorized_uris`
+  // into a hard per-integration egress allowlist is a separate, deliberate
+  // security decision (see #543); the listener seam accepts it when we choose.
   const isLocalSource = getIntegrationSourceKind(manifest) === "local";
-  const usesEnvDelivery = !!auth.delivery?.env && Object.keys(auth.delivery.env).length > 0;
   const declaresEgress = (auth.authorized_uris?.length ?? 0) > 0 || auth.allow_all_uris === true;
-  if (
-    isLocalSource &&
-    resolvedAtLeastOne &&
-    usesEnvDelivery &&
-    auth.type !== "mtls" &&
-    Object.keys(httpDeliveryAuths).length === 0 &&
-    declaresEgress
-  ) {
-    httpDeliveryAuths[row.authKey] = {
-      headerName: "",
-      headerPrefix: "",
-      value: "",
-      allowServerOverride: false,
-      authType: auth.type,
-      authorizedUris: [...(auth.authorized_uris ?? [])],
-      expiresAtEpochMs: null,
-    };
-  }
+  const needsEgress = isLocalSource && resolvedAtLeastOne && auth.type !== "mtls" && declaresEgress;
 
   // apiCall integrations stay viable on a resolved connection alone — a
   // `custom` auth resolves no delivery plan but the credential fields are
@@ -860,5 +854,6 @@ async function resolveDeliveries(
     spawnEnv,
     ...(Object.keys(httpDeliveryAuths).length > 0 ? { httpDeliveryAuths } : {}),
     ...(Object.keys(fileMounts).length > 0 ? { fileMounts } : {}),
+    ...(needsEgress ? { needsEgress: true } : {}),
   };
 }

--- a/apps/api/test/integration/services/integration-spawn-resolver-env-egress.test.ts
+++ b/apps/api/test/integration/services/integration-spawn-resolver-env-egress.test.ts
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Spawn resolver — env-delivery egress gate.
+ * Spawn resolver — env-delivery egress signal (#543).
  *
  * A `delivery.env` local-source integration (the server holds its own
  * credentials and authenticates itself — e.g. a form/session login) sits on
- * the per-run network with no direct egress in docker mode. Its only route out
- * is the per-integration MITM listener, which a `delivery.env` auth wouldn't
- * otherwise mount (it resolves no injection plan). The resolver must emit a
- * forward-only `httpDeliveryAuths` entry (empty injection plan, carrying
- * `authorizedUris`) purely to mount that listener — the runner's egress route.
- * It injects NOTHING (the env credentials are delivered separately via
- * `spawnEnv`); the MITM's SSRF floor is the hard egress boundary, not
- * `authorized_uris` (which only scopes credential injection in the delivery path).
+ * the per-run network with no direct egress in docker mode. It resolves NO
+ * injection plan, so the resolver raises an explicit `needsEgress` flag and
+ * the sidecar mounts a plain CONNECT egress listener for it (tunnel + SSRF
+ * floor, no TLS termination, no cert mint). It must NOT emit a fake
+ * `httpDeliveryAuths` entry (the pre-#543 presence-token workaround). The env
+ * credentials are delivered separately via `spawnEnv`.
  */
 
 import { describe, it, expect, beforeEach } from "bun:test";
@@ -106,7 +104,7 @@ async function seedAll(ctx: TestContext, manifest: Record<string, unknown>) {
   });
 }
 
-describe("resolveIntegrationSpawns — env-delivery egress gate", () => {
+describe("resolveIntegrationSpawns — env-delivery egress signal (#543)", () => {
   let ctx: TestContext;
 
   beforeEach(async () => {
@@ -114,7 +112,7 @@ describe("resolveIntegrationSpawns — env-delivery egress gate", () => {
     ctx = await createTestContext({ orgSlug: "orga" });
   });
 
-  it("mounts a forward-only egress listener (empty plan + authorizedUris) and delivers env creds", async () => {
+  it("raises needsEgress (no fake httpDeliveryAuths) and delivers env creds", async () => {
     await seedAll(ctx, integManifest());
 
     const specs = await resolveIntegrationSpawns({
@@ -132,16 +130,13 @@ describe("resolveIntegrationSpawns — env-delivery egress gate", () => {
       CRM_PASSWORD: "secret",
     });
 
-    // Forward-only egress entry mounts the MITM listener without injecting.
-    expect(spec.httpDeliveryAuths).toBeDefined();
-    const plan = spec.httpDeliveryAuths!.session;
-    expect(plan).toBeDefined();
-    expect(plan!.headerName).toBe(""); // empty plan → planner injects nothing
-    expect(plan!.value).toBe("");
-    expect(plan!.authorizedUris).toEqual(["https://crm.example.com/**"]);
+    // The runner gets an explicit egress signal — and NO fake injection plan.
+    // The sidecar mounts a plain CONNECT egress listener off `needsEgress`.
+    expect(spec.needsEgress).toBe(true);
+    expect(spec.httpDeliveryAuths).toBeUndefined();
   });
 
-  it("also gates an allow_all_uris env integration", async () => {
+  it("also signals egress for an allow_all_uris env integration", async () => {
     await seedAll(ctx, integManifest({ allowAllUris: true }));
 
     const specs = await resolveIntegrationSpawns({
@@ -150,7 +145,7 @@ describe("resolveIntegrationSpawns — env-delivery egress gate", () => {
       agentManifest: agentManifest(),
     });
     const spec = specs[0]!;
-    expect(spec.httpDeliveryAuths?.session).toBeDefined();
-    expect(spec.httpDeliveryAuths!.session!.headerName).toBe("");
+    expect(spec.needsEgress).toBe(true);
+    expect(spec.httpDeliveryAuths).toBeUndefined();
   });
 });

--- a/packages/core/src/sidecar-types.ts
+++ b/packages/core/src/sidecar-types.ts
@@ -334,6 +334,28 @@ export interface IntegrationSpawnSpec {
    */
   httpDeliveryAuths?: Record<string, HttpDeliveryAuthSpec>;
   /**
+   * Explicit egress signal — `true` when this local-source runner needs a
+   * controlled outbound route but NO header injection. A local runner sits on
+   * the per-run network (`internal: true` in docker mode) with no direct
+   * egress; its only way out is a per-integration listener the sidecar mounts
+   * and hands the runner as `HTTPS_PROXY`.
+   *
+   * Egress is orthogonal to credential injection (issue #543). A
+   * `delivery.http` integration gets its egress route from the MITM listener
+   * its injection plan already mounts ({@link httpDeliveryAuths}). A
+   * `delivery.env` integration (the server authenticates itself, e.g. a
+   * form/session login) resolves NO injection plan — this flag tells the
+   * sidecar to mount a plain CONNECT egress listener (tunnel + SSRF floor, no
+   * TLS termination, no cert mint) so the runner can reach upstream.
+   *
+   * Never set for `mtls` (the runner must reach upstream directly so the
+   * client-cert handshake is not terminated) nor for non-local sources
+   * (remote MCP / serverless have no runner). When both this and a non-empty
+   * {@link httpDeliveryAuths} are present, the MITM listener wins and provides
+   * egress — the sidecar picks ONE listener per integration, MITM-first.
+   */
+  needsEgress?: boolean;
+  /**
    * R8a defensive filter — names from `manifest.hidden_tools` (AFPS
    * §3.4 / `integration.schema.json`). Install-time validation already
    * subtracts these from the agent's tool catalog via

--- a/runtime-pi/sidecar/connect-tunnel.ts
+++ b/runtime-pi/sidecar/connect-tunnel.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared HTTP CONNECT-tunnel primitives.
+ *
+ * Both the agent's shared {@link createForwardProxy} (port 8081) and the
+ * per-integration plain egress listener ({@link createIntegrationEgressListener},
+ * issue #543) terminate the same `CONNECT host:port` preamble, apply the same
+ * SSRF floor, and then blind-relay raw TCP both directions. This module holds
+ * the mechanical parts they share so there is ONE implementation of target
+ * parsing, connect-with-timeout, and bidirectional relay — the SSRF policy and
+ * any upstream-proxy chaining stay in each caller (they differ).
+ */
+
+import { connect as netConnect } from "node:net";
+import type { Socket } from "node:net";
+
+/** Idle window after which a relayed tunnel is torn down (no data flowing). */
+export const TUNNEL_IDLE_TIMEOUT_MS = 120_000; // 2 min
+/** Max time to wait for the upstream TCP connection to establish. */
+export const TUNNEL_CONNECT_TIMEOUT_MS = 10_000;
+
+/**
+ * Parse a CONNECT target (`host:port`, IPv6 `[::1]:443`, or bare `host`).
+ * Returns `null` on a malformed target (empty host / missing `]`). Port
+ * defaults to 443 when absent or unparseable.
+ */
+export function parseConnectTarget(target: string): { host: string; port: number } | null {
+  let host: string;
+  let port: number;
+  if (target.startsWith("[")) {
+    const closeBracket = target.indexOf("]");
+    if (closeBracket === -1) return null;
+    host = target.slice(1, closeBracket);
+    const rest = target.slice(closeBracket + 1);
+    port = rest.startsWith(":") ? parseInt(rest.slice(1)) || 443 : 443;
+  } else {
+    const colonIdx = target.lastIndexOf(":");
+    if (colonIdx === -1) {
+      host = target;
+      port = 443;
+    } else {
+      host = target.slice(0, colonIdx);
+      port = parseInt(target.slice(colonIdx + 1)) || 443;
+    }
+  }
+  if (!host) return null;
+  return { host, port };
+}
+
+/**
+ * `net.connect` with a connect-establishment timeout — destroys the socket
+ * (surfacing an error) if the TCP handshake doesn't complete in time.
+ */
+export function netConnectWithTimeout(
+  port: number,
+  host: string,
+  onConnect: () => void,
+  timeoutMs = TUNNEL_CONNECT_TIMEOUT_MS,
+): Socket {
+  const socket = netConnect(port, host, () => {
+    clearTimeout(timer);
+    onConnect();
+  });
+  const timer = setTimeout(() => {
+    socket.destroy(new Error(`Connect timeout after ${timeoutMs}ms to ${host}:${port}`));
+  }, timeoutMs);
+  socket.on("close", () => clearTimeout(timer));
+  return socket;
+}
+
+/**
+ * Blind bidirectional relay between two sockets, with an idle timeout and
+ * mutual teardown on error/close. Used after a CONNECT tunnel is established.
+ */
+export function relaySockets(s1: Socket, s2: Socket, idleMs = TUNNEL_IDLE_TIMEOUT_MS): void {
+  s1.pipe(s2);
+  s2.pipe(s1);
+  s1.setTimeout(idleMs, () => s1.destroy());
+  s2.setTimeout(idleMs, () => s2.destroy());
+  s1.on("error", () => s2.destroy());
+  s2.on("error", () => s1.destroy());
+  s1.on("close", () => {
+    if (!s2.destroyed) s2.destroy();
+  });
+  s2.on("close", () => {
+    if (!s1.destroyed) s1.destroy();
+  });
+}

--- a/runtime-pi/sidecar/forward-proxy.ts
+++ b/runtime-pi/sidecar/forward-proxy.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createServer as createHttpServer, request as httpRequest } from "node:http";
-import { connect as netConnect } from "node:net";
 import type { Socket } from "node:net";
 import type { IncomingMessage, ServerResponse, Server as HttpServer } from "node:http";
 import {
@@ -10,6 +9,12 @@ import {
   HOP_BY_HOP_HEADERS,
   type SidecarConfig,
 } from "./helpers.ts";
+import {
+  parseConnectTarget,
+  netConnectWithTimeout,
+  relaySockets,
+  TUNNEL_IDLE_TIMEOUT_MS,
+} from "./connect-tunnel.ts";
 import { logger } from "./logger.ts";
 
 export interface ForwardProxyDeps {
@@ -32,8 +37,6 @@ export function createForwardProxy(deps: ForwardProxyDeps): ForwardProxyResult {
   const listenHost = deps.listenHost ?? "0.0.0.0";
   const isBlockedHostFn = deps.isBlockedHostFn ?? isBlockedHost;
 
-  const CONNECT_TIMEOUT_MS = 10_000;
-  const SOCKET_IDLE_TIMEOUT_MS = 120_000; // 2 min idle → destroy tunnel
   const MAX_CONNECT_HEADER_SIZE = 16_384; // 16 KB — CONNECT response headers should be tiny
 
   function getUpstreamProxy(
@@ -77,25 +80,10 @@ export function createForwardProxy(deps: ForwardProxyDeps): ForwardProxyResult {
     }
   }
 
-  function relay(s1: Socket, s2: Socket): void {
-    s1.pipe(s2);
-    s2.pipe(s1);
-    // Idle timeout — destroys both sides if no data flows for SOCKET_IDLE_TIMEOUT_MS
-    s1.setTimeout(SOCKET_IDLE_TIMEOUT_MS, () => {
-      s1.destroy();
-    });
-    s2.setTimeout(SOCKET_IDLE_TIMEOUT_MS, () => {
-      s2.destroy();
-    });
-    s1.on("error", () => s2.destroy());
-    s2.on("error", () => s1.destroy());
-    s1.on("close", () => {
-      if (!s2.destroyed) s2.destroy();
-    });
-    s2.on("close", () => {
-      if (!s1.destroyed) s1.destroy();
-    });
-  }
+  // Tunnel parsing / connect-with-timeout / relay live in connect-tunnel.ts —
+  // shared verbatim with the per-integration egress listener (#543). Local
+  // alias keeps the call sites below unchanged.
+  const relay = (s1: Socket, s2: Socket) => relaySockets(s1, s2, TUNNEL_IDLE_TIMEOUT_MS);
 
   /** Strip hop-by-hop headers + Connection-listed headers from incoming request. */
   function forwardHeaders(
@@ -116,19 +104,6 @@ export function createForwardProxy(deps: ForwardProxyDeps): ForwardProxyResult {
       out[key] = value;
     }
     return out;
-  }
-
-  /** Connect with a timeout — destroys the socket if it doesn't connect in time. */
-  function netConnectWithTimeout(port: number, host: string, onConnect: () => void): Socket {
-    const socket = netConnect(port, host, () => {
-      clearTimeout(timer);
-      onConnect();
-    });
-    const timer = setTimeout(() => {
-      socket.destroy(new Error(`Connect timeout after ${CONNECT_TIMEOUT_MS}ms to ${host}:${port}`));
-    }, CONNECT_TIMEOUT_MS);
-    socket.on("close", () => clearTimeout(timer));
-    return socket;
   }
 
   // The platform API is a trusted destination: the agent can only send
@@ -234,34 +209,13 @@ export function createForwardProxy(deps: ForwardProxyDeps): ForwardProxyResult {
     const target = req.url ?? "";
 
     // Parse host:port — handles IPv6 bracket notation ([::1]:443)
-    let host: string;
-    let port: number;
-    if (target.startsWith("[")) {
-      const closeBracket = target.indexOf("]");
-      if (closeBracket === -1) {
-        clientSocket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
-        clientSocket.destroy();
-        return;
-      }
-      host = target.slice(1, closeBracket);
-      const rest = target.slice(closeBracket + 1);
-      port = rest.startsWith(":") ? parseInt(rest.slice(1)) || 443 : 443;
-    } else {
-      const colonIdx = target.lastIndexOf(":");
-      if (colonIdx === -1) {
-        host = target;
-        port = 443;
-      } else {
-        host = target.slice(0, colonIdx);
-        port = parseInt(target.slice(colonIdx + 1)) || 443;
-      }
-    }
-
-    if (!host) {
+    const parsedTarget = parseConnectTarget(target);
+    if (!parsedTarget) {
       clientSocket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
       clientSocket.destroy();
       return;
     }
+    const { host, port } = parsedTarget;
 
     // SSRF protection — block CONNECT tunnels to internal/private networks,
     // except the trusted platform API (handles local-dev host.docker.internal).

--- a/runtime-pi/sidecar/integration-egress-listener.ts
+++ b/runtime-pi/sidecar/integration-egress-listener.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Per-integration PLAIN CONNECT egress listener (issue #543).
+ *
+ * A local-source runner sits on the per-run network (`internal: true` in
+ * docker mode) with no direct egress. When the integration injects a
+ * credential header it gets a TLS-terminating MITM listener
+ * ({@link createIntegrationMitmListener}) which doubles as its egress route.
+ * When it injects NOTHING (a `delivery.env` auth — the server authenticates
+ * itself, e.g. a form/session login) it only needs a way OUT, not a proxy
+ * that opens its TLS. This listener is that way out:
+ *
+ *   - terminates the `CONNECT host:port` preamble,
+ *   - applies the SSRF floor at CONNECT (the ONLY hard boundary — internal /
+ *     cloud-metadata targets are refused before any tunnel opens),
+ *   - blind-relays raw TCP both directions (NO TLS termination, NO per-SNI
+ *     cert mint, NO header injection).
+ *
+ * It deliberately mirrors the MITM listener's {@link MitmListenerHandle}
+ * surface (`ready` / `address` / `proxyUrl` / `close`) so `integrations-boot`
+ * collects and tears down both listener kinds uniformly. CONNECT-only, exactly
+ * like the MITM listener (which 405s plain HTTP) — env-delivery runners
+ * previously routed through MITM, so HTTPS-only egress is unchanged behaviour.
+ *
+ * Egress is intentionally open to any external host today; turning
+ * `authorizedUris` into a hard per-integration allowlist is a separate,
+ * deliberate security decision (#543). The param is accepted now so that
+ * enforcement, if adopted, lands here at CONNECT.
+ */
+
+import { createServer as netCreateServer } from "node:net";
+import type { Socket } from "node:net";
+
+import { isBlockedHost } from "./helpers.ts";
+import { parseConnectTarget, netConnectWithTimeout, relaySockets } from "./connect-tunnel.ts";
+import type { MitmListenerHandle } from "./integration-mitm-listener.ts";
+
+export interface EgressListenerEvent {
+  kind: "tunnel-opened" | "tunnel-refused" | "tunnel-error";
+  /** `host:port` target of the CONNECT (never carries a path / query). */
+  target: string;
+  /** Populated for `tunnel-refused` (SSRF / allowlist) and `tunnel-error`. */
+  reason?: string;
+}
+
+export interface CreateEgressListenerOptions {
+  /** Bind host — adapter-chosen (0.0.0.0 bridged / 127.0.0.1 shared NS). */
+  host?: string;
+  /** Telemetry sink (host:port + outcome only — never request contents). */
+  onEvent?: (event: EgressListenerEvent) => void;
+  /** Injectable SSRF predicate (tests pass a permissive stub). */
+  isBlockedHostFn?: typeof isBlockedHost;
+  /**
+   * Optional hard egress allowlist (#543 follow-up). When provided, a CONNECT
+   * whose host matches NONE of the patterns is refused. `undefined` (default)
+   * leaves egress SSRF-floored-open — today's behaviour. The matcher is
+   * supplied by the caller to avoid coupling this transport file to the
+   * URI-pattern grammar.
+   */
+  authorizedHostMatcher?: (host: string) => boolean;
+}
+
+/**
+ * Create a per-integration plain CONNECT egress listener on an ephemeral port.
+ * Returns a {@link MitmListenerHandle}-shaped handle for uniform lifecycle
+ * management alongside MITM listeners.
+ */
+export function createIntegrationEgressListener(
+  options: CreateEgressListenerOptions = {},
+): MitmListenerHandle {
+  const host = options.host ?? "127.0.0.1";
+  const isBlockedHostFn = options.isBlockedHostFn ?? isBlockedHost;
+  const emit = options.onEvent ?? (() => {});
+  const matcher = options.authorizedHostMatcher;
+
+  const server = netCreateServer();
+
+  server.on("connection", (clientSocket: Socket) => {
+    // The kernel hands us a raw TCP socket; we must read the CONNECT preamble
+    // ourselves (net.Server has no `connect` event — that's http.Server).
+    clientSocket.once("data", (chunk: Buffer) => {
+      const preamble = chunk.toString("latin1");
+      const firstLine = preamble.slice(0, preamble.indexOf("\r\n"));
+      const match = /^CONNECT\s+(\S+)\s+HTTP\/1\.[01]$/i.exec(firstLine);
+      if (!match) {
+        clientSocket.write("HTTP/1.1 405 Method Not Allowed\r\n\r\n");
+        clientSocket.destroy();
+        return;
+      }
+      const target = match[1] ?? "";
+      const parsed = parseConnectTarget(target);
+      if (!parsed) {
+        clientSocket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
+        clientSocket.destroy();
+        return;
+      }
+      const { host: targetHost, port } = parsed;
+
+      // SSRF floor — the hard boundary. Refuse internal / cloud-metadata
+      // targets before opening any tunnel.
+      if (isBlockedHostFn(targetHost.toLowerCase())) {
+        emit({ kind: "tunnel-refused", target, reason: "ssrf" });
+        clientSocket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
+        clientSocket.destroy();
+        return;
+      }
+
+      // Optional hard egress allowlist (#543 follow-up; no-op by default).
+      if (matcher && !matcher(targetHost.toLowerCase())) {
+        emit({ kind: "tunnel-refused", target, reason: "not-authorized" });
+        clientSocket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
+        clientSocket.destroy();
+        return;
+      }
+
+      const upstream = netConnectWithTimeout(port, targetHost, () => {
+        clientSocket.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+        emit({ kind: "tunnel-opened", target });
+        relaySockets(clientSocket, upstream);
+      });
+      upstream.on("error", (err: Error) => {
+        emit({ kind: "tunnel-error", target, reason: err.message });
+        clientSocket.destroy();
+      });
+      clientSocket.on("error", () => upstream.destroy());
+    });
+    clientSocket.on("error", () => clientSocket.destroy());
+  });
+
+  let readyResolve!: () => void;
+  const ready = new Promise<void>((res) => {
+    readyResolve = res;
+  });
+  // Ephemeral port (0 → kernel-assigned, read back via address() after ready).
+  server.listen(0, host, () => readyResolve());
+
+  const addr = () => {
+    const a = server.address();
+    return a && typeof a === "object" ? { host: a.address, port: a.port } : { host, port: 0 };
+  };
+
+  return {
+    ready,
+    address: addr,
+    proxyUrl() {
+      const a = addr();
+      return `http://${a.host}:${a.port}`;
+    },
+    close() {
+      return new Promise<void>((res) => server.close(() => res()));
+    },
+  };
+}

--- a/runtime-pi/sidecar/integration-egress-listener.ts
+++ b/runtime-pi/sidecar/integration-egress-listener.ts
@@ -78,10 +78,27 @@ export function createIntegrationEgressListener(
 
   server.on("connection", (clientSocket: Socket) => {
     // The kernel hands us a raw TCP socket; we must read the CONNECT preamble
-    // ourselves (net.Server has no `connect` event — that's http.Server).
-    clientSocket.once("data", (chunk: Buffer) => {
-      const preamble = chunk.toString("latin1");
-      const firstLine = preamble.slice(0, preamble.indexOf("\r\n"));
+    // ourselves (net.Server has no `connect` event — that's http.Server). The
+    // request line can be split across TCP segments, so accumulate until the
+    // first CRLF instead of assuming it arrives in one chunk; cap the buffer so
+    // a peer that never sends a CRLF can't grow it unbounded. Headers after the
+    // request line are ignored (we tunnel, not inspect); a well-behaved CONNECT
+    // client waits for the 200 before sending tunnel bytes, so none are lost.
+    const MAX_PREAMBLE_BYTES = 8_192;
+    let preamble = "";
+    const onData = (chunk: Buffer) => {
+      preamble += chunk.toString("latin1");
+      const lineEnd = preamble.indexOf("\r\n");
+      if (lineEnd === -1) {
+        if (preamble.length > MAX_PREAMBLE_BYTES) {
+          clientSocket.off("data", onData);
+          clientSocket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
+          clientSocket.destroy();
+        }
+        return; // request line not complete yet — await more segments
+      }
+      clientSocket.off("data", onData);
+      const firstLine = preamble.slice(0, lineEnd);
       const match = /^CONNECT\s+(\S+)\s+HTTP\/1\.[01]$/i.exec(firstLine);
       if (!match) {
         clientSocket.write("HTTP/1.1 405 Method Not Allowed\r\n\r\n");
@@ -124,7 +141,8 @@ export function createIntegrationEgressListener(
         clientSocket.destroy();
       });
       clientSocket.on("error", () => upstream.destroy());
-    });
+    };
+    clientSocket.on("data", onData);
     clientSocket.on("error", () => clientSocket.destroy());
   });
 

--- a/runtime-pi/sidecar/integration-runtime-adapter-docker.ts
+++ b/runtime-pi/sidecar/integration-runtime-adapter-docker.ts
@@ -20,7 +20,8 @@ import { SubprocessTransport } from "@appstrate/mcp-transport";
 import { logger } from "./logger.ts";
 import type { IntegrationSpawnSpec } from "./integrations-boot.ts";
 import {
-  buildMitmEnvBlock,
+  buildProxyEnvBlock,
+  buildCaEnvBlock,
   isPathSafeForMount,
   registerIntegrationRuntimeAdapter,
   resolveBundleEntry,
@@ -367,7 +368,7 @@ export function createDockerIntegrationRuntimeAdapter(): IntegrationRuntimeAdapt
     },
 
     async spawn(options: SpawnIntegrationOptions): Promise<SpawnedIntegration> {
-      const { runId, spec, bundleRoot, mitm, workspaceHandle, onStderrLine } = options;
+      const { runId, spec, bundleRoot, egress, workspaceHandle, onStderrLine } = options;
       const plan = planContainer(spec, bundleRoot);
       const safeNs = spec.namespace.replace(/[^a-zA-Z0-9_-]+/g, "_").replace(/^_+|_+$/g, "");
       const containerName = `appstrate-integ-${safeNs}-${runId.slice(0, 8)}-${Date.now()}`;
@@ -376,9 +377,17 @@ export function createDockerIntegrationRuntimeAdapter(): IntegrationRuntimeAdapt
       for (const [k, v] of Object.entries(spec.spawnEnv)) {
         envFlags.push("-e", `${k}=${v}`);
       }
-      if (mitm) {
-        for (const [k, v] of Object.entries(buildMitmEnvBlock(mitm.proxyUrl, CA_CONTAINER_PATH))) {
+      if (egress) {
+        // Proxy routing for BOTH listener kinds (MITM + plain CONNECT).
+        for (const [k, v] of Object.entries(buildProxyEnvBlock(egress.proxyUrl))) {
           envFlags.push("-e", `${k}=${v}`);
+        }
+        // CA trust ONLY for a TLS-terminating MITM listener; a plain CONNECT
+        // egress listener has a null caCertHostPath → no CA env, no cert mint.
+        if (egress.caCertHostPath !== null) {
+          for (const [k, v] of Object.entries(buildCaEnvBlock(CA_CONTAINER_PATH))) {
+            envFlags.push("-e", `${k}=${v}`);
+          }
         }
       }
 
@@ -458,8 +467,11 @@ export function createDockerIntegrationRuntimeAdapter(): IntegrationRuntimeAdapt
       // the runner image as the WORKDIR), so the runner's entrypoint
       // sees `/bundle/server/index.js` at the path the manifest declared.
       await dockerExec(["cp", `${bundleRoot}/.`, `${containerId}:/bundle/`]);
-      if (mitm) {
-        await dockerExec(["cp", mitm.caCertHostPath, `${containerId}:${CA_CONTAINER_PATH}`]);
+      // Deliver the run CA only for a TLS-terminating MITM listener. A plain
+      // CONNECT egress listener does not terminate TLS, so the runner needs no
+      // extra CA (null caCertHostPath).
+      if (egress && egress.caCertHostPath !== null) {
+        await dockerExec(["cp", egress.caCertHostPath, `${containerId}:${CA_CONTAINER_PATH}`]);
       }
 
       // AFPS §7.6 (CC-5) — materialise `delivery.files` entries into

--- a/runtime-pi/sidecar/integration-runtime-adapter-process.ts
+++ b/runtime-pi/sidecar/integration-runtime-adapter-process.ts
@@ -21,7 +21,8 @@ import { SubprocessTransport } from "@appstrate/mcp-transport";
 import { logger } from "./logger.ts";
 import type { IntegrationSpawnSpec } from "./integrations-boot.ts";
 import {
-  buildMitmEnvBlock,
+  buildProxyEnvBlock,
+  buildCaEnvBlock,
   isPathSafeForMount,
   registerIntegrationRuntimeAdapter,
   resolveBundleEntry,
@@ -213,13 +214,18 @@ export function createProcessIntegrationRuntimeAdapter(): IntegrationRuntimeAdap
     },
 
     async spawn(options: SpawnIntegrationOptions): Promise<SpawnedIntegration> {
-      const { runId, spec, bundleRoot, mitm, workspaceHandle, onStderrLine } = options;
+      const { runId, spec, bundleRoot, egress, workspaceHandle, onStderrLine } = options;
       const plan = planSubprocess(spec, bundleRoot);
       const procEnv: Record<string, string> = { ...spec.spawnEnv };
-      if (mitm) {
-        // Subprocess sees the host fs directly; pass the CA path through
-        // unchanged (no docker cp).
-        Object.assign(procEnv, buildMitmEnvBlock(mitm.proxyUrl, mitm.caCertHostPath));
+      if (egress) {
+        // Proxy routing for BOTH listener kinds (MITM + plain CONNECT).
+        Object.assign(procEnv, buildProxyEnvBlock(egress.proxyUrl));
+        // CA trust ONLY for a TLS-terminating MITM listener. Subprocess sees
+        // the host fs directly; pass the CA path through unchanged (no docker
+        // cp). A plain CONNECT egress listener has a null caCertHostPath.
+        if (egress.caCertHostPath !== null) {
+          Object.assign(procEnv, buildCaEnvBlock(egress.caCertHostPath));
+        }
       }
       // Per-run shared workspace exposure for the subprocess. Unlike
       // docker mode (which bind-mounts a volume), the subprocess just

--- a/runtime-pi/sidecar/integration-runtime-adapter.ts
+++ b/runtime-pi/sidecar/integration-runtime-adapter.ts
@@ -45,15 +45,27 @@ export interface RuntimeAdapterRunContext {
 }
 
 /**
- * Per-integration MITM context the adapter must wire into the runner
- * (env vars + CA file delivery). `null` means env-delivery only (no
- * MITM listener was spawned for this integration's auths).
+ * Per-integration egress context the adapter wires into the runner (proxy
+ * env vars + optional CA file delivery). `null` means the runner gets no
+ * egress route (mtls / `delivery.files` runners reach upstream directly).
+ *
+ * Egress is decoupled from credential injection (#543). `caCertHostPath`
+ * discriminates the listener kind:
+ *   - non-null → a MITM listener (TLS terminate + inject) is in front; the
+ *     runner must trust the run CA, so the adapter copies the PEM in and sets
+ *     the CA env block.
+ *   - null → a plain CONNECT egress listener (tunnel + SSRF floor, no TLS
+ *     termination); no CA needed, so the adapter sets only the proxy env block.
  */
-export interface RuntimeMitmContext {
+export interface RuntimeEgressContext {
   /** Full HTTPS_PROXY URL the runner targets (e.g. `http://sidecar:39472`). */
   readonly proxyUrl: string;
-  /** Absolute path on the sidecar's fs to the run-CA PEM file. */
-  readonly caCertHostPath: string;
+  /**
+   * Absolute path on the sidecar's fs to the run-CA PEM file when a
+   * TLS-terminating MITM listener is in front; `null` for a plain CONNECT
+   * egress listener (no TLS termination → the runner needs no extra CA).
+   */
+  readonly caCertHostPath: string | null;
 }
 
 export interface SpawnIntegrationOptions {
@@ -61,8 +73,13 @@ export interface SpawnIntegrationOptions {
   readonly spec: IntegrationSpawnSpec;
   /** Absolute path on the sidecar's fs to the extracted bundle root. */
   readonly bundleRoot: string;
-  /** MITM context (proxy URL + CA file path). `null` = env-delivery only. */
-  readonly mitm: RuntimeMitmContext | null;
+  /**
+   * Egress context (proxy URL + optional CA file path). `null` = no egress
+   * route (mtls / `delivery.files` reach upstream directly). A non-null
+   * `caCertHostPath` signals a TLS-terminating MITM listener; `null` signals
+   * a plain CONNECT egress listener.
+   */
+  readonly egress: RuntimeEgressContext | null;
   /**
    * Per-run shared workspace handle decoded from the sidecar's
    * `WORKSPACE_HANDLE_JSON` env var. Adapters mount/expose it under
@@ -237,26 +254,14 @@ export function isPathSafeForMount(
 }
 
 /**
- * Build the standard MITM-proxy env block. Adapters call this with the
- * proxy URL the runner targets and the path the CA cert lands at inside
- * the runner's filesystem (the path differs by adapter — Docker copies
- * the cert into the container's `/tmp/appstrate-ca.pem`; the process
- * adapter passes the host path directly because the subprocess shares
- * the parent's fs).
- *
- * Names are the standardised conventions honoured by Node (via
- * undici-style dispatchers + NODE_TLS_REJECT_UNAUTHORIZED), Python
- * (requests / httpx / urllib via REQUESTS_CA_BUNDLE / SSL_CERT_FILE),
- * curl (CURL_CA_BUNDLE), and git (GIT_SSL_CAINFO — git wraps libcurl
- * but uses its OWN env var, ignoring CURL_CA_BUNDLE/SSL_CERT_FILE).
- * Without GIT_SSL_CAINFO a mcp-server that shells out to `git`
- * (clone/fetch/push over HTTPS) sees `SSL certificate problem: unable
- * to get local issuer certificate` even with the MITM proxy reachable.
+ * Proxy-routing half of the egress env block — points every standard
+ * `HTTP(S)_PROXY` var at the per-integration listener. Always applied when an
+ * egress context is present, for BOTH listener kinds (MITM and plain CONNECT),
+ * because routing the runner's traffic out is orthogonal to whether the proxy
+ * terminates TLS. The CA half ({@link buildCaEnvBlock}) is layered on top only
+ * for the MITM kind.
  */
-export function buildMitmEnvBlock(
-  proxyUrl: string,
-  caCertPathInRuntime: string,
-): Record<string, string> {
+export function buildProxyEnvBlock(proxyUrl: string): Record<string, string> {
   return {
     HTTPS_PROXY: proxyUrl,
     HTTP_PROXY: proxyUrl,
@@ -264,6 +269,26 @@ export function buildMitmEnvBlock(
     http_proxy: proxyUrl,
     NO_PROXY: "127.0.0.1,localhost",
     no_proxy: "127.0.0.1,localhost",
+  };
+}
+
+/**
+ * CA-trust half of the egress env block — only needed when a TLS-terminating
+ * MITM listener is in front, so the runner trusts the per-SNI leaf certs it
+ * mints. A plain CONNECT egress listener does NOT terminate TLS, so no extra
+ * CA is required and this block is skipped (no cert mint, no `docker cp`).
+ *
+ * Names are the standardised conventions honoured by Node
+ * (NODE_EXTRA_CA_CERTS), Python (requests / httpx / urllib via
+ * REQUESTS_CA_BUNDLE / SSL_CERT_FILE), curl (CURL_CA_BUNDLE), and git
+ * (GIT_SSL_CAINFO — git wraps libcurl but uses its OWN env var, ignoring
+ * CURL_CA_BUNDLE/SSL_CERT_FILE). Without GIT_SSL_CAINFO a mcp-server that
+ * shells out to `git` (clone/fetch/push over HTTPS) sees `SSL certificate
+ * problem: unable to get local issuer certificate` even with the proxy
+ * reachable.
+ */
+export function buildCaEnvBlock(caCertPathInRuntime: string): Record<string, string> {
+  return {
     NODE_EXTRA_CA_CERTS: caCertPathInRuntime,
     SSL_CERT_FILE: caCertPathInRuntime,
     REQUESTS_CA_BUNDLE: caCertPathInRuntime,

--- a/runtime-pi/sidecar/integrations-boot.ts
+++ b/runtime-pi/sidecar/integrations-boot.ts
@@ -58,6 +58,7 @@ import {
   createIntegrationMitmListener,
   type MitmListenerHandle,
 } from "./integration-mitm-listener.ts";
+import { createIntegrationEgressListener } from "./integration-egress-listener.ts";
 import {
   createIntegrationCredentialsSource,
   fetchInitialIntegrationCredentials,
@@ -74,7 +75,7 @@ import {
   selectIntegrationRuntimeAdapter,
   type IntegrationRuntimeAdapter,
   type RuntimeAdapterRunContext,
-  type RuntimeMitmContext,
+  type RuntimeEgressContext,
 } from "./integration-runtime-adapter.ts";
 // Side-effect imports — each adapter module registers itself on load.
 // New adapters (firecracker, podman, …) plug in with one more import here.
@@ -658,6 +659,13 @@ async function spawnAndConnectLocalIntegration(params: {
   workspaceHandle: WorkspaceHandle | null;
   /** Front this integration with a MITM listener (also needs `ca` + `source`). */
   wantsMitm: boolean;
+  /**
+   * Issue #543 — the runner needs a controlled egress route but no header
+   * injection (a `delivery.env` auth declaring an outbound surface). When set
+   * and `wantsMitm` is false, mount a plain CONNECT egress listener. MITM
+   * wins when both are set (it already provides egress).
+   */
+  wantsEgress: boolean;
   /** Allowlist for `host.register`. `[]` exposes nothing (connect-run). */
   allowedTools: readonly string[] | undefined;
   /**
@@ -676,12 +684,17 @@ async function spawnAndConnectLocalIntegration(params: {
 }): Promise<SpawnAndConnectResult> {
   const { spec, runId, adapter, adapterCtx, host, bundleFetchOpts, ca, logLabel } = params;
 
-  let mitmCtx: RuntimeMitmContext | null = null;
-  // The listener is mounted only when this integration wants MITM, a CA came
-  // up, AND the caller hoisted a source. When mounted, the shared `source` is
-  // what the connect-login hook drives — surfaced back to the caller as
-  // `mitmSource` (kept null when no listener exists, so the hook's "MITM
-  // required" guard still fires on a CA-bring-up failure).
+  // One listener per integration, picked MITM-first (#543). `egressCtx` is
+  // handed to the adapter as the runner's HTTPS_PROXY:
+  //   - MITM listener   → caCertHostPath set (TLS terminate + inject).
+  //   - plain CONNECT    → caCertHostPath null (tunnel + SSRF floor only).
+  //   - neither          → null (mtls / delivery.files reach upstream directly).
+  let egressCtx: RuntimeEgressContext | null = null;
+  // The MITM listener is mounted only when this integration wants MITM, a CA
+  // came up, AND the caller hoisted a source. When mounted, the shared
+  // `source` is what the connect-login hook drives — surfaced back to the
+  // caller as `mitmSource` (kept null when no listener exists, so the hook's
+  // "MITM required" guard still fires on a CA-bring-up failure).
   let mitmMounted = false;
   if (params.wantsMitm && ca !== null && params.source !== null) {
     const source = params.source;
@@ -723,11 +736,30 @@ async function spawnAndConnectLocalIntegration(params: {
     params.mitmListeners.push(listener);
     mitmMounted = true;
     const port = listener.address().port;
-    mitmCtx = { proxyUrl: adapterCtx.proxyUrlFor(port), caCertHostPath: ca.certHostPath };
+    egressCtx = { proxyUrl: adapterCtx.proxyUrlFor(port), caCertHostPath: ca.certHostPath };
     logger.info(`${logLabel} MITM listener ready`, {
       integrationId: spec.integrationId,
       localUrl: listener.proxyUrl(),
-      runnerProxyUrl: mitmCtx.proxyUrl,
+      runnerProxyUrl: egressCtx.proxyUrl,
+    });
+  } else if (params.wantsEgress) {
+    // No injection plan, but the runner declares an outbound surface — give it
+    // a plain CONNECT egress route (tunnel + SSRF floor, NO TLS termination,
+    // NO cert mint). `caCertHostPath: null` tells the adapter to skip the CA
+    // env block + cert delivery.
+    const listener = createIntegrationEgressListener({
+      host: adapterCtx.listenerBindHost,
+      onEvent: (event) =>
+        logger.info(`${logLabel} egress event`, { integrationId: spec.integrationId, ...event }),
+    });
+    await listener.ready;
+    params.mitmListeners.push(listener);
+    const port = listener.address().port;
+    egressCtx = { proxyUrl: adapterCtx.proxyUrlFor(port), caCertHostPath: null };
+    logger.info(`${logLabel} egress listener ready`, {
+      integrationId: spec.integrationId,
+      localUrl: listener.proxyUrl(),
+      runnerProxyUrl: egressCtx.proxyUrl,
     });
   }
 
@@ -744,7 +776,7 @@ async function spawnAndConnectLocalIntegration(params: {
     runId,
     spec,
     bundleRoot: root,
-    mitm: mitmCtx,
+    egress: egressCtx,
     workspaceHandle: params.workspaceHandle,
     onStderrLine: (line) => {
       logger.info(`${logLabel} integration stderr`, { integrationId: spec.integrationId, line });
@@ -1241,9 +1273,12 @@ export async function bootIntegrations(
       // MITM is created only when the CA came up AND this integration declared
       // `delivery.http`. `mitmSource` is returned so the connect-login hook
       // (run-start acquisition, below) drives `setSessionOutputs` on the same
-      // source the MITM listener reads from.
+      // source the MITM listener reads from. `wantsEgress` (#543) is the
+      // fallback: a no-injection runner that still needs an outbound route gets
+      // a plain CONNECT egress listener instead.
       const wantsMitm =
         spec.httpDeliveryAuths !== undefined && Object.keys(spec.httpDeliveryAuths).length > 0;
+      const wantsEgress = spec.needsEgress === true;
       const {
         allocatedNs,
         mitmSource,
@@ -1262,6 +1297,7 @@ export async function bootIntegrations(
         ca: runCa,
         workspaceHandle,
         wantsMitm,
+        wantsEgress,
         allowedTools: spec.toolAllowlist,
         // R8a — propagate `hidden_tools` so the host filters them out at
         // runtime, regardless of whether install-time validation removed them.
@@ -1508,6 +1544,9 @@ export async function runConnectOnce(
       // regardless of the launching orchestrator's env.
       workspaceHandle: null,
       wantsMitm: true,
+      // connect-run always mounts the MITM listener (it provides egress too),
+      // so the plain-egress fallback never applies here.
+      wantsEgress: false,
       allowedTools: [],
       logLabel: "connect-run",
       clients,

--- a/runtime-pi/sidecar/test/integration-egress-listener.test.ts
+++ b/runtime-pi/sidecar/test/integration-egress-listener.test.ts
@@ -155,6 +155,53 @@ describe("integration-egress-listener (#543)", () => {
     expect(statusCode).toBe(405);
   });
 
+  it("relays when the CONNECT request line is split across TCP segments", async () => {
+    const echo = await startTcpEcho();
+    const { handle, events } = await makeListener();
+    const port = handle.address().port;
+    const target = `127.0.0.1:${echo.port}`;
+
+    const res = await new Promise<{ statusCode: number; echoed: string }>((resolve, reject) => {
+      const socket = netConnect(port, "127.0.0.1", () => {
+        // Fragment the request line itself across two writes — the verb lands
+        // in one segment, the rest (incl. the CRLF) in the next.
+        socket.write("CONN");
+        setTimeout(() => socket.write(`ECT ${target} HTTP/1.1\r\nHost: ${target}\r\n\r\n`), 20);
+      });
+      let phase: "header" | "tunnel" = "header";
+      let buf = "";
+      let echoed = "";
+      let statusCode = 0;
+      socket.on("data", (chunk) => {
+        if (phase === "header") {
+          buf += chunk.toString("latin1");
+          const end = buf.indexOf("\r\n\r\n");
+          if (end === -1) return;
+          statusCode = parseInt(buf.split(" ")[1] ?? "0");
+          if (statusCode !== 200) {
+            socket.destroy();
+            resolve({ statusCode, echoed });
+            return;
+          }
+          phase = "tunnel";
+          socket.write("ping");
+        } else {
+          echoed += chunk.toString();
+          if (echoed.length >= 4) {
+            socket.destroy();
+            resolve({ statusCode, echoed });
+          }
+        }
+      });
+      socket.on("error", reject);
+      setTimeout(() => reject(new Error("CONNECT timeout")), 5000);
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.echoed).toBe("ping");
+    expect(events.some((e) => e.kind === "tunnel-opened")).toBe(true);
+  });
+
   it("enforces the optional hard allowlist when supplied", async () => {
     const echo = await startTcpEcho();
     const { handle, events } = await makeListener({

--- a/runtime-pi/sidecar/test/integration-egress-listener.test.ts
+++ b/runtime-pi/sidecar/test/integration-egress-listener.test.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Plain CONNECT egress listener (#543).
+ *
+ * Proves the no-injection egress path: a CONNECT tunnel to an allowed host
+ * relays raw bytes (NO TLS termination, NO cert mint), the SSRF floor refuses
+ * internal / cloud-metadata targets, non-CONNECT verbs are rejected, and the
+ * optional hard allowlist (follow-up seam) gates by host when supplied.
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { createServer as netCreateServer, connect as netConnect } from "node:net";
+import type { Server as NetServer } from "node:net";
+
+import {
+  createIntegrationEgressListener,
+  type EgressListenerEvent,
+} from "../integration-egress-listener.ts";
+import type { MitmListenerHandle } from "../integration-mitm-listener.ts";
+
+const listeners: MitmListenerHandle[] = [];
+const tcpServers: NetServer[] = [];
+
+afterEach(async () => {
+  await Promise.all(listeners.map((l) => l.close().catch(() => {})));
+  listeners.length = 0;
+  await Promise.all(tcpServers.map((s) => new Promise<void>((res) => s.close(() => res()))));
+  tcpServers.length = 0;
+});
+
+/** A raw TCP echo server — stands in for an upstream the runner tunnels to. */
+function startTcpEcho(): Promise<{ port: number }> {
+  return new Promise((resolve) => {
+    const server = netCreateServer((socket) => {
+      socket.on("data", (chunk) => socket.write(chunk));
+      socket.on("error", () => socket.destroy());
+    });
+    tcpServers.push(server);
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      resolve({ port: typeof addr === "object" && addr ? addr.port : 0 });
+    });
+  });
+}
+
+function makeListener(
+  overrides: Parameters<typeof createIntegrationEgressListener>[0] = {},
+): Promise<{ handle: MitmListenerHandle; events: EgressListenerEvent[] }> {
+  const events: EgressListenerEvent[] = [];
+  const handle = createIntegrationEgressListener({
+    host: "127.0.0.1",
+    // Allow loopback by default so the echo server is reachable in tests.
+    isBlockedHostFn: () => false,
+    onEvent: (e) => events.push(e),
+    ...overrides,
+  });
+  listeners.push(handle);
+  return handle.ready.then(() => ({ handle, events }));
+}
+
+/**
+ * Open a CONNECT tunnel through the listener. Resolves with the status line
+ * and, if the tunnel established, the echo round-trip of `probe`.
+ */
+function connectAndProbe(
+  proxyPort: number,
+  target: string,
+  probe?: string,
+): Promise<{ statusCode: number; echoed?: string }> {
+  return new Promise((resolve, reject) => {
+    const socket = netConnect(proxyPort, "127.0.0.1", () => {
+      socket.write(`CONNECT ${target} HTTP/1.1\r\nHost: ${target}\r\n\r\n`);
+    });
+    let phase: "header" | "tunnel" = "header";
+    let buf = "";
+    let echoed = "";
+    let statusCode = 0;
+    socket.on("data", (chunk) => {
+      if (phase === "header") {
+        buf += chunk.toString("latin1");
+        const end = buf.indexOf("\r\n\r\n");
+        if (end === -1) return;
+        statusCode = parseInt(buf.split(" ")[1] ?? "0");
+        if (statusCode !== 200 || !probe) {
+          socket.destroy();
+          resolve({ statusCode });
+          return;
+        }
+        phase = "tunnel";
+        socket.write(probe);
+      } else {
+        echoed += chunk.toString();
+        if (echoed.length >= (probe?.length ?? 0)) {
+          socket.destroy();
+          resolve({ statusCode, echoed });
+        }
+      }
+    });
+    socket.on("error", reject);
+    setTimeout(() => {
+      socket.destroy();
+      reject(new Error("CONNECT timeout"));
+    }, 5000);
+  });
+}
+
+describe("integration-egress-listener (#543)", () => {
+  it("relays a CONNECT tunnel to an allowed host (no TLS termination)", async () => {
+    const echo = await startTcpEcho();
+    const { handle, events } = await makeListener();
+    const port = handle.address().port;
+
+    const res = await connectAndProbe(port, `127.0.0.1:${echo.port}`, "ping");
+    expect(res.statusCode).toBe(200);
+    expect(res.echoed).toBe("ping");
+    expect(events.some((e) => e.kind === "tunnel-opened")).toBe(true);
+  });
+
+  it("refuses an SSRF target at CONNECT (cloud metadata)", async () => {
+    // Use the REAL SSRF predicate for this one.
+    const { handle, events } = await makeListener({ isBlockedHostFn: undefined });
+    const port = handle.address().port;
+
+    const res = await connectAndProbe(port, "169.254.169.254:80");
+    expect(res.statusCode).toBe(403);
+    expect(events.some((e) => e.kind === "tunnel-refused" && e.reason === "ssrf")).toBe(true);
+  });
+
+  it("refuses RFC1918 at CONNECT with the real SSRF floor", async () => {
+    const { handle } = await makeListener({ isBlockedHostFn: undefined });
+    const port = handle.address().port;
+    const res = await connectAndProbe(port, "10.0.0.5:443");
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("rejects non-CONNECT verbs with 405", async () => {
+    const { handle } = await makeListener();
+    const port = handle.address().port;
+    const statusCode = await new Promise<number>((resolve, reject) => {
+      const socket = netConnect(port, "127.0.0.1", () => {
+        socket.write("GET http://example.com/ HTTP/1.1\r\nHost: example.com\r\n\r\n");
+      });
+      let buf = "";
+      socket.on("data", (chunk) => {
+        buf += chunk.toString();
+        if (buf.includes("\r\n\r\n")) {
+          socket.destroy();
+          resolve(parseInt(buf.split(" ")[1] ?? "0"));
+        }
+      });
+      socket.on("error", reject);
+      setTimeout(() => reject(new Error("timeout")), 3000);
+    });
+    expect(statusCode).toBe(405);
+  });
+
+  it("enforces the optional hard allowlist when supplied", async () => {
+    const echo = await startTcpEcho();
+    const { handle, events } = await makeListener({
+      authorizedHostMatcher: (h) => h === "allowed.example.com",
+    });
+    const port = handle.address().port;
+
+    // 127.0.0.1 passes the (stubbed) SSRF floor but fails the allowlist.
+    const res = await connectAndProbe(port, `127.0.0.1:${echo.port}`);
+    expect(res.statusCode).toBe(403);
+    expect(events.some((e) => e.kind === "tunnel-refused" && e.reason === "not-authorized")).toBe(
+      true,
+    );
+  });
+});

--- a/runtime-pi/sidecar/test/integration-runtime-adapter-select.test.ts
+++ b/runtime-pi/sidecar/test/integration-runtime-adapter-select.test.ts
@@ -17,7 +17,8 @@ import { describe, it, expect } from "bun:test";
 import {
   registerIntegrationRuntimeAdapter,
   selectIntegrationRuntimeAdapter,
-  buildMitmEnvBlock,
+  buildProxyEnvBlock,
+  buildCaEnvBlock,
   type IntegrationRuntimeAdapter,
 } from "../integration-runtime-adapter.ts";
 
@@ -86,11 +87,10 @@ describe("selectIntegrationRuntimeAdapter", () => {
   });
 });
 
-describe("buildMitmEnvBlock", () => {
-  it("returns the standard proxy + CA trust-store env shape", () => {
+describe("buildProxyEnvBlock", () => {
+  it("returns ONLY the proxy-routing env vars (no CA — #543 split)", () => {
     const proxyUrl = "http://sidecar:39472";
-    const caPath = "/tmp/appstrate-ca.pem";
-    const env = buildMitmEnvBlock(proxyUrl, caPath);
+    const env = buildProxyEnvBlock(proxyUrl);
 
     expect(env).toEqual({
       HTTPS_PROXY: proxyUrl,
@@ -99,17 +99,30 @@ describe("buildMitmEnvBlock", () => {
       http_proxy: proxyUrl,
       NO_PROXY: "127.0.0.1,localhost",
       no_proxy: "127.0.0.1,localhost",
+    });
+    // The CA trust vars must NOT leak into the proxy half — a plain CONNECT
+    // egress listener uses this block alone, with no cert mint.
+    expect(env.NODE_EXTRA_CA_CERTS).toBeUndefined();
+  });
+});
+
+describe("buildCaEnvBlock", () => {
+  it("returns ONLY the CA trust-store env vars (MITM half)", () => {
+    const caPath = "/tmp/appstrate-ca.pem";
+    const env = buildCaEnvBlock(caPath);
+
+    expect(env).toEqual({
       NODE_EXTRA_CA_CERTS: caPath,
       SSL_CERT_FILE: caPath,
       REQUESTS_CA_BUNDLE: caPath,
       CURL_CA_BUNDLE: caPath,
       GIT_SSL_CAINFO: caPath,
     });
+    expect(env.HTTPS_PROXY).toBeUndefined();
   });
 
-  it("threads distinct proxy + CA paths through unchanged", () => {
-    const env = buildMitmEnvBlock("http://127.0.0.1:8080", "/host/path/ca.pem");
-    expect(env.HTTPS_PROXY).toBe("http://127.0.0.1:8080");
+  it("threads the CA path through unchanged", () => {
+    const env = buildCaEnvBlock("/host/path/ca.pem");
     expect(env.NODE_EXTRA_CA_CERTS).toBe("/host/path/ca.pem");
     expect(env.REQUESTS_CA_BUNDLE).toBe("/host/path/ca.pem");
   });

--- a/runtime-pi/sidecar/test/integration-runtime-adapter-workspace.test.ts
+++ b/runtime-pi/sidecar/test/integration-runtime-adapter-workspace.test.ts
@@ -75,7 +75,7 @@ describe("process adapter — workspace env propagation", () => {
         workspaceMount: { mount: "/workspace", access: "rw" },
       }),
       bundleRoot,
-      mitm: null,
+      egress: null,
       workspaceHandle: { kind: "directory", path: workspacePath },
       onStderrLine: () => {},
     });
@@ -110,7 +110,7 @@ describe("process adapter — workspace env propagation", () => {
         workspaceMount: { mount: "/workspace", access: "rw" },
       }),
       bundleRoot,
-      mitm: null,
+      egress: null,
       workspaceHandle: null, // Orchestrator carried no handle.
       onStderrLine: () => {},
     });
@@ -139,7 +139,7 @@ describe("process adapter — workspace env propagation", () => {
       runId: "run-3",
       spec: baseSpec(), // no workspaceMount
       bundleRoot,
-      mitm: null,
+      egress: null,
       workspaceHandle: { kind: "directory", path: workspacePath },
       onStderrLine: () => {},
     });


### PR DESCRIPTION
Closes #543.

## Problem

A local-source integration runner sits on the per-run network (`internal: true` in docker mode) with no direct egress; its only route out is a per-integration listener the sidecar mounts as the runner's `HTTPS_PROXY`. That route was **coupled to credential injection**: the sidecar only mounted a listener when the spawn spec carried an `httpDeliveryAuths` injection plan.

A `delivery.env` integration (the server authenticates itself — e.g. a form/session login) resolves no injection plan, so #542 worked around the gap by emitting a forward-only **empty** `httpDeliveryAuths` entry purely to trigger the mount. Two smells:

1. **Semantic overload** — `httpDeliveryAuths` means "header injection plan"; an all-empty entry repurposed as an egress-mount trigger.
2. **Runtime overhead** — a per-SNI cert mint + TLS termination for traffic the proxy never inspects.

## Fix — approach (B): explicit egress signal + plain CONNECT listener

Egress and injection are now orthogonal:

- **`IntegrationSpawnSpec.needsEgress`** — the resolver raises it for any non-mtls local runner that declares an outbound surface, and **no longer emits the fake injection entry**. `httpDeliveryAuths` is back to meaning exactly "header injection plan".
- **New plain CONNECT egress listener** (`integration-egress-listener.ts`) — tunnel + SSRF floor, **no** TLS termination, **no** cert mint, **no** injection. Shares the CONNECT primitives (`connect-tunnel.ts`: target parse / connect-with-timeout / relay) with the agent's forward proxy so there is one implementation.
- **Sidecar picks ONE listener per integration, MITM-first**: injection plan → MITM listener (which already provides egress); else `needsEgress` → plain CONNECT listener; else (mtls / `delivery.files`) → no listener, reach upstream directly.
- **Env block split** — `buildProxyEnvBlock` (proxy routing, always) + `buildCaEnvBlock` (CA trust, MITM only). `RuntimeMitmContext` → `RuntimeEgressContext` with `caCertHostPath: string | null`; `null` skips the CA env + `docker cp` for plain-egress runners.

## Acceptance criteria (#543)

- [x] `delivery.env` local runners egress **without** a fake `httpDeliveryAuths` entry
- [x] No TLS termination / cert mint for integrations that inject nothing
- [x] `delivery.http` injection path unchanged (MITM-first)
- [x] `mtls` runners reach upstream directly (never behind a TLS-terminating proxy)
- [x] SSRF floor preserved on every egress path
- [x] Regression tests in process mode (resolver signal + listener behaviour)

## Tests

- `integration-spawn-resolver-env-egress.test.ts` — rewritten: asserts `needsEgress === true` and **no** `httpDeliveryAuths` (was asserting the empty-plan workaround).
- `integration-egress-listener.test.ts` (new) — CONNECT relay to allowed host, SSRF refusal (cloud-metadata + RFC1918), 405 on non-CONNECT, optional hard allowlist.
- `integration-runtime-adapter-select.test.ts` — split `buildMitmEnvBlock` coverage into `buildProxyEnvBlock` / `buildCaEnvBlock`.
- Full sidecar suite green (537 tests); `bun run check` passes.

## Follow-up (out of scope, deliberate)

A hard `authorized_uris` per-integration egress allowlist remains a separate security decision. The listener accepts an optional `authorizedHostMatcher` seam (no-op by default) so that enforcement, if adopted, lands at CONNECT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)