### PR TITLE
fix(core): show api_call integrations in schedule connection-overrides picker

### DIFF
--- a/packages/core/src/integration.ts
+++ b/packages/core/src/integration.ts
@@ -610,8 +610,14 @@ export function isApiCallToolName(name: string): boolean {
  * (per-auth map) for consent inference — it is NOT an exclusivity lock. No
  * tool→auth hard-lock is modelled today, so any declared auth (e.g. a `pat`
  * alternative alongside `oauth`) can serve any selected tool. The picker must
- * therefore offer every declared auth, not just a scope-referenced one. Returns
- * `[]` when the agent picked zero tools and zero scopes (declared-but-inert).
+ * therefore offer every declared auth, not just a scope-referenced one.
+ *
+ * An integration that exposes `api_call` ({@link getApiCallConfigs}) is its own
+ * selection signal: the agent consumes it through `api_call` with an explicit
+ * `auth_key` pin, so it has no MCP tools/scopes to select yet still needs a
+ * connection (e.g. a `source.kind: "none"` REST integration). Returns `[]`
+ * only when the agent picked zero tools, zero scopes AND the integration
+ * exposes no api_call (genuinely declared-but-inert).
  */
 export function connectableAuthKeysForAgent(
   manifest: IntegrationManifest,
@@ -621,7 +627,8 @@ export function connectableAuthKeysForAgent(
   const hasSelection =
     isToolsWildcard(agentTools) ||
     (Array.isArray(agentTools) && agentTools.length > 0) ||
-    (agentScopes?.length ?? 0) > 0;
+    (agentScopes?.length ?? 0) > 0 ||
+    getApiCallConfigs(manifest).length > 0;
   if (!hasSelection) return [];
   return manifest.auths ? Object.keys(manifest.auths) : [];
 }

--- a/packages/core/test/integration.test.ts
+++ b/packages/core/test/integration.test.ts
@@ -1251,6 +1251,28 @@ describe("connectableAuthKeysForAgent", () => {
       "pat",
     ]);
   });
+
+  it("offers declared auths for an api_call integration with no tools/scopes", () => {
+    // api_call-only integration (source.kind "none", api vendor extension):
+    // the agent consumes it via api_call with an explicit auth_key pin, so it
+    // has no tools/scopes yet still needs a connection. The picker MUST offer
+    // it — this is the empty schedule-override box bug.
+    const m = parse(
+      baseManifest({
+        source: { kind: "none" },
+        auths: {
+          primary: {
+            type: "api_key",
+            credentials: { schema: { type: "object", properties: {} } },
+            authorized_uris: ["https://api/**"],
+            delivery: { env: { K: { value: "{$credential.k}" } } },
+          },
+        },
+        _meta: { "dev.appstrate/api": { auths: { primary: {} } } },
+      }),
+    );
+    expect(connectableAuthKeysForAgent(m, undefined, undefined)).toEqual(["primary"]);
+  });
 });
 
 function multiAuthManifest_(): IntegrationManifest {


### PR DESCRIPTION
## Problem

The schedule edit form's **Connexions d'intégration** block renders empty for agents whose integrations are all `api_call`-based (e.g. `@tractr/fathom-to-repo-prompt-only`, which depends on Fathom + GitHub REST APIs).

Repro: a schedule whose agent declares integrations in `integrations_configuration` with only an `auth_key` pin (no `tools`, no `scopes`) → the override box shows no rows.

## Root cause

`connectableAuthKeysForAgent` returned `[]` whenever the agent declared zero tools **and** zero scopes, treating the integration as *declared-but-inert*. That assumption is false for `api_call`-only integrations (`source.kind: "none"` REST APIs): the agent consumes them through `api_call` with an explicit `auth_key` pin, so they have no MCP tools/scopes to select yet still need a connection.

The schedule connection-overrides picker (`run-overrides-panel.tsx:376`) gates each row on this function and renders `null` when it returns `[]`, so every row disappeared. The agent-page connection card (`agent-integrations-block.tsx`) has no such gate — hence the agent's own "Connexions" tab showed the integrations fine while the schedule form did not.

## Fix

Count `api_call` exposure (`getApiCallConfigs(manifest)`) as a selection signal inside `connectableAuthKeysForAgent`, reusing the existing helper. No new parameters, no per-caller special-casing — the resolver is correct everywhere it's used.

## Tests

- New case: `connectableAuthKeysForAgent` returns the declared auth for an api_call integration with no tools/scopes.
- Existing 5 cases unchanged (remote MCP fixtures expose no api_call → behavior preserved).
- `bun run check` green (typecheck + lint + format + detect:breaking: no OpenAPI changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)