### PR TITLE
feat(uploads): stream input-document consume instead of buffering in the API

### DIFF
--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -13,6 +13,7 @@ import {
 } from "../services/state/runs.ts";
 import { getVersionDetail } from "../services/package-versions.ts";
 import { parseRequestInput } from "../services/input-parser.ts";
+import { deleteRunWorkspace } from "../services/run-workspace-storage.ts";
 import { asJSONSchemaObject } from "@appstrate/core/form";
 import { mergeAndValidateConfigOverride } from "../services/agent-readiness.ts";
 import { abortRun } from "../services/run-tracker.ts";
@@ -69,86 +70,93 @@ export function createRunsRouter() {
         };
       }
 
-      const inputResult = await parseRequestInput(
-        c,
-        effectiveAgent.manifest.input?.schema
-          ? asJSONSchemaObject(effectiveAgent.manifest.input.schema)
-          : undefined,
-      );
-
-      const {
-        input: parsedInput,
-        uploadedFiles,
-        modelIdOverride,
-        proxyIdOverride,
-        configOverride,
-        connectionOverrides,
-      } = inputResult;
-
-      // An explicit per-run `modelId` override must reference a real model
-      // (system key or org-model UUID). Reject unknown/malformed values with a
-      // clean 404 rather than letting them silently fall through to the org
-      // default downstream (or crash the uuid cast — see loadModel).
-      await assertExplicitModelExists(orgId, modelIdOverride);
-
-      // Shared preflight: resolve config, validate readiness. Threading
-      // `connectionOverrides` here is what makes the
-      // MissingConnectionsModal retry actually work — readiness sees the
-      // caller's pick and skips the must_choose error on >1 candidates.
-      // Pre-fix, the readiness gate fired must_choose regardless of the
-      // override, so the picker UX loop never exited.
-      const {
-        config,
-        modelId: preflightModelId,
-        proxyId: preflightProxyId,
-      } = await resolveRunPreflight({
-        agent: effectiveAgent,
-        applicationId: c.get("applicationId"),
-        orgId,
-        actor,
-        connectionOverrides: connectionOverrides ?? null,
-      });
-
-      // Deep-merge any per-run `config` override on top of the persisted
-      // application config and re-validate against the manifest schema.
-      // Single helper shared with the scheduler so both paths converge to
-      // an identical resolved config for the same `(persisted, override)`.
-      const mergedConfig = mergeAndValidateConfigOverride(effectiveAgent, config, configOverride);
-
       // Single canonical prefix — `run_` — shared with inline + remote origins.
+      // Minted BEFORE input parsing so input documents can be streamed straight
+      // into this run's workspace namespace during consume (no buffering them in
+      // API memory until the run row exists). The run row is still created later
+      // with this same id.
       const runId = `run_${crypto.randomUUID()}`;
 
-      // Build file metadata for prompt context (no URLs — files injected directly into container)
-      const fileRefs = uploadedFiles?.map((f) => ({
-        fieldName: f.fieldName,
-        name: f.name,
-        type: f.type,
-        size: f.size,
-      }));
+      try {
+        const inputResult = await parseRequestInput(
+          c,
+          runId,
+          effectiveAgent.manifest.input?.schema
+            ? asJSONSchemaObject(effectiveAgent.manifest.input.schema)
+            : undefined,
+        );
 
-      const runner = await resolveRunnerContext(c);
-      await prepareAndExecuteRun({
-        runId,
-        agent: effectiveAgent,
-        orgId,
-        actor,
-        input: parsedInput,
-        files: fileRefs,
-        config: mergedConfig,
-        configOverride: configOverride ?? null,
-        modelId: modelIdOverride ?? preflightModelId,
-        proxyId: proxyIdOverride ?? preflightProxyId,
-        overrideVersionLabel,
-        applicationId: c.get("applicationId"),
-        uploadedFiles,
-        apiKeyId: c.get("apiKeyId") ?? undefined,
-        connectionOverrides: connectionOverrides ?? null,
-        traceparent: c.get("traceparent"),
-        runnerName: runner.name,
-        runnerKind: runner.kind,
-      });
+        const {
+          input: parsedInput,
+          uploadedFiles,
+          modelIdOverride,
+          proxyIdOverride,
+          configOverride,
+          connectionOverrides,
+        } = inputResult;
 
-      return c.json({ runId });
+        // An explicit per-run `modelId` override must reference a real model
+        // (system key or org-model UUID). Reject unknown/malformed values with a
+        // clean 404 rather than letting them silently fall through to the org
+        // default downstream (or crash the uuid cast — see loadModel).
+        await assertExplicitModelExists(orgId, modelIdOverride);
+
+        // Shared preflight: resolve config, validate readiness. Threading
+        // `connectionOverrides` here is what makes the
+        // MissingConnectionsModal retry actually work — readiness sees the
+        // caller's pick and skips the must_choose error on >1 candidates.
+        // Pre-fix, the readiness gate fired must_choose regardless of the
+        // override, so the picker UX loop never exited.
+        const {
+          config,
+          modelId: preflightModelId,
+          proxyId: preflightProxyId,
+        } = await resolveRunPreflight({
+          agent: effectiveAgent,
+          applicationId: c.get("applicationId"),
+          orgId,
+          actor,
+          connectionOverrides: connectionOverrides ?? null,
+        });
+
+        // Deep-merge any per-run `config` override on top of the persisted
+        // application config and re-validate against the manifest schema.
+        // Single helper shared with the scheduler so both paths converge to
+        // an identical resolved config for the same `(persisted, override)`.
+        const mergedConfig = mergeAndValidateConfigOverride(effectiveAgent, config, configOverride);
+
+        const runner = await resolveRunnerContext(c);
+        await prepareAndExecuteRun({
+          runId,
+          agent: effectiveAgent,
+          orgId,
+          actor,
+          input: parsedInput,
+          // File metadata for prompt context — the document bytes were already
+          // streamed into the run workspace during consume.
+          files: uploadedFiles,
+          config: mergedConfig,
+          configOverride: configOverride ?? null,
+          modelId: modelIdOverride ?? preflightModelId,
+          proxyId: proxyIdOverride ?? preflightProxyId,
+          overrideVersionLabel,
+          applicationId: c.get("applicationId"),
+          apiKeyId: c.get("apiKeyId") ?? undefined,
+          connectionOverrides: connectionOverrides ?? null,
+          traceparent: c.get("traceparent"),
+          runnerName: runner.name,
+          runnerKind: runner.kind,
+        });
+
+        return c.json({ runId });
+      } catch (err) {
+        // Roll back any input documents streamed into the run workspace before
+        // the run launched (size/MIME mismatch, failed preflight, …). Once
+        // `prepareAndExecuteRun` resolves the run owns its own teardown, so this
+        // only fires on the pre-launch error path. Best-effort + idempotent.
+        await deleteRunWorkspace(runId);
+        throw err;
+      }
     },
   );
 

--- a/apps/api/src/services/input-parser.ts
+++ b/apps/api/src/services/input-parser.ts
@@ -124,6 +124,47 @@ export function assertDocsWithinCap(files: { size: number }[], maxBytes: number)
 }
 
 /**
+ * Cap on how many input documents stream into the run workspace at once. Each
+ * in-flight stream holds a storage-adapter buffer (~5 MiB for the S3 multipart
+ * part), so an unbounded `Promise.all` over a large array-file field could pin
+ * `documents × 5 MiB`. Bounding it keeps the per-run streaming memory floor flat
+ * regardless of document count.
+ */
+const DOC_STREAM_CONCURRENCY = 4;
+
+/**
+ * Map over `items` running at most `limit` callbacks concurrently, preserving
+ * input order in the result. On the first rejection, in-flight callbacks are
+ * allowed to settle but no new ones start, and the rejection propagates — the
+ * caller rolls back any partial work (here: the run workspace, by doc name, so
+ * stragglers that finished are cleaned regardless).
+ */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  let aborted = false;
+  async function worker(): Promise<void> {
+    while (!aborted) {
+      const i = nextIndex++;
+      if (i >= items.length) break;
+      try {
+        results[i] = await fn(items[i]!, i);
+      } catch (err) {
+        aborted = true;
+        throw err;
+      }
+    }
+  }
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
+/**
  * Parse and validate the run request body. Returns parsed input + resolved
  * uploaded files. Throws `ApiError` (invalidRequest / notFound) on any
  * validation or resolution failure.
@@ -182,8 +223,10 @@ export async function parseRequestInput(
       // for this run; no run row or bundle exists yet, so the doc objects +
       // manifest are the only state to clean.
       try {
-        const consumed = await Promise.all(
-          resolved.map(async ({ ref, id }, i) => {
+        const consumed = await mapWithConcurrency(
+          resolved,
+          DOC_STREAM_CONCURRENCY,
+          async ({ ref, id }, i) => {
             const docName = docNames[i]!;
             const declaredSize = metas.get(id)!.size;
             // Sink: sniff the head, count bytes, and pipe everything to the run
@@ -227,7 +270,7 @@ export async function parseRequestInput(
               size: meta.size,
               docName,
             };
-          }),
+          },
         );
 
         // Write the documents manifest once every document has streamed — it

--- a/apps/api/src/services/input-parser.ts
+++ b/apps/api/src/services/input-parser.ts
@@ -10,11 +10,18 @@
  */
 
 import type { Context } from "hono";
+import { fileTypeStream } from "file-type";
 import type { UploadedFile } from "./run-launcher/types.ts";
 import { isFileField, type JSONSchemaObject, type JSONSchema7 } from "@appstrate/core/form";
 import { validateInput } from "./schema.ts";
 import { invalidRequest, payloadTooLarge, validationFailed } from "../lib/errors.ts";
-import { consumeUpload, isUploadUri, parseUploadUri } from "./uploads.ts";
+import { consumeUploadStream, peekUploads, isUploadUri, parseUploadUri } from "./uploads.ts";
+import { sanitizeStorageKey } from "./file-storage.ts";
+import {
+  streamRunDocument,
+  writeRunDocumentsManifest,
+  deleteRunDocuments,
+} from "./run-workspace-storage.ts";
 import { getEnv } from "@appstrate/env";
 
 export interface ParsedInput {
@@ -123,6 +130,7 @@ export function assertDocsWithinCap(files: { size: number }[], maxBytes: number)
  */
 export async function parseRequestInput(
   c: Context,
+  runId: string,
   inputSchema?: JSONSchemaObject,
 ): Promise<ParsedInput> {
   let body: RunRequestBody = {};
@@ -139,41 +147,114 @@ export async function parseRequestInput(
     const refs = collectUploadRefs(inputSchema, input);
     const orgId = c.get("orgId");
     const applicationId = c.get("applicationId");
-    // Resolve all upload references in parallel — each `consumeUpload` is an
-    // independent atomic claim. For multi-file forms this cuts wall-time from
-    // O(N * roundtrip) to O(roundtrip).
-    uploadedFiles = await Promise.all(
-      refs.map(async (ref) => {
-        const id = parseUploadUri(ref.uri);
-        if (!id) throw invalidRequest(`Invalid upload URI '${ref.uri}'`, ref.fieldName);
-        const consumed = await consumeUpload(id, { orgId, applicationId });
-        return {
-          fieldName: ref.fieldName,
-          name: consumed.name,
-          type: consumed.mime,
-          size: consumed.size,
-          buffer: consumed.buffer,
-        };
-      }),
-    );
 
-    // Bound the total input-document payload. Documents are delivered to the
-    // agent out-of-band (fetched + streamed to disk), so an oversized payload
-    // is a policy violation rather than a crash — but enforcing it here also
-    // caps what the platform buffers per run. Reject before launch so the
-    // caller gets a clean 413 instead of a run that fails mid-flight.
-    assertDocsWithinCap(uploadedFiles, getEnv().WORKSPACE_MAX_DOCS_BYTES);
+    // Resolve every URI to an upload id up front so a malformed URI fails before
+    // we touch storage.
+    const resolved = refs.map((ref) => {
+      const id = parseUploadUri(ref.uri);
+      if (!id) throw invalidRequest(`Invalid upload URI '${ref.uri}'`, ref.fieldName);
+      return { ref, id };
+    });
 
-    const inputValidation = validateInput(input, inputSchema);
-    if (!inputValidation.valid) {
-      throw validationFailed(
-        inputValidation.errors.map((e) => ({
-          field: e.field ? `input.${e.field}` : "input",
-          code: "invalid_input",
-          title: "Invalid Input",
-          message: e.message,
-        })),
+    if (resolved.length > 0) {
+      // Bound the total input-document payload on DECLARED sizes BEFORE streaming
+      // any bytes. Documents are delivered to the agent out-of-band (fetched +
+      // streamed to disk), so an oversized payload is a policy violation rather
+      // than a crash. The per-file `bytes === size` check inside consume keeps
+      // each actual size ≤ its declared size, so a declared total under the cap
+      // bounds the actual total too. Reject before launch so the caller gets a
+      // clean 413 instead of a run that fails mid-flight.
+      const metas = await peekUploads(
+        resolved.map((r) => r.id),
+        { orgId, applicationId },
       );
+      assertDocsWithinCap([...metas.values()], getEnv().WORKSPACE_MAX_DOCS_BYTES);
+
+      // The run-workspace document object name. Must match the path the
+      // prompt-builder hands the agent (`./documents/<sanitizeStorageKey(name)>`)
+      // and the manifest entry the agent fetches by.
+      const docNames = resolved.map(({ id }) => sanitizeStorageKey(metas.get(id)!.name));
+
+      // Stream each upload straight from the uploads bucket into the run
+      // workspace — validating size + MIME on the fly — so the platform never
+      // buffers a whole document in memory. On ANY failure (bad URI, size/MIME
+      // mismatch, or input validation below) roll back every document streamed
+      // for this run; no run row or bundle exists yet, so the doc objects +
+      // manifest are the only state to clean.
+      try {
+        const consumed = await Promise.all(
+          resolved.map(async ({ ref, id }, i) => {
+            const docName = docNames[i]!;
+            // Sink: sniff the head, count bytes, and pipe everything to the run
+            // workspace. `fileTypeStream` re-emits the full stream and exposes
+            // `.fileType` once the head has been read — available after the pipe
+            // drains. The counting passthrough yields the size the size-check
+            // (and manifest) needs.
+            const meta = await consumeUploadStream(id, { orgId, applicationId }, async (src) => {
+              const detection = await fileTypeStream(src);
+              let bytes = 0;
+              const counter = new TransformStream<Uint8Array, Uint8Array>({
+                transform(chunk, controller) {
+                  bytes += chunk.byteLength;
+                  controller.enqueue(chunk);
+                },
+              });
+              await streamRunDocument(runId, docName, detection.pipeThrough(counter));
+              return { bytes, sniffedMime: detection.fileType?.mime };
+            });
+            return {
+              fieldName: ref.fieldName,
+              name: meta.name,
+              type: meta.mime,
+              size: meta.size,
+              docName,
+            };
+          }),
+        );
+
+        // Write the documents manifest once every document has streamed — it
+        // doubles as the agent's enumeration index and the run-workspace
+        // deletion index on teardown.
+        await writeRunDocumentsManifest(
+          runId,
+          consumed.map((d) => ({ name: d.docName, size: d.size })),
+        );
+
+        uploadedFiles = consumed.map(({ fieldName, name, type, size }) => ({
+          fieldName,
+          name,
+          type,
+          size,
+        }));
+
+        const inputValidation = validateInput(input, inputSchema);
+        if (!inputValidation.valid) {
+          throw validationFailed(
+            inputValidation.errors.map((e) => ({
+              field: e.field ? `input.${e.field}` : "input",
+              code: "invalid_input",
+              title: "Invalid Input",
+              message: e.message,
+            })),
+          );
+        }
+      } catch (err) {
+        await deleteRunDocuments(runId, docNames);
+        throw err;
+      }
+    } else {
+      // No file fields populated — still validate the JSON input shape.
+      const inputValidation = validateInput(input, inputSchema);
+      if (!inputValidation.valid) {
+        throw validationFailed(
+          inputValidation.errors.map((e) => ({
+            field: e.field ? `input.${e.field}` : "input",
+            code: "invalid_input",
+            title: "Invalid Input",
+            message: e.message,
+          })),
+        );
+      }
     }
   }
 

--- a/apps/api/src/services/input-parser.ts
+++ b/apps/api/src/services/input-parser.ts
@@ -185,6 +185,7 @@ export async function parseRequestInput(
         const consumed = await Promise.all(
           resolved.map(async ({ ref, id }, i) => {
             const docName = docNames[i]!;
+            const declaredSize = metas.get(id)!.size;
             // Sink: sniff the head, count bytes, and pipe everything to the run
             // workspace. `fileTypeStream` re-emits the full stream and exposes
             // `.fileType` once the head has been read — available after the pipe
@@ -196,6 +197,23 @@ export async function parseRequestInput(
               const counter = new TransformStream<Uint8Array, Uint8Array>({
                 transform(chunk, controller) {
                   bytes += chunk.byteLength;
+                  // Abort the moment the stream overshoots the declared size,
+                  // rather than copying a declared-small / uploaded-huge object
+                  // into the run workspace in full just to delete it after the
+                  // post-drain size check. Errors the stream → the S3 multipart
+                  // upload aborts (or the FS write stops) → consume releases the
+                  // claim and the route rolls the workspace back. The
+                  // post-drain `bytes === size` check in consume still catches
+                  // the under-size case (and is the correctness backstop for any
+                  // sink that does not abort early).
+                  if (bytes > declaredSize) {
+                    controller.error(
+                      invalidRequest(
+                        `Upload '${id}' size mismatch: declared ${declaredSize} bytes, exceeded mid-stream`,
+                      ),
+                    );
+                    return;
+                  }
                   controller.enqueue(chunk);
                 },
               });

--- a/apps/api/src/services/input-parser.ts
+++ b/apps/api/src/services/input-parser.ts
@@ -4,14 +4,15 @@
  * Request input parsing.
  *
  * The request body is always JSON. File fields carry `upload://upl_xxx` URIs
- * that point to previously staged uploads. Each URI is resolved into a
- * `UploadedFile` (buffer + metadata) via the uploads service, which also
- * performs magic-byte MIME validation and marks the upload as consumed.
+ * that point to previously staged uploads. Each URI is streamed straight from
+ * the uploads bucket into the run workspace via the uploads service (which
+ * performs size + magic-byte MIME validation and marks the upload as consumed),
+ * leaving a `FileReference` (metadata only — no buffer) on the parsed input.
  */
 
 import type { Context } from "hono";
 import { fileTypeStream } from "file-type";
-import type { UploadedFile } from "./run-launcher/types.ts";
+import type { FileReference } from "./run-launcher/types.ts";
 import { isFileField, type JSONSchemaObject, type JSONSchema7 } from "@appstrate/core/form";
 import { validateInput } from "./schema.ts";
 import { invalidRequest, payloadTooLarge, validationFailed } from "../lib/errors.ts";
@@ -26,7 +27,7 @@ import { getEnv } from "@appstrate/env";
 
 export interface ParsedInput {
   input?: Record<string, unknown>;
-  uploadedFiles?: UploadedFile[];
+  uploadedFiles?: FileReference[];
   /** Per-run model override (wire field `modelId` on the request body). */
   modelIdOverride?: string;
   /** Per-run proxy override (wire field `proxyId` on the request body). */
@@ -61,6 +62,21 @@ interface RunRequestBody {
   proxyId?: string;
   config?: Record<string, unknown>;
   connection_overrides?: Record<string, string>;
+}
+
+/** Validate `input` against the manifest schema, throwing `validationFailed` (422). */
+function assertInputValid(input: Record<string, unknown>, inputSchema: JSONSchemaObject): void {
+  const inputValidation = validateInput(input, inputSchema);
+  if (!inputValidation.valid) {
+    throw validationFailed(
+      inputValidation.errors.map((e) => ({
+        field: e.field ? `input.${e.field}` : "input",
+        code: "invalid_input",
+        title: "Invalid Input",
+        message: e.message,
+      })),
+    );
+  }
 }
 
 function getArrayItems(prop: JSONSchema7): JSONSchema7 | undefined {
@@ -182,7 +198,7 @@ export async function parseRequestInput(
     body = {};
   }
   const input = body.input ?? {};
-  let uploadedFiles: UploadedFile[] = [];
+  let uploadedFiles: FileReference[] = [];
 
   if (inputSchema) {
     const refs = collectUploadRefs(inputSchema, input);
@@ -197,32 +213,35 @@ export async function parseRequestInput(
       return { ref, id };
     });
 
-    if (resolved.length > 0) {
-      // Bound the total input-document payload on DECLARED sizes BEFORE streaming
-      // any bytes. Documents are delivered to the agent out-of-band (fetched +
-      // streamed to disk), so an oversized payload is a policy violation rather
-      // than a crash. The per-file `bytes === size` check inside consume keeps
-      // each actual size ≤ its declared size, so a declared total under the cap
-      // bounds the actual total too. Reject before launch so the caller gets a
-      // clean 413 instead of a run that fails mid-flight.
-      const metas = await peekUploads(
-        resolved.map((r) => r.id),
-        { orgId, applicationId },
-      );
-      assertDocsWithinCap([...metas.values()], getEnv().WORKSPACE_MAX_DOCS_BYTES);
+    // Document object names — set once uploads are streamed, used to roll the
+    // run workspace back if anything below the stream fails. Empty until we
+    // stream, so a pre-stream failure (bad URI, cap, peek) rolls back nothing.
+    let docNames: string[] = [];
+    try {
+      if (resolved.length > 0) {
+        // Bound the total input-document payload on DECLARED sizes BEFORE
+        // streaming any bytes. Documents are delivered to the agent out-of-band
+        // (fetched + streamed to disk), so an oversized payload is a policy
+        // violation rather than a crash. The per-file `bytes === size` check
+        // inside consume keeps each actual size ≤ its declared size, so a
+        // declared total under the cap bounds the actual total too. Reject
+        // before launch so the caller gets a clean 413 instead of a mid-flight
+        // run failure.
+        const metas = await peekUploads(
+          resolved.map((r) => r.id),
+          { orgId, applicationId },
+        );
+        assertDocsWithinCap([...metas.values()], getEnv().WORKSPACE_MAX_DOCS_BYTES);
 
-      // The run-workspace document object name. Must match the path the
-      // prompt-builder hands the agent (`./documents/<sanitizeStorageKey(name)>`)
-      // and the manifest entry the agent fetches by.
-      const docNames = resolved.map(({ id }) => sanitizeStorageKey(metas.get(id)!.name));
+        // The run-workspace document object name. Must match the path the
+        // prompt-builder hands the agent (`./documents/<sanitizeStorageKey(name)>`)
+        // and the manifest entry the agent fetches by.
+        docNames = resolved.map(({ id }) => sanitizeStorageKey(metas.get(id)!.name));
 
-      // Stream each upload straight from the uploads bucket into the run
-      // workspace — validating size + MIME on the fly — so the platform never
-      // buffers a whole document in memory. On ANY failure (bad URI, size/MIME
-      // mismatch, or input validation below) roll back every document streamed
-      // for this run; no run row or bundle exists yet, so the doc objects +
-      // manifest are the only state to clean.
-      try {
+        // Stream each upload straight from the uploads bucket into the run
+        // workspace — validating size + MIME on the fly — so the platform never
+        // buffers a whole document in memory. Bounded concurrency keeps the
+        // streaming memory floor flat regardless of document count.
         const consumed = await mapWithConcurrency(
           resolved,
           DOC_STREAM_CONCURRENCY,
@@ -245,9 +264,9 @@ export async function parseRequestInput(
                   // into the run workspace in full just to delete it after the
                   // post-drain size check. Errors the stream → the S3 multipart
                   // upload aborts (or the FS write stops) → consume releases the
-                  // claim and the route rolls the workspace back. The
-                  // post-drain `bytes === size` check in consume still catches
-                  // the under-size case (and is the correctness backstop for any
+                  // claim and the run workspace is rolled back. The post-drain
+                  // `bytes === size` check in consume still catches the
+                  // under-size case (and is the correctness backstop for any
                   // sink that does not abort early).
                   if (bytes > declaredSize) {
                     controller.error(
@@ -263,13 +282,7 @@ export async function parseRequestInput(
               await streamRunDocument(runId, docName, detection.pipeThrough(counter));
               return { bytes, sniffedMime: detection.fileType?.mime };
             });
-            return {
-              fieldName: ref.fieldName,
-              name: meta.name,
-              type: meta.mime,
-              size: meta.size,
-              docName,
-            };
+            return { fieldName: ref.fieldName, name: meta.name, type: meta.mime, size: meta.size };
           },
         );
 
@@ -278,44 +291,18 @@ export async function parseRequestInput(
         // deletion index on teardown.
         await writeRunDocumentsManifest(
           runId,
-          consumed.map((d) => ({ name: d.docName, size: d.size })),
+          consumed.map((d, i) => ({ name: docNames[i]!, size: d.size })),
         );
 
-        uploadedFiles = consumed.map(({ fieldName, name, type, size }) => ({
-          fieldName,
-          name,
-          type,
-          size,
-        }));
+        uploadedFiles = consumed;
+      }
 
-        const inputValidation = validateInput(input, inputSchema);
-        if (!inputValidation.valid) {
-          throw validationFailed(
-            inputValidation.errors.map((e) => ({
-              field: e.field ? `input.${e.field}` : "input",
-              code: "invalid_input",
-              title: "Invalid Input",
-              message: e.message,
-            })),
-          );
-        }
-      } catch (err) {
-        await deleteRunDocuments(runId, docNames);
-        throw err;
-      }
-    } else {
-      // No file fields populated — still validate the JSON input shape.
-      const inputValidation = validateInput(input, inputSchema);
-      if (!inputValidation.valid) {
-        throw validationFailed(
-          inputValidation.errors.map((e) => ({
-            field: e.field ? `input.${e.field}` : "input",
-            code: "invalid_input",
-            title: "Invalid Input",
-            message: e.message,
-          })),
-        );
-      }
+      // Validate the JSON input shape — once, whether or not the run carries
+      // documents. A failure here still rolls back any streamed documents.
+      assertInputValid(input, inputSchema);
+    } catch (err) {
+      if (docNames.length > 0) await deleteRunDocuments(runId, docNames);
+      throw err;
     }
   }
 

--- a/apps/api/src/services/run-launcher/execute-background.ts
+++ b/apps/api/src/services/run-launcher/execute-background.ts
@@ -4,7 +4,7 @@ import { logger } from "../../lib/logger.ts";
 import type { LoadedPackage } from "../../types/index.ts";
 import { updateRun } from "../state/runs.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
-import type { AppstrateRunPlan, UploadedFile } from "./types.ts";
+import type { AppstrateRunPlan } from "./types.ts";
 import type { ExecutionContext } from "@appstrate/afps-runtime/types";
 import { runPlatformContainer } from "./pi.ts";
 import type { PlatformContainerResult } from "./pi.ts";
@@ -25,7 +25,6 @@ export interface ExecuteAgentInBackgroundInput {
   context: ExecutionContext;
   plan: AppstrateRunPlan;
   agentPackage?: Buffer | null;
-  inputFiles?: UploadedFile[];
   modelSource?: string | null;
   /** Sink credentials minted by `run-pipeline.ts` and persisted on the run row. */
   sinkCredentials: SinkCredentials;
@@ -59,7 +58,6 @@ export async function executeAgentInBackground(
     context,
     plan,
     agentPackage,
-    inputFiles,
     modelSource,
     sinkCredentials,
   } = input;
@@ -90,7 +88,6 @@ export async function executeAgentInBackground(
     const runPlan: AppstrateRunPlan = {
       ...plan,
       agentPackage: agentPackage ?? undefined,
-      inputFiles,
     };
 
     let lifecycle: PlatformContainerResult;

--- a/apps/api/src/services/run-launcher/pi.ts
+++ b/apps/api/src/services/run-launcher/pi.ts
@@ -26,7 +26,6 @@ import { logger } from "../../lib/logger.ts";
 import type { AppstrateRunPlan } from "./types.ts";
 import { buildPlatformSystemPrompt } from "./prompt-builder.ts";
 import { buildRuntimePiEnv } from "@appstrate/runner-pi";
-import { sanitizeStorageKey } from "../file-storage.ts";
 import {
   getOrchestrator,
   type ContainerOrchestrator,
@@ -36,7 +35,7 @@ import {
 import { getErrorMessage } from "@appstrate/core/errors";
 import type { ExecutionContext } from "@appstrate/afps-runtime/types";
 import type { SinkCredentials } from "../../lib/mint-sink-credentials.ts";
-import { uploadRunWorkspace, deleteRunWorkspace } from "../run-workspace-storage.ts";
+import { uploadRunBundle, deleteRunWorkspace } from "../run-workspace-storage.ts";
 
 import { getEnv } from "@appstrate/env";
 import { isOAuthModelProvider, getModelProvider } from "../model-providers/registry.ts";
@@ -68,10 +67,11 @@ export interface RunPlatformContainerInput {
   orchestrator?: ContainerOrchestrator;
   /**
    * Injectable workspace provisioning — production defaults to the
-   * run-workspace storage helpers. The agent fetches this archive itself at
-   * startup; tests substitute a capturing stub.
+   * run-workspace storage helpers. The agent fetches the bundle itself at
+   * startup; input documents were already streamed into the workspace during
+   * upload-consume. Tests substitute a capturing stub.
    */
-  uploadWorkspace?: typeof uploadRunWorkspace;
+  uploadBundle?: typeof uploadRunBundle;
   deleteWorkspace?: typeof deleteRunWorkspace;
 }
 
@@ -91,7 +91,7 @@ export async function runPlatformContainer(
 ): Promise<PlatformContainerResult> {
   const { runId, context, plan, sinkCredentials, signal } = input;
   const orch = input.orchestrator ?? getOrchestrator();
-  const uploadWorkspace = input.uploadWorkspace ?? uploadRunWorkspace;
+  const uploadBundle = input.uploadBundle ?? uploadRunBundle;
   const deleteWorkspace = input.deleteWorkspace ?? deleteRunWorkspace;
 
   const prompt = await buildPlatformSystemPrompt(context, plan);
@@ -241,35 +241,27 @@ export async function runPlatformContainer(
       traceparent: context.traceparent,
     });
 
-    // The bundle (small, constant) and input documents (large, variable) are
-    // provisioned separately: the agent extracts the bundle but streams each
-    // document straight to `documents/<name>` on disk, so it never buffers the
-    // whole payload. Document object names carry no path prefix — the agent
-    // writes them under `documents/` itself (matches the `./documents/<name>`
-    // paths the prompt-builder hands the agent).
-    const documents = (plan.inputFiles ?? []).map((f) => ({
-      name: sanitizeStorageKey(f.name),
-      content: f.buffer,
-    }));
-
     await orch.ensureImages(
       skipSidecar ? [getEnv().PI_IMAGE] : [getEnv().PI_IMAGE, getEnv().SIDECAR_IMAGE],
     );
 
-    // Sidecar + agent + workspace upload in parallel. The workspace archive
-    // (AFPS bundle + input documents) is uploaded to run-scoped storage; the
-    // agent container fetches and extracts it itself at startup
-    // (`GET /api/runs/:runId/workspace`). This replaces the old
-    // seed-into-the-run-volume delivery, whose correctness depended on the
-    // volume driver — a tmpfs-backed `local` volume is NOT shared between the
-    // short-lived seed helper and the agent container, so the bundle silently
-    // vanished and skills never materialised (issue #549). With the agent
-    // self-provisioning, the run volume is pure agent-local scratch again, so
-    // its backing (disk or tmpfs) is a free performance choice. The upload
-    // must finish before `startWorkload` (inside waitForWorkload) so the
-    // object exists when the agent boots; racing it alongside the create
-    // calls here satisfies that ordering. When `skipSidecar`, only the agent
-    // is created (it reaches the platform directly over its egress network).
+    // Sidecar + agent + bundle upload in parallel. The AFPS bundle is uploaded
+    // to run-scoped storage; the agent container fetches and extracts it itself
+    // at startup (`GET /api/runs/:runId/workspace`). Input documents were
+    // already streamed into the same run-workspace namespace during
+    // upload-consume — the agent fetches each one (`GET
+    // /api/runs/:runId/documents/:name`) and streams it to disk, never buffering
+    // the whole payload. This replaces the old seed-into-the-run-volume
+    // delivery, whose correctness depended on the volume driver — a tmpfs-backed
+    // `local` volume is NOT shared between the short-lived seed helper and the
+    // agent container, so the bundle silently vanished and skills never
+    // materialised (issue #549). With the agent self-provisioning, the run
+    // volume is pure agent-local scratch again, so its backing (disk or tmpfs)
+    // is a free performance choice. The upload must finish before
+    // `startWorkload` (inside waitForWorkload) so the object exists when the
+    // agent boots; racing it alongside the create calls here satisfies that
+    // ordering. When `skipSidecar`, only the agent is created (it reaches the
+    // platform directly over its egress network).
     const [sidecar, agent] = await Promise.all([
       skipSidecar ? Promise.resolve(undefined) : orch.createSidecar(runId, boundary, sidecarSpec),
       orch.createWorkload(
@@ -286,7 +278,7 @@ export async function runPlatformContainer(
         },
         boundary,
       ),
-      uploadWorkspace(runId, { bundle: plan.agentPackage ?? undefined, documents }),
+      uploadBundle(runId, plan.agentPackage ?? undefined),
     ]);
     sidecarHandle = sidecar;
     agentHandle = agent;

--- a/apps/api/src/services/run-launcher/types.ts
+++ b/apps/api/src/services/run-launcher/types.ts
@@ -16,10 +16,9 @@ export interface UploadedFile {
   name: string;
   type: string;
   size: number;
-  buffer: Buffer;
 }
 
-export type FileReference = Omit<UploadedFile, "buffer">;
+export type FileReference = UploadedFile;
 
 /**
  * Platform-specific run configuration — everything that does NOT fit in the
@@ -71,10 +70,12 @@ export interface AppstrateRunPlan {
   timeout: number;
 
   // --- Files ---
-  /** File references surfaced in the prompt ("## Documents" section). */
+  /**
+   * Input-document references surfaced in the prompt ("## Documents" section).
+   * The document bytes themselves are streamed into the run workspace during
+   * upload-consume — the plan carries only metadata, never the content.
+   */
   files?: FileReference[];
-  /** Uploaded file buffers — materialised into the container workspace. */
-  inputFiles?: UploadedFile[];
   /** Packaged bundle ZIP — injected as `/workspace/agent-package.afps`. */
   agentPackage?: Buffer | null;
 

--- a/apps/api/src/services/run-launcher/types.ts
+++ b/apps/api/src/services/run-launcher/types.ts
@@ -11,14 +11,17 @@ import type { ResolvedModel } from "../org-models.ts";
 export type { ToolMeta, TokenUsage, ResolvedModel };
 export { modelCostSchema, tokenUsageSchema };
 
-export interface UploadedFile {
+/**
+ * Reference to an input document surfaced to a run — field, filename, MIME, and
+ * size. Document bytes are streamed into the run workspace during upload-consume,
+ * so this carries metadata only (no content).
+ */
+export interface FileReference {
   fieldName: string;
   name: string;
   type: string;
   size: number;
 }
-
-export type FileReference = UploadedFile;
 
 /**
  * Platform-specific run configuration — everything that does NOT fit in the

--- a/apps/api/src/services/run-pipeline.ts
+++ b/apps/api/src/services/run-pipeline.ts
@@ -21,7 +21,7 @@ import { getOrchestrator } from "./orchestrator/index.ts";
 import { ApiError } from "../lib/errors.ts";
 import type { LoadedPackage } from "../types/index.ts";
 import type { Actor } from "../lib/actor.ts";
-import type { UploadedFile, FileReference } from "./run-launcher/types.ts";
+import type { FileReference } from "./run-launcher/types.ts";
 import { runPreflightGates } from "./run-preflight-gates.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
 
@@ -75,8 +75,6 @@ export interface RunPipelineParams {
   scheduleId?: string;
   /** Application ID — required for all runs. */
   applicationId: string;
-  /** Uploaded files to inject into the container. */
-  uploadedFiles?: UploadedFile[];
   /** API key ID that triggered the run (if auth via API key). */
   apiKeyId?: string;
   /**
@@ -185,7 +183,6 @@ export async function prepareAndExecuteRun(params: RunPipelineParams): Promise<R
     overrideVersionLabel,
     scheduleId,
     applicationId,
-    uploadedFiles,
     apiKeyId,
   } = params;
   // --- Step 1: Shared preflight gates (rate, concurrency, timeout cap,
@@ -346,7 +343,6 @@ export async function prepareAndExecuteRun(params: RunPipelineParams): Promise<R
     context,
     plan,
     agentPackage,
-    inputFiles: uploadedFiles,
     modelSource,
     sinkCredentials,
   }).catch((err) => {

--- a/apps/api/src/services/run-workspace-storage.ts
+++ b/apps/api/src/services/run-workspace-storage.ts
@@ -32,20 +32,6 @@ import { logger } from "../lib/logger.ts";
 
 const BUCKET = "run-workspace";
 
-/** One input document destined for the agent's `documents/<name>`. */
-export interface RunDocument {
-  /** Sanitised filename, no path prefix. */
-  name: string;
-  content: Buffer | Uint8Array;
-}
-
-/** What a run carries into its workspace: the AFPS bundle + input documents. */
-export interface RunWorkspaceUpload {
-  /** `agent-package.afps` bytes. Omitted only when the run has no package. */
-  bundle?: Buffer | Uint8Array;
-  documents: RunDocument[];
-}
-
 /** Manifest entry the agent uses to enumerate + fetch its documents. */
 export interface RunDocumentMeta {
   name: string;
@@ -62,38 +48,50 @@ const manifestKey = (runId: string): string => `${runId}/manifest.json`;
 const documentKey = (runId: string, name: string): string => `${runId}/documents/${name}`;
 
 /**
- * Provision a run's workspace storage: the bundle (`agent-package.afps`), one
- * object per input document, and the documents manifest. Overwrites any
- * existing objects (a run id is single-use). No-op for an absent bundle and no
- * documents.
+ * Stream a single input document into the run's workspace storage. The bytes
+ * are piped from the source stream straight to the document object without
+ * being buffered in API memory — the platform never holds the whole document.
+ *
+ * Documents are streamed in during upload-consume (before the run launches),
+ * not packaged with the bundle, so the manifest is written separately once all
+ * documents have streamed (see {@link writeRunDocumentsManifest}).
  */
-export async function uploadRunWorkspace(runId: string, upload: RunWorkspaceUpload): Promise<void> {
-  const ops: Promise<unknown>[] = [];
+export function streamRunDocument(
+  runId: string,
+  name: string,
+  stream: ReadableStream<Uint8Array>,
+): Promise<string> {
+  return storage.uploadStream(BUCKET, documentKey(runId, name), stream);
+}
 
-  if (upload.bundle) {
-    // The bundle is the `.afps` package — itself a ZIP the agent runtime reads.
-    // Stored verbatim (no extra archive wrapper); the agent writes it straight
-    // to its workspace root.
-    ops.push(storage.uploadFile(BUCKET, bundleKey(runId), upload.bundle));
-  }
+/**
+ * Write the documents manifest the agent uses to enumerate + fetch its inputs.
+ * Called once, after every document for the run has been streamed in.
+ */
+export function writeRunDocumentsManifest(
+  runId: string,
+  documents: RunDocumentMeta[],
+): Promise<string> {
+  const manifest: RunDocumentsManifest = { documents };
+  return storage.uploadFile(
+    BUCKET,
+    manifestKey(runId),
+    new TextEncoder().encode(JSON.stringify(manifest)),
+  );
+}
 
-  if (upload.documents.length > 0) {
-    for (const doc of upload.documents) {
-      ops.push(storage.uploadFile(BUCKET, documentKey(runId, doc.name), doc.content));
-    }
-    const manifest: RunDocumentsManifest = {
-      documents: upload.documents.map((d) => ({ name: d.name, size: d.content.byteLength })),
-    };
-    ops.push(
-      storage.uploadFile(
-        BUCKET,
-        manifestKey(runId),
-        new TextEncoder().encode(JSON.stringify(manifest)),
-      ),
-    );
-  }
-
-  await Promise.all(ops);
+/**
+ * Upload the run's AFPS bundle (`agent-package.afps` = manifest + prompt +
+ * skills). Small and constant — stored verbatim; the agent writes it straight
+ * to its workspace root. Input documents are streamed separately during
+ * upload-consume. No-op when the run has no package.
+ */
+export async function uploadRunBundle(
+  runId: string,
+  bundle: Buffer | Uint8Array | undefined,
+): Promise<void> {
+  if (!bundle) return;
+  await storage.uploadFile(BUCKET, bundleKey(runId), bundle);
 }
 
 /** Fetch the run's bundle (`agent-package.afps` bytes). Returns null when none. */
@@ -117,6 +115,27 @@ export function downloadRunDocumentStream(
   name: string,
 ): Promise<ReadableStream<Uint8Array> | null> {
   return storage.downloadStream(BUCKET, documentKey(runId, name));
+}
+
+/**
+ * Roll back documents streamed in during upload-consume when a run aborts
+ * before its row + bundle exist (e.g. a size/MIME mismatch or input-validation
+ * failure mid-trigger). The manifest is not yet the deletion index at this
+ * stage — it may be absent or partial — so the caller passes the doc names it
+ * attempted. Best-effort + idempotent on missing keys.
+ */
+export async function deleteRunDocuments(runId: string, names: string[]): Promise<void> {
+  const keys = [manifestKey(runId), ...names.map((n) => documentKey(runId, n))];
+  await Promise.all(
+    keys.map((k) =>
+      storage.deleteFile(BUCKET, k).catch((error) => {
+        logger.warn("Failed to delete run document (best-effort)", {
+          runId,
+          error: getErrorMessage(error),
+        });
+      }),
+    ),
+  );
 }
 
 /**

--- a/apps/api/src/services/uploads.ts
+++ b/apps/api/src/services/uploads.ts
@@ -6,7 +6,8 @@
  *   POST /api/uploads       → createUpload()  (row + signed URL)
  *   PUT  <signed url>       → (S3 direct, or /api/uploads/_content for FS)
  *   POST /api/agents/:id/run { input: { file: "upload://upl_xxx" } }
- *                            → consumeUpload() resolves to buffer, marks consumed
+ *                            → consumeUploadStream() streams the bytes to the
+ *                              caller's sink + marks consumed (no buffering)
  *
  * Security layers:
  *  - Auth + app context on POST /api/uploads (middleware)
@@ -54,10 +55,13 @@ export interface CreateUploadResponse {
   expiresAt: string;
 }
 
-/** Metadata for a consumed upload — the bytes have already been streamed to the
- * caller's sink, so no buffer is carried. Mirrors UploadedFile (minus content)
- * from run-launcher/types. */
-export interface ConsumedUpload {
+/**
+ * Declared metadata for a staged upload: shared by `peekUploads` (read without
+ * claiming) and `consumeUploadStream` (returned after the bytes have streamed to
+ * the caller's sink). No buffer is carried — mirrors the `FileReference` shape
+ * in run-launcher/types.
+ */
+export interface UploadMeta {
   id: string;
   name: string;
   mime: string;
@@ -234,14 +238,6 @@ function isUnsniffableMime(mime: string): boolean {
   return false;
 }
 
-/** Declared metadata for a staged upload, read without claiming or downloading. */
-export interface UploadMeta {
-  id: string;
-  name: string;
-  mime: string;
-  size: number;
-}
-
 /**
  * Read declared metadata for a set of staged uploads — without claiming or
  * downloading them. Verifies each exists, belongs to the caller's tenant, and
@@ -295,7 +291,7 @@ export async function consumeUploadStream(
   uploadId: string,
   ctx: { orgId: string; applicationId: string },
   sink: UploadStreamSink,
-): Promise<ConsumedUpload> {
+): Promise<UploadMeta> {
   // Pre-check so we can return the right shape of error (not-found vs
   // cross-tenant vs already-consumed vs expired). The atomic claim below
   // is what makes concurrent calls safe — this SELECT is just UX.

--- a/apps/api/src/services/uploads.ts
+++ b/apps/api/src/services/uploads.ts
@@ -29,7 +29,7 @@ import { getErrorMessage } from "@appstrate/core/errors";
 import { StorageAlreadyExistsError } from "@appstrate/core/storage";
 import { prefixedId } from "../lib/ids.ts";
 import { logger } from "../lib/logger.ts";
-import { invalidRequest, notFound, conflict, gone } from "../lib/errors.ts";
+import { invalidRequest, notFound, conflict, gone, type ApiError } from "../lib/errors.ts";
 
 /** Strip charset / boundary / other parameters from a MIME string and lowercase it. */
 function normalizeMime(mime: string): string {
@@ -269,14 +269,39 @@ export async function peekUploads(
 }
 
 /**
- * Look up an upload row, verify ownership + freshness, claim it atomically,
- * then STREAM the payload through `sink` (which pipes it to its destination)
- * while validating size + magic-byte MIME on the fly — the platform never
- * buffers the whole upload in memory.
+ * Diagnose why an atomic claim returned no row, on the cold (failure) path only,
+ * so the caller still gets a precise error instead of a generic conflict. Reads
+ * the row by id and maps: missing / cross-tenant → not-found, past expiry →
+ * gone, otherwise (already consumed, or re-claimable after a race) → conflict.
+ * Returns the error to throw rather than throwing, so the caller's control flow
+ * narrows `row` to defined.
+ */
+async function unclaimableUploadError(
+  uploadId: string,
+  ctx: { orgId: string; applicationId: string },
+): Promise<ApiError> {
+  const [row] = await db.select().from(uploads).where(eq(uploads.id, uploadId)).limit(1);
+  // Hide cross-tenant existence behind the same not-found as a missing row.
+  if (!row || row.orgId !== ctx.orgId || row.applicationId !== ctx.applicationId) {
+    return notFound(`Upload '${uploadId}' not found`);
+  }
+  if (row.expiresAt.getTime() < Date.now()) {
+    return gone("upload_expired", `Upload '${uploadId}' has expired`);
+  }
+  return conflict("upload_consumed", `Upload '${uploadId}' has already been consumed`);
+}
+
+/**
+ * Claim an upload atomically, then STREAM the payload through `sink` (which pipes
+ * it to its destination) while validating size + magic-byte MIME on the fly —
+ * the platform never buffers the whole upload in memory.
  *
- * The claim (`UPDATE … WHERE consumedAt IS NULL RETURNING`) is what prevents
- * the TOCTOU double-consume — two concurrent runs posting the same URI will
- * see exactly one winning row.
+ * The claim is a single `UPDATE … WHERE consumedAt IS NULL … RETURNING` that both
+ * prevents the TOCTOU double-consume (two concurrent runs posting the same URI
+ * see exactly one winning row) AND returns the row data, so the happy path needs
+ * no separate SELECT. A returned row is, by construction, owned, fresh, and
+ * freshly-claimed; an empty result is diagnosed on the cold path for a precise
+ * error.
  *
  * Size + MIME are validated *after* the stream drains (size is only known at
  * end; MIME is sniffed from the head by the sink). On mismatch the claim is
@@ -292,23 +317,13 @@ export async function consumeUploadStream(
   ctx: { orgId: string; applicationId: string },
   sink: UploadStreamSink,
 ): Promise<UploadMeta> {
-  // Pre-check so we can return the right shape of error (not-found vs
-  // cross-tenant vs already-consumed vs expired). The atomic claim below
-  // is what makes concurrent calls safe — this SELECT is just UX.
-  const [row] = await db.select().from(uploads).where(eq(uploads.id, uploadId)).limit(1);
-  if (!row) throw notFound(`Upload '${uploadId}' not found`);
-  if (row.orgId !== ctx.orgId || row.applicationId !== ctx.applicationId) {
-    // Hide cross-tenant existence
-    throw notFound(`Upload '${uploadId}' not found`);
-  }
-  if (row.expiresAt.getTime() < Date.now()) {
-    throw gone("upload_expired", `Upload '${uploadId}' has expired`);
-  }
-
-  // Atomic claim: only the caller whose UPDATE flips NULL → claimedAt proceeds.
-  // Any racing caller gets zero rows back and is reported as already-consumed.
+  // Atomic claim that also reads the row: only the caller whose UPDATE flips
+  // NULL → claimedAt proceeds, and the same statement hands back the row data
+  // (storageKey, size, mime, name) needed below — no separate pre-check SELECT
+  // on the happy path. The WHERE guards (tenant + not-consumed + not-expired)
+  // make a returned row owned, fresh, and freshly-claimed by construction.
   const claimedAt = new Date();
-  const claimed = await db
+  const [row] = await db
     .update(uploads)
     .set({ consumedAt: claimedAt })
     .where(
@@ -320,9 +335,11 @@ export async function consumeUploadStream(
         sql`${uploads.expiresAt} >= now()`,
       ),
     )
-    .returning({ id: uploads.id });
-  if (claimed.length === 0) {
-    throw conflict("upload_consumed", `Upload '${uploadId}' has already been consumed`);
+    .returning();
+  // Nothing claimed → diagnose why on the cold path (not-found vs cross-tenant
+  // vs expired vs already-consumed) so the caller still gets a precise error.
+  if (!row) {
+    throw await unclaimableUploadError(uploadId, ctx);
   }
 
   // Past this point the claim has succeeded. If anything downstream throws

--- a/apps/api/src/services/uploads.ts
+++ b/apps/api/src/services/uploads.ts
@@ -16,12 +16,11 @@
  */
 
 import { and, eq, lt, isNull, isNotNull, inArray, or, sql } from "drizzle-orm";
-import { fileTypeFromBuffer } from "file-type";
 import { db } from "@appstrate/db/client";
 import { uploads } from "@appstrate/db/schema";
 import {
   uploadFile as storagePut,
-  downloadFile as storageGet,
+  downloadStream as storageDownloadStream,
   deleteFile as storageDelete,
   createUploadUrl,
 } from "@appstrate/db/storage";
@@ -55,14 +54,25 @@ export interface CreateUploadResponse {
   expiresAt: string;
 }
 
-/** Shape consumed by the run pipeline — mirrors UploadedFile from run-launcher/types. */
+/** Metadata for a consumed upload — the bytes have already been streamed to the
+ * caller's sink, so no buffer is carried. Mirrors UploadedFile (minus content)
+ * from run-launcher/types. */
 export interface ConsumedUpload {
   id: string;
   name: string;
   mime: string;
   size: number;
-  buffer: Buffer;
 }
+
+/**
+ * Sink the upload bytes are streamed through. Receives the upload's content as
+ * a stream and reports how many bytes it observed plus the magic-byte sniffed
+ * MIME (undefined for formats `file-type` cannot identify). The caller (consume)
+ * validates these against the declared upload row.
+ */
+export type UploadStreamSink = (
+  stream: ReadableStream<Uint8Array>,
+) => Promise<{ bytes: number; sniffedMime: string | undefined }>;
 
 // ---------------------------------------------------------------------------
 // Utilities
@@ -224,20 +234,67 @@ function isUnsniffableMime(mime: string): boolean {
   return false;
 }
 
+/** Declared metadata for a staged upload, read without claiming or downloading. */
+export interface UploadMeta {
+  id: string;
+  name: string;
+  mime: string;
+  size: number;
+}
+
+/**
+ * Read declared metadata for a set of staged uploads — without claiming or
+ * downloading them. Verifies each exists, belongs to the caller's tenant, and
+ * has not expired (same error shapes as consume). Used to enforce the per-run
+ * document cap on *declared* sizes before any bytes are streamed: the per-file
+ * `bytes === size` check in consume keeps each actual size ≤ its declared size,
+ * so a declared total under the cap bounds the actual total too.
+ */
+export async function peekUploads(
+  uploadIds: string[],
+  ctx: { orgId: string; applicationId: string },
+): Promise<Map<string, UploadMeta>> {
+  if (uploadIds.length === 0) return new Map();
+  const rows = await db.select().from(uploads).where(inArray(uploads.id, uploadIds));
+  const byId = new Map(rows.map((r) => [r.id, r]));
+  const result = new Map<string, UploadMeta>();
+  for (const id of uploadIds) {
+    const row = byId.get(id);
+    // Hide cross-tenant existence behind the same not-found as a missing row.
+    if (!row || row.orgId !== ctx.orgId || row.applicationId !== ctx.applicationId) {
+      throw notFound(`Upload '${id}' not found`);
+    }
+    if (row.expiresAt.getTime() < Date.now()) {
+      throw gone("upload_expired", `Upload '${id}' has expired`);
+    }
+    result.set(id, { id, name: row.name, mime: row.mime, size: row.size });
+  }
+  return result;
+}
+
 /**
  * Look up an upload row, verify ownership + freshness, claim it atomically,
- * download the payload, and sniff the MIME via magic bytes.
+ * then STREAM the payload through `sink` (which pipes it to its destination)
+ * while validating size + magic-byte MIME on the fly — the platform never
+ * buffers the whole upload in memory.
  *
  * The claim (`UPDATE … WHERE consumedAt IS NULL RETURNING`) is what prevents
  * the TOCTOU double-consume — two concurrent runs posting the same URI will
  * see exactly one winning row.
  *
+ * Size + MIME are validated *after* the stream drains (size is only known at
+ * end; MIME is sniffed from the head by the sink). On mismatch the claim is
+ * released and the source object dropped so the client can re-PUT. The sink's
+ * partially-written destination is NOT cleaned here — the caller owns the
+ * destination namespace (e.g. the run workspace) and rolls it back en bloc.
+ *
  * Throws `invalidRequest` / `notFound` / `conflict` / `gone` with stable
  * codes — callers map them back to RFC 9457 problem responses.
  */
-export async function consumeUpload(
+export async function consumeUploadStream(
   uploadId: string,
   ctx: { orgId: string; applicationId: string },
+  sink: UploadStreamSink,
 ): Promise<ConsumedUpload> {
   // Pre-check so we can return the right shape of error (not-found vs
   // cross-tenant vs already-consumed vs expired). The atomic claim below
@@ -280,28 +337,31 @@ export async function consumeUpload(
   const [bucket, ...rest] = row.storageKey.split("/");
   const path = rest.join("/");
   try {
-    const data = await storageGet(bucket!, path);
-    if (!data) {
+    const source = await storageDownloadStream(bucket!, path);
+    if (!source) {
       throw invalidRequest(`Upload '${uploadId}' binary is missing — client did not PUT the file`);
     }
 
-    const buffer = Buffer.from(data);
+    // Stream the bytes through the caller's sink (which pipes them to their
+    // destination). The sink reports the observed byte count and the MIME
+    // sniffed from the head — both are only known once the stream drains.
+    const { bytes, sniffedMime } = await sink(source);
 
     // Reject mismatched size outright — an attacker can declare 1KB in the
     // pre-signed request and PUT 100MB if the storage adapter doesn't enforce
     // ContentLength at sign time (S3 currently does not).
-    if (buffer.length !== row.size) {
+    if (bytes !== row.size) {
       logger.warn("upload size mismatch on consume", {
         uploadId,
         declared: row.size,
-        actual: buffer.length,
+        actual: bytes,
       });
       throw invalidRequest(
-        `Upload '${uploadId}' size mismatch: declared ${row.size} bytes, got ${buffer.length}`,
+        `Upload '${uploadId}' size mismatch: declared ${row.size} bytes, got ${bytes}`,
       );
     }
 
-    // Magic-byte MIME check (file-type reads first ~4100 bytes).
+    // Magic-byte MIME check (the sink sniffs the first ~4100 bytes of the head).
     //
     // When the manifest declares a concrete binary MIME (application/pdf,
     // image/png, …), we require `file-type` to recognise the bytes AND match.
@@ -315,25 +375,24 @@ export async function consumeUpload(
     //    the declared MIME for these — manifests that need binary-grade
     //    validation must declare a sniffable MIME.
     if (row.mime && row.mime !== "application/octet-stream" && !isUnsniffableMime(row.mime)) {
-      const sniffed = await fileTypeFromBuffer(buffer);
-      if (!sniffed || sniffed.mime !== row.mime) {
+      if (!sniffedMime || sniffedMime !== row.mime) {
         logger.warn("upload mime mismatch on consume", {
           uploadId,
           declared: row.mime,
-          sniffed: sniffed?.mime ?? null,
+          sniffed: sniffedMime ?? null,
         });
         throw invalidRequest(
-          sniffed
-            ? `Upload '${uploadId}' content type '${sniffed.mime}' does not match declared '${row.mime}'`
+          sniffedMime
+            ? `Upload '${uploadId}' content type '${sniffedMime}' does not match declared '${row.mime}'`
             : `Upload '${uploadId}' content does not match declared mime '${row.mime}'`,
         );
       }
     }
 
-    // The buffer is now in memory and will be injected into the run container.
-    // The storage copy is dead weight from here on — delete it best-effort so
-    // we don't leak S3/FS objects for every run. The GC's consumed-retention
-    // sweep is the safety net when this delete fails.
+    // Bytes have been streamed to the sink's destination. The source copy is
+    // dead weight from here on — delete it best-effort so we don't leak S3/FS
+    // objects for every run. The GC's consumed-retention sweep is the safety
+    // net when this delete fails.
     await storageDelete(bucket!, path).catch((delErr) => {
       logger.warn("failed to delete upload storage after consume", {
         uploadId,
@@ -345,8 +404,7 @@ export async function consumeUpload(
       id: uploadId,
       name: row.name,
       mime: row.mime,
-      size: buffer.length,
-      buffer,
+      size: bytes,
     };
   } catch (err) {
     // Order matters: delete the stored bytes FIRST, then release the claim.

--- a/apps/api/test/integration/routes/runs-workspace-fetch.test.ts
+++ b/apps/api/test/integration/routes/runs-workspace-fetch.test.ts
@@ -30,7 +30,9 @@ import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
 import { seedPackage } from "../../helpers/seed.ts";
 import {
-  uploadRunWorkspace,
+  uploadRunBundle,
+  streamRunDocument,
+  writeRunDocumentsManifest,
   downloadRunWorkspace,
   downloadRunDocumentsManifest,
   downloadRunDocumentStream,
@@ -40,6 +42,28 @@ import {
 const app = getTestApp();
 
 const RUN_SECRET = "a".repeat(43); // matches mintSinkCredentials base64url(32 bytes)
+
+/**
+ * Provision a run workspace the way the production trigger now does: bundle via
+ * uploadRunBundle, each document streamed in, then the manifest written once.
+ * Mirrors the split that lets the platform stream documents through without
+ * buffering them (the bundle stays a verbatim upload).
+ */
+async function seedWorkspace(
+  runId: string,
+  upload: { bundle?: Buffer; documents: { name: string; content: Buffer }[] },
+): Promise<void> {
+  if (upload.bundle) await uploadRunBundle(runId, upload.bundle);
+  if (upload.documents.length > 0) {
+    for (const doc of upload.documents) {
+      await streamRunDocument(runId, doc.name, new Response(doc.content).body!);
+    }
+    await writeRunDocumentsManifest(
+      runId,
+      upload.documents.map((d) => ({ name: d.name, size: d.content.byteLength })),
+    );
+  }
+}
 
 function signedGetHeaders(secret: string): Record<string, string> {
   const msgId = `msg_${crypto.randomUUID()}`;
@@ -77,7 +101,7 @@ async function seedRunWithSink(
 describe("run-workspace storage round-trip", () => {
   it("uploads, downloads, and deletes the bundle + documents + manifest", async () => {
     const runId = `run_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
-    await uploadRunWorkspace(runId, {
+    await seedWorkspace(runId, {
       bundle: Buffer.from("PACKAGE-BYTES"),
       documents: [
         { name: "report.txt", content: Buffer.from("hello world") },
@@ -110,15 +134,15 @@ describe("run-workspace storage round-trip", () => {
 
   it("uploads only a bundle when there are no documents (no manifest)", async () => {
     const runId = `run_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
-    await uploadRunWorkspace(runId, { bundle: Buffer.from("BUNDLE"), documents: [] });
+    await seedWorkspace(runId, { bundle: Buffer.from("BUNDLE"), documents: [] });
     expect(await downloadRunWorkspace(runId)).not.toBeNull();
     expect(await downloadRunDocumentsManifest(runId)).toBeNull();
     await deleteRunWorkspace(runId);
   });
 
-  it("uploadRunWorkspace is a no-op with no bundle and no documents", async () => {
+  it("writes nothing with no bundle and no documents", async () => {
     const runId = `run_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
-    await uploadRunWorkspace(runId, { documents: [] });
+    await seedWorkspace(runId, { documents: [] });
     expect(await downloadRunWorkspace(runId)).toBeNull();
     expect(await downloadRunDocumentsManifest(runId)).toBeNull();
   });
@@ -141,7 +165,7 @@ describe("GET /api/runs/:runId/workspace", () => {
 
   it("returns the provisioned bundle to a signed request", async () => {
     const runId = await seedRunWithSink(ctx, "@test/ws-agent");
-    await uploadRunWorkspace(runId, { bundle: Buffer.from("BUNDLE"), documents: [] });
+    await seedWorkspace(runId, { bundle: Buffer.from("BUNDLE"), documents: [] });
 
     const res = await app.request(`/api/runs/${runId}/workspace`, {
       method: "GET",
@@ -166,7 +190,7 @@ describe("GET /api/runs/:runId/workspace", () => {
 
   it("rejects an invalid signature with 401", async () => {
     const runId = await seedRunWithSink(ctx, "@test/ws-agent");
-    await uploadRunWorkspace(runId, { bundle: Buffer.from("BUNDLE"), documents: [] });
+    await seedWorkspace(runId, { bundle: Buffer.from("BUNDLE"), documents: [] });
 
     const res = await app.request(`/api/runs/${runId}/workspace`, {
       method: "GET",
@@ -179,7 +203,7 @@ describe("GET /api/runs/:runId/workspace", () => {
 
   it("rejects a closed sink with 410", async () => {
     const runId = await seedRunWithSink(ctx, "@test/ws-agent", { sinkClosedAt: new Date() });
-    await uploadRunWorkspace(runId, { bundle: Buffer.from("BUNDLE"), documents: [] });
+    await seedWorkspace(runId, { bundle: Buffer.from("BUNDLE"), documents: [] });
 
     const res = await app.request(`/api/runs/${runId}/workspace`, {
       method: "GET",
@@ -210,7 +234,7 @@ describe("GET /api/runs/:runId/documents[/:name]", () => {
 
   it("returns the manifest then streams each document", async () => {
     const runId = await seedRunWithSink(ctx, "@test/docs-agent");
-    await uploadRunWorkspace(runId, {
+    await seedWorkspace(runId, {
       bundle: Buffer.from("BUNDLE"),
       documents: [{ name: "a.txt", content: Buffer.from("doc-a") }],
     });
@@ -235,7 +259,7 @@ describe("GET /api/runs/:runId/documents[/:name]", () => {
 
   it("returns 404 on the manifest when the run carries no documents", async () => {
     const runId = await seedRunWithSink(ctx, "@test/docs-agent");
-    await uploadRunWorkspace(runId, { bundle: Buffer.from("BUNDLE"), documents: [] });
+    await seedWorkspace(runId, { bundle: Buffer.from("BUNDLE"), documents: [] });
 
     const res = await app.request(`/api/runs/${runId}/documents`, {
       method: "GET",
@@ -248,7 +272,7 @@ describe("GET /api/runs/:runId/documents[/:name]", () => {
 
   it("returns 404 for a document the run does not have", async () => {
     const runId = await seedRunWithSink(ctx, "@test/docs-agent");
-    await uploadRunWorkspace(runId, {
+    await seedWorkspace(runId, {
       bundle: Buffer.from("BUNDLE"),
       documents: [{ name: "a.txt", content: Buffer.from("doc-a") }],
     });
@@ -264,7 +288,7 @@ describe("GET /api/runs/:runId/documents[/:name]", () => {
 
   it("rejects an invalid signature with 401", async () => {
     const runId = await seedRunWithSink(ctx, "@test/docs-agent");
-    await uploadRunWorkspace(runId, {
+    await seedWorkspace(runId, {
       bundle: Buffer.from("BUNDLE"),
       documents: [{ name: "a.txt", content: Buffer.from("doc-a") }],
     });

--- a/apps/api/test/integration/services/input-parser-stream.test.ts
+++ b/apps/api/test/integration/services/input-parser-stream.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration tests for `parseRequestInput`'s streamed document consume — the
+ * glue that pipes each staged upload straight from the uploads bucket into the
+ * run workspace (no full buffer in API memory), writes the documents manifest,
+ * and rolls the workspace back when a document fails validation.
+ *
+ * Drives `parseRequestInput` directly with a minimal fake Hono context so the
+ * run-trigger pipeline (Docker, LLM) is not involved. Real Postgres + FS
+ * storage.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import type { Context } from "hono";
+import { db } from "@appstrate/db/client";
+import { uploads } from "@appstrate/db/schema";
+import { eq } from "drizzle-orm";
+import { truncateAll } from "../../helpers/db.ts";
+import { createTestContext } from "../../helpers/auth.ts";
+import { parseRequestInput } from "../../../src/services/input-parser.ts";
+import {
+  downloadRunDocumentStream,
+  downloadRunDocumentsManifest,
+} from "../../../src/services/run-workspace-storage.ts";
+import { uploadFile as storagePut, fileExists as storageExists } from "@appstrate/db/storage";
+import { ApiError } from "../../../src/lib/errors.ts";
+import type { JSONSchemaObject } from "@appstrate/core/form";
+
+const UPLOAD_BUCKET = "uploads";
+const PDF_BYTES = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a]); // %PDF-1.4\n
+
+const fileSchema: JSONSchemaObject = {
+  type: "object",
+  properties: {
+    doc: { type: "string", format: "uri", contentMediaType: "application/pdf" },
+  },
+};
+
+async function seedUpload(
+  ctx: { orgId: string; applicationId: string },
+  opts: { id: string; bytes: Buffer; mime?: string; sizeOverride?: number },
+): Promise<void> {
+  const storagePath = `${ctx.applicationId}/${opts.id}/file.pdf`;
+  await storagePut(UPLOAD_BUCKET, storagePath, opts.bytes);
+  await db.insert(uploads).values({
+    id: opts.id,
+    orgId: ctx.orgId,
+    applicationId: ctx.applicationId,
+    createdBy: null,
+    storageKey: `${UPLOAD_BUCKET}/${storagePath}`,
+    name: "file.pdf",
+    mime: opts.mime ?? "application/pdf",
+    size: opts.sizeOverride ?? opts.bytes.length,
+    expiresAt: new Date(Date.now() + 900 * 1000),
+  });
+}
+
+/** Minimal Hono context stub — parseRequestInput only reads the JSON body and orgId/applicationId. */
+function fakeCtx(body: unknown, ctx: { orgId: string; applicationId: string }): Context {
+  return {
+    req: { json: async () => body },
+    get: (key: string) =>
+      key === "orgId" ? ctx.orgId : key === "applicationId" ? ctx.applicationId : undefined,
+  } as unknown as Context;
+}
+
+describe("parseRequestInput — streamed document consume", () => {
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it("streams the upload into the run workspace + writes the manifest", async () => {
+    const ctx = await createTestContext({ orgSlug: "org-stream-ok" });
+    const scope = { orgId: ctx.orgId, applicationId: ctx.defaultAppId };
+    const id = "upl_stream_ok_1";
+    const storagePath = `${ctx.defaultAppId}/${id}/file.pdf`;
+    await seedUpload(scope, { id, bytes: PDF_BYTES });
+
+    const runId = `run_${crypto.randomUUID()}`;
+    const result = await parseRequestInput(
+      fakeCtx({ input: { doc: `upload://${id}` } }, scope),
+      runId,
+      fileSchema,
+    );
+
+    // Metadata surfaced, no buffer.
+    expect(result.uploadedFiles).toHaveLength(1);
+    const file = result.uploadedFiles![0]!;
+    expect(file).toMatchObject({
+      fieldName: "doc",
+      name: "file.pdf",
+      type: "application/pdf",
+      size: PDF_BYTES.length,
+    });
+    expect("buffer" in file).toBe(false);
+
+    // Document landed in the run workspace + manifest enumerates it.
+    const docStream = await downloadRunDocumentStream(runId, "file.pdf");
+    expect(docStream).not.toBeNull();
+    expect(new Uint8Array(await new Response(docStream!).arrayBuffer())).toEqual(
+      new Uint8Array(PDF_BYTES),
+    );
+    const manifest = await downloadRunDocumentsManifest(runId);
+    expect(manifest?.documents).toEqual([{ name: "file.pdf", size: PDF_BYTES.length }]);
+
+    // Source upload consumed + its storage object dropped.
+    const [row] = await db.select().from(uploads).where(eq(uploads.id, id)).limit(1);
+    expect(row?.consumedAt).not.toBeNull();
+    expect(await storageExists(UPLOAD_BUCKET, storagePath)).toBe(false);
+  });
+
+  it("rolls the workspace back + releases the claim on a size mismatch", async () => {
+    const ctx = await createTestContext({ orgSlug: "org-stream-size" });
+    const scope = { orgId: ctx.orgId, applicationId: ctx.defaultAppId };
+    const id = "upl_stream_size_1";
+    // Declared size larger than the bytes actually staged → mismatch at drain.
+    await seedUpload(scope, { id, bytes: PDF_BYTES, sizeOverride: PDF_BYTES.length + 1 });
+
+    const runId = `run_${crypto.randomUUID()}`;
+    await expect(
+      parseRequestInput(fakeCtx({ input: { doc: `upload://${id}` } }, scope), runId, fileSchema),
+    ).rejects.toMatchObject({ status: 400 });
+
+    // Workspace rolled back — no orphaned document or manifest.
+    expect(await downloadRunDocumentStream(runId, "file.pdf")).toBeNull();
+    expect(await downloadRunDocumentsManifest(runId)).toBeNull();
+    // Claim released so the client can re-upload + retry.
+    const [row] = await db.select().from(uploads).where(eq(uploads.id, id)).limit(1);
+    expect(row?.consumedAt).toBeNull();
+  });
+
+  it("rolls the workspace back on a MIME mismatch", async () => {
+    const ctx = await createTestContext({ orgSlug: "org-stream-mime" });
+    const scope = { orgId: ctx.orgId, applicationId: ctx.defaultAppId };
+    const id = "upl_stream_mime_1";
+    // Declared application/pdf, but the bytes are plain text → magic-byte sniff fails.
+    await seedUpload(scope, {
+      id,
+      bytes: Buffer.from("not a pdf", "utf-8"),
+      mime: "application/pdf",
+    });
+
+    const runId = `run_${crypto.randomUUID()}`;
+    let thrown: unknown;
+    try {
+      await parseRequestInput(
+        fakeCtx({ input: { doc: `upload://${id}` } }, scope),
+        runId,
+        fileSchema,
+      );
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(ApiError);
+    expect((thrown as ApiError).status).toBe(400);
+    expect(await downloadRunDocumentStream(runId, "file.pdf")).toBeNull();
+    expect(await downloadRunDocumentsManifest(runId)).toBeNull();
+  });
+});

--- a/apps/api/test/integration/services/input-parser-stream.test.ts
+++ b/apps/api/test/integration/services/input-parser-stream.test.ts
@@ -130,6 +130,28 @@ describe("parseRequestInput — streamed document consume", () => {
     expect(row?.consumedAt).toBeNull();
   });
 
+  it("aborts mid-stream when an upload overshoots its declared size", async () => {
+    const ctx = await createTestContext({ orgSlug: "org-stream-overshoot" });
+    const scope = { orgId: ctx.orgId, applicationId: ctx.defaultAppId };
+    const id = "upl_stream_overshoot_1";
+    // Declares 5 bytes but stages ~64 KB — the declared-small / uploaded-huge
+    // abuse the early-abort guard exists for. The counter must error the stream
+    // before the whole object lands in the run workspace.
+    const huge = Buffer.concat([PDF_BYTES, Buffer.alloc(64 * 1024, 0x20)]);
+    await seedUpload(scope, { id, bytes: huge, sizeOverride: 5 });
+
+    const runId = `run_${crypto.randomUUID()}`;
+    await expect(
+      parseRequestInput(fakeCtx({ input: { doc: `upload://${id}` } }, scope), runId, fileSchema),
+    ).rejects.toMatchObject({ status: 400 });
+
+    // Workspace rolled back, claim released — same guarantees as any rejection.
+    expect(await downloadRunDocumentStream(runId, "file.pdf")).toBeNull();
+    expect(await downloadRunDocumentsManifest(runId)).toBeNull();
+    const [row] = await db.select().from(uploads).where(eq(uploads.id, id)).limit(1);
+    expect(row?.consumedAt).toBeNull();
+  });
+
   it("rolls the workspace back on a MIME mismatch", async () => {
     const ctx = await createTestContext({ orgSlug: "org-stream-mime" });
     const scope = { orgId: ctx.orgId, applicationId: ctx.defaultAppId };

--- a/apps/api/test/integration/services/upload-consume.test.ts
+++ b/apps/api/test/integration/services/upload-consume.test.ts
@@ -1,22 +1,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Integration tests for `consumeUpload` — exercise the atomic claim that
+ * Integration tests for `consumeUploadStream` — exercise the atomic claim that
  * prevents two concurrent runs from consuming the same upload:// URI, plus
- * cross-tenant isolation and the expired/missing-binary paths.
+ * cross-tenant isolation, the streamed size/MIME validation, and the
+ * expired/missing-binary paths.
  *
- * Uses a real Postgres + filesystem storage; no routes exercised.
+ * Uses a real Postgres + filesystem storage; no routes exercised. The sink
+ * mirrors production — `fileTypeStream` sniffs the head, a manual drain counts
+ * the bytes — without writing to a run workspace, so the tests stay focused on
+ * consume semantics.
  */
 
 import { describe, it, expect, beforeEach } from "bun:test";
+import { fileTypeStream } from "file-type";
 import { db } from "@appstrate/db/client";
 import { uploads } from "@appstrate/db/schema";
 import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext } from "../../helpers/auth.ts";
 import {
-  consumeUpload,
+  consumeUploadStream,
   writeFsUploadContent,
   cleanupExpiredUploads,
+  type UploadStreamSink,
 } from "../../../src/services/uploads.ts";
 import {
   uploadFile as storagePut,
@@ -28,6 +34,23 @@ import { ApiError } from "../../../src/lib/errors.ts";
 
 const UPLOAD_BUCKET = "uploads";
 const PDF_BYTES = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a]); // %PDF-1.4\n
+
+/**
+ * Drain the upload stream the way the run-trigger sink does: sniff the MIME
+ * from the head via `fileTypeStream`, count every byte. Reports the actual size
+ * + sniffed MIME so consume can validate them against the declared upload row.
+ */
+const drainSink: UploadStreamSink = async (stream) => {
+  const detection = await fileTypeStream(stream);
+  let bytes = 0;
+  const reader = detection.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    bytes += value.byteLength;
+  }
+  return { bytes, sniffedMime: detection.fileType?.mime };
+};
 
 async function seedUpload(
   ctx: { orgId: string; applicationId: string },
@@ -59,7 +82,7 @@ async function seedUpload(
   return opts.id;
 }
 
-describe("consumeUpload", () => {
+describe("consumeUploadStream", () => {
   beforeEach(async () => {
     await truncateAll();
   });
@@ -73,8 +96,8 @@ describe("consumeUpload", () => {
     );
 
     const settled = await Promise.allSettled([
-      consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId }),
-      consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId }),
+      consumeUploadStream(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId }, drainSink),
+      consumeUploadStream(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId }, drainSink),
     ]);
     const fulfilled = settled.filter((s) => s.status === "fulfilled");
     const rejected = settled.filter((s) => s.status === "rejected");
@@ -92,9 +115,13 @@ describe("consumeUpload", () => {
       { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
       { id, bytes: PDF_BYTES },
     );
-    await consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId });
+    await consumeUploadStream(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId }, drainSink);
     try {
-      await consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId });
+      await consumeUploadStream(
+        id,
+        { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+        drainSink,
+      );
       throw new Error("expected to throw");
     } catch (e) {
       expect(e).toBeInstanceOf(ApiError);
@@ -111,7 +138,11 @@ describe("consumeUpload", () => {
       { id, bytes: PDF_BYTES },
     );
     try {
-      await consumeUpload(id, { orgId: other.orgId, applicationId: other.defaultAppId });
+      await consumeUploadStream(
+        id,
+        { orgId: other.orgId, applicationId: other.defaultAppId },
+        drainSink,
+      );
       throw new Error("expected to throw");
     } catch (e) {
       expect(e).toBeInstanceOf(ApiError);
@@ -127,7 +158,11 @@ describe("consumeUpload", () => {
       { id, bytes: PDF_BYTES, expiresInSec: -10 },
     );
     try {
-      await consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId });
+      await consumeUploadStream(
+        id,
+        { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+        drainSink,
+      );
       throw new Error("expected to throw");
     } catch (e) {
       expect(e).toBeInstanceOf(ApiError);
@@ -143,7 +178,11 @@ describe("consumeUpload", () => {
       { id, bytes: PDF_BYTES, sizeOverride: 1 },
     );
     try {
-      await consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId });
+      await consumeUploadStream(
+        id,
+        { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+        drainSink,
+      );
       throw new Error("expected to throw");
     } catch (e) {
       expect(e).toBeInstanceOf(ApiError);
@@ -160,7 +199,11 @@ describe("consumeUpload", () => {
       { id, bytes: PDF_BYTES, skipStoragePut: true },
     );
     try {
-      await consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId });
+      await consumeUploadStream(
+        id,
+        { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+        drainSink,
+      );
       throw new Error("expected to throw");
     } catch (e) {
       expect(e).toBeInstanceOf(ApiError);
@@ -176,10 +219,14 @@ describe("consumeUpload", () => {
       { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
       { id, bytes, mime: "text/plain" },
     );
-    const consumed = await consumeUpload(id, {
-      orgId: ctx.orgId,
-      applicationId: ctx.defaultAppId,
-    });
+    const consumed = await consumeUploadStream(
+      id,
+      {
+        orgId: ctx.orgId,
+        applicationId: ctx.defaultAppId,
+      },
+      drainSink,
+    );
     expect(consumed.size).toBe(bytes.length);
     expect(consumed.mime).toBe("text/plain");
   });
@@ -193,7 +240,11 @@ describe("consumeUpload", () => {
       { id, bytes, mime: "application/pdf" },
     );
     try {
-      await consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId });
+      await consumeUploadStream(
+        id,
+        { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+        drainSink,
+      );
       throw new Error("expected to throw");
     } catch (e) {
       expect(e).toBeInstanceOf(ApiError);
@@ -211,7 +262,11 @@ describe("consumeUpload", () => {
       { id, bytes: PDF_BYTES, sizeOverride: PDF_BYTES.length + 1 },
     );
     try {
-      await consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId });
+      await consumeUploadStream(
+        id,
+        { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+        drainSink,
+      );
       throw new Error("expected to throw");
     } catch (e) {
       expect((e as ApiError).status).toBe(400);
@@ -231,7 +286,7 @@ describe("consumeUpload", () => {
     );
     expect(await storageExists(UPLOAD_BUCKET, storagePath)).toBe(true);
 
-    await consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId });
+    await consumeUploadStream(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId }, drainSink);
 
     // Storage copy is dead weight after consume — must be gone.
     expect(await storageExists(UPLOAD_BUCKET, storagePath)).toBe(false);
@@ -250,7 +305,11 @@ describe("consumeUpload", () => {
     );
     expect(await storageExists(UPLOAD_BUCKET, storagePath)).toBe(true);
 
-    await consumeUpload(id, { orgId: ctx.orgId, applicationId: ctx.defaultAppId }).catch(() => {});
+    await consumeUploadStream(
+      id,
+      { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      drainSink,
+    ).catch(() => {});
 
     // Release path drops the bytes so re-upload to a fresh slot can succeed.
     expect(await storageExists(UPLOAD_BUCKET, storagePath)).toBe(false);

--- a/apps/api/test/unit/map-with-concurrency.test.ts
+++ b/apps/api/test/unit/map-with-concurrency.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the bounded-concurrency mapper used to stream a run's input
+ * documents without an unbounded fan-out. Covers order preservation, the
+ * concurrency cap, and the abort-on-first-rejection behaviour the workspace
+ * rollback relies on.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { mapWithConcurrency } from "../../src/services/input-parser.ts";
+
+const tick = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("mapWithConcurrency", () => {
+  it("preserves input order in the result", async () => {
+    const out = await mapWithConcurrency([1, 2, 3, 4, 5], 2, async (n) => {
+      await tick();
+      return n * n;
+    });
+    expect(out).toEqual([1, 4, 9, 16, 25]);
+  });
+
+  it("never runs more than `limit` callbacks at once", async () => {
+    let active = 0;
+    let peak = 0;
+    await mapWithConcurrency(
+      Array.from({ length: 20 }, (_, i) => i),
+      3,
+      async () => {
+        active++;
+        peak = Math.max(peak, active);
+        await tick();
+        active--;
+        return null;
+      },
+    );
+    expect(peak).toBeLessThanOrEqual(3);
+    expect(peak).toBeGreaterThan(1); // actually parallelised, not serialised
+  });
+
+  it("uses at most `items.length` workers when limit exceeds the item count", async () => {
+    let active = 0;
+    let peak = 0;
+    await mapWithConcurrency([1, 2], 16, async (n) => {
+      active++;
+      peak = Math.max(peak, active);
+      await tick();
+      active--;
+      return n;
+    });
+    expect(peak).toBeLessThanOrEqual(2);
+  });
+
+  it("rejects on the first error and starts no further items", async () => {
+    let started = 0;
+    let thrown: unknown;
+    try {
+      await mapWithConcurrency(
+        Array.from({ length: 10 }, (_, i) => i),
+        2,
+        async (i) => {
+          started++;
+          await tick();
+          if (i === 0) throw new Error("boom");
+          return i;
+        },
+      );
+    } catch (e) {
+      thrown = e;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toBe("boom");
+    // With a cap of 2 and the failure on the first item, the in-flight pair may
+    // both start, but the loop stops pulling new work — nowhere near all 10.
+    expect(started).toBeLessThan(10);
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -249,12 +249,14 @@
       },
       "peerDependencies": {
         "@aws-sdk/client-s3": "^3",
+        "@aws-sdk/lib-storage": "^3",
         "@aws-sdk/s3-request-presigner": "^3",
         "hono": "^4.12.9",
         "typescript": "^5",
       },
       "optionalPeers": [
         "@aws-sdk/client-s3",
+        "@aws-sdk/lib-storage",
         "@aws-sdk/s3-request-presigner",
         "hono",
       ],
@@ -268,6 +270,7 @@
         "@appstrate/emails": "workspace:*",
         "@appstrate/env": "workspace:*",
         "@aws-sdk/client-s3": "^3.1038.0",
+        "@aws-sdk/lib-storage": "^3.1038.0",
         "@aws-sdk/s3-request-presigner": "^3.1038.0",
         "@better-auth/drizzle-adapter": "^1.5.3",
         "@electric-sql/pglite": "^0.4.5",
@@ -498,6 +501,8 @@
     "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.36", "", { "dependencies": { "@aws-sdk/core": "^3.974.6", "@aws-sdk/nested-clients": "^3.997.4", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-uzrURO7frJhHQVVNR5zBJcCYeMYflmXcWBK1+MiBym2Dfjh6nXATrMixrmGZi+97Q7ETZ+y/4lUwAy0Nfnznjw=="],
 
     "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.14", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@smithy/eventstream-codec": "^4.2.14", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg=="],
+
+    "@aws-sdk/lib-storage": ["@aws-sdk/lib-storage@3.1063.0", "", { "dependencies": { "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "buffer": "5.6.0", "events": "3.3.0", "stream-browserify": "3.0.0", "tslib": "^2.6.2" }, "peerDependencies": { "@aws-sdk/client-s3": "^3.1063.0" } }, "sha512-WfDUIna6HicL8oTs26etBIr7yGwHIkadr8ecp/SjQAhX3t5xM/PLJCl0ZJ+bcLtYyjmWrO3Ydyf/EUyraEz8Qw=="],
 
     "@aws-sdk/middleware-bucket-endpoint": ["@aws-sdk/middleware-bucket-endpoint@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-arn-parser": "^3.972.3", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA=="],
 
@@ -1361,6 +1366,8 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
+    "buffer": ["buffer@5.6.0", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4" } }, "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw=="],
+
     "buffer-crc32": ["buffer-crc32@0.2.13", "", {}, "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
@@ -1566,6 +1573,8 @@
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
@@ -2189,6 +2198,8 @@
 
     "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
 
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
     "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
 
     "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
@@ -2299,9 +2310,13 @@
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
 
+    "stream-browserify": ["stream-browserify@3.0.0", "", { "dependencies": { "inherits": "~2.0.4", "readable-stream": "^3.5.0" } }, "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA=="],
+
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
@@ -2488,6 +2503,10 @@
     "@aws-crypto/util/@aws-sdk/types": ["@aws-sdk/types@3.973.6", "", { "dependencies": { "@smithy/types": "^4.13.1", "tslib": "^2.6.2" } }, "sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw=="],
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-sdk/lib-storage/@smithy/core": ["@smithy/core@3.24.6", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug=="],
+
+    "@aws-sdk/lib-storage/@smithy/types": ["@smithy/types@4.14.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,12 +91,16 @@
   },
   "peerDependencies": {
     "@aws-sdk/client-s3": "^3",
+    "@aws-sdk/lib-storage": "^3",
     "@aws-sdk/s3-request-presigner": "^3",
     "hono": "^4.12.9",
     "typescript": "^5"
   },
   "peerDependenciesMeta": {
     "@aws-sdk/client-s3": {
+      "optional": true
+    },
+    "@aws-sdk/lib-storage": {
       "optional": true
     },
     "@aws-sdk/s3-request-presigner": {

--- a/packages/core/src/storage-fs.ts
+++ b/packages/core/src/storage-fs.ts
@@ -145,6 +145,21 @@ export function createFileSystemStorage(config: FileSystemStorageConfig): Storag
       return makeKey(bucket, path);
     },
 
+    async uploadStream(bucket, path, stream, opts) {
+      if (opts?.exclusive) {
+        throw new Error("uploadStream does not support exclusive uploads");
+      }
+      const fullPath = resolve(bucket, path);
+      await mkdir(dirname(fullPath), { recursive: true });
+      await verifyContainment(dirname(fullPath));
+      // Bun.write streams a Response body straight to disk without reading the
+      // whole payload into memory — wrap the web ReadableStream in a Response so
+      // it pipes chunk-by-chunk.
+      await Bun.write(fullPath, new Response(stream));
+      await verifyContainment(fullPath);
+      return makeKey(bucket, path);
+    },
+
     async downloadFile(bucket, path) {
       const fullPath = resolve(bucket, path);
       await verifyContainment(fullPath);

--- a/packages/core/src/storage-s3.ts
+++ b/packages/core/src/storage-s3.ts
@@ -117,11 +117,19 @@ export function createS3Storage(config: S3StorageConfig): Storage {
       const key = makeKey(bucket, path);
       // `@aws-sdk/lib-storage` Upload runs a multipart upload that consumes the
       // source stream chunk-by-chunk with backpressure — no full buffering and
-      // no need to know the content length up front. The default 5 MiB part
-      // size is the floor S3 allows for multipart parts.
+      // no need to know the content length up front.
+      //
+      // `partSize` is pinned to the 5 MiB S3 floor and `queueSize` to 1 so the
+      // in-flight buffer is one part (~5 MiB) rather than the SDK default of
+      // queueSize 4 × 5 MiB = ~20 MiB. This keeps per-stream memory bounded and
+      // predictable when many documents stream concurrently; the trade-off is no
+      // parallel part upload per object, which is fine for input documents
+      // (modest sizes, latency dominated by the copy itself, not part fan-out).
       const upload = new Upload({
         client,
         params: { Bucket: config.bucket, Key: key, Body: stream },
+        partSize: 5 * 1024 * 1024,
+        queueSize: 1,
       });
       await upload.done();
       return key;

--- a/packages/core/src/storage-s3.ts
+++ b/packages/core/src/storage-s3.ts
@@ -10,6 +10,7 @@ import {
   DeleteObjectCommand,
 } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { Upload } from "@aws-sdk/lib-storage";
 import type { Storage, CreateUploadUrlOptions, UploadUrlDescriptor } from "./storage.ts";
 import { StorageAlreadyExistsError } from "./storage.ts";
 
@@ -106,6 +107,23 @@ export function createS3Storage(config: S3StorageConfig): Storage {
         }
         throw err;
       }
+      return key;
+    },
+
+    async uploadStream(bucket, path, stream, opts) {
+      if (opts?.exclusive) {
+        throw new Error("uploadStream does not support exclusive uploads");
+      }
+      const key = makeKey(bucket, path);
+      // `@aws-sdk/lib-storage` Upload runs a multipart upload that consumes the
+      // source stream chunk-by-chunk with backpressure — no full buffering and
+      // no need to know the content length up front. The default 5 MiB part
+      // size is the floor S3 allows for multipart parts.
+      const upload = new Upload({
+        client,
+        params: { Bucket: config.bucket, Key: key, Body: stream },
+      });
+      await upload.done();
       return key;
     },
 

--- a/packages/core/src/storage.ts
+++ b/packages/core/src/storage.ts
@@ -55,6 +55,24 @@ export interface Storage {
     data: Uint8Array | Buffer,
     opts?: UploadFileOptions,
   ): Promise<string>;
+  /**
+   * Stream binary data to the given bucket/path without buffering the whole
+   * payload in memory. Prefer this over uploadFile() when the source is itself
+   * a stream (e.g. copying a large object between buckets) — it pipes from the
+   * source to the backend a chunk at a time. Backends: S3 uses a multipart
+   * upload (`@aws-sdk/lib-storage`), which handles an unknown content length;
+   * filesystem pipes the web stream straight to disk. Returns the storage key.
+   *
+   * `opts.exclusive` is NOT supported on this path (S3 multipart cannot send
+   * `If-None-Match: *`) and throws if set — callers needing exclusivity must
+   * use uploadFile(). Streamed destinations here are single-use keys.
+   */
+  uploadStream(
+    bucket: string,
+    path: string,
+    stream: ReadableStream<Uint8Array>,
+    opts?: UploadFileOptions,
+  ): Promise<string>;
   /** Download a file from storage. Returns null if the file does not exist. */
   downloadFile(bucket: string, path: string): Promise<Uint8Array | null>;
   /**

--- a/packages/core/test/storage-fs.test.ts
+++ b/packages/core/test/storage-fs.test.ts
@@ -83,6 +83,32 @@ describe("createFileSystemStorage", () => {
     });
   });
 
+  describe("uploadStream", () => {
+    it("streams data to disk and round-trips it", async () => {
+      const content = "streamed-to-disk payload";
+      await storage.uploadStream("strm", "out.txt", new Response(content).body!);
+      const result = await storage.downloadFile("strm", "out.txt");
+      expect(new TextDecoder().decode(result!)).toBe(content);
+    });
+
+    it("creates nested directories automatically", async () => {
+      await storage.uploadStream("strm", "x/y/z/file.bin", new Response("nested").body!);
+      const result = await storage.downloadFile("strm", "x/y/z/file.bin");
+      expect(new TextDecoder().decode(result!)).toBe("nested");
+    });
+
+    it("returns the storage key", async () => {
+      const key = await storage.uploadStream("b", "p/f.bin", new Response("k").body!);
+      expect(key).toBe(join("b", "p", "f.bin"));
+    });
+
+    it("rejects exclusive uploads (unsupported on the stream path)", async () => {
+      await expect(
+        storage.uploadStream("b", "excl.bin", new Response("x").body!, { exclusive: true }),
+      ).rejects.toThrow(/exclusive/);
+    });
+  });
+
   describe("downloadFile", () => {
     it("returns null for non-existent files", async () => {
       const result = await storage.downloadFile("bucket", "does-not-exist.txt");

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -25,6 +25,7 @@
     "@appstrate/emails": "workspace:*",
     "@appstrate/env": "workspace:*",
     "@aws-sdk/client-s3": "^3.1038.0",
+    "@aws-sdk/lib-storage": "^3.1038.0",
     "@aws-sdk/s3-request-presigner": "^3.1038.0",
     "@better-auth/drizzle-adapter": "^1.5.3",
     "@electric-sql/pglite": "^0.4.5",

--- a/packages/db/src/storage.ts
+++ b/packages/db/src/storage.ts
@@ -43,6 +43,15 @@ export function uploadFile(
   return getStore().uploadFile(bucket, path, data, opts);
 }
 
+export function uploadStream(
+  bucket: string,
+  path: string,
+  stream: ReadableStream<Uint8Array>,
+  opts?: UploadFileOptions,
+): Promise<string> {
+  return getStore().uploadStream(bucket, path, stream, opts);
+}
+
 export function downloadFile(bucket: string, path: string): Promise<Uint8Array | null> {
   return getStore().downloadFile(bucket, path);
 }


### PR DESCRIPTION
Closes #561.

## Problem

Input documents were buffered **fully in API memory** during `consumeUpload` — the whole object was read into a `Buffer` and held there until `uploadRunWorkspace` re-uploaded it to run-scoped storage. PR #558 fixed the agent-side memory risk and added the 256 MiB `WORKSPACE_MAX_DOCS_BYTES` cap; this PR removes the remaining API-side full buffer.

## Key insight

The issue framed the blocker as *"`consumeUpload` runs before the run row exists — no `runId` yet"*. But the `runId` is a **client-minted UUID** (`run_${crypto.randomUUID()}`), not DB-allocated — so it can be minted *before* input parsing. The run-workspace namespace (`run-workspace/<runId>/…`) only needs the id string; the DB row is still created later with the same id. That dissolves the ordering problem without reordering `createRun`.

## Approach

Each upload is streamed straight from the **uploads** bucket into the **run-workspace** bucket, validating size + MIME on the fly. No document ever fully resides in API memory.

- **`Storage.uploadStream(bucket, path, stream)`** — new primitive. S3 multipart via `@aws-sdk/lib-storage`; filesystem via `Bun.write(path, new Response(stream))`. (`exclusive` unsupported on this path — single-use keys only.)
- **`run-workspace-storage`** — `streamRunDocument` + `writeRunDocumentsManifest` + `uploadRunBundle` replace the buffer-mode `uploadRunWorkspace`; `deleteRunDocuments` handles pre-launch rollback.
- **`consumeUploadStream`** replaces `consumeUpload` — same atomic claim + delete-source/release-claim semantics, but streams through a caller-supplied sink that counts bytes and sniffs the MIME from the head (`fileTypeStream`) instead of downloading to a `Buffer`. Size + MIME validated after the stream drains (delete-on-mismatch).
- **`parseRequestInput(c, runId, schema)`** — pre-checks the per-run cap on *declared* sizes, streams each document into the run workspace, writes the manifest, and rolls the workspace back on any failure. The run route mints the id first and cleans up on the pre-launch error path.
- Drop `UploadedFile.buffer` and the now-dead `inputFiles` plumbing — the plan carries only document metadata; `pi.ts` uploads just the bundle.

## Memory profile (honest numbers)

The win is removing the **full-file** buffer (previously up to the per-file size, e.g. tens/hundreds of MiB). The streamed path's floor is **not** a few KB — it is bounded and predictable instead:

- **Per document, in flight:** the MIME-sniff head (`fileTypeStream`, ~few KB) **+** the storage adapter's part buffer. For S3 the multipart `Upload` is pinned to `partSize` 5 MiB / `queueSize` 1 → **~5 MiB per object** (vs the SDK default `queueSize` 4 × 5 MiB ≈ 20 MiB). For the filesystem adapter it's a small pipe buffer.
- **Per run:** documents stream through a **bounded mapper (max 4 concurrent)** rather than an unbounded `Promise.all`, so a large array-file field can't pin `documents × part-buffer`. Floor ≈ `4 × ~5 MiB` regardless of document count.

## Hardening — early abort on oversize

The size check exists precisely because S3 does not enforce `ContentLength` at sign time, so a *declared-small / uploaded-huge* upload is possible. The production sink's counting passthrough **errors the stream the moment the byte count exceeds the declared size**, so the multipart upload aborts (or the FS write stops) *before* the oversized payload lands in the run workspace — rather than copying it in full and deleting it after a post-drain check. The post-drain `bytes === size` check in `consumeUploadStream` remains the under-size case and the correctness backstop for any sink that does not abort early.

## Tests

- FS `uploadStream` round-trip (+ exclusive rejection).
- `consumeUploadStream` streamed size/MIME validation, claim/cleanup (15 tests).
- run-workspace stream + manifest round-trip.
- `input-parser-stream`: happy path, size/MIME rollback, **mid-stream overshoot abort**.
- `mapWithConcurrency` unit: order, concurrency cap, abort-on-first-rejection.

`bun run check` (tsc + eslint + prettier + verify-openapi + detect:breaking) green. No OpenAPI changes.

## Trade-off / scope

Per the issue, this targets memory pressure under concurrent doc-heavy runs, not a correctness bug — the cap already bounds API memory and the real OOM (agent side) was fixed in #558. The storage primitive is additive; the consume swap is the behavioral edit. **Known residual:** there is no run-workspace GC, so if a best-effort rollback delete fails on the pre-launch error path the object leaks until... nothing sweeps it (only `pi.ts`'s teardown cleans, and that runs only for launched runs). A run-workspace GC sweep would be a reasonable follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)