### PR TITLE
fix(storage): stream uploadStream to disk without hanging or buffering

### DIFF
--- a/packages/core/src/storage-fs.ts
+++ b/packages/core/src/storage-fs.ts
@@ -7,6 +7,13 @@ import { createHmac, timingSafeEqual } from "node:crypto";
 import type { Storage, CreateUploadUrlOptions, UploadUrlDescriptor } from "./storage.ts";
 import { StorageAlreadyExistsError } from "./storage.ts";
 
+/**
+ * FileSink buffer watermark for `uploadStream` (bytes). The sink flushes to disk
+ * once pending writes cross this threshold, capping resident memory per stream.
+ * 1 MiB trades a few extra writes for bounded memory under the 256 MiB doc cap.
+ */
+const STREAM_FLUSH_BYTES = 1024 * 1024;
+
 /** Configuration for the filesystem storage backend. */
 export interface FileSystemStorageConfig {
   /** Root directory for all stored files. */
@@ -152,10 +159,46 @@ export function createFileSystemStorage(config: FileSystemStorageConfig): Storag
       const fullPath = resolve(bucket, path);
       await mkdir(dirname(fullPath), { recursive: true });
       await verifyContainment(dirname(fullPath));
-      // Bun.write streams a Response body straight to disk without reading the
-      // whole payload into memory — wrap the web ReadableStream in a Response so
-      // it pipes chunk-by-chunk.
-      await Bun.write(fullPath, new Response(stream));
+      // Pull the web ReadableStream chunk-by-chunk into a FileSink — never
+      // buffering the whole payload in memory.
+      //
+      // We deliberately do NOT use `Bun.write(path, new Response(stream))`:
+      // for a non-trivial (file-backed / async / transform-piped) stream that
+      // call hangs indefinitely, and `Bun.write(path, stream)` without the
+      // Response wrapper silently stringifies the stream object to disk
+      // ("[object ReadableStream]") instead of streaming its bytes. The
+      // explicit reader loop drives the source — including any upstream
+      // TransformStream (e.g. the consume byte-counter) — and surfaces a
+      // mid-stream `controller.error()` as a thrown read so the caller can
+      // roll back the partially-written destination.
+      //
+      // `highWaterMark` is load-bearing: a default FileSink accumulates *every*
+      // written chunk in memory and flushes only on `end()`, which would
+      // reintroduce the full in-memory buffering this streaming path exists to
+      // avoid. With an explicit watermark the sink flushes to disk once the
+      // pending buffer crosses it, bounding resident memory to ~one watermark.
+      const writer = Bun.file(fullPath).writer({ highWaterMark: STREAM_FLUSH_BYTES });
+      const reader = stream.getReader();
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          writer.write(value);
+        }
+        await writer.end();
+      } catch (err) {
+        // Flush + close the sink so the partial file's fd is released (the
+        // caller rolls back the destination namespace), and cancel the source
+        // so its underlying fd/socket isn't leaked. `end()` returns a byte
+        // count (not a promise), so guard rather than chaining `.catch`.
+        try {
+          await writer.end();
+        } catch {
+          // already errored — nothing to recover
+        }
+        await reader.cancel(err).catch(() => {});
+        throw err;
+      }
       await verifyContainment(fullPath);
       return makeKey(bucket, path);
     },

--- a/packages/core/test/storage-fs.test.ts
+++ b/packages/core/test/storage-fs.test.ts
@@ -107,6 +107,80 @@ describe("createFileSystemStorage", () => {
         storage.uploadStream("b", "excl.bin", new Response("x").body!, { exclusive: true }),
       ).rejects.toThrow(/exclusive/);
     });
+
+    // Regression: a pre-buffered `new Response("string").body` stream resolves
+    // synchronously and masked the real bug. The production consume path feeds a
+    // file-backed stream piped through a TransformStream — that combination hung
+    // forever under the old `Bun.write(path, new Response(stream))` impl and
+    // wrote "[object ReadableStream]" under a bare `Bun.write(path, stream)`.
+    it("round-trips a file-backed stream piped through a TransformStream", async () => {
+      const payload = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a]);
+      await storage.uploadFile("strm", "source.bin", payload);
+      const source = await storage.downloadStream("strm", "source.bin");
+      expect(source).not.toBeNull();
+
+      let seen = 0;
+      const counter = new TransformStream<Uint8Array, Uint8Array>({
+        transform(chunk, controller) {
+          seen += chunk.byteLength;
+          controller.enqueue(chunk);
+        },
+      });
+
+      await storage.uploadStream("strm", "dest.bin", source!.pipeThrough(counter));
+
+      const result = await storage.downloadFile("strm", "dest.bin");
+      expect(result).toEqual(payload);
+      expect(seen).toBe(payload.byteLength);
+    });
+
+    it("flushes to disk mid-stream rather than buffering the whole payload", async () => {
+      // The sink must write progressively. A default FileSink buffers every
+      // chunk until end(); this asserts bytes hit disk *before* the stream
+      // closes, so resident memory stays bounded under large uploads.
+      const chunk = new Uint8Array(1024 * 1024); // 1 MiB
+      const totalChunks = 8;
+      let onDiskMidStream = -1;
+
+      const source = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (let i = 0; i < totalChunks; i++) controller.enqueue(chunk);
+          controller.close();
+        },
+      });
+
+      const probe = new TransformStream<Uint8Array, Uint8Array>({
+        async transform(c, controller) {
+          controller.enqueue(c);
+          // After the first chunk, give the sink a tick to flush, then read the
+          // on-disk size — it must be > 0 well before the stream ends.
+          if (onDiskMidStream === -1) {
+            await new Promise((r) => setTimeout(r, 0));
+            const partial = await storage.downloadFile("strm", "big.bin");
+            onDiskMidStream = partial?.byteLength ?? 0;
+          }
+        },
+      });
+
+      await storage.uploadStream("strm", "big.bin", source.pipeThrough(probe));
+
+      const result = await storage.downloadFile("strm", "big.bin");
+      expect(result?.byteLength).toBe(totalChunks * chunk.byteLength);
+      expect(onDiskMidStream).toBeGreaterThan(0);
+      expect(onDiskMidStream).toBeLessThan(totalChunks * chunk.byteLength);
+    });
+
+    it("propagates a mid-stream transform error and leaves a partial file the caller can roll back", async () => {
+      const boom = new TransformStream<Uint8Array, Uint8Array>({
+        transform(_chunk, controller) {
+          controller.error(new Error("boom"));
+        },
+      });
+      const source = new Response(new Uint8Array([1, 2, 3])).body!;
+      await expect(
+        storage.uploadStream("strm", "broken.bin", source.pipeThrough(boom)),
+      ).rejects.toThrow(/boom/);
+    });
   });
 
   describe("downloadFile", () => {


### PR DESCRIPTION
## Problem

`main` CI is red — the **Test** workflow's E2E job fails on 3 tests in `e2e/tests/uploads/upload-flow.api.spec.ts`. All three hang on `POST .../run` until the 30s Playwright timeout (`Request context disposed`). Unit + Integration are green.

Root cause: PR #595 added `FileSystemStorage.uploadStream` as `Bun.write(path, new Response(stream))`. In **Bun 1.3.11** that call **hangs indefinitely** for any non-trivial (file-backed / async / transform-piped) stream, and the unwrapped `Bun.write(path, stream)` silently **stringifies** the stream object to disk (`[object ReadableStream]`).

The e2e upload flow consumes an upload through `Bun.file().stream()` → `fileTypeStream` → `TransformStream` (byte-counter) → `uploadStream` on the **filesystem** backend (PGlite tier), so the run handler never returns.

Why it slipped through merge CI:
- The FS unit test fed a pre-buffered in-memory `new Response("string").body` — resolves synchronously, masks the hang.
- Integration consume tests run against MinIO/S3 (`@aws-sdk/lib-storage` multipart — unaffected).
- Only the e2e suite exercised real FS streaming.

## Fix

Replace the `Response` wrapper with an explicit reader loop into a `FileSink`:

- Drives the upstream `TransformStream` so the consume byte-counter runs.
- Surfaces a mid-stream `controller.error()` as a thrown read → caller rolls back the destination.
- **`highWaterMark` is load-bearing**: a default `FileSink` accumulates every chunk in memory until `end()`, which would reintroduce the full in-memory buffering this streaming path exists to remove. An explicit watermark (1 MiB) flushes to disk progressively, bounding resident memory.
- On error: flush+close the sink and `reader.cancel(err)` so the source fd/socket isn't leaked.

## Tests

Hardened `packages/core/test/storage-fs.test.ts` with the failure shapes the original test missed:
- file-backed stream piped through a `TransformStream` (the shape that hung),
- proof the sink flushes mid-stream rather than buffering the whole payload,
- mid-stream error propagation.

`storage-fs.test.ts`: 24 pass. `tsc` + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)