### PR TITLE
fix(connect): surface DCR rejection reason instead of opaque 403

### DIFF
--- a/apps/api/src/services/connect/oauth2-strategy.ts
+++ b/apps/api/src/services/connect/oauth2-strategy.ts
@@ -86,15 +86,23 @@ export class OAuth2Strategy implements IntegrationConnectStrategy {
     );
     const client = resolved.client;
     if (!client) {
-      // Distinguish the two "no client" causes: an auto-provisioning auth
-      // (public client on a remote MCP integration) tries to self-register via
-      // CIMD/DCR, so a missing client means discovery/registration failed — not
-      // that an admin forgot to register. Confidential/classic auths still
-      // require a manually-registered client.
+      // Two families of "no client":
+      //   - auto-provisioning auth (public client on a remote MCP integration):
+      //     client acquisition failed. `resolved.provisioningFailure` carries
+      //     the complete reason + remedy, authored by whichever step failed (no
+      //     registration endpoint, blocked endpoint, AS rejection, network, …).
+      //     Render it verbatim — no per-cause branch.
+      //   - confidential/classic auth: an admin must pre-register a client.
+      if (usesAutoProvisionedClient(manifest, auth)) {
+        const failure = resolved.provisioningFailure;
+        const detail = failure?.message ?? "discovery or client registration failed";
+        const statusPart = failure?.status ? ` (HTTP ${failure.status})` : "";
+        throw forbidden(
+          `Could not automatically provision an OAuth client for '${ctx.integrationId}' auth '${ctx.authKey}'${statusPart}: ${detail}`,
+        );
+      }
       throw forbidden(
-        usesAutoProvisionedClient(manifest, auth)
-          ? `Could not automatically provision an OAuth client for '${ctx.integrationId}' auth '${ctx.authKey}': the authorization server did not advertise dynamic client registration, or discovery/registration failed. Register a client manually, or retry once the server is reachable.`
-          : `Administrator must register OAuth client credentials for '${ctx.integrationId}' auth '${ctx.authKey}' before connection`,
+        `Administrator must register OAuth client credentials for '${ctx.integrationId}' auth '${ctx.authKey}' before connection`,
       );
     }
     const effectiveRedirectUri = client.redirect_uri ?? redirectUri;

--- a/apps/api/src/services/integration-connections.ts
+++ b/apps/api/src/services/integration-connections.ts
@@ -500,6 +500,17 @@ export interface ResolvedOAuthConnect {
   tokenEndpoint?: string;
   /** RFC 8707 resource indicator (discovered for MCP, else manifest `resource`). */
   resource?: string;
+  /**
+   * Set when auto-provisioning a client failed and `client` is null. The
+   * failing step authors the complete, operator-facing reason — *including the
+   * remedy* — so the caller renders it verbatim and never decides what to
+   * advise. Adding a failure point (no registration endpoint, blocked endpoint,
+   * AS rejection, network failure, future CIMD) is "set the field with its own
+   * message"; no new branch and no remedy heuristic in the caller. `status` is
+   * the authorization server's HTTP status when the failure came from a
+   * response, surfaced alongside the message.
+   */
+  provisioningFailure?: { message: string; status?: number };
 }
 
 /**
@@ -658,7 +669,13 @@ export async function ensureIntegrationOAuthClient(
   const registrationEndpoint = endpoints.registrationEndpoint;
   if (!registrationEndpoint) {
     logger.warn("auto-DCR: no registration_endpoint discovered", { packageId, authKey, issuer });
-    return resolved;
+    return {
+      ...resolved,
+      provisioningFailure: {
+        message:
+          "the authorization server did not advertise dynamic client registration; register an OAuth client manually, or retry once the server advertises it",
+      },
+    };
   }
 
   // SSRF guard — the endpoint is manifest/discovery-derived and we POST to it.
@@ -669,7 +686,13 @@ export async function ensureIntegrationOAuthClient(
       authKey,
       registrationEndpoint,
     });
-    return resolved;
+    return {
+      ...resolved,
+      provisioningFailure: {
+        message:
+          "the discovered registration endpoint was refused as an unsafe (loopback/internal) target; register an OAuth client manually instead",
+      },
+    };
   }
 
   // Narrow the concurrency window: re-check in case a parallel Connect just
@@ -723,7 +746,29 @@ export async function ensureIntegrationOAuthClient(
         status: err.status,
         err: err.message,
       });
-      return resolved;
+      // Two distinct DCR failures, authored explicitly (not inferred
+      // downstream): a server response (HTTP status present) is a deliberate
+      // refusal — surface the AS `error_description`, which carries its own
+      // remedy (e.g. an allowlist form). Fall back to a generic line rather
+      // than `err.message` so the raw (possibly non-JSON) response body is not
+      // echoed into the operator-facing 403 — it stays in the warn log above.
+      // No status means a network/timeout/malformed-body failure, where a retry
+      // is the remedy.
+      const reachedServer = err.status !== undefined;
+      return {
+        ...resolved,
+        provisioningFailure: reachedServer
+          ? {
+              message:
+                err.errorDescription ??
+                "the authorization server rejected dynamic client registration",
+              status: err.status,
+            }
+          : {
+              message:
+                "could not reach the authorization server to register a client; retry once it is reachable",
+            },
+      };
     }
     throw err;
   }

--- a/apps/api/test/integration/routes/integrations.test.ts
+++ b/apps/api/test/integration/routes/integrations.test.ts
@@ -739,6 +739,11 @@ describe("OAuth2 connect initiate", () => {
       },
     );
     expect(res.status).toBe(403);
+    // The error names the specific provisioning failure (no registration
+    // endpoint discovered against the unreachable AS) and carries its remedy.
+    const body = (await res.json()) as { detail: string };
+    expect(body.detail).toContain("did not advertise dynamic client registration");
+    expect(body.detail).toContain("register an OAuth client manually");
   });
 
   it("returns a PKCE-protected authorize URL after registering OAuth client", async () => {

--- a/packages/connect/src/dcr.ts
+++ b/packages/connect/src/dcr.ts
@@ -49,10 +49,31 @@ export interface DynamicClientRegistration {
 /** Raised when dynamic registration fails (non-2xx, malformed body, network). */
 export class DynamicClientRegistrationError extends Error {
   readonly status?: number;
-  constructor(message: string, status?: number) {
+  /**
+   * RFC 6749 §5.2 / RFC 7591 §3.2.2 `error_description`, when the AS returned a
+   * JSON error body — the human-readable reason registration was rejected (e.g.
+   * an allowlist notice). The actionable part to surface to the operator.
+   */
+  readonly errorDescription?: string;
+  constructor(message: string, status?: number, errorDescription?: string) {
     super(message);
     this.name = "DynamicClientRegistrationError";
     this.status = status;
+    this.errorDescription = errorDescription;
+  }
+}
+
+/**
+ * Best-effort extraction of the RFC 6749/7591 `error_description` from a
+ * registration error body. Returns `undefined` when the body isn't a JSON error
+ * object — the caller keeps the raw status/text.
+ */
+function parseOAuthErrorDescription(body: string): string | undefined {
+  try {
+    const json = JSON.parse(body) as { error_description?: unknown };
+    return typeof json.error_description === "string" ? json.error_description : undefined;
+  } catch {
+    return undefined;
   }
 }
 
@@ -109,6 +130,7 @@ export async function registerDynamicClient(
     throw new DynamicClientRegistrationError(
       `Dynamic client registration returned ${res.status}${detail ? `: ${detail}` : ""}`,
       res.status,
+      parseOAuthErrorDescription(detail),
     );
   }
 

--- a/packages/connect/test/dcr.test.ts
+++ b/packages/connect/test/dcr.test.ts
@@ -91,6 +91,48 @@ describe("registerDynamicClient (RFC 7591)", () => {
     ).rejects.toMatchObject({ name: "DynamicClientRegistrationError", status: 403 });
   });
 
+  it("parses the OAuth error_description from a rejection body", async () => {
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({
+          error: "invalid_request",
+          error_description: "Your integration is not currently allowlisted.",
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof fetch;
+    await expect(
+      registerDynamicClient({
+        registrationEndpoint: "https://as/register",
+        redirectUri: "https://app/cb",
+        clientName: "X",
+        fetchImpl,
+      }),
+    ).rejects.toMatchObject({
+      name: "DynamicClientRegistrationError",
+      status: 400,
+      errorDescription: "Your integration is not currently allowlisted.",
+    });
+  });
+
+  it("leaves errorDescription undefined when the rejection body is not JSON", async () => {
+    const fetchImpl = (async () =>
+      new Response("plain text rejection", { status: 400 })) as unknown as typeof fetch;
+    try {
+      await registerDynamicClient({
+        registrationEndpoint: "https://as/register",
+        redirectUri: "https://app/cb",
+        clientName: "X",
+        fetchImpl,
+      });
+      throw new Error("expected registration to reject");
+    } catch (err) {
+      expect(err).toBeInstanceOf(DynamicClientRegistrationError);
+      const dcrErr = err as DynamicClientRegistrationError;
+      expect(dcrErr.status).toBe(400);
+      expect(dcrErr.errorDescription).toBeUndefined();
+    }
+  });
+
   it("throws when the response omits client_id", async () => {
     const fetchImpl = (async () => jsonResponse({ not_a_client: true })) as unknown as typeof fetch;
     await expect(


### PR DESCRIPTION
## Summary

Fixes #601. Connecting a remote-MCP integration whose authorization server gates Dynamic Client Registration (DCR) behind an allowlist failed with a **misleading 403** — it claimed the AS *"did not advertise dynamic client registration"* and told the operator to *"retry once reachable"*. Both false: discovery succeeded, the `registration_endpoint` was found, and the registration **POST** was rejected (HTTP 400). A retry never helps.

The root cause is broader than one message: **every** failure point in auto-provisioning a client was swallowed and collapsed into a single generic catch-all in `OAuth2Strategy.begin`.

## Change — one self-describing failure channel

The failing step authors the **complete operator-facing reason, including its remedy**, into `ResolvedOAuthConnect.provisioningFailure`. The strategy renders it verbatim — it only prefixes the integration id + AS status. No per-cause branch, no remedy heuristic in the caller. A new failure point (e.g. CIMD) is "set the field with its own message".

| Failure point | message (+ remedy, authored at the detection site) | status |
| --- | --- | --- |
| no `registration_endpoint` discovered | did not advertise DCR; register manually, or retry once it advertises | — |
| endpoint blocked by SSRF guard | refused as unsafe (loopback/internal); register manually instead | — |
| AS rejected registration (non-2xx) | AS `error_description` (carries its own remedy, e.g. allowlist form) | HTTP status |
| network / timeout / malformed body | could not reach the server to register; retry once reachable | — |

The AS-rejection vs network distinction is authored **explicitly** at the catch site (`err.status !== undefined`), not inferred downstream — which also fixes network DCR failures previously reported as terminal.

## Files

- `packages/connect/src/dcr.ts` — parse RFC 6749/7591 `error_description` onto `DynamicClientRegistrationError` (additive optional ctor arg)
- `apps/api/src/services/integration-connections.ts` — `ResolvedOAuthConnect.provisioningFailure { message, status? }`, filled at each swallow point (additive optional field)
- `apps/api/src/services/connect/oauth2-strategy.ts` — zero-logic render in the existing `!client` block (replaces the branch ladder)

No new types, classes, or control-flow layers. No structured remedy enum — the message is free text, single-sourced where the cause is known.

## Test

- `packages/connect/test/dcr.test.ts`: parses `error_description` from a JSON rejection body; leaves it `undefined` for non-JSON bodies.
- `apps/api/test/integration/routes/integrations.test.ts`: asserts the connect 403 body names the specific failure + its remedy.
- Full connect suite (248) + targeted integration test pass. tsc (connect + api), eslint, prettier, OpenAPI breaking-change detector, full pre-push `check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)