### PR TITLE
feat(sidecar): structured debug envelope for credential-proxy calls (#404)

### DIFF
--- a/packages/afps-runtime/src/resolvers/api-call-engine.ts
+++ b/packages/afps-runtime/src/resolvers/api-call-engine.ts
@@ -258,14 +258,17 @@ export interface RedirectFollowOptions {
  * Caller-supplied cookies are preserved across hops (the jar wins on name
  * conflict so server-rotated values replace stale caller-supplied ones).
  *
- * Returns the terminal `Response` plus the URL it was served from so
- * callers driving redirect-chain flows (OAuth code, CAS ticket,
- * magic-link) can extract callback query params without parsing bodies
- * (see #471).
+ * Returns the terminal `Response`, the URL it was served from (so
+ * callers driving redirect-chain flows — OAuth code, CAS ticket,
+ * magic-link — can extract callback query params without parsing
+ * bodies, see #471), and `hops`: the number of redirects followed
+ * (`0` when the first response was terminal). The hop count is surfaced
+ * for operator diagnostics (see #404) so a debug log can distinguish a
+ * clean call from one that bounced through a redirect chain.
  */
 export async function fetchFollowingRedirectsCapturingCookies(
   opts: RedirectFollowOptions,
-): Promise<{ response: Response; finalUrl: string }> {
+): Promise<{ response: Response; finalUrl: string; hops: number }> {
   const {
     url,
     init,
@@ -290,10 +293,10 @@ export async function fetchFollowingRedirectsCapturingCookies(
     mergeSetCookieIntoJar(response.headers.getSetCookie(), cookieJar, integrationId);
 
     if (response.status < 300 || response.status >= 400) {
-      return { response, finalUrl: currentUrl };
+      return { response, finalUrl: currentUrl, hops: hop };
     }
     const location = response.headers.get("location");
-    if (!location) return { response, finalUrl: currentUrl };
+    if (!location) return { response, finalUrl: currentUrl, hops: hop };
 
     // Per WHATWG fetch (HTTP-redirect fetch step 11) + RFC 9110 §15.4:
     //   - 301/302 downgrade POST → GET (other methods preserved)
@@ -417,7 +420,7 @@ export class PreflightError extends Error {
 
 export async function guardedFetch(
   opts: GuardedFetchOptions,
-): Promise<{ response: Response; finalUrl: string }> {
+): Promise<{ response: Response; finalUrl: string; hops: number }> {
   const fetchFn = opts.fetchFn ?? fetch;
   const pre = preflightUrl(opts.url, {
     authorizedUris: opts.authorizedUris,
@@ -436,7 +439,8 @@ export async function guardedFetch(
     initAny.duplex = "half";
     initAny.redirect = "manual";
     const response = await fetchFn(opts.url, init);
-    return { response, finalUrl: response.url || opts.url };
+    // Streaming path issues a single unfollowed request — no manual hops.
+    return { response, finalUrl: response.url || opts.url, hops: 0 };
   }
 
   return fetchFollowingRedirectsCapturingCookies({

--- a/runtime-pi/sidecar/credential-proxy.ts
+++ b/runtime-pi/sidecar/credential-proxy.ts
@@ -48,6 +48,7 @@ import {
 } from "@appstrate/afps-runtime/resolvers";
 import { getErrorMessage } from "@appstrate/core/errors";
 import { logger } from "./logger.ts";
+import { filterSensitiveHeaders } from "./redact.ts";
 
 /**
  * Body modes the proxy core accepts. The HTTP handler can produce
@@ -278,7 +279,18 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
    */
   const doUpstreamRequest = async (
     activeCreds: CredentialsResponse,
-  ): Promise<{ response: Response; finalUrl: string }> => {
+  ): Promise<{
+    response: Response;
+    finalUrl: string;
+    hops: number;
+    /**
+     * Names (never values) of the headers sent on the wire after
+     * credential injection — surfaced for the debug diagnostic envelope
+     * so an operator can see *which* headers were injected without ever
+     * logging the secret itself.
+     */
+    requestHeaderNames: string[];
+  }> => {
     const resolvedHeaders: Record<string, string> = {};
     for (const [key, value] of Object.entries(callerHeaders)) {
       resolvedHeaders[key] = substituteVars(value, activeCreds.credentials);
@@ -331,9 +343,15 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
       init.duplex = "half";
       init.redirect = "manual";
       const response = await fetchFn(resolvedUrl, init);
-      return { response, finalUrl: response.url || resolvedUrl };
+      // Streaming path issues a single unfollowed request — no manual hops.
+      return {
+        response,
+        finalUrl: response.url || resolvedUrl,
+        hops: 0,
+        requestHeaderNames: Object.keys(resolvedHeaders),
+      };
     }
-    return fetchFollowingRedirectsCapturingCookies({
+    const followed = await fetchFollowingRedirectsCapturingCookies({
       url: resolvedUrl,
       init,
       fetchFn,
@@ -345,16 +363,22 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
       // Preserve the sidecar's structured per-hop refusal logging.
       logger,
     });
+    return { ...followed, requestHeaderNames: Object.keys(resolvedHeaders) };
   };
 
   // 7. First outbound request. Network/timeout errors surface as a
   //    structured failure rather than a raw exception.
+  const requestStartedAt = performance.now();
   let upstream: Response;
   let upstreamFinalUrl: string = resolvedUrl;
+  let upstreamHops = 0;
+  let requestHeaderNames: string[] = [];
   try {
     const r = await doUpstreamRequest(creds);
     upstream = r.response;
     upstreamFinalUrl = r.finalUrl;
+    upstreamHops = r.hops;
+    requestHeaderNames = r.requestHeaderNames;
   } catch (err) {
     return wrapRequestError(err, resolvedUrl);
   }
@@ -381,6 +405,8 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
           const r = await doUpstreamRequest(fresh);
           upstream = r.response;
           upstreamFinalUrl = r.finalUrl;
+          upstreamHops = r.hops;
+          requestHeaderNames = r.requestHeaderNames;
         } catch (err) {
           return wrapRequestError(err, resolvedUrl);
         }
@@ -405,6 +431,37 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
     reportedAuthFailures.add(integrationId);
     logger.warn("Upstream returned 401 after refresh attempt", { integrationId });
   }
+
+  // 10. Success-path diagnostic envelope (#404). One structured line per
+  //     completed call — resolved auth mode, hop count, status, duration,
+  //     and the request/response header *names* (values redacted). Only
+  //     emitted at LOG_LEVEL=debug, so it is silent in default production
+  //     output yet available when an operator is debugging a provider call
+  //     (401/403/redirect loop) without leaking the injected secret.
+  logger.debug("integration api_call completed", {
+    integrationId,
+    method,
+    host: redactHost(upstreamFinalUrl),
+    status: upstream.status,
+    durationMs: Math.round(performance.now() - requestStartedAt),
+    hops: upstreamHops,
+    redirected: upstreamFinalUrl !== resolvedUrl,
+    // How the credential was applied: a server-injected header (named, never
+    // valued) or no injection at all (URL/query-embedded or anonymous).
+    authMode: creds.credentialHeaderName ? "header" : "none",
+    injectedHeader: creds.credentialHeaderName?.toLowerCase() ?? null,
+    // Which URL-trust policy gated the call.
+    urlPolicy: creds.allowAllUris
+      ? "allow_all"
+      : creds.authorizedUris && creds.authorizedUris.length
+        ? "allowlist"
+        : "ssrf_guard",
+    authRefreshed,
+    requestHeaderNames,
+    // Drops Set-Cookie / WWW-Authenticate / Authorization etc.; keeps
+    // operator-useful headers like Location for redirect-loop diagnosis.
+    responseHeaders: filterSensitiveHeaders(upstream.headers),
+  });
 
   return { ok: true, response: upstream, finalUrl: upstreamFinalUrl, authRefreshed };
 }

--- a/runtime-pi/sidecar/logger.ts
+++ b/runtime-pi/sidecar/logger.ts
@@ -19,10 +19,11 @@ function envLevel(): Level {
   return "info";
 }
 
-const minLevel = LEVEL_VALUES[envLevel()];
-
 function emit(level: Level, msg: string, data?: Record<string, unknown>): void {
-  if (LEVEL_VALUES[level] < minLevel) return;
+  // Evaluated per-call (not captured at import) so `LOG_LEVEL` can be raised
+  // to `debug` for diagnostics without a process restart, and so tests can
+  // toggle the threshold around a single call.
+  if (LEVEL_VALUES[level] < LEVEL_VALUES[envLevel()]) return;
   const line = JSON.stringify({
     level,
     time: new Date().toISOString(),

--- a/runtime-pi/sidecar/test/credential-proxy.test.ts
+++ b/runtime-pi/sidecar/test/credential-proxy.test.ts
@@ -1183,3 +1183,144 @@ describe("executeApiCall — finalUrl exposure (#471)", () => {
     }
   });
 });
+
+describe("executeApiCall — debug diagnostic envelope (#404)", () => {
+  /**
+   * Capture stdout lines written by the sidecar logger during `fn`, restore
+   * the original writer afterwards, and return the parsed JSON log records.
+   * The diagnostic envelope is a `debug` line, so it lands on stdout.
+   */
+  async function captureLogs(
+    level: string | undefined,
+    fn: () => Promise<void>,
+  ): Promise<Array<Record<string, unknown>>> {
+    const prevLevel = process.env.LOG_LEVEL;
+    if (level === undefined) delete process.env.LOG_LEVEL;
+    else process.env.LOG_LEVEL = level;
+    const lines: string[] = [];
+    const original = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((chunk: unknown): boolean => {
+      lines.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      await fn();
+    } finally {
+      process.stdout.write = original;
+      if (prevLevel === undefined) delete process.env.LOG_LEVEL;
+      else process.env.LOG_LEVEL = prevLevel;
+    }
+    return lines
+      .join("")
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+  }
+
+  const call = (deps: ApiCallDeps) =>
+    executeApiCall(
+      {
+        integrationId: "gmail",
+        targetUrl: "https://api.example.com/messages",
+        method: "GET",
+        callerHeaders: { "X-Custom": "x" },
+        body: { kind: "none" },
+      },
+      deps,
+    );
+
+  it("emits one structured envelope at LOG_LEVEL=debug with redacted headers", async () => {
+    const fetchFn = mock(
+      async () =>
+        new Response('{"data":1}', {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            "Set-Cookie": "sess=abc; HttpOnly",
+            "WWW-Authenticate": "Bearer realm=x",
+          },
+        }),
+    );
+    const records = await captureLogs("debug", async () => {
+      const r = await call(makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }));
+      expect(r.ok).toBe(true);
+    });
+    const envelope = records.find((r) => r.msg === "integration api_call completed");
+    expect(envelope).toBeDefined();
+    expect(envelope!.integrationId).toBe("gmail");
+    expect(envelope!.method).toBe("GET");
+    expect(envelope!.host).toBe("api.example.com");
+    expect(envelope!.status).toBe(200);
+    expect(envelope!.hops).toBe(0);
+    expect(envelope!.redirected).toBe(false);
+    expect(envelope!.authMode).toBe("header");
+    expect(envelope!.injectedHeader).toBe("authorization");
+    expect(envelope!.urlPolicy).toBe("allowlist");
+    expect(typeof envelope!.durationMs).toBe("number");
+    // Request header names surface the injected `authorization` header — by
+    // NAME only, never its value.
+    const reqNames = (envelope!.requestHeaderNames as string[]).map((h) => h.toLowerCase());
+    expect(reqNames).toContain("authorization");
+    expect(reqNames).toContain("x-custom");
+    expect(JSON.stringify(envelope)).not.toContain("tok-123");
+    expect(JSON.stringify(envelope)).not.toContain("Bearer tok-123");
+    // Response headers drop the credential-bearing entries.
+    const respHeaders = envelope!.responseHeaders as Record<string, string>;
+    const respKeys = Object.keys(respHeaders).map((k) => k.toLowerCase());
+    expect(respKeys).not.toContain("set-cookie");
+    expect(respKeys).not.toContain("www-authenticate");
+    expect(respKeys).toContain("content-type");
+  });
+
+  it("is silent at the default LOG_LEVEL (info)", async () => {
+    const records = await captureLogs(undefined, async () => {
+      const r = await call(makeDeps());
+      expect(r.ok).toBe(true);
+    });
+    expect(records.find((r) => r.msg === "integration api_call completed")).toBeUndefined();
+  });
+
+  it("reports the redirect hop count and final host", async () => {
+    const fetchFn = mock(async (url: string | URL) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.endsWith("/messages")) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://api.example.com/inbox" },
+        });
+      }
+      return new Response("ok", { status: 200 });
+    });
+    const records = await captureLogs("debug", async () => {
+      const r = await call(makeDeps({ fetchFn: fetchFn as unknown as typeof fetch }));
+      expect(r.ok).toBe(true);
+    });
+    const envelope = records.find((r) => r.msg === "integration api_call completed");
+    expect(envelope).toBeDefined();
+    expect(envelope!.hops).toBe(1);
+    expect(envelope!.redirected).toBe(true);
+    expect(envelope!.host).toBe("api.example.com");
+  });
+
+  it("labels authMode 'none' and urlPolicy 'allow_all' when no header is injected", async () => {
+    const fetchCredentials = mock(
+      async (): Promise<CredentialsResponse> => ({
+        credentials: {},
+        authorizedUris: null,
+        allowAllUris: true,
+        // No credentialHeaderName → no server-side injection (authMode "none").
+        // credentialFieldName is always populated server-side regardless.
+        credentialFieldName: "access_token",
+      }),
+    );
+    const records = await captureLogs("debug", async () => {
+      const r = await call(makeDeps({ fetchCredentials }));
+      expect(r.ok).toBe(true);
+    });
+    const envelope = records.find((r) => r.msg === "integration api_call completed");
+    expect(envelope).toBeDefined();
+    expect(envelope!.authMode).toBe("none");
+    expect(envelope!.injectedHeader).toBeNull();
+    expect(envelope!.urlPolicy).toBe("allow_all");
+  });
+});


### PR DESCRIPTION
Closes #404.

## What

Adds a success-path **diagnostic log envelope** to the sidecar credential-proxy so an operator debugging a failing provider call (401 / 403 / redirect loop) can understand what happened — without ever leaking the injected secret.

`executeApiCall` now emits **one `logger.debug` record per completed call**:

| Field | Meaning |
|---|---|
| `integrationId`, `method`, `host` | who/what (host = hostname only, via `redactHost` — no path/query/userinfo) |
| `status`, `durationMs` | upstream status + total wall time |
| `hops`, `redirected` | redirect chain depth (0 = clean) |
| `authMode` (`header`/`none`), `injectedHeader` | how the credential was applied — header **name** only |
| `urlPolicy` (`allowlist`/`allow_all`/`ssrf_guard`) | which URL-trust gate ran |
| `authRefreshed` | whether a mid-run 401 triggered a token refresh |
| `requestHeaderNames` | names (never values) of headers sent on the wire |
| `responseHeaders` | passed through `filterSensitiveHeaders` — drops `Set-Cookie`/`WWW-Authenticate`/`Authorization`, keeps operator-useful headers like `Location` |

## Why this shape

This supersedes the stale references in the original issue:

- **No `curl-runner`** — that component no longer exists; outbound provider calls flow through `runtime-pi/sidecar/credential-proxy.ts` + the shared redirect follower in `@appstrate/afps-runtime`.
- **No new `APPSTRATE_DEBUG_PROXY` flag** — gated by the existing **`LOG_LEVEL=debug`** convention (silent in default production output). Operators raise one knob they already know.
- **Redaction reuses existing primitives** — `redact.filterSensitiveHeaders` (added in #397) and `redactHost`. The success-path was the remaining gap after #476 already added per-hop redirect-refusal logging.

Field semantics follow [OpenTelemetry HTTP-client conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/) (method, status, duration, resend/hop count), expressed in the platform's camelCase logger-field style.

## Supporting changes

- `fetchFollowingRedirectsCapturingCookies` / `guardedFetch` now return `hops` (redirects followed; `0` when the first response was terminal) so the envelope reports an exact count. **Additive** — existing `{ response, finalUrl }` destructuring callers are unaffected.
- The sidecar `logger` evaluates `LOG_LEVEL` **per call** instead of capturing it once at import, so the threshold can be raised without a process restart (and tests can toggle it around a single call).

## Tests

4 new cases in `credential-proxy.test.ts`:
- envelope emitted at `LOG_LEVEL=debug`, asserts the request secret and response credential headers are **absent** from the serialized record
- **silent** at the default level (info)
- redirect **hop counting** (`hops: 1`, `redirected: true`, final host)
- no-injection labelling (`authMode: none`, `urlPolicy: allow_all`)

Full repo `check` (turbo typecheck + lint + format + verify:openapi + detect:breaking + …) passes; sidecar suite 544 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)