### PR TITLE
docs(sidecar): explain LLM stream has no body timeout under Bun

### DIFF
--- a/runtime-pi/sidecar/app.ts
+++ b/runtime-pi/sidecar/app.ts
@@ -464,6 +464,17 @@ export function createApp(deps: AppDeps): Hono {
 
     let upstream: Response;
     try {
+      // `AbortSignal.timeout(LLM_PROXY_TIMEOUT_MS)` is the ONLY deadline on
+      // an LLM stream — an absolute 30 min cap, not an inactivity timer.
+      // There is deliberately no inter-chunk (body) timeout: undici's
+      // hardcoded 300 s `bodyTimeout` (which once motivated a global
+      // `globalThis.fetch` → undici swap, reverted in #366, see issue #369)
+      // does not exist here — the sidecar runs under Bun and `fetch` is
+      // Bun's native implementation, not undici. A long inter-chunk gap on a
+      // streamed completion therefore cannot trip a body timeout; it is only
+      // bounded by the 30 min absolute deadline. Inter-chunk silence is still
+      // observed (`maxIdleMs` in `llm.stream.observed`, #426) so any real
+      // stall surfaces in logs without re-introducing undici.
       upstream = await fetchFn(targetUrl, {
         method,
         headers: forwardedHeaders,


### PR DESCRIPTION
## Summary
Adds an explanatory comment in `runtime-pi/sidecar/app.ts` documenting why the LLM stream proxy has no inter-chunk body timeout.

- `AbortSignal.timeout(LLM_PROXY_TIMEOUT_MS)` is the **only** deadline — an absolute 30 min cap, not an inactivity timer.
- No body timeout exists because the sidecar runs under **Bun** (native `fetch`), not undici (whose hardcoded 300 s `bodyTimeout` once motivated the global fetch→undici swap in #366, reverted in #369).
- Inter-chunk silence is still observed via `maxIdleMs` in `llm.stream.observed` (#426), so real stalls surface in logs.

Comment-only change. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)