### PR TITLE
chore(core): bump to 2.25.0

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to `@appstrate/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.25.0] — 2026-06-07
+
+Storage streaming + integration spawn/egress contract additions. All additive — no removals, no breaking changes.
+
+### Added
+
+- **`Storage.uploadStream(bucket, path, stream, opts?)`** — pipe binary data to a
+  backend without buffering the whole payload in memory (S3 multipart via
+  `@aws-sdk/lib-storage`; filesystem pipes the web stream straight to disk).
+  `opts.exclusive` is unsupported on this path and throws. Implemented in both
+  `storage-s3` and `storage-fs` backends.
+- **`IntegrationSpawnSpec.mcpServer.version`** — the concrete published version
+  the run resolved at kickoff, forwarded to the mcp-server-bundle byte route so
+  runnable bytes match the manifest version (eliminates manifest/bytes skew,
+  issue #588). Omitted for system mcp-servers and remote/serverless integrations.
+- **`IntegrationSpawnSpec.needsEgress`** — explicit egress signal for a
+  local-source runner that needs a controlled outbound route but no header
+  injection (e.g. a `delivery.env` integration that authenticates itself); the
+  sidecar mounts a plain CONNECT egress listener (issue #543).
+
+### Changed
+
+- **`connectableAuthKeysForAgent`** — an integration exposing `api_call` is now
+  its own selection signal: it returns the declared auth keys even when the agent
+  picked zero tools and zero scopes, since `api_call` is consumed with an explicit
+  `auth_key` pin and still needs a connection. Returns `[]` only when there are no
+  tools, no scopes, AND no `api_call` configs.
+
 ## [2.24.0] — 2026-06-05
 
 Module-contract cleanup + table-centralization (PR #586, supersedes #577/#583).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Bump \`@appstrate/core\` to 2.25.0 for the v1.0.0-beta.24 release.

Unreleased core/src changes since \`core@2.24.0\`:

### Added
- \`Storage.uploadStream()\` — stream binary data without buffering (S3 multipart / fs pipe).
- \`IntegrationSpawnSpec.mcpServer.version\` — forward resolved version to byte route (#588).
- \`IntegrationSpawnSpec.needsEgress\` — plain CONNECT egress for self-authenticating local runners (#543).

### Changed
- \`connectableAuthKeysForAgent\` — \`api_call\` exposure is now its own selection signal.

All additive — minor bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)