### PR TITLE
feat(core): canonical encodePackageIdPath path encoder (#609 Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,8 @@ Authoritative reference: **`docs/CASING_CONVENTIONS.md`**. TL;DR:
 
 When in doubt: wire = snake_case, internal = camelCase. Audit: `/audit-casing` (6 parallel agents, 100% compliance check).
 
+**Package IDs in URL paths**: two shapes by rule — single package → `{scope}/{name}`, route referencing ≥2 packages → `{packageId}` (e.g. `/api/integrations/*`). Both resolve to the same `@scope/name` wire path. Always encode with `encodePackageIdPath` from `@appstrate/core/naming` — never `encodeURIComponent` on the whole id (it 404s the route regexes). Full rule: `docs/CASING_CONVENTIONS.md` → "Package identifiers in URL paths".
+
 ### Module System
 
 Formalized system for optional features. Contract in `@appstrate/core/module` (published on npm) so external modules implement without depending on the API package. **Authoring guide + full lifecycle/permissions/hooks detail: `apps/api/src/modules/README.md`.**

--- a/apps/web/src/hooks/use-integrations.ts
+++ b/apps/web/src/hooks/use-integrations.ts
@@ -21,6 +21,7 @@ import type {
   IntegrationPin,
   IntegrationSummary,
 } from "@appstrate/shared-types";
+import { encodePackageIdPath } from "@appstrate/core/naming";
 import { api, apiList, type ListEnvelope } from "../api";
 import { useCurrentOrgId } from "./use-org";
 import { useCurrentApplicationId } from "./use-current-application";
@@ -82,7 +83,7 @@ export function buildUpdateConnectionRequest(args: {
 }): [string, RequestInit] {
   const { packageId, connectionId, label, sharedWithOrg, extraHeaders } = args;
   return [
-    `/integrations/${encodeURI(packageId)}/connections/${connectionId}`,
+    `/integrations/${encodePackageIdPath(packageId)}/connections/${connectionId}`,
     {
       method: "PATCH",
       body: JSON.stringify({
@@ -113,7 +114,7 @@ export function useIntegrationDetail(packageId: string | undefined) {
   return useQuery({
     queryKey: [...KEY(orgId, applicationId), "detail", packageId] as const,
     enabled: Boolean(orgId && applicationId && packageId),
-    queryFn: () => api<IntegrationDetail>(`/integrations/${encodeURI(packageId!)}`),
+    queryFn: () => api<IntegrationDetail>(`/integrations/${encodePackageIdPath(packageId!)}`),
   });
 }
 
@@ -125,7 +126,7 @@ export function useIntegrationConnections(packageId: string | undefined) {
     enabled: Boolean(orgId && applicationId && packageId),
     queryFn: async () => {
       const envelope = await api<ListEnvelope<IntegrationConnection>>(
-        `/integrations/${encodeURI(packageId!)}/connections`,
+        `/integrations/${encodePackageIdPath(packageId!)}/connections`,
       );
       return envelope.data;
     },
@@ -149,7 +150,7 @@ export function useIntegrationAgentResolution(
     enabled: Boolean(orgId && applicationId && integrationId && agentPackageId),
     queryFn: () =>
       api<IntegrationAgentResolution>(
-        `/integrations/${encodeURI(integrationId!)}/agent-resolution/${encodeURI(agentPackageId!)}`,
+        `/integrations/${encodePackageIdPath(integrationId!)}/agent-resolution/${encodePackageIdPath(agentPackageId!)}`,
       ),
   });
 }
@@ -162,7 +163,7 @@ export function useActivateIntegration() {
   return useMutation({
     mutationFn: (packageId: string) =>
       api<{ active: boolean; activated_at: string }>(
-        `/integrations/${encodeURI(packageId)}/activate`,
+        `/integrations/${encodePackageIdPath(packageId)}/activate`,
         { method: "POST", body: "{}" },
       ),
     onSuccess: () => {
@@ -180,7 +181,7 @@ export function useDeactivateIntegration() {
   const applicationId = useCurrentApplicationId();
   return useMutation({
     mutationFn: (packageId: string) =>
-      api<{ active: boolean }>(`/integrations/${encodeURI(packageId)}/deactivate`, {
+      api<{ active: boolean }>(`/integrations/${encodePackageIdPath(packageId)}/deactivate`, {
         method: "DELETE",
       }),
     onSuccess: () => {
@@ -209,7 +210,7 @@ export function useConnectIntegrationFields() {
       connectionId?: string;
     }) =>
       api<IntegrationConnection>(
-        `/integrations/${encodeURI(packageId)}/auths/${encodeURI(authKey)}/connect/fields`,
+        `/integrations/${encodePackageIdPath(packageId)}/auths/${encodeURI(authKey)}/connect/fields`,
         {
           method: "POST",
           body: JSON.stringify({
@@ -249,7 +250,7 @@ export function useInitiateIntegrationOAuth() {
       connectionId?: string;
     }) =>
       api<{ auth_url: string; state: string }>(
-        `/integrations/${encodeURI(packageId)}/auths/${encodeURI(authKey)}/connect/oauth2`,
+        `/integrations/${encodePackageIdPath(packageId)}/auths/${encodeURI(authKey)}/connect/oauth2`,
         {
           method: "POST",
           body: JSON.stringify({
@@ -275,7 +276,7 @@ export function useIntegrationOAuthClient(
     queryFn: async (): Promise<IntegrationOAuthClient | null> => {
       try {
         return await api<IntegrationOAuthClient>(
-          `/integrations/${encodeURI(packageId!)}/oauth-clients/${encodeURI(authKey!)}`,
+          `/integrations/${encodePackageIdPath(packageId!)}/oauth-clients/${encodeURI(authKey!)}`,
         );
       } catch (err: unknown) {
         // 404 = not configured yet; treat as null so the UI can render
@@ -314,7 +315,7 @@ export function useUpsertIntegrationOAuthClient() {
       redirectUri?: string;
     }) =>
       api<IntegrationOAuthClient>(
-        `/integrations/${encodeURI(packageId)}/oauth-clients/${encodeURI(authKey)}`,
+        `/integrations/${encodePackageIdPath(packageId)}/oauth-clients/${encodeURI(authKey)}`,
         {
           method: "PUT",
           body: JSON.stringify({
@@ -345,7 +346,7 @@ export function useIntegrationPins(packageId: string | undefined) {
   const applicationId = useCurrentApplicationId();
   return useQuery({
     queryKey: [...KEY(orgId, applicationId), "pins", packageId] as const,
-    queryFn: () => apiList<IntegrationPin>(`/integrations/${encodeURI(packageId!)}/pins`),
+    queryFn: () => apiList<IntegrationPin>(`/integrations/${encodePackageIdPath(packageId!)}/pins`),
     enabled: !!packageId && !!orgId && !!applicationId,
   });
 }
@@ -361,7 +362,9 @@ export function useAgentsConsumingIntegration(packageId: string | undefined) {
   return useQuery({
     queryKey: [...KEY(orgId, applicationId), "consuming-agents", packageId] as const,
     queryFn: () =>
-      apiList<ConsumingAgentSummary>(`/integrations/${encodeURI(packageId!)}/consuming-agents`),
+      apiList<ConsumingAgentSummary>(
+        `/integrations/${encodePackageIdPath(packageId!)}/consuming-agents`,
+      ),
     enabled: !!packageId && !!orgId && !!applicationId,
   });
 }
@@ -379,7 +382,7 @@ export function useUpdateIntegrationSettings() {
       packageId: string;
       blockUserConnections: boolean;
     }) =>
-      api<{ blocked: boolean }>(`/integrations/${encodeURI(packageId)}/settings`, {
+      api<{ blocked: boolean }>(`/integrations/${encodePackageIdPath(packageId)}/settings`, {
         method: "PATCH",
         body: JSON.stringify({ block_user_connections: blockUserConnections }),
         headers: { "Content-Type": "application/json" },
@@ -409,7 +412,7 @@ export function useUpsertIntegrationPin() {
       connectionId: string;
     }) =>
       api<IntegrationPin>(
-        `/integrations/${encodeURI(packageId)}/pins/${encodeURI(agentPackageId)}`,
+        `/integrations/${encodePackageIdPath(packageId)}/pins/${encodePackageIdPath(agentPackageId)}`,
         {
           method: "PUT",
           body: JSON.stringify({ connection_id: connectionId }),
@@ -433,7 +436,7 @@ export function useDeleteIntegrationPin() {
   return useMutation({
     mutationFn: ({ packageId, agentPackageId }: { packageId: string; agentPackageId: string }) =>
       api<{ deleted: boolean }>(
-        `/integrations/${encodeURI(packageId)}/pins/${encodeURI(agentPackageId)}`,
+        `/integrations/${encodePackageIdPath(packageId)}/pins/${encodePackageIdPath(agentPackageId)}`,
         { method: "DELETE" },
       ),
     onSuccess: (_data, vars) => {
@@ -454,7 +457,7 @@ export function useIntegrationOrgDefault(packageId: string | undefined) {
     queryKey: [...KEY(orgId, applicationId), "org-default", packageId] as const,
     queryFn: () =>
       api<{ default: IntegrationOrgDefault | null }>(
-        `/integrations/${encodeURI(packageId!)}/default`,
+        `/integrations/${encodePackageIdPath(packageId!)}/default`,
       ).then((r) => r.default),
     enabled: !!packageId && !!orgId && !!applicationId,
   });
@@ -475,7 +478,7 @@ export function useUpsertIntegrationOrgDefault() {
       connectionId: string;
       enforce: boolean;
     }) =>
-      api<IntegrationOrgDefault>(`/integrations/${encodeURI(packageId)}/default`, {
+      api<IntegrationOrgDefault>(`/integrations/${encodePackageIdPath(packageId)}/default`, {
         method: "PUT",
         body: JSON.stringify({ connection_id: connectionId, enforce }),
         headers: { "Content-Type": "application/json" },
@@ -498,7 +501,7 @@ export function useDeleteIntegrationOrgDefault() {
   const applicationId = useCurrentApplicationId();
   return useMutation({
     mutationFn: ({ packageId }: { packageId: string }) =>
-      api<{ deleted: boolean }>(`/integrations/${encodeURI(packageId)}/default`, {
+      api<{ deleted: boolean }>(`/integrations/${encodePackageIdPath(packageId)}/default`, {
         method: "DELETE",
       }),
     onSuccess: (_data, vars) => {
@@ -551,7 +554,7 @@ export function useDeleteIntegrationOAuthClient() {
   return useMutation({
     mutationFn: ({ packageId, authKey }: { packageId: string; authKey: string }) =>
       api<{ deleted: boolean }>(
-        `/integrations/${encodeURI(packageId)}/oauth-clients/${encodeURI(authKey)}`,
+        `/integrations/${encodePackageIdPath(packageId)}/oauth-clients/${encodeURI(authKey)}`,
         { method: "DELETE" },
       ),
     onSuccess: (_data, vars) => {

--- a/docs/CASING_CONVENTIONS.md
+++ b/docs/CASING_CONVENTIONS.md
@@ -324,6 +324,26 @@ Treat any new management-CRUD route on a BA plugin table the same way (mirror th
 
 ---
 
+## Package identifiers in URL paths
+
+A package (`@scope/name`) appears in API paths in **two shapes**, by an explicit rule:
+
+- **Single top-level package → `{scope}/{name}`** (two path params). Route pattern `/:scope{@[^/]+}/:name`. Used by agents, `packages/*` (registry tier), runs, schedules. ~34 routes.
+- **Route references ≥2 packages → `{packageId}`** (one param holding `@scope/name`). Route pattern `/:packageId{@[^/]+/[^/]+}`. Used by `/api/integrations/*` (runtime tier), where routes like `/integrations/{packageId}/agent-resolution/{agentPackageId}` carry two packages in one path — two `{scope}/{name}` pairs would be ambiguous to parse. ~19 routes.
+
+Both shapes resolve to the **same on-wire path** (`@foo/bar`); the difference is only how Hono splits it into params. So the choice is a route-authoring rule, not a wire-format difference.
+
+**Encoding (the footgun):** naive `encodeURIComponent(packageId)` 404s **both** route shapes — it percent-encodes `@`→`%40` and `/`→`%2F`, which the route regexes reject. Consumers MUST use **`encodePackageIdPath(packageId)` from `@appstrate/core/naming`** — it validates the id and encodes each segment while keeping the `@`/`/` separators literal. Do not hand-roll a path encoder; do not call `encodeURIComponent` on the whole id.
+
+```ts
+import { encodePackageIdPath } from "@appstrate/core/naming";
+api(`/integrations/${encodePackageIdPath(packageId)}/connections`);
+```
+
+This is the single canonical contract for frontend, SDK, github-action, and MCP consumers. (Filed as issue #609; the MCP server's prior client-side `encodePath` is superseded by this core helper.)
+
+---
+
 ## Field-name catalog (canonical)
 
 ### Manifest fields (AFPS — all snake_case)

--- a/packages/core/src/naming.ts
+++ b/packages/core/src/naming.ts
@@ -51,6 +51,29 @@ export function buildPackageId(scope: string, name: string): string {
 }
 
 /**
+ * Encode a packageId ("@scope/name") into a URL path segment, keeping the
+ * `@` and `/` separators literal so it matches BOTH route shapes:
+ *   - `/:scope{@[^/]+}/:name`            (single top-level package)
+ *   - `/:packageId{@[^/]+/[^/]+}`        (routes that reference ≥2 packages)
+ *
+ * Naive `encodeURIComponent(packageId)` 404s both shapes because it
+ * percent-encodes `@`→%40 and `/`→%2F, neither of which the route regexes
+ * accept. Use this canonical encoder instead of hand-rolling — it is the
+ * one contract every consumer (frontend, SDK, github-action, MCP) should
+ * import rather than re-discovering the footgun.
+ *
+ * Each segment is `encodeURIComponent`-encoded individually (defensive even
+ * if `SLUG_PATTERN` ever loosens); the `@`/`/` separators stay literal.
+ *
+ * @throws Error if packageId is not a valid "@scope/name".
+ */
+export function encodePackageIdPath(packageId: string): string {
+  const parsed = parseScopedName(packageId);
+  if (!parsed) throw new Error(`Invalid packageId: ${packageId}`);
+  return `@${encodeURIComponent(parsed.scope)}/${encodeURIComponent(parsed.name)}`;
+}
+
+/**
  * Convert an arbitrary human string into a URL-safe slug.
  * Lower-cases, strips diacritics, collapses non-[a-z0-9] runs into `-`
  * and trims leading/trailing dashes. Optional `maxLen` caps the result

--- a/packages/core/test/naming.test.ts
+++ b/packages/core/test/naming.test.ts
@@ -6,6 +6,7 @@ import {
   stripScope,
   parseScopedName,
   buildPackageId,
+  encodePackageIdPath,
   isOwnedByOrg,
   isValidToolName,
   normalizeToolName,
@@ -111,6 +112,42 @@ describe("buildPackageId", () => {
 
   it('("@org", "a") → "@org/a"', () => {
     expect(buildPackageId("@org", "a")).toBe("@org/a");
+  });
+});
+
+describe("encodePackageIdPath", () => {
+  it('"@foo/bar" → "@foo/bar" (separators stay literal)', () => {
+    expect(encodePackageIdPath("@foo/bar")).toBe("@foo/bar");
+  });
+
+  it('"@org123/pkg-name" round-trips unchanged', () => {
+    expect(encodePackageIdPath("@org123/pkg-name")).toBe("@org123/pkg-name");
+  });
+
+  it("output matches both route regexes", () => {
+    const out = encodePackageIdPath("@acme/my-skill");
+    // /:packageId{@[^/]+/[^/]+}
+    expect(/^@[^/]+\/[^/]+$/.test(out)).toBe(true);
+    // /:scope{@[^/]+}/:name → first segment is the scope param
+    const [scope, name] = out.split("/");
+    expect(/^@[^/]+$/.test(scope!)).toBe(true);
+    expect(name).toBe("my-skill");
+  });
+
+  it("throws on missing @ prefix", () => {
+    expect(() => encodePackageIdPath("foo/bar")).toThrow("Invalid packageId");
+  });
+
+  it("throws on scope-only input", () => {
+    expect(() => encodePackageIdPath("@foo")).toThrow("Invalid packageId");
+  });
+
+  it("throws on nested (3-segment) input", () => {
+    expect(() => encodePackageIdPath("@foo/bar/baz")).toThrow("Invalid packageId");
+  });
+
+  it("throws on empty string", () => {
+    expect(() => encodePackageIdPath("")).toThrow("Invalid packageId");
   });
 });
 


### PR DESCRIPTION
## What

Adds `encodePackageIdPath(packageId)` to `@appstrate/core/naming` — the single canonical contract for encoding `@scope/name` into an API URL path. Resolves **Phase 1 (Option C)** of #609.

## Why

The API identifies a package two ways: `{scope}/{name}` (~34 routes) and `{packageId}` (~19 routes, all under `/api/integrations`). Both resolve to the same on-wire path (`@foo/bar`), but a naive `encodeURIComponent(packageId)` 404s both route shapes — it percent-encodes `@`→`%40` and `/`→`%2F`, which the route regexes (`@[^/]+/[^/]+`) reject. This footgun surfaced in the MCP server (PR #606) and threatened every future consumer.

The split itself is coherent (routes referencing ≥2 packages use `{packageId}` because two `{scope}/{name}` pairs would be ambiguous — e.g. `/integrations/{packageId}/agent-resolution/{agentPackageId}`), just undocumented. This PR ships one tested encoder so nobody re-hand-rolls it, and writes the rule down.

## Changes

- **core** — `encodePackageIdPath` + 7 tests. Validates via `parseScopedName`, encodes each segment, keeps `@`/`/` literal (defensive even if `SLUG_PATTERN` loosens).
- **web** — `use-integrations.ts` adopts it (16 packageId sites; 5 `authKey` sites correctly left).
- **docs** — `CASING_CONVENTIONS.md` new "Package identifiers in URL paths" section: the split rule + mandatory encoder contract. `CLAUDE.md` one-line pointer.

## Option B rejected (documented in #609)

No full-uniformity migration. Hono matches the route regex **before** the `Appstrate-Version` middleware runs, so path aliasing can't be version-gated → B would mean permanent dual-path registration. The encoder makes uniformity unnecessary.

## Behavior note

`encodePackageIdPath` throws on invalid input where old `encodeURI` silently built an `"undefined"` path. queryFns are `enabled`-guarded and mutationFns receive defined args, so no new throw paths — bad input now fails loud instead of 404ing. Intended.

## Follow-ups (out of scope, separate repos)

- `github-action` + MCP server adopt the helper when they next bump `@appstrate/core`.
- Republish `@appstrate/core` (`git tag core@X.Y.Z`) after merge so external consumers can import.

## Test plan

- [x] `bun test packages/core/test/naming.test.ts` — 42 pass
- [x] `bun run check` — tsc + eslint + prettier + verify-openapi, 29/29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #609
