### PR TITLE
chore(core): bump to 2.26.0

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to `@appstrate/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.26.0] — 2026-06-07
+
+Canonical packageId path encoding. Additive — no removals, no breaking changes.
+
+### Added
+
+- **`encodePackageIdPath(packageId)`** (`@appstrate/core/naming`) — encodes an
+  `"@scope/name"` packageId into a URL path segment, keeping the `@`/`/`
+  separators literal so it matches both route shapes (`/:scope{@…}/:name` and
+  `/:packageId{@…/…}`). Replaces hand-rolled `encodeURIComponent(packageId)`,
+  which percent-encodes `@`→`%40` and `/`→`%2F` and 404s every scoped route.
+  The one contract all consumers (frontend, SDK, github-action, MCP) should
+  import. Throws on invalid packageId.
+
 ## [2.25.0] — 2026-06-07
 
 Storage streaming + integration spawn/egress contract additions. All additive — no removals, no breaking changes.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "2.25.0",
+  "version": "2.26.0",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
Bump `@appstrate/core` to 2.26.0 to publish `encodePackageIdPath` (#609) to npm.

Canonical `"@scope/name"` → URL path-segment encoder that keeps the `@`/`/` separators literal so it matches both scoped route shapes. Additive — no removals, no breaking changes.

Schemas regenerated (no diff). Part of the v1.0.0-beta.25 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)