### PR TITLE
chore(deps): harden pi SDK supply-chain (exact pin + single-file swap barrier + eslint guard)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -44,7 +44,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.70.6",
+    "@mariozechner/pi-coding-agent": "0.70.6",
     "@types/bun": "latest",
     "@types/ioredis": "^5.0.0",
     "@types/nodemailer": "^8.0.0",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -46,8 +46,8 @@
   "dependencies": {
     "@apidevtools/swagger-parser": "^12.1.0",
     "@clack/prompts": "^1.2.0",
-    "@mariozechner/pi-ai": "^0.70.6",
-    "@mariozechner/pi-coding-agent": "^0.70.6",
+    "@mariozechner/pi-ai": "0.70.6",
+    "@mariozechner/pi-coding-agent": "0.70.6",
     "@napi-rs/keyring": "^1.2.0",
     "async-mutex": "^0.5.0",
     "commander": "^14.0.3",

--- a/apps/cli/src/commands/run/model.ts
+++ b/apps/cli/src/commands/run/model.ts
@@ -21,7 +21,7 @@
  * the upstream.
  */
 
-import type { Api, Model } from "@mariozechner/pi-ai";
+import type { Api, Model } from "../../lib/pi-sdk.ts";
 import { deriveProviderFromApi, PROVIDER_BY_API } from "@appstrate/runner-pi";
 import { listModelPresets, PROXY_SUPPORTED_APIS, type ModelPreset } from "../../lib/models.ts";
 

--- a/apps/cli/src/lib/pi-sdk.ts
+++ b/apps/cli/src/lib/pi-sdk.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Single import surface ("barrel") for the Pi Coding Agent SDK
+ * (`@mariozechner/pi-ai`) inside the `@appstrate/cli`.
+ *
+ * This is the ONLY file under `apps/cli/` allowed to import from the Pi
+ * SDK directly — enforced by the `no-restricted-imports` ESLint guard
+ * (see `eslint.config.mjs`). The CLI's surface is tiny (`Api`, `Model`
+ * types only), but routing it through a barrel keeps the swap-cost
+ * uniform with `runner-pi` and `runtime-pi`.
+ *
+ * Re-exports preserve type identity (`export type { ... }`).
+ *
+ * Rationale + fork-contingency plan: `docs/architecture/SUPPLY_CHAIN.md`.
+ */
+
+// --- types ---
+export type { Api, Model } from "@mariozechner/pi-ai";

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@commitlint/cli": "^20.5.2",
         "@commitlint/config-conventional": "^20.5.0",
         "@eslint/js": "^10.0.1",
-        "@mariozechner/pi-ai": "^0.70.6",
+        "@mariozechner/pi-ai": "0.70.6",
         "@readme/openapi-parser": "^6.0.1",
         "@redocly/openapi-core": "^2.30.2",
         "@types/bun": "latest",
@@ -71,7 +71,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@mariozechner/pi-coding-agent": "^0.70.6",
+        "@mariozechner/pi-coding-agent": "0.70.6",
         "@types/bun": "latest",
         "@types/ioredis": "^5.0.0",
         "@types/nodemailer": "^8.0.0",
@@ -87,8 +87,8 @@
       "dependencies": {
         "@apidevtools/swagger-parser": "^12.1.0",
         "@clack/prompts": "^1.2.0",
-        "@mariozechner/pi-ai": "^0.70.6",
-        "@mariozechner/pi-coding-agent": "^0.70.6",
+        "@mariozechner/pi-ai": "0.70.6",
+        "@mariozechner/pi-coding-agent": "0.70.6",
         "@napi-rs/keyring": "^1.2.0",
         "async-mutex": "^0.5.0",
         "commander": "^14.0.3",
@@ -197,14 +197,14 @@
       },
       "devDependencies": {
         "@appstrate/core": "workspace:*",
-        "@mariozechner/pi-ai": "^0.70.6",
-        "@mariozechner/pi-coding-agent": "^0.70.6",
+        "@mariozechner/pi-ai": "0.70.6",
+        "@mariozechner/pi-coding-agent": "0.70.6",
         "@types/mustache": "^4.2.6",
         "@types/semver": "^7.7.1",
       },
       "peerDependencies": {
-        "@mariozechner/pi-ai": "^0.70.6",
-        "@mariozechner/pi-coding-agent": "^0.70.6",
+        "@mariozechner/pi-ai": "0.70.6",
+        "@mariozechner/pi-coding-agent": "0.70.6",
       },
       "optionalPeers": [
         "@mariozechner/pi-ai",
@@ -236,7 +236,7 @@
     },
     "packages/core": {
       "name": "@appstrate/core",
-      "version": "2.24.0",
+      "version": "2.26.0",
       "dependencies": {
         "@afps-spec/schema": "^0.6.0",
         "@appstrate/afps-shared": "^0.1.0",
@@ -332,12 +332,12 @@
         "ajv": "^8.20.0",
       },
       "devDependencies": {
-        "@mariozechner/pi-ai": "^0.70.6",
-        "@mariozechner/pi-coding-agent": "^0.70.6",
+        "@mariozechner/pi-ai": "0.70.6",
+        "@mariozechner/pi-coding-agent": "0.70.6",
       },
       "peerDependencies": {
-        "@mariozechner/pi-ai": "^0.70.6",
-        "@mariozechner/pi-coding-agent": "^0.70.6",
+        "@mariozechner/pi-ai": "0.70.6",
+        "@mariozechner/pi-coding-agent": "0.70.6",
       },
     },
     "packages/shared-types": {
@@ -393,8 +393,8 @@
         "@appstrate/core": "workspace:*",
         "@appstrate/mcp-transport": "workspace:*",
         "@appstrate/runner-pi": "workspace:*",
-        "@mariozechner/pi-ai": "^0.70.6",
-        "@mariozechner/pi-coding-agent": "^0.70.6",
+        "@mariozechner/pi-ai": "0.70.6",
+        "@mariozechner/pi-coding-agent": "0.70.6",
       },
     },
     "runtime-pi/sidecar": {

--- a/docs/architecture/SUPPLY_CHAIN.md
+++ b/docs/architecture/SUPPLY_CHAIN.md
@@ -1,0 +1,143 @@
+# Supply-Chain Posture — Pi SDK (single-vendor dependency)
+
+Status: active. Addresses [#616](https://github.com/appstrate/appstrate/issues/616) item 2
+("single-vendor SDK supply-chain risk").
+
+The agent execution path depends on a single-maintainer SDK published by one
+author:
+
+- `@mariozechner/pi-ai`
+- `@mariozechner/pi-coding-agent`
+
+(plus their transitive siblings `@mariozechner/pi-agent-core`,
+`@mariozechner/pi-tui`).
+
+This document records why that risk is bounded today, the controls in place,
+and the concrete plan for substituting a forked/vendored SDK in an emergency.
+It is intended to double as the rationale for a future ADR.
+
+## 1. Isolation wall — the coupling is shallow
+
+The Pi SDK is **not** a cross-cutting dependency. It is confined to the agent
+runner and its container image. The platform core, the cloud billing module,
+and the published `@appstrate/core` library import it **zero** times.
+
+```
+apps/api   (Hono backend)      → 0 pi-* imports
+cloud      (billing module)    → 0 pi-* imports
+packages/core (@appstrate/core)→ 0 pi-* imports
+```
+
+All SDK usage lives behind a hard process/architecture boundary: the agent runs
+inside a sandboxed container, and credentials are mediated by the sidecar (see
+`SIDECAR.md`). The SDK never sees platform credentials and never executes inside
+the API process.
+
+The entire import surface, after this hardening, is **three barrel files**:
+
+| Package                | Barrel                             | Symbols consumed                                                                                                                                                                                            |
+| ---------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@appstrate/runner-pi` | `packages/runner-pi/src/pi-sdk.ts` | `AuthStorage`, `createAgentSession`, `DefaultResourceLoader`, `ModelRegistry`, `SessionManager`, `SettingsManager`, `Type` (values); `ExtensionAPI`, `ExtensionFactory`, `Api`, `KnownApi`, `Model` (types) |
+| `runtime-pi` (image)   | `runtime-pi/pi-sdk.ts`             | `Type` (value); `ExtensionAPI`, `ExtensionFactory`, `Api`, `Model` (types)                                                                                                                                  |
+| `@appstrate/cli`       | `apps/cli/src/lib/pi-sdk.ts`       | `Api`, `Model` (types)                                                                                                                                                                                      |
+
+Every other module imports these symbols from its package-local barrel, never
+from the SDK directly.
+
+> `examples/custom-skill/skill.ts` intentionally imports
+> `@mariozechner/pi-coding-agent` directly — it is user-facing documentation that
+> demonstrates the real SDK extension API a skill author writes against, not
+> platform code. It is outside the guard scope on purpose.
+
+## 2. Controls
+
+### Exact version pin (no caret)
+
+Both packages are pinned to an **exact** version (`0.70.6`, no `^`) in every
+`package.json` that declares them — `package.json` (root), `apps/api`,
+`apps/cli`, `runtime-pi`, `packages/runner-pi` (deps + peer + dev),
+`packages/afps-runtime` (peer + dev). Combined with the committed `bun.lock`
+(integrity hashes), this blocks **silent minor/patch bumps** of a single-author
+dependency — every version change is an explicit, reviewable diff.
+
+Peer-dependency ranges on the published `@appstrate/runner-pi` /
+`@appstrate/afps-runtime` are pinned exact for the same reason: external embedders
+get the same controlled version, and the fork-contingency below remains a
+one-line override for them too.
+
+### Single swap point (barrel) + ESLint guard
+
+Because the SDK is imported only through the three `pi-sdk.ts` barrels, swapping
+the implementation is a change to those files alone — no agent logic moves.
+
+A `no-restricted-imports` rule in `eslint.config.mjs` forbids any direct
+`@mariozechner/pi-*` import outside the barrels (the barrels are exempted via
+`ignores`). This keeps the property true going forward — a new file that imports
+the SDK directly fails `bun run check`.
+
+### Renovate / Dependabot
+
+`renovate.json` carries a dedicated rule for the two packages: grouped into one
+PR, labelled `supply-chain` / `pi-sdk`, `rangeStrategy: pin`, **no auto-merge**,
+and gated behind `dependencyDashboardApproval`. Updates to this dependency are a
+deliberate human decision, not an automated background bump.
+
+## 3. Swap-cost estimate
+
+| Scenario                                   | Cost                                                                                    |
+| ------------------------------------------ | --------------------------------------------------------------------------------------- |
+| Pin a new upstream version                 | 1 line per declaring `package.json` + `bun install` (lockfile diff reviewed)            |
+| Substitute a drop-in fork (same API)       | 1 `package.json` `overrides` entry (see below) — **0 source edits**                     |
+| Substitute a fork with API drift           | edit the 3 barrel files to adapt re-exports; agent logic untouched                      |
+| Replace the SDK entirely with a new runner | re-implement behind the 3 barrels + the `Runner` interface in `@appstrate/afps-runtime` |
+
+The realistic emergency case (compromised/yanked package, maintainer
+abandonment) is the **drop-in fork**: one `overrides` line, no code change.
+
+## 4. Fork-contingency plan (emergency substitution)
+
+> Out of scope for this change: we do **not** vendor `node_modules` or stand up a
+> registry mirror here. This section documents the concrete recipe so it can be
+> executed under pressure.
+
+If the upstream package must be replaced (compromise, yank, abandonment), point
+the dependency tree at a controlled artifact using a Bun/npm **`overrides`** block
+in the **root** `package.json`. Overrides apply to every workspace package
+transitively, so this is a single edit:
+
+```jsonc
+// package.json (root)
+{
+  "overrides": {
+    "zod": "4.4.3",
+    // --- emergency Pi SDK substitution (pick ONE form per package) ---
+
+    // a) npm alias to a published fork under our own scope:
+    "@mariozechner/pi-ai": "npm:@appstrate/pi-ai-fork@0.70.6",
+    "@mariozechner/pi-coding-agent": "npm:@appstrate/pi-coding-agent-fork@0.70.6",
+
+    // b) pinned git fork (tag or commit SHA):
+    // "@mariozechner/pi-ai": "github:appstrate/pi-ai-fork#v0.70.6",
+
+    // c) vendored tarball committed to the repo (fully offline):
+    // "@mariozechner/pi-ai": "file:./vendor/mariozechner-pi-ai-0.70.6.tgz"
+  },
+}
+```
+
+Then:
+
+```sh
+bun install            # re-resolves the tree against the override
+bun run check          # tsc + eslint guard + prettier + verify:openapi
+bun test               # runner-pi / runtime-pi / cli suites
+```
+
+The fork must keep the symbols listed in the barrel table above. If the fork's
+API drifts, adapt the three `pi-sdk.ts` barrels (re-map names, wrap shapes) —
+that is the only place the rest of the codebase touches the SDK.
+
+For a fully air-gapped posture (vendored tarball or registry mirror), pair option
+(c) with a committed `vendor/` artifact and verify its SHA against the original
+before committing. That work is deliberately deferred — this document is the
+playbook for when it becomes necessary.

--- a/docs/architecture/SUPPLY_CHAIN.md
+++ b/docs/architecture/SUPPLY_CHAIN.md
@@ -71,9 +71,19 @@ Because the SDK is imported only through the three `pi-sdk.ts` barrels, swapping
 the implementation is a change to those files alone — no agent logic moves.
 
 A `no-restricted-imports` rule in `eslint.config.mjs` forbids any direct
-`@mariozechner/pi-*` import outside the barrels (the barrels are exempted via
-`ignores`). This keeps the property true going forward — a new file that imports
-the SDK directly fails `bun run check`.
+`@mariozechner/pi-*` import (the whole vendor family — including subpaths) outside
+the barrels (the barrels are exempted via `ignores`). The guard covers every
+declared SDK consumer tree: `packages/runner-pi/src`, `runtime-pi`, `apps/cli/src`,
+`apps/api/src`, and `packages/afps-runtime/src`. `afps-runtime` is SDK-agnostic and
+imports zero pi-\* symbols today, so it has no barrel — the guard simply keeps it
+that way (a future direct import there fails `bun run check`). This keeps the
+property true going forward — a new file that imports the SDK directly fails
+`bun run check`.
+
+A barrel-completeness test (`test/supply-chain-barrels.test.ts`) asserts each
+barrel actually re-exports the value symbols its consumers import — a missing
+re-export is a runtime crash the lint guard cannot catch. Type-only re-exports are
+covered by `tsc` on the barrels' real consumers.
 
 ### Renovate / Dependabot
 

--- a/docs/architecture/SUPPLY_CHAIN.md
+++ b/docs/architecture/SUPPLY_CHAIN.md
@@ -80,6 +80,12 @@ that way (a future direct import there fails `bun run check`). This keeps the
 property true going forward — a new file that imports the SDK directly fails
 `bun run check`.
 
+`packages/core/src` is guarded the same way through core's own
+`no-restricted-imports` block (it already bans cross-package workspace imports):
+core imports the Pi SDK zero times and has no barrel, so the ban there is absolute.
+It lives in core's block rather than the shared guard block because flat-config
+last-match-wins would otherwise clobber core's workspace-independence rule.
+
 A barrel-completeness test (`test/supply-chain-barrels.test.ts`) asserts each
 barrel actually re-exports the value symbols its consumers import — a missing
 re-export is a runtime crash the lint guard cannot catch. Type-only re-exports are

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,6 +52,14 @@ export default tseslint.config(
               message:
                 "core must remain independent — no imports from other workspace packages",
             },
+            {
+              // Supply-chain guard: core imports the Pi SDK zero times and must
+              // stay that way. core has no pi-sdk barrel (nothing to route
+              // through), so the ban is absolute here. See docs/architecture/SUPPLY_CHAIN.md
+              group: ["@mariozechner/pi-*", "@mariozechner/pi-*/**"],
+              message:
+                "core must not import the Pi SDK — the agent runner owns that dependency. See docs/architecture/SUPPLY_CHAIN.md",
+            },
           ],
         },
       ],

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,13 +58,16 @@ export default tseslint.config(
     },
   },
   {
-    // Supply-chain guard: the single-vendor Pi SDK
-    // (@mariozechner/pi-ai, @mariozechner/pi-coding-agent) may only be
-    // imported through each package's `pi-sdk.ts` barrel, so swapping or
-    // forking it is a one-file change. Barrels are exempt via `ignores`.
-    // Rationale: docs/architecture/SUPPLY_CHAIN.md
+    // Supply-chain guard: the single-vendor Pi SDK (the whole
+    // `@mariozechner/pi-*` family — pi-ai, pi-coding-agent, and siblings
+    // pi-agent-core / pi-tui) may only be imported through each package's
+    // `pi-sdk.ts` barrel, so swapping or forking it is a one-file change.
+    // Barrels are exempt via `ignores`. `packages/afps-runtime/src` is
+    // SDK-agnostic and imports zero pi-* symbols today, so it has no barrel —
+    // the guard simply keeps it that way. Rationale: docs/architecture/SUPPLY_CHAIN.md
     files: [
       "packages/runner-pi/src/**/*.ts",
+      "packages/afps-runtime/src/**/*.ts",
       "apps/cli/src/**/*.ts",
       "apps/api/src/**/*.ts",
       "runtime-pi/**/*.ts",
@@ -83,12 +86,8 @@ export default tseslint.config(
         {
           patterns: [
             {
-              group: ["@mariozechner/pi-ai", "@mariozechner/pi-ai/*"],
-              message:
-                "Import the Pi SDK only through the package-local pi-sdk barrel (pi-sdk.ts) — see docs/architecture/SUPPLY_CHAIN.md",
-            },
-            {
-              group: ["@mariozechner/pi-coding-agent", "@mariozechner/pi-coding-agent/*"],
+              // `**` (not `*`) so deep subpaths like pi-ai/dist/foo are caught.
+              group: ["@mariozechner/pi-*", "@mariozechner/pi-*/**"],
               message:
                 "Import the Pi SDK only through the package-local pi-sdk barrel (pi-sdk.ts) — see docs/architecture/SUPPLY_CHAIN.md",
             },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,6 +58,47 @@ export default tseslint.config(
     },
   },
   {
+    // Supply-chain guard: the single-vendor Pi SDK
+    // (@mariozechner/pi-ai, @mariozechner/pi-coding-agent) may only be
+    // imported through each package's `pi-sdk.ts` barrel, so swapping or
+    // forking it is a one-file change. Barrels are exempt via `ignores`.
+    // Rationale: docs/architecture/SUPPLY_CHAIN.md
+    files: [
+      "packages/runner-pi/src/**/*.ts",
+      "apps/cli/src/**/*.ts",
+      "runtime-pi/**/*.ts",
+    ],
+    ignores: [
+      "packages/runner-pi/src/pi-sdk.ts",
+      "apps/cli/src/lib/pi-sdk.ts",
+      "runtime-pi/pi-sdk.ts",
+      "runtime-pi/sidecar/**",
+      "runtime-pi/runners/**",
+    ],
+    languageOptions: {
+      parser: tseslint.parser,
+    },
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: ["@mariozechner/pi-ai", "@mariozechner/pi-ai/*"],
+              message:
+                "Import the Pi SDK only through the package-local pi-sdk barrel (pi-sdk.ts) — see docs/architecture/SUPPLY_CHAIN.md",
+            },
+            {
+              group: ["@mariozechner/pi-coding-agent", "@mariozechner/pi-coding-agent/*"],
+              message:
+                "Import the Pi SDK only through the package-local pi-sdk barrel (pi-sdk.ts) — see docs/architecture/SUPPLY_CHAIN.md",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ["apps/web/src/**/*.{ts,tsx}", "packages/ui/src/**/*.{ts,tsx}"],
     languageOptions: {
       globals: globals.browser,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -66,14 +66,13 @@ export default tseslint.config(
     files: [
       "packages/runner-pi/src/**/*.ts",
       "apps/cli/src/**/*.ts",
+      "apps/api/src/**/*.ts",
       "runtime-pi/**/*.ts",
     ],
     ignores: [
       "packages/runner-pi/src/pi-sdk.ts",
       "apps/cli/src/lib/pi-sdk.ts",
       "runtime-pi/pi-sdk.ts",
-      "runtime-pi/sidecar/**",
-      "runtime-pi/runners/**",
     ],
     languageOptions: {
       parser: tseslint.parser,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@commitlint/cli": "^20.5.2",
     "@commitlint/config-conventional": "^20.5.0",
     "@eslint/js": "^10.0.1",
-    "@mariozechner/pi-ai": "^0.70.6",
+    "@mariozechner/pi-ai": "0.70.6",
     "@readme/openapi-parser": "^6.0.1",
     "@redocly/openapi-core": "^2.30.2",
     "@types/bun": "latest",

--- a/packages/afps-runtime/package.json
+++ b/packages/afps-runtime/package.json
@@ -76,8 +76,8 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.70.6",
-    "@mariozechner/pi-ai": "^0.70.6"
+    "@mariozechner/pi-coding-agent": "0.70.6",
+    "@mariozechner/pi-ai": "0.70.6"
   },
   "peerDependenciesMeta": {
     "@mariozechner/pi-coding-agent": {
@@ -91,7 +91,7 @@
     "@appstrate/core": "workspace:*",
     "@types/mustache": "^4.2.6",
     "@types/semver": "^7.7.1",
-    "@mariozechner/pi-coding-agent": "^0.70.6",
-    "@mariozechner/pi-ai": "^0.70.6"
+    "@mariozechner/pi-coding-agent": "0.70.6",
+    "@mariozechner/pi-ai": "0.70.6"
   }
 }

--- a/packages/runner-pi/package.json
+++ b/packages/runner-pi/package.json
@@ -51,11 +51,11 @@
     "ajv": "^8.20.0"
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.70.6",
-    "@mariozechner/pi-ai": "^0.70.6"
+    "@mariozechner/pi-coding-agent": "0.70.6",
+    "@mariozechner/pi-ai": "0.70.6"
   },
   "devDependencies": {
-    "@mariozechner/pi-coding-agent": "^0.70.6",
-    "@mariozechner/pi-ai": "^0.70.6"
+    "@mariozechner/pi-coding-agent": "0.70.6",
+    "@mariozechner/pi-ai": "0.70.6"
   }
 }

--- a/packages/runner-pi/src/api-call-bridge.ts
+++ b/packages/runner-pi/src/api-call-bridge.ts
@@ -12,8 +12,7 @@
  * The unified `api_call` surface exposes one tool per integration — the
  * integration is implied by the tool name, not a parameter.
  */
-import { Type } from "@mariozechner/pi-ai";
-import type { ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { Type, type ExtensionAPI, type ExtensionFactory } from "./pi-sdk.ts";
 import type { Bundle } from "@appstrate/afps-runtime/bundle";
 import type { RuntimeEventEmitter } from "./runtime-tools/mcp-forward.ts";
 import {

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -34,8 +34,10 @@ import {
   SessionManager,
   SettingsManager,
   type ExtensionFactory,
-} from "@mariozechner/pi-coding-agent";
-import type { Api, KnownApi, Model } from "@mariozechner/pi-ai";
+  type Api,
+  type KnownApi,
+  type Model,
+} from "./pi-sdk.ts";
 import type { ModelApiShape } from "@appstrate/core/sidecar-types";
 import type { RunEvent, ExecutionContext } from "@appstrate/afps-runtime/types";
 import {

--- a/packages/runner-pi/src/pi-sdk.ts
+++ b/packages/runner-pi/src/pi-sdk.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Single import surface ("barrel") for the Pi Coding Agent SDK
+ * (`@mariozechner/pi-ai`, `@mariozechner/pi-coding-agent`).
+ *
+ * This is the ONLY file in `@appstrate/runner-pi` allowed to import from
+ * the Pi SDK directly — enforced by the `no-restricted-imports` ESLint
+ * guard (see `eslint.config.mjs`). Every other module imports the symbols
+ * it needs from here, so swapping or forking the single-vendor SDK is a
+ * one-file change.
+ *
+ * Re-exports preserve type identity (`export type { ... }`), so consumers
+ * see the exact same nominal types as a direct SDK import would yield.
+ *
+ * Rationale + fork-contingency plan: `docs/architecture/SUPPLY_CHAIN.md`.
+ */
+
+// --- values ---
+export {
+  AuthStorage,
+  createAgentSession,
+  DefaultResourceLoader,
+  ModelRegistry,
+  SessionManager,
+  SettingsManager,
+} from "@mariozechner/pi-coding-agent";
+export { Type } from "@mariozechner/pi-ai";
+
+// --- types ---
+export type { ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent";
+export type { Api, KnownApi, Model } from "@mariozechner/pi-ai";

--- a/packages/runner-pi/src/runtime-tools/mcp-forward.ts
+++ b/packages/runner-pi/src/runtime-tools/mcp-forward.ts
@@ -26,8 +26,7 @@
  * code in either the runner-pi or runtime-pi tree.
  */
 
-import { Type } from "@mariozechner/pi-ai";
-import type { ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { Type, type ExtensionAPI, type ExtensionFactory } from "../pi-sdk.ts";
 import type { AppstrateMcpClient, CallToolResult } from "@appstrate/mcp-transport";
 import { RUNTIME_INJECTED_TOOLS, type RuntimeInjectedTool } from "./index.ts";
 

--- a/packages/runner-pi/src/runtime-tools/runtime-tool-extensions.ts
+++ b/packages/runner-pi/src/runtime-tools/runtime-tool-extensions.ts
@@ -22,8 +22,7 @@
  * a sink can pass an explicit `emit` to route events directly.
  */
 
-import { Type } from "@mariozechner/pi-ai";
-import type { ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { Type, type ExtensionAPI, type ExtensionFactory } from "../pi-sdk.ts";
 import {
   buildRuntimeToolDefs,
   reEmitRuntimeToolEvents,

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,15 @@
       "matchPackageNames": ["@appstrate/core"],
       "groupName": "appstrate core",
       "automerge": false
+    },
+    {
+      "description": "Pi SDK is a single-maintainer, pinned-exact supply-chain dependency. Group both packages into one PR, require manual dashboard approval, never auto-merge. Ordered last so it overrides the devDependencies automerge rule. See docs/architecture/SUPPLY_CHAIN.md",
+      "matchPackageNames": ["@mariozechner/pi-ai", "@mariozechner/pi-coding-agent"],
+      "groupName": "pi sdk (manual review)",
+      "labels": ["dependencies", "supply-chain", "pi-sdk"],
+      "rangeStrategy": "pin",
+      "automerge": false,
+      "dependencyDashboardApproval": true
     }
   ]
 }

--- a/runtime-pi/entrypoint.ts
+++ b/runtime-pi/entrypoint.ts
@@ -34,8 +34,7 @@
 
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
-import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
-import type { Api, Model } from "@mariozechner/pi-ai";
+import type { ExtensionFactory, Api, Model } from "./pi-sdk.ts";
 import {
   PiRunner,
   prepareBundleForPi,

--- a/runtime-pi/extension-wrapper.ts
+++ b/runtime-pi/extension-wrapper.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import type { ExtensionFactory } from "./pi-sdk.ts";
 import type { AppstrateCtxProvider } from "@appstrate/runner-pi";
 import { getErrorMessage } from "@appstrate/core/errors";
 

--- a/runtime-pi/mcp/api-upload-extension.ts
+++ b/runtime-pi/mcp/api-upload-extension.ts
@@ -29,8 +29,7 @@
  *     the gating + schema live in one place).
  */
 
-import { Type } from "@mariozechner/pi-ai";
-import type { ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { Type, type ExtensionAPI, type ExtensionFactory } from "../pi-sdk.ts";
 import type { AppstrateMcpClient } from "@appstrate/mcp-transport";
 import type { RuntimeEventEmitter } from "@appstrate/runner-pi";
 import { McpApiUploadResolver } from "./api-upload-resolver.ts";

--- a/runtime-pi/mcp/direct.ts
+++ b/runtime-pi/mcp/direct.ts
@@ -25,9 +25,8 @@
  * orchestration-only.
  */
 
-import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import { isApiCallTool, isApiUploadTool, type AppstrateMcpClient } from "@appstrate/mcp-transport";
-import { Type } from "@mariozechner/pi-ai";
+import { Type, type ExtensionFactory } from "../pi-sdk.ts";
 import {
   buildRuntimeToolFactories,
   callToolResultToPi,

--- a/runtime-pi/package.json
+++ b/runtime-pi/package.json
@@ -11,7 +11,7 @@
     "@appstrate/core": "workspace:*",
     "@appstrate/mcp-transport": "workspace:*",
     "@appstrate/runner-pi": "workspace:*",
-    "@mariozechner/pi-coding-agent": "^0.70.6",
-    "@mariozechner/pi-ai": "^0.70.6"
+    "@mariozechner/pi-coding-agent": "0.70.6",
+    "@mariozechner/pi-ai": "0.70.6"
   }
 }

--- a/runtime-pi/pi-sdk.ts
+++ b/runtime-pi/pi-sdk.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Single import surface ("barrel") for the Pi Coding Agent SDK
+ * (`@mariozechner/pi-ai`, `@mariozechner/pi-coding-agent`) inside the
+ * `runtime-pi` container image.
+ *
+ * This is the ONLY file under `runtime-pi/` allowed to import from the Pi
+ * SDK directly — enforced by the `no-restricted-imports` ESLint guard
+ * (see `eslint.config.mjs`). Every other module imports the symbols it
+ * needs from here, so swapping or forking the single-vendor SDK is a
+ * one-file change.
+ *
+ * Re-exports preserve type identity (`export type { ... }`).
+ *
+ * Rationale + fork-contingency plan: `docs/architecture/SUPPLY_CHAIN.md`.
+ */
+
+// --- values ---
+export { Type } from "@mariozechner/pi-ai";
+
+// --- types ---
+export type { ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent";
+export type { Api, Model } from "@mariozechner/pi-ai";

--- a/test/supply-chain-barrels.test.ts
+++ b/test/supply-chain-barrels.test.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Barrel-completeness guard for the single-vendor Pi SDK.
+ *
+ * The "one-file swap" guarantee in docs/architecture/SUPPLY_CHAIN.md assumes each
+ * `pi-sdk.ts` barrel re-exports EVERY symbol its consumers import. The ESLint
+ * `no-restricted-imports` guard cannot catch a *missing* re-export — that surfaces
+ * only as a runtime `undefined` (for values) or a tsc error (for types).
+ *
+ * This test closes the runtime half: it imports each barrel and asserts the
+ * VALUE symbols consumers use are actually defined at runtime. Type-only
+ * re-exports cannot be checked at runtime (they erase to nothing); they are
+ * covered by `tsc` on each barrel's real consumers — e.g. the `apps/cli` barrel
+ * is pure type-only (`Api`, `Model`), and `apps/cli/src/commands/run/model.ts`
+ * would fail to typecheck if those re-exports went missing.
+ *
+ * Imported via relative paths (not package names) because the barrels are
+ * package-internal files, not part of any package's `exports` map. This file
+ * lives at the repo root `test/` dir intentionally: it is outside every
+ * package's tsc `include`, so importing three barrels from three packages in one
+ * file introduces no cross-package tsc coupling.
+ */
+
+import { describe, it, expect } from "bun:test";
+
+import * as runnerPiBarrel from "../packages/runner-pi/src/pi-sdk.ts";
+import * as runtimePiBarrel from "../runtime-pi/pi-sdk.ts";
+// Pure type-only barrel — at runtime this is an empty module object. Imported to
+// prove it loads; its symbol completeness (Api, Model) is enforced by tsc on its
+// real consumer (apps/cli/src/commands/run/model.ts).
+import * as cliBarrel from "../apps/cli/src/lib/pi-sdk.ts";
+
+describe("supply-chain: pi-sdk barrel completeness", () => {
+  it("@appstrate/runner-pi barrel re-exports every value symbol its consumers import", () => {
+    const expectedValues = [
+      "AuthStorage",
+      "createAgentSession",
+      "DefaultResourceLoader",
+      "ModelRegistry",
+      "SessionManager",
+      "SettingsManager",
+      "Type",
+    ] as const;
+
+    for (const name of expectedValues) {
+      expect(
+        (runnerPiBarrel as Record<string, unknown>)[name],
+        `runner-pi pi-sdk barrel is missing value export "${name}"`,
+      ).toBeDefined();
+    }
+  });
+
+  it("runtime-pi barrel re-exports the value symbol its consumers import", () => {
+    expect(
+      (runtimePiBarrel as Record<string, unknown>).Type,
+      'runtime-pi pi-sdk barrel is missing value export "Type"',
+    ).toBeDefined();
+  });
+
+  it("@appstrate/cli barrel is type-only (no runtime value exports) and loads cleanly", () => {
+    // No value exports to assert — type completeness (Api, Model) is a tsc concern,
+    // enforced on the barrel's real consumer. Loading without throwing is the check.
+    expect(cliBarrel).toBeDefined();
+  });
+});

--- a/test/supply-chain-barrels.test.ts
+++ b/test/supply-chain-barrels.test.ts
@@ -26,10 +26,6 @@ import { describe, it, expect } from "bun:test";
 
 import * as runnerPiBarrel from "../packages/runner-pi/src/pi-sdk.ts";
 import * as runtimePiBarrel from "../runtime-pi/pi-sdk.ts";
-// Pure type-only barrel — at runtime this is an empty module object. Imported to
-// prove it loads; its symbol completeness (Api, Model) is enforced by tsc on its
-// real consumer (apps/cli/src/commands/run/model.ts).
-import * as cliBarrel from "../apps/cli/src/lib/pi-sdk.ts";
 
 describe("supply-chain: pi-sdk barrel completeness", () => {
   it("@appstrate/runner-pi barrel re-exports every value symbol its consumers import", () => {
@@ -56,11 +52,5 @@ describe("supply-chain: pi-sdk barrel completeness", () => {
       (runtimePiBarrel as Record<string, unknown>).Type,
       'runtime-pi pi-sdk barrel is missing value export "Type"',
     ).toBeDefined();
-  });
-
-  it("@appstrate/cli barrel is type-only (no runtime value exports) and loads cleanly", () => {
-    // No value exports to assert — type completeness (Api, Model) is a tsc concern,
-    // enforced on the barrel's real consumer. Loading without throwing is the check.
-    expect(cliBarrel).toBeDefined();
   });
 });


### PR DESCRIPTION
## Why

The agent execution path depends on a **single-maintainer** SDK (`@mariozechner/pi-ai`, `@mariozechner/pi-coding-agent`). Addresses #616 item 2.

**The coupling is shallow.** The platform core (`apps/api`), the cloud billing module, and the published `@appstrate/core` library import the SDK **zero** times. All usage lives behind a hard container/sidecar boundary and was confined to two packages plus the CLI. This PR makes that posture explicit, reproducible, and enforced.

## What

- **Exact pin (no caret)** — `^0.70.6` → `0.70.6` in every `package.json` that declares the SDK: root, `apps/api`, `apps/cli`, `runtime-pi`, `packages/runner-pi` (deps+peer+dev), `packages/afps-runtime` (peer+dev). `bun.lock` resolution is **unchanged** (still `0.70.6` + same integrity) — only the declared range strings flip. Blocks silent minor/patch bumps of a single-author dep.
- **Single swap barrel per package** — the SDK is now imported through one `pi-sdk.ts` barrel per package; **9 consuming files re-pointed** to import from the barrel instead of the SDK. Mechanical re-export, type identity preserved (`export type { ... }`):
  - `packages/runner-pi/src/pi-sdk.ts`
  - `runtime-pi/pi-sdk.ts`
  - `apps/cli/src/lib/pi-sdk.ts`
- **ESLint guard** — `no-restricted-imports` forbids direct `@mariozechner/pi-*` imports outside the barrels (barrels exempted via `ignores`). The guard *rule* now reaches `runtime-pi/**` too (previously outside every ESLint config block) — it applies only this one rule there, not the full recommended ruleset, so it adds no unrelated lint errors to those container files. `packages/core/src` is covered the same way via core's own `no-restricted-imports` block (core imports the SDK zero times and has no barrel — an absolute ban; kept in core's block so flat-config last-match-wins doesn't clobber core's workspace-independence rule). Verified it fires on a deliberate bad import, then removed. Enforces the property going forward via `bun run check`.
- **Renovate** — dedicated rule for the two packages: grouped one PR, labels `supply-chain`/`pi-sdk`, `rangeStrategy: pin`, **no auto-merge**, `dependencyDashboardApproval` (ordered last to override the devDependencies automerge rule).
- **Docs** — `docs/architecture/SUPPLY_CHAIN.md`: isolation wall, exact-pin rationale, barrel = single swap point, swap-cost table, and a concrete `package.json` `overrides` fork-contingency snippet. Doubles as the rationale for a future ADR.

## Swap-cost now

Drop-in fork (same API) = **1 `overrides` line, 0 source edits**. Fork with API drift = edit the **3 barrel files** only; agent logic untouched.

## Tests

Run from repo root (required secrets supplied; this worktree has no `.env`):

- `bun run check` — **29/29 tasks** (tsc strict all packages, eslint incl. new guard, prettier, verify:openapi, detect:breaking, conformance, module-isolation/contract). No type regressions.
- `bun test packages/runner-pi/test` — **133 pass / 0 fail**
- `bun test runtime-pi/test` — **102 pass / 0 fail** (covers the edited `extension-wrapper`, `mcp-direct`, `api-upload-extension`)
- `bun test runtime-pi/sidecar/test` — **544 pass / 0 fail** (untouched; sanity)
- `apps/cli` has no test files; change is type-only, validated by `tsc --noEmit` (clean)
- ESLint guard proof: probe imports in `runner-pi/src` and `runtime-pi/` both flagged `no-restricted-imports`; barrels pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
