### PR TITLE
feat(oidc,mcp,cli): bind org at consent — MCP clients & CLI need no X-Org-Id

### DIFF
--- a/apps/api/src/modules/oidc/auth/plugins.ts
+++ b/apps/api/src/modules/oidc/auth/plugins.ts
@@ -62,6 +62,7 @@ import { getAppstrateScopes, OIDC_IDENTITY_SCOPES } from "./scopes.ts";
 import { getModuleEndUserAllowedScopes } from "@appstrate/core/permissions";
 import { isBlockedUrlWithDns } from "../../../lib/ssrf-dns.ts";
 import { markClientSelfService } from "../services/oauth-admin.ts";
+import { getPendingConsentOrg } from "../services/consent-org.ts";
 import { getMcpResourceUri } from "../../mcp/resource.ts";
 
 export type ActorType = "dashboard_user" | "end_user" | "user";
@@ -257,12 +258,40 @@ export function oidcBetterAuthPlugins(opts: OidcBetterAuthPluginsOptions = {}): 
       },
 
       /**
+       * Org binding for self-service (instance-level) clients. The user picks
+       * a target org on the consent screen; the consent POST handler validates
+       * membership and exposes it via `getPendingConsentOrg()`. Returning it as
+       * the `referenceId` stamps it onto the `oauthConsent` row + authorization
+       * code, and it persists on the refresh-token row — so every (re)mint of
+       * this grant carries the same org. Surfaces below in
+       * `customAccessTokenClaims` as the `org_id` claim. Org-level and
+       * application-level clients never set a pending org (their org is fixed
+       * in client metadata), so this returns `undefined` and is a no-op for
+       * them.
+       */
+      postLogin: {
+        // `shouldRedirect: false` → we never divert to BA's separate
+        // account-selection page; the org picker is embedded in our own
+        // consent screen (`pages/consent.ts`). `page` is required by the type
+        // but unreachable while `shouldRedirect` always returns false.
+        page: "/api/oauth/consent",
+        shouldRedirect: async () => false,
+        consentReferenceId: async () => getPendingConsentOrg(),
+      },
+
+      /**
        * Polymorphic claim builder. Branches on `metadata.level` (set at
        * client registration via `services/oauth-admin.ts`) and returns a
-       * snake_case claim payload compatible with RFC 9068 + OIDC Core.
+       * snake_case claim payload compatible with RFC 9068 + OIDC Core. For
+       * instance-level (self-service) tokens, `referenceId` carries the
+       * consent-chosen org and becomes the `org_id` claim.
        */
-      customAccessTokenClaims: async ({ user, metadata }) =>
-        buildClaimsForClient(user ?? null, metadata as ClientMetadata | undefined),
+      customAccessTokenClaims: async ({ user, metadata, referenceId }) =>
+        buildClaimsForClient(
+          user ?? null,
+          metadata as ClientMetadata | undefined,
+          typeof referenceId === "string" ? referenceId : undefined,
+        ),
 
       /**
        * Surface the same polymorphic claims on /userinfo so satellites can
@@ -400,11 +429,12 @@ function strOrNull(value: unknown): string | null {
 async function buildClaimsForClient(
   user: { id: string; email: string; name?: string | null; emailVerified?: boolean } | null,
   metadata: ClientMetadata | undefined,
+  referenceId?: string,
 ): Promise<Record<string, unknown>> {
   if (!user) return {};
   const level = metadata?.level;
   if (level === "instance") {
-    return buildInstanceLevelClaims(user);
+    return buildInstanceLevelClaims(user, referenceId);
   }
   if (level === "org") {
     return buildOrgLevelClaims(user, metadata!);
@@ -421,24 +451,31 @@ async function buildClaimsForClient(
   });
 }
 
-async function buildInstanceLevelClaims(user: {
-  id: string;
-  email: string;
-  name?: string | null;
-  emailVerified?: boolean;
-}): Promise<Record<string, unknown>> {
+async function buildInstanceLevelClaims(
+  user: {
+    id: string;
+    email: string;
+    name?: string | null;
+    emailVerified?: boolean;
+  },
+  referenceId?: string,
+): Promise<Record<string, unknown>> {
   // Instance clients serve platform audiences — dashboard SPA + satellite
   // admin tools. Reject end-user realm sessions so an OIDC token minted
   // under app A's scope cannot be replayed to mint an instance token.
   await assertUserRealm(user.id, "platform", { clientLevel: "instance" });
-  // Instance tokens carry NO org or application context. The user is a
-  // Better Auth user who may belong to multiple organizations — org is
-  // resolved per-request via X-Org-Id after authentication.
+  // Org context is optional for instance tokens. A self-service client (MCP /
+  // CLI) binds an org at consent → it arrives here as `referenceId` and
+  // becomes the `org_id` claim, which the auth strategy pins (no `X-Org-Id`
+  // needed). A token with no bound org omits the claim and resolves org
+  // per-request via `X-Org-Id`, as before. The strategy re-verifies membership
+  // on every request, so a stale/forged claim cannot grant access.
   return {
     actor_type: "user",
     email: user.email,
     email_verified: user.emailVerified === true,
     name: user.name ?? user.email,
+    ...(referenceId ? { org_id: referenceId } : {}),
   };
 }
 

--- a/apps/api/src/modules/oidc/auth/strategy.ts
+++ b/apps/api/src/modules/oidc/auth/strategy.ts
@@ -162,17 +162,22 @@ async function resolveInstanceUser(claims: AccessTokenClaims): Promise<AuthResol
     });
     return null;
   }
-  // Instance tokens carry no org context. Return a partial resolution —
-  // orgId and orgRole are left undefined. The auth pipeline defers org
-  // resolution to the X-Org-Id middleware (same path as session auth).
-  // Permissions are also deferred — the pipeline derives them from orgRole
-  // after org-context resolves, via resolvePermissions(orgRole).
+  // Instance tokens defer org resolution to the X-Org-Id middleware (same
+  // path as session auth) — UNLESS the token was bound to an org at consent
+  // (a self-service MCP/CLI token carrying an `org_id` claim). In that case we
+  // pin it here: `requireOrgContext` reads it as the `pinned` org, re-verifies
+  // membership, and derives `orgRole` + permissions — so the caller never has
+  // to send `X-Org-Id`. We still set `deferOrgResolution` so the rest of the
+  // pipeline (membership re-check + `resolvePermissions(orgRole)`) runs
+  // exactly as for the header path; only the org *source* changes. An org-less
+  // token (no claim) keeps the legacy header behaviour — full back-compat.
   return {
     user: {
       id: authUserRow.id,
       email: authUserRow.email,
       name: authUserRow.name ?? "",
     },
+    orgId: claims.orgId,
     authMethod: "oauth2-instance",
     permissions: [],
     deferOrgResolution: true,

--- a/apps/api/src/modules/oidc/pages/activate.ts
+++ b/apps/api/src/modules/oidc/pages/activate.ts
@@ -27,7 +27,9 @@
 
 import { html, type RawHtml } from "./html.ts";
 import { renderLayout } from "./layout.ts";
+import { renderOrgField } from "./org-field.ts";
 import type { ResolvedAppBranding } from "../services/branding.ts";
+import type { ConsentOrgOption } from "../services/consent-org.ts";
 
 /** Common props across the three renders — all of them need branding. */
 interface ActivateBaseProps {
@@ -87,6 +89,12 @@ export interface ActivateConsentPageProps extends ActivateBaseProps {
   scopes: string[];
   /** CSRF token pairing the approve/deny buttons with a signed cookie. */
   csrfToken: string;
+  /**
+   * Organizations the user may bind this CLI session to. One → bound silently;
+   * many → a picker. Submitted as `org_id` with the approval and stamped onto
+   * the issued token's `org_id` claim (so the CLI needs no `X-Org-Id`).
+   */
+  orgs?: ConsentOrgOption[];
 }
 
 const SCOPE_DESCRIPTIONS_FR: Record<string, string> = {
@@ -128,6 +136,7 @@ export function renderActivateConsentPage(props: ActivateConsentPageProps): RawH
       <form method="POST" action="/activate/approve">
         <input type="hidden" name="_csrf" value="${props.csrfToken}" />
         <input type="hidden" name="user_code" value="${props.userCodeRaw}" />
+        ${renderOrgField(props.orgs ?? [])}
         <button type="submit" class="allow">Autoriser</button>
       </form>
     </div>

--- a/apps/api/src/modules/oidc/pages/consent.ts
+++ b/apps/api/src/modules/oidc/pages/consent.ts
@@ -14,8 +14,9 @@
  * field does not match the cookie.
  */
 
-import { html, raw, type RawHtml } from "./html.ts";
+import { html, type RawHtml } from "./html.ts";
 import { renderLayout } from "./layout.ts";
+import { renderOrgField } from "./org-field.ts";
 import type { ResolvedAppBranding } from "../services/branding.ts";
 import type { ConsentOrgOption } from "../services/consent-org.ts";
 
@@ -58,34 +59,6 @@ export interface ConsentPageProps {
   selectedOrgId?: string;
   /** Optional error message displayed above the form. */
   error?: string;
-}
-
-/**
- * The org-binding form control, rendered INSIDE the accept form so `org_id`
- * is submitted with the approval. Zero orgs → nothing. One → a hidden input
- * plus a context line. Many → a labelled `<select>`.
- */
-function renderOrgField(orgs: ConsentOrgOption[], selectedOrgId?: string): RawHtml | string {
-  if (orgs.length === 0) return "";
-  const selected =
-    selectedOrgId && orgs.some((o) => o.id === selectedOrgId) ? selectedOrgId : orgs[0]!.id;
-  if (orgs.length === 1) {
-    const only = orgs[0]!;
-    return html`
-      <input type="hidden" name="org_id" value="${only.id}" />
-      <p class="org-single">Organisation : <strong>${only.name}</strong></p>
-    `;
-  }
-  const options = orgs.map(
-    (o) =>
-      html`<option value="${o.id}" ${o.id === selected ? raw(" selected") : ""}>${o.name}</option>`,
-  );
-  return html`
-    <label class="org-label" for="org_id">Organisation</label>
-    <select id="org_id" name="org_id" class="org-select">
-      ${options}
-    </select>
-  `;
 }
 
 export function renderConsentPage(props: ConsentPageProps): RawHtml {

--- a/apps/api/src/modules/oidc/pages/consent.ts
+++ b/apps/api/src/modules/oidc/pages/consent.ts
@@ -55,8 +55,6 @@ export interface ConsentPageProps {
    * `X-Org-Id`). One → bound silently. Many → a `<select>` is shown.
    */
   orgs?: ConsentOrgOption[];
-  /** Pre-selected org id in the picker (defaults to the first). */
-  selectedOrgId?: string;
   /** Optional error message displayed above the form. */
   error?: string;
 }
@@ -65,7 +63,7 @@ export function renderConsentPage(props: ConsentPageProps): RawHtml {
   const scopeItems = props.scopes.map((s) => html`<li>${describeScope(s)}</li>`);
   const title = `Autorisation — ${props.branding.name}`;
   const errorBlock = props.error ? html`<div class="error" role="alert">${props.error}</div>` : "";
-  const orgField = renderOrgField(props.orgs ?? [], props.selectedOrgId);
+  const orgField = renderOrgField(props.orgs ?? []);
   const bodyHtml = html`
     <h1>Autorisation</h1>
     ${errorBlock}

--- a/apps/api/src/modules/oidc/pages/consent.ts
+++ b/apps/api/src/modules/oidc/pages/consent.ts
@@ -14,9 +14,10 @@
  * field does not match the cookie.
  */
 
-import { html, type RawHtml } from "./html.ts";
+import { html, raw, type RawHtml } from "./html.ts";
 import { renderLayout } from "./layout.ts";
 import type { ResolvedAppBranding } from "../services/branding.ts";
+import type { ConsentOrgOption } from "../services/consent-org.ts";
 
 const SCOPE_DESCRIPTIONS_FR: Record<string, string> = {
   openid: "Votre identité",
@@ -47,14 +48,51 @@ export interface ConsentPageProps {
   csrfToken: string;
   /** Resolved branding for the owning application. */
   branding: ResolvedAppBranding;
+  /**
+   * Organizations the user may bind this grant to (self-service clients only).
+   * Empty/absent → no org picker (token resolves org per-request via
+   * `X-Org-Id`). One → bound silently. Many → a `<select>` is shown.
+   */
+  orgs?: ConsentOrgOption[];
+  /** Pre-selected org id in the picker (defaults to the first). */
+  selectedOrgId?: string;
   /** Optional error message displayed above the form. */
   error?: string;
+}
+
+/**
+ * The org-binding form control, rendered INSIDE the accept form so `org_id`
+ * is submitted with the approval. Zero orgs → nothing. One → a hidden input
+ * plus a context line. Many → a labelled `<select>`.
+ */
+function renderOrgField(orgs: ConsentOrgOption[], selectedOrgId?: string): RawHtml | string {
+  if (orgs.length === 0) return "";
+  const selected =
+    selectedOrgId && orgs.some((o) => o.id === selectedOrgId) ? selectedOrgId : orgs[0]!.id;
+  if (orgs.length === 1) {
+    const only = orgs[0]!;
+    return html`
+      <input type="hidden" name="org_id" value="${only.id}" />
+      <p class="org-single">Organisation : <strong>${only.name}</strong></p>
+    `;
+  }
+  const options = orgs.map(
+    (o) =>
+      html`<option value="${o.id}" ${o.id === selected ? raw(" selected") : ""}>${o.name}</option>`,
+  );
+  return html`
+    <label class="org-label" for="org_id">Organisation</label>
+    <select id="org_id" name="org_id" class="org-select">
+      ${options}
+    </select>
+  `;
 }
 
 export function renderConsentPage(props: ConsentPageProps): RawHtml {
   const scopeItems = props.scopes.map((s) => html`<li>${describeScope(s)}</li>`);
   const title = `Autorisation — ${props.branding.name}`;
   const errorBlock = props.error ? html`<div class="error" role="alert">${props.error}</div>` : "";
+  const orgField = renderOrgField(props.orgs ?? [], props.selectedOrgId);
   const bodyHtml = html`
     <h1>Autorisation</h1>
     ${errorBlock}
@@ -75,6 +113,7 @@ export function renderConsentPage(props: ConsentPageProps): RawHtml {
       <form method="POST" action="${props.action}">
         <input type="hidden" name="_csrf" value="${props.csrfToken}" />
         <input type="hidden" name="accept" value="true" />
+        ${orgField}
         <button type="submit" class="allow">Autoriser</button>
       </form>
     </div>

--- a/apps/api/src/modules/oidc/pages/org-field.ts
+++ b/apps/api/src/modules/oidc/pages/org-field.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared org-binding form control for the consent screens (web OAuth consent
+ * and the CLI device `/activate` consent). Rendered INSIDE the accept form so
+ * `org_id` is submitted with the approval.
+ *
+ *   - Zero orgs → nothing (token resolves org per-request via `X-Org-Id`).
+ *   - One org → a hidden input plus a context line (bound silently).
+ *   - Many orgs → a labelled `<select>`.
+ */
+
+import { html, raw, type RawHtml } from "./html.ts";
+import type { ConsentOrgOption } from "../services/consent-org.ts";
+
+export function renderOrgField(orgs: ConsentOrgOption[], selectedOrgId?: string): RawHtml | string {
+  if (orgs.length === 0) return "";
+  const selected =
+    selectedOrgId && orgs.some((o) => o.id === selectedOrgId) ? selectedOrgId : orgs[0]!.id;
+  if (orgs.length === 1) {
+    const only = orgs[0]!;
+    return html`
+      <input type="hidden" name="org_id" value="${only.id}" />
+      <p class="org-single">Organisation : <strong>${only.name}</strong></p>
+    `;
+  }
+  const options = orgs.map(
+    (o) =>
+      html`<option value="${o.id}" ${o.id === selected ? raw(" selected") : ""}>${o.name}</option>`,
+  );
+  return html`
+    <label class="org-label" for="org_id">Organisation</label>
+    <select id="org_id" name="org_id" class="org-select">
+      ${options}
+    </select>
+  `;
+}

--- a/apps/api/src/modules/oidc/pages/org-field.ts
+++ b/apps/api/src/modules/oidc/pages/org-field.ts
@@ -10,13 +10,11 @@
  *   - Many orgs → a labelled `<select>`.
  */
 
-import { html, raw, type RawHtml } from "./html.ts";
+import { html, type RawHtml } from "./html.ts";
 import type { ConsentOrgOption } from "../services/consent-org.ts";
 
-export function renderOrgField(orgs: ConsentOrgOption[], selectedOrgId?: string): RawHtml | string {
+export function renderOrgField(orgs: ConsentOrgOption[]): RawHtml | string {
   if (orgs.length === 0) return "";
-  const selected =
-    selectedOrgId && orgs.some((o) => o.id === selectedOrgId) ? selectedOrgId : orgs[0]!.id;
   if (orgs.length === 1) {
     const only = orgs[0]!;
     return html`
@@ -24,10 +22,8 @@ export function renderOrgField(orgs: ConsentOrgOption[], selectedOrgId?: string)
       <p class="org-single">Organisation : <strong>${only.name}</strong></p>
     `;
   }
-  const options = orgs.map(
-    (o) =>
-      html`<option value="${o.id}" ${o.id === selected ? raw(" selected") : ""}>${o.name}</option>`,
-  );
+  // The first org is selected by default (browsers select the first <option>).
+  const options = orgs.map((o) => html`<option value="${o.id}">${o.name}</option>`);
   return html`
     <label class="org-label" for="org_id">Organisation</label>
     <select id="org_id" name="org_id" class="org-select">

--- a/apps/api/src/modules/oidc/routes.ts
+++ b/apps/api/src/modules/oidc/routes.ts
@@ -92,6 +92,12 @@ import { renderVerifyEmailSentPage } from "./pages/verify-email-sent.ts";
 import { renderForgotPasswordPage } from "./pages/forgot-password.ts";
 import { renderResetPasswordPage, renderInvalidTokenPage } from "./pages/reset-password.ts";
 import { renderConsentPage } from "./pages/consent.ts";
+import {
+  listUserOrgs,
+  isUserOrgMember,
+  withPendingConsentOrg,
+  type ConsentOrgOption,
+} from "./services/consent-org.ts";
 import { renderErrorPage } from "./pages/error.ts";
 import {
   renderActivateEntryPage,
@@ -378,6 +384,48 @@ function isInstanceSmtpEnabled(): boolean {
  */
 function allowSignupForClient(client: { allowSignup: boolean }): boolean {
   return client.allowSignup;
+}
+
+/**
+ * Whether a client supports consent-time org binding. Only **self-service**
+ * (instance-level, non-first-party) clients — i.e. MCP clients — let the user
+ * pick a target org. Org-level/application-level clients have a fixed org; the
+ * first-party dashboard skips the consent screen entirely.
+ */
+function bindsOrgAtConsent(client: { level: string; isFirstParty: boolean }): boolean {
+  return client.level === "instance" && !client.isFirstParty;
+}
+
+/** Orgs offered in the consent picker (empty unless the client binds org). */
+async function consentOrgOptions(
+  c: Context<AppEnv>,
+  client: { level: string; isFirstParty: boolean },
+): Promise<ConsentOrgOption[]> {
+  if (!bindsOrgAtConsent(client)) return [];
+  const session = await getAuth().api.getSession({ headers: c.req.raw.headers });
+  if (!session?.user?.id) return [];
+  return listUserOrgs(session.user.id);
+}
+
+/**
+ * The org to bind to a just-approved grant. Returns `undefined` for clients
+ * that don't bind org, or when the user has no org / submitted none. Rejects a
+ * submitted org the user is not a member of (defence in depth — the strategy
+ * re-checks membership on every request, but never mint a token for an org the
+ * caller can't access).
+ */
+async function resolveBoundConsentOrg(
+  c: Context<AppEnv>,
+  client: { level: string; isFirstParty: boolean },
+  submittedOrgId: string | undefined,
+): Promise<string | undefined> {
+  if (!bindsOrgAtConsent(client) || !submittedOrgId) return undefined;
+  const session = await getAuth().api.getSession({ headers: c.req.raw.headers });
+  if (!session?.user?.id) return undefined;
+  if (!(await isUserOrgMember(session.user.id, submittedOrgId))) {
+    throw forbidden("You are not a member of the selected organization");
+  }
+  return submittedOrgId;
 }
 
 /**
@@ -1860,12 +1908,14 @@ export function createOidcRouter() {
     }
 
     const scopes = scope.split(/\s+/).filter(Boolean);
+    const orgs = await consentOrgOptions(c, ctx.client);
     const body = renderConsentPage({
       clientName: ctx.client.name ?? ctx.client.clientId,
       scopes,
       action: `/api/oauth/consent${url.search}`,
       branding: ctx.branding,
       csrfToken: ctx.csrfToken,
+      orgs,
     });
     return c.html(body.value);
   });
@@ -1886,12 +1936,19 @@ export function createOidcRouter() {
         action: `/api/oauth/consent${url.search}`,
         branding: ctx.branding,
         csrfToken: ctx.csrfToken,
+        orgs: await consentOrgOptions(c, ctx.client),
         error: "Votre session a expiré. Veuillez réessayer.",
       });
       return c.html(body.value, 403);
     }
 
     const accept = readFormString(form, "accept") === "true";
+    // Self-service clients may bind a chosen org to the grant (so the issued
+    // token carries it and no `X-Org-Id` is needed). Validate membership on
+    // accept; ignored for clients that don't bind org or on deny.
+    const boundOrg = accept
+      ? await resolveBoundConsentOrg(c, ctx.client, readFormString(form, "org_id"))
+      : undefined;
     const oauthQuery = url.search.startsWith("?") ? url.search.slice(1) : url.search;
     if (!oauthQuery) {
       throw invalidRequest(
@@ -1915,12 +1972,17 @@ export function createOidcRouter() {
     const authApi = getOidcAuthApi();
     let consentResponse: Response;
     try {
-      consentResponse = (await authApi.oauth2Consent({
-        body: { accept, oauth_query: oauthQuery },
-        request: c.req.raw,
-        headers: c.req.raw.headers,
-        asResponse: true,
-      })) as Response;
+      // `withPendingConsentOrg` exposes `boundOrg` to the oauth-provider's
+      // `consentReferenceId` hook for the duration of this call, so the grant
+      // (and its refresh token) is stamped with the org.
+      consentResponse = (await withPendingConsentOrg(boundOrg, () =>
+        authApi.oauth2Consent({
+          body: { accept, oauth_query: oauthQuery },
+          request: c.req.raw,
+          headers: c.req.raw.headers,
+          asResponse: true,
+        }),
+      )) as Response;
     } catch (err) {
       if (err instanceof UnverifiedEmailConflictError) {
         const loginPage = renderLoginPage({

--- a/apps/api/src/modules/oidc/routes.ts
+++ b/apps/api/src/modules/oidc/routes.ts
@@ -2134,6 +2134,8 @@ export function createOidcRouter() {
       .filter(Boolean);
     const userCodeDisplay = `${cleanUserCode.slice(0, 4)}-${cleanUserCode.slice(4)}`;
 
+    const orgs = await listUserOrgs(session.user.id);
+
     const page = renderActivateConsentPage({
       branding: PLATFORM_DEFAULT_BRANDING,
       clientName: client?.name ?? record.clientId,
@@ -2141,6 +2143,7 @@ export function createOidcRouter() {
       userCodeRaw: cleanUserCode,
       scopes,
       csrfToken,
+      orgs,
     });
     return c.html(page.value);
   });
@@ -2196,6 +2199,24 @@ export function createOidcRouter() {
       .where(eq(deviceCode.userCode, userCode))
       .limit(1);
 
+    // Org the user picked on the consent screen. Validate membership BEFORE
+    // approving so we never bind (nor approve into) an org the user can't
+    // access. Absent → unbound grant (legacy header path). The device-code
+    // exchange stamps this as the token's `org_id` claim.
+    const pickedOrgId = readFormString(form, "org_id");
+    if (pickedOrgId && session?.user?.id) {
+      if (!(await isUserOrgMember(session.user.id, pickedOrgId))) {
+        return c.html(
+          renderActivateResultPage({
+            branding: PLATFORM_DEFAULT_BRANDING,
+            outcome: "denied",
+            error: "Vous n'êtes pas membre de l'organisation sélectionnée.",
+          }).value,
+          403,
+        );
+      }
+    }
+
     try {
       // BA 1.7 split claim from approve: associate the device code with the
       // signed-in user (GET /device) before approving it, else /device/approve
@@ -2224,6 +2245,16 @@ export function createOidcRouter() {
         }).value,
         400,
       );
+    }
+
+    // Persist the bound org onto the (now approved) device-code row so the
+    // CLI's token exchange picks it up as the `org_id` claim. Membership was
+    // validated above.
+    if (pickedOrgId && session?.user?.id) {
+      await db
+        .update(deviceCode)
+        .set({ orgId: pickedOrgId })
+        .where(eq(deviceCode.userCode, userCode));
     }
 
     logger.info("cli.device.approved", {

--- a/apps/api/src/modules/oidc/services/cli-tokens.ts
+++ b/apps/api/src/modules/oidc/services/cli-tokens.ts
@@ -189,6 +189,7 @@ export async function exchangeDeviceCodeForTokens(params: {
         rowId: string;
         user: { id: string; email: string; name: string | null; emailVerified: boolean };
         scope: string;
+        orgId: string | null;
       }
     | { kind: "error"; code: CliTokenErrorCode; description: string };
 
@@ -286,13 +287,13 @@ export async function exchangeDeviceCodeForTokens(params: {
       clientId,
       userId: userRow.id,
     });
-    return { kind: "ok", rowId: row.id, user: userRow, scope };
+    return { kind: "ok", rowId: row.id, user: userRow, scope, orgId: row.orgId };
   });
 
   if (readOutcome.kind === "error") {
     throw new CliTokenError(readOutcome.code, readOutcome.description);
   }
-  const { rowId, user, scope } = readOutcome;
+  const { rowId, user, scope, orgId } = readOutcome;
 
   // Pre-compute the family id so we can stamp it on the JWT (for
   // server-side revocation enforcement on every Bearer call) AND on the
@@ -309,6 +310,7 @@ export async function exchangeDeviceCodeForTokens(params: {
     scope,
     clientId,
     cliFamilyId: familyId,
+    orgId,
   });
 
   // Second transaction: persist refresh token + consume device_code row
@@ -337,6 +339,7 @@ export async function exchangeDeviceCodeForTokens(params: {
       // on this head row only; rotation rows leave the columns NULL.
       parentId: null,
       familyId,
+      orgId,
       metadata,
     });
     // One-shot contract.
@@ -412,6 +415,7 @@ export async function rotateRefreshToken(params: {
         scope: string;
         parentId: string;
         familyId: string;
+        orgId: string | null;
       }
     | {
         kind: "error";
@@ -520,6 +524,7 @@ export async function rotateRefreshToken(params: {
       scope: narrowedScope,
       parentId: row.id,
       familyId: row.familyId,
+      orgId: row.orgId,
     };
   });
 
@@ -547,7 +552,7 @@ export async function rotateRefreshToken(params: {
   // Happy path: validateOutcome.kind === "ok". Mint JWT OUTSIDE any
   // transaction (signJWT goes through BA's adapter), then persist the
   // new child refresh token in a separate transaction.
-  const { user, scope, parentId, familyId } = validateOutcome;
+  const { user, scope, parentId, familyId, orgId } = validateOutcome;
   const accessToken = await mintAccessJwt({
     userId: user.id,
     email: user.email,
@@ -556,6 +561,7 @@ export async function rotateRefreshToken(params: {
     scope,
     clientId,
     cliFamilyId: familyId,
+    orgId,
   });
   const { refreshPlain, selfRevoked } = await db.transaction(async (tx) => {
     const persisted = await persistRefreshTokenInTx(tx, {
@@ -564,6 +570,7 @@ export async function rotateRefreshToken(params: {
       scope,
       parentId,
       familyId,
+      orgId,
     });
     // Concurrent-reuse defense: a racing rotation on the same parent
     // token may have revoked the family AFTER our validate-tx committed
@@ -1091,12 +1098,15 @@ async function persistRefreshTokenInTx(
     scope: string;
     parentId: string | null;
     familyId: string;
+    /** Org bound at login. Stored on every row (head + rotation children) so a
+     *  refreshed access token re-stamps the same `org_id` claim. */
+    orgId: string | null;
     /** Only honored on the head of family (`parentId === null`). Rotation
      *  children always store `null` for the metadata columns. */
     metadata?: DeviceMetadata;
   },
 ): Promise<{ refreshPlain: string }> {
-  const { userId, clientId, scope, parentId, familyId, metadata } = params;
+  const { userId, clientId, scope, parentId, familyId, orgId, metadata } = params;
   const refreshPlain = generateRefreshToken();
   const refreshHash = hashRefreshToken(refreshPlain);
   const expiresAt = new Date(Date.now() + REFRESH_TOKEN_TTL_SECONDS * 1000);
@@ -1109,6 +1119,7 @@ async function persistRefreshTokenInTx(
     familyId,
     parentId,
     scope,
+    orgId,
     expiresAt,
     createdAt: new Date(),
     usedAt: null,
@@ -1151,6 +1162,9 @@ async function mintAccessJwt(claims: {
    *  the JWT so the OIDC strategy can reject tokens whose family has been
    *  revoked, without waiting for the next refresh. */
   cliFamilyId: string;
+  /** Org bound at login. Stamped as the `org_id` claim, which the OIDC
+   *  strategy pins (so the CLI needs no `X-Org-Id`). Absent → header path. */
+  orgId?: string | null;
 }): Promise<string> {
   const env = getEnv();
   // Strip any trailing slash from APP_URL before composing iss/aud so
@@ -1192,6 +1206,9 @@ async function mintAccessJwt(claims: {
   };
   if (claims.scope.length > 0) {
     payload.scope = claims.scope;
+  }
+  if (claims.orgId) {
+    payload.org_id = claims.orgId;
   }
   const api = getOidcAuthApi();
   const result = (await api.signJWT({

--- a/apps/api/src/modules/oidc/services/consent-org.ts
+++ b/apps/api/src/modules/oidc/services/consent-org.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Consent-time organization binding for self-service (DCR / CIMD) OAuth
+ * clients.
+ *
+ * A self-service client (e.g. an MCP client like Claude Code) is
+ * **instance-level** — one client serves a user who may belong to several
+ * organizations. Unlike an org-level client, whose org is fixed at
+ * registration (`metadata.referencedOrgId`), a self-service client has no
+ * org baked in. We let the user pick the target org on the consent screen and
+ * bind it to the issued token so the caller never has to send `X-Org-Id`.
+ *
+ * The binding rides Better Auth's `referenceId` seam: the
+ * `postLogin.consentReferenceId` hook stamps the chosen org onto the
+ * `oauthConsent` row and the authorization code; the plugin then surfaces it
+ * to `customAccessTokenClaims` (and again on every refresh, as the
+ * `referenceId` persists on the refresh-token row). The token carries the org
+ * as its `org_id` claim and the auth strategy pins it.
+ *
+ * The hook only receives `{ user, session, scopes }` — not the consent form —
+ * so the chosen org is passed to it out-of-band via an `AsyncLocalStorage`
+ * scope wrapping the synchronous `oauth2Consent` call. This is leak-free (no
+ * cross-request bleed, no TTL bookkeeping) because the write and the read
+ * happen in the same call chain on the same worker.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { and, eq } from "drizzle-orm";
+import { db } from "@appstrate/db/client";
+import { organizationMembers, organizations } from "@appstrate/db/schema";
+import type { OrgRole } from "../../../types/index.ts";
+
+const pendingConsentOrg = new AsyncLocalStorage<string>();
+
+/** Run `fn` with `orgId` bound as the pending consent org for this call chain. */
+export function withPendingConsentOrg<T>(
+  orgId: string | undefined,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!orgId) return fn();
+  return pendingConsentOrg.run(orgId, fn);
+}
+
+/** The org the user picked for the in-flight consent, if any (read by the hook). */
+export function getPendingConsentOrg(): string | undefined {
+  return pendingConsentOrg.getStore();
+}
+
+export interface ConsentOrgOption {
+  id: string;
+  name: string;
+  slug: string;
+  role: OrgRole;
+}
+
+/** Organizations the user belongs to, for the consent-screen org picker. */
+export async function listUserOrgs(userId: string): Promise<ConsentOrgOption[]> {
+  return db
+    .select({
+      id: organizations.id,
+      name: organizations.name,
+      slug: organizations.slug,
+      role: organizationMembers.role,
+    })
+    .from(organizationMembers)
+    .innerJoin(organizations, eq(organizations.id, organizationMembers.orgId))
+    .where(eq(organizationMembers.userId, userId))
+    .orderBy(organizations.name);
+}
+
+/** Whether the user is a member of the org — gate before binding a chosen org. */
+export async function isUserOrgMember(userId: string, orgId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ orgId: organizationMembers.orgId })
+    .from(organizationMembers)
+    .where(and(eq(organizationMembers.userId, userId), eq(organizationMembers.orgId, orgId)))
+    .limit(1);
+  return Boolean(row);
+}

--- a/apps/api/src/modules/oidc/test/integration/services/cli-token-flow.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/cli-token-flow.test.ts
@@ -37,7 +37,7 @@ import { db } from "@appstrate/db/client";
 import { user as userTable, session as sessionTable } from "@appstrate/db/schema";
 import { getTestApp } from "../../../../../../test/helpers/app.ts";
 import { truncateAll } from "../../../../../../test/helpers/db.ts";
-import { createTestContext } from "../../../../../../test/helpers/auth.ts";
+import { createTestContext, createTestOrg } from "../../../../../../test/helpers/auth.ts";
 import { flushRedis } from "../../../../../../test/helpers/redis.ts";
 import oidcModule from "../../../index.ts";
 import { resetOidcGuardsLimiters } from "../../../auth/guards.ts";
@@ -203,6 +203,59 @@ describe("POST /api/auth/cli/token — grant_type=device_code (issue #165)", () 
       .where(eq(deviceCode.deviceCode, deviceCodeValue))
       .limit(1);
     expect(deviceRow).toBeUndefined();
+  });
+
+  it("binds the consent-chosen org onto the token and preserves it across refresh", async () => {
+    const { cookie, userId } = await signUpPlatformUser();
+    const { org } = await createTestOrg(userId, { slug: "clibind" });
+    const { deviceCodeValue } = await runDeviceFlow(cookie);
+    // Simulate the /activate consent binding: the approve handler stamps the
+    // chosen org onto the device_code row before the CLI exchanges it.
+    await db
+      .update(deviceCode)
+      .set({ orgId: org.id })
+      .where(eq(deviceCode.deviceCode, deviceCodeValue));
+
+    const res = await app.request("/api/auth/cli/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+        device_code: deviceCodeValue,
+        client_id: "appstrate-cli",
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { access_token: string; refresh_token: string };
+
+    // The minted access token carries the bound org as `org_id`.
+    const claims = await verifyToken(body.access_token);
+    expect(claims?.orgId).toBe(org.id);
+
+    // The bound org is stored on the refresh head row...
+    const hash = _hashRefreshTokenForTesting(body.refresh_token);
+    const [row] = await db
+      .select({ orgId: cliRefreshToken.orgId })
+      .from(cliRefreshToken)
+      .where(eq(cliRefreshToken.tokenHash, hash))
+      .limit(1);
+    expect(row?.orgId).toBe(org.id);
+
+    // ...and survives rotation: the refreshed access token keeps the claim.
+    const rotateRes = await app.request("/api/auth/cli/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "refresh_token",
+        refresh_token: body.refresh_token,
+        client_id: "appstrate-cli",
+      }),
+    });
+    expect(rotateRes.status).toBe(200);
+    const rotated = (await rotateRes.json()) as { access_token: string };
+    const rotatedClaims = await verifyToken(rotated.access_token);
+    expect(rotatedClaims?.orgId).toBe(org.id);
+    expect(claims?.authUserId).toBe(userId);
   });
 
   it("returns authorization_pending when the user hasn't approved yet", async () => {

--- a/apps/api/src/modules/oidc/test/integration/services/consent-org-binding.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/consent-org-binding.test.ts
@@ -75,6 +75,7 @@ interface ConsentResult {
   tokenStatus: number;
   payload: Record<string, unknown> | null;
   accessToken: string | null;
+  refreshToken: string | null;
 }
 
 /**
@@ -134,7 +135,13 @@ async function driveConsent(
     redirect: "manual",
   });
   if (consentRes.status >= 400) {
-    return { consentStatus: consentRes.status, tokenStatus: 0, payload: null, accessToken: null };
+    return {
+      consentStatus: consentRes.status,
+      tokenStatus: 0,
+      payload: null,
+      accessToken: null,
+      refreshToken: null,
+    };
   }
 
   const loc = consentRes.headers.get("location");
@@ -169,14 +176,34 @@ async function driveConsent(
       tokenStatus: tokenRes.status,
       payload: null,
       accessToken: null,
+      refreshToken: null,
     };
   }
-  const accessToken = ((await tokenRes.json()) as { access_token: string }).access_token;
+  const tokens = (await tokenRes.json()) as { access_token: string; refresh_token?: string };
   return {
     consentStatus: consentRes.status,
     tokenStatus: tokenRes.status,
-    payload: decodeJwt(accessToken) as Record<string, unknown>,
-    accessToken,
+    payload: decodeJwt(tokens.access_token) as Record<string, unknown>,
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token ?? null,
+  };
+}
+
+/** Exchange a refresh token for a fresh pair, bound to the MCP resource. */
+async function refreshMcpToken(clientId: string, refreshToken: string) {
+  const res = await app.request("/api/auth/oauth2/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: refreshToken,
+      client_id: clientId,
+      resource: getMcpResourceUri(),
+    }).toString(),
+  });
+  return {
+    status: res.status,
+    body: (await res.json().catch(() => ({}))) as Record<string, unknown>,
   };
 }
 
@@ -243,5 +270,51 @@ describe("consent-time org binding (self-service clients)", () => {
       headers: { Authorization: `Bearer ${accessToken}`, "X-Org-Id": crypto.randomUUID() },
     });
     expect(spoofed.status).toBe(403);
+  });
+});
+
+describe("MCP OAuth refresh hygiene (RFC 9700 §4.14)", () => {
+  // The MCP path uses Better Auth's `/oauth2/token`, which natively rotates
+  // refresh tokens and detects reuse: presenting an already-rotated token tears
+  // down the whole family. This locks in the guarantee the MCP onboarding
+  // depends on (no need to reimplement reuse detection for `oauth_refresh_tokens`).
+  let ctx: TestContext;
+
+  beforeAll(() => {
+    overrideJwksResolver(null);
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+    await flushRedis();
+    overrideJwksResolver(null);
+    resetOidcGuardsLimiters();
+    resetProtectedResources();
+    registerProtectedResource("/api/mcp", getMcpResourceUri);
+    ctx = await createTestContext({ orgSlug: "mcprefresh" });
+  });
+
+  it("rotates the refresh token and revokes the family on reuse", async () => {
+    const clientId = await registerSelfServiceClient();
+    const { refreshToken } = await driveConsent(clientId, ctx.cookie, ctx.orgId);
+    expect(refreshToken).toBeTruthy();
+
+    // First rotation succeeds and returns a new refresh token.
+    const rotated = await refreshMcpToken(clientId, refreshToken!);
+    expect(rotated.status).toBe(200);
+    const next = rotated.body.refresh_token as string;
+    expect(typeof next).toBe("string");
+    expect(next).not.toBe(refreshToken);
+
+    // Reusing the ALREADY-ROTATED token is rejected...
+    const reuse = await refreshMcpToken(clientId, refreshToken!);
+    expect(reuse.status).toBe(400);
+    expect(reuse.body.error).toBe("invalid_grant");
+
+    // ...and the reuse tore down the whole family, so the legitimately-rotated
+    // token is now dead too.
+    const afterReuse = await refreshMcpToken(clientId, next);
+    expect(afterReuse.status).toBe(400);
+    expect(afterReuse.body.error).toBe("invalid_grant");
   });
 });

--- a/apps/api/src/modules/oidc/test/integration/services/consent-org-binding.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/consent-org-binding.test.ts
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Consent-time org binding for self-service (DCR / CIMD) clients.
+ *
+ * A self-service instance client (e.g. an MCP client) has no org baked in. The
+ * user picks one on the consent screen; the chosen org is stamped onto the
+ * grant via Better Auth's `referenceId` seam (`postLogin.consentReferenceId`
+ * reads the `AsyncLocalStorage` set by the consent POST handler) and surfaces
+ * as the token's `org_id` claim — so the caller never needs `X-Org-Id`.
+ *
+ * This drives the full authorization-code + PKCE dance through the module's own
+ * consent handler and asserts the minted token's claims:
+ *  - org submitted → `org_id` claim == the chosen org, `actor_type: "user"`.
+ *  - no org submitted → no `org_id` claim (back-compat: header path).
+ *  - a foreign org submitted → 403 (membership is enforced before binding).
+ *
+ * Strategy-side pinning of that claim (no `X-Org-Id` needed, header-spoof
+ * rejected) is covered end-to-end against a booted server in
+ * `e2e/tests/mcp/mcp.api.spec.ts`.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from "bun:test";
+import { decodeJwt } from "jose";
+import { getTestApp } from "../../../../../../test/helpers/app.ts";
+import { truncateAll } from "../../../../../../test/helpers/db.ts";
+import { flushRedis } from "../../../../../../test/helpers/redis.ts";
+import { createTestContext, type TestContext } from "../../../../../../test/helpers/auth.ts";
+import { overrideJwksResolver } from "../../../services/enduser-token.ts";
+import { resetOidcGuardsLimiters } from "../../../auth/guards.ts";
+import {
+  registerProtectedResource,
+  resetProtectedResources,
+} from "../../../../../lib/protected-resources.ts";
+import { getMcpResourceUri } from "../../../../mcp/resource.ts";
+import oidcModule from "../../../index.ts";
+
+const app = getTestApp({ modules: [oidcModule] });
+
+const REDIRECT = "http://localhost:9971/callback";
+
+function base64url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+async function sha256Base64Url(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(input));
+  return base64url(new Uint8Array(digest));
+}
+function randomVerifier(): string {
+  return base64url(crypto.getRandomValues(new Uint8Array(32)));
+}
+
+/** Register a public self-service client (instance-level, via RFC 7591 DCR). */
+async function registerSelfServiceClient(): Promise<string> {
+  const res = await app.request("/api/auth/oauth2/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      client_name: "Claude Code (org-binding test)",
+      redirect_uris: [REDIRECT],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+      scope: "openid profile email offline_access",
+    }),
+  });
+  expect([200, 201]).toContain(res.status);
+  return String(((await res.json()) as { client_id: string }).client_id);
+}
+
+interface ConsentResult {
+  consentStatus: number;
+  tokenStatus: number;
+  payload: Record<string, unknown> | null;
+  accessToken: string | null;
+}
+
+/**
+ * Run authorize → consent → token for a logged-in user, optionally submitting
+ * `org_id` on the consent form. Returns the consent status, token status, and
+ * the decoded access-token payload (when a token was minted).
+ */
+async function driveConsent(
+  clientId: string,
+  cookie: string,
+  submitOrgId?: string,
+): Promise<ConsentResult> {
+  const verifier = randomVerifier();
+  const challenge = await sha256Base64Url(verifier);
+  const authorizeUrl =
+    `/api/auth/oauth2/authorize?` +
+    new URLSearchParams({
+      response_type: "code",
+      client_id: clientId,
+      redirect_uri: REDIRECT,
+      scope: "openid profile email offline_access",
+      state: base64url(crypto.getRandomValues(new Uint8Array(16))),
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+    }).toString();
+
+  const authorizeRes = await app.request(authorizeUrl, {
+    headers: { cookie, accept: "text/html" },
+    redirect: "manual",
+  });
+  expect(authorizeRes.status).toBe(302);
+  const consentUrl = new URL(authorizeRes.headers.get("location")!, "http://localhost");
+  expect(consentUrl.pathname).toBe("/api/oauth/consent");
+
+  const consentPage = await app.request(consentUrl.pathname + consentUrl.search, {
+    headers: { cookie, accept: "text/html" },
+  });
+  expect(consentPage.status).toBe(200);
+  const csrfCookie = (consentPage.headers.get("set-cookie") ?? "")
+    .split(",")
+    .map((c) => c.trim())
+    .find((c) => c.startsWith("oidc_csrf="))!
+    .split(";")[0]!;
+  const csrfToken = (await consentPage.text()).match(/name="_csrf" value="([^"]+)"/)![1]!;
+
+  const form = new URLSearchParams({ _csrf: csrfToken, accept: "true" });
+  if (submitOrgId !== undefined) form.set("org_id", submitOrgId);
+  const consentRes = await app.request(consentUrl.pathname + consentUrl.search, {
+    method: "POST",
+    headers: {
+      cookie: `${cookie}; ${csrfCookie}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+      accept: "application/json",
+      origin: "http://localhost:3000",
+    },
+    body: form.toString(),
+    redirect: "manual",
+  });
+  if (consentRes.status >= 400) {
+    return { consentStatus: consentRes.status, tokenStatus: 0, payload: null, accessToken: null };
+  }
+
+  const loc = consentRes.headers.get("location");
+  let code: string | null;
+  if (loc) {
+    code = new URL(loc, "http://localhost").searchParams.get("code");
+  } else {
+    const json = (await consentRes.json()) as { redirect_uri?: string; url?: string };
+    code = new URL(json.redirect_uri ?? json.url ?? REDIRECT, "http://localhost").searchParams.get(
+      "code",
+    );
+  }
+  expect(code).toBeTruthy();
+
+  const tokenRes = await app.request("/api/auth/oauth2/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code: code!,
+      redirect_uri: REDIRECT,
+      client_id: clientId,
+      code_verifier: verifier,
+      // Self-service clients may only request the MCP protected-resource
+      // audience; required for the plugin to mint a JWT (vs. opaque) token.
+      resource: getMcpResourceUri(),
+    }).toString(),
+  });
+  if (tokenRes.status !== 200) {
+    return {
+      consentStatus: consentRes.status,
+      tokenStatus: tokenRes.status,
+      payload: null,
+      accessToken: null,
+    };
+  }
+  const accessToken = ((await tokenRes.json()) as { access_token: string }).access_token;
+  return {
+    consentStatus: consentRes.status,
+    tokenStatus: tokenRes.status,
+    payload: decodeJwt(accessToken) as Record<string, unknown>,
+    accessToken,
+  };
+}
+
+describe("consent-time org binding (self-service clients)", () => {
+  let ctx: TestContext;
+
+  beforeAll(() => {
+    overrideJwksResolver(null);
+  });
+
+  beforeEach(async () => {
+    await truncateAll();
+    await flushRedis();
+    overrideJwksResolver(null);
+    resetOidcGuardsLimiters();
+    resetProtectedResources();
+    registerProtectedResource("/api/mcp", getMcpResourceUri);
+    ctx = await createTestContext({ orgSlug: "orgbind" });
+  });
+
+  it("binds the chosen org onto the token as the org_id claim", async () => {
+    const clientId = await registerSelfServiceClient();
+    const { tokenStatus, payload } = await driveConsent(clientId, ctx.cookie, ctx.orgId);
+    expect(tokenStatus).toBe(200);
+    expect(payload?.actor_type).toBe("user");
+    expect(payload?.org_id).toBe(ctx.orgId);
+  });
+
+  it("omits org_id when none is chosen (header-path back-compat)", async () => {
+    const clientId = await registerSelfServiceClient();
+    const { tokenStatus, payload } = await driveConsent(clientId, ctx.cookie, undefined);
+    expect(tokenStatus).toBe(200);
+    expect(payload?.actor_type).toBe("user");
+    expect(payload?.org_id).toBeUndefined();
+  });
+
+  it("rejects binding an org the user is not a member of", async () => {
+    const clientId = await registerSelfServiceClient();
+    const foreignOrgId = crypto.randomUUID();
+    const { consentStatus, tokenStatus } = await driveConsent(clientId, ctx.cookie, foreignOrgId);
+    expect(consentStatus).toBe(403);
+    expect(tokenStatus).toBe(0);
+  });
+
+  it("pins the bound org so an org-scoped route resolves WITHOUT X-Org-Id", async () => {
+    const clientId = await registerSelfServiceClient();
+    const { accessToken } = await driveConsent(clientId, ctx.cookie, ctx.orgId);
+    expect(accessToken).toBeTruthy();
+
+    // Drop the protected-resource registration so the audience guard is a
+    // no-op here — this test isolates *org pinning* from audience confinement
+    // (which is covered separately). The token's `org_id` claim alone must
+    // resolve org context.
+    resetProtectedResources();
+
+    const noHeader = await app.request("/api/applications", {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+    expect(noHeader.status).toBe(200);
+
+    // A conflicting X-Org-Id is rejected — the token's org is authoritative,
+    // it cannot be spoofed to another org the user happens to belong to.
+    const spoofed = await app.request("/api/applications", {
+      headers: { Authorization: `Bearer ${accessToken}`, "X-Org-Id": crypto.randomUUID() },
+    });
+    expect(spoofed.status).toBe(403);
+  });
+});

--- a/apps/cli/src/commands/login.ts
+++ b/apps/cli/src/commands/login.ts
@@ -246,11 +246,21 @@ async function runLogin(profileName: string, instance: string, opts: LoginOption
     ...(preservedAppId ? { applicationId: preservedAppId } : {}),
   });
 
-  // Step 7 — pin an organization. Issue #209. Credentials are already
-  // persisted so `listOrgs` / `createOrg` (both authenticated) work.
-  // Any failure here leaves the login valid but unpinned — surfaced as
-  // a hint to the user, never as a hard failure.
-  const pinned = await pinOrgOnProfile(profileName, opts);
+  // Step 7 — pin an organization. When the token is org-bound (the user
+  // chose an org in the browser during approval), that org is authoritative —
+  // the server pins it from the `org_id` claim, so the CLI must use exactly it
+  // (a mismatched `X-Org-Id` would be rejected). Persist it and skip the
+  // terminal picker. Otherwise (legacy/unbound token) fall back to the picker.
+  // Issue #209. Credentials are already persisted so `listOrgs` / `createOrg`
+  // (both authenticated) work. Any failure here leaves the login valid but
+  // unpinned — surfaced as a hint to the user, never as a hard failure.
+  let pinned: Org | null;
+  if (identity.orgId) {
+    await updateProfile(profileName, { orgId: identity.orgId });
+    pinned = await resolveBoundOrg(profileName, identity.orgId);
+  } else {
+    pinned = await pinOrgOnProfile(profileName, opts);
+  }
 
   // Step 8 — cascade into application pinning. Issue #217. Requires an
   // `orgId` in context (listApplications is org-scoped), so we gate on
@@ -280,6 +290,21 @@ async function runLogin(profileName: string, instance: string, opts: LoginOption
  * Writes the pinned `orgId` back onto `config.toml` in place. The caller
  * has already persisted the rest of the profile via `setProfile()`.
  */
+/**
+ * Resolve display info for a token-bound org. The org id is already persisted
+ * (authoritative); we look up its name for the login summary, falling back to
+ * the id if the list call flakes — name is cosmetic here.
+ */
+async function resolveBoundOrg(profileName: string, orgId: string): Promise<Org> {
+  try {
+    const match = (await listOrgs(profileName)).find((o) => o.id === orgId);
+    if (match) return match;
+  } catch {
+    // best-effort: the org is already pinned; only the display name is missing
+  }
+  return { id: orgId, name: orgId, slug: orgId, role: "", createdAt: "" };
+}
+
 async function pinOrgOnProfile(profileName: string, opts: LoginOptions): Promise<Org | null> {
   const deps = { ...defaultDeps, ...(opts.deps ?? {}) };
 

--- a/apps/cli/src/commands/org.ts
+++ b/apps/cli/src/commands/org.ts
@@ -22,7 +22,29 @@
 import { resolveActiveProfile, requireLoggedIn, updateProfile } from "../lib/config.ts";
 import { listOrgs, createOrg, resolveOrgRef, type Org } from "../lib/orgs.ts";
 import { listApplications, findDefaultApplication, type Application } from "../lib/applications.ts";
+import { resolveAuthContext } from "../lib/api.ts";
+import { decodeAccessTokenIdentity } from "../lib/jwt-identity.ts";
 import { askText, select, exitWithError } from "../lib/ui.ts";
+
+/**
+ * The org a session is bound to (chosen in the browser at login and stamped on
+ * the token), if any. A bound session cannot switch org by re-pinning a header
+ * — the server pins the token's org and rejects a mismatched `X-Org-Id` — so
+ * the org commands must route the user back through `appstrate login`. Returns
+ * `undefined` for legacy/unbound tokens, which still re-pin locally.
+ */
+async function sessionBoundOrgId(profileName: string): Promise<string | undefined> {
+  try {
+    const auth = await resolveAuthContext(profileName);
+    return decodeAccessTokenIdentity(auth.accessToken).orgId;
+  } catch {
+    return undefined;
+  }
+}
+
+const BOUND_SWITCH_HINT =
+  "This session is bound to an organization (chosen at login). " +
+  "Run `appstrate login` to switch — you'll pick the organization in the browser.\n";
 
 export interface OrgBaseOptions {
   profile?: string;
@@ -110,6 +132,11 @@ export async function orgSwitchCommand(
   requireLoggedIn(profileName, profile);
   const picker = { ...defaultDeps, ...deps };
 
+  if (await sessionBoundOrgId(profileName)) {
+    process.stderr.write(BOUND_SWITCH_HINT);
+    process.exit(1);
+  }
+
   try {
     const orgs = await listOrgs(profileName);
     if (orgs.length === 0) {
@@ -169,6 +196,15 @@ export async function orgCreateCommand(
       input = prompted;
     }
     const created = await createOrg(profileName, input);
+    // A bound session can't re-pin via header (the token's org is authoritative),
+    // so create the org but route the user through `login` to start using it.
+    if (await sessionBoundOrgId(profileName)) {
+      process.stdout.write(
+        `Created "${created.name}" (${created.id}). ` +
+          "Run `appstrate login` to switch to it (pick it in the browser).\n",
+      );
+      return;
+    }
     // Server auto-provisions a default application on org creation — clear
     // any stale app pin from the previous org and re-pin the new default.
     await updateProfile(profileName, { orgId: created.id, applicationId: undefined });

--- a/apps/cli/src/lib/jwt-identity.ts
+++ b/apps/cli/src/lib/jwt-identity.ts
@@ -16,6 +16,13 @@
 export interface AccessTokenIdentity {
   userId: string;
   email: string;
+  /**
+   * Org the session is bound to, chosen in the browser during the device-flow
+   * approval and stamped on the token by the server. When present it is
+   * authoritative — the server pins it, so the CLI must use exactly this org
+   * (a mismatched `X-Org-Id` is rejected). Absent on legacy/unbound tokens.
+   */
+  orgId?: string;
 }
 
 export function decodeAccessTokenIdentity(accessToken: string): AccessTokenIdentity {
@@ -28,7 +35,8 @@ export function decodeAccessTokenIdentity(accessToken: string): AccessTokenIdent
   if (typeof email !== "string" || !email) {
     throw new Error("Access token is missing the `email` claim.");
   }
-  return { userId: sub, email };
+  const orgId = typeof claims.org_id === "string" && claims.org_id ? claims.org_id : undefined;
+  return { userId: sub, email, ...(orgId ? { orgId } : {}) };
 }
 
 /**

--- a/apps/cli/test/login-org.test.ts
+++ b/apps/cli/test/login-org.test.ts
@@ -84,9 +84,11 @@ function captureIo(): void {
  * Build a JWT with `sub` + `email` claims so `decodeAccessTokenIdentity`
  * succeeds. We don't sign — the CLI doesn't verify locally.
  */
-function makeJwt(sub = "u_test", email = "alice@example.com"): string {
+function makeJwt(sub = "u_test", email = "alice@example.com", orgId?: string): string {
   const header = Buffer.from(JSON.stringify({ alg: "ES256", typ: "JWT" })).toString("base64url");
-  const payload = Buffer.from(JSON.stringify({ sub, email })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({ sub, email, ...(orgId ? { org_id: orgId } : {}) }),
+  ).toString("base64url");
   return `${header}.${payload}.sig`;
 }
 
@@ -230,6 +232,53 @@ async function readPinnedAppId(profile = "default"): Promise<string | undefined>
 }
 
 describe("login org-pin branch", () => {
+  it("binds the token's org_id claim and skips the terminal picker", async () => {
+    // The org was chosen in the browser at /activate and stamped on the token.
+    // With ≥2 orgs an unbound token would invoke the picker; the bound token
+    // must NOT — the claim is authoritative.
+    let pickerCalled = false;
+    installDefaultResponders({
+      cliToken: () =>
+        new Response(
+          JSON.stringify({
+            access_token: makeJwt("u_test", "alice@example.com", "org_bound"),
+            refresh_token: "rt-xyz",
+            token_type: "Bearer",
+            expires_in: 900,
+            refresh_expires_in: 30 * 24 * 60 * 60,
+            scope: "cli",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      listOrgs: () =>
+        new Response(
+          JSON.stringify({
+            object: "list",
+            hasMore: false,
+            data: [
+              { id: "org_bound", name: "Bound", slug: "bound", role: "owner", createdAt: "t" },
+              { id: "org_other", name: "Other", slug: "other", role: "member", createdAt: "t" },
+            ],
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    });
+
+    await loginCommand({
+      profile: "default",
+      instance: "https://app.example.com",
+      deps: {
+        pickOrg: async () => {
+          pickerCalled = true;
+          return null;
+        },
+      },
+    });
+
+    expect(await readPinnedOrgId()).toBe("org_bound");
+    expect(pickerCalled).toBe(false);
+  });
+
   it("auto-pins the single org when the user belongs to exactly one", async () => {
     installDefaultResponders({
       listOrgs: () =>

--- a/apps/cli/test/org-command.test.ts
+++ b/apps/cli/test/org-command.test.ts
@@ -145,7 +145,11 @@ afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true });
 });
 
-async function seedLoggedIn(orgId?: string, profile = "default", applicationId?: string): Promise<void> {
+async function seedLoggedIn(
+  orgId?: string,
+  profile = "default",
+  applicationId?: string,
+): Promise<void> {
   await setProfile(profile, {
     instance: "https://app.example.com",
     userId: "u_1",
@@ -155,6 +159,21 @@ async function seedLoggedIn(orgId?: string, profile = "default", applicationId?:
   });
   await saveTokens(profile, {
     accessToken: "tok-abc",
+    expiresAt: Date.now() + 15 * 60 * 1000,
+    refreshToken: "rt-xyz",
+    refreshExpiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+  });
+}
+
+/** Seed a logged-in profile whose access token is org-bound (carries `org_id`). */
+async function seedBoundSession(boundOrgId: string, profile = "default"): Promise<void> {
+  await seedLoggedIn(boundOrgId, profile);
+  const header = Buffer.from(JSON.stringify({ alg: "ES256", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(
+    JSON.stringify({ sub: "u_1", email: "alice@example.com", org_id: boundOrgId }),
+  ).toString("base64url");
+  await saveTokens(profile, {
+    accessToken: `${header}.${payload}.sig`,
     expiresAt: Date.now() + 15 * 60 * 1000,
     refreshToken: "rt-xyz",
     refreshExpiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
@@ -265,6 +284,16 @@ describe("org switch", () => {
 
     expect(await pinnedOrgId()).toBe("org_2");
     expect(stdoutChunks.join("")).toContain('Pinned "Beta"');
+  });
+
+  it("refuses to switch an org-bound session, pointing to login, and leaves the pin", async () => {
+    await seedBoundSession("org_1");
+    await expect(orgSwitchCommand({ profile: "default", ref: "org_2" })).rejects.toBeInstanceOf(
+      ExitError,
+    );
+    expect(stderrChunks.join("")).toContain("appstrate login");
+    // The bound org is untouched — no broken pin/header mismatch.
+    expect(await pinnedOrgId()).toBe("org_1");
   });
 
   it("pins the org matching the positional arg (by slug)", async () => {

--- a/docs/guides/connecting-mcp-clients.md
+++ b/docs/guides/connecting-mcp-clients.md
@@ -62,16 +62,19 @@ What happens under the hood:
    - **DCR** (RFC 7591 Dynamic Client Registration) — the fallback for clients
      that can't host a metadata document. Self-service registration is bounded
      to identity + MCP scopes and rate-limited.
-4. The user logs in and consents in the browser; the client receives an access
-   token **audience-bound** to `https://YOUR_INSTANCE/api/mcp` (RFC 8707). The
-   MCP server rejects any token not issued for it, and the token is rejected on
-   every OTHER platform route — it can only ever drive `/api/mcp`.
+4. The user logs in and consents in the browser. If they belong to more than one
+   organization, the consent screen shows an **organization picker**; the chosen
+   org is bound to the grant. The client receives an access token
+   **audience-bound** to `https://YOUR_INSTANCE/api/mcp` (RFC 8707) and carrying
+   the chosen org. The MCP server rejects any token not issued for it, and the
+   token is rejected on every OTHER platform route — it can only ever drive
+   `/api/mcp`.
 
-> **Organization context.** An OAuth-onboarded client acts as the connecting
-> user, who may belong to several organizations. Send the target org with an
-> `X-Org-Id: org_xxx` header (same as the API-key path); without it the request
-> has no organization to resolve permissions against. A client that supports
-> custom headers (Claude Code: `--header`) can set it once at connect time.
+> **Organization context.** No `X-Org-Id` header is needed on the OAuth path:
+> the organization is chosen on the consent screen and bound to the token (the
+> server pins it). To target a different org, re-run the connection and pick it
+> again in the browser. (The header is still honoured if sent, but it must match
+> the token's bound org.)
 
 ### Self-hosting requirements for Path B
 

--- a/e2e/tests/mcp/mcp.api.spec.ts
+++ b/e2e/tests/mcp/mcp.api.spec.ts
@@ -196,6 +196,7 @@ test.describe("MCP over a self-service OAuth client (DCR + PKCE)", () => {
     request: APIRequestContext,
     cookie: string,
     clientId: string,
+    bindOrgId?: string,
   ): Promise<{ code: string; verifier: string }> {
     const verifier = randomVerifier();
     const challenge = await sha256Base64Url(verifier);
@@ -236,7 +237,9 @@ test.describe("MCP over a self-service OAuth client (DCR + PKCE)", () => {
         accept: "application/json",
         origin: BASE,
       },
-      form: { _csrf: csrfToken, accept: "true" },
+      form: bindOrgId
+        ? { _csrf: csrfToken, accept: "true", org_id: bindOrgId }
+        : { _csrf: csrfToken, accept: "true" },
       maxRedirects: 0,
     });
     expect([200, 302]).toContain(consentRes.status());
@@ -401,6 +404,50 @@ test.describe("MCP over a self-service OAuth client (DCR + PKCE)", () => {
         headers: { ...headers, "X-Application-Id": orgContext.org.defaultAppId },
       });
       expect(lifted.status()).toBe(401);
+    } finally {
+      await anon.dispose();
+    }
+  });
+
+  test("an org bound at consent drives /api/mcp with NO X-Org-Id header", async ({
+    playwright,
+    orgContext,
+  }) => {
+    // The headline of the org-binding work: the user picks an org on the
+    // consent screen, it rides the grant as the token's `org_id` claim, and the
+    // MCP client calls /api/mcp with ONLY a Bearer token — no `X-Org-Id`. The
+    // strategy pins the org from the claim; an invoke then dispatches in-process
+    // against that org.
+    const anon = await playwright.request.newContext();
+    try {
+      const clientId = await registerDcrClient(anon);
+      const { code, verifier } = await authorizeToCode(
+        anon,
+        orgContext.auth.cookie,
+        clientId,
+        orgContext.org.orgId,
+      );
+      const minted = await exchange(anon, clientId, code, verifier, MCP_URL);
+      expect(minted.status).toBe(200);
+      const accessToken = minted.body.access_token as string;
+      expect(typeof accessToken).toBe("string");
+
+      // NO X-Org-Id — org context comes entirely from the bound token.
+      const headers = { Authorization: `Bearer ${accessToken}` };
+
+      const init = await mcpRpc(anon, headers, INIT);
+      expect(init.status).toBe(200);
+      expect(init.envelope.result?.serverInfo).toBeTruthy();
+
+      const invoke = await mcpRpc(anon, headers, {
+        jsonrpc: "2.0",
+        id: 7,
+        method: "tools/call",
+        params: { name: "invoke_operation", arguments: { operation_id: "listApplications" } },
+      });
+      const payload = toolPayload(invoke.envelope);
+      expect(payload.isError).toBe(false);
+      expect(payload.data.status).toBe(200);
     } finally {
       await anon.dispose();
     }

--- a/packages/db/drizzle/0008_cheerful_hammerhead.sql
+++ b/packages/db/drizzle/0008_cheerful_hammerhead.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "cli_refresh_tokens" ADD COLUMN "org_id" uuid;--> statement-breakpoint
+ALTER TABLE "device_codes" ADD COLUMN "org_id" uuid;--> statement-breakpoint
+ALTER TABLE "cli_refresh_tokens" ADD CONSTRAINT "cli_refresh_tokens_org_id_organizations_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "device_codes" ADD CONSTRAINT "device_codes_org_id_organizations_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."organizations"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/drizzle/meta/0008_snapshot.json
+++ b/packages/db/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,6862 @@
+{
+  "id": "6113094c-be81-47b2-bca3-5b5998828eb0",
+  "prevId": "a034ec32-4c1c-49e1-925d-3dd311bd6186",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realm": {
+          "name": "realm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'platform'"
+        }
+      },
+      "indexes": {
+        "session_realm_idx": {
+          "name": "session_realm_idx",
+          "columns": [
+            {
+              "expression": "realm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realm": {
+          "name": "realm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'platform'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_realm_idx": {
+          "name": "user_realm_idx",
+          "columns": [
+            {
+              "expression": "realm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_keys_org_id": {
+          "name": "idx_api_keys_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_keys_application_id": {
+          "name": "idx_api_keys_application_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_keys_key_hash": {
+          "name": "idx_api_keys_key_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_keys_key_prefix": {
+          "name": "idx_api_keys_key_prefix",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_org_id_organizations_id_fk": {
+          "name": "api_keys_org_id_organizations_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_application_id_applications_id_fk": {
+          "name": "api_keys_application_id_applications_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_created_by_user_id_fk": {
+          "name": "api_keys_created_by_user_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider_credentials": {
+      "name": "model_provider_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_encrypted": {
+          "name": "credentials_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url_override": {
+          "name": "base_url_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_provider_credentials_org_id": {
+          "name": "idx_model_provider_credentials_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_credentials_org_provider": {
+          "name": "idx_model_provider_credentials_org_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_credentials_expires_at_oauth": {
+          "name": "idx_model_provider_credentials_expires_at_oauth",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"model_provider_credentials\".\"expires_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_provider_credentials_org_id_organizations_id_fk": {
+          "name": "model_provider_credentials_org_id_organizations_id_fk",
+          "tableFrom": "model_provider_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_credentials_created_by_user_id_fk": {
+          "name": "model_provider_credentials_created_by_user_id_fk",
+          "tableFrom": "model_provider_credentials",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider_pairings": {
+      "name": "model_provider_pairings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_from_ip": {
+          "name": "consumed_from_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_provider_pairings_org_id": {
+          "name": "idx_model_provider_pairings_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_pairings_expires_at": {
+          "name": "idx_model_provider_pairings_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "consumed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_provider_pairings_user_id_user_id_fk": {
+          "name": "model_provider_pairings_user_id_user_id_fk",
+          "tableFrom": "model_provider_pairings",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_pairings_org_id_organizations_id_fk": {
+          "name": "model_provider_pairings_org_id_organizations_id_fk",
+          "tableFrom": "model_provider_pairings",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_pairings_credential_id_model_provider_credentials_id_fk": {
+          "name": "model_provider_pairings_credential_id_model_provider_credentials_id_fk",
+          "tableFrom": "model_provider_pairings",
+          "tableTo": "model_provider_credentials",
+          "columnsFrom": ["credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_provider_pairings_token_hash_unique": {
+          "name": "model_provider_pairings_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_invitations": {
+      "name": "org_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_invitations_token": {
+          "name": "idx_org_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_invitations_org_id": {
+          "name": "idx_org_invitations_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_invitations_email": {
+          "name": "idx_org_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_invitations_org_id_organizations_id_fk": {
+          "name": "org_invitations_org_id_organizations_id_fk",
+          "tableFrom": "org_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_invitations_invited_by_user_id_fk": {
+          "name": "org_invitations_invited_by_user_id_fk",
+          "tableFrom": "org_invitations",
+          "tableTo": "user",
+          "columnsFrom": ["invited_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "org_invitations_accepted_by_user_id_fk": {
+          "name": "org_invitations_accepted_by_user_id_fk",
+          "tableFrom": "org_invitations",
+          "tableTo": "user",
+          "columnsFrom": ["accepted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_invitations_token_unique": {
+          "name": "org_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_models": {
+      "name": "org_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_models_org_id": {
+          "name": "idx_org_models_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_models_one_default": {
+          "name": "idx_org_models_one_default",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"org_models\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_models_org_id_organizations_id_fk": {
+          "name": "org_models_org_id_organizations_id_fk",
+          "tableFrom": "org_models",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_models_credential_id_model_provider_credentials_id_fk": {
+          "name": "org_models_credential_id_model_provider_credentials_id_fk",
+          "tableFrom": "org_models",
+          "tableTo": "model_provider_credentials",
+          "columnsFrom": ["credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "org_models_created_by_user_id_fk": {
+          "name": "org_models_created_by_user_id_fk",
+          "tableFrom": "org_models",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "org_models_source_valid": {
+          "name": "org_models_source_valid",
+          "value": "source IN ('built-in', 'custom')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_proxies": {
+      "name": "org_proxies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_encrypted": {
+          "name": "url_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_proxies_org_id": {
+          "name": "idx_org_proxies_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_proxies_one_default": {
+          "name": "idx_org_proxies_one_default",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"org_proxies\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_proxies_org_id_organizations_id_fk": {
+          "name": "org_proxies_org_id_organizations_id_fk",
+          "tableFrom": "org_proxies",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_proxies_created_by_user_id_fk": {
+          "name": "org_proxies_created_by_user_id_fk",
+          "tableFrom": "org_proxies",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "org_proxies_source_valid": {
+          "name": "org_proxies_source_valid",
+          "value": "source IN ('built-in', 'custom')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_members_user_id": {
+          "name": "idx_org_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_members_org_id_organizations_id_fk": {
+          "name": "org_members_org_id_organizations_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_members_user_id_user_id_fk": {
+          "name": "org_members_user_id_user_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_members_org_id_user_id_pk": {
+          "name": "org_members_org_id_user_id_pk",
+          "columns": ["org_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_settings": {
+          "name": "org_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_created_by_user_id_fk": {
+          "name": "organizations_created_by_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_applications_org_id": {
+          "name": "idx_applications_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_applications_one_default": {
+          "name": "idx_applications_one_default",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"applications\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_org_id_organizations_id_fk": {
+          "name": "applications_org_id_organizations_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applications_created_by_user_id_fk": {
+          "name": "applications_created_by_user_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.end_users": {
+      "name": "end_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_end_users_external_id": {
+          "name": "idx_end_users_external_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"end_users\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_end_users_app_email": {
+          "name": "idx_end_users_app_email",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "email IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_end_users_application_id": {
+          "name": "idx_end_users_application_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_end_users_org_id": {
+          "name": "idx_end_users_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "end_users_application_id_applications_id_fk": {
+          "name": "end_users_application_id_applications_id_fk",
+          "tableFrom": "end_users",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "end_users_org_id_organizations_id_fk": {
+          "name": "end_users_org_id_organizations_id_fk",
+          "tableFrom": "end_users",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_user_id_fk": {
+          "name": "profiles_id_user_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "user",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "language_check": {
+          "name": "language_check",
+          "value": "\"profiles\".\"language\" IN ('fr', 'en')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.application_packages": {
+      "name": "application_packages",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_id": {
+          "name": "proxy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_user_connections": {
+          "name": "block_user_connections",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_application_packages_package_id": {
+          "name": "idx_application_packages_package_id",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_application_packages_app_id": {
+          "name": "idx_application_packages_app_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_packages_application_id_applications_id_fk": {
+          "name": "application_packages_application_id_applications_id_fk",
+          "tableFrom": "application_packages",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_packages_package_id_packages_id_fk": {
+          "name": "application_packages_package_id_packages_id_fk",
+          "tableFrom": "application_packages",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_packages_version_id_package_versions_id_fk": {
+          "name": "application_packages_version_id_package_versions_id_fk",
+          "tableFrom": "application_packages",
+          "tableTo": "package_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "application_packages_application_id_package_id_pk": {
+          "name": "application_packages_application_id_package_id_pk",
+          "columns": ["application_id", "package_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.package_dist_tags": {
+      "name": "package_dist_tags",
+      "schema": "",
+      "columns": {
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "package_dist_tags_package_id_packages_id_fk": {
+          "name": "package_dist_tags_package_id_packages_id_fk",
+          "tableFrom": "package_dist_tags",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_dist_tags_version_id_package_versions_id_fk": {
+          "name": "package_dist_tags_version_id_package_versions_id_fk",
+          "tableFrom": "package_dist_tags",
+          "tableTo": "package_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "package_dist_tags_package_id_tag_pk": {
+          "name": "package_dist_tags_package_id_tag_pk",
+          "columns": ["package_id", "tag"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.package_version_dependencies": {
+      "name": "package_version_dependencies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dep_scope": {
+          "name": "dep_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dep_name": {
+          "name": "dep_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dep_type": {
+          "name": "dep_type",
+          "type": "package_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_range": {
+          "name": "version_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pkg_ver_deps_unique": {
+          "name": "pkg_ver_deps_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dep_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dep_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dep_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pkg_ver_deps_version_id": {
+          "name": "idx_pkg_ver_deps_version_id",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_version_dependencies_version_id_package_versions_id_fk": {
+          "name": "package_version_dependencies_version_id_package_versions_id_fk",
+          "tableFrom": "package_version_dependencies",
+          "tableTo": "package_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.package_versions": {
+      "name": "package_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_size": {
+          "name": "artifact_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yanked": {
+          "name": "yanked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "yanked_reason": {
+          "name": "yanked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "package_versions_pkg_version_unique": {
+          "name": "package_versions_pkg_version_unique",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_package_versions_package_id": {
+          "name": "idx_package_versions_package_id",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_versions_package_id_packages_id_fk": {
+          "name": "package_versions_package_id_packages_id_fk",
+          "tableFrom": "package_versions",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_versions_created_by_user_id_fk": {
+          "name": "package_versions_created_by_user_id_fk",
+          "tableFrom": "package_versions",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "package_versions_manifest_v0": {
+          "name": "package_versions_manifest_v0",
+          "value": "\"manifest\" IS NULL OR (\"manifest\" ->> 'schema_version') IS NULL OR (\"manifest\" ->> 'schema_version') LIKE '0.%'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.packages": {
+      "name": "packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "package_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "package_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "draft_manifest": {
+          "name": "draft_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_content": {
+          "name": "draft_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_installed": {
+          "name": "auto_installed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ephemeral": {
+          "name": "ephemeral",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lock_version": {
+          "name": "lock_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_packages_org_id": {
+          "name": "idx_packages_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_packages_type": {
+          "name": "idx_packages_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_packages_org_type": {
+          "name": "idx_packages_org_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_packages_ephemeral_created": {
+          "name": "idx_packages_ephemeral_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"packages\".\"ephemeral\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "packages_org_id_organizations_id_fk": {
+          "name": "packages_org_id_organizations_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "packages_created_by_user_id_fk": {
+          "name": "packages_created_by_user_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "packages_id_format": {
+          "name": "packages_id_format",
+          "value": "\"packages\".\"id\" ~ '^@[a-z0-9][a-z0-9-]*/[a-z0-9][a-z0-9-]*$'"
+        },
+        "packages_draft_manifest_v0": {
+          "name": "packages_draft_manifest_v0",
+          "value": "\"draft_manifest\" IS NULL OR (\"draft_manifest\" ->> 'schema_version') IS NULL OR (\"draft_manifest\" ->> 'schema_version') LIKE '0.%'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credential_proxy_usage": {
+      "name": "credential_proxy_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_credential_proxy_usage_org_id": {
+          "name": "idx_credential_proxy_usage_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credential_proxy_usage_run_id": {
+          "name": "idx_credential_proxy_usage_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credential_proxy_usage_org_created": {
+          "name": "idx_credential_proxy_usage_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credential_proxy_usage_org_id_organizations_id_fk": {
+          "name": "credential_proxy_usage_org_id_organizations_id_fk",
+          "tableFrom": "credential_proxy_usage",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_proxy_usage_api_key_id_api_keys_id_fk": {
+          "name": "credential_proxy_usage_api_key_id_api_keys_id_fk",
+          "tableFrom": "credential_proxy_usage",
+          "tableTo": "api_keys",
+          "columnsFrom": ["api_key_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credential_proxy_usage_user_id_user_id_fk": {
+          "name": "credential_proxy_usage_user_id_user_id_fk",
+          "tableFrom": "credential_proxy_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credential_proxy_usage_run_id_runs_id_fk": {
+          "name": "credential_proxy_usage_run_id_runs_id_fk",
+          "tableFrom": "credential_proxy_usage",
+          "tableTo": "runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credential_proxy_usage_application_id_applications_id_fk": {
+          "name": "credential_proxy_usage_application_id_applications_id_fk",
+          "tableFrom": "credential_proxy_usage",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "credential_proxy_usage_request_id_unique": {
+          "name": "credential_proxy_usage_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["request_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "credential_proxy_usage_principal_single": {
+          "name": "credential_proxy_usage_principal_single",
+          "value": "api_key_id IS NULL OR user_id IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.llm_usage": {
+      "name": "llm_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "llm_usage_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "real_model": {
+          "name": "real_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api": {
+          "name": "api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_llm_usage_org_id": {
+          "name": "idx_llm_usage_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_usage_api_key_id": {
+          "name": "idx_llm_usage_api_key_id",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_usage_user_id": {
+          "name": "idx_llm_usage_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_usage_run_id": {
+          "name": "idx_llm_usage_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_usage_org_created": {
+          "name": "idx_llm_usage_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_llm_usage_proxy_request_id": {
+          "name": "uq_llm_usage_proxy_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "source = 'proxy' AND request_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_llm_usage_runner_run_id": {
+          "name": "uq_llm_usage_runner_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "source = 'runner' AND run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "llm_usage_org_id_organizations_id_fk": {
+          "name": "llm_usage_org_id_organizations_id_fk",
+          "tableFrom": "llm_usage",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "llm_usage_api_key_id_api_keys_id_fk": {
+          "name": "llm_usage_api_key_id_api_keys_id_fk",
+          "tableFrom": "llm_usage",
+          "tableTo": "api_keys",
+          "columnsFrom": ["api_key_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "llm_usage_user_id_user_id_fk": {
+          "name": "llm_usage_user_id_user_id_fk",
+          "tableFrom": "llm_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "llm_usage_run_id_runs_id_fk": {
+          "name": "llm_usage_run_id_runs_id_fk",
+          "tableFrom": "llm_usage",
+          "tableTo": "runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "llm_usage_principal_single": {
+          "name": "llm_usage_principal_single",
+          "value": "api_key_id IS NULL OR user_id IS NULL"
+        },
+        "llm_usage_proxy_has_request_id": {
+          "name": "llm_usage_proxy_has_request_id",
+          "value": "source <> 'proxy' OR request_id IS NOT NULL"
+        },
+        "llm_usage_runner_has_run_id": {
+          "name": "llm_usage_runner_has_run_id",
+          "value": "source <> 'runner' OR run_id IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.package_persistence": {
+      "name": "package_persistence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pkp_key_unique": {
+          "name": "pkp_key_unique",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(COALESCE(\"actor_id\", '__shared__'))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "key IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pkp_lookup": {
+          "name": "pkp_lookup",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pkp_org": {
+          "name": "pkp_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_persistence_package_id_packages_id_fk": {
+          "name": "package_persistence_package_id_packages_id_fk",
+          "tableFrom": "package_persistence",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_persistence_application_id_applications_id_fk": {
+          "name": "package_persistence_application_id_applications_id_fk",
+          "tableFrom": "package_persistence",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_persistence_org_id_organizations_id_fk": {
+          "name": "package_persistence_org_id_organizations_id_fk",
+          "tableFrom": "package_persistence",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_persistence_run_id_runs_id_fk": {
+          "name": "package_persistence_run_id_runs_id_fk",
+          "tableFrom": "package_persistence",
+          "tableTo": "runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pkp_actor_type_valid": {
+          "name": "pkp_actor_type_valid",
+          "value": "actor_type IN ('user', 'end_user', 'shared')"
+        },
+        "pkp_actor_id_shape": {
+          "name": "pkp_actor_id_shape",
+          "value": "(actor_type = 'shared' AND actor_id IS NULL) OR (actor_type <> 'shared' AND actor_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_logs": {
+      "name": "run_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'progress'"
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'debug'"
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_logs_run_id": {
+          "name": "idx_run_logs_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_logs_lookup": {
+          "name": "idx_run_logs_lookup",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_logs_org_id": {
+          "name": "idx_run_logs_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_logs_run_id_runs_id_fk": {
+          "name": "run_logs_run_id_runs_id_fk",
+          "tableFrom": "run_logs",
+          "tableTo": "runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_logs_org_id_organizations_id_fk": {
+          "name": "run_logs_org_id_organizations_id_fk",
+          "tableFrom": "run_logs",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_logs_level_valid": {
+          "name": "run_logs_level_valid",
+          "value": "level IN ('debug', 'info', 'warn', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkpoint": {
+          "name": "checkpoint",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_usage": {
+          "name": "token_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_label": {
+          "name": "version_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_dirty": {
+          "name": "version_dirty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_label": {
+          "name": "proxy_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_label": {
+          "name": "model_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_source": {
+          "name": "model_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_number": {
+          "name": "run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_overrides": {
+          "name": "connection_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_connections": {
+          "name": "resolved_connections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_override": {
+          "name": "config_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_scope": {
+          "name": "agent_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_origin": {
+          "name": "run_origin",
+          "type": "run_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'platform'"
+        },
+        "sink_secret_encrypted": {
+          "name": "sink_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sink_expires_at": {
+          "name": "sink_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sink_closed_at": {
+          "name": "sink_closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_sequence": {
+          "name": "last_event_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "context_snapshot": {
+          "name": "context_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_name": {
+          "name": "runner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_kind": {
+          "name": "runner_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_credential_id": {
+          "name": "model_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_runs_package_id": {
+          "name": "idx_runs_package_id",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_status": {
+          "name": "idx_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_user_id": {
+          "name": "idx_runs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_end_user_id": {
+          "name": "idx_runs_end_user_id",
+          "columns": [
+            {
+              "expression": "end_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_package_started": {
+          "name": "idx_runs_package_started",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_schedule_id": {
+          "name": "idx_runs_schedule_id",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"schedule_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_app_status_started": {
+          "name": "idx_runs_app_status_started",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_org_id": {
+          "name": "idx_runs_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_notification": {
+          "name": "idx_runs_notification",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notified_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_sink_expires_at": {
+          "name": "idx_runs_sink_expires_at",
+          "columns": [
+            {
+              "expression": "sink_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"sink_expires_at\" IS NOT NULL AND \"runs\".\"sink_closed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_stall_sweep": {
+          "name": "idx_runs_stall_sweep",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"sink_closed_at\" IS NULL AND \"runs\".\"sink_expires_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_package_id_packages_id_fk": {
+          "name": "runs_package_id_packages_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runs_user_id_user_id_fk": {
+          "name": "runs_user_id_user_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runs_end_user_id_end_users_id_fk": {
+          "name": "runs_end_user_id_end_users_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "end_users",
+          "columnsFrom": ["end_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runs_application_id_applications_id_fk": {
+          "name": "runs_application_id_applications_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_org_id_organizations_id_fk": {
+          "name": "runs_org_id_organizations_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_schedule_id_package_schedules_id_fk": {
+          "name": "runs_schedule_id_package_schedules_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "package_schedules",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runs_api_key_id_api_keys_id_fk": {
+          "name": "runs_api_key_id_api_keys_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "api_keys",
+          "columnsFrom": ["api_key_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runs_model_credential_id_model_provider_credentials_id_fk": {
+          "name": "runs_model_credential_id_model_provider_credentials_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "model_provider_credentials",
+          "columnsFrom": ["model_credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runs_at_most_one_actor": {
+          "name": "runs_at_most_one_actor",
+          "value": "NOT (user_id IS NOT NULL AND end_user_id IS NOT NULL)"
+        },
+        "runs_open_sink_has_secret": {
+          "name": "runs_open_sink_has_secret",
+          "value": "sink_expires_at IS NULL OR sink_secret_encrypted IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.package_schedules": {
+      "name": "package_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_override": {
+          "name": "config_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id_override": {
+          "name": "model_id_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_id_override": {
+          "name": "proxy_id_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_override": {
+          "name": "version_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_overrides": {
+          "name": "connection_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_schedules_package_id": {
+          "name": "idx_schedules_package_id",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_user_id": {
+          "name": "idx_schedules_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_end_user_id": {
+          "name": "idx_schedules_end_user_id",
+          "columns": [
+            {
+              "expression": "end_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_package_schedules_org_id": {
+          "name": "idx_package_schedules_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_package_schedules_app_id": {
+          "name": "idx_package_schedules_app_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_schedules_package_id_packages_id_fk": {
+          "name": "package_schedules_package_id_packages_id_fk",
+          "tableFrom": "package_schedules",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_schedules_user_id_user_id_fk": {
+          "name": "package_schedules_user_id_user_id_fk",
+          "tableFrom": "package_schedules",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_schedules_end_user_id_end_users_id_fk": {
+          "name": "package_schedules_end_user_id_end_users_id_fk",
+          "tableFrom": "package_schedules",
+          "tableTo": "end_users",
+          "columnsFrom": ["end_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_schedules_org_id_organizations_id_fk": {
+          "name": "package_schedules_org_id_organizations_id_fk",
+          "tableFrom": "package_schedules",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_schedules_application_id_applications_id_fk": {
+          "name": "package_schedules_application_id_applications_id_fk",
+          "tableFrom": "package_schedules",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "package_schedules_at_most_one_actor": {
+          "name": "package_schedules_at_most_one_actor",
+          "value": "NOT (user_id IS NOT NULL AND end_user_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_package_id": {
+          "name": "integration_package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_encrypted": {
+          "name": "credentials_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_claims": {
+          "name": "identity_claims",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes_granted": {
+          "name": "scopes_granted",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "needs_reconnection": {
+          "name": "needs_reconnection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_failure_count": {
+          "name": "refresh_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_refresh_failure_at": {
+          "name": "last_refresh_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_with_org": {
+          "name": "shared_with_org",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integration_conn_lookup": {
+          "name": "idx_integration_conn_lookup",
+          "columns": [
+            {
+              "expression": "integration_package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auth_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_conn_user": {
+          "name": "idx_integration_conn_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"integration_connections\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_conn_end_user": {
+          "name": "idx_integration_conn_end_user",
+          "columns": [
+            {
+              "expression": "end_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"integration_connections\".\"end_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_conn_app": {
+          "name": "idx_integration_conn_app",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_conn_shared": {
+          "name": "idx_integration_conn_shared",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auth_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"integration_connections\".\"shared_with_org\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connections_integration_package_id_packages_id_fk": {
+          "name": "integration_connections_integration_package_id_packages_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "packages",
+          "columnsFrom": ["integration_package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_application_id_applications_id_fk": {
+          "name": "integration_connections_application_id_applications_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_user_id_user_id_fk": {
+          "name": "integration_connections_user_id_user_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_end_user_id_end_users_id_fk": {
+          "name": "integration_connections_end_user_id_end_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "end_users",
+          "columnsFrom": ["end_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "integration_conn_exactly_one_owner": {
+          "name": "integration_conn_exactly_one_owner",
+          "value": "(user_id IS NOT NULL AND end_user_id IS NULL) OR (user_id IS NULL AND end_user_id IS NOT NULL)"
+        },
+        "integration_connections_auth_key_valid": {
+          "name": "integration_connections_auth_key_valid",
+          "value": "\"auth_key\" ~ '^[a-z][a-z0-9_]*$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.integration_oauth_clients": {
+      "name": "integration_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_package_id": {
+          "name": "integration_package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_encrypted": {
+          "name": "client_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integration_oauth_clients_unique": {
+          "name": "idx_integration_oauth_clients_unique",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auth_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_oauth_clients_app": {
+          "name": "idx_integration_oauth_clients_app",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_oauth_clients_package": {
+          "name": "idx_integration_oauth_clients_package",
+          "columns": [
+            {
+              "expression": "integration_package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_oauth_clients_application_id_applications_id_fk": {
+          "name": "integration_oauth_clients_application_id_applications_id_fk",
+          "tableFrom": "integration_oauth_clients",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_oauth_clients_integration_package_id_packages_id_fk": {
+          "name": "integration_oauth_clients_integration_package_id_packages_id_fk",
+          "tableFrom": "integration_oauth_clients",
+          "tableTo": "packages",
+          "columnsFrom": ["integration_package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_pins": {
+      "name": "integration_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_package_id": {
+          "name": "integration_package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integration_pins_unique": {
+          "name": "idx_integration_pins_unique",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"user_id\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_pins_app_pkg": {
+          "name": "idx_integration_pins_app_pkg",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_pins_connection": {
+          "name": "idx_integration_pins_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_pins_user": {
+          "name": "idx_integration_pins_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"integration_pins\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_pins_application_id_applications_id_fk": {
+          "name": "integration_pins_application_id_applications_id_fk",
+          "tableFrom": "integration_pins",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_pins_package_id_packages_id_fk": {
+          "name": "integration_pins_package_id_packages_id_fk",
+          "tableFrom": "integration_pins",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_pins_integration_package_id_packages_id_fk": {
+          "name": "integration_pins_integration_package_id_packages_id_fk",
+          "tableFrom": "integration_pins",
+          "tableTo": "packages",
+          "columnsFrom": ["integration_package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_pins_user_id_user_id_fk": {
+          "name": "integration_pins_user_id_user_id_fk",
+          "tableFrom": "integration_pins",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_pins_connection_id_integration_connections_id_fk": {
+          "name": "integration_pins_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_pins",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_pins_created_by_user_id_fk": {
+          "name": "integration_pins_created_by_user_id_fk",
+          "tableFrom": "integration_pins",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_org_defaults": {
+      "name": "integration_org_defaults",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_package_id": {
+          "name": "integration_package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enforce": {
+          "name": "enforce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integration_org_defaults_unique": {
+          "name": "idx_integration_org_defaults_unique",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_org_defaults_app": {
+          "name": "idx_integration_org_defaults_app",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_org_defaults_connection": {
+          "name": "idx_integration_org_defaults_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_org_defaults_application_id_applications_id_fk": {
+          "name": "integration_org_defaults_application_id_applications_id_fk",
+          "tableFrom": "integration_org_defaults",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_org_defaults_integration_package_id_packages_id_fk": {
+          "name": "integration_org_defaults_integration_package_id_packages_id_fk",
+          "tableFrom": "integration_org_defaults",
+          "tableTo": "packages",
+          "columnsFrom": ["integration_package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_org_defaults_connection_id_integration_connections_id_fk": {
+          "name": "integration_org_defaults_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_org_defaults",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_org_defaults_created_by_user_id_fk": {
+          "name": "integration_org_defaults_created_by_user_id_fk",
+          "tableFrom": "integration_org_defaults",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploads": {
+      "name": "uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_uploads_app": {
+          "name": "idx_uploads_app",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uploads_expires_unconsumed": {
+          "name": "idx_uploads_expires_unconsumed",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"uploads\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploads_org_id_organizations_id_fk": {
+          "name": "uploads_org_id_organizations_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploads_application_id_applications_id_fk": {
+          "name": "uploads_application_id_applications_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploads_created_by_user_id_fk": {
+          "name": "uploads_created_by_user_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_events_org_created": {
+          "name": "idx_audit_events_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_events_resource": {
+          "name": "idx_audit_events_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_events_actor": {
+          "name": "idx_audit_events_actor",
+          "columns": [
+            {
+              "expression": "actor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_application_id_applications_id_fk": {
+          "name": "audit_events_application_id_applications_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency": {
+          "name": "latency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_webhook_deliveries_webhook_id": {
+          "name": "idx_webhook_deliveries_webhook_id",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_webhook_deliveries_event_id": {
+          "name": "idx_webhook_deliveries_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_webhook_deliveries_status": {
+          "name": "idx_webhook_deliveries_status",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": ["webhook_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_mode": {
+          "name": "payload_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_next": {
+          "name": "secret_next",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_next_expires_at": {
+          "name": "secret_next_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_webhooks_org_id": {
+          "name": "idx_webhooks_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_webhooks_application_id": {
+          "name": "idx_webhooks_application_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_webhooks_app_enabled": {
+          "name": "idx_webhooks_app_enabled",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_org_id_organizations_id_fk": {
+          "name": "webhooks_org_id_organizations_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhooks_application_id_applications_id_fk": {
+          "name": "webhooks_application_id_applications_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhooks_package_id_packages_id_fk": {
+          "name": "webhooks_package_id_packages_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "webhooks_level_values": {
+          "name": "webhooks_level_values",
+          "value": "level IN ('org', 'application')"
+        },
+        "webhooks_level_check": {
+          "name": "webhooks_level_check",
+          "value": "(level = 'org' AND application_id IS NULL) OR (level = 'application' AND application_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.application_smtp_configs": {
+      "name": "application_smtp_configs",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_encrypted": {
+          "name": "pass_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_key_version": {
+          "name": "encryption_key_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secure_mode": {
+          "name": "secure_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_smtp_configs_application_id_applications_id_fk": {
+          "name": "application_smtp_configs_application_id_applications_id_fk",
+          "tableFrom": "application_smtp_configs",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "application_smtp_configs_secure_mode_check": {
+          "name": "application_smtp_configs_secure_mode_check",
+          "value": "secure_mode IN ('auto', 'tls', 'starttls', 'none')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.application_social_providers": {
+      "name": "application_social_providers",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_encrypted": {
+          "name": "client_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encryption_key_version": {
+          "name": "encryption_key_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'v1'"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_social_providers_application_id_applications_id_fk": {
+          "name": "application_social_providers_application_id_applications_id_fk",
+          "tableFrom": "application_social_providers",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "application_social_providers_application_id_provider_pk": {
+          "name": "application_social_providers_application_id_provider_pk",
+          "columns": ["application_id", "provider"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "application_social_providers_provider_check": {
+          "name": "application_social_providers_provider_check",
+          "value": "provider IN ('google', 'github')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cli_refresh_tokens": {
+      "name": "cli_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_ip": {
+          "name": "created_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cli_refresh_tokens_family": {
+          "name": "idx_cli_refresh_tokens_family",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cli_refresh_tokens_user": {
+          "name": "idx_cli_refresh_tokens_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_refresh_tokens_user_id_user_id_fk": {
+          "name": "cli_refresh_tokens_user_id_user_id_fk",
+          "tableFrom": "cli_refresh_tokens",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cli_refresh_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "cli_refresh_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "cli_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cli_refresh_tokens_org_id_organizations_id_fk": {
+          "name": "cli_refresh_tokens_org_id_organizations_id_fk",
+          "tableFrom": "cli_refresh_tokens",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cli_refresh_tokens_parent_id_fkey": {
+          "name": "cli_refresh_tokens_parent_id_fkey",
+          "tableFrom": "cli_refresh_tokens",
+          "tableTo": "cli_refresh_tokens",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_refresh_tokens_token_hash_unique": {
+          "name": "cli_refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_codes_user_id_user_id_fk": {
+          "name": "device_codes_user_id_user_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_codes_client_id_oauth_clients_client_id_fk": {
+          "name": "device_codes_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_codes_org_id_organizations_id_fk": {
+          "name": "device_codes_org_id_organizations_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["device_code"]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_session_id_session_id_fk": {
+          "name": "oauth_access_tokens_session_id_session_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_user_id_user_id_fk": {
+          "name": "oauth_access_tokens_user_id_user_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk": {
+          "name": "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_refresh_tokens",
+          "columnsFrom": ["refresh_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_tokens_token_unique": {
+          "name": "oauth_access_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_first_party": {
+          "name": "is_first_party",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'instance'"
+        },
+        "referenced_org_id": {
+          "name": "referenced_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenced_application_id": {
+          "name": "referenced_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_signup": {
+          "name": "allow_signup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signup_role": {
+          "name": "signup_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        }
+      },
+      "indexes": {
+        "idx_oauth_clients_org": {
+          "name": "idx_oauth_clients_org",
+          "columns": [
+            {
+              "expression": "referenced_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_app": {
+          "name": "idx_oauth_clients_app",
+          "columns": [
+            {
+              "expression": "referenced_application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_user_id_user_id_fk": {
+          "name": "oauth_clients_user_id_user_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_clients_referenced_org_id_organizations_id_fk": {
+          "name": "oauth_clients_referenced_org_id_organizations_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "organizations",
+          "columnsFrom": ["referenced_org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_clients_referenced_application_id_applications_id_fk": {
+          "name": "oauth_clients_referenced_application_id_applications_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "applications",
+          "columnsFrom": ["referenced_application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "oauth_clients_level_check": {
+          "name": "oauth_clients_level_check",
+          "value": "(level = 'org' AND referenced_org_id IS NOT NULL AND referenced_application_id IS NULL) OR (level = 'application' AND referenced_application_id IS NOT NULL AND referenced_org_id IS NULL) OR (level = 'instance' AND referenced_org_id IS NULL AND referenced_application_id IS NULL)"
+        },
+        "oauth_clients_signup_role_check": {
+          "name": "oauth_clients_signup_role_check",
+          "value": "signup_role IN ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_consents": {
+      "name": "oauth_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consents_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_consents_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_user_id_user_id_fk": {
+          "name": "oauth_consents_user_id_user_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_session_id_session_id_fk": {
+          "name": "oauth_refresh_tokens_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_user_id_user_id_fk": {
+          "name": "oauth_refresh_tokens_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_token_unique": {
+          "name": "oauth_refresh_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_end_user_profiles": {
+      "name": "oidc_end_user_profiles",
+      "schema": "",
+      "columns": {
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oidc_profiles_auth_user": {
+          "name": "idx_oidc_profiles_auth_user",
+          "columns": [
+            {
+              "expression": "auth_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_end_user_profiles_end_user_id_end_users_id_fk": {
+          "name": "oidc_end_user_profiles_end_user_id_end_users_id_fk",
+          "tableFrom": "oidc_end_user_profiles",
+          "tableTo": "end_users",
+          "columnsFrom": ["end_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oidc_end_user_profiles_auth_user_id_user_id_fk": {
+          "name": "oidc_end_user_profiles_auth_user_id_user_id_fk",
+          "tableFrom": "oidc_end_user_profiles",
+          "tableTo": "user",
+          "columnsFrom": ["auth_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": ["pending", "accepted", "expired", "cancelled"]
+    },
+    "public.llm_usage_source": {
+      "name": "llm_usage_source",
+      "schema": "public",
+      "values": ["proxy", "runner"]
+    },
+    "public.org_role": {
+      "name": "org_role",
+      "schema": "public",
+      "values": ["owner", "admin", "member", "viewer"]
+    },
+    "public.package_source": {
+      "name": "package_source",
+      "schema": "public",
+      "values": ["local", "system"]
+    },
+    "public.package_type": {
+      "name": "package_type",
+      "schema": "public",
+      "values": ["agent", "skill", "integration", "mcp-server"]
+    },
+    "public.run_origin": {
+      "name": "run_origin",
+      "schema": "public",
+      "values": ["platform", "remote"]
+    },
+    "public.run_status": {
+      "name": "run_status",
+      "schema": "public",
+      "values": ["pending", "running", "success", "failed", "timeout", "cancelled"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1780845239370,
       "tag": "0007_icy_susan_delgado",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1780888621794,
+      "tag": "0008_cheerful_hammerhead",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/oidc.ts
+++ b/packages/db/src/schema/oidc.ts
@@ -65,6 +65,10 @@ export const deviceCode = pgTable("device_codes", {
     onDelete: "cascade",
   }),
   scope: text("scope"),
+  // Org the user bound to this grant on the /activate consent screen. Read at
+  // device-code exchange to stamp the access token's `org_id` claim, so the
+  // CLI needs no `X-Org-Id`. Null → unbound (legacy header path).
+  orgId: uuid("org_id").references(() => organizations.id, { onDelete: "cascade" }),
   attempts: integer("attempts").notNull().default(0),
 });
 
@@ -207,6 +211,10 @@ export const cliRefreshToken = pgTable(
     // inside the callback). Matches `ON DELETE SET NULL` from 0005.
     parentId: text("parent_id"),
     scope: text("scope"),
+    // Org bound to this token family at login (carried from the device_code).
+    // Copied parent→child on every rotation so a refreshed access token keeps
+    // the same `org_id` claim. Null → unbound (legacy header path).
+    orgId: uuid("org_id").references(() => organizations.id, { onDelete: "cascade" }),
     expiresAt: timestamp("expires_at").notNull(),
     createdAt: timestamp("created_at").notNull().defaultNow(),
     usedAt: timestamp("used_at"),


### PR DESCRIPTION
## Summary

Builds on the merged MCP SOTA auth (#621). A self-service (DCR/CIMD) client is **instance-level** — one client for a user who may belong to several orgs — so its token carried no org and every MCP call needed an `X-Org-Id` header. This **binds the org at the consent step** and unifies that mechanism across both the MCP web-OAuth consent and the CLI device-flow login, so neither needs `X-Org-Id`.

A fresh `claude mcp add …/api/mcp` now: browser login → **org picker on the consent screen** → token carries the org → calls `/api/mcp` with only a Bearer token. The same picker appears on the CLI's `/activate` page.

## Design (small backend cost — reuses existing middleware)

- **`org_id` is orthogonal to `actor_type`.** `resolveInstanceUser` sets `orgId` from the claim while keeping `deferOrgResolution`, so the existing org-context + permission middleware do the membership re-check and `resolvePermissions(orgRole)` exactly as for the header path. No duplication of `resolveDashboardUser`.
- **Threading seam (web/OAuth):** the org chosen on the consent screen rides Better Auth's `referenceId` — `postLogin.consentReferenceId` reads an `AsyncLocalStorage` set by the consent POST handler (leak-free, no TTL), and it persists on the refresh-token row so every (re)mint keeps the org. Surfaces as the `org_id` claim via `customAccessTokenClaims`.
- **CLI (mints its own JWT, not via BA):** new nullable `org_id` on `device_codes` (set at `/activate` approval) and `cli_refresh_tokens` (carried so rotation preserves the claim) — migration 0008. `cli-tokens.ts` stamps the claim through exchange + rotation; the CLI reads org from the token and skips the terminal picker.

## Security / back-compat

- Membership enforced at bind time **and** on every request (the strategy re-checks). A conflicting `X-Org-Id` is rejected — the bound org can't be spoofed.
- A token with no bound org omits the claim and resolves org via `X-Org-Id` as before (full back-compat).
- Org-level / application-level clients are unaffected (their org is fixed in client metadata); the first-party dashboard skips consent.

## ⚠️ Reviewer notes

- **CLI behaviour change (deliberate):** a bound CLI session can't switch org by re-pinning a header (the server pins the token's org), so `org switch` / `org create` now route the user back through `appstrate login` instead of writing a broken pin. Switching org = re-login (mirrors per-workspace OAuth). Confirm this trade-off.
- **Architecture:** this introduces "org in the token" into a platform that was otherwise 100% per-request `X-Org-Id`. Coherent, but worth a deliberate ack.
- **Refresh hygiene:** a spike found Better Auth 1.7 already implements RFC 9700 §4.14 reuse-detection + family-invalidation on `/oauth2/token`, so the MCP path inherits it — no custom logic added. A regression test locks it in. The CLI's separate `cli-tokens.ts` family logic is **not** redundant (different endpoint/requirements).

## Tests

- **integration** (`consent-org-binding`): org chosen → `org_id` claim; none → no claim (header back-compat); foreign org → 403; bound token drives an org-scoped route with **no** `X-Org-Id`, conflicting header → 403; MCP refresh reuse → `invalid_grant` + family teardown.
- **integration** (`cli-token-flow`): bound device code → claim, stored on the refresh head, preserved across rotation.
- **CLI** (`login-org`, `org-command`): token claim persisted + terminal picker skipped; `org switch` on a bound session errors toward `login`, leaves the pin intact.
- **e2e** (`mcp.api.spec`): org bound at consent drives `/api/mcp` with no `X-Org-Id`.
- Full suite green: `bun test apps/api` (2793), CLI (1027), tsc + eslint + prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
