### PR TITLE
fix(oidc): RFC 8252 port-flexible matching for localhost loopback redirects (Claude Code OAuth)

### DIFF
--- a/apps/api/src/modules/oidc/test/integration/services/loopback-redirect.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/loopback-redirect.test.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * RFC 8252 §7.3 loopback redirect port-flexibility for native MCP clients.
+ *
+ * A native client (Claude Code) registers a fixed loopback redirect — e.g.
+ * `http://localhost/callback` (its CIMD document declares exactly
+ * `["http://localhost/callback","http://127.0.0.1/callback"]`) — but at runtime
+ * listens on an ephemeral port and sends `http://localhost:<port>/callback`.
+ * The authorization server MUST match these ignoring the port.
+ *
+ * Better Auth's `findRegisteredRedirectUri` applied the port-flexible match only
+ * when the registered host was a loopback IP *literal* (`isLoopbackIP`), which
+ * excludes the literal name `localhost` — so `http://localhost/callback` failed
+ * to match `http://localhost:63785/callback` and the authorize step returned
+ * `invalid_redirect`. We patch the plugin to use `isLoopbackHost` (which
+ * includes `localhost`). This test locks in the fix.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { getTestApp } from "../../../../../../test/helpers/app.ts";
+import { truncateAll } from "../../../../../../test/helpers/db.ts";
+import { flushRedis } from "../../../../../../test/helpers/redis.ts";
+import { resetOidcGuardsLimiters } from "../../../auth/guards.ts";
+import { createTestContext, type TestContext } from "../../../../../../test/helpers/auth.ts";
+import oidcModule from "../../../index.ts";
+
+const app = getTestApp({ modules: [oidcModule] });
+
+/** Register a public native client whose only redirect is a port-less loopback. */
+async function registerLoopbackClient(redirectUri: string): Promise<string> {
+  const res = await app.request("/api/auth/oauth2/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      client_name: "Native loopback client",
+      redirect_uris: [redirectUri],
+      grant_types: ["authorization_code", "refresh_token"],
+      response_types: ["code"],
+      token_endpoint_auth_method: "none",
+      scope: "openid profile email offline_access",
+    }),
+  });
+  expect([200, 201]).toContain(res.status);
+  return String(((await res.json()) as { client_id: string }).client_id);
+}
+
+async function authorizeRedirectLocation(
+  clientId: string,
+  cookie: string,
+  redirectUri: string,
+): Promise<string> {
+  const url =
+    `/api/auth/oauth2/authorize?` +
+    new URLSearchParams({
+      response_type: "code",
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      scope: "openid profile email offline_access",
+      state: "xyz",
+      code_challenge: "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+      code_challenge_method: "S256",
+    }).toString();
+  const res = await app.request(url, {
+    headers: { cookie, accept: "text/html" },
+    redirect: "manual",
+  });
+  expect(res.status).toBe(302);
+  return res.headers.get("location") ?? "";
+}
+
+describe("RFC 8252 loopback redirect port-flexibility", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    await flushRedis();
+    resetOidcGuardsLimiters();
+    ctx = await createTestContext({ orgSlug: "loopback" });
+  });
+
+  it("matches an ephemeral-port localhost redirect against a port-less registration", async () => {
+    const clientId = await registerLoopbackClient("http://localhost/callback");
+    // The runtime redirect carries an ephemeral port the registration can't know.
+    const location = await authorizeRedirectLocation(
+      clientId,
+      ctx.cookie,
+      "http://localhost:63785/callback",
+    );
+    // A successful match routes to the consent screen; the bug routed to the
+    // server error page with error=invalid_redirect.
+    expect(location).not.toContain("invalid_redirect");
+    expect(new URL(location, "http://localhost").pathname).toBe("/api/oauth/consent");
+  });
+
+  it("still matches a 127.0.0.1 ephemeral-port redirect against a 127.0.0.1 registration", async () => {
+    const clientId = await registerLoopbackClient("http://127.0.0.1/callback");
+    const location = await authorizeRedirectLocation(
+      clientId,
+      ctx.cookie,
+      "http://127.0.0.1:54321/callback",
+    );
+    expect(location).not.toContain("invalid_redirect");
+    expect(new URL(location, "http://localhost").pathname).toBe("/api/oauth/consent");
+  });
+
+  it("still enforces path: a loopback redirect with a different path is rejected", async () => {
+    const clientId = await registerLoopbackClient("http://localhost/callback");
+    // Same loopback host (passes the HTTP-loopback gate) but a different path →
+    // port-flexibility must NOT relax the path check.
+    const location = await authorizeRedirectLocation(
+      clientId,
+      ctx.cookie,
+      "http://localhost:63785/evil",
+    );
+    expect(location).toContain("invalid_redirect");
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -415,6 +415,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@better-auth/oauth-provider@1.7.0-beta.4": "patches/@better-auth%2Foauth-provider@1.7.0-beta.4.patch",
+  },
   "overrides": {
     "zod": "4.4.3",
   },

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "zod": "4.4.3"
   },
   "patchedDependencies": {
-    "@redocly/openapi-core@2.25.2": "patches/@redocly%2Fopenapi-core@2.25.2.patch"
+    "@redocly/openapi-core@2.25.2": "patches/@redocly%2Fopenapi-core@2.25.2.patch",
+    "@better-auth/oauth-provider@1.7.0-beta.4": "patches/@better-auth%2Foauth-provider@1.7.0-beta.4.patch"
   }
 }

--- a/patches/@better-auth%2Foauth-provider@1.7.0-beta.4.patch
+++ b/patches/@better-auth%2Foauth-provider@1.7.0-beta.4.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index fed8ce01a0570c647db71d1149c9453d50dd46e6..7c28053d733a20c10ba91b6d8b51d93fb7cc308c 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -4162,7 +4162,7 @@ function findRegisteredRedirectUri(registered, requested) {
+ 		if (!req) return false;
+ 		try {
+ 			const reg = new URL(url);
+-			return isLoopbackIP(reg.hostname) && reg.hostname === req.hostname && reg.pathname === req.pathname && reg.protocol === req.protocol && reg.search === req.search;
++			return isLoopbackHost(reg.hostname) && reg.hostname === req.hostname && reg.pathname === req.pathname && reg.protocol === req.protocol && reg.search === req.search;
+ 		} catch {
+ 			return false;
+ 		}


### PR DESCRIPTION
## Problem

`claude mcp add http://localhost:3000/api/mcp` (and any native MCP client) could not complete the browser OAuth flow against an Appstrate instance — the authorize step returned:

```
/api/auth/error?error=invalid_redirect&error_description=invalid+redirect+uri
```

Claude Code's CIMD document declares `redirect_uris: ["http://localhost/callback","http://127.0.0.1/callback"]`, but at runtime it listens on an **ephemeral port** and sends `http://localhost:63785/callback`. RFC 8252 §7.3 requires the AS to match loopback redirects **ignoring the port**.

## Root cause (upstream)

`@better-auth/oauth-provider`'s `findRegisteredRedirectUri` applies the port-flexible loopback match only when the registered host passes `isLoopbackIP` — which classifies the **literal name `localhost` as NOT loopback** (only `127.0.0.1` / `::1` are). So:

- registered `http://localhost/callback` vs requested `http://localhost:63785/callback` → `isLoopbackIP("localhost")` is false → no port-flex → strict equality fails.
- registered `http://127.0.0.1/callback` → loopback IP, but `hostname "127.0.0.1" !== "localhost"` → no match.

Neither registered URI matched → `invalid_redirect`.

## Fix

Patch the plugin to use `isLoopbackHost` (includes `localhost`, `*.localhost`, and the IP literals) instead of `isLoopbackIP` for that one check. The match still requires identical host, path, protocol, and query — **only the port flexes**, exactly per RFC 8252 §7.3. Applied via `bun patch` (`patchedDependencies`); an upstream fix should follow.

## Tests

`loopback-redirect.test.ts` (integration, real BA plugin):
- ephemeral-port `http://localhost:63785/callback` now matches a `http://localhost/callback` registration → routes to consent (not the error page).
- same for `127.0.0.1`.
- a different **path** on a loopback host is still rejected — port-flexibility does not relax the path check.

## Notes

- Independent of #622 (org-binding); both target `feat/mcp-server`. Merge order doesn't matter.
- This unblocks the real `claude mcp add` browser flow end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
