### PR TITLE
fix(docker): ship @appstrate/mcp-transport node_modules in runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ COPY --from=deps /app/packages/connect/node_modules ./packages/connect/node_modu
 COPY --from=deps /app/packages/core/node_modules ./packages/core/node_modules
 COPY --from=deps /app/packages/db/node_modules ./packages/db/node_modules
 COPY --from=deps /app/packages/env/node_modules ./packages/env/node_modules
+COPY --from=deps /app/packages/mcp-transport/node_modules ./packages/mcp-transport/node_modules
 COPY --from=deps /app/packages/runner-pi/node_modules ./packages/runner-pi/node_modules
 COPY --from=deps /app/packages/shared-types/node_modules ./packages/shared-types/node_modules
 


### PR DESCRIPTION
## Problem

Production **v1.0.0-beta.26** crash-loops at boot (HTTP 503):

```
error: Module "mcp" could not be loaded: Cannot find module
'@modelcontextprotocol/sdk/client/index.js' from
'/app/packages/mcp-transport/src/index.ts'
  at loadModules (apps/api/src/lib/modules/module-loader.ts:109)
  at async boot (apps/api/src/lib/boot.ts:91)
```

## Root cause

- The `mcp` built-in module (added to default `MODULES`) imports `@appstrate/mcp-transport`.
- `@modelcontextprotocol/sdk` is **nested** under `packages/mcp-transport/node_modules/` (bun did not hoist it to root).
- The main `Dockerfile` runtime stage copies `node_modules` via a **manual allowlist** (explicitly not graph-derived). The list omitted `mcp-transport`, so its nested SDK never shipped → crash-loop. The allowlist's own comment predicts exactly this failure mode.
- `runtime-pi/Dockerfile` already copies `packages/mcp-transport/node_modules` (L153) — only the main image had the gap.

## Fix

One line added to the runtime allowlist:

```dockerfile
COPY --from=deps /app/packages/mcp-transport/node_modules ./packages/mcp-transport/node_modules
```

## Follow-up (not in this PR)

`runtime-pi/sidecar/Dockerfile` copies mcp-transport `src` + `package.json` but no `node_modules` — latent gap if the SDK isn't otherwise resolved there. Sidecar shipped mcp-transport since before beta.26 without issue, so likely fine; worth a separate verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)