### PR TITLE
feat(runtime-pi): pre-install common Python data libs in agent venv

### DIFF
--- a/packages/afps-runtime/src/bundle/platform-prompt.ts
+++ b/packages/afps-runtime/src/bundle/platform-prompt.ts
@@ -155,6 +155,15 @@ export function renderPlatformPrompt(opts: PlatformPromptOptions): string {
     "- **Network access**: Outbound HTTP/HTTPS is available. " +
       "Use `curl`, `fetch`, or any HTTP client to call public APIs and websites directly.",
   );
+  // Pre-installed Python libs (#628). The runtime image bakes common data
+  // libraries into the agent venv — stating it here stops agents (and
+  // weaker models especially) from running speculative `pip install`
+  // steps or spiralling on ModuleNotFoundError before trying the import.
+  sections.push(
+    "- **Python**: `python3` is available with common data libraries pre-installed " +
+      "(`openpyxl`, `pandas`, `requests`, `PyPDF2`). Import them directly — no `pip install` needed. " +
+      "Other packages can be added with `pip install` (the environment is discarded when the run ends).",
+  );
   if (opts.timeoutSeconds) {
     sections.push(
       `- **Timeout**: You have ${opts.timeoutSeconds} seconds to complete this task. ` +

--- a/packages/afps-runtime/test/bundle/platform-prompt.test.ts
+++ b/packages/afps-runtime/test/bundle/platform-prompt.test.ts
@@ -22,6 +22,13 @@ describe("renderPlatformPrompt", () => {
     expect(out).toContain("Ephemeral container");
   });
 
+  it("advertises the pre-installed Python data libraries (#628)", () => {
+    // Must stay in sync with the venv install line in runtime-pi/Dockerfile.
+    const out = renderPlatformPrompt({ template: "TEMPLATE", context: ctx() });
+    expect(out).toContain("`openpyxl`, `pandas`, `requests`, `PyPDF2`");
+    expect(out).toContain("no `pip install` needed");
+  });
+
   it("emits a Communication section forbidding free-text replies to the user", () => {
     const out = renderPlatformPrompt({ template: "TEMPLATE", context: ctx() });
     expect(out).toContain("### Communication");

--- a/runtime-pi/Dockerfile
+++ b/runtime-pi/Dockerfile
@@ -121,6 +121,23 @@ LABEL org.opencontainers.image.title="Appstrate Pi" \
 # rooted in the venv's own site-packages (always present), and the path
 # self-aligns with whatever python3 ships in the base image.
 #
+# Common data libraries are baked into the venv (#628, #316 items 2-3):
+#   - openpyxl   Excel read/write — concrete demand from office-automation
+#                skills (edi-order-parser, orgabusiness-export-compta)
+#   - pandas     tabular data wrangling (CSV/Excel pipelines)
+#   - requests   de-facto HTTP client that generated Python assumes exists
+#   - pypdf2     PDF read/split/merge (PyPDF2 3.0.1 is the final release —
+#                superseded by pypdf, but skills and LLMs still
+#                `import PyPDF2` by that name, so we ship what they import)
+# Pre-installing costs ~150 MB uncompressed (pandas + numpy dominate;
+# the other three total <10 MB) but removes a cold `pip install`
+# (5-15 s) plus a ModuleNotFoundError retry loop from every run that
+# touches spreadsheets or PDFs. Versions are deliberately
+# unpinned: they resolve at image build time and the image is immutable
+# per release tag, so runs are reproducible without a pin list to
+# maintain. All four ship pure-python or musllinux wheels — no build
+# toolchain (gcc, musl-dev) is needed in the image.
+#
 # Create the unprivileged `pi` user in the same layer so subsequent
 # `COPY --chown=pi:pi` resolves without a separate chown pass.
 RUN apk add --no-cache \
@@ -134,6 +151,7 @@ RUN apk add --no-cache \
  && adduser  -D -u 1001 -G pi -s /bin/bash pi \
  && python3 -m venv /opt/agent-venv \
  && /opt/agent-venv/bin/pip install --no-cache-dir --upgrade pip \
+ && /opt/agent-venv/bin/pip install --no-cache-dir openpyxl pandas requests pypdf2 \
  && chown -R pi:pi /opt/agent-venv
 
 # Put the venv first on PATH so `python3` and `pip` resolve to the venv


### PR DESCRIPTION
Refs #628 — implements **item A** (item B stays open, assessment posted on the issue).

## What

- `runtime-pi/Dockerfile`: the agent venv (`/opt/agent-venv`) now bakes in `openpyxl pandas requests pypdf2` (one extra `pip install` line in the existing layer), with a comment block documenting why each lib is there and the size trade-off.
- `packages/afps-runtime/src/bundle/platform-prompt.ts`: new **Python** bullet in the `### Environment` section advertising the pre-installed libs, so agents import them directly instead of running speculative `pip install` steps or spiralling on `ModuleNotFoundError` (the failure mode from the issue's field evidence).
- `packages/afps-runtime/test/bundle/platform-prompt.test.ts`: test pinning the new bullet to the Dockerfile install line.

## Decisions

- **Versions unpinned**: they resolve at image build time and the image is immutable per release tag, so runs are reproducible per tag without a pin list to maintain. All four ship pure-python or musllinux wheels — no build toolchain added to the image.
- **`pypdf2` as named in the issue**: PyPDF2 3.0.1 is the final release (superseded by `pypdf`), but skills and LLMs still `import PyPDF2` by that name, so we ship what they import. Noted in the Dockerfile comment.
- **Size**: the issue estimated 50-80 MB; measured cost is **~150 MB uncompressed** (pandas 70 MB + numpy 70 MB dominate; openpyxl/PyPDF2/requests total <10 MB). Documented honestly in the Dockerfile. If that's too much, dropping pandas alone removes ~140 MB — but pandas is the lib generated Python reaches for first on CSV/Excel work.
- Checked for other places assuming "no libs exist" (platform prompt sections, docs, `scripts/conformance/`) — none found beyond the prompt addition above.

## Verification

- `docker build -f runtime-pi/Dockerfile .` (same invocation as `release.yml` / the `runtime-e2e` job) — **builds clean**.
- In the built image: `python3 -c "import openpyxl, pandas, requests, PyPDF2"` → ok (openpyxl 3.1.5, pandas 3.0.3, requests 2.34.2, PyPDF2 3.0.1, Python 3.12.13). No pyarrow pulled in.
- `bun test` on `platform-prompt{,-parity}.test.ts` → 53 pass.
- `bun run check` from repo root → 29/29 tasks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)