### PR TITLE
feat(api): long-poll option on getRun (?wait=<seconds>|true)

### DIFF
--- a/apps/api/src/modules/mcp/router.ts
+++ b/apps/api/src/modules/mcp/router.ts
@@ -126,7 +126,7 @@ Organization → Applications (id \`app_…\`, one default) → Agents → Runs.
 This MCP server is scoped to ONE organization — the one this endpoint serves — and every operation runs against it plus its default application; you never send those ids per call. To act in another organization, connect that organization's own MCP server (its URL carries its id). Within the org, operations use the default application unless an operation takes an explicit application id.
 
 ## Beyond the per-operation schemas
-- Runs are asynchronous: triggering one returns a runId, then it moves pending→running→success|failed|timeout|cancelled — poll a run get/list operation for status.
+- Runs are asynchronous: triggering one returns a runId, then it moves pending→running→success|failed|timeout|cancelled. To wait for completion, call the run get operation with \`query: { wait: true }\` — the server long-polls up to ~55 s and returns the run when it goes terminal; a still-non-terminal response just means call it again (no sleep needed).
 - Streaming/SSE operations (live logs, realtime) cannot be called through this server; fetch logs or poll instead.
 - Wire JSON is snake_case, except universal id/timestamp fields (id, createdAt…) which stay camelCase.`;
 

--- a/apps/api/src/openapi/paths/runs.ts
+++ b/apps/api/src/openapi/paths/runs.ts
@@ -488,12 +488,30 @@ export const runsPaths = {
     get: {
       operationId: "getRun",
       tags: ["Runs"],
-      summary: "Get run status/result",
-      description: "Get run details including status, result, input, and duration.",
+      summary: "Get run status/result (optionally long-poll until terminal)",
+      description:
+        "Get run details including status, result, input, and duration.\n\nPass `?wait=<seconds>` (or `?wait=true` for the maximum) to long-poll: the server holds the request until the run reaches a terminal status (`success`, `failed`, `timeout`, `cancelled`) or the wait elapses, then returns the current run object exactly as the plain call does. The wait is capped at **55 seconds** — deliberately below the 60 s idle timeouts that ship as defaults in common reverse proxies (nginx `proxy_read_timeout`, ALB idle timeout) so the long poll always completes with a real response instead of a proxy 504; values above the cap are clamped. A response with a non-terminal `status` simply means the wait timed out — issue the same call again to keep waiting. One long poll replaces N sleep+getRun round-trips, which is the recommended completion-wait pattern for MCP clients (the SSE stream is not reachable through the MCP server).",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
         { name: "id", in: "path", required: true, schema: { type: "string" } },
+        {
+          name: "wait",
+          in: "query",
+          required: false,
+          schema: {
+            oneOf: [
+              { type: "boolean", description: "`true` waits the maximum 55 s; `false` disables." },
+              {
+                type: "integer",
+                minimum: 0,
+                description: "Wait budget in seconds. Values above 55 are clamped to 55.",
+              },
+            ],
+          },
+          description:
+            "Hold the request until the run reaches a terminal status or this many seconds elapse (capped at 55, see operation description), then return the run object. `0`/`false`/absent = return immediately (default). Negative, fractional, or non-numeric values return 400.",
+        },
       ],
       responses: {
         "200": {

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -36,6 +36,8 @@ import { runInlinePreflight } from "../services/inline-run-preflight.ts";
 import { synthesiseFinalize } from "../services/run-event-ingestion.ts";
 import { getEnv } from "@appstrate/env";
 import { currentTraceparent } from "../observability/index.ts";
+import { TERMINAL_RUN_STATUSES } from "@appstrate/db/schema";
+import { parseWaitQuery, waitForRunTerminal } from "../services/run-wait.ts";
 
 /**
  * Resolve the traceparent to seed the run-execution trace tree with, honoring
@@ -208,9 +210,22 @@ export function createRunsRouter() {
   // See apps/api/src/routes/notifications.ts.
 
   // GET /api/runs/:id — get a single run
+  //
+  // Optional `?wait=<seconds|true>` long-poll (issue #631): holds the
+  // request until the run reaches a terminal status or the wait elapses
+  // (capped at MAX_WAIT_SECONDS, below typical proxy idle timeouts), then
+  // returns the run object exactly as the plain call does. A non-terminal
+  // status in the response means "poll again". The wakeup is event-driven
+  // (run_update PG NOTIFY) with a periodic DB re-check as fallback — see
+  // services/run-wait.ts. Auth/scoping is identical to the plain call:
+  // ownership is verified BEFORE any waiting starts.
   router.get("/runs/:id", async (c) => {
     const runId = c.req.param("id");
     const scope = getAppScope(c);
+    // Validate the wait param before touching the DB so a malformed value
+    // 400s even for runs the caller could not read.
+    const waitMs = parseWaitQuery(c.req.query("wait"));
+
     const row = await getRunFull(scope, runId);
     if (!row) {
       throw notFound("Run not found");
@@ -219,6 +234,25 @@ export function createRunsRouter() {
     if (endUser && row.endUserId !== endUser.id) {
       throw notFound("Run not found");
     }
+
+    if (waitMs > 0 && !TERMINAL_RUN_STATUSES.has(row.status)) {
+      await waitForRunTerminal({
+        runId,
+        scope,
+        timeoutMs: waitMs,
+        // Client disconnect aborts the server-side wait — no leaked
+        // timers/subscriptions for a response nobody will read.
+        signal: c.req.raw.signal,
+      });
+      const fresh = await getRunFull(scope, runId);
+      // The run can be deleted mid-wait (e.g. DELETE agent runs) — surface
+      // the same 404 the initial read would have.
+      if (!fresh) {
+        throw notFound("Run not found");
+      }
+      return c.json(fresh);
+    }
+
     return c.json(row);
   });
 

--- a/apps/api/src/services/run-wait.ts
+++ b/apps/api/src/services/run-wait.ts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Long-poll support for `GET /api/runs/:id?wait=…` (issue #631).
+ *
+ * MCP clients cannot consume the SSE stream, so without this they must
+ * loop `sleep` + `getRun`, burning one round-trip (and context tokens for
+ * the full run payload) per poll. `?wait=<seconds>` instead holds the
+ * request server-side until the run reaches a terminal status or the wait
+ * elapses, then returns the run object as usual — each iteration is one
+ * cheap long poll instead of N short polls.
+ *
+ * Wakeup mechanism (in priority order):
+ *
+ *  1. **PG NOTIFY** — the `runs_notify_trigger` fires `run_update` on every
+ *     `runs` UPDATE; `services/realtime.ts` LISTENs once per process and
+ *     fans out to in-process subscribers. This works across multi-instance
+ *     deployments (each instance holds its own LISTEN connection to the
+ *     shared PostgreSQL) AND in Tier-0 (PGlite implements LISTEN/NOTIFY
+ *     in-process). No Redis involved.
+ *  2. **Fallback DB poll** — a 2 s interval re-reads `runs.status` with a
+ *     single narrow indexed query. Covers the case where the realtime
+ *     listener is not initialized or a NOTIFY is lost; each poll borrows a
+ *     pooled connection for one query — the wait never pins a connection.
+ *
+ * The wait is capped at {@link MAX_WAIT_SECONDS} (55 s), deliberately below
+ * the 60 s idle/read timeouts that ship as defaults in common reverse
+ * proxies (nginx `proxy_read_timeout`, AWS ALB idle timeout, Cloudflare's
+ * 100 s, …) so the long poll always completes with a real response instead
+ * of a proxy-generated 504. A response carrying a non-terminal status just
+ * means "poll again".
+ */
+
+import { z } from "zod";
+import { and, eq } from "drizzle-orm";
+import { db } from "@appstrate/db/client";
+import { runs, TERMINAL_RUN_STATUSES, type RunStatus } from "@appstrate/db/schema";
+import { addSubscriber, removeSubscriber } from "./realtime.ts";
+import { invalidRequest } from "../lib/errors.ts";
+import type { AppScope } from "../lib/scope.ts";
+
+/**
+ * Server-side wait ceiling, in seconds. Kept below typical proxy idle
+ * timeouts (commonly 60 s) — see module doc. Values above the cap are
+ * clamped rather than rejected so clients can pass a generous number and
+ * let the server decide (same convention as long-poll `timeout` params in
+ * e.g. the Kubernetes watch API).
+ */
+export const MAX_WAIT_SECONDS = 55;
+
+/** Fallback DB re-check cadence while waiting (see module doc, point 2). */
+const FALLBACK_POLL_INTERVAL_MS = 2_000;
+
+/**
+ * `?wait=` accepts `true`/`false` (boolean form) or a non-negative integer
+ * number of seconds. Negative, fractional, or non-numeric values are
+ * rejected; values above {@link MAX_WAIT_SECONDS} are clamped to it.
+ */
+const waitQuerySchema = z.union([
+  z.literal("true").transform(() => MAX_WAIT_SECONDS),
+  z.literal("false").transform(() => 0),
+  z.coerce
+    .number()
+    .int()
+    .min(0)
+    .transform((n) => Math.min(n, MAX_WAIT_SECONDS)),
+]);
+
+/**
+ * Parse the raw `wait` query value into a wait budget in milliseconds.
+ *
+ * - `undefined` (param absent) → `0` (no wait — today's behavior)
+ * - `""` (bare `?wait`) and `"true"` → the {@link MAX_WAIT_SECONDS} cap
+ * - `"false"` / `"0"` → `0`
+ * - integer seconds → clamped to the cap
+ * - anything else → 400 `invalid_request`
+ */
+export function parseWaitQuery(raw: string | undefined): number {
+  if (raw === undefined) return 0;
+  const parsed = waitQuerySchema.safeParse(raw === "" ? "true" : raw);
+  if (!parsed.success) {
+    throw invalidRequest(
+      `Invalid 'wait' value: expected true, false, or a non-negative integer number of seconds (max ${MAX_WAIT_SECONDS})`,
+      "wait",
+    );
+  }
+  return parsed.data * 1000;
+}
+
+/** One narrow indexed read: is the run terminal right now? */
+async function isRunTerminal(scope: AppScope, runId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ status: runs.status })
+    .from(runs)
+    .where(
+      and(
+        eq(runs.id, runId),
+        eq(runs.orgId, scope.orgId),
+        eq(runs.applicationId, scope.applicationId),
+      ),
+    )
+    .limit(1);
+  // A run deleted mid-wait resolves the wait too — the caller re-reads and
+  // surfaces its own 404 rather than holding the request for nothing.
+  return row === undefined || TERMINAL_RUN_STATUSES.has(row.status);
+}
+
+/**
+ * Hold until the run reaches a terminal status, the timeout elapses, or the
+ * caller aborts — whichever comes first. Resolves `void` in every case; the
+ * caller re-reads the run row afterwards and returns whatever state it
+ * finds (non-terminal = the client should poll again).
+ *
+ * Cleanup contract: every exit path (event, poll hit, timeout, abort)
+ * removes the realtime subscriber and clears both timers — nothing leaks
+ * past resolution, including on client disconnect (`signal`).
+ */
+export async function waitForRunTerminal(opts: {
+  runId: string;
+  scope: AppScope;
+  /** Wait budget in milliseconds (already capped by {@link parseWaitQuery}). */
+  timeoutMs: number;
+  /** Request abort signal — stops the wait when the client disconnects. */
+  signal?: AbortSignal;
+  /** Fallback DB poll cadence override (tests). */
+  pollIntervalMs?: number;
+}): Promise<void> {
+  const { runId, scope, timeoutMs, signal } = opts;
+  const pollIntervalMs = opts.pollIntervalMs ?? FALLBACK_POLL_INTERVAL_MS;
+
+  if (signal?.aborted || timeoutMs <= 0) return;
+
+  await new Promise<void>((resolve) => {
+    const subId = `wait-${runId}-${crypto.randomUUID().slice(0, 8)}`;
+    let done = false;
+    let pollInFlight = false;
+
+    const finish = (): void => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      clearInterval(interval);
+      signal?.removeEventListener("abort", finish);
+      removeSubscriber(subId);
+      resolve();
+    };
+
+    const timer = setTimeout(finish, timeoutMs);
+
+    // Fallback poll — guarded so a slow query never stacks concurrent reads.
+    const interval = setInterval(() => {
+      if (pollInFlight) return;
+      pollInFlight = true;
+      void isRunTerminal(scope, runId)
+        .then((terminal) => {
+          if (terminal) finish();
+        })
+        .catch(() => {
+          // Transient read failure — the next tick (or the timeout) covers it.
+        })
+        .finally(() => {
+          pollInFlight = false;
+        });
+    }, pollIntervalMs);
+
+    signal?.addEventListener("abort", finish, { once: true });
+
+    // Primary wakeup: the realtime fan-out of the `run_update` PG NOTIFY.
+    // The filter reuses the same org/application isolation gates as the SSE
+    // subscribers; `isAdmin` only affects the run_log channel (unused here).
+    addSubscriber({
+      id: subId,
+      filter: {
+        runId,
+        orgId: scope.orgId,
+        applicationId: scope.applicationId,
+        isAdmin: true,
+      },
+      send: (evt) => {
+        if (evt.event !== "run_update") return;
+        const status = evt.data["status"];
+        if (typeof status === "string" && TERMINAL_RUN_STATUSES.has(status as RunStatus)) {
+          finish();
+        }
+      },
+    });
+
+    // Close the subscribe-after-read race: the run may have gone terminal
+    // between the caller's snapshot and the subscription above.
+    void isRunTerminal(scope, runId)
+      .then((terminal) => {
+        if (terminal) finish();
+      })
+      .catch(() => {});
+  });
+}

--- a/apps/api/test/integration/routes/runs-wait.test.ts
+++ b/apps/api/test/integration/routes/runs-wait.test.ts
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `GET /api/runs/:id?wait=…` long-poll (issue #631).
+ *
+ * Covers: wait-param validation, immediate return when the run is already
+ * terminal, wait-then-return when the run transitions mid-poll, and the
+ * timeout path (non-terminal response = "poll again").
+ *
+ * The transition test exercises whichever wakeup path is live in this
+ * process: the `run_update` PG NOTIFY fan-out when `initRealtime()` ran
+ * (we call it explicitly, mirroring realtime-sse.test.ts), with the 2 s
+ * fallback DB poll as a backstop — both complete well inside the asserted
+ * bound.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@appstrate/db/client";
+import { runs } from "@appstrate/db/schema";
+import { getTestApp } from "../../helpers/app.ts";
+import { truncateAll } from "../../helpers/db.ts";
+import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
+import { seedAgent, seedRun } from "../../helpers/seed.ts";
+import { initRealtime } from "../../../src/services/realtime.ts";
+
+const app = getTestApp();
+
+describe("GET /api/runs/:id?wait — long-poll", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    await initRealtime();
+    ctx = await createTestContext({ orgSlug: "waitorg" });
+    await seedAgent({ id: "@waitorg/wait-agent", orgId: ctx.orgId, createdBy: ctx.user.id });
+  });
+
+  function seedWaitRun(status: "pending" | "running" | "success" | "failed") {
+    return seedRun({
+      packageId: "@waitorg/wait-agent",
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      userId: ctx.user.id,
+      status,
+    });
+  }
+
+  // ─── Param validation ──────────────────────────────────────
+
+  it.each(["abc", "-1", "1.5", "[]"])("returns 400 for wait=%s", async (value) => {
+    const run = await seedWaitRun("success");
+
+    const res = await app.request(`/api/runs/${run.id}?wait=${encodeURIComponent(value)}`, {
+      headers: authHeaders(ctx),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code?: string; detail?: string };
+    expect(body.code).toBe("invalid_request");
+    expect(body.detail).toContain("wait");
+  });
+
+  it("validates the wait param even for an unreadable run (400 before 404)", async () => {
+    const res = await app.request("/api/runs/run_nonexistent?wait=-5", {
+      headers: authHeaders(ctx),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  // ─── Immediate return ──────────────────────────────────────
+
+  it("returns immediately when the run is already terminal", async () => {
+    const run = await seedWaitRun("success");
+
+    const start = Date.now();
+    const res = await app.request(`/api/runs/${run.id}?wait=30`, {
+      headers: authHeaders(ctx),
+    });
+    const elapsed = Date.now() - start;
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string; status: string };
+    expect(body.id).toBe(run.id);
+    expect(body.status).toBe("success");
+    // No 30 s hold — terminal short-circuits before any waiting starts.
+    expect(elapsed).toBeLessThan(2_000);
+  });
+
+  it("accepts wait=true (default cap) and wait above the cap (clamped)", async () => {
+    const run = await seedWaitRun("failed");
+
+    for (const wait of ["true", "9999"]) {
+      const res = await app.request(`/api/runs/${run.id}?wait=${wait}`, {
+        headers: authHeaders(ctx),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { status: string };
+      expect(body.status).toBe("failed");
+    }
+  });
+
+  it("treats wait=0 and wait=false as no-wait on a non-terminal run", async () => {
+    const run = await seedWaitRun("running");
+
+    for (const wait of ["0", "false"]) {
+      const start = Date.now();
+      const res = await app.request(`/api/runs/${run.id}?wait=${wait}`, {
+        headers: authHeaders(ctx),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { status: string };
+      expect(body.status).toBe("running");
+      expect(Date.now() - start).toBeLessThan(1_000);
+    }
+  });
+
+  // ─── Wait-then-return on transition ────────────────────────
+
+  it("holds a non-terminal run and returns once it transitions to terminal", async () => {
+    const run = await seedWaitRun("running");
+
+    const start = Date.now();
+    const resPromise = app.request(`/api/runs/${run.id}?wait=30`, {
+      headers: authHeaders(ctx),
+    });
+
+    // Flip the run to terminal while the long poll is in flight. The
+    // UPDATE fires the runs_notify_trigger → run_update NOTIFY → wait
+    // resolves (fallback: the 2 s DB re-check).
+    await Bun.sleep(200);
+    await db
+      .update(runs)
+      .set({ status: "success", completedAt: new Date() })
+      .where(eq(runs.id, run.id));
+
+    const res = await resPromise;
+    const elapsed = Date.now() - start;
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string; status: string };
+    expect(body.id).toBe(run.id);
+    expect(body.status).toBe("success");
+    // Returned on the transition, not the 30 s budget. Bound generous
+    // enough for the 2 s fallback-poll path on slow CI.
+    expect(elapsed).toBeGreaterThanOrEqual(200);
+    expect(elapsed).toBeLessThan(10_000);
+  }, 15_000);
+
+  // ─── Timeout path ──────────────────────────────────────────
+
+  it("returns the current (non-terminal) run when the wait elapses — caller polls again", async () => {
+    const run = await seedWaitRun("running");
+
+    const start = Date.now();
+    const res = await app.request(`/api/runs/${run.id}?wait=1`, {
+      headers: authHeaders(ctx),
+    });
+    const elapsed = Date.now() - start;
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { id: string; status: string };
+    expect(body.id).toBe(run.id);
+    expect(body.status).toBe("running");
+    // Held for roughly the requested budget, then answered normally.
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+    expect(elapsed).toBeLessThan(5_000);
+  }, 15_000);
+
+  // ─── Auth unchanged ────────────────────────────────────────
+
+  it("returns 401 without authentication regardless of wait", async () => {
+    const res = await app.request("/api/runs/run_anything?wait=5");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for another org's run without waiting", async () => {
+    const otherCtx = await createTestContext({ orgSlug: "waitother" });
+    await seedAgent({ id: "@waitother/agent", orgId: otherCtx.orgId });
+    const run = await seedRun({
+      packageId: "@waitother/agent",
+      orgId: otherCtx.orgId,
+      applicationId: otherCtx.defaultAppId,
+      userId: otherCtx.user.id,
+      status: "running",
+    });
+
+    const start = Date.now();
+    const res = await app.request(`/api/runs/${run.id}?wait=30`, {
+      headers: authHeaders(ctx),
+    });
+
+    expect(res.status).toBe(404);
+    // Ownership is checked BEFORE waiting — no 30 s hold on a 404.
+    expect(Date.now() - start).toBeLessThan(2_000);
+  });
+});

--- a/apps/api/test/integration/services/run-wait.test.ts
+++ b/apps/api/test/integration/services/run-wait.test.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Service-level tests for `waitForRunTerminal` (issue #631) — the pieces
+ * the HTTP-level tests can't reach directly: the fallback DB poll cadence
+ * (Tier-0 / lost-NOTIFY degradation), the abort signal, and the
+ * subscribe-after-read race on an already-terminal run.
+ *
+ * These tests deliberately do NOT call `initRealtime()`: when this file
+ * runs standalone the realtime fan-out is absent and the fallback poll is
+ * the only wakeup, proving the mechanism works without LISTEN/NOTIFY
+ * delivery. (In a full-suite run another file may have initialized
+ * realtime in the shared process — the assertions hold either way.)
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@appstrate/db/client";
+import { runs } from "@appstrate/db/schema";
+import { truncateAll } from "../../helpers/db.ts";
+import { createTestContext, type TestContext } from "../../helpers/auth.ts";
+import { seedAgent, seedRun } from "../../helpers/seed.ts";
+import {
+  waitForRunTerminal,
+  parseWaitQuery,
+  MAX_WAIT_SECONDS,
+} from "../../../src/services/run-wait.ts";
+
+describe("waitForRunTerminal", () => {
+  let ctx: TestContext;
+  let scope: { orgId: string; applicationId: string };
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "waitsvc" });
+    scope = { orgId: ctx.orgId, applicationId: ctx.defaultAppId };
+    await seedAgent({ id: "@waitsvc/agent", orgId: ctx.orgId, createdBy: ctx.user.id });
+  });
+
+  function seedSvcRun(status: "running" | "success") {
+    return seedRun({
+      packageId: "@waitsvc/agent",
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      userId: ctx.user.id,
+      status,
+    });
+  }
+
+  it("resolves via the fallback DB poll when the run transitions", async () => {
+    const run = await seedSvcRun("running");
+
+    const start = Date.now();
+    const waitPromise = waitForRunTerminal({
+      runId: run.id,
+      scope,
+      timeoutMs: 10_000,
+      pollIntervalMs: 50,
+    });
+
+    await Bun.sleep(150);
+    await db.update(runs).set({ status: "success" }).where(eq(runs.id, run.id));
+
+    await waitPromise;
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(150);
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
+  it("resolves immediately for an already-terminal run (subscribe-then-check race)", async () => {
+    const run = await seedSvcRun("success");
+
+    const start = Date.now();
+    await waitForRunTerminal({ runId: run.id, scope, timeoutMs: 10_000, pollIntervalMs: 5_000 });
+    // Resolved by the immediate post-subscribe re-check, not poll/timeout.
+    expect(Date.now() - start).toBeLessThan(2_000);
+  });
+
+  it("resolves when the abort signal fires (client disconnect)", async () => {
+    const run = await seedSvcRun("running");
+    const controller = new AbortController();
+
+    const start = Date.now();
+    const waitPromise = waitForRunTerminal({
+      runId: run.id,
+      scope,
+      timeoutMs: 30_000,
+      pollIntervalMs: 5_000,
+      signal: controller.signal,
+    });
+
+    setTimeout(() => controller.abort(), 100);
+    await waitPromise;
+    expect(Date.now() - start).toBeLessThan(2_000);
+  });
+
+  it("returns synchronously when the signal is already aborted", async () => {
+    const run = await seedSvcRun("running");
+    const controller = new AbortController();
+    controller.abort();
+
+    const start = Date.now();
+    await waitForRunTerminal({
+      runId: run.id,
+      scope,
+      timeoutMs: 30_000,
+      signal: controller.signal,
+    });
+    expect(Date.now() - start).toBeLessThan(100);
+  });
+
+  it("resolves on timeout when the run never transitions", async () => {
+    const run = await seedSvcRun("running");
+
+    const start = Date.now();
+    await waitForRunTerminal({ runId: run.id, scope, timeoutMs: 300, pollIntervalMs: 5_000 });
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(280);
+    expect(elapsed).toBeLessThan(2_000);
+  });
+
+  it("resolves promptly when the run does not exist (deleted mid-flight)", async () => {
+    const start = Date.now();
+    await waitForRunTerminal({
+      runId: "run_gone",
+      scope,
+      timeoutMs: 10_000,
+      pollIntervalMs: 5_000,
+    });
+    // The immediate re-check treats "row missing" as terminal.
+    expect(Date.now() - start).toBeLessThan(2_000);
+  });
+});
+
+describe("parseWaitQuery", () => {
+  it("maps absent / false / 0 to no wait", () => {
+    expect(parseWaitQuery(undefined)).toBe(0);
+    expect(parseWaitQuery("false")).toBe(0);
+    expect(parseWaitQuery("0")).toBe(0);
+  });
+
+  it("maps true and bare ?wait to the cap", () => {
+    expect(parseWaitQuery("true")).toBe(MAX_WAIT_SECONDS * 1000);
+    expect(parseWaitQuery("")).toBe(MAX_WAIT_SECONDS * 1000);
+  });
+
+  it("accepts integer seconds and clamps above the cap", () => {
+    expect(parseWaitQuery("10")).toBe(10_000);
+    expect(parseWaitQuery(String(MAX_WAIT_SECONDS))).toBe(MAX_WAIT_SECONDS * 1000);
+    expect(parseWaitQuery("9999")).toBe(MAX_WAIT_SECONDS * 1000);
+  });
+
+  it("rejects negative, fractional, and non-numeric values", () => {
+    for (const bad of ["-1", "1.5", "abc", "NaN", "Infinity"]) {
+      expect(() => parseWaitQuery(bad)).toThrow();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #631.

## What

`GET /api/runs/:id?wait=<seconds>` (or `wait=true` for the max): the server holds the request until the run reaches a terminal status (`success`/`failed`/`timeout`/`cancelled`) or the wait elapses, then returns the run object exactly as the plain call does. A non-terminal response means "poll again". Cap is **55 s** — deliberately below the 60 s idle timeouts common in reverse proxies; values above are clamped.

## How

- **Event-driven wakeup** via the existing `run_update` PG NOTIFY channel (`runs_notify_trigger` → `services/realtime.ts` in-process fan-out). Works across multi-instance deployments (per-instance LISTEN on shared PostgreSQL) **and in Tier 0** — PGlite implements LISTEN/NOTIFY in-process, no Redis involved.
- 2 s fallback DB re-check covers a missed NOTIFY; each check is one narrow indexed query — the wait never pins a DB connection.
- Client disconnect (request signal) aborts the wait — no leaked timers or subscriptions.
- `wait` param Zod-validated (integer, non-negative, `true`/`false`); auth/ownership verified before any waiting starts.
- MCP clients get it automatically: `invoke_operation` forwards query params, `describe_operation` surfaces the new OpenAPI parameter, and the MCP server instructions now point run-completion waits at it instead of sleep+poll loops.

## Files

- `apps/api/src/services/run-wait.ts` — wait orchestration (subscribe + fallback poll + abort)
- `apps/api/src/routes/runs.ts` — param validation + handler wiring
- `apps/api/src/openapi/paths/runs.ts` — OpenAPI param documentation
- `apps/api/src/modules/mcp/router.ts` — MCP instructions update

## Verified

- `bun test` on the two new test files: **22 pass / 0 fail** (immediate return when terminal, wait-then-return on transition, timeout path, clamping, validation rejects).
- `bun run check`: 29/29 tasks green, verify-openapi ALL CHECKS PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)