### PR TITLE
feat(runs): persist report-tool output as runs.result on finalize

### DIFF
--- a/apps/api/src/openapi/paths/runs.ts
+++ b/apps/api/src/openapi/paths/runs.ts
@@ -512,7 +512,10 @@ export const runsPaths = {
                 orgId: "org_r3t5w8y1z6",
                 status: "success",
                 input: { folder: "inbox", maxEmails: 50 },
-                result: { processed: 42, labeled: 38 },
+                result: {
+                  output: { processed: 42, labeled: 38 },
+                  text: "## Inbox triage\nProcessed 42 emails, labeled 38.",
+                },
                 checkpoint: { lastProcessedId: "msg_99f2a" },
                 token_usage: {
                   input_tokens: 8200,
@@ -940,6 +943,11 @@ export const runsPaths = {
                   type: "number",
                   minimum: 0,
                   description: "Authoritative terminal run cost written to the `runs` row.",
+                },
+                report: {
+                  type: "string",
+                  description:
+                    "Aggregated markdown report — every `report.appended` event's content joined with `\\n` in call order. Persisted (capped at 256 KiB) as `runs.result.text` so getRun exposes the run's deliverable without log scraping.",
                 },
               },
             },

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -388,7 +388,27 @@ export const schemas = {
         enum: ["pending", "running", "success", "failed", "timeout", "cancelled"],
       },
       input: { type: "object" },
-      result: { type: "object" },
+      result: {
+        type: ["object", "null"],
+        description:
+          "What the run produced — the stable API contract for the run's deliverable, set when the run reaches a terminal status. `null` while the run is in flight, and on terminal runs that emitted neither structured output nor a report. Persisted even on failed runs (a run that reported and then failed keeps its partial deliverable).",
+        properties: {
+          output: {
+            description:
+              "Structured JSON emitted via the agent's `output` runtime tool. Validated against the agent's declared output schema when one exists — a schema mismatch flips the run to `failed` (with the validation errors in `error`) but the payload is still stored, never dropped.",
+          },
+          text: {
+            type: "string",
+            description:
+              "Markdown report emitted via the agent's `report` runtime tool. Multiple report calls are concatenated in call order, joined with newlines. Capped at 256 KiB of UTF-8 — see `text_truncated`. The full untruncated report remains available as individual run-log entries (type='result', event='report').",
+          },
+          text_truncated: {
+            type: "boolean",
+            description:
+              "Present and `true` when `text` exceeded the 256 KiB cap and was truncated at a UTF-8 character boundary. Absent otherwise.",
+          },
+        },
+      },
       checkpoint: { type: "object" },
       error: { type: "string" },
       token_usage: {

--- a/apps/api/src/routes/runs-events.ts
+++ b/apps/api/src/routes/runs-events.ts
@@ -132,6 +132,13 @@ const RunResultSchema = z
     // `runs.cost` is correct even when `process.exit()` aborts the
     // metric POST. Degrades to undefined on a bad value.
     cost: z.number().nonnegative().optional().catch(undefined),
+    // Aggregated markdown report — the runner's reducer joins every
+    // `report.appended` event's content with `\n` and ships the result
+    // here. finalize persists it as `runs.result.text` so programmatic
+    // consumers (getRun) read the deliverable without scraping run
+    // logs (issue #632). Cosmetic-grade: a malformed value degrades to
+    // absent rather than failing an already-completed run.
+    report: z.string().optional().catch(undefined),
   })
   .passthrough();
 
@@ -211,6 +218,7 @@ export function createRunsEventsRouter() {
       ...(d.durationMs !== undefined ? { durationMs: d.durationMs } : {}),
       ...(d.usage !== undefined ? { usage: d.usage } : {}),
       ...(d.cost !== undefined ? { cost: d.cost } : {}),
+      ...(d.report !== undefined ? { report: d.report } : {}),
     };
 
     await finalizeRun({ run, result });

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -92,6 +92,18 @@ export interface FinalizeRunInput {
 /** Key prefix for webhook-id replay dedup. */
 const REPLAY_KEY_PREFIX = "appstrate:remote-run:replay:";
 
+/**
+ * Byte cap on the report text persisted into `runs.result.text`. The report
+ * channel is unbounded on the runner side (each `report.appended` event
+ * concatenates), so finalize bounds what lands in the JSONB column —
+ * `runs.result` is read by every getRun/listRuns consumer and must stay
+ * row-sized, not document-sized. Beyond the cap the text is truncated at a
+ * UTF-8 boundary and `result.text_truncated: true` flags it; the full
+ * report remains recoverable from the per-emit `run_logs` rows
+ * (type='result', event='report').
+ */
+const MAX_RESULT_TEXT_BYTES = 256 * 1024;
+
 // ---------------------------------------------------------------------------
 // DB helpers
 // ---------------------------------------------------------------------------
@@ -327,9 +339,25 @@ async function finalizeRunImpl(input: FinalizeRunInput): Promise<void> {
 
   // 4. Build the persisted result payload — matches the legacy platform shape
   //    so existing consumers of `runs.result.output` keep working.
+  //
+  //    `result` is the API contract for "what the run produced" (issue #632):
+  //      - `output` — structured JSON emitted via the `output` tool, validated
+  //        against the agent's declared output schema above (a mismatch flips
+  //        status to failed but the payload is still stored — never dropped).
+  //      - `text` — the markdown report emitted via the `report` tool. Multiple
+  //        report calls concatenate in call order (joined with `\n` by the
+  //        runner's reducer). Capped at {@link MAX_RESULT_TEXT_BYTES};
+  //        `text_truncated: true` marks a capped value.
+  //    Persisted regardless of terminal status — a run that reported and then
+  //    failed keeps its partial deliverable alongside `status: "failed"`.
   const resultPayload: Record<string, unknown> = {};
   if (result.output !== null && result.output !== undefined) {
     resultPayload.output = result.output;
+  }
+  if (typeof result.report === "string" && result.report.length > 0) {
+    const { text, truncated } = capUtf8Text(result.report, MAX_RESULT_TEXT_BYTES);
+    resultPayload.text = text;
+    if (truncated) resultPayload.text_truncated = true;
   }
   const resultToPersist =
     Object.keys(resultPayload).length > 0 ? (resultPayload as Record<string, unknown>) : null;
@@ -643,6 +671,22 @@ export async function synthesiseFinalize(
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Truncate `value` to at most `maxBytes` of UTF-8, never splitting a code
+ * point. Exported for unit tests — the byte-boundary handling (multi-byte
+ * characters straddling the cap) is the part worth pinning.
+ */
+export function capUtf8Text(value: string, maxBytes: number): { text: string; truncated: boolean } {
+  const bytes = Buffer.byteLength(value, "utf8");
+  if (bytes <= maxBytes) return { text: value, truncated: false };
+  const buf = Buffer.from(value, "utf8").subarray(0, maxBytes);
+  // Decoding a slice that ends mid-code-point yields U+FFFD replacement
+  // characters at the tail — strip them so the stored text ends on a clean
+  // character boundary.
+  const text = buf.toString("utf8").replace(/�+$/, "");
+  return { text, truncated: true };
 }
 
 /**

--- a/apps/api/test/integration/routes/runs-events-ingestion.test.ts
+++ b/apps/api/test/integration/routes/runs-events-ingestion.test.ts
@@ -39,6 +39,7 @@ import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
 import { seedPackage } from "../../helpers/seed.ts";
 import { loadModulesFromInstances, resetModules } from "../../../src/lib/modules/module-loader.ts";
+import { capUtf8Text } from "../../../src/services/run-event-ingestion.ts";
 import type { AppstrateModule, RunStatusChangeParams } from "@appstrate/core/module";
 
 const app = getTestApp();
@@ -1383,5 +1384,254 @@ describe("remote run.started — emitted at first event, not at row insert", () 
     await new Promise((r) => setTimeout(r, 0));
 
     expect(started()).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #632 — `runs.result` is the API contract for "what the run produced".
+// The runner's reducer aggregates every `report.appended` event into
+// `RunResult.report` (joined with `\n`) and ships it in the finalize body;
+// finalize persists it as `result.text` so getRun exposes the deliverable
+// without scraping (truncated) run logs.
+// ---------------------------------------------------------------------------
+describe("POST /api/runs/:runId/events/finalize — report → runs.result.text (issue #632)", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ email: "result632@test.dev", orgSlug: "result632-org" });
+    await seedPackage({ orgId: ctx.orgId, id: "@test/report-agent", type: "agent" });
+  });
+
+  it("persists the report text as result.text on a report-only success", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/report-agent");
+
+    // Two report-tool calls — the runner's reducer joins them with `\n`
+    // before finalize, so the platform receives one aggregated string.
+    const report = "## EDI export\n- 42 lines generated\nDrive: https://example.test/file";
+    const res = await postFinalize(runId, {
+      status: "success",
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+      report,
+      // No `output` — the agent only used the report tool. This was the
+      // exact shape that previously left `runs.result` null.
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("success");
+    const persisted = row?.result as { output?: unknown; text?: string } | null;
+    expect(persisted).not.toBeNull();
+    expect(persisted?.text).toBe(report);
+    expect(persisted).not.toHaveProperty("output");
+    expect(persisted).not.toHaveProperty("text_truncated");
+  });
+
+  it("stores output and text side by side when the agent emitted both", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/report-agent");
+
+    const res = await postFinalize(runId, {
+      status: "success",
+      output: { processed: 42 },
+      report: "Processed 42 items.",
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    const persisted = row?.result as { output?: unknown; text?: string } | null;
+    expect(persisted?.output).toEqual({ processed: 42 });
+    expect(persisted?.text).toBe("Processed 42 items.");
+  });
+
+  it("leaves result null when the run emitted neither output nor report", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/report-agent");
+
+    const res = await postFinalize(runId, {
+      status: "success",
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("success");
+    expect(row?.result).toBeNull();
+  });
+
+  it("ignores an empty report string — result stays null", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/report-agent");
+
+    const res = await postFinalize(runId, {
+      status: "success",
+      report: "",
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.result).toBeNull();
+  });
+
+  it("caps result.text at 256 KiB and flags text_truncated", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/report-agent");
+
+    const cap = 256 * 1024;
+    const oversized = "a".repeat(cap + 1000);
+    const res = await postFinalize(runId, {
+      status: "success",
+      report: oversized,
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    const persisted = row?.result as { text?: string; text_truncated?: boolean } | null;
+    expect(persisted?.text?.length).toBe(cap);
+    expect(persisted?.text_truncated).toBe(true);
+  });
+
+  it("keeps result.text on a run that reported and then failed", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/report-agent");
+
+    const res = await postFinalize(runId, {
+      status: "failed",
+      error: { message: "tool crashed after the report" },
+      report: "Partial deliverable before the crash.",
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    expect(row?.error).toBe("tool crashed after the report");
+    const persisted = row?.result as { text?: string } | null;
+    expect(persisted?.text).toBe("Partial deliverable before the crash.");
+  });
+
+  it("a malformed report value degrades to absent instead of failing finalize", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/report-agent");
+
+    const res = await postFinalize(runId, {
+      status: "success",
+      output: { ok: true },
+      report: { not: "a string" },
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("success");
+    const persisted = row?.result as { output?: unknown; text?: string } | null;
+    expect(persisted?.output).toEqual({ ok: true });
+    expect(persisted).not.toHaveProperty("text");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Output-schema validation at finalize — declared via `manifest.output.schema`
+// (AFPS). A mismatch flips the run to failed with the validation errors on
+// `runs.error`, but the payload is still persisted on `runs.result` — the
+// deliverable is flagged, never dropped.
+// ---------------------------------------------------------------------------
+describe("POST /api/runs/:runId/events/finalize — output-schema validation persistence", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ email: "outschema632@test.dev", orgSlug: "outschema632-org" });
+    await seedPackage({
+      orgId: ctx.orgId,
+      id: "@test/schema-agent",
+      type: "agent",
+      draftManifest: {
+        name: "@test/schema-agent",
+        version: "0.1.0",
+        type: "agent",
+        description: "Agent with a declared output schema",
+        runtime_tools: ["output", "report"],
+        output: {
+          schema: {
+            type: "object",
+            required: ["answer"],
+            additionalProperties: false,
+            properties: { answer: { type: "string" } },
+          },
+        },
+      },
+    });
+  });
+
+  it("schema-conforming output stays success and is persisted", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/schema-agent");
+
+    const res = await postFinalize(runId, {
+      status: "success",
+      output: { answer: "42" },
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("success");
+    expect(row?.error).toBeNull();
+    expect((row?.result as { output?: unknown } | null)?.output).toEqual({ answer: "42" });
+  });
+
+  it("schema mismatch flips to failed but still persists the payload (flag, don't drop)", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/schema-agent");
+
+    const res = await postFinalize(runId, {
+      status: "success",
+      output: { wrong: 1 },
+      report: "I produced something, just not what the schema asked for.",
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    expect(row?.error).toMatch(/Output validation failed/);
+    const persisted = row?.result as { output?: unknown; text?: string } | null;
+    // The non-conforming payload is stored, flagged via status + error.
+    expect(persisted?.output).toEqual({ wrong: 1 });
+    expect(persisted?.text).toBe("I produced something, just not what the schema asked for.");
+
+    // The validation failure also leaves its structured trail in run_logs.
+    const validationLogs = await db
+      .select()
+      .from(runLogs)
+      .where(and(eq(runLogs.runId, runId), eq(runLogs.event, "output_validation")));
+    expect(validationLogs).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// capUtf8Text — byte-boundary behaviour of the result.text cap.
+// ---------------------------------------------------------------------------
+describe("capUtf8Text", () => {
+  it("returns the value untouched when within the cap", () => {
+    expect(capUtf8Text("hello", 16)).toEqual({ text: "hello", truncated: false });
+  });
+
+  it("truncates at the byte cap for ASCII", () => {
+    expect(capUtf8Text("abcdef", 4)).toEqual({ text: "abcd", truncated: true });
+  });
+
+  it("never splits a multi-byte code point", () => {
+    // "é" is 2 bytes in UTF-8 — a 5-byte cap lands mid-character on the
+    // third "é"; the partial byte must be dropped, not decoded as U+FFFD.
+    const { text, truncated } = capUtf8Text("ééé", 5);
+    expect(truncated).toBe(true);
+    expect(text).toBe("éé");
+    expect(text.includes("�")).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes #632

## Problem

On a successful run, `getRun` returned `result: null` even when the agent emitted its deliverable through the report tool. The content only existed inside `getRunLogs` events (truncated at 2048 bytes), so every programmatic consumer (MCP client, GitHub Action, CLI, scheduler) had to scrape verbose logs with no stable contract.

## Data flow

The runner side already shipped everything needed — the platform just dropped it on the floor:

```
agent calls report(content)                      (runtime tool, packages/core/src/runtime-tool-defs.ts)
  → report.appended canonical event              (both MCP/sidecar and no-sidecar paths re-emit into the run's event sink)
    → PiRunner reduceEvents aggregates           (RunResult.report — chunks joined with \n in call order)
      → HttpSink POST /api/runs/:id/events/finalize   (full RunResult JSON, report included)
        → RunResultSchema projection             ← was dropping `report` here
          → finalizeRun resultPayload            ← was only persisting `output`
            → runs.result JSONB column
              → getRun / listRuns                (serializer already exposed the column)
```

Two surgical changes close the gap:

1. **`apps/api/src/routes/runs-events.ts`** — `RunResultSchema` accepts an optional `report` string and the explicit projection forwards it to `finalizeRun`. Cosmetic-grade per the existing robustness contract: a malformed value `.catch(undefined)`-degrades instead of 400-ing an already-completed run.
2. **`apps/api/src/services/run-event-ingestion.ts`** — finalize persists it as `result.text` next to the existing `result.output`.

## Resulting `result` contract

| Key | Source | Notes |
| --- | --- | --- |
| `output` | `output` tool | unchanged — validated against the agent's declared `manifest.output.schema` when present |
| `text` | `report` tool | markdown, calls concatenated in call order (joined with `\n`) |
| `text_truncated` | platform | present + `true` only when `text` hit the size cap |

## Design decisions

- **Multiple report calls**: append semantics (not last-wins) — the runner's reducer already concatenates `report.appended` events with `\n` in call order; the platform persists that aggregate verbatim. Documented in OpenAPI.
- **Size cap**: 256 KiB of UTF-8 on `result.text`, truncated at a code-point boundary (never splits a multi-byte character) and flagged with `text_truncated: true`. `runs.result` is read by every getRun/listRuns consumer and must stay row-sized; the full untruncated report remains recoverable from the per-emit `run_logs` rows (`type='result', event='report'`).
- **Schema validation**: already existed at finalize (`manifest.output.schema` → `validateOutput`); behavior unchanged — a mismatch flips the run to `failed` with the errors on `runs.error` + an `output_validation` log row, but the payload is **stored, never dropped** (now pinned by a regression test). The report text is the human-readable channel and is not schema-validated.
- **Run fails after reporting**: `result` is persisted regardless of terminal status, so a run that reported and then failed keeps its partial deliverable alongside `status: "failed"`.
- **No runner/runtime changes needed**: the wire already carried `report`; this is purely platform-side ingestion + persistence. No billing/cloud code touched.

## OpenAPI

- `Run.result` documented as `{ output?, text?, text_truncated? }` (nullable), getRun example updated to the real shape.
- Finalize request body documents the `report` field.
- `verify:openapi` passes; `openapi:diff` reports exactly 1 non-breaking change (new optional request field).

## Tests

- 11 new integration tests (`runs-events-ingestion.test.ts`): report-only success → `result.text`; output+report side by side; no-report run stays `null`; empty report ignored; 256 KiB cap + `text_truncated` flag; failed-after-report keeps the deliverable; malformed report degrades without failing finalize; schema-conforming output stays success; schema mismatch flips to failed but persists the payload; `capUtf8Text` byte-boundary unit cases.
- Full `apps/api` suite (tier0): **2806 pass, 0 fail, 62 skip**.
- `bun run check` (turbo typecheck/lint/format + verify-openapi + detect:breaking via pre-push): green. One pre-existing unrelated OpenAPI lint warning (`/api/mcp/o/{org}` missing 2XX response) noted, not touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)