### PR TITLE
feat: getRunLogs level filter, cursor pagination, tunable tool-result truncation cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -273,6 +273,17 @@ CONNECTION_ENCRYPTION_KEY=jChGxOEG1YjCtrkrTYhO7FFdIKaHpe/j1PBY/LqID6s=
 # SIDECAR_MAX_REQUEST_BODY_BYTES=10485760     # default 10 MB (sidecar inbound POST size)
 # SIDECAR_MAX_MCP_ENVELOPE_BYTES=16777216     # default 16 MB (MCP envelope, sized for base64 inflation)
 
+# ─── Optional: Tool-result truncation cap (#633) ─────────────
+# Per-tool-result byte cap applied by the runner BEFORE the result reaches the
+# event sink and `run_logs` — write-time truncation: whatever is cut here is
+# unrecoverable through `getRunLogs`. Raise it when consumers read run output
+# from the logs and 2 KB tool results lose the part they need. Keep it
+# comfortably below 32768: the platform drops any `run_logs.data` payload
+# exceeding 32 KB wholesale (runLogDataSchema), which is worse than truncation.
+# Forwarded into agent containers automatically; invalid values fall back to
+# the default.
+# TOOL_RESULT_BYTE_LIMIT=2048                 # default 2 KB (per tool result)
+
 # ─── Optional: Sidecar token-budget overrides (#464) ─────────
 # Per-call and cumulative-per-run inline-vs-spill thresholds for `provider_call`
 # tool outputs. The sidecar's TokenBudget refuses to inline content that would

--- a/apps/api/src/lib/pagination-link.ts
+++ b/apps/api/src/lib/pagination-link.ts
@@ -74,6 +74,30 @@ export function setCursorLinkHeader({
   }
 }
 
+interface SinceLinkArgs {
+  c: Context;
+  /** True when the current page is followed by another. */
+  hasMore: boolean;
+  /** Monotonic id of the last row on this page; required when `hasMore`. */
+  lastId?: number | undefined;
+}
+
+/**
+ * Set RFC 5988 `Link` header for `?since=<id>`-cursor responses
+ * (e.g. `/api/runs/{id}/logs`). Same hypermedia contract as the
+ * Stripe-style helper above, but keyed on the endpoint's existing
+ * monotonic `since` cursor so the polling-tail contract and the
+ * pagination contract are one and the same parameter. Other query
+ * params (`level`, `limit`, …) are preserved so the `next` URL
+ * carries the caller's filters forward.
+ */
+export function setSinceLinkHeader({ c, hasMore, lastId }: SinceLinkArgs): void {
+  if (!hasMore || lastId === undefined) return;
+  const url = new URL(c.req.url);
+  url.searchParams.set("since", String(lastId));
+  c.header("Link", `<${url.toString()}>; rel="next"`);
+}
+
 interface OffsetLinkArgs {
   c: Context;
   /** Current page limit. */

--- a/apps/api/src/openapi/headers.ts
+++ b/apps/api/src/openapi/headers.ts
@@ -31,4 +31,12 @@ export const headers = {
     description: "Seconds to wait before retrying. Present on 429 responses.",
     schema: { type: "integer" },
   },
+  Link: {
+    description:
+      'RFC 5988 pagination link(s), e.g. `<https://…?since=42&limit=100>; rel="next"`. Present only when another page follows — absence means the listing is complete.',
+    schema: {
+      type: "string",
+      example: '<https://example.com/api/runs/run_x/logs?since=42&limit=100>; rel="next"',
+    },
+  },
 } as const;

--- a/apps/api/src/openapi/paths/runs.ts
+++ b/apps/api/src/openapi/paths/runs.ts
@@ -548,7 +548,7 @@ export const runsPaths = {
       tags: ["Runs"],
       summary: "Get run logs",
       description:
-        "Get persisted log entries for a run. Pass `?since=<id>` to receive only entries with `id > since` — the cursor used by the CLI's polling tail to bound per-poll payload growth. `id` is a monotonic BIGSERIAL; an invalid cursor falls back to the full list rather than 400.",
+        'Get persisted log entries for a run. Pass `?since=<id>` to receive only entries with `id > since` — the cursor used by the CLI\'s polling tail to bound per-poll payload growth, and the pagination cursor when combined with `?limit=`. Pass `?level=` to filter by minimum severity (`level=info` skips debug breadcrumbs). When `limit` is set and more entries follow, an RFC 5988 `Link: <…?since=<lastId>>; rel="next"` response header points at the next page. `id` is a monotonic BIGSERIAL; invalid `since`/`level`/`limit` values fall back to the unfiltered default rather than 400 so a stale cursor never breaks a polling tail. Without query parameters the full chronological history is returned (backward-compatible default). Note: tool-result payloads inside `data` are truncated at write time by the runner (default 2048 bytes, operator-tunable via `TOOL_RESULT_BYTE_LIMIT`) — entries already persisted truncated cannot be recovered by this endpoint.',
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -559,7 +559,23 @@ export const runsPaths = {
           required: false,
           schema: { type: "integer", format: "int64", minimum: 0 },
           description:
-            "Return only log entries with `id > since`. Used by the CLI's `appstrate run` remote polling loop to fetch incremental tails without re-shipping the full history each poll.",
+            'Return only log entries with `id > since`. Used by the CLI\'s `appstrate run` remote polling loop to fetch incremental tails without re-shipping the full history each poll, and as the cursor in the `Link; rel="next"` pagination header.',
+        },
+        {
+          name: "level",
+          in: "query",
+          required: false,
+          schema: { type: "string", enum: ["debug", "info", "warn", "error"] },
+          description:
+            "Minimum severity to include (`debug < info < warn < error`). `level=info` returns info, warn and error entries. Defaults to `debug` (everything).",
+        },
+        {
+          name: "limit",
+          in: "query",
+          required: false,
+          schema: { type: "integer", minimum: 1, maximum: 1000 },
+          description:
+            'Maximum number of entries to return. When more entries follow, the response carries a `Link; rel="next"` header whose URL re-uses `since` as the cursor. Absent means no cap (full history).',
         },
       ],
       responses: {
@@ -568,6 +584,7 @@ export const runsPaths = {
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
+            Link: { $ref: "#/components/headers/Link" },
           },
           content: {
             "application/json": {

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -11,6 +11,7 @@ import {
   deletePackageRuns,
   listPackageRuns,
   listRunLogs,
+  RUN_LOG_LEVELS,
 } from "../services/state/runs.ts";
 import { getVersionDetail } from "../services/package-versions.ts";
 import { parseRequestInput } from "../services/input-parser.ts";
@@ -21,7 +22,7 @@ import { abortRun } from "../services/run-tracker.ts";
 import { rateLimit } from "../middleware/rate-limit.ts";
 import { idempotency } from "../middleware/idempotency.ts";
 import { notFound, conflict } from "../lib/errors.ts";
-import { setOffsetLinkHeader } from "../lib/pagination-link.ts";
+import { setOffsetLinkHeader, setSinceLinkHeader } from "../lib/pagination-link.ts";
 import { requireAgent } from "../middleware/guards.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
 import { getOrchestrator } from "../services/orchestrator/index.ts";
@@ -232,6 +233,17 @@ export function createRunsRouter() {
   // length. Invalid values (non-numeric, negative) are silently ignored
   // rather than 400'd: a stale or malformed cursor on a re-fetch must
   // never break the tail.
+  //
+  // Optional `?level=<debug|info|warn|error>` filters by MINIMUM severity
+  // (`level=info` skips debug breadcrumbs). Optional `?limit=<1..1000>`
+  // caps the page size; when more rows follow, an RFC 5988
+  // `Link: <…?since=<lastId>>; rel="next"` header points at the next page
+  // — `since` doubles as both the polling-tail cursor and the pagination
+  // cursor, so the two contracts cannot drift. All three params follow
+  // the endpoint's lenient posture: malformed values fall back to the
+  // unfiltered default rather than 400, because a stale cursor or a
+  // typo'd filter on a re-fetch must never break the tail. Default
+  // behavior (no params) is unchanged: the full chronological history.
   router.get("/runs/:id/logs", async (c) => {
     const runId = c.req.param("id");
     const scope = getAppScope(c);
@@ -251,13 +263,31 @@ export function createRunsRouter() {
       if (Number.isInteger(parsed) && parsed >= 0) sinceId = parsed;
     }
 
+    const minLevel = z.enum(RUN_LOG_LEVELS).optional().catch(undefined).parse(c.req.query("level"));
+
+    const limit = z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(1000)
+      .optional()
+      .catch(undefined)
+      .parse(c.req.query("limit"));
+
     // Ownership was just verified via getRun(scope) above — we can hand
-    // off to the org-scoped log reader safely.
-    const logs = await listRunLogs({
+    // off to the org-scoped log reader safely. Over-fetch by one row when
+    // a limit is set so `hasMore` is known without a COUNT round-trip.
+    const rows = await listRunLogs({
       runId,
       orgId: scope.orgId,
       ...(sinceId !== undefined ? { sinceId } : {}),
+      ...(minLevel !== undefined ? { minLevel } : {}),
+      ...(limit !== undefined ? { limit: limit + 1 } : {}),
     });
+
+    const hasMore = limit !== undefined && rows.length > limit;
+    const logs = hasMore ? rows.slice(0, limit) : rows;
+    setSinceLinkHeader({ c, hasMore, lastId: logs.at(-1)?.id });
 
     return c.json(logs);
   });

--- a/apps/api/src/services/state/runs.ts
+++ b/apps/api/src/services/state/runs.ts
@@ -955,23 +955,36 @@ export async function getRunByOrg(args: { runId: string; orgId: string }) {
  * history. Not legal with `order: "desc"` — the call throws to surface
  * the misuse rather than silently fall back to a full scan.
  *
+ * `minLevel` filters by minimum severity using the fixed `run_logs.level`
+ * domain (`debug < info < warn < error`): `minLevel: "info"` returns
+ * info/warn/error rows and skips the debug breadcrumbs. Implemented as an
+ * `IN (...)` filter so the check constraint's domain stays the single
+ * source of truth — no numeric severity column needed.
+ *
  * Org-scoped by design — `run_logs` has no `applicationId` column, and
  * the object-args shape is the module-facing public contract. App-scoped
  * callers must verify run ownership via `getRun(scope, runId)` first.
  */
+export const RUN_LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
+export type RunLogLevel = (typeof RUN_LOG_LEVELS)[number];
+
 export async function listRunLogs(args: {
   runId: string;
   orgId: string;
   limit?: number;
   order?: "asc" | "desc";
   sinceId?: number;
+  minLevel?: RunLogLevel;
 }) {
-  const { runId, orgId, limit, order = "asc", sinceId } = args;
+  const { runId, orgId, limit, order = "asc", sinceId, minLevel } = args;
   if (sinceId !== undefined && order === "desc") {
     throw new Error("listRunLogs: sinceId is not supported with order=desc");
   }
   const filters = [eq(runLogs.runId, runId), eq(runLogs.orgId, orgId)];
   if (sinceId !== undefined) filters.push(gt(runLogs.id, sinceId));
+  if (minLevel !== undefined && minLevel !== "debug") {
+    filters.push(inArray(runLogs.level, RUN_LOG_LEVELS.slice(RUN_LOG_LEVELS.indexOf(minLevel))));
+  }
   const q = db
     .select()
     .from(runLogs)

--- a/apps/api/test/integration/routes/runs.test.ts
+++ b/apps/api/test/integration/routes/runs.test.ts
@@ -622,6 +622,168 @@ describe("Runs API", () => {
       const body = (await res.json()) as unknown[];
       expect(body).toHaveLength(0);
     });
+
+    it("filters by ?level= minimum severity", async () => {
+      await seedAgent({ id: "@runorg/level-agent", orgId: ctx.orgId, createdBy: ctx.user.id });
+      const run = await seedRun({
+        packageId: "@runorg/level-agent",
+        orgId: ctx.orgId,
+        applicationId: ctx.defaultAppId,
+        userId: ctx.user.id,
+        status: "running",
+      });
+      await seedRunLog({ runId: run.id, orgId: ctx.orgId, message: "boot", level: "debug" });
+      await seedRunLog({ runId: run.id, orgId: ctx.orgId, message: "progress", level: "info" });
+      await seedRunLog({ runId: run.id, orgId: ctx.orgId, message: "careful", level: "warn" });
+      await seedRunLog({ runId: run.id, orgId: ctx.orgId, message: "boom", level: "error" });
+
+      // level=info → info, warn, error (skips debug)
+      const res = await app.request(`/api/runs/${run.id}/logs?level=info`, {
+        headers: authHeaders(ctx),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Array<{ level: string; message: string }>;
+      expect(body.map((l) => l.level)).toEqual(["info", "warn", "error"]);
+
+      // level=error → error only
+      const resErr = await app.request(`/api/runs/${run.id}/logs?level=error`, {
+        headers: authHeaders(ctx),
+      });
+      const bodyErr = (await resErr.json()) as Array<{ level: string }>;
+      expect(bodyErr.map((l) => l.level)).toEqual(["error"]);
+
+      // level=debug → everything (explicit minimum == default)
+      const resAll = await app.request(`/api/runs/${run.id}/logs?level=debug`, {
+        headers: authHeaders(ctx),
+      });
+      const bodyAll = (await resAll.json()) as unknown[];
+      expect(bodyAll).toHaveLength(4);
+    });
+
+    it("ignores an invalid ?level= value (returns full list)", async () => {
+      await seedAgent({ id: "@runorg/badlevel-agent", orgId: ctx.orgId, createdBy: ctx.user.id });
+      const run = await seedRun({
+        packageId: "@runorg/badlevel-agent",
+        orgId: ctx.orgId,
+        applicationId: ctx.defaultAppId,
+        userId: ctx.user.id,
+        status: "running",
+      });
+      await seedRunLog({ runId: run.id, orgId: ctx.orgId, message: "a", level: "debug" });
+      await seedRunLog({ runId: run.id, orgId: ctx.orgId, message: "b", level: "info" });
+
+      const res = await app.request(`/api/runs/${run.id}/logs?level=loud`, {
+        headers: authHeaders(ctx),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as unknown[];
+      expect(body).toHaveLength(2);
+    });
+
+    it("paginates with ?limit= and emits a Link rel=next header re-using since", async () => {
+      await seedAgent({ id: "@runorg/page-agent", orgId: ctx.orgId, createdBy: ctx.user.id });
+      const run = await seedRun({
+        packageId: "@runorg/page-agent",
+        orgId: ctx.orgId,
+        applicationId: ctx.defaultAppId,
+        userId: ctx.user.id,
+        status: "running",
+      });
+      const log1 = await seedRunLog({ runId: run.id, orgId: ctx.orgId, message: "one" });
+      const log2 = await seedRunLog({ runId: run.id, orgId: ctx.orgId, message: "two" });
+      const log3 = await seedRunLog({ runId: run.id, orgId: ctx.orgId, message: "three" });
+
+      const res = await app.request(`/api/runs/${run.id}/logs?limit=2`, {
+        headers: authHeaders(ctx),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Array<{ id: number }>;
+      expect(body.map((l) => l.id)).toEqual([log1.id, log2.id]);
+
+      // Link header points at the next page, keyed on the last returned id.
+      const link = res.headers.get("Link");
+      expect(link).toContain(`since=${log2.id}`);
+      expect(link).toContain('rel="next"');
+      expect(link).toContain("limit=2");
+
+      // Following the cursor returns the final page with no further Link.
+      const res2 = await app.request(`/api/runs/${run.id}/logs?limit=2&since=${log2.id}`, {
+        headers: authHeaders(ctx),
+      });
+      expect(res2.status).toBe(200);
+      const body2 = (await res2.json()) as Array<{ id: number }>;
+      expect(body2.map((l) => l.id)).toEqual([log3.id]);
+      expect(res2.headers.get("Link")).toBeNull();
+    });
+
+    it("?limit= exactly matching the row count emits no Link header", async () => {
+      await seedAgent({ id: "@runorg/exact-agent", orgId: ctx.orgId, createdBy: ctx.user.id });
+      const run = await seedRun({
+        packageId: "@runorg/exact-agent",
+        orgId: ctx.orgId,
+        applicationId: ctx.defaultAppId,
+        userId: ctx.user.id,
+        status: "running",
+      });
+      await seedRunLog({ runId: run.id, orgId: ctx.orgId, message: "only" });
+
+      const res = await app.request(`/api/runs/${run.id}/logs?limit=1`, {
+        headers: authHeaders(ctx),
+      });
+      expect(res.status).toBe(200);
+      expect((await res.json()) as unknown[]).toHaveLength(1);
+      expect(res.headers.get("Link")).toBeNull();
+    });
+
+    it("combines ?since=, ?level= and ?limit=", async () => {
+      await seedAgent({ id: "@runorg/combo-agent", orgId: ctx.orgId, createdBy: ctx.user.id });
+      const run = await seedRun({
+        packageId: "@runorg/combo-agent",
+        orgId: ctx.orgId,
+        applicationId: ctx.defaultAppId,
+        userId: ctx.user.id,
+        status: "running",
+      });
+      const first = await seedRunLog({ runId: run.id, orgId: ctx.orgId, level: "info" });
+      await seedRunLog({ runId: run.id, orgId: ctx.orgId, level: "debug" });
+      const kept1 = await seedRunLog({ runId: run.id, orgId: ctx.orgId, level: "warn" });
+      const kept2 = await seedRunLog({ runId: run.id, orgId: ctx.orgId, level: "error" });
+      await seedRunLog({ runId: run.id, orgId: ctx.orgId, level: "info" });
+
+      const res = await app.request(
+        `/api/runs/${run.id}/logs?since=${first.id}&level=info&limit=2`,
+        { headers: authHeaders(ctx) },
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Array<{ id: number }>;
+      expect(body.map((l) => l.id)).toEqual([kept1.id, kept2.id]);
+      const link = res.headers.get("Link");
+      expect(link).toContain(`since=${kept2.id}`);
+      expect(link).toContain("level=info");
+      expect(link).toContain('rel="next"');
+    });
+
+    it("default behavior without new params is unchanged (full list, no Link)", async () => {
+      await seedAgent({ id: "@runorg/compat-agent", orgId: ctx.orgId, createdBy: ctx.user.id });
+      const run = await seedRun({
+        packageId: "@runorg/compat-agent",
+        orgId: ctx.orgId,
+        applicationId: ctx.defaultAppId,
+        userId: ctx.user.id,
+        status: "running",
+      });
+      await seedRunLog({ runId: run.id, orgId: ctx.orgId, level: "debug" });
+      await seedRunLog({ runId: run.id, orgId: ctx.orgId, level: "info" });
+      await seedRunLog({ runId: run.id, orgId: ctx.orgId, level: "error" });
+
+      const res = await app.request(`/api/runs/${run.id}/logs`, {
+        headers: authHeaders(ctx),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as unknown[];
+      expect(body).toHaveLength(3);
+      expect(res.headers.get("Link")).toBeNull();
+    });
   });
 
   // ─── POST /api/runs/:id/cancel ─────────────────────────────

--- a/packages/runner-pi/src/container-env.ts
+++ b/packages/runner-pi/src/container-env.ts
@@ -172,6 +172,19 @@ export function buildRuntimePiEnv(opts: RuntimePiEnvOptions): Record<string, str
   // runtime never builds JSON-RPC envelopes itself.
   Object.assign(env, pickOperatorSidecarEnv(["SIDECAR_MAX_REQUEST_BODY_BYTES"]));
 
+  // Forward the operator-tunable tool-result truncation cap (read by
+  // `truncateToolResult` in pi-runner.ts). Tool results are truncated at
+  // WRITE time before they reach the event sink / `run_logs`, so this is
+  // the only knob that controls how much of a tool result survives into
+  // `getRunLogs`. Absent or empty → the runner's compiled 2048-byte
+  // default. Keep below the platform's 32 KB `run_logs.data` cap.
+  {
+    const toolResultLimit = process.env.TOOL_RESULT_BYTE_LIMIT;
+    if (toolResultLimit !== undefined && toolResultLimit !== "") {
+      env.TOOL_RESULT_BYTE_LIMIT = toolResultLimit;
+    }
+  }
+
   return env;
 }
 

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -549,8 +549,28 @@ type PiSubscribedEvent = { type: string } & Record<string, unknown>;
  * tool calls per run × 2KB = 200KB stays well below the platform's
  * `SIDECAR_MAX_MCP_ENVELOPE_BYTES` defaults and a single `run_logs`
  * row stays cheap.
+ *
+ * Operator-tunable via the `TOOL_RESULT_BYTE_LIMIT` env var (same
+ * runtime-env contract as `MODEL_RETRY_ENABLED`, forwarded into the
+ * agent container by `container-env.ts`). Tool results carrying the
+ * run's actual output are truncated at WRITE time — no read-side knob
+ * can recover them afterwards — so deployments whose consumers read
+ * `getRunLogs` for results raise this cap here. Keep it comfortably
+ * below the platform's 32 KB `run_logs.data` write-boundary cap
+ * (`runLogDataSchema`): a `data` payload exceeding that is dropped
+ * wholesale, which is strictly worse than truncation. Invalid or
+ * non-positive values fall back to the compiled default.
  */
 const TOOL_RESULT_BYTE_LIMIT = 2048;
+
+/** Resolve the effective tool-result cap: env override or compiled default. */
+export function toolResultByteLimit(): number {
+  const raw = process.env.TOOL_RESULT_BYTE_LIMIT;
+  if (raw === undefined || raw === "") return TOOL_RESULT_BYTE_LIMIT;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) return TOOL_RESULT_BYTE_LIMIT;
+  return parsed;
+}
 
 /**
  * Truncate an arbitrary tool result for safe transport on the event
@@ -567,7 +587,7 @@ const TOOL_RESULT_BYTE_LIMIT = 2048;
  */
 export function truncateToolResult(
   result: unknown,
-  limitBytes: number = TOOL_RESULT_BYTE_LIMIT,
+  limitBytes: number = toolResultByteLimit(),
 ): unknown {
   if (result === undefined || result === null) return result;
   if (typeof result === "string") {

--- a/packages/runner-pi/test/container-env.test.ts
+++ b/packages/runner-pi/test/container-env.test.ts
@@ -163,6 +163,29 @@ describe("buildRuntimePiEnv", () => {
     }
   });
 
+  it("forwards TOOL_RESULT_BYTE_LIMIT to the agent container when set on the host", () => {
+    const original = process.env.TOOL_RESULT_BYTE_LIMIT;
+    process.env.TOOL_RESULT_BYTE_LIMIT = "16384";
+    try {
+      const env = buildRuntimePiEnv({ model, agentPrompt: "p" });
+      expect(env.TOOL_RESULT_BYTE_LIMIT).toBe("16384");
+    } finally {
+      if (original === undefined) delete process.env.TOOL_RESULT_BYTE_LIMIT;
+      else process.env.TOOL_RESULT_BYTE_LIMIT = original;
+    }
+  });
+
+  it("does not emit TOOL_RESULT_BYTE_LIMIT when unset on the host", () => {
+    const original = process.env.TOOL_RESULT_BYTE_LIMIT;
+    delete process.env.TOOL_RESULT_BYTE_LIMIT;
+    try {
+      const env = buildRuntimePiEnv({ model, agentPrompt: "p" });
+      expect(env.TOOL_RESULT_BYTE_LIMIT).toBeUndefined();
+    } finally {
+      if (original !== undefined) process.env.TOOL_RESULT_BYTE_LIMIT = original;
+    }
+  });
+
   it("does not emit SIDECAR_MAX_REQUEST_BODY_BYTES when unset on the host", () => {
     const original = process.env.SIDECAR_MAX_REQUEST_BODY_BYTES;
     delete process.env.SIDECAR_MAX_REQUEST_BODY_BYTES;

--- a/packages/runner-pi/test/session-bridge.test.ts
+++ b/packages/runner-pi/test/session-bridge.test.ts
@@ -447,6 +447,40 @@ describe("truncateToolResult", () => {
       reason: "non_serialisable",
     });
   });
+
+  it("honors the TOOL_RESULT_BYTE_LIMIT env override as the default cap", () => {
+    const original = process.env.TOOL_RESULT_BYTE_LIMIT;
+    process.env.TOOL_RESULT_BYTE_LIMIT = "8192";
+    try {
+      // 3000 bytes fits under the raised cap — returned verbatim where the
+      // compiled 2048 default would have truncated it.
+      const s = "a".repeat(3000);
+      expect(truncateToolResult(s)).toBe(s);
+      // …and a payload above the raised cap still truncates against it.
+      const big = { data: "x".repeat(10000) };
+      const out = truncateToolResult(big) as Record<string, unknown>;
+      expect(out.__truncated).toBe(true);
+      expect(out.limit).toBe(8192);
+    } finally {
+      if (original === undefined) delete process.env.TOOL_RESULT_BYTE_LIMIT;
+      else process.env.TOOL_RESULT_BYTE_LIMIT = original;
+    }
+  });
+
+  it("falls back to the compiled default on an invalid TOOL_RESULT_BYTE_LIMIT", () => {
+    const original = process.env.TOOL_RESULT_BYTE_LIMIT;
+    try {
+      for (const bad of ["not-a-number", "-1", "0", "12.5"]) {
+        process.env.TOOL_RESULT_BYTE_LIMIT = bad;
+        const out = truncateToolResult({ data: "x".repeat(3000) }) as Record<string, unknown>;
+        expect(out.__truncated).toBe(true);
+        expect(out.limit).toBe(2048);
+      }
+    } finally {
+      if (original === undefined) delete process.env.TOOL_RESULT_BYTE_LIMIT;
+      else process.env.TOOL_RESULT_BYTE_LIMIT = original;
+    }
+  });
 });
 
 describe("installSessionBridge — agent_end + usage accumulation", () => {


### PR DESCRIPTION
Fixes #633

## Where the truncation happens — and what that means

The 2048-byte `__truncated` cap is applied at **write time**, inside the runner (`packages/runner-pi/src/pi-runner.ts`, `TOOL_RESULT_BYTE_LIMIT`), before the tool result ever reaches the event sink and the `run_logs` row. Whatever is cut there is **unrecoverable** on the read side — which is why this PR does *not* add the proposed `getRunLogEntry` per-entry fetch: it could only re-serve the same truncated payload. The fix has to be at the write boundary:

- **`TOOL_RESULT_BYTE_LIMIT` env var** — operator-tunable cap (default unchanged at 2048), read by `truncateToolResult` (same runtime-env contract as `MODEL_RETRY_ENABLED`) and forwarded from the host into agent containers by `buildRuntimePiEnv`, following the existing `SIDECAR_MAX_REQUEST_BODY_BYTES` operator-env pattern. Documented in `.env.example`, including the hard companion constraint: stay below 32 KB, because `runLogDataSchema` drops any `run_logs.data` payload over 32 KB *wholesale* at the platform write boundary — strictly worse than truncation.

## Read API: filter + pagination (reusing existing conventions, no new DSL)

`GET /api/runs/{id}/logs` gains:

- **`level=<debug|info|warn|error>`** — minimum-severity filter matching the fixed `run_logs.level` domain (`run_logs_level_valid` check constraint). `level=info` skips the debug/boot breadcrumbs.
- **`limit=<1..1000>`** — page-size cap. When more entries follow, the response carries an RFC 5988 `Link: <…?since=<lastId>>; rel="next"` header (the #278 convention already used by `/api/runs` and `/api/end-users` via `pagination-link.ts`). Crucially, the pagination cursor **is** the endpoint's existing `since` param — the CLI's polling-tail cursor and the pagination cursor are one and the same monotonic id, so MCP clients get incremental tailing without SSE and there's no second competing cursor vocabulary.

All params follow the endpoint's documented lenient posture: malformed `since`/`level`/`limit` fall back to the unfiltered default instead of 400, so a stale cursor never breaks a tail.

## Backward compatibility

Default behavior without query params is byte-for-byte unchanged (full chronological array, no `Link` header), so existing consumers need no changes:

- web SPA (`use-runs.ts` fetches `/runs/:id/logs` bare)
- CLI `runRemote` polling loop (`?since=` semantics untouched)
- github-action polling fallback

## OpenAPI

`getRunLogs` spec updated (new params, `Link` response header component, write-time-truncation note in the description). `verify:openapi` passes (203 endpoints); `detect-breaking-changes` reports 0 breaking against the baseline.

## Tests

- `apps/api/test/integration/routes/runs.test.ts` — 6 new tests: level filter (min-severity + invalid value fallback), limit + `Link` cursor round-trip, exact-limit no-Link, combined `since+level+limit`, backward-compat default. Full file: 49 pass / 0 fail against the local test Postgres.
- `packages/runner-pi` — env-override + invalid-value-fallback tests for `truncateToolResult`, container-env forwarding tests. Full package suite: 137 pass / 0 fail.
- `bun run check` (turbo: tsc + eslint + prettier × 29 tasks + OpenAPI verification): all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)