### PR TITLE
feat(proxies): return full resource from mutating endpoints (#646)

### DIFF
--- a/apps/api/src/openapi/paths/proxies.ts
+++ b/apps/api/src/openapi/paths/proxies.ts
@@ -88,12 +88,33 @@ export const proxiesPaths = {
           content: {
             "application/json": {
               schema: {
-                type: "object",
-                properties: {
-                  id: { type: "string" },
-                },
+                allOf: [
+                  { $ref: "#/components/schemas/OrgProxy" },
+                  {
+                    type: "object",
+                    properties: {
+                      id: {
+                        type: "string",
+                        description:
+                          "The created proxy's id. Same value as the resource's `id`; retained as a top-level field for backward compatibility.",
+                      },
+                    },
+                  },
+                ],
+                description:
+                  "The created proxy resource — same shape as the `GET /api/proxies` list items — so no follow-up GET is needed.",
               },
-              example: { id: "cm6pqr679" },
+              example: {
+                id: "cm6pqr679",
+                label: "US Residential Proxy",
+                urlPrefix: "http://user:****@us-proxy.example.com:8080",
+                source: "custom",
+                enabled: true,
+                isDefault: false,
+                created_by: "usr_k7x9m2p4q1",
+                createdAt: "2026-01-10T08:00:00Z",
+                updatedAt: "2026-01-10T08:00:00Z",
+              },
             },
           },
         },
@@ -138,7 +159,35 @@ export const proxiesPaths = {
           },
           content: {
             "application/json": {
-              schema: { type: "object", properties: { success: { type: "boolean" } } },
+              schema: {
+                type: "object",
+                required: ["success", "proxy"],
+                properties: {
+                  success: {
+                    type: "boolean",
+                    description: "Always true on success. Retained for backward compatibility.",
+                  },
+                  proxy: {
+                    description:
+                      "The affected default proxy resource — same shape as the `GET /api/proxies` list items — or null when the default was unset (proxyId null).",
+                    oneOf: [{ $ref: "#/components/schemas/OrgProxy" }, { type: "null" }],
+                  },
+                },
+              },
+              example: {
+                success: true,
+                proxy: {
+                  id: "cm6pqr679",
+                  label: "US Residential Proxy",
+                  urlPrefix: "http://user:****@us-proxy.example.com:8080",
+                  source: "custom",
+                  enabled: true,
+                  isDefault: true,
+                  created_by: "usr_k7x9m2p4q1",
+                  createdAt: "2026-01-10T08:00:00Z",
+                  updatedAt: "2026-01-10T08:00:00Z",
+                },
+              },
             },
           },
         },
@@ -183,7 +232,34 @@ export const proxiesPaths = {
           },
           content: {
             "application/json": {
-              schema: { type: "object", properties: { id: { type: "string" } } },
+              schema: {
+                allOf: [
+                  { $ref: "#/components/schemas/OrgProxy" },
+                  {
+                    type: "object",
+                    properties: {
+                      id: {
+                        type: "string",
+                        description:
+                          "The updated proxy's id. Same value as the resource's `id`; retained as a top-level field for backward compatibility.",
+                      },
+                    },
+                  },
+                ],
+                description:
+                  "The updated proxy resource — same shape as the `GET /api/proxies` list items — so no follow-up GET is needed.",
+              },
+              example: {
+                id: "cm6pqr679",
+                label: "US Residential Proxy",
+                urlPrefix: "http://user:****@us-proxy.example.com:8080",
+                source: "custom",
+                enabled: true,
+                isDefault: false,
+                created_by: "usr_k7x9m2p4q1",
+                createdAt: "2026-01-10T08:00:00Z",
+                updatedAt: "2026-01-12T09:00:00Z",
+              },
             },
           },
         },

--- a/apps/api/src/routes/proxies.ts
+++ b/apps/api/src/routes/proxies.ts
@@ -9,6 +9,7 @@ import { requirePermission } from "../middleware/require-permission.ts";
 import { isSystemProxy } from "../services/proxy-registry.ts";
 import {
   listOrgProxies,
+  getOrgProxy,
   createOrgProxy,
   updateOrgProxy,
   deleteOrgProxy,
@@ -66,7 +67,11 @@ export function createProxiesRouter() {
         resourceId: id,
         after: { label: data.label, url: data.url },
       });
-      return c.json({ id }, 201);
+      // Return the created resource — same shape as the GET list serializer —
+      // so callers don't need a follow-up GET. The legacy `id` field is kept
+      // alongside the resource for backward compatibility.
+      const proxy = await getOrgProxy(orgId, id);
+      return c.json({ id, ...proxy }, 201);
     } catch (err) {
       const msg = getErrorMessage(err);
       if (msg.includes("blocked network")) {
@@ -91,7 +96,12 @@ export function createProxiesRouter() {
         resourceType: "proxy",
         resourceId: data.proxyId,
       });
-      return c.json({ success: true });
+      // Return the affected default proxy resource so callers see the new
+      // default state without a follow-up GET. `success` is kept for backward
+      // compatibility. When the default is unset (proxyId null) there is no
+      // resource, so `proxy` is null.
+      const proxy = data.proxyId ? await getOrgProxy(orgId, data.proxyId) : null;
+      return c.json({ success: true, proxy });
     } catch (err) {
       logger.error("Set default proxy failed", {
         error: getErrorMessage(err),
@@ -138,7 +148,11 @@ export function createProxiesRouter() {
         resourceId: proxyId,
         after: data as unknown as Record<string, unknown>,
       });
-      return c.json({ id: proxyId });
+      // Return the updated resource — same shape as the GET list serializer —
+      // so callers don't need a follow-up GET. The legacy `id` field is kept
+      // alongside the resource for backward compatibility.
+      const proxy = await getOrgProxy(orgId, proxyId);
+      return c.json({ id: proxyId, ...proxy });
     } catch (err) {
       const msg = getErrorMessage(err);
       if (msg.includes("blocked network")) {

--- a/apps/api/src/services/org-proxies.ts
+++ b/apps/api/src/services/org-proxies.ts
@@ -65,6 +65,19 @@ export async function listOrgProxies(orgId: string): Promise<OrgProxyInfo[]> {
   });
 }
 
+// --- Single-item read (system + DB) ---
+
+/**
+ * Fetch a single proxy (built-in or custom) in the exact same shape as
+ * {@link listOrgProxies} / the `GET` list serializer. Used by mutating
+ * handlers to return the resulting resource without a follow-up GET.
+ * Returns null if no proxy with that id is visible to the org.
+ */
+export async function getOrgProxy(orgId: string, proxyId: string): Promise<OrgProxyInfo | null> {
+  const proxies = await listOrgProxies(orgId);
+  return proxies.find((p) => p.id === proxyId) ?? null;
+}
+
 // --- CRUD (DB proxies only) ---
 
 export async function createOrgProxy(

--- a/apps/api/test/integration/routes/proxies.test.ts
+++ b/apps/api/test/integration/routes/proxies.test.ts
@@ -28,7 +28,7 @@ describe("Proxies API", () => {
   });
 
   describe("POST /api/proxies", () => {
-    it("creates a proxy", async () => {
+    it("creates a proxy and returns the full resource", async () => {
       const res = await app.request("/api/proxies", {
         method: "POST",
         headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
@@ -40,7 +40,89 @@ describe("Proxies API", () => {
 
       expect(res.status).toBe(201);
       const body = (await res.json()) as any;
+      // Legacy compat field retained.
       expect(body.id).toBeTruthy();
+      // Full resource — same shape as the GET list serializer.
+      expect(body.label).toBe("Test Proxy");
+      expect(body.source).toBe("custom");
+      expect(body.enabled).toBe(true);
+      expect(body.isDefault).toBe(false);
+      expect(body.urlPrefix).toBeTruthy();
+      expect(body.createdAt).toBeTruthy();
+      expect(body.updatedAt).toBeTruthy();
+    });
+  });
+
+  describe("PUT /api/proxies/:id", () => {
+    it("updates a proxy and returns the full resource", async () => {
+      const createRes = await app.request("/api/proxies", {
+        method: "POST",
+        headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+        body: JSON.stringify({
+          label: "Before",
+          url: "http://before.example.com:8080",
+        }),
+      });
+      const { id } = (await createRes.json()) as any;
+
+      const res = await app.request(`/api/proxies/${id}`, {
+        method: "PUT",
+        headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+        body: JSON.stringify({ label: "After", enabled: false }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      // Legacy compat field retained.
+      expect(body.id).toBe(id);
+      // Full resource reflecting the update.
+      expect(body.label).toBe("After");
+      expect(body.enabled).toBe(false);
+      expect(body.source).toBe("custom");
+      expect(body.updatedAt).toBeTruthy();
+    });
+  });
+
+  describe("PUT /api/proxies/default", () => {
+    it("sets the default proxy and returns the affected resource", async () => {
+      const createRes = await app.request("/api/proxies", {
+        method: "POST",
+        headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+        body: JSON.stringify({
+          label: "Default Candidate",
+          url: "http://default.example.com:8080",
+        }),
+      });
+      const { id } = (await createRes.json()) as any;
+
+      const res = await app.request("/api/proxies/default", {
+        method: "PUT",
+        headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+        body: JSON.stringify({ proxyId: id }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      // Legacy compat field retained.
+      expect(body.success).toBe(true);
+      // Affected resource returned.
+      expect(body.proxy).toBeTruthy();
+      expect(body.proxy.id).toBe(id);
+      expect(body.proxy.isDefault).toBe(true);
+      expect(body.proxy.label).toBe("Default Candidate");
+    });
+
+    it("returns success with null proxy when unsetting the default", async () => {
+      const res = await app.request("/api/proxies/default", {
+        method: "PUT",
+        headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+        body: JSON.stringify({ proxyId: null }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.success).toBe(true);
+      expect(body.proxy).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

Resolves the **proxies** family of #646 (API convention: mutating endpoints return the resource, not an id/success stub). Mirrors the reference implementation from #645 (`POST .../run` → full Run DTO).

Mutating proxy endpoints returned id-only / `{success:true}` stubs, forcing clients into a follow-up `GET` to see the resulting state. They now return the proxy resource, reusing the **same serializer** as the `GET /api/proxies` list endpoint.

## Endpoints changed

- `POST /api/proxies` → `201` + created proxy resource (was `{id}`)
- `PUT /api/proxies/:id` → `200` + updated proxy resource (was `{id}`)
- `PUT /api/proxies/default` → `200` + `{ success, proxy }` where `proxy` is the affected default resource, or `null` when unset (was `{success:true}`)

## Serializer reused

Extracted `getOrgProxy(orgId, proxyId)` in `apps/api/src/services/org-proxies.ts` — returns a single proxy in the **exact same shape** as `listOrgProxies` (the GET list serializer), so create/update/default return precisely what the list endpoint returns. No change to the list output.

## Compat fields retained (additive — 0 breaking)

- `POST` / `PUT /:id`: legacy `id` kept as a top-level field alongside the resource (the resource's own `id` is identical).
- `PUT /default`: legacy `success: true` kept; the affected resource is nested under `proxy` (nullable, since unsetting the default has no resource).

OpenAPI responses compose `allOf: [OrgProxy, { id }]` (for create/update) and an explicit `{ success, proxy }` object (for default). `detect:breaking` flattens `allOf` (landed in #645), so the change registers as **additive**.

## Consumers

Grepped `apps/web` (`hooks/use-proxies.ts`) and the CLI — no consumer reads the old stub shape (web hooks only invalidate React Query caches; the create mutation's `<{id}>` type still resolves since `id` is retained). github-action is a separate repo and additive responses need no change. No consumer touched.

## Validation

- `bun run check` (tsc + eslint + prettier + verify-openapi + **detect:breaking**) — passes, **0 breaking changes**.
- `bun test apps/api/test/integration/routes/proxies.test.ts` — 7 pass / 0 fail (3 existing + 4 new asserting full-resource + retained compat fields on create / update / set-default / unset-default).

## #646 checklist (proxies family)

- [x] `POST /proxies` → return resource (serializer: `listOrgProxies`)
- [x] `PUT /proxies/:id` → return resource
- [x] `PUT /proxies/default` → return the new default proxy

Refs #646.

🤖 Generated with [Claude Code](https://claude.com/claude-code)