### PR TITLE
feat(orgs): return full member/invitation DTO from role-update endpoints

### DIFF
--- a/apps/api/src/openapi/paths/organizations.ts
+++ b/apps/api/src/openapi/paths/organizations.ts
@@ -314,19 +314,20 @@ export const organizationsPaths = {
       },
       responses: {
         "200": {
-          description: "Role updated",
+          description: "Updated member — same shape as the members list in GET /api/orgs/{orgId}",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  userId: { type: "string" },
-                  role: { type: "string", enum: [...ASSIGNABLE_ROLES] },
-                },
+              schema: { $ref: "#/components/schemas/OrgMember" },
+              example: {
+                userId: "usr_def456",
+                displayName: "Bob",
+                email: "bob@acme.com",
+                role: "admin",
+                joinedAt: "2026-01-12T10:00:00Z",
               },
             },
           },
@@ -390,19 +391,22 @@ export const organizationsPaths = {
       },
       responses: {
         "200": {
-          description: "Invitation role updated",
+          description:
+            "Updated invitation — same shape as the invitations list in GET /api/orgs/{orgId}",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  id: { type: "string" },
-                  role: { type: "string", enum: [...ASSIGNABLE_ROLES] },
-                },
+              schema: { $ref: "#/components/schemas/OrgInvitationInfo" },
+              example: {
+                id: "inv_abc123",
+                email: "carol@acme.com",
+                role: "admin",
+                token: "tok_xyz789",
+                expiresAt: "2026-02-01T00:00:00Z",
+                createdAt: "2026-01-25T00:00:00Z",
               },
             },
           },

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -12,6 +12,7 @@ import {
   deleteOrganization,
   getOrgMembers,
   getOrgMember,
+  getOrgMemberWithProfile,
   addMember,
   removeMember,
   updateMemberRole,
@@ -408,7 +409,18 @@ router.put("/:orgId/invitations/:invitationId", async (c) => {
     orgIdOverride: orgId,
   });
 
-  return c.json({ id: updated.id, role: updated.role });
+  // Return the full invitation DTO — same shape as the invitations list in
+  // GET /orgs/:orgId — so callers see the resulting state without a
+  // follow-up GET (issue #646). `id` + `role` remain present as a superset,
+  // so legacy consumers reading those fields are unaffected.
+  return c.json({
+    id: updated.id,
+    email: updated.email,
+    role: updated.role,
+    token: updated.token,
+    expiresAt: updated.expiresAt?.toISOString(),
+    createdAt: updated.createdAt?.toISOString(),
+  });
 });
 
 // DELETE /api/orgs/:orgId/members/:userId — remove a member (admin+)
@@ -471,7 +483,22 @@ router.put("/:orgId/members/:userId", async (c) => {
     after: { role: data.role },
     orgIdOverride: orgId,
   });
-  return c.json({ userId: targetUserId, role: data.role });
+
+  // Return the full member DTO — same shape as the members list in
+  // GET /orgs/:orgId — so callers see the resulting state without a
+  // follow-up GET (issue #646). `userId` + `role` remain present as a
+  // superset, so legacy consumers reading those fields are unaffected.
+  const updated = await getOrgMemberWithProfile(orgId, targetUserId);
+  if (!updated) {
+    throw notFound("Member not found");
+  }
+  return c.json({
+    userId: updated.userId,
+    role: updated.role,
+    joinedAt: updated.joinedAt,
+    displayName: updated.displayName,
+    email: updated.email,
+  });
 });
 
 // GET /api/orgs/:orgId/settings — get org settings (any member)

--- a/apps/api/src/services/organizations.ts
+++ b/apps/api/src/services/organizations.ts
@@ -183,6 +183,32 @@ export async function getOrgMember(orgId: string, userId: string) {
   return row ?? null;
 }
 
+/**
+ * Single-member counterpart to {@link getOrgMembers}: returns one member row
+ * enriched with the same `displayName` + `email` fields the list endpoint
+ * exposes, so a mutation handler can echo the full member DTO without a
+ * follow-up GET. Returns null when the user is not a member of the org.
+ */
+export async function getOrgMemberWithProfile(orgId: string, userId: string) {
+  const member = await getOrgMember(orgId, userId);
+  if (!member) return null;
+
+  const [profileRow, userRow] = await Promise.all([
+    db
+      .select({ displayName: profiles.displayName })
+      .from(profiles)
+      .where(eq(profiles.id, userId))
+      .limit(1),
+    db.select({ email: user.email }).from(user).where(eq(user.id, userId)).limit(1),
+  ]);
+
+  return {
+    ...member,
+    displayName: profileRow[0]?.displayName ?? undefined,
+    email: userRow[0]?.email ?? undefined,
+  };
+}
+
 export async function findUserByEmail(email: string): Promise<{ id: string } | null> {
   const [row] = await db.select({ id: user.id }).from(user).where(eq(user.email, email)).limit(1);
 

--- a/apps/api/test/integration/routes/organizations.test.ts
+++ b/apps/api/test/integration/routes/organizations.test.ts
@@ -10,7 +10,9 @@ import {
   createTestOrg,
   addOrgMember,
   authHeaders,
+  orgOnlyHeaders,
 } from "../../helpers/auth.ts";
+import { createInvitation } from "../../../src/services/invitations.ts";
 import { seedApiKey } from "../../helpers/seed.ts";
 import { assertDbHas } from "../../helpers/assertions.ts";
 import {
@@ -303,6 +305,73 @@ describe("Organizations API", () => {
 
       // addMember is idempotent — duplicate silently ignored, returns 201
       expect(res.status).toBe(201);
+    });
+  });
+
+  // Issue #646 — mutating endpoints return the full resource, not a stub.
+  describe("PUT /api/orgs/:orgId/members/:userId", () => {
+    it("returns the full member DTO (not just {userId, role})", async () => {
+      const ctx = await createTestContext({ orgSlug: "roleorg" });
+      const member = await createTestUser({ email: "promote@test.com" });
+      await addOrgMember(ctx.orgId, member.id, "member");
+
+      const res = await app.request(`/api/orgs/${ctx.orgId}/members/${member.id}`, {
+        method: "PUT",
+        headers: orgOnlyHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({ role: "admin" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      // Legacy fields preserved (superset)
+      expect(body.userId).toBe(member.id);
+      expect(body.role).toBe("admin");
+      // Full member DTO — same shape as the members list in GET /api/orgs/:orgId
+      expect(body.email).toBe("promote@test.com");
+      expect(body).toHaveProperty("joinedAt");
+      expect(body.joinedAt).toBeTruthy();
+
+      // Persisted
+      await assertDbHas(
+        organizationMembers,
+        and(eq(organizationMembers.userId, member.id), eq(organizationMembers.role, "admin"))!,
+      );
+    });
+  });
+
+  describe("PUT /api/orgs/:orgId/invitations/:invitationId", () => {
+    it("returns the full invitation DTO (not just {id, role})", async () => {
+      const ctx = await createTestContext({ orgSlug: "invorg" });
+      const invitation = await createInvitation({
+        email: "invitee@test.com",
+        orgId: ctx.orgId,
+        role: "member",
+        invitedBy: ctx.user.id,
+        skipEmail: true,
+      });
+
+      const res = await app.request(`/api/orgs/${ctx.orgId}/invitations/${invitation.id}`, {
+        method: "PUT",
+        headers: orgOnlyHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({ role: "admin" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      // Legacy fields preserved (superset)
+      expect(body.id).toBe(invitation.id);
+      expect(body.role).toBe("admin");
+      // Full invitation DTO — same shape as the invitations list in GET /api/orgs/:orgId
+      expect(body.email).toBe("invitee@test.com");
+      expect(body.token).toBe(invitation.token);
+      expect(body).toHaveProperty("expiresAt");
+      expect(body).toHaveProperty("createdAt");
+
+      // Persisted
+      await assertDbHas(
+        orgInvitations,
+        and(eq(orgInvitations.id, invitation.id), eq(orgInvitations.role, "admin"))!,
+      );
     });
   });
 


### PR DESCRIPTION
Refs #646 — API convention: mutating endpoints return the resource, not an id/role stub.

Resolves the **orgs members + invitations** family from the issue inventory:

- [x] `PUT /orgs/:orgId/members/:userId` → full member DTO (return member DTO)
- [x] `PUT /orgs/:orgId/invitations/:invitationId` → full invitation DTO (return invitation DTO)

## What changed

- **`PUT /orgs/:orgId/members/:userId`** previously returned `{userId, role}`. Now returns the full member DTO — `{userId, role, joinedAt, displayName, email}` — the exact shape each member takes in the list embedded in `GET /orgs/:orgId`. Added a single-member serializer `getOrgMemberWithProfile()` mirroring `getOrgMembers()`' profile+email enrichment, without touching the list path.
- **`PUT /orgs/:orgId/invitations/:invitationId`** previously returned `{id, role}`. Now returns the full invitation DTO — `{id, email, role, token, expiresAt, createdAt}` — the shape the invitations list returns. `updateInvitationRole()` already `.returning()`s the full row, so no extra I/O.

## Compat

Both new responses are **supersets** of the old stubs (member keeps `userId`+`role`, invitation keeps `id`+`role`), so no `allOf` compat envelope is needed — the legacy fields already live in the `OrgMember` / `OrgInvitationInfo` component schemas, which the OpenAPI responses now `$ref` directly. Verified the only consumers (`apps/web/src/pages/org-settings/members.tsx` role-change mutations) ignore the response body and just invalidate React Query caches, so the additive change is safe.

## Out of scope (left alone, per issue)

`POST /orgs/:orgId/members` (dual add-or-invite, custom result), all `DELETE → {ok:true}`.

## Validation

- `bun run check` — 29/29 tasks pass (verify:openapi, detect:breaking, typecheck, lint, format). The 5 OpenAPI lint warnings are pre-existing (run/mcp endpoints), none new.
- `detect:breaking` — **0 breaking**, 7 non-breaking response-field additions for these two endpoints.
- Added 2 integration tests asserting the full DTO shape on both PUTs; `organizations.test.ts` 34 pass / 0 fail, related `invitations.test.ts` + `require-permission.test.ts` 28 pass / 0 fail (real PostgreSQL test DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)