### PR TITLE
feat(api): models + credentials mutations return the resource (#646)

### DIFF
--- a/apps/api/src/openapi/paths/model-provider-credentials.ts
+++ b/apps/api/src/openapi/paths/model-provider-credentials.ts
@@ -232,20 +232,15 @@ export const modelProviderCredentialsPaths = {
       },
       responses: {
         "201": {
-          description: "Model provider credential created",
+          description:
+            "Model provider credential created — the full created credential resource (same non-secret shape as `GET`/`list`). The api key / OAuth token is never echoed back. `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  id: { type: "string" },
-                },
-              },
-              example: { id: "cm7stu902" },
+              schema: { $ref: "#/components/schemas/ModelProviderCredential" },
             },
           },
         },
@@ -358,14 +353,15 @@ export const modelProviderCredentialsPaths = {
       },
       responses: {
         "200": {
-          description: "Model provider credential updated",
+          description:
+            "Model provider credential updated — the full updated credential resource (same non-secret shape as `GET`/`list`). The api key / OAuth token is never echoed back. `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
           },
           content: {
             "application/json": {
-              schema: { type: "object", properties: { id: { type: "string" } } },
+              schema: { $ref: "#/components/schemas/ModelProviderCredential" },
             },
           },
         },

--- a/apps/api/src/openapi/paths/models.ts
+++ b/apps/api/src/openapi/paths/models.ts
@@ -115,20 +115,15 @@ export const modelsPaths = {
       },
       responses: {
         "201": {
-          description: "Model created",
+          description:
+            "Model created — the full created model resource (same shape as `GET`/`list`). `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  id: { type: "string" },
-                },
-              },
-              example: { id: "cm5mno345" },
+              schema: { $ref: "#/components/schemas/OrgModel" },
             },
           },
         },
@@ -165,14 +160,29 @@ export const modelsPaths = {
       },
       responses: {
         "200": {
-          description: "Default model updated",
+          description:
+            "Default model updated. Returns the new effective default model resource (same shape as `GET`/`list`) plus a legacy `success` flag. When the default is cleared (`modelId: null`) and no default remains in effect, only `{ success: true }` is returned.",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
           },
           content: {
             "application/json": {
-              schema: { type: "object", properties: { success: { type: "boolean" } } },
+              schema: {
+                allOf: [
+                  { $ref: "#/components/schemas/OrgModel" },
+                  {
+                    type: "object",
+                    properties: {
+                      success: {
+                        type: "boolean",
+                        description:
+                          "Legacy acknowledgement flag, always `true`. Retained for backward compatibility; prefer reading the model fields.",
+                      },
+                    },
+                  },
+                ],
+              },
             },
           },
         },
@@ -468,14 +478,15 @@ export const modelsPaths = {
       },
       responses: {
         "200": {
-          description: "Model updated",
+          description:
+            "Model updated — the full updated model resource (same shape as `GET`/`list`). `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
           },
           content: {
             "application/json": {
-              schema: { type: "object", properties: { id: { type: "string" } } },
+              schema: { $ref: "#/components/schemas/OrgModel" },
             },
           },
         },

--- a/apps/api/src/routes/model-provider-credentials.ts
+++ b/apps/api/src/routes/model-provider-credentials.ts
@@ -18,6 +18,7 @@ import {
   createApiKeyCredential,
   deleteModelProviderCredential,
   deriveCredentialLabel,
+  getOrgModelProviderCredential,
   listOrgModelProviderCredentials,
   loadInferenceCredentials,
   updateModelProviderCredential,
@@ -216,7 +217,12 @@ export function createModelProviderCredentialsRouter() {
         resourceId: id,
         after: { label, providerId, baseUrlOverride: baseUrlOverride ?? null },
       });
-      return c.json({ id }, 201);
+      // Return the full created resource — the public, non-secret
+      // `ModelProviderCredentialInfo` shape (same as GET/list). The api key is
+      // NEVER echoed back. `id` is part of that shape, so legacy `{ id }`
+      // consumers keep working (#646).
+      const credential = await getOrgModelProviderCredential(orgId, id);
+      return c.json(credential ?? { id }, 201);
     } catch (err) {
       if (err instanceof ApiError) throw err;
       logger.error("Model provider credential create failed", {
@@ -314,7 +320,11 @@ export function createModelProviderCredentialsRouter() {
         resourceId: id,
         after: auditData as Record<string, unknown>,
       });
-      return c.json({ id });
+      // Return the full updated resource (non-secret `ModelProviderCredentialInfo`
+      // shape, same as GET/list). The api key is NEVER echoed back; `id` stays
+      // part of the shape so legacy `{ id }` consumers are unaffected (#646).
+      const credential = await getOrgModelProviderCredential(orgId, id);
+      return c.json(credential ?? { id });
     } catch (err) {
       logger.error("Model provider credential update failed", {
         id,

--- a/apps/api/src/routes/models.ts
+++ b/apps/api/src/routes/models.ts
@@ -10,6 +10,7 @@ import { isSystemModel, getSystemModelProviderKeys } from "../services/model-reg
 import { modelCostSchema } from "@appstrate/core/module";
 import {
   listOrgModels,
+  getOrgModel,
   createOrgModel,
   updateOrgModel,
   deleteOrgModel,
@@ -152,7 +153,13 @@ export function createModelsRouter() {
         resourceId: id,
         after: { label, modelId, credentialId },
       });
-      return c.json({ id }, 201);
+      // Return the full created resource (same shape as GET/list) so callers
+      // see the resolved state without a follow-up fetch (#646). `id` is part
+      // of the OrgModel shape, so the legacy `{ id }` consumers keep working.
+      // Fall back to the id stub only if the freshly-created row can't be
+      // re-projected (e.g. credential became unreachable mid-request).
+      const model = await getOrgModel(orgId, id);
+      return c.json(model ?? { id }, 201);
     } catch (err) {
       if (err instanceof ApiError) throw err;
       logger.error("Model create failed", {
@@ -248,7 +255,16 @@ export function createModelsRouter() {
         resourceType: "model",
         resourceId: data.modelId,
       });
-      return c.json({ success: true });
+      // Return the new default model resource so callers see the resulting
+      // state without a follow-up GET (#646). `isDefault` is recomputed by
+      // listOrgModels (DB flag, or the system-default fallback when no DB row
+      // is flagged), so this surfaces the *effective* default regardless of
+      // whether `modelId` pointed at a DB or system model. When the default is
+      // cleared (`modelId: null`) and nothing remains in effect, only the
+      // legacy `success` flag is returned. `success` is retained additively.
+      const all = await listOrgModels(orgId);
+      const def = all.find((m) => m.isDefault);
+      return c.json(def ? { ...def, success: true } : { success: true });
     } catch (err) {
       logger.error("Set default model failed", {
         error: getErrorMessage(err),
@@ -441,7 +457,10 @@ export function createModelsRouter() {
         resourceId: modelId,
         after: data as unknown as Record<string, unknown>,
       });
-      return c.json({ id: modelId });
+      // Return the full updated resource (#646). `id` stays part of the shape,
+      // so legacy `{ id }` consumers are unaffected.
+      const model = await getOrgModel(orgId, modelId);
+      return c.json(model ?? { id: modelId });
     } catch (err) {
       logger.error("Model update failed", {
         modelId,

--- a/apps/api/src/services/model-providers/credentials.ts
+++ b/apps/api/src/services/model-providers/credentials.ts
@@ -513,6 +513,25 @@ export async function listOrgModelProviderCredentials(
 }
 
 /**
+ * Fetch a single model-provider credential by id, projected through the exact
+ * same serializer as {@link listOrgModelProviderCredentials} — i.e. the public
+ * `ModelProviderCredentialInfo` shape that NEVER carries plaintext (api key /
+ * OAuth token). Returns `undefined` when the id is unknown to either source.
+ *
+ * Used by the create/update handlers to return the full (non-secret) resource
+ * instead of an id-only stub (issue #646). Re-runs the list serializer rather
+ * than duplicating the system+DB merge — guarantees the returned shape matches
+ * `GET`/list and can never leak secret material.
+ */
+export async function getOrgModelProviderCredential(
+  orgId: string,
+  id: string,
+): Promise<ModelProviderCredentialInfo | undefined> {
+  const all = await listOrgModelProviderCredentials(orgId);
+  return all.find((c) => c.id === id);
+}
+
+/**
  * Resolve a credential id to plaintext credentials usable for inference
  * (model probe, LLM proxy, sidecar config). Combines the two read paths
  * into one — system (env-driven) keys from `SYSTEM_PROVIDER_KEYS` and

--- a/apps/api/src/services/org-models.ts
+++ b/apps/api/src/services/org-models.ts
@@ -118,6 +118,22 @@ export async function listOrgModels(orgId: string): Promise<OrgModelInfo[]> {
 }
 
 /**
+ * Fetch a single org model by id, projected through the exact same serializer
+ * as {@link listOrgModels} (so a mutation's return shape matches `GET`/list
+ * byte-for-byte). Returns `undefined` when the id is unknown or its backing
+ * credential is unreachable (the row is then absent from the list too).
+ *
+ * Used by the create/update handlers to return the full resource instead of an
+ * id-only stub (issue #646). Deliberately re-runs `listOrgModels` rather than
+ * duplicating the merge/credential-resolution logic — these lists are small
+ * (per-org models) and correctness/parity beats shaving one credential lookup.
+ */
+export async function getOrgModel(orgId: string, id: string): Promise<OrgModelInfo | undefined> {
+  const all = await listOrgModels(orgId);
+  return all.find((m) => m.id === id);
+}
+
+/**
  * Derive a model label when the caller doesn't supply one. Picks the catalog
  * label (`(catalogProviderId ?? providerId, modelId)`) and dedupes against
  * existing org rows by appending ` (2)`, ` (3)`, …  Unknown models fall back

--- a/apps/api/test/integration/routes/model-provider-credentials.test.ts
+++ b/apps/api/test/integration/routes/model-provider-credentials.test.ts
@@ -140,7 +140,7 @@ describe("Model Provider Keys API", () => {
   });
 
   describe("POST /api/model-provider-credentials", () => {
-    it("creates a model provider key", async () => {
+    it("creates a model provider key and returns the full non-secret resource", async () => {
       const res = await app.request("/api/model-provider-credentials", {
         method: "POST",
         headers: authHeaders(ctx, { "Content-Type": "application/json" }),
@@ -153,13 +153,26 @@ describe("Model Provider Keys API", () => {
 
       expect(res.status).toBe(201);
       const body = (await res.json()) as any;
+      // Legacy `id` alias preserved.
       expect(body.id).toBeDefined();
       expect(typeof body.id).toBe("string");
+      // #646: full resource (same shape as GET/list) returned, not an id stub.
+      expect(body.label).toBe("Test Key");
+      expect(body.source).toBe("custom");
+      expect(body.providerId).toBe("openai");
+      expect(body.authMode).toBe("api_key");
+      expect(body.createdAt).toBeDefined();
+      expect(body.updatedAt).toBeDefined();
+      // Security: the api key / any secret material must NEVER be echoed back.
+      const serialized = JSON.stringify(body);
+      expect(serialized).not.toContain("sk-test-key-123");
+      expect(body).not.toHaveProperty("apiKey");
+      expect(body).not.toHaveProperty("credentialsEncrypted");
     });
   });
 
   describe("PUT /api/model-provider-credentials/:id", () => {
-    it("updates model provider key label", async () => {
+    it("updates the label and returns the full non-secret resource", async () => {
       // Create a model provider key first
       const createRes = await app.request("/api/model-provider-credentials", {
         method: "POST",
@@ -173,16 +186,26 @@ describe("Model Provider Keys API", () => {
       expect(createRes.status).toBe(201);
       const { id } = (await createRes.json()) as any;
 
-      // Update the label
+      // Update the label (and rotate the key — must not leak in the response).
       const res = await app.request(`/api/model-provider-credentials/${id}`, {
         method: "PUT",
         headers: authHeaders(ctx, { "Content-Type": "application/json" }),
-        body: JSON.stringify({ label: "Updated Label" }),
+        body: JSON.stringify({ label: "Updated Label", apiKey: "sk-rotated-secret-456" }),
       });
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
+      // Legacy `id` alias preserved.
       expect(body.id).toBe(id);
+      // #646: full updated resource reflects the new label without a follow-up GET.
+      expect(body.label).toBe("Updated Label");
+      expect(body.source).toBe("custom");
+      // Security: neither the original nor the rotated key may appear.
+      const serialized = JSON.stringify(body);
+      expect(serialized).not.toContain("sk-test-key-123");
+      expect(serialized).not.toContain("sk-rotated-secret-456");
+      expect(body).not.toHaveProperty("apiKey");
+      expect(body).not.toHaveProperty("credentialsEncrypted");
     });
   });
 

--- a/apps/api/test/integration/routes/models.test.ts
+++ b/apps/api/test/integration/routes/models.test.ts
@@ -73,8 +73,18 @@ describe("Models API", () => {
 
       expect(res.status).toBe(201);
       const body = (await res.json()) as any;
+      // Legacy `id` alias preserved.
       expect(body.id).toBeDefined();
       expect(typeof body.id).toBe("string");
+      // #646: full created resource (same shape as GET/list), not an id stub.
+      expect(body.label).toBe("GPT-4o");
+      expect(body.modelId).toBe("gpt-4o");
+      expect(body.credentialId).toBe(credentialId);
+      expect(body.source).toBe("custom");
+      expect(typeof body.enabled).toBe("boolean");
+      expect(typeof body.isDefault).toBe("boolean");
+      expect(body.createdAt).toBeDefined();
+      expect(body.updatedAt).toBeDefined();
     });
 
     it("rejects non-UUID credentialId with 400 (built-in slugs like 'anthropic')", async () => {
@@ -124,6 +134,39 @@ describe("Models API", () => {
     });
   });
 
+  describe("PUT /api/models/:id", () => {
+    it("updates a model and returns the full updated resource", async () => {
+      const credentialId = await createProviderKey();
+
+      const createRes = await app.request("/api/models", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          label: "Before",
+          modelId: "gpt-4o",
+          credentialId,
+        }),
+      });
+      expect(createRes.status).toBe(201);
+      const { id } = (await createRes.json()) as any;
+
+      const res = await app.request(`/api/models/${id}`, {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({ label: "After", enabled: false }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      // Legacy `id` alias preserved.
+      expect(body.id).toBe(id);
+      // #646: full updated resource reflects the change without a follow-up GET.
+      expect(body.label).toBe("After");
+      expect(body.enabled).toBe(false);
+      expect(body.source).toBe("custom");
+    });
+  });
+
   describe("PUT /api/models/default", () => {
     it("sets the default model", async () => {
       const credentialId = await createProviderKey();
@@ -150,7 +193,13 @@ describe("Models API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
+      // Legacy `success` flag preserved.
       expect(body.success).toBe(true);
+      // #646: the new default model resource is returned (effective default).
+      expect(body.id).toBe(id);
+      expect(body.isDefault).toBe(true);
+      expect(body.label).toBe("Default Model");
+      expect(body.modelId).toBe("gpt-4o");
     });
 
     it("clears the default model with null", async () => {


### PR DESCRIPTION
Refs #646 — second rollout step after #645 (runs). Aligns the **models + model-provider-credentials** family to the convention: mutating endpoints return the full resource (same serializer as `GET`/list), not an id/`success` stub.

## Endpoints

- [x] `POST /models` → full `OrgModel` (was `{ id }`)
- [x] `PUT /models/:id` → full `OrgModel` (was `{ id }`)
- [x] `PUT /models/default` → new effective default `OrgModel` + legacy `success` (was `{ success: true }`)
- [x] `POST /model-provider-credentials` → full `ModelProviderCredential` (was `{ id }`)
- [x] `PUT /model-provider-credentials/:id` → full `ModelProviderCredential` (was `{ id }`)

## Approach

Two new single-item serializers reuse the existing list serializers verbatim, so the mutation return shape is identical to `GET`/list and the list output is unchanged:

- `getOrgModel(orgId, id)` → re-projects through `listOrgModels`
- `getOrgModelProviderCredential(orgId, id)` → re-projects through `listOrgModelProviderCredentials`

Both fall back to the legacy `{ id }` stub if the freshly-mutated row can't be re-projected (defensive; e.g. a credential turning unreachable mid-request).

`PUT /models/default` returns the *effective* default (recomputed `isDefault`, covering the system-default fallback). When cleared to `null` with no default in effect, only `{ success: true }` is returned — documented in the OpenAPI response description.

## Secret safety (verified)

The credential responses go through the same `ModelProviderCredentialInfo` projection the list/`GET` already exposes, which **never** carries plaintext. Tests assert the api key is absent from the create response **and** that a rotated key on update is not echoed (`apiKey` / `credentialsEncrypted` absent, raw secret strings not present anywhere in the body).

## Compatibility

Additive only. `id` is part of each resource shape, so existing consumers (`apps/web` hooks reading `result.id`) are unaffected — verified, no consumer changes needed. `success` retained on `PUT /models/default` via `allOf`. OpenAPI responses now `$ref` the resource schemas.

- `detect:breaking`: **0 breaking**, all additions non-breaking (`allOf` flattening from #645 applied)
- `verify:openapi`: passed (code ⊆ spec, Zod↔OpenAPI match)

## Tests

Strengthened the bun:test integration suites (`models.test.ts`, `model-provider-credentials.test.ts`) to assert full resource fields on create/update/set-default, plus the credential no-secret-leak checks. Added a missing `PUT /api/models/:id` test. All 35 pass in isolation (Tier 0 / PGlite). Note: running the two files together against a shared dev Postgres shows pre-existing cross-file truncation races unrelated to this change — clean under isolated DBs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)