### PR TITLE
feat(api): return resource from agent settings + integration activate/deactivate (#646)

### DIFF
--- a/apps/api/src/openapi/paths/agents.ts
+++ b/apps/api/src/openapi/paths/agents.ts
@@ -199,14 +199,29 @@ export const agentsPaths = {
       },
       responses: {
         "200": {
-          description: "Agent proxy updated",
+          description: "Agent proxy updated — returns the affected proxy setting",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
           },
           content: {
             "application/json": {
-              schema: { type: "object", properties: { success: { type: "boolean" } } },
+              // Returns the affected proxy-setting resource (same shape as
+              // GET …/proxy), composed with the legacy `success` flag kept
+              // additively for backward compatibility (issue #646).
+              schema: {
+                allOf: [
+                  {
+                    type: "object",
+                    required: ["proxyId", "resolved"],
+                    properties: {
+                      proxyId: { type: ["string", "null"] },
+                      resolved: { type: "boolean" },
+                    },
+                  },
+                  { type: "object", properties: { success: { type: "boolean" } } },
+                ],
+              },
             },
           },
         },
@@ -501,14 +516,28 @@ export const agentsPaths = {
       },
       responses: {
         "200": {
-          description: "Agent model updated",
+          description: "Agent model updated — returns the affected model setting",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
           },
           content: {
             "application/json": {
-              schema: { type: "object", properties: { success: { type: "boolean" } } },
+              // Returns the affected model-setting resource (same shape as
+              // GET …/model), composed with the legacy `success` flag kept
+              // additively for backward compatibility (issue #646).
+              schema: {
+                allOf: [
+                  {
+                    type: "object",
+                    required: ["modelId"],
+                    properties: {
+                      modelId: { type: ["string", "null"] },
+                    },
+                  },
+                  { type: "object", properties: { success: { type: "boolean" } } },
+                ],
+              },
             },
           },
         },

--- a/apps/api/src/openapi/paths/integrations.ts
+++ b/apps/api/src/openapi/paths/integrations.ts
@@ -347,17 +347,26 @@ export const integrationsPaths = {
       },
       responses: {
         "201": {
-          description: "Activated",
+          description: "Activated — returns the full integration detail",
           headers: baseResponseHeaders,
           content: {
             "application/json": {
+              // Returns the full integration DTO (same serializer as
+              // GET /integrations/:packageId) so callers see the resulting
+              // state in one round-trip and activate/deactivate are symmetric.
+              // Legacy `active` / `activated_at` kept additively (issue #646).
               schema: {
-                type: "object",
-                required: ["active", "activated_at"],
-                properties: {
-                  active: { type: "boolean" },
-                  activated_at: { type: "string", format: "date-time" },
-                },
+                allOf: [
+                  integrationDetailSchema,
+                  {
+                    type: "object",
+                    required: ["active", "activated_at"],
+                    properties: {
+                      active: { type: "boolean" },
+                      activated_at: { type: "string", format: "date-time" },
+                    },
+                  },
+                ],
               },
             },
           },
@@ -386,14 +395,22 @@ export const integrationsPaths = {
       ],
       responses: {
         "200": {
-          description: "Deactivated",
+          description: "Deactivated — returns the full integration detail",
           headers: baseResponseHeaders,
           content: {
             "application/json": {
+              // Returns the full integration DTO (same serializer as
+              // GET /integrations/:packageId), symmetric with activate.
+              // Legacy `active` kept additively (issue #646).
               schema: {
-                type: "object",
-                required: ["active"],
-                properties: { active: { type: "boolean" } },
+                allOf: [
+                  integrationDetailSchema,
+                  {
+                    type: "object",
+                    required: ["active"],
+                    properties: { active: { type: "boolean" } },
+                  },
+                ],
               },
             },
           },

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -169,7 +169,12 @@ export function createAgentsRouter() {
         after: { proxyId: data.proxyId },
       });
 
-      return c.json({ success: true });
+      // Return the affected proxy-setting resource — same shape and read path
+      // (`getPackageConfig`) as GET /agents/:scope/:name/proxy — so callers see
+      // the persisted override without a follow-up GET (issue #646). The
+      // legacy `success` flag is kept additively for backward compatibility.
+      const { proxyId } = await getPackageConfig(scope.applicationId, agent.id);
+      return c.json({ success: true, proxyId, resolved: proxyId !== "none" });
     },
   );
 
@@ -202,7 +207,12 @@ export function createAgentsRouter() {
         after: { modelId: data.modelId },
       });
 
-      return c.json({ success: true });
+      // Return the affected model-setting resource — same shape and read path
+      // (`getPackageConfig`) as GET /agents/:scope/:name/model — so callers see
+      // the persisted override without a follow-up GET (issue #646). The legacy
+      // `success` flag is kept additively for backward compatibility.
+      const { modelId } = await getPackageConfig(scope.applicationId, agent.id);
+      return c.json({ success: true, modelId });
     },
   );
 

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -328,6 +328,7 @@ export function createIntegrationsRouter() {
     async (c) => {
       const packageId = c.req.param("packageId")!;
       const scope = getAppScope(c);
+      const actor = getActor(c);
       await assertIsIntegration(scope, packageId);
       const row = await installPackage(scope, packageId);
       await recordAuditFromContext(c, {
@@ -335,7 +336,12 @@ export function createIntegrationsRouter() {
         resourceType: "integration",
         resourceId: packageId,
       });
-      return c.json({ active: true, activated_at: row.installedAt.toISOString() }, 201);
+      // Return the full integration DTO — same serializer as
+      // GET /integrations/:packageId — so callers see the resulting state in
+      // one round-trip and activate/deactivate are symmetric (issue #646). The
+      // legacy `active` / `activated_at` fields are kept additively.
+      const detail = await getIntegrationAuthStatuses(scope, packageId, actor);
+      return c.json({ ...detail, active: true, activated_at: row.installedAt.toISOString() }, 201);
     },
   );
 
@@ -345,6 +351,7 @@ export function createIntegrationsRouter() {
     async (c) => {
       const packageId = c.req.param("packageId")!;
       const scope = getAppScope(c);
+      const actor = getActor(c);
       await assertIsIntegration(scope, packageId);
       await uninstallPackage(scope, packageId);
       await recordAuditFromContext(c, {
@@ -352,7 +359,12 @@ export function createIntegrationsRouter() {
         resourceType: "integration",
         resourceId: packageId,
       });
-      return c.json({ active: false });
+      // Return the full integration DTO — same serializer as
+      // GET /integrations/:packageId — symmetric with activate (issue #646).
+      // Deactivation is non-destructive: the manifest + surviving connections
+      // still serialize. The legacy `active` flag is kept additively.
+      const detail = await getIntegrationAuthStatuses(scope, packageId, actor);
+      return c.json({ ...detail, active: false });
     },
   );
 

--- a/apps/api/test/integration/routes/agents.test.ts
+++ b/apps/api/test/integration/routes/agents.test.ts
@@ -616,4 +616,70 @@ describe("Agents API", () => {
       expect(res.status).toBe(404);
     });
   });
+
+  describe("PUT /api/agents/:scope/:name/proxy", () => {
+    it("returns the affected proxy setting (same shape as GET), not a bare stub", async () => {
+      await seedInstalledAgent({
+        id: "@myorg/proxy-agent",
+        orgId: ctx.orgId,
+        createdBy: ctx.user.id,
+        applicationId: ctx.defaultAppId,
+      });
+
+      const res = await app.request("/api/agents/@myorg/proxy-agent/proxy", {
+        method: "PUT",
+        headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+        body: JSON.stringify({ proxyId: "none" }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        success: boolean;
+        proxyId: string | null;
+        resolved: boolean;
+      };
+      // Resource reflecting the new proxy + legacy `success` compat (issue #646).
+      expect(body.proxyId).toBe("none");
+      expect(body.resolved).toBe(false);
+      expect(body.success).toBe(true);
+
+      // The returned shape matches what GET …/proxy serves.
+      const get = await app.request("/api/agents/@myorg/proxy-agent/proxy", {
+        headers: authHeaders(ctx),
+      });
+      const getBody = (await get.json()) as { proxyId: string | null; resolved: boolean };
+      expect(getBody.proxyId).toBe(body.proxyId);
+      expect(getBody.resolved).toBe(body.resolved);
+    });
+  });
+
+  describe("PUT /api/agents/:scope/:name/model", () => {
+    it("returns the affected model setting (same shape as GET), not a bare stub", async () => {
+      await seedInstalledAgent({
+        id: "@myorg/model-agent",
+        orgId: ctx.orgId,
+        createdBy: ctx.user.id,
+        applicationId: ctx.defaultAppId,
+      });
+
+      const res = await app.request("/api/agents/@myorg/model-agent/model", {
+        method: "PUT",
+        headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+        body: JSON.stringify({ modelId: "model-123" }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { success: boolean; modelId: string | null };
+      // Resource reflecting the new model + legacy `success` compat (issue #646).
+      expect(body.modelId).toBe("model-123");
+      expect(body.success).toBe(true);
+
+      // Reverting to org default returns the null resource, not a stub.
+      const revert = await app.request("/api/agents/@myorg/model-agent/model", {
+        method: "PUT",
+        headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+        body: JSON.stringify({ modelId: null }),
+      });
+      const revertBody = (await revert.json()) as { modelId: string | null };
+      expect(revertBody.modelId).toBeNull();
+    });
+  });
 });

--- a/apps/api/test/integration/routes/integrations.test.ts
+++ b/apps/api/test/integration/routes/integrations.test.ts
@@ -335,8 +335,22 @@ describe("POST /api/integrations/:packageId/activate + DELETE .../deactivate", (
       body: JSON.stringify({}),
     });
     expect(activate.status).toBe(201);
-    const body = (await activate.json()) as { active: boolean; activated_at: string };
+    const body = (await activate.json()) as {
+      active: boolean;
+      activated_at: string;
+      manifest: { name: string };
+      auths: unknown[];
+      tool_catalog: unknown[];
+      allow_undeclared_tools: boolean;
+    };
+    // Returns the full integration DTO (same shape as GET /:packageId) plus
+    // the legacy `active`/`activated_at` compat fields (issue #646).
     expect(body.active).toBe(true);
+    expect(typeof body.activated_at).toBe("string");
+    expect(body.manifest.name).toBe("@myorg/gmail");
+    expect(Array.isArray(body.auths)).toBe(true);
+    expect(Array.isArray(body.tool_catalog)).toBe(true);
+    expect(typeof body.allow_undeclared_tools).toBe("boolean");
 
     const activeRow = await db
       .select()
@@ -354,8 +368,20 @@ describe("POST /api/integrations/:packageId/activate + DELETE .../deactivate", (
       headers: authHeaders(ctx),
     });
     expect(deactivate.status).toBe(200);
-    const deactivateBody = (await deactivate.json()) as { active: boolean };
+    const deactivateBody = (await deactivate.json()) as {
+      active: boolean;
+      manifest: { name: string };
+      auths: unknown[];
+      tool_catalog: unknown[];
+      allow_undeclared_tools: boolean;
+    };
+    // Symmetric with activate: deactivate also returns the full integration
+    // DTO, with `active: false` kept additively (issue #646).
     expect(deactivateBody.active).toBe(false);
+    expect(deactivateBody.manifest.name).toBe("@myorg/gmail");
+    expect(Array.isArray(deactivateBody.auths)).toBe(true);
+    expect(Array.isArray(deactivateBody.tool_catalog)).toBe(true);
+    expect(typeof deactivateBody.allow_undeclared_tools).toBe("boolean");
     const after = await db
       .select()
       .from(applicationPackages)


### PR DESCRIPTION
## Summary

Part of #646 (API convention: mutating endpoints return the resource, not an id/success stub) for the **agent settings + integration activate/deactivate** family. Follows the pattern established by #645 (full Run DTO from trigger).

Each mutating endpoint now returns the affected resource — the same serializer/shape as its `GET` — so callers see the resulting state in one round-trip. Legacy fields are retained additively, so the change is non-breaking.

## Endpoints changed

| Endpoint | Before | After |
| --- | --- | --- |
| `PUT /agents/:scope/:name/proxy` | `{success:true}` | `{proxyId, resolved}` (shape of `GET …/proxy`) + legacy `success` |
| `PUT /agents/:scope/:name/model` | `{success:true}` | `{modelId}` (shape of `GET …/model`) + legacy `success` |
| `POST /integrations/:packageId/activate` | `{active, activated_at}` | full integration DTO (`getIntegrationAuthStatuses`) + legacy `active`/`activated_at` |
| `DELETE /integrations/:packageId/deactivate` | `{active:false}` | full integration DTO + legacy `active` |

### Symmetry fix

`activate`/`deactivate` were asymmetric (activate returned `{active, activated_at}`, deactivate returned `{active}`). They now both return the **same** full integration DTO — the serializer behind `GET /integrations/:packageId` — with the legacy `active` (+ `activated_at` on activate) kept as an additive compat envelope. Deactivation is non-destructive (manifest + surviving connections still serialize), so the same serializer works post-uninstall.

### Serializers reused

- Agent proxy/model: re-read via `getPackageConfig` — identical shape and read path to the `GET …/proxy` / `GET …/model` handlers.
- Integrations: `getIntegrationAuthStatuses` — the serializer behind `GET /integrations/:packageId`.

## Compat / breaking

OpenAPI responses compose `allOf: [<resource>, { …compat }]` (the `detect-breaking-changes.ts` allOf-flattening landed in #645). Legacy `success` / `active` / `activated_at` fields are retained, so `detect:breaking` reports **0 breaking** (additive-only). Web consumers (`useActivateIntegration`, `useDeactivateIntegration`, `useSetAgentProxy`, `useSetAgentModel`) invalidate queries and ignore the response body, so no client edits are needed.

> Note: `PUT /agents/:scope/:name/config` already returns a richer `{config, validation}` ad-hoc shape; left as-is per the issue's guidance (not one of the 4 targets).

## Tasks (issue checklist)

- [x] `PUT /agents/:scope/:name/proxy` → returns proxy setting
- [x] `PUT /agents/:scope/:name/model` → returns model setting
- [x] `POST /integrations/:packageId/activate` / `DELETE …/deactivate` → return the integration DTO; **made symmetric**

## Tests

bun:test integration coverage added/extended: each endpoint returns the full resource, and activate/deactivate return the symmetric integration DTO. New/updated tests pass; full `bun run check` passes (29/29 tasks, verify:openapi + detect:breaking 0 breaking). The full-file run of `agents.test.ts` / `integrations.test.ts` is flaky in this sandbox due to the pre-existing shared-DB fire-and-forget FK contamination documented in `apps/api/test/helpers/db.ts` (wholesale 0-pass/all-pass swings on warmup) — individual and clean full runs are green.

Refs #646.

🤖 Generated with [Claude Code](https://claude.com/claude-code)