### PR TITLE
feat(packages): return the resource from mutating endpoints (#646)

### DIFF
--- a/apps/api/src/openapi/paths/packages.ts
+++ b/apps/api/src/openapi/paths/packages.ts
@@ -1,5 +1,122 @@
 // SPDX-License-Identifier: Apache-2.0
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Mutation response schemas (issue #646)
+//
+// Mutating package endpoints return the affected resource — the same shape as
+// the corresponding GET detail — composed with `allOf` so the operation-result
+// envelope (`packageId` / `lock_version` / `message` / `warnings` /
+// `restored_version`) is preserved ADDITIVELY. The legacy stub fields are kept
+// as top-level aliases for backward compatibility. `detect-breaking-changes.ts`
+// flattens `allOf`, so these read as supersets of the previous shapes (0 removed
+// fields → additive).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** `POST /packages/{type}` → created package resource + create envelope. */
+function packageCreateResponseSchema(detailRef: string) {
+  return {
+    allOf: [
+      { $ref: detailRef },
+      {
+        type: "object",
+        properties: {
+          packageId: {
+            type: "string",
+            description:
+              "Legacy alias of the created package's `id`, kept for backward compatibility. Prefer `id`.",
+          },
+          lock_version: {
+            type: "integer",
+            description: "Optimistic-lock token to send with the next update.",
+          },
+          message: { type: "string", description: "Human-readable operation message." },
+          warnings: {
+            type: "array",
+            items: { type: "string" },
+            description: "Non-blocking validation warnings (present only when any).",
+          },
+        },
+      },
+    ],
+    description:
+      "The created package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, `message`, optional `warnings`). No follow-up GET needed.",
+  };
+}
+
+/** `PUT /packages/{type}/...` → updated package resource + update envelope. */
+function packageUpdateResponseSchema(detailRef: string) {
+  return {
+    allOf: [
+      { $ref: detailRef },
+      {
+        type: "object",
+        properties: {
+          packageId: {
+            type: "string",
+            description:
+              "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`.",
+          },
+          lock_version: {
+            type: "integer",
+            description:
+              "New optimistic-lock token after this update — read it back before the next edit.",
+          },
+          warnings: {
+            type: "array",
+            items: { type: "string" },
+            description: "Non-blocking validation warnings (present only when any).",
+          },
+        },
+      },
+    ],
+    description:
+      "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed.",
+  };
+}
+
+/** `POST /packages/{type}/.../versions` → created version resource + `message`. */
+function versionCreateResponseSchema() {
+  return {
+    allOf: [
+      { $ref: "#/components/schemas/PackageVersionDetail" },
+      {
+        type: "object",
+        properties: {
+          message: { type: "string", description: "Human-readable operation message." },
+        },
+      },
+    ],
+    description:
+      "The created version resource — same shape as the GET version detail (manifest, integrity, dist_tags, …) — plus a human-readable `message`. `id` (version row id) and `version` are part of the resource. No follow-up GET needed.",
+  };
+}
+
+/** `POST /packages/.../versions/{v}/restore` → restored version resource + envelope. */
+function versionRestoreResponseSchema() {
+  return {
+    allOf: [
+      { $ref: "#/components/schemas/PackageVersionDetail" },
+      {
+        type: "object",
+        properties: {
+          message: { type: "string", description: "Human-readable operation message." },
+          restored_version: {
+            type: "string",
+            description: "Legacy alias of the restored version's `version`.",
+          },
+          lock_version: {
+            type: "integer",
+            description:
+              "The package's NEW optimistic-lock token after the draft was overwritten — not part of the version resource; read it back before the next draft edit.",
+          },
+        },
+      },
+    ],
+    description:
+      "The restored version resource — same shape as the GET version detail — plus the operation-result envelope (`message`, `restored_version` legacy alias of `version`, and the package's new `lock_version`).",
+  };
+}
+
 export const packagesPaths = {
   "/api/packages/import-bundle": {
     post: {
@@ -437,19 +554,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  packageId: { type: "string" },
-                  lock_version: { type: "integer" },
-                  message: { type: "string" },
-                },
-              },
-              example: {
-                packageId: "@acme/summarize",
-                lock_version: 1,
-                message: "Skill created",
-              },
+              schema: packageCreateResponseSchema("#/components/schemas/OrgPackageItemDetail"),
             },
           },
         },
@@ -571,14 +676,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  id: { type: "integer" },
-                  version: { type: "string" },
-                  message: { type: "string" },
-                },
-              },
+              schema: versionCreateResponseSchema(),
             },
           },
         },
@@ -617,14 +715,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  message: { type: "string" },
-                  restored_version: { type: "string" },
-                  lock_version: { type: "integer" },
-                },
-              },
+              schema: versionRestoreResponseSchema(),
             },
           },
         },
@@ -785,13 +876,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  packageId: { type: "string" },
-                  lock_version: { type: "integer" },
-                },
-              },
+              schema: packageUpdateResponseSchema("#/components/schemas/OrgPackageItemDetail"),
             },
           },
         },
@@ -906,14 +991,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  packageId: { type: "string" },
-                  lock_version: { type: "integer" },
-                  message: { type: "string" },
-                },
-              },
+              schema: packageCreateResponseSchema("#/components/schemas/AgentDetail"),
             },
           },
         },
@@ -988,13 +1066,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  packageId: { type: "string" },
-                  lock_version: { type: "integer" },
-                },
-              },
+              schema: packageUpdateResponseSchema("#/components/schemas/AgentDetail"),
             },
           },
         },
@@ -1154,14 +1226,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  id: { type: "integer" },
-                  version: { type: "string" },
-                  message: { type: "string" },
-                },
-              },
+              schema: versionCreateResponseSchema(),
             },
           },
         },
@@ -1202,14 +1267,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  message: { type: "string" },
-                  restored_version: { type: "string" },
-                  lock_version: { type: "integer" },
-                },
-              },
+              schema: versionRestoreResponseSchema(),
             },
           },
         },
@@ -1348,16 +1406,36 @@ export const packagesPaths = {
           content: {
             "application/json": {
               schema: {
-                type: "object",
-                required: ["packageId", "type", "forked_from"],
-                properties: {
-                  packageId: { type: "string", description: "New package ID under org scope" },
-                  type: {
-                    type: "string",
-                    enum: ["agent", "skill", "mcp-server", "integration"],
+                allOf: [
+                  {
+                    // The forked package resource — same shape as the new
+                    // package's GET detail, selected by `type` at runtime
+                    // (issue #646). Fields vary by type, so they are documented
+                    // as a `oneOf` rather than statically merged.
+                    oneOf: [
+                      { $ref: "#/components/schemas/AgentDetail" },
+                      { $ref: "#/components/schemas/OrgPackageItemDetail" },
+                    ],
                   },
-                  forked_from: { type: "string", description: "Source package ID" },
-                },
+                  {
+                    type: "object",
+                    required: ["packageId", "type", "forked_from"],
+                    properties: {
+                      packageId: {
+                        type: "string",
+                        description:
+                          "New package ID under org scope. Legacy alias of the forked resource's `id`.",
+                      },
+                      type: {
+                        type: "string",
+                        enum: ["agent", "skill", "mcp-server", "integration"],
+                      },
+                      forked_from: { type: "string", description: "Source package ID" },
+                    },
+                  },
+                ],
+                description:
+                  "The forked package resource — same shape as the new package's GET detail (`AgentDetail` when `type` is `agent`, otherwise `OrgPackageItemDetail`) — merged with the fork operation envelope (`packageId` legacy alias of `id`, `type`, `forked_from`). No follow-up GET needed.",
               },
             },
           },
@@ -1454,13 +1532,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  packageId: { type: "string" },
-                  lock_version: { type: "integer" },
-                },
-              },
+              schema: packageUpdateResponseSchema("#/components/schemas/OrgPackageItemDetail"),
             },
           },
         },
@@ -1585,13 +1657,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  packageId: { type: "string" },
-                  lock_version: { type: "integer" },
-                },
-              },
+              schema: packageUpdateResponseSchema("#/components/schemas/AgentDetail"),
             },
           },
         },
@@ -1731,14 +1797,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  packageId: { type: "string" },
-                  lock_version: { type: "integer" },
-                  message: { type: "string" },
-                },
-              },
+              schema: packageCreateResponseSchema("#/components/schemas/OrgPackageItemDetail"),
             },
           },
         },
@@ -1860,14 +1919,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  id: { type: "integer" },
-                  version: { type: "string" },
-                  message: { type: "string" },
-                },
-              },
+              schema: versionCreateResponseSchema(),
             },
           },
         },
@@ -1906,14 +1958,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  message: { type: "string" },
-                  restored_version: { type: "string" },
-                  lock_version: { type: "integer" },
-                },
-              },
+              schema: versionRestoreResponseSchema(),
             },
           },
         },
@@ -2082,13 +2127,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  packageId: { type: "string" },
-                  lock_version: { type: "integer" },
-                },
-              },
+              schema: packageUpdateResponseSchema("#/components/schemas/OrgPackageItemDetail"),
             },
           },
         },
@@ -2212,13 +2251,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  packageId: { type: "string" },
-                  lock_version: { type: "integer" },
-                },
-              },
+              schema: packageUpdateResponseSchema("#/components/schemas/OrgPackageItemDetail"),
             },
           },
         },
@@ -2369,14 +2402,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  packageId: { type: "string" },
-                  lock_version: { type: "integer" },
-                  message: { type: "string" },
-                },
-              },
+              schema: packageCreateResponseSchema("#/components/schemas/OrgPackageItemDetail"),
             },
           },
         },
@@ -2498,14 +2524,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  id: { type: "integer" },
-                  version: { type: "string" },
-                  message: { type: "string" },
-                },
-              },
+              schema: versionCreateResponseSchema(),
             },
           },
         },
@@ -2544,14 +2563,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  message: { type: "string" },
-                  restored_version: { type: "string" },
-                  lock_version: { type: "integer" },
-                },
-              },
+              schema: versionRestoreResponseSchema(),
             },
           },
         },
@@ -2720,13 +2732,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  packageId: { type: "string" },
-                  lock_version: { type: "integer" },
-                },
-              },
+              schema: packageUpdateResponseSchema("#/components/schemas/OrgPackageItemDetail"),
             },
           },
         },
@@ -2850,13 +2856,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  packageId: { type: "string" },
-                  lock_version: { type: "integer" },
-                },
-              },
+              schema: packageUpdateResponseSchema("#/components/schemas/OrgPackageItemDetail"),
             },
           },
         },

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -368,6 +368,36 @@ export const schemas = {
       createdAt: { type: ["string", "null"], format: "date-time" },
     },
   },
+  // Canonical version detail DTO — the exact shape the `GET .../versions/{version}`
+  // endpoints serialize (the per-type GET detail uses a type-specific manifest
+  // `$ref`; this generic form is reused by the version create/restore mutation
+  // responses so they echo the resulting version resource — issue #646).
+  PackageVersionDetail: {
+    type: "object",
+    properties: {
+      id: { type: "integer", description: "Version row id" },
+      version: { type: "string", description: "Semver version string (e.g. 1.0.0)" },
+      manifest: {
+        type: "object",
+        additionalProperties: true,
+        description: "Full version manifest (AFPS)",
+      },
+      content: {
+        type: ["string", "null"],
+        description: "Primary content file extracted from the version ZIP",
+      },
+      source_code: {
+        type: ["string", "null"],
+        description: "Secondary source file content (e.g. .ts), when present",
+      },
+      yanked: { type: "boolean", description: "Whether this version has been yanked" },
+      yanked_reason: { type: ["string", "null"] },
+      integrity: { type: "string", description: "SRI integrity hash (sha256-...)" },
+      artifact_size: { type: "integer", description: "Artifact ZIP size in bytes" },
+      createdAt: { type: ["string", "null"], format: "date-time" },
+      dist_tags: { type: "array", items: { type: "string" } },
+    },
+  },
   Run: {
     type: "object",
     required: ["id", "orgId", "applicationId", "status", "version_dirty", "started_at"],

--- a/apps/api/src/routes/agent-detail-handler.ts
+++ b/apps/api/src/routes/agent-detail-handler.ts
@@ -2,7 +2,7 @@
 
 import type { Context } from "hono";
 import type { AppEnv } from "../types/index.ts";
-import { getPackageWithAccess } from "../services/package-catalog.ts";
+import { getPackage, getPackageWithAccess } from "../services/package-catalog.ts";
 import { getOrgItem } from "../services/package-items/crud.ts";
 import { CONFIG_BY_TYPE } from "../services/package-items/config.ts";
 import {
@@ -19,20 +19,39 @@ import { getItemId } from "./packages.ts";
 import { notFound } from "../lib/errors.ts";
 import { getAppScope } from "../lib/scope.ts";
 
-export async function agentDetailHandler(c: Context<AppEnv>) {
+/**
+ * Build the canonical Agent detail DTO — the exact object the `GET` agent
+ * detail endpoint serializes. Extracted so mutating endpoints (create / update /
+ * fork / restore) can echo the full resource instead of an id-only stub
+ * (issue #646), reusing the single GET serializer.
+ *
+ * `requireAccess` defaults to `true` (the GET semantics: agent must be installed
+ * in the current app). Mutation responses pass `false` — the caller just wrote
+ * the agent within their org, so org-scope is the right gate and the app-install
+ * gate must not 404 a successful write that was not auto-installed.
+ *
+ * Returns `null` when the agent is not found (or not accessible under
+ * `requireAccess`), so the GET wrapper can map it to a 404 and mutation callers
+ * can fall back to the legacy envelope.
+ */
+export async function buildAgentDetailDto(
+  c: Context<AppEnv>,
+  opts: { itemId?: string; requireAccess?: boolean } = {},
+): Promise<Record<string, unknown> | null> {
   const scope = getAppScope(c);
   const { orgId, applicationId } = scope;
-  const itemId = getItemId(c);
+  const itemId = opts.itemId ?? getItemId(c);
+  const requireAccess = opts.requireAccess !== false;
 
   const [agent, rawItem, versionCount, latestVersionDate] = await Promise.all([
-    getPackageWithAccess(itemId, orgId, applicationId),
+    requireAccess ? getPackageWithAccess(itemId, orgId, applicationId) : getPackage(itemId, orgId),
     getOrgItem(orgId, itemId, CONFIG_BY_TYPE.agent),
     getVersionCount(itemId),
     getLatestVersionCreatedAt(itemId),
   ]);
 
   if (!agent) {
-    throw notFound(`Agent '${itemId}' not found`);
+    return null;
   }
 
   const m = agent.manifest;
@@ -57,7 +76,7 @@ export async function agentDetailHandler(c: Context<AppEnv>) {
     latestVersionDate,
   );
 
-  return c.json({
+  return {
     id: agent.id,
     display_name: m.display_name,
     description: m.description,
@@ -108,5 +127,13 @@ export async function agentDetailHandler(c: Context<AppEnv>) {
           prompt: agent.prompt,
         }
       : {}),
-  });
+  };
+}
+
+export async function agentDetailHandler(c: Context<AppEnv>) {
+  const dto = await buildAgentDetailDto(c, {});
+  if (!dto) {
+    throw notFound(`Agent '${getItemId(c)}' not found`);
+  }
+  return c.json(dto);
 }

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -48,7 +48,7 @@ import {
   createVersionAndUpload,
   deletePackageVersion,
 } from "../services/package-versions.ts";
-import { agentDetailHandler } from "./agent-detail-handler.ts";
+import { agentDetailHandler, buildAgentDetailDto } from "./agent-detail-handler.ts";
 import { rateLimit } from "../middleware/rate-limit.ts";
 import { requirePackageInOrg } from "../middleware/guards.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
@@ -338,6 +338,18 @@ interface PackageRouteConfig {
   requireContent?: boolean;
   /** Custom GET detail handler, replaces makeGetHandler when provided. */
   getHandler?: (c: Context<AppEnv>) => Promise<Response>;
+  /**
+   * Custom builder for the package detail DTO returned by mutating endpoints
+   * (create / update / fork). When provided it overrides the generic
+   * `buildPackageDetailDto` so the type's own GET serializer is reused
+   * (agents return the richer Agent detail via `buildAgentDetailDto`).
+   * Returns `null` when the package cannot be resolved.
+   */
+  detailDto?: (
+    c: Context<AppEnv>,
+    itemId: string,
+    orgId: string,
+  ) => Promise<Record<string, unknown> | null>;
 }
 
 // Every AFPS package type exposes user-facing routes. `Partial` is kept so
@@ -362,6 +374,10 @@ const ROUTE_CONFIGS: Partial<Record<PackageType, PackageRouteConfig>> = {
     requireContent: true,
     requireMutableForVersionOps: true,
     getHandler: agentDetailHandler,
+    // Mutating endpoints echo the full Agent detail (same serializer as the
+    // GET). `requireAccess: false` — the caller just wrote this agent in their
+    // org, so the app-install gate must not 404 a successful write.
+    detailDto: (c, itemId) => buildAgentDetailDto(c, { itemId, requireAccess: false }),
   },
   // Integrations are authored via a JSON-body manifest editor (parity with
   // agents/skills). The stored `manifest.json` content mirrors the DB
@@ -532,8 +548,16 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
         );
       }
 
+      // Return the created package resource — same DTO/serializer as the GET
+      // detail — so callers see the launched state without a follow-up GET
+      // (issue #646). `packageId` (legacy alias of the DTO's `id`),
+      // `lock_version` (optimistic-lock token), and `message` are retained
+      // additively as operation-result envelope. Defensive fallback to the
+      // legacy stub if the just-created row can't be re-read.
+      const detail = await loadPackageDetailDto(c, rcfg, packageId, orgId);
       return c.json(
         {
+          ...(detail ?? {}),
           packageId,
           lock_version: item.lockVersion,
           message: `${rcfg.cfg.label.slice(0, -1)} created`,
@@ -640,8 +664,12 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
       );
     }
 
+    // Return the created package resource (same serializer as GET detail) with
+    // the operation envelope retained additively (issue #646).
+    const detail = await loadPackageDetailDto(c, rcfg, item.id, orgId);
     return c.json(
       {
+        ...(detail ?? {}),
         packageId: item.id,
         lock_version: item.lockVersion,
         message: `${rcfg.cfg.label.slice(0, -1)} created`,
@@ -660,47 +688,84 @@ export function getItemId(c: Context<AppEnv>): string {
   return c.req.param("id")!;
 }
 
+/**
+ * Build the canonical package detail DTO for skills / integrations / mcp-servers
+ * — the exact object the `GET` detail endpoint serializes (`OrgPackageItemDetail`).
+ * Org-scoped (no app-install gate): the GET handler applies that gate before
+ * calling this, while mutating endpoints (create / update / fork) reuse this
+ * directly to echo what the caller just wrote (issue #646). Returns `null` when
+ * the package is not found in the org.
+ */
+async function buildPackageDetailDto(
+  rcfg: PackageRouteConfig,
+  itemId: string,
+  orgId: string,
+): Promise<Record<string, unknown> | null> {
+  const [item, versionCount, latestVersionDate] = await Promise.all([
+    getOrgItem(orgId, itemId, rcfg.cfg),
+    getVersionCount(itemId),
+    getLatestVersionCreatedAt(itemId),
+  ]);
+
+  if (!item) return null;
+
+  // Extract secondary source file from S3 storage (e.g. .ts for tools)
+  let sourceText: string | null = null;
+  if (rcfg.sourceFileName) {
+    const files = await downloadPackageFiles(rcfg.cfg.storageFolder, orgId, itemId);
+    const sourceData = files?.[rcfg.sourceFileName(itemId)];
+    if (sourceData) {
+      sourceText = new TextDecoder().decode(sourceData);
+    }
+  }
+
+  return {
+    ...item,
+    ...(sourceText != null ? { source_code: sourceText } : {}),
+    version_count: versionCount,
+    has_unarchived_changes: computeHasUnpublishedChanges(
+      item.source,
+      versionCount,
+      item.updatedAt ? new Date(item.updatedAt) : null,
+      latestVersionDate,
+    ),
+  };
+}
+
+/**
+ * Resolve the package detail DTO a mutating endpoint should echo — the agent's
+ * richer Agent detail when configured (`rcfg.detailDto`), otherwise the generic
+ * package detail. Single source of truth so create / update / fork stay in
+ * lockstep with their respective GET serializers.
+ */
+function loadPackageDetailDto(
+  c: Context<AppEnv>,
+  rcfg: PackageRouteConfig,
+  itemId: string,
+  orgId: string,
+): Promise<Record<string, unknown> | null> {
+  return rcfg.detailDto
+    ? rcfg.detailDto(c, itemId, orgId)
+    : buildPackageDetailDto(rcfg, itemId, orgId);
+}
+
 function makeGetHandler(rcfg: PackageRouteConfig) {
   return async (c: Context<AppEnv>) => {
     const orgId = c.get("orgId");
     const applicationId = c.get("applicationId");
     const itemId = getItemId(c);
-    const [item, versionCount, latestVersionDate] = await Promise.all([
-      getOrgItem(orgId, itemId, rcfg.cfg),
-      getVersionCount(itemId),
-      getLatestVersionCreatedAt(itemId),
-    ]);
-
-    if (!item) {
-      throw notFound(`${rcfg.cfg.label.slice(0, -1)} '${itemId}' not found`);
-    }
 
     // Enforce app-level access: all apps can only access installed packages
     if (!(await hasPackageAccess({ orgId, applicationId }, itemId))) {
       throw notFound(`${rcfg.cfg.label.slice(0, -1)} '${itemId}' not found`);
     }
 
-    // Extract secondary source file from S3 storage (e.g. .ts for tools)
-    let sourceText: string | null = null;
-    if (rcfg.sourceFileName) {
-      const files = await downloadPackageFiles(rcfg.cfg.storageFolder, orgId, itemId);
-      const sourceData = files?.[rcfg.sourceFileName(itemId)];
-      if (sourceData) {
-        sourceText = new TextDecoder().decode(sourceData);
-      }
+    const dto = await buildPackageDetailDto(rcfg, itemId, orgId);
+    if (!dto) {
+      throw notFound(`${rcfg.cfg.label.slice(0, -1)} '${itemId}' not found`);
     }
 
-    return c.json({
-      ...item,
-      ...(sourceText != null ? { source_code: sourceText } : {}),
-      version_count: versionCount,
-      has_unarchived_changes: computeHasUnpublishedChanges(
-        item.source,
-        versionCount,
-        item.updatedAt ? new Date(item.updatedAt) : null,
-        latestVersionDate,
-      ),
-    });
+    return c.json(dto);
   };
 }
 
@@ -824,7 +889,13 @@ function makeUpdateHandler(rcfg: PackageRouteConfig) {
       });
     }
 
+    // Return the updated package resource (same serializer as GET detail) with
+    // the operation envelope retained additively — `packageId` (legacy alias of
+    // `id`), `lock_version` (the new optimistic-lock token consumers must read
+    // back for the next edit), and `warnings` (issue #646).
+    const detail = await loadPackageDetailDto(c, rcfg, itemId, orgId);
     return c.json({
+      ...(detail ?? {}),
       packageId: updated.id,
       lock_version: updated.lockVersion,
       ...(warnings.length > 0 ? { warnings } : {}),
@@ -879,6 +950,54 @@ function makeListVersionsHandler(rcfg: PackageRouteConfig) {
   };
 }
 
+/**
+ * Build the canonical version detail DTO — the exact object the `GET` version
+ * detail endpoint serializes. Reused by the version create / restore endpoints
+ * so they echo the resulting version resource instead of an id/message stub
+ * (issue #646). Returns `null` when the version query resolves nothing.
+ */
+async function buildVersionDetailDto(
+  rcfg: PackageRouteConfig,
+  itemId: string,
+  versionQuery: string,
+): Promise<Record<string, unknown> | null> {
+  const detail = await getVersionDetail(itemId, versionQuery);
+  if (!detail) return null;
+
+  const matchingTags = await getMatchingDistTags(itemId, detail.version);
+
+  // Extract primary content file from the ZIP
+  let content: string | null = null;
+  let sourceText: string | null = null;
+  if (detail.content) {
+    const fileName = rcfg.storageFileName(itemId);
+    const fileData = detail.content[fileName];
+    if (fileData) {
+      content = new TextDecoder().decode(fileData);
+    }
+    if (rcfg.sourceFileName) {
+      const sourceData = detail.content[rcfg.sourceFileName(itemId)];
+      if (sourceData) {
+        sourceText = new TextDecoder().decode(sourceData);
+      }
+    }
+  }
+
+  return {
+    id: detail.id,
+    version: detail.version,
+    manifest: detail.manifest,
+    content,
+    ...(sourceText != null ? { source_code: sourceText } : {}),
+    yanked: detail.yanked,
+    yanked_reason: detail.yankedReason,
+    integrity: detail.integrity,
+    artifact_size: detail.artifactSize,
+    createdAt: detail.createdAt,
+    dist_tags: matchingTags,
+  };
+}
+
 function makeVersionDetailHandler(rcfg: PackageRouteConfig) {
   return async (c: Context<AppEnv>) => {
     const orgId = c.get("orgId");
@@ -890,43 +1009,12 @@ function makeVersionDetailHandler(rcfg: PackageRouteConfig) {
       throw notFound(`${rcfg.cfg.label.slice(0, -1)} '${itemId}' not found`);
     }
 
-    const detail = await getVersionDetail(itemId, versionQuery);
-    if (!detail) {
+    const dto = await buildVersionDetailDto(rcfg, itemId, versionQuery);
+    if (!dto) {
       throw notFound(`Version '${versionQuery}' not found`);
     }
 
-    const matchingTags = await getMatchingDistTags(itemId, detail.version);
-
-    // Extract primary content file from the ZIP
-    let content: string | null = null;
-    let sourceText: string | null = null;
-    if (detail.content) {
-      const fileName = rcfg.storageFileName(itemId);
-      const fileData = detail.content[fileName];
-      if (fileData) {
-        content = new TextDecoder().decode(fileData);
-      }
-      if (rcfg.sourceFileName) {
-        const sourceData = detail.content[rcfg.sourceFileName(itemId)];
-        if (sourceData) {
-          sourceText = new TextDecoder().decode(sourceData);
-        }
-      }
-    }
-
-    return c.json({
-      id: detail.id,
-      version: detail.version,
-      manifest: detail.manifest,
-      content,
-      ...(sourceText != null ? { source_code: sourceText } : {}),
-      yanked: detail.yanked,
-      yanked_reason: detail.yankedReason,
-      integrity: detail.integrity,
-      artifact_size: detail.artifactSize,
-      createdAt: detail.createdAt,
-      dist_tags: matchingTags,
-    });
+    return c.json(dto);
   };
 }
 
@@ -996,8 +1084,19 @@ function makeCreateVersionHandler(rcfg: PackageRouteConfig) {
       throw invalidRequest("Failed to create version (invalid or duplicate)");
     }
 
+    // Return the created version resource — same DTO/serializer as the GET
+    // version detail — so callers see the snapshot (manifest, integrity,
+    // dist_tags, …) without a follow-up GET (issue #646). `id` (version row id)
+    // and `version` are already part of the resource; `message` is retained
+    // additively as operation-result envelope.
+    const detail = await buildVersionDetailDto(rcfg, itemId, result.version);
     return c.json(
-      { id: result.id, version: result.version, message: `Version ${result.version} created` },
+      {
+        ...(detail ?? {}),
+        id: result.id,
+        version: result.version,
+        message: `Version ${result.version} created`,
+      },
       201,
     );
   };
@@ -1085,7 +1184,15 @@ function makeRestoreVersionHandler(rcfg: PackageRouteConfig) {
       });
     }
 
+    // Return the restored version resource — same DTO/serializer as the GET
+    // version detail (issue #646). The operation envelope is retained
+    // additively: `message`, `restored_version` (legacy alias of the resource's
+    // `version`), and `lock_version` — the package's NEW optimistic-lock token
+    // (not part of the version resource), which consumers must read back before
+    // the next draft edit.
+    const versionDto = await buildVersionDetailDto(rcfg, itemId, detail.version);
     return c.json({
+      ...(versionDto ?? {}),
       message: `Version ${detail.version} restored`,
       restored_version: detail.version,
       lock_version: updated.lockVersion,
@@ -1236,7 +1343,24 @@ export function createPackagesRouter() {
       );
     }
 
-    return c.json(result, 201);
+    // Return the forked package resource — same DTO/serializer as the new
+    // package's GET detail, selected by its type (issue #646). The fork
+    // operation fields (`packageId` legacy alias of `id`, `type`, `forked_from`)
+    // are retained additively. Falls back to the fork-result stub if the
+    // freshly-forked row can't be re-read.
+    const forkedRcfg = ROUTE_CONFIGS[result.type as PackageType];
+    const detail = forkedRcfg
+      ? await loadPackageDetailDto(c, forkedRcfg, result.packageId, orgId)
+      : null;
+    return c.json(
+      {
+        ...(detail ?? {}),
+        packageId: result.packageId,
+        type: result.type,
+        forked_from: result.forked_from,
+      },
+      201,
+    );
   });
 
   // --- Package import/download/publish routes ---

--- a/apps/api/test/integration/routes/packages.test.ts
+++ b/apps/api/test/integration/routes/packages.test.ts
@@ -1267,4 +1267,199 @@ describe("Packages API", () => {
       expect(res.status).toBe(404);
     });
   });
+
+  // ═══════════════════════════════════════════════
+  // Issue #646 — mutating endpoints return the affected resource (same shape as
+  // the GET detail) while retaining the operation envelope additively.
+  // ═══════════════════════════════════════════════
+
+  describe("issue #646 — mutating package endpoints return the resource", () => {
+    const agentManifest = (name: string, version = "0.1.0") => ({
+      name,
+      version,
+      type: "agent",
+      schema_version: "0.1",
+      display_name: "Resource Agent",
+      description: "Returns the full resource on mutation",
+    });
+
+    it("POST create agent returns the Agent detail DTO + create envelope", async () => {
+      const res = await app.request("/api/packages/agents", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          manifest: agentManifest("@pkgorg/res-agent"),
+          content: "You are a helpful assistant.",
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as any;
+      // Operation envelope retained additively.
+      expect(body.packageId).toBe("@pkgorg/res-agent");
+      expect(body.lock_version).toBeNumber();
+      expect(body.message).toBeString();
+      // Full Agent detail resource (same serializer as GET detail).
+      expect(body.id).toBe("@pkgorg/res-agent");
+      expect(body.display_name).toBe("Resource Agent");
+      expect(body.dependencies).toBeDefined();
+      expect(body.config).toBeDefined();
+      expect(body.version_count).toBeNumber();
+    });
+
+    it("POST create integration returns the package detail DTO + create envelope", async () => {
+      const res = await app.request("/api/packages/integrations", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          manifest: {
+            name: "@pkgorg/res-integration",
+            version: "0.1.0",
+            type: "integration",
+            schema_version: "0.1",
+            display_name: "Resource Integration",
+            description: "A remote HTTP MCP integration",
+            source: {
+              kind: "remote",
+              remote: { url: "https://example.com/mcp/v1", transport: "streamable-http" },
+            },
+            auths: {
+              primary: {
+                type: "api_key",
+                authorized_uris: ["https://example.com/**"],
+                credentials: {
+                  schema: {
+                    type: "object",
+                    required: ["api_key"],
+                    properties: { api_key: { type: "string" } },
+                  },
+                },
+                delivery: {
+                  http: {
+                    in: "header",
+                    name: "Authorization",
+                    prefix: "Bearer ",
+                    value: "{$credential.api_key}",
+                  },
+                },
+              },
+            },
+          },
+        }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as any;
+      expect(body.packageId).toBe("@pkgorg/res-integration");
+      expect(body.lock_version).toBeNumber();
+      // Full OrgPackageItemDetail resource.
+      expect(body.id).toBe("@pkgorg/res-integration");
+      expect(body.manifest).toBeDefined();
+      expect(body.version_count).toBeNumber();
+      expect(body.has_unarchived_changes).toBeBoolean();
+    });
+
+    it("PUT update agent returns the Agent detail DTO + lock_version envelope", async () => {
+      const create = await app.request("/api/packages/agents", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          manifest: agentManifest("@pkgorg/upd-res-agent"),
+          content: "original prompt",
+        }),
+      });
+      const created = (await create.json()) as any;
+
+      const res = await app.request("/api/packages/agents/@pkgorg/upd-res-agent", {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          manifest: agentManifest("@pkgorg/upd-res-agent"),
+          content: "updated prompt",
+          lock_version: created.lock_version,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      // Envelope retained — new lock token consumers read back.
+      expect(body.packageId).toBe("@pkgorg/upd-res-agent");
+      expect(body.lock_version).toBeGreaterThan(created.lock_version);
+      // Full Agent detail resource.
+      expect(body.id).toBe("@pkgorg/upd-res-agent");
+      expect(body.dependencies).toBeDefined();
+      expect(body.config).toBeDefined();
+    });
+
+    it("POST create version returns the version detail DTO + message envelope", async () => {
+      const create = await app.request("/api/packages/agents", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          manifest: agentManifest("@pkgorg/ver-res-agent"),
+          content: "v1 prompt",
+        }),
+      });
+      const created = (await create.json()) as any;
+
+      // Change the draft so a new version is not a no-op.
+      await app.request("/api/packages/agents/@pkgorg/ver-res-agent", {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          manifest: agentManifest("@pkgorg/ver-res-agent"),
+          content: "v2 prompt",
+          lock_version: created.lock_version,
+        }),
+      });
+
+      const res = await app.request("/api/packages/agents/@pkgorg/ver-res-agent/versions", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({ version: "0.2.0" }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as any;
+      // Envelope retained.
+      expect(body.id).toBeNumber();
+      expect(body.version).toBe("0.2.0");
+      expect(body.message).toBeString();
+      // Full version detail resource (same serializer as GET version detail).
+      expect(body.manifest).toBeDefined();
+      expect(body.integrity).toBeString();
+      expect(Array.isArray(body.dist_tags)).toBe(true);
+    });
+
+    it("POST restore version returns the version detail DTO + restore envelope", async () => {
+      const create = await app.request("/api/packages/agents", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          manifest: agentManifest("@pkgorg/restore-res-agent"),
+          content: "v1 prompt",
+        }),
+      });
+      const created = (await create.json()) as any;
+
+      const res = await app.request(
+        "/api/packages/agents/@pkgorg/restore-res-agent/versions/0.1.0/restore",
+        {
+          method: "POST",
+          headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        },
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      // Operation envelope retained additively.
+      expect(body.message).toBeString();
+      expect(body.restored_version).toBe("0.1.0");
+      expect(body.lock_version).toBeGreaterThan(created.lock_version);
+      // Full version detail resource for the restored version.
+      expect(body.version).toBe("0.1.0");
+      expect(body.manifest).toBeDefined();
+      expect(Array.isArray(body.dist_tags)).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
Refs #646 — resolves the **packages family** (the largest, trickiest surface: 4 divergent response shapes). Follows the pattern merged in #645.

Mutating package endpoints now return the affected resource — same serializer as the corresponding `GET` detail — instead of an id/message stub, so callers no longer need a follow-up `GET`. The operation envelope (`lock_version` / `message` / `warnings` / `restored_version` / legacy `packageId`) is retained **additively** via `allOf: [<resource>, {…envelope}]`.

## Inventory checked off

- [x] `POST /packages/{skills,agents,integrations}` (+ `mcp-servers`) → `{packageId, lock_version, message}`
- [x] `PUT /packages/...` (scoped + by-id) → `{packageId, lock_version, …warnings}`
- [x] `POST /packages/.../versions` → `{id, version, message}`
- [x] `POST /packages/.../versions/restore` → `{message, restored_version, lock_version}`
- [x] `POST /packages/:scope/:name/fork` → partial fork result

## Per-endpoint: resource returned + retained envelope fields

| Endpoint | Resource returned | Envelope retained additively |
|---|---|---|
| `POST /packages/{skills,integrations,mcp-servers}` | `OrgPackageItemDetail` | `packageId` (alias of `id`), `lock_version`, `message`, `warnings` |
| `POST /packages/agents` | `AgentDetail` | `packageId`, `lock_version`, `message` |
| `PUT /packages/{skills,integrations,mcp-servers}/...` (scoped + by-id) | `OrgPackageItemDetail` | `packageId`, `lock_version`, `warnings` |
| `PUT /packages/agents/...` (scoped + by-id) | `AgentDetail` | `packageId`, `lock_version` |
| `POST /packages/.../versions` | `PackageVersionDetail` (new component) | `message` (`id`/`version` are part of the resource) |
| `POST /packages/.../versions/{v}/restore` | `PackageVersionDetail` | `message`, `restored_version` (alias of `version`), and the package's **new** `lock_version` (not part of the version resource) |
| `POST /packages/:scope/:name/fork` | forked package detail (`oneOf` Agent/OrgPackageItem, selected by `type`) | `packageId` (alias of `id`), `type`, `forked_from` |

## Approach

GET serializers were extracted into reusable builders — `buildPackageDetailDto` / `buildVersionDetailDto` (in `routes/packages.ts`) and `buildAgentDetailDto` (in `routes/agent-detail-handler.ts`) — so the mutation responses reuse the **exact** GET shapes (no drift). Mutation responses load the detail with the **app-install access gate bypassed** (org-scope only): the caller just wrote the package in their org, so a successful write that wasn't auto-installed must never 404. Each mutation falls back to the legacy stub if the just-written row can't be re-read (defensive, mirrors #645).

OpenAPI responses compose `allOf: [<resource ref>, {…envelope}]`; a new `PackageVersionDetail` component schema was added for the version detail shape.

## Consumers checked

- `apps/web` hooks (`useCreatePackage`, `useUpdatePackage`, `useCreateVersion`, `useRestoreVersion`, `useForkPackage`) and `fork-package-modal` / `package-editor` — all read only **retained** fields (`packageId`, `lock_version`, `restored_version`, `result.packageId`/`type`). Additive → unchanged.
- `apps/cli` — does not consume these package-mutation bodies. Unaffected.
- `github-action` (separate repo) — additive, fine.

## Core touched?

**No.** No `@appstrate/core` change → no npm bump required.

## Gate

`bun run check` passes — `detect:breaking` reports **0 breaking / 354 non-breaking** (purely additive), `verify:openapi` ALL CHECKS PASSED (the 5 lint warnings are pre-existing, from #645's run example + the `mcp/o/{org}` endpoint).

## Tests

- All existing package/agent/integration integration suites pass (203 tests across the touched suites).
- Adds 5 integration tests asserting each mutation returns the full Package/Version DTO **and** still carries `lock_version` / `message` / `restored_version` where it did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)