### PR TITLE
fix(uploads): accept application/zip sniff for declared ZIP-container MIMEs

### DIFF
--- a/apps/api/src/services/input-parser.ts
+++ b/apps/api/src/services/input-parser.ts
@@ -44,6 +44,7 @@ import {
   isUploadUri,
   parseUploadUri,
   isUnsniffableMime,
+  sniffedMimeMatchesDeclared,
   normalizeMime,
   sanitizeFilename,
   type UploadMeta,
@@ -518,7 +519,7 @@ export async function parseRequestInput(
         inline.forEach(({ ref, file }, i) => {
           const sniffed = inlineSniffed[i]?.mime;
           if (file.mime !== "application/octet-stream" && !isUnsniffableMime(file.mime)) {
-            if (!sniffed || sniffed !== file.mime) {
+            if (!sniffedMimeMatchesDeclared(file.mime, sniffed)) {
               throw invalidRequest(
                 sniffed
                   ? `Field '${ref.fieldName}' inline content type '${sniffed}' does not match declared '${file.mime}'`

--- a/apps/api/src/services/uploads.ts
+++ b/apps/api/src/services/uploads.ts
@@ -278,7 +278,6 @@ export function isUnsniffableMime(mime: string): boolean {
  * sniff match.
  */
 const ZIP_CONTAINER_MIMES = new Set([
-  "application/zip",
   // OOXML
   "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // xlsx
   "application/vnd.openxmlformats-officedocument.spreadsheetml.template", // xltx
@@ -305,20 +304,46 @@ const ZIP_CONTAINER_MIMES = new Set([
 ]);
 
 /**
+ * Legacy Office formats stored in an OLE2 / Compound File Binary container.
+ * `file-type` identifies the container magic (`application/x-cfb`) but never
+ * refines it to the concrete format, so every legitimate legacy Office upload
+ * sniffs as the generic parent — same shape as the ZIP family above.
+ */
+const CFB_CONTAINER_MIMES = new Set([
+  "application/msword", // .doc
+  "application/vnd.ms-excel", // .xls
+  "application/vnd.ms-powerpoint", // .ppt
+  "application/vnd.ms-outlook", // .msg
+  "application/vnd.visio", // .vsd
+]);
+
+/**
+ * Container families for declared-vs-sniffed refinement: `generic` is the
+ * parent MIME the sniffer reports for the raw container, `members` are the
+ * concrete formats stored in it.
+ */
+const CONTAINER_FAMILIES: ReadonlyArray<{ generic: string; members: Set<string> }> = [
+  { generic: "application/zip", members: ZIP_CONTAINER_MIMES },
+  { generic: "application/x-cfb", members: CFB_CONTAINER_MIMES },
+];
+
+/**
  * Declared-vs-sniffed MIME compatibility for the magic-byte check. Exact match
- * always passes; otherwise refinement is strictly parent↔child against the
- * generic `application/zip` (declared xlsx / sniffed application/zip, declared
- * application/zip / sniffed xlsx). Two SPECIFIC container types never satisfy
- * each other — declared xlsx with sniffed docm/xlsm stays a mismatch, so a
- * macro-enabled document cannot ride in under a macro-free declaration when
- * the sniffer DID identify it. Exported so the inline `data:` URI input path
- * (input-parser) applies the exact same policy as the staged-upload path.
+ * always passes; otherwise refinement is strictly parent↔child against a
+ * container family's generic type (declared xlsx / sniffed application/zip,
+ * declared application/zip / sniffed xlsx). Two SPECIFIC container types never
+ * satisfy each other — declared xlsx with sniffed docm/xlsm stays a mismatch,
+ * so a macro-enabled document cannot ride in under a macro-free declaration
+ * when the sniffer DID identify it. Exported so the inline `data:` URI input
+ * path (input-parser) applies the exact same policy as the staged-upload path.
  */
 export function sniffedMimeMatchesDeclared(declared: string, sniffed: string | undefined): boolean {
   if (!sniffed) return false;
   if (sniffed === declared) return true;
-  if (sniffed === "application/zip") return ZIP_CONTAINER_MIMES.has(declared);
-  if (declared === "application/zip") return ZIP_CONTAINER_MIMES.has(sniffed);
+  for (const { generic, members } of CONTAINER_FAMILIES) {
+    if (sniffed === generic && members.has(declared)) return true;
+    if (declared === generic && members.has(sniffed)) return true;
+  }
   return false;
 }
 

--- a/apps/api/src/services/uploads.ts
+++ b/apps/api/src/services/uploads.ts
@@ -266,6 +266,58 @@ export function isUnsniffableMime(mime: string): boolean {
 }
 
 /**
+ * MIMEs whose on-disk format is a ZIP container. `file-type` samples only the
+ * head of the stream (~4100 bytes); when the identifying entry of an OOXML/ODF
+ * archive ([Content_Types].xml, mimetype) sits beyond the sample window — the
+ * normal layout for openpyxl/LibreOffice/Google-exported files — it falls back
+ * to plain `application/zip`. Treating that fallback as a mismatch would
+ * reject legitimate office documents, so declared-vs-sniffed comparison uses
+ * Marcel/Tika-style subtype refinement: a declared member of this family is
+ * compatible with a sniffed `application/zip` (and vice versa). A declaration
+ * outside the family (application/pdf, image/png, …) still requires an exact
+ * sniff match.
+ */
+const ZIP_CONTAINER_MIMES = new Set([
+  "application/zip",
+  // OOXML
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", // xlsx
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.template", // xltx
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document", // docx
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.template", // dotx
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation", // pptx
+  "application/vnd.openxmlformats-officedocument.presentationml.slideshow", // ppsx
+  "application/vnd.openxmlformats-officedocument.presentationml.template", // potx
+  // OOXML macro-enabled
+  "application/vnd.ms-excel.sheet.macroenabled.12", // xlsm
+  "application/vnd.ms-excel.template.macroenabled.12", // xltm
+  "application/vnd.ms-word.document.macroenabled.12", // docm
+  "application/vnd.ms-word.template.macroenabled.12", // dotm
+  "application/vnd.ms-powerpoint.presentation.macroenabled.12", // pptm
+  "application/vnd.ms-powerpoint.slideshow.macroenabled.12", // ppsm
+  // OpenDocument
+  "application/vnd.oasis.opendocument.text", // odt
+  "application/vnd.oasis.opendocument.spreadsheet", // ods
+  "application/vnd.oasis.opendocument.presentation", // odp
+  "application/vnd.oasis.opendocument.graphics", // odg
+  // Other ZIP-based formats
+  "application/epub+zip",
+  "application/java-archive", // jar
+]);
+
+/**
+ * Declared-vs-sniffed MIME compatibility for the magic-byte check. Exact match
+ * always passes; within the ZIP-container family the generic and the specific
+ * type refine each other (declared xlsx / sniffed application/zip, declared
+ * application/zip / sniffed xlsx). Exported so the inline `data:` URI input
+ * path (input-parser) applies the exact same policy as the staged-upload path.
+ */
+export function sniffedMimeMatchesDeclared(declared: string, sniffed: string | undefined): boolean {
+  if (!sniffed) return false;
+  if (sniffed === declared) return true;
+  return ZIP_CONTAINER_MIMES.has(declared) && ZIP_CONTAINER_MIMES.has(sniffed);
+}
+
+/**
  * Read declared metadata for a set of staged uploads — without claiming or
  * downloading them. Verifies each exists, belongs to the caller's tenant, and
  * has not expired (same error shapes as consume). Used to enforce the per-run
@@ -423,7 +475,7 @@ export async function consumeUploadStream(
     //    the declared MIME for these — manifests that need binary-grade
     //    validation must declare a sniffable MIME.
     if (row.mime && row.mime !== "application/octet-stream" && !isUnsniffableMime(row.mime)) {
-      if (!sniffedMime || sniffedMime !== row.mime) {
+      if (!sniffedMimeMatchesDeclared(row.mime, sniffedMime)) {
         logger.warn("upload mime mismatch on consume", {
           uploadId,
           declared: row.mime,

--- a/apps/api/src/services/uploads.ts
+++ b/apps/api/src/services/uploads.ts
@@ -306,15 +306,20 @@ const ZIP_CONTAINER_MIMES = new Set([
 
 /**
  * Declared-vs-sniffed MIME compatibility for the magic-byte check. Exact match
- * always passes; within the ZIP-container family the generic and the specific
- * type refine each other (declared xlsx / sniffed application/zip, declared
- * application/zip / sniffed xlsx). Exported so the inline `data:` URI input
- * path (input-parser) applies the exact same policy as the staged-upload path.
+ * always passes; otherwise refinement is strictly parent↔child against the
+ * generic `application/zip` (declared xlsx / sniffed application/zip, declared
+ * application/zip / sniffed xlsx). Two SPECIFIC container types never satisfy
+ * each other — declared xlsx with sniffed docm/xlsm stays a mismatch, so a
+ * macro-enabled document cannot ride in under a macro-free declaration when
+ * the sniffer DID identify it. Exported so the inline `data:` URI input path
+ * (input-parser) applies the exact same policy as the staged-upload path.
  */
 export function sniffedMimeMatchesDeclared(declared: string, sniffed: string | undefined): boolean {
   if (!sniffed) return false;
   if (sniffed === declared) return true;
-  return ZIP_CONTAINER_MIMES.has(declared) && ZIP_CONTAINER_MIMES.has(sniffed);
+  if (sniffed === "application/zip") return ZIP_CONTAINER_MIMES.has(declared);
+  if (declared === "application/zip") return ZIP_CONTAINER_MIMES.has(sniffed);
+  return false;
 }
 
 /**

--- a/apps/api/test/integration/services/upload-consume.test.ts
+++ b/apps/api/test/integration/services/upload-consume.test.ts
@@ -368,6 +368,28 @@ describe("consumeUploadStream", () => {
     expect(consumed.mime).toBe(declared);
   });
 
+  it("legacy .xls (OLE2/CFB container) declared as ms-excel is accepted", async () => {
+    // file-type identifies the OLE2 magic as generic application/x-cfb and
+    // never refines it to the concrete legacy Office format — parent↔child
+    // refinement must bridge the gap, same as the ZIP family.
+    const ctx = await createTestContext({ orgSlug: "org-xls" });
+    const id = "upl_xls_1";
+    const cfb = new Uint8Array(512);
+    cfb.set([0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+    const bytes = Buffer.from(cfb);
+    await seedUpload(
+      { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      { id, bytes, mime: "application/vnd.ms-excel" },
+    );
+    const consumed = await consumeUploadStream(
+      id,
+      { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      drainSink,
+    );
+    expect(consumed.size).toBe(bytes.length);
+    expect(consumed.mime).toBe("application/vnd.ms-excel");
+  });
+
   it("zip bytes declared as pdf are still rejected (family refinement is zip-only)", async () => {
     const ctx = await createTestContext({ orgSlug: "org-zip-spoof" });
     const id = "upl_zip_spoof_1";

--- a/apps/api/test/integration/services/upload-consume.test.ts
+++ b/apps/api/test/integration/services/upload-consume.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, it, expect, beforeEach } from "bun:test";
 import { fileTypeStream } from "file-type";
+import { zipSync } from "fflate";
 import { db } from "@appstrate/db/client";
 import { uploads } from "@appstrate/db/schema";
 import { truncateAll } from "../../helpers/db.ts";
@@ -323,6 +324,69 @@ describe("consumeUploadStream", () => {
       expect(e).toBeInstanceOf(ApiError);
       expect((e as ApiError).status).toBe(400);
       expect((e as ApiError).message.toLowerCase()).toContain("mime");
+    }
+  });
+
+  it("xlsx whose head sniffs as application/zip is accepted (#zip-container refinement)", async () => {
+    // Mirror the openpyxl/LibreOffice OOXML layout: content entries first,
+    // `[Content_Types].xml` LAST. The big stored entry pushes the identifying
+    // entry past `fileTypeStream`'s ~4100-byte sample, so the sniffer falls
+    // back to plain `application/zip` — which must refine into the declared
+    // spreadsheet type instead of failing the consume.
+    const ctx = await createTestContext({ orgSlug: "org-xlsx" });
+    const id = "upl_xlsx_1";
+    const enc = new TextEncoder();
+    // Incompressible pseudo-random payload (deterministic LCG) — keeps the
+    // deflated sheet entry well past the sniffer's sample window, like the
+    // real-world spreadsheet data this reproduces.
+    const sheetData = new Uint8Array(20000);
+    let seed = 0x12345678;
+    for (let i = 0; i < sheetData.length; i++) {
+      seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+      sheetData[i] = seed & 0xff;
+    }
+    const bytes = Buffer.from(
+      zipSync({
+        "docProps/app.xml": enc.encode(`<x>${"a".repeat(150)}</x>`),
+        "xl/worksheets/sheet1.xml": sheetData,
+        "[Content_Types].xml": enc.encode(
+          '<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/></Types>',
+        ),
+      }),
+    );
+    const declared = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    await seedUpload(
+      { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      { id, bytes, mime: declared },
+    );
+    const consumed = await consumeUploadStream(
+      id,
+      { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      drainSink,
+    );
+    expect(consumed.size).toBe(bytes.length);
+    expect(consumed.mime).toBe(declared);
+  });
+
+  it("zip bytes declared as pdf are still rejected (family refinement is zip-only)", async () => {
+    const ctx = await createTestContext({ orgSlug: "org-zip-spoof" });
+    const id = "upl_zip_spoof_1";
+    const bytes = Buffer.from(zipSync({ "a.txt": new TextEncoder().encode("hi") }));
+    await seedUpload(
+      { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+      { id, bytes, mime: "application/pdf" },
+    );
+    try {
+      await consumeUploadStream(
+        id,
+        { orgId: ctx.orgId, applicationId: ctx.defaultAppId },
+        drainSink,
+      );
+      throw new Error("expected to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiError);
+      expect((e as ApiError).status).toBe(400);
+      expect((e as ApiError).message).toContain("does not match declared");
     }
   });
 

--- a/apps/api/test/unit/services/upload-mime-policy.test.ts
+++ b/apps/api/test/unit/services/upload-mime-policy.test.ts
@@ -54,4 +54,18 @@ describe("sniffedMimeMatchesDeclared", () => {
     // gzip/rar are NOT zip containers — no family pass-through.
     expect(sniffedMimeMatchesDeclared(XLSX, "application/gzip")).toBe(false);
   });
+
+  it("two specific container types never satisfy each other", () => {
+    // Refinement is parent↔child only — when the sniffer DID identify the
+    // concrete format, a different concrete declaration is a real mismatch.
+    // Notably keeps macro-enabled documents out of macro-free declarations.
+    expect(sniffedMimeMatchesDeclared(XLSX, DOCX)).toBe(false);
+    expect(sniffedMimeMatchesDeclared(XLSX, "application/vnd.ms-excel.sheet.macroenabled.12")).toBe(
+      false,
+    );
+    expect(
+      sniffedMimeMatchesDeclared(DOCX, "application/vnd.ms-word.document.macroenabled.12"),
+    ).toBe(false);
+    expect(sniffedMimeMatchesDeclared("application/epub+zip", XLSX)).toBe(false);
+  });
 });

--- a/apps/api/test/unit/services/upload-mime-policy.test.ts
+++ b/apps/api/test/unit/services/upload-mime-policy.test.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `sniffedMimeMatchesDeclared` — the declared-vs-sniffed MIME
+ * compatibility policy shared by the staged-upload consume path and the inline
+ * `data:` URI input path. Pins the Marcel/Tika-style ZIP-container refinement
+ * (a sniffed `application/zip` satisfies a declared OOXML/ODF type, because
+ * `file-type`'s head sample cannot always reach the archive's identifying
+ * entry) without weakening the exact-match rule outside that family.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { sniffedMimeMatchesDeclared } from "../../../src/services/uploads.ts";
+
+const XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+const DOCX = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+describe("sniffedMimeMatchesDeclared", () => {
+  it("exact match passes", () => {
+    expect(sniffedMimeMatchesDeclared("application/pdf", "application/pdf")).toBe(true);
+    expect(sniffedMimeMatchesDeclared(XLSX, XLSX)).toBe(true);
+  });
+
+  it("undefined sniff never matches", () => {
+    expect(sniffedMimeMatchesDeclared("application/pdf", undefined)).toBe(false);
+    expect(sniffedMimeMatchesDeclared(XLSX, undefined)).toBe(false);
+  });
+
+  it("sniffed application/zip refines into a declared ZIP-container type", () => {
+    expect(sniffedMimeMatchesDeclared(XLSX, "application/zip")).toBe(true);
+    expect(sniffedMimeMatchesDeclared(DOCX, "application/zip")).toBe(true);
+    expect(
+      sniffedMimeMatchesDeclared("application/vnd.oasis.opendocument.text", "application/zip"),
+    ).toBe(true);
+    expect(sniffedMimeMatchesDeclared("application/epub+zip", "application/zip")).toBe(true);
+  });
+
+  it("declared application/zip accepts a sniffed specific container type", () => {
+    // file-type recognises some zips as their specific format (jar, xlsx) —
+    // a user uploading one under the generic declared type must not be
+    // rejected for the sniffer being MORE precise than the declaration.
+    expect(sniffedMimeMatchesDeclared("application/zip", XLSX)).toBe(true);
+    expect(sniffedMimeMatchesDeclared("application/zip", "application/java-archive")).toBe(true);
+  });
+
+  it("sniffed application/zip does NOT satisfy a non-container declaration", () => {
+    expect(sniffedMimeMatchesDeclared("application/pdf", "application/zip")).toBe(false);
+    expect(sniffedMimeMatchesDeclared("image/png", "application/zip")).toBe(false);
+  });
+
+  it("non-zip mismatches still fail", () => {
+    expect(sniffedMimeMatchesDeclared("application/pdf", "image/png")).toBe(false);
+    expect(sniffedMimeMatchesDeclared(XLSX, "application/pdf")).toBe(false);
+    // gzip/rar are NOT zip containers — no family pass-through.
+    expect(sniffedMimeMatchesDeclared(XLSX, "application/gzip")).toBe(false);
+  });
+});

--- a/apps/api/test/unit/services/upload-mime-policy.test.ts
+++ b/apps/api/test/unit/services/upload-mime-policy.test.ts
@@ -55,6 +55,24 @@ describe("sniffedMimeMatchesDeclared", () => {
     expect(sniffedMimeMatchesDeclared(XLSX, "application/gzip")).toBe(false);
   });
 
+  it("sniffed application/x-cfb refines into a declared legacy Office type", () => {
+    // file-type identifies the OLE2 container magic but never refines it to
+    // the concrete format — every legitimate .doc/.xls/.ppt sniffs as x-cfb.
+    expect(sniffedMimeMatchesDeclared("application/msword", "application/x-cfb")).toBe(true);
+    expect(sniffedMimeMatchesDeclared("application/vnd.ms-excel", "application/x-cfb")).toBe(true);
+    expect(sniffedMimeMatchesDeclared("application/vnd.ms-powerpoint", "application/x-cfb")).toBe(
+      true,
+    );
+    expect(sniffedMimeMatchesDeclared("application/x-cfb", "application/x-cfb")).toBe(true);
+  });
+
+  it("container families do not cross", () => {
+    // A zip member never refines from the cfb generic and vice versa.
+    expect(sniffedMimeMatchesDeclared(XLSX, "application/x-cfb")).toBe(false);
+    expect(sniffedMimeMatchesDeclared("application/vnd.ms-excel", "application/zip")).toBe(false);
+    expect(sniffedMimeMatchesDeclared("application/pdf", "application/x-cfb")).toBe(false);
+  });
+
   it("two specific container types never satisfy each other", () => {
     // Refinement is parent↔child only — when the sniffer DID identify the
     // concrete format, a different concrete declaration is a real mismatch.


### PR DESCRIPTION
## Problem

Triggering a run with a legitimate `.xlsx` input fails:

```
Upload 'upl_…' content type 'application/zip' does not match declared
'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
```

`file-type`'s stream detection samples only the first ~4100 bytes. OOXML/ODF archives whose identifying entry (`[Content_Types].xml`, `mimetype`) sits past that window sniff as plain `application/zip`. This is the **normal layout** for openpyxl / LibreOffice / Google-exported files (`[Content_Types].xml` written last, after hundreds of KB of sheet data) — only Excel-desktop files reliably put it first. The strict declared-vs-sniffed equality check in `consumeUploadStream` therefore rejected valid office documents.

Reproduced with a real-world openpyxl-generated workbook: full-buffer detection → `xlsx`, 4100-byte sample → `application/zip`.

The same gap exists for legacy Office: `file-type` identifies the OLE2 magic as generic `application/x-cfb` and **never** refines it to the concrete format, so every legitimate `.doc`/`.xls`/`.ppt` upload failed the check too.

## Fix

Marcel/Tika-style **parent↔child** subtype refinement (the `sub-class-of` semantics Rails ActiveStorage uses), driven by a container-family table — `generic` parent MIME ↔ concrete `members`:

| Family | Generic parent | Members |
|---|---|---|
| ZIP | `application/zip` | OOXML (incl. macro variants), OpenDocument, epub, jar |
| OLE2/CFB | `application/x-cfb` | doc, xls, ppt, msg, vsd |

Matrix:

- declared `xlsx` + sniffed `application/zip` → accepted (sniffer hit its sample limit)
- declared `application/vnd.ms-excel` + sniffed `application/x-cfb` → accepted (sniffer never refines CFB)
- declared `application/zip` + sniffed `xlsx`/`jar` → accepted (sniffer more precise than declaration)
- declared `application/pdf` + sniffed `application/zip` or `x-cfb` → **rejected** (outside the family)
- declared `xlsx` + sniffed `docm`/`xlsm` → **rejected** (two specific types never satisfy each other — a macro-enabled document cannot ride in under a macro-free declaration when the sniffer identified it)
- declared `xlsx` + sniffed `x-cfb`, declared `vnd.ms-excel` + sniffed `zip` → **rejected** (families do not cross)
- declared `xlsx` + sniffed `application/gzip` → **rejected** (gzip is not a zip container)

New `sniffedMimeMatchesDeclared()` helper in `uploads.ts`, applied by both the staged-upload consume path and the inline `data:` URI input path so the two keep identical policy. The allowlists are bounded by construction: they only need to mirror what `file-type`'s detectors can return (closed, version-pinned set).

## Security

No regression of substance: the magic-byte check validates format, not innocuousness — a crafted real-xlsx already passed the strict check. The actual defenses are unchanged: byte-exact declared-size enforcement (mid-stream abort), no server-side parsing/extraction of the uploaded archive, consumption only inside the sandboxed agent container. The parent↔child restriction preserves the one meaningful sniff signal in the family: macro-enabled vs macro-free when detection succeeds.

## Tests

- Unit: `upload-mime-policy.test.ts` pins the refinement matrix (exact match, zip↔container and cfb↔legacy-Office both directions, non-container rejections, cross-member and cross-family rejections incl. macro variants, gzip excluded).
- Integration: fflate-built fixture mirroring the openpyxl layout (incompressible deflated sheet entry first, `[Content_Types].xml` last — verified to sniff as `application/zip` through `fileTypeStream`) accepted under a declared xlsx MIME; OLE2-magic fixture accepted under declared `application/vnd.ms-excel`; zip bytes declared as PDF still rejected.

`bun run check` 29/29, API unit suite green, upload/input-parser integration suites green (Tier-0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)