### PR TITLE
refactor(api)!: bare member/invitation/profile resources from org + profile mutations (batch F, #657)

### DIFF
--- a/apps/api/src/openapi/baseline.json
+++ b/apps/api/src/openapi/baseline.json
@@ -796,7 +796,7 @@
         },
         "responses": {
           "200": {
-            "description": "Agent proxy updated",
+            "description": "Agent proxy updated — returns the affected proxy setting",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -808,12 +808,28 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": ["proxyId", "resolved"],
+                      "properties": {
+                        "proxyId": {
+                          "type": ["string", "null"]
+                        },
+                        "resolved": {
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean"
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -1284,7 +1300,7 @@
         },
         "responses": {
           "200": {
-            "description": "Agent model updated",
+            "description": "Agent model updated — returns the affected model setting",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -1296,12 +1312,25 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": ["modelId"],
+                      "properties": {
+                        "modelId": {
+                          "type": ["string", "null"]
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean"
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -1513,7 +1542,7 @@
         "operationId": "runAgent",
         "tags": ["Runs"],
         "summary": "Execute an agent",
-        "description": "Start an agent run (fire-and-forget). Returns the run ID. Rate-limited to 20/min. Supports JSON body or multipart/form-data with file uploads.",
+        "description": "Start an agent run (fire-and-forget). Returns the created run resource — same shape as `GET /runs/{id}` — including the resolved `model_label` / `model_source`. Rate-limited to 20/min. The body is JSON. File-typed input fields (`format: uri` + `contentMediaType` in the agent's input schema) accept either of two forms: (1) an `upload://upl_xxx` reference from `createUpload` — stage the bytes first by PUTting them to the signed URL (see `createUpload` for the step-by-step recipe); or (2) an inline RFC 2397 data URI `data:<mime>;name=<filename>;base64,<payload>` with up to 4 MiB of decoded content (`name` is optional) — the single-call path for JSON-only clients such as MCP. Inline bytes are written to the run workspace as a document and the payload is stripped from the persisted run input (the stored value keeps only a `data:<mime>;name=<doc>;base64,` marker). Declared binary MIMEs are verified by magic-byte sniffing in both forms. Send `rerun_from` instead of `input` to replay a previous run's input — same documents, new overrides — without re-uploading. The effective model is resolved at run creation with precedence: request `modelId` > agent model setting > org default model > system default. Without an explicit `modelId`, a change to the org default model between triggers applies to the next run — send `modelId` to pin a specific model per run.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -1543,7 +1572,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Version query to execute (exact version, dist-tag, or semver range). When provided, the run uses the versioned manifest and prompt instead of the live agent."
+            "description": "Which agent definition to execute: `draft` (the live editor working copy), `published` (the latest published version — 404 `no_published_version` if nothing is published), or a version spec (exact version, dist-tag, or semver range; 3-step resolution). **Default when omitted: the latest published version when one exists, the draft otherwise** — programmatic callers (API, MCP, CLI, CI) run what was published unless they explicitly ask for the draft. The editor UI passes `version=draft` for test-runs. The run object's `version_ref` states which definition executed. Ignored for system agents."
           }
         ],
         "requestBody": {
@@ -1554,11 +1583,15 @@
                 "properties": {
                   "input": {
                     "type": "object",
-                    "description": "Run input values"
+                    "description": "Run input values, validated against the agent's input schema. File fields take `upload://upl_xxx` references (from `createUpload`) or inline `data:<mime>;name=<filename>;base64,<payload>` URIs (≤4 MiB decoded)."
+                  },
+                  "rerun_from": {
+                    "type": "string",
+                    "description": "Run id whose `input` to replay verbatim on this run. Mutually exclusive with `input` (400 if both are sent). The referenced run must be visible in the caller's org + application scope (404 otherwise; end-users can only replay their own runs) and must belong to the agent being triggered (409 `rerun_agent_mismatch`). File fields keep their `upload://` URIs in the stored input, and consumed uploads stay re-consumable for `UPLOAD_RETENTION_HOURS` (default 24 h) after their first consume — so a cancelled or completed run can be re-triggered with the same documents and different overrides (`modelId`, `config`, `?version`, `connection_overrides`) in a single call, without re-uploading. Returns 410 `upload_expired` when a referenced upload's reuse window has elapsed (re-upload required)."
                   },
                   "modelId": {
                     "type": "string",
-                    "description": "Model ID override for this run. Takes priority over agent and org defaults."
+                    "description": "Model ID override for this run — a system model key or an org-model UUID. Pins THIS run to that model, taking priority over the full resolution cascade (request `modelId` > agent model setting > org default model > system default). Without it, the org default is resolved at run creation — not ahead of time — so changing the org default between triggers silently changes the model used by subsequent runs. Returns 404 when the referenced model does not exist. The response echoes the resolved `model_label` + `model_source` so callers can verify which model the run actually uses."
                   },
                   "proxyId": {
                     "type": "string",
@@ -1583,22 +1616,6 @@
                 },
                 "config": {
                   "dryRun": true
-                }
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "input": {
-                    "type": "string",
-                    "description": "JSON-encoded input values"
-                  },
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "File upload"
-                  }
                 }
               }
             }
@@ -1627,15 +1644,28 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "runId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Run"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "runId": {
+                          "type": "string",
+                          "description": "Legacy alias of the run's `id`, kept for backward compatibility. Prefer `id`."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created run resource — same shape as `GET /runs/{id}`. Includes the resolved `model_label` / `model_source` (detect org-default drift at trigger time per #635), `status`, `version_ref`, `agent_scope`, etc., so no follow-up GET is needed. `runId` is a legacy alias of `id`."
                 },
                 "example": {
-                  "runId": "run_cm1abc123def456"
+                  "id": "run_cm1abc123def456",
+                  "runId": "run_cm1abc123def456",
+                  "status": "pending",
+                  "model_label": "Claude Sonnet 4",
+                  "model_source": "org"
                 }
               }
             }
@@ -1667,7 +1697,29 @@
             "$ref": "#/components/responses/NotFound"
           },
           "409": {
-            "$ref": "#/components/responses/IdempotencyInProgress"
+            "description": "Concurrent request with the same Idempotency-Key still in flight, or the `rerun_from` run belongs to a different agent (`rerun_agent_mismatch`)",
+            "headers": {
+              "Request-Id": {
+                "$ref": "#/components/headers/RequestId"
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "A referenced upload has expired before consume, or its post-consume reuse window has elapsed (`upload_expired`) — stage a fresh upload and retry",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "412": {
             "description": "Missing integration connection (`missing_integration_connection`)",
@@ -2248,8 +2300,8 @@
       "get": {
         "operationId": "getRun",
         "tags": ["Runs"],
-        "summary": "Get run status/result",
-        "description": "Get run details including status, result, input, and duration.",
+        "summary": "Get run status/result (optionally long-poll until terminal)",
+        "description": "Get run details including status, result, input, and duration.\n\nPass `?wait=<seconds>` (or `?wait=true` for the maximum) to long-poll: the server holds the request until the run reaches a terminal status (`success`, `failed`, `timeout`, `cancelled`) or the wait elapses, then returns the current run object exactly as the plain call does. The wait is capped at **55 seconds** — deliberately below the 60 s idle timeouts that ship as defaults in common reverse proxies (nginx `proxy_read_timeout`, ALB idle timeout) so the long poll always completes with a real response instead of a proxy 504; values above the cap are clamped. A response with a non-terminal `status` simply means the wait timed out — issue the same call again to keep waiting. One long poll replaces N sleep+getRun round-trips, which is the recommended completion-wait pattern for MCP clients (the SSE stream is not reachable through the MCP server).",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -2264,6 +2316,25 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "boolean",
+                  "description": "`true` waits the maximum 55 s; `false` disables."
+                },
+                {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "Wait budget in seconds. Values above 55 are clamped to 55."
+                }
+              ]
+            },
+            "description": "Hold the request until the run reaches a terminal status or this many seconds elapse (capped at 55, see operation description), then return the run object. `0`/`false`/absent = return immediately (default). Negative, fractional, or non-numeric values return 400."
           }
         ],
         "responses": {
@@ -2293,8 +2364,11 @@
                     "maxEmails": 50
                   },
                   "result": {
-                    "processed": 42,
-                    "labeled": 38
+                    "output": {
+                      "processed": 42,
+                      "labeled": 38
+                    },
+                    "text": "## Inbox triage\nProcessed 42 emails, labeled 38."
                   },
                   "checkpoint": {
                     "lastProcessedId": "msg_99f2a"
@@ -2311,6 +2385,7 @@
                   "scheduleId": "sched_cm1abc456def789",
                   "version_label": "1.2.0",
                   "version_dirty": false,
+                  "version_ref": "1.2.0",
                   "proxy_label": null,
                   "model_label": "Claude Sonnet 4",
                   "model_source": "system",
@@ -2336,7 +2411,7 @@
         "operationId": "getRunLogs",
         "tags": ["Runs"],
         "summary": "Get run logs",
-        "description": "Get persisted log entries for a run. Pass `?since=<id>` to receive only entries with `id > since` — the cursor used by the CLI's polling tail to bound per-poll payload growth. `id` is a monotonic BIGSERIAL; an invalid cursor falls back to the full list rather than 400.",
+        "description": "Get persisted log entries for a run. Pass `?since=<id>` to receive only entries with `id > since` — the cursor used by the CLI's polling tail to bound per-poll payload growth, and the pagination cursor when combined with `?limit=`. Pass `?level=` to filter by minimum severity (`level=info` skips debug breadcrumbs). When `limit` is set and more entries follow, an RFC 5988 `Link: <…?since=<lastId>>; rel=\"next\"` response header points at the next page. `id` is a monotonic BIGSERIAL; invalid `since`/`level`/`limit` values fall back to the unfiltered default rather than 400 so a stale cursor never breaks a polling tail. Without query parameters the full chronological history is returned (backward-compatible default). Note: tool-result payloads inside `data` are truncated at write time by the runner (default 2048 bytes, operator-tunable via `TOOL_RESULT_BYTE_LIMIT`) — entries already persisted truncated cannot be recovered by this endpoint.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -2361,7 +2436,28 @@
               "format": "int64",
               "minimum": 0
             },
-            "description": "Return only log entries with `id > since`. Used by the CLI's `appstrate run` remote polling loop to fetch incremental tails without re-shipping the full history each poll."
+            "description": "Return only log entries with `id > since`. Used by the CLI's `appstrate run` remote polling loop to fetch incremental tails without re-shipping the full history each poll, and as the cursor in the `Link; rel=\"next\"` pagination header."
+          },
+          {
+            "name": "level",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["debug", "info", "warn", "error"]
+            },
+            "description": "Minimum severity to include (`debug < info < warn < error`). `level=info` returns info, warn and error entries. Defaults to `debug` (everything)."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000
+            },
+            "description": "Maximum number of entries to return. When more entries follow, the response carries a `Link; rel=\"next\"` header whose URL re-uses `since` as the cursor. Absent means no cap (full history)."
           }
         ],
         "responses": {
@@ -2373,6 +2469,9 @@
               },
               "Appstrate-Version": {
                 "$ref": "#/components/headers/AppstrateVersion"
+              },
+              "Link": {
+                "$ref": "#/components/headers/Link"
               }
             },
             "content": {
@@ -2920,6 +3019,10 @@
                     "type": "number",
                     "minimum": 0,
                     "description": "Authoritative terminal run cost written to the `runs` row."
+                  },
+                  "report": {
+                    "type": "string",
+                    "description": "Aggregated markdown report — every `report.appended` event's content joined with `\\n` in call order. Persisted (capped at 256 KiB) as `runs.result.text` so getRun exposes the run's deliverable without log scraping."
                   }
                 }
               }
@@ -3621,7 +3724,7 @@
                   },
                   "version_override": {
                     "type": "string",
-                    "description": "Pin the agent version every run triggered by this schedule. Literal label or dist-tag."
+                    "description": "Which agent definition every run triggered by this schedule executes: `draft`, `published`, or a version spec (exact version, dist-tag, or semver range). Default when omitted: the latest published version when one exists, the draft otherwise. The pinned definition (manifest + prompt) is resolved at each fire."
                   },
                   "connection_overrides": {
                     "type": "object",
@@ -3823,7 +3926,8 @@
                     "type": ["string", "null"]
                   },
                   "version_override": {
-                    "type": ["string", "null"]
+                    "type": ["string", "null"],
+                    "description": "Version selector (`draft` | `published` | version spec). Pass `null` to clear (falls back to the default: latest published version when one exists, draft otherwise)."
                   },
                   "connection_overrides": {
                     "type": ["object", "null"],
@@ -4024,13 +4128,40 @@
         "operationId": "listIntegrations",
         "tags": ["Integrations"],
         "summary": "List available integrations",
-        "description": "List every AFPS integration accessible to the current org (own + system), enriched with `active` + `block_user_connections` flags for the current application.",
+        "description": "List every AFPS integration accessible to the current org (own + system), enriched with `active` + `block_user_connections` flags for the current application. Supports offset pagination (`limit`/`offset`) and a `fields` projection selector — request `?fields=id,source` to drop the heavy per-row `manifest` and fetch only what you need.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
           },
           {
             "$ref": "#/components/parameters/XAppId"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Comma-separated allowlist of fields to return per item (`id` is always included). Allowed: id, manifest, orgId, source, active, block_user_connections. An unknown field is a 400.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4402,7 +4533,7 @@
         },
         "responses": {
           "201": {
-            "description": "Activated",
+            "description": "Activated — returns the full integration detail",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -4414,17 +4545,182 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": ["active", "activated_at"],
-                  "properties": {
-                    "active": {
-                      "type": "boolean"
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": ["manifest", "auths", "tool_catalog", "allow_undeclared_tools"],
+                      "properties": {
+                        "manifest": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "auths": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "auth_key",
+                              "type",
+                              "required",
+                              "scopes",
+                              "resource",
+                              "connections",
+                              "has_oauth_client",
+                              "client_auto_provisioned"
+                            ],
+                            "properties": {
+                              "auth_key": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": ["oauth2", "api_key", "basic", "mtls", "custom"],
+                                "description": "Auth method type (AFPS §7.2). For `mtls`, client cert + key are supplied via `credentials.schema` and injected at runtime through `delivery.files`."
+                              },
+                              "required": {
+                                "type": "boolean"
+                              },
+                              "scopes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "resource": {
+                                "type": ["string", "null"],
+                                "description": "RFC 8707 resource indicator declared by the manifest (`auths.{key}.resource`). AFPS §7.3 name — matches the RFC."
+                              },
+                              "connections": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "id",
+                                    "packageId",
+                                    "auth_key",
+                                    "account_id",
+                                    "identity_claims",
+                                    "scopes_granted",
+                                    "needs_reconnection",
+                                    "expiresAt",
+                                    "owner_type",
+                                    "owner_id",
+                                    "createdAt",
+                                    "updatedAt"
+                                  ],
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "packageId": {
+                                      "type": "string"
+                                    },
+                                    "auth_key": {
+                                      "type": "string"
+                                    },
+                                    "account_id": {
+                                      "type": "string"
+                                    },
+                                    "identity_claims": {
+                                      "type": ["object", "null"],
+                                      "additionalProperties": true
+                                    },
+                                    "scopes_granted": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "needs_reconnection": {
+                                      "type": "boolean"
+                                    },
+                                    "expiresAt": {
+                                      "type": ["string", "null"],
+                                      "format": "date-time"
+                                    },
+                                    "owner_type": {
+                                      "type": "string",
+                                      "enum": ["user", "end_user"]
+                                    },
+                                    "owner_id": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "shared_with_org": {
+                                      "type": "boolean"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  }
+                                }
+                              },
+                              "has_oauth_client": {
+                                "type": "boolean"
+                              },
+                              "client_auto_provisioned": {
+                                "type": "boolean",
+                                "description": "True for an oauth2 auth on a remote MCP integration (`source.kind: \"remote\"`). Per the MCP Authorization spec the OAuth client is provisioned automatically at connect time — discovery of the authorization server (RFC 9728 → RFC 8414) plus client acquisition without manual pre-registration (CIMD when advertised, else RFC 7591 dynamic registration) — so no pre-registered client is required."
+                              }
+                            }
+                          }
+                        },
+                        "tool_catalog": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": ["name"],
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "policy": {
+                                "type": "object",
+                                "properties": {
+                                  "required_scopes": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "allow_undeclared_tools": {
+                          "type": "boolean"
+                        }
+                      }
                     },
-                    "activated_at": {
-                      "type": "string",
-                      "format": "date-time"
+                    {
+                      "type": "object",
+                      "required": ["active", "activated_at"],
+                      "properties": {
+                        "active": {
+                          "type": "boolean"
+                        },
+                        "activated_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -4470,7 +4766,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Deactivated",
+            "description": "Deactivated — returns the full integration detail",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -4482,13 +4778,178 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": ["active"],
-                  "properties": {
-                    "active": {
-                      "type": "boolean"
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": ["manifest", "auths", "tool_catalog", "allow_undeclared_tools"],
+                      "properties": {
+                        "manifest": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "auths": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "auth_key",
+                              "type",
+                              "required",
+                              "scopes",
+                              "resource",
+                              "connections",
+                              "has_oauth_client",
+                              "client_auto_provisioned"
+                            ],
+                            "properties": {
+                              "auth_key": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": ["oauth2", "api_key", "basic", "mtls", "custom"],
+                                "description": "Auth method type (AFPS §7.2). For `mtls`, client cert + key are supplied via `credentials.schema` and injected at runtime through `delivery.files`."
+                              },
+                              "required": {
+                                "type": "boolean"
+                              },
+                              "scopes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "resource": {
+                                "type": ["string", "null"],
+                                "description": "RFC 8707 resource indicator declared by the manifest (`auths.{key}.resource`). AFPS §7.3 name — matches the RFC."
+                              },
+                              "connections": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "id",
+                                    "packageId",
+                                    "auth_key",
+                                    "account_id",
+                                    "identity_claims",
+                                    "scopes_granted",
+                                    "needs_reconnection",
+                                    "expiresAt",
+                                    "owner_type",
+                                    "owner_id",
+                                    "createdAt",
+                                    "updatedAt"
+                                  ],
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "packageId": {
+                                      "type": "string"
+                                    },
+                                    "auth_key": {
+                                      "type": "string"
+                                    },
+                                    "account_id": {
+                                      "type": "string"
+                                    },
+                                    "identity_claims": {
+                                      "type": ["object", "null"],
+                                      "additionalProperties": true
+                                    },
+                                    "scopes_granted": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "needs_reconnection": {
+                                      "type": "boolean"
+                                    },
+                                    "expiresAt": {
+                                      "type": ["string", "null"],
+                                      "format": "date-time"
+                                    },
+                                    "owner_type": {
+                                      "type": "string",
+                                      "enum": ["user", "end_user"]
+                                    },
+                                    "owner_id": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "shared_with_org": {
+                                      "type": "boolean"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  }
+                                }
+                              },
+                              "has_oauth_client": {
+                                "type": "boolean"
+                              },
+                              "client_auto_provisioned": {
+                                "type": "boolean",
+                                "description": "True for an oauth2 auth on a remote MCP integration (`source.kind: \"remote\"`). Per the MCP Authorization spec the OAuth client is provisioned automatically at connect time — discovery of the authorization server (RFC 9728 → RFC 8414) plus client acquisition without manual pre-registration (CIMD when advertised, else RFC 7591 dynamic registration) — so no pre-registered client is required."
+                              }
+                            }
+                          }
+                        },
+                        "tool_catalog": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": ["name"],
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "policy": {
+                                "type": "object",
+                                "properties": {
+                                  "required_scopes": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "allow_undeclared_tools": {
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": ["active"],
+                      "properties": {
+                        "active": {
+                          "type": "boolean"
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -6207,7 +6668,7 @@
         },
         "responses": {
           "201": {
-            "description": "Model created",
+            "description": "Model created — the full created model resource (same shape as `GET`/`list`). `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -6219,15 +6680,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "example": {
-                  "id": "cm5mno345"
+                  "$ref": "#/components/schemas/OrgModel"
                 }
               }
             }
@@ -6274,7 +6727,7 @@
         },
         "responses": {
           "200": {
-            "description": "Default model updated",
+            "description": "Default model updated. Returns the new effective default model resource (same shape as `GET`/`list`) plus a legacy `success` flag. When the default is cleared (`modelId: null`) and no default remains in effect, only `{ success: true }` is returned.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -6286,12 +6739,20 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgModel"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Legacy acknowledgement flag, always `true`. Retained for backward compatibility; prefer reading the model fields."
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -6722,7 +7183,7 @@
         },
         "responses": {
           "200": {
-            "description": "Model updated",
+            "description": "Model updated — the full updated model resource (same shape as `GET`/`list`). `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -6734,12 +7195,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgModel"
                 }
               }
             }
@@ -6846,10 +7302,37 @@
         "operationId": "listModelProviderRegistry",
         "tags": ["Model Provider Credentials"],
         "summary": "List the in-code model provider registry",
-        "description": "Returns the catalog of LLM providers Appstrate knows how to talk to. The UI uses this to render the provider picker without hard-coding the catalog client-side.",
+        "description": "Returns the catalog of LLM providers Appstrate knows how to talk to. The UI uses this to render the provider picker without hard-coding the catalog client-side. Supports offset pagination (`limit`/`offset`) and a `fields` projection selector — request `?fields=providerId,authMode` to skip the heavy per-provider `models` catalog (the bulk of the payload) when you only need to know which providers exist.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Comma-separated allowlist of fields to return per provider (`providerId` is always included). Allowed: providerId, displayName, iconUrl, description, docsUrl, apiShape, defaultBaseUrl, baseUrlOverridable, authMode, featured, models. An unknown field is a 400.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -7124,7 +7607,7 @@
         },
         "responses": {
           "201": {
-            "description": "Model provider credential created",
+            "description": "Model provider credential created — the full created credential resource (same non-secret shape as `GET`/`list`). The api key / OAuth token is never echoed back. `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -7136,15 +7619,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "example": {
-                  "id": "cm7stu902"
+                  "$ref": "#/components/schemas/ModelProviderCredential"
                 }
               }
             }
@@ -7298,7 +7773,7 @@
         },
         "responses": {
           "200": {
-            "description": "Model provider credential updated",
+            "description": "Model provider credential updated — the full updated credential resource (same non-secret shape as `GET`/`list`). The api key / OAuth token is never echoed back. `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -7310,12 +7785,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ModelProviderCredential"
                 }
               }
             }
@@ -7858,15 +8328,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgProxy"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "The created proxy's id. Same value as the resource's `id`; retained as a top-level field for backward compatibility."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created proxy resource — same shape as the `GET /api/proxies` list items — so no follow-up GET is needed."
                 },
                 "example": {
-                  "id": "cm6pqr679"
+                  "id": "cm6pqr679",
+                  "label": "US Residential Proxy",
+                  "urlPrefix": "http://user:****@us-proxy.example.com:8080",
+                  "source": "custom",
+                  "enabled": true,
+                  "isDefault": false,
+                  "created_by": "usr_k7x9m2p4q1",
+                  "createdAt": "2026-01-10T08:00:00Z",
+                  "updatedAt": "2026-01-10T08:00:00Z"
                 }
               }
             }
@@ -7929,10 +8416,37 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["success", "proxy"],
                   "properties": {
                     "success": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "description": "Always true on success. Retained for backward compatibility."
+                    },
+                    "proxy": {
+                      "description": "The affected default proxy resource — same shape as the `GET /api/proxies` list items — or null when the default was unset (proxyId null).",
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/OrgProxy"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
                     }
+                  }
+                },
+                "example": {
+                  "success": true,
+                  "proxy": {
+                    "id": "cm6pqr679",
+                    "label": "US Residential Proxy",
+                    "urlPrefix": "http://user:****@us-proxy.example.com:8080",
+                    "source": "custom",
+                    "enabled": true,
+                    "isDefault": true,
+                    "created_by": "usr_k7x9m2p4q1",
+                    "createdAt": "2026-01-10T08:00:00Z",
+                    "updatedAt": "2026-01-10T08:00:00Z"
                   }
                 }
               }
@@ -8006,12 +8520,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgProxy"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "The updated proxy's id. Same value as the resource's `id`; retained as a top-level field for backward compatibility."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated proxy resource — same shape as the `GET /api/proxies` list items — so no follow-up GET is needed."
+                },
+                "example": {
+                  "id": "cm6pqr679",
+                  "label": "US Residential Proxy",
+                  "urlPrefix": "http://user:****@us-proxy.example.com:8080",
+                  "source": "custom",
+                  "enabled": true,
+                  "isDefault": false,
+                  "created_by": "usr_k7x9m2p4q1",
+                  "createdAt": "2026-01-10T08:00:00Z",
+                  "updatedAt": "2026-01-12T09:00:00Z"
                 }
               }
             }
@@ -8787,7 +9321,7 @@
         },
         "responses": {
           "201": {
-            "description": "User added or invitation created",
+            "description": "Polymorphic bare resource: when the user already exists (and no invitation flow applies) they are added directly and the created member is returned (OrgMember — discriminate on `userId`); otherwise an invitation is created and returned (OrgInvitationInfo — discriminate on `id` + `token`). Both use the same serializers as the lists in GET /api/orgs/{orgId}.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -8799,39 +9333,37 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "added": {
-                      "type": "boolean",
-                      "description": "True if user was added directly"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgMember"
                     },
-                    "invited": {
-                      "type": "boolean",
-                      "description": "True if invitation was sent"
-                    },
-                    "userId": {
-                      "type": "string",
-                      "description": "User ID (if added)"
-                    },
-                    "email": {
-                      "type": "string",
-                      "description": "Email (if invited)"
-                    },
-                    "role": {
-                      "type": "string"
-                    },
-                    "token": {
-                      "type": "string",
-                      "description": "Invitation token (only if invited)"
+                    {
+                      "$ref": "#/components/schemas/OrgInvitationInfo"
+                    }
+                  ]
+                },
+                "examples": {
+                  "memberAdded": {
+                    "summary": "Existing user added directly",
+                    "value": {
+                      "userId": "usr_def456",
+                      "displayName": "Bob",
+                      "email": "bob@acme.com",
+                      "role": "member",
+                      "joinedAt": "2026-01-12T10:00:00Z"
+                    }
+                  },
+                  "invitationCreated": {
+                    "summary": "Invitation created",
+                    "value": {
+                      "id": "inv_abc123",
+                      "email": "newuser@example.com",
+                      "role": "member",
+                      "token": "inv_abc123def456",
+                      "expiresAt": "2026-02-01T00:00:00Z",
+                      "createdAt": "2026-01-25T00:00:00Z"
                     }
                   }
-                },
-                "example": {
-                  "added": false,
-                  "invited": true,
-                  "email": "newuser@example.com",
-                  "role": "member",
-                  "token": "inv_abc123def456"
                 }
               }
             }
@@ -8894,7 +9426,7 @@
         },
         "responses": {
           "200": {
-            "description": "Role updated",
+            "description": "Updated member — same shape as the members list in GET /api/orgs/{orgId}",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -8906,16 +9438,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "userId": {
-                      "type": "string"
-                    },
-                    "role": {
-                      "type": "string",
-                      "enum": ["viewer", "member", "admin"]
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgMember"
+                },
+                "example": {
+                  "userId": "usr_def456",
+                  "displayName": "Bob",
+                  "email": "bob@acme.com",
+                  "role": "admin",
+                  "joinedAt": "2026-01-12T10:00:00Z"
                 }
               }
             }
@@ -9033,7 +9563,7 @@
         },
         "responses": {
           "200": {
-            "description": "Invitation role updated",
+            "description": "Updated invitation — same shape as the invitations list in GET /api/orgs/{orgId}",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -9045,16 +9575,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "role": {
-                      "type": "string",
-                      "enum": ["viewer", "member", "admin"]
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgInvitationInfo"
+                },
+                "example": {
+                  "id": "inv_abc123",
+                  "email": "carol@acme.com",
+                  "role": "admin",
+                  "token": "tok_xyz789",
+                  "expiresAt": "2026-02-01T00:00:00Z",
+                  "createdAt": "2026-01-25T00:00:00Z"
                 }
               }
             }
@@ -9250,26 +9779,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "displayName": {
-                      "type": ["string", "null"]
-                    },
-                    "language": {
-                      "type": "string",
-                      "enum": ["fr", "en"]
-                    },
-                    "email": {
-                      "type": "string",
-                      "format": "email"
-                    },
-                    "name": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/UserProfile"
                 },
                 "example": {
                   "id": "usr_abc123",
@@ -9320,7 +9830,7 @@
         },
         "responses": {
           "200": {
-            "description": "Profile updated",
+            "description": "Updated profile — same serializer as GET /api/profile",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -9332,24 +9842,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    },
-                    "language": {
-                      "type": ["string", "null"],
-                      "enum": ["fr", "en", null]
-                    },
-                    "displayName": {
-                      "type": ["string", "null"]
-                    }
-                  }
+                  "$ref": "#/components/schemas/UserProfile"
                 },
                 "example": {
-                  "ok": true,
+                  "id": "usr_abc123",
+                  "displayName": "Alice Martin",
                   "language": "en",
-                  "displayName": "Alice Martin"
+                  "email": "alice@example.com",
+                  "name": "Alice Martin"
                 }
               }
             }
@@ -9359,6 +9859,9 @@
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
           },
           "500": {
             "$ref": "#/components/responses/InternalServerError"
@@ -10100,7 +10603,7 @@
         },
         "responses": {
           "200": {
-            "description": "Invitation accepted",
+            "description": "Invitation accepted — returns the joined organization (same shape as the items in GET /api/orgs, with `role` set to the invitation role). For new users a session cookie is set via Set-Cookie.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -10112,27 +10615,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
-                    },
-                    "is_new_user": {
-                      "type": "boolean"
-                    },
-                    "orgId": {
-                      "type": "string"
-                    },
-                    "requires_login": {
-                      "type": "boolean",
-                      "description": "Present when is_new_user is false"
-                    }
-                  }
+                  "$ref": "#/components/schemas/Organization"
                 },
                 "example": {
-                  "success": true,
-                  "is_new_user": true,
-                  "orgId": "550e8400-e29b-41d4-a716-446655440000"
+                  "id": "550e8400-e29b-41d4-a716-446655440000",
+                  "name": "Acme Corp",
+                  "slug": "acme-corp",
+                  "role": "member",
+                  "createdAt": "2026-01-10T08:00:00Z"
                 }
               }
             }
@@ -10631,7 +11121,7 @@
         "operationId": "getMcpServerBundle",
         "tags": ["Internal"],
         "summary": "Fetch the AFPS bundle bytes for a referenced mcp-server package",
-        "description": "Container-to-host only. Auth via Bearer run token. Called by the sidecar's integrations-boot to materialise an integration's MCP server before spawning a runner container. In AFPS a local-source integration references a SEPARATE mcp-server package via `source.server.name`; this endpoint serves that package's bundle. It verifies that the run's agent declares an installed integration (in `dependencies.integrations`) that references this mcp-server — orthogonal access control to the credentials endpoint. Returns the raw ZIP archive (`application/zip`).",
+        "description": "Container-to-host only. Auth via Bearer run token. Called by the sidecar's integrations-boot to materialise an integration's MCP server before spawning a runner container. In AFPS a local-source integration references a SEPARATE mcp-server package via `source.server.name`; this endpoint serves that package's bundle. It verifies that the run's agent declares an installed integration (in `dependencies.integrations`) that references this mcp-server — orthogonal access control to the credentials endpoint. Returns the raw ZIP archive (`application/zip`). The sidecar passes `?version=` with the concrete version the spawn resolver pinned from `source.server.version` (#588) so the bytes match the manifest the resolver read; absent, the latest non-yanked version is served (back-compat).",
         "security": [
           {
             "bearerExecToken": []
@@ -10643,6 +11133,15 @@
           },
           {
             "$ref": "#/components/parameters/PackageName"
+          },
+          {
+            "name": "version",
+            "in": "query",
+            "required": false,
+            "description": "Concrete published version to serve (the version the spawn resolver pinned from `source.server.version`). When omitted, the latest non-yanked version is served.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -11571,23 +12070,36 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the created package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "Optimistic-lock token to send with the next update."
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
-                },
-                "example": {
-                  "packageId": "@acme/summarize",
-                  "lock_version": 1,
-                  "message": "Skill created"
+                  ],
+                  "description": "The created package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, `message`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -11767,18 +12279,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "version": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created version resource — same shape as the GET version detail (manifest, integrity, dist_tags, …) — plus a human-readable `message`. `id` (version row id) and `version` are part of the resource. No follow-up GET needed."
                 }
               }
             }
@@ -11838,18 +12353,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "restored_version": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "restored_version": {
+                          "type": "string",
+                          "description": "Legacy alias of the restored version's `version`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "The package's NEW optimistic-lock token after the draft was overwritten — not part of the version resource; read it back before the next draft edit."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The restored version resource — same shape as the GET version detail — plus the operation-result envelope (`message`, `restored_version` legacy alias of `version`, and the package's new `lock_version`)."
                 }
               }
             }
@@ -12122,15 +12648,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -12300,18 +12843,36 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/AgentDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the created package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "Optimistic-lock token to send with the next update."
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, `message`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -12431,15 +12992,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/AgentDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -12675,18 +13253,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "version": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created version resource — same shape as the GET version detail (manifest, integrity, dist_tags, …) — plus a human-readable `message`. `id` (version row id) and `version` are part of the resource. No follow-up GET needed."
                 }
               }
             }
@@ -12755,18 +13336,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "restored_version": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "restored_version": {
+                          "type": "string",
+                          "description": "Legacy alias of the restored version's `version`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "The package's NEW optimistic-lock token after the draft was overwritten — not part of the version resource; read it back before the next draft edit."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The restored version resource — same shape as the GET version detail — plus the operation-result envelope (`message`, `restored_version` legacy alias of `version`, and the package's new `lock_version`)."
                 }
               }
             }
@@ -12993,22 +13585,37 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": ["packageId", "type", "forked_from"],
-                  "properties": {
-                    "packageId": {
-                      "type": "string",
-                      "description": "New package ID under org scope"
+                  "allOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/AgentDetail"
+                        },
+                        {
+                          "$ref": "#/components/schemas/OrgPackageItemDetail"
+                        }
+                      ]
                     },
-                    "type": {
-                      "type": "string",
-                      "enum": ["agent", "skill", "mcp-server", "integration"]
-                    },
-                    "forked_from": {
-                      "type": "string",
-                      "description": "Source package ID"
+                    {
+                      "type": "object",
+                      "required": ["packageId", "type", "forked_from"],
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "New package ID under org scope. Legacy alias of the forked resource's `id`."
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": ["agent", "skill", "mcp-server", "integration"]
+                        },
+                        "forked_from": {
+                          "type": "string",
+                          "description": "Source package ID"
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The forked package resource — same shape as the new package's GET detail (`AgentDetail` when `type` is `agent`, otherwise `OrgPackageItemDetail`) — merged with the fork operation envelope (`packageId` legacy alias of `id`, `type`, `forked_from`). No follow-up GET needed."
                 }
               }
             }
@@ -13147,15 +13754,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -13336,15 +13960,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/AgentDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -13530,18 +14171,36 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the created package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "Optimistic-lock token to send with the next update."
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, `message`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -13721,18 +14380,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "version": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created version resource — same shape as the GET version detail (manifest, integrity, dist_tags, …) — plus a human-readable `message`. `id` (version row id) and `version` are part of the resource. No follow-up GET needed."
                 }
               }
             }
@@ -13792,18 +14454,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "restored_version": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "restored_version": {
+                          "type": "string",
+                          "description": "Legacy alias of the restored version's `version`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "The package's NEW optimistic-lock token after the draft was overwritten — not part of the version resource; read it back before the next draft edit."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The restored version resource — same shape as the GET version detail — plus the operation-result envelope (`message`, `restored_version` legacy alias of `version`, and the package's new `lock_version`)."
                 }
               }
             }
@@ -14077,15 +14750,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -14265,15 +14955,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -14478,18 +15185,36 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the created package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "Optimistic-lock token to send with the next update."
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, `message`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -14669,18 +15394,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "version": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created version resource — same shape as the GET version detail (manifest, integrity, dist_tags, …) — plus a human-readable `message`. `id` (version row id) and `version` are part of the resource. No follow-up GET needed."
                 }
               }
             }
@@ -14740,18 +15468,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "restored_version": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "restored_version": {
+                          "type": "string",
+                          "description": "Legacy alias of the restored version's `version`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "The package's NEW optimistic-lock token after the draft was overwritten — not part of the version resource; read it back before the next draft edit."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The restored version resource — same shape as the GET version detail — plus the operation-result envelope (`message`, `restored_version` legacy alias of `version`, and the package's new `lock_version`)."
                 }
               }
             }
@@ -15025,15 +15764,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -15213,15 +15969,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -16536,7 +17309,7 @@
         "operationId": "createUpload",
         "tags": ["Uploads"],
         "summary": "Create a direct-upload descriptor",
-        "description": "Reserve an upload slot and return a signed URL the client PUTs the binary to. The returned `uri` (e.g. `upload://upl_xxx`) is embedded in agent `input` fields; the run pipeline resolves and consumes it atomically. Rate-limited to 20/min.",
+        "description": "Reserve an upload slot and return a signed URL the client PUTs the binary to. Full upload→run recipe: (1) POST /api/uploads with the file's `name`, exact `size` in bytes, and `mime` — the response carries a `uri` (e.g. `upload://upl_xxx`), a signed `url`, and `headers`. (2) PUT the raw file bytes (not multipart) to `url`, sending exactly the returned `headers` (typically just `Content-Type`). No other headers are required — in particular no checksum headers; the signed URL does not bind one. (3) Call `runAgent` with `uri` as the value of the file-typed input field. The actual byte count must equal the declared `size`, and binary MIMEs are verified by magic-byte sniffing. Consumed uploads are NOT single-use: the bytes stay retained — and the `uri` re-consumable — for `UPLOAD_RETENTION_HOURS` (default 24 h) after the first consume, so the same input can be re-run (e.g. via `rerun_from` after cancelling) without re-uploading. Unconsumed uploads expire with the signed URL. Small files (≤4 MiB decoded) can skip this flow entirely: inline the content directly in the `runAgent` input as `data:<mime>;name=<filename>;base64,<payload>`. Rate-limited to 20/min.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -16606,12 +17379,12 @@
                     },
                     "uri": {
                       "type": "string",
-                      "description": "Reference to embed in agent input (e.g. `upload://upl_xxx`)."
+                      "description": "Reference to embed in the agent's file-typed input field on `runAgent` (e.g. `upload://upl_xxx`)."
                     },
                     "url": {
                       "type": "string",
                       "format": "uri",
-                      "description": "Pre-signed PUT URL. Points at S3/MinIO directly, or at the platform FS sink."
+                      "description": "Pre-signed PUT URL. Points at S3/MinIO directly, or at the platform FS sink. PUT the raw binary body to it before the upload expires."
                     },
                     "method": {
                       "type": "string",
@@ -16622,7 +17395,7 @@
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Headers the client MUST forward on the PUT request."
+                      "description": "The complete set of headers the client MUST send verbatim on the PUT request (typically just `Content-Type`). Nothing else is required — no checksum headers."
                     },
                     "expiresAt": {
                       "type": "string",
@@ -18289,6 +19062,13 @@
         "schema": {
           "type": "integer"
         }
+      },
+      "Link": {
+        "description": "RFC 5988 pagination link(s), e.g. `<https://…?since=42&limit=100>; rel=\"next\"`. Present only when another page follows — absence means the listing is complete.",
+        "schema": {
+          "type": "string",
+          "example": "<https://example.com/api/runs/run_x/logs?since=42&limit=100>; rel=\"next\""
+        }
       }
     },
     "schemas": {
@@ -18486,6 +19266,30 @@
           }
         }
       },
+      "UserProfile": {
+        "type": "object",
+        "description": "The dashboard user's profile — single serializer shared by GET and PATCH /api/profile.",
+        "required": ["id", "language", "email", "name"],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": ["string", "null"]
+          },
+          "language": {
+            "type": "string",
+            "enum": ["fr", "en"]
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
       "Organization": {
         "type": "object",
         "required": ["id", "name", "slug", "role", "createdAt"],
@@ -18639,7 +19443,7 @@
           },
           "scope": {
             "type": ["string", "null"],
-            "description": "Scope from manifest name (e.g. @myorg from @myorg/name)"
+            "description": "Scope from manifest name, including the leading `@` (e.g. `@myorg` from `@myorg/name`). Directly usable as the `{scope}` path parameter of package/agent operations."
           },
           "version": {
             "type": ["string", "null"],
@@ -18697,7 +19501,7 @@
           },
           "scope": {
             "type": ["string", "null"],
-            "description": "Scope from manifest name"
+            "description": "Scope from manifest name, including the leading `@` (e.g. `@myorg`). Directly usable as the `{scope}` path parameter of package/agent operations."
           },
           "version": {
             "type": ["string", "null"],
@@ -18925,9 +19729,68 @@
           }
         }
       },
+      "PackageVersionDetail": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Version row id"
+          },
+          "version": {
+            "type": "string",
+            "description": "Semver version string (e.g. 1.0.0)"
+          },
+          "manifest": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Full version manifest (AFPS)"
+          },
+          "content": {
+            "type": ["string", "null"],
+            "description": "Primary content file extracted from the version ZIP"
+          },
+          "source_code": {
+            "type": ["string", "null"],
+            "description": "Secondary source file content (e.g. .ts), when present"
+          },
+          "yanked": {
+            "type": "boolean",
+            "description": "Whether this version has been yanked"
+          },
+          "yanked_reason": {
+            "type": ["string", "null"]
+          },
+          "integrity": {
+            "type": "string",
+            "description": "SRI integrity hash (sha256-...)"
+          },
+          "artifact_size": {
+            "type": "integer",
+            "description": "Artifact ZIP size in bytes"
+          },
+          "createdAt": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "dist_tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "Run": {
         "type": "object",
-        "required": ["id", "orgId", "applicationId", "status", "version_dirty", "started_at"],
+        "required": [
+          "id",
+          "orgId",
+          "applicationId",
+          "status",
+          "version_dirty",
+          "version_ref",
+          "started_at"
+        ],
         "properties": {
           "id": {
             "type": "string"
@@ -18951,7 +19814,21 @@
             "type": "object"
           },
           "result": {
-            "type": "object"
+            "type": ["object", "null"],
+            "description": "What the run produced — the stable API contract for the run's deliverable, set when the run reaches a terminal status. `null` while the run is in flight, and on terminal runs that emitted neither structured output nor a report. Persisted even on failed runs (a run that reported and then failed keeps its partial deliverable).",
+            "properties": {
+              "output": {
+                "description": "Structured JSON emitted via the agent's `output` runtime tool. Validated against the agent's declared output schema when one exists — a schema mismatch flips the run to `failed` (with the validation errors in `error`) but the payload is still stored, never dropped."
+              },
+              "text": {
+                "type": "string",
+                "description": "Markdown report emitted via the agent's `report` runtime tool. Multiple report calls are concatenated in call order, joined with newlines. Capped at 256 KiB of UTF-8 — see `text_truncated`. The full untruncated report remains available as individual run-log entries (type='result', event='report')."
+              },
+              "text_truncated": {
+                "type": "boolean",
+                "description": "Present and `true` when `text` exceeded the 256 KiB cap and was truncated at a UTF-8 character boundary. Absent otherwise."
+              }
+            }
           },
           "checkpoint": {
             "type": "object"
@@ -18999,11 +19876,15 @@
           },
           "version_label": {
             "type": ["string", "null"],
-            "description": "Version label at run time (e.g. '1.0.0')"
+            "description": "Version label at run time (e.g. '1.0.0'). For draft runs this is the latest published version the draft sits on top of — read `version_ref` to know which definition actually executed."
           },
           "version_dirty": {
             "type": "boolean",
-            "description": "Whether the draft had unpublished changes at run time"
+            "description": "Whether the draft had unpublished changes at run time. Kept for backward compatibility — prefer `version_ref`, which states unambiguously what executed."
+          },
+          "version_ref": {
+            "type": "string",
+            "description": "Unambiguous reference to the agent definition the run executed: 'draft' when the mutable draft ran with unpublished changes (or the agent has no published version), or the concrete semver (e.g. '2.1.0') when the run executed that published definition (or a draft identical to it)."
           },
           "proxy_label": {
             "type": ["string", "null"],
@@ -19015,7 +19896,7 @@
           },
           "model_source": {
             "type": ["string", "null"],
-            "description": "Model source: 'system' (platform-provided) or 'org' (user-configured)"
+            "description": "Model source: 'system' (platform-provided) or 'org' (user-configured). Resolved at run creation — an org-default change between triggers applies to subsequent runs unless the run was pinned via the runAgent `modelId` override."
           },
           "cost": {
             "type": ["number", "null"],
@@ -19074,7 +19955,7 @@
           },
           "agent_scope": {
             "type": ["string", "null"],
-            "description": "Denormalized agent scope at run creation. Survives rename, delete, or shadow compaction — the global run view falls back to this when the source package is gone."
+            "description": "Denormalized agent scope at run creation, including the leading `@` (e.g. `@myorg`). Survives rename, delete, or shadow compaction — the global run view falls back to this when the source package is gone."
           },
           "agent_name": {
             "type": ["string", "null"],

--- a/apps/api/src/openapi/paths/invitations.ts
+++ b/apps/api/src/openapi/paths/invitations.ts
@@ -103,29 +103,21 @@ export const invitationsPaths = {
       },
       responses: {
         "200": {
-          description: "Invitation accepted",
+          description:
+            "Invitation accepted — returns the joined organization (same shape as the items in GET /api/orgs, with `role` set to the invitation role). For new users a session cookie is set via Set-Cookie.",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  success: { type: "boolean" },
-                  is_new_user: { type: "boolean" },
-                  orgId: { type: "string" },
-                  requires_login: {
-                    type: "boolean",
-                    description: "Present when is_new_user is false",
-                  },
-                },
-              },
+              schema: { $ref: "#/components/schemas/Organization" },
               example: {
-                success: true,
-                is_new_user: true,
-                orgId: "550e8400-e29b-41d4-a716-446655440000",
+                id: "550e8400-e29b-41d4-a716-446655440000",
+                name: "Acme Corp",
+                slug: "acme-corp",
+                role: "member",
+                createdAt: "2026-01-10T08:00:00Z",
               },
             },
           },

--- a/apps/api/src/openapi/paths/organizations.ts
+++ b/apps/api/src/openapi/paths/organizations.ts
@@ -250,7 +250,8 @@ export const organizationsPaths = {
       },
       responses: {
         "201": {
-          description: "User added or invitation created",
+          description:
+            "Polymorphic bare resource: when the user already exists (and no invitation flow applies) they are added directly and the created member is returned (OrgMember — discriminate on `userId`); otherwise an invitation is created and returned (OrgInvitationInfo — discriminate on `id` + `token`). Both use the same serializers as the lists in GET /api/orgs/{orgId}.",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
@@ -258,25 +259,33 @@ export const organizationsPaths = {
           content: {
             "application/json": {
               schema: {
-                type: "object",
-                properties: {
-                  added: { type: "boolean", description: "True if user was added directly" },
-                  invited: { type: "boolean", description: "True if invitation was sent" },
-                  userId: { type: "string", description: "User ID (if added)" },
-                  email: { type: "string", description: "Email (if invited)" },
-                  role: { type: "string" },
-                  token: {
-                    type: "string",
-                    description: "Invitation token (only if invited)",
+                oneOf: [
+                  { $ref: "#/components/schemas/OrgMember" },
+                  { $ref: "#/components/schemas/OrgInvitationInfo" },
+                ],
+              },
+              examples: {
+                memberAdded: {
+                  summary: "Existing user added directly",
+                  value: {
+                    userId: "usr_def456",
+                    displayName: "Bob",
+                    email: "bob@acme.com",
+                    role: "member",
+                    joinedAt: "2026-01-12T10:00:00Z",
                   },
                 },
-              },
-              example: {
-                added: false,
-                invited: true,
-                email: "newuser@example.com",
-                role: "member",
-                token: "inv_abc123def456",
+                invitationCreated: {
+                  summary: "Invitation created",
+                  value: {
+                    id: "inv_abc123",
+                    email: "newuser@example.com",
+                    role: "member",
+                    token: "inv_abc123def456",
+                    expiresAt: "2026-02-01T00:00:00Z",
+                    createdAt: "2026-01-25T00:00:00Z",
+                  },
+                },
               },
             },
           },

--- a/apps/api/src/openapi/paths/profile.ts
+++ b/apps/api/src/openapi/paths/profile.ts
@@ -16,16 +16,7 @@ export const profilePaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  id: { type: "string" },
-                  displayName: { type: ["string", "null"] },
-                  language: { type: "string", enum: ["fr", "en"] },
-                  email: { type: "string", format: "email" },
-                  name: { type: "string" },
-                },
-              },
+              schema: { $ref: "#/components/schemas/UserProfile" },
               example: {
                 id: "usr_abc123",
                 displayName: "Alice Martin",
@@ -62,27 +53,27 @@ export const profilePaths = {
       },
       responses: {
         "200": {
-          description: "Profile updated",
+          description: "Updated profile — same serializer as GET /api/profile",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  ok: { type: "boolean" },
-                  language: { type: ["string", "null"], enum: ["fr", "en", null] },
-                  displayName: { type: ["string", "null"] },
-                },
+              schema: { $ref: "#/components/schemas/UserProfile" },
+              example: {
+                id: "usr_abc123",
+                displayName: "Alice Martin",
+                language: "en",
+                email: "alice@example.com",
+                name: "Alice Martin",
               },
-              example: { ok: true, language: "en", displayName: "Alice Martin" },
             },
           },
         },
         "401": { $ref: "#/components/responses/Unauthorized" },
         "403": { $ref: "#/components/responses/Forbidden" },
+        "404": { $ref: "#/components/responses/NotFound" },
         "500": { $ref: "#/components/responses/InternalServerError" },
       },
     },

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -133,6 +133,19 @@ export const schemas = {
       displayName: { type: "string" },
     },
   },
+  UserProfile: {
+    type: "object",
+    description:
+      "The dashboard user's profile — single serializer shared by GET and PATCH /api/profile.",
+    required: ["id", "language", "email", "name"],
+    properties: {
+      id: { type: "string" },
+      displayName: { type: ["string", "null"] },
+      language: { type: "string", enum: ["fr", "en"] },
+      email: { type: "string", format: "email" },
+      name: { type: "string" },
+    },
+  },
   Organization: {
     type: "object",
     required: ["id", "name", "slug", "role", "createdAt"],

--- a/apps/api/src/routes/invitations.ts
+++ b/apps/api/src/routes/invitations.ts
@@ -15,7 +15,7 @@ import {
   type AssignableRole,
 } from "../services/invitations.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
-import { addMember } from "../services/organizations.ts";
+import { addMember, getOrgById } from "../services/organizations.ts";
 
 const router = new Hono();
 
@@ -74,6 +74,25 @@ router.post("/:token/accept", async (c) => {
   assertInvitationExists(invitation);
   assertInvitationUsable(invitation);
 
+  // Bare joined-org resource — same shape as the items in GET /api/orgs
+  // (issue #657). The web accept page reads `id` to pin the org store.
+  const org = await getOrgById(invitation.orgId);
+  if (!org) {
+    throw new ApiError({
+      status: 404,
+      code: "org_not_found",
+      title: "Not Found",
+      detail: "Organization not found",
+    });
+  }
+  const joinedOrg = {
+    id: org.id,
+    name: org.name,
+    slug: org.slug,
+    role: invitation.role,
+    createdAt: org.createdAt,
+  };
+
   // Check if user already exists
   const [existingUser] = await db
     .select({ id: user.id })
@@ -129,14 +148,7 @@ router.post("/:token/accept", async (c) => {
         headers.set("Set-Cookie", setCookieHeader);
       }
 
-      return new Response(
-        JSON.stringify({
-          success: true,
-          is_new_user: true,
-          orgId: invitation.orgId,
-        }),
-        { status: 200, headers },
-      );
+      return new Response(JSON.stringify(joinedOrg), { status: 200, headers });
     } catch (err) {
       if (err instanceof ApiError) throw err;
       logger.error("Invitation accept failed (new user)", {
@@ -165,12 +177,7 @@ router.post("/:token/accept", async (c) => {
 
     await markInvitationAccepted(invitation.id, existingUser.id);
 
-    return c.json({
-      success: true,
-      is_new_user: false,
-      orgId: invitation.orgId,
-      requires_login: !session?.user,
-    });
+    return c.json(joinedOrg);
   }
 });
 

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -300,6 +300,21 @@ router.post("/:orgId/members", async (c) => {
 
   const targetUser = await findUserByEmail(data.email.trim());
 
+  // Polymorphic response (documented as oneOf in OpenAPI): the operation
+  // either creates an invitation (201 + bare OrgInvitationInfo — has `id` +
+  // `token`) or adds an existing user directly (201 + bare OrgMember — has
+  // `userId`). Both DTOs use the same serializers as the lists in
+  // GET /orgs/:orgId. The `token` is exposed because this endpoint is
+  // admin-gated, consistent with the invitations list.
+  const serializeInvitation = (inv: Awaited<ReturnType<typeof createInvitation>>) => ({
+    id: inv.id,
+    email: inv.email,
+    role: inv.role,
+    token: inv.token,
+    expiresAt: inv.expiresAt?.toISOString(),
+    createdAt: inv.createdAt?.toISOString(),
+  });
+
   if (targetUser) {
     if (getAppConfig().features.smtp) {
       // User exists + SMTP → create invitation with magic link (auto-auth on click)
@@ -318,7 +333,7 @@ router.post("/:orgId/members", async (c) => {
         after: { email: invitation.email, role },
         orgIdOverride: orgId,
       });
-      return c.json({ invited: true, email: invitation.email, role }, 201);
+      return c.json(serializeInvitation(invitation), 201);
     }
     // User exists + no SMTP → add directly
     try {
@@ -338,7 +353,20 @@ router.post("/:orgId/members", async (c) => {
       after: { email: data.email.trim(), role },
       orgIdOverride: orgId,
     });
-    return c.json({ userId: targetUser.id, role, added: true }, 201);
+    const member = await getOrgMemberWithProfile(orgId, targetUser.id);
+    if (!member) {
+      throw notFound("Member not found");
+    }
+    return c.json(
+      {
+        userId: member.userId,
+        role: member.role,
+        joinedAt: member.joinedAt,
+        displayName: member.displayName,
+        email: member.email,
+      },
+      201,
+    );
   }
 
   // User doesn't exist — create invitation
@@ -357,7 +385,7 @@ router.post("/:orgId/members", async (c) => {
       after: { email: invitation.email, role },
       orgIdOverride: orgId,
     });
-    return c.json({ invited: true, email: invitation.email, role, token: invitation.token }, 201);
+    return c.json(serializeInvitation(invitation), 201);
   } catch (err) {
     throw new ApiError({
       status: 500,
@@ -409,10 +437,9 @@ router.put("/:orgId/invitations/:invitationId", async (c) => {
     orgIdOverride: orgId,
   });
 
-  // Return the full invitation DTO — same shape as the invitations list in
-  // GET /orgs/:orgId — so callers see the resulting state without a
-  // follow-up GET (issue #646). `id` + `role` remain present as a superset,
-  // so legacy consumers reading those fields are unaffected.
+  // Bare updated resource — same serializer as the invitations list in
+  // GET /orgs/:orgId (issue #657). `token` is included because the
+  // endpoint is owner-gated, consistent with the list.
   return c.json({
     id: updated.id,
     email: updated.email,
@@ -484,10 +511,8 @@ router.put("/:orgId/members/:userId", async (c) => {
     orgIdOverride: orgId,
   });
 
-  // Return the full member DTO — same shape as the members list in
-  // GET /orgs/:orgId — so callers see the resulting state without a
-  // follow-up GET (issue #646). `userId` + `role` remain present as a
-  // superset, so legacy consumers reading those fields are unaffected.
+  // Bare updated resource — same serializer as the members list in
+  // GET /orgs/:orgId (issue #657).
   const updated = await getOrgMemberWithProfile(orgId, targetUserId);
   if (!updated) {
     throw notFound("Member not found");

--- a/apps/api/src/routes/profile.ts
+++ b/apps/api/src/routes/profile.ts
@@ -24,22 +24,14 @@ export const batchLookupSchema = z.object({
 
 const profileRouter = new Hono<AppEnv>();
 
-// Issue #172 (extension) — `/api/profile` is the dashboard user's own
-// identity record (Better Auth-owned `user.name` is mutated by PATCH).
-// API keys must not be able to read or rewrite the human creator's
-// account: a customer integration shouldn't get the platform user's
-// PII via GET, nor be able to rename the dashboard owner via PATCH.
-profileRouter.get("/profile", async (c) => {
-  if (c.get("authMethod") === "api_key") {
-    throw forbidden("API keys cannot access the dashboard user profile");
-  }
-  const user = c.get("user");
-  // Intentionally joins `profiles` with `user` so the response carries
-  // the authoritative (BA-owned) email — the CLI's `whoami` surfaces
-  // this as the "current identity" check, catching cases where the
-  // locally cached email is stale after a dashboard-side email change.
-  // One indexed join on the user PK is cheap versus maintaining a
-  // second email copy on `profiles`.
+// Single profile serializer — shared by GET and PATCH so both return the
+// exact same resource shape (issue #657). Intentionally joins `profiles`
+// with `user` so the response carries the authoritative (BA-owned) email —
+// the CLI's `whoami` surfaces this as the "current identity" check,
+// catching cases where the locally cached email is stale after a
+// dashboard-side email change. One indexed join on the user PK is cheap
+// versus maintaining a second email copy on `profiles`.
+async function getProfileResource(userId: string) {
   const rows = await db
     .select({
       id: profiles.id,
@@ -50,20 +42,28 @@ profileRouter.get("/profile", async (c) => {
     })
     .from(profiles)
     .innerJoin(userTable, eq(userTable.id, profiles.id))
-    .where(eq(profiles.id, user.id))
+    .where(eq(profiles.id, userId))
     .limit(1);
 
-  if (!rows[0]) {
+  return rows[0] ?? null;
+}
+
+// Issue #172 (extension) — `/api/profile` is the dashboard user's own
+// identity record (Better Auth-owned `user.name` is mutated by PATCH).
+// API keys must not be able to read or rewrite the human creator's
+// account: a customer integration shouldn't get the platform user's
+// PII via GET, nor be able to rename the dashboard owner via PATCH.
+profileRouter.get("/profile", async (c) => {
+  if (c.get("authMethod") === "api_key") {
+    throw forbidden("API keys cannot access the dashboard user profile");
+  }
+  const user = c.get("user");
+  const profile = await getProfileResource(user.id);
+  if (!profile) {
     throw notFound("Profile not found");
   }
 
-  return c.json({
-    id: rows[0].id,
-    displayName: rows[0].displayName,
-    language: rows[0].language,
-    email: rows[0].email,
-    name: rows[0].name,
-  });
+  return c.json(profile);
 });
 
 profileRouter.patch("/profile", async (c) => {
@@ -96,7 +96,13 @@ profileRouter.patch("/profile", async (c) => {
     throw internalError();
   }
 
-  return c.json({ ok: true, language: language ?? null, displayName: displayName ?? null });
+  // Bare updated resource — same serializer as GET /api/profile (issue #657).
+  const profile = await getProfileResource(user.id);
+  if (!profile) {
+    throw notFound("Profile not found");
+  }
+
+  return c.json(profile);
 });
 
 // POST /api/profiles/batch — batch lookup display names by user IDs (scoped to org members)

--- a/apps/api/test/integration/routes/invitations.test.ts
+++ b/apps/api/test/integration/routes/invitations.test.ts
@@ -68,10 +68,16 @@ describe("Invitations API", () => {
       });
 
       expect(res.status).toBe(200);
+      // Bare joined-org resource — same shape as the items in GET /api/orgs
       const body = (await res.json()) as any;
-      expect(body.success).toBe(true);
-      expect(body.is_new_user).toBe(true);
-      expect(body.orgId).toBe(ctx.orgId);
+      expect(body.id).toBe(ctx.orgId);
+      expect(body.name).toBeTruthy();
+      expect(body.slug).toBe("inviteorg");
+      expect(body.role).toBe("member");
+      expect(body.createdAt).toBeTruthy();
+      expect(body).not.toHaveProperty("success");
+      // New-user flow sets the session cookie on the response
+      expect(res.headers.get("set-cookie")).toBeTruthy();
     });
 
     it("rejects already accepted invitation", async () => {
@@ -118,14 +124,16 @@ describe("Invitations API", () => {
       });
 
       expect(res.status).toBe(200);
+      // Bare joined-org resource with the invitation's role
       const body = (await res.json()) as any;
-      expect(body.success).toBe(true);
-      expect(body.is_new_user).toBe(false);
-      expect(body.orgId).toBe(ctx.orgId);
-      expect(body.requires_login).toBe(false);
+      expect(body.id).toBe(ctx.orgId);
+      expect(body.slug).toBe("inviteorg");
+      expect(body.role).toBe("admin");
+      expect(body).not.toHaveProperty("success");
+      expect(body).not.toHaveProperty("requires_login");
     });
 
-    it("returns requiresLogin when existing user is not authenticated", async () => {
+    it("accepts for an unauthenticated existing user and returns the joined org", async () => {
       await createTestUser({ email: "noauth@test.com" });
 
       const inv = await seedInvitation({
@@ -143,9 +151,8 @@ describe("Invitations API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.success).toBe(true);
-      expect(body.is_new_user).toBe(false);
-      expect(body.requires_login).toBe(true);
+      expect(body.id).toBe(ctx.orgId);
+      expect(body.role).toBe(inv.role);
     });
 
     it("reports isNewUser=false in info when user exists", async () => {
@@ -214,7 +221,7 @@ describe("Invitations API", () => {
       // Should succeed (idempotent), not 500
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.success).toBe(true);
+      expect(body.id).toBe(ctx.orgId);
     });
   });
 });

--- a/apps/api/test/integration/routes/organizations.test.ts
+++ b/apps/api/test/integration/routes/organizations.test.ts
@@ -255,9 +255,14 @@ describe("Organizations API", () => {
 
       expect(res.status).toBe(201);
       const body = (await res.json()) as any;
-      expect(body.added).toBe(true);
+      // Bare created member — same shape as the members list in GET /api/orgs/:orgId
       expect(body.userId).toBe(member.id);
       expect(body.role).toBe("member");
+      expect(body.email).toBe("member@test.com");
+      expect(body.joinedAt).toBeTruthy();
+      // No operation scraps
+      expect(body).not.toHaveProperty("added");
+      expect(body).not.toHaveProperty("invited");
 
       // Verify membership in DB
       await assertDbHas(organizationMembers, eq(organizationMembers.userId, member.id));
@@ -273,9 +278,17 @@ describe("Organizations API", () => {
 
       expect(res.status).toBe(201);
       const body = (await res.json()) as any;
-      expect(body.invited).toBe(true);
+      // Bare created invitation — same shape as the invitations list in
+      // GET /api/orgs/:orgId (token included: endpoint is admin-gated)
+      expect(body.id).toBeTruthy();
       expect(body.email).toBe("newuser@test.com");
       expect(body.role).toBe("admin");
+      expect(body.token).toBeTruthy();
+      expect(body.expiresAt).toBeTruthy();
+      expect(body.createdAt).toBeTruthy();
+      // No operation scraps
+      expect(body).not.toHaveProperty("invited");
+      expect(body).not.toHaveProperty("added");
 
       // Verify invitation in DB
       await assertDbHas(orgInvitations, eq(orgInvitations.email, "newuser@test.com"));
@@ -308,9 +321,9 @@ describe("Organizations API", () => {
     });
   });
 
-  // Issue #646 — mutating endpoints return the full resource, not a stub.
+  // Issue #657 — mutations return the bare full resource, not a stub.
   describe("PUT /api/orgs/:orgId/members/:userId", () => {
-    it("returns the full member DTO (not just {userId, role})", async () => {
+    it("returns the bare member DTO (same shape as the members list)", async () => {
       const ctx = await createTestContext({ orgSlug: "roleorg" });
       const member = await createTestUser({ email: "promote@test.com" });
       await addOrgMember(ctx.orgId, member.id, "member");
@@ -323,13 +336,18 @@ describe("Organizations API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      // Legacy fields preserved (superset)
+      // Bare member DTO — same shape as the members list in GET /api/orgs/:orgId
       expect(body.userId).toBe(member.id);
       expect(body.role).toBe("admin");
-      // Full member DTO — same shape as the members list in GET /api/orgs/:orgId
       expect(body.email).toBe("promote@test.com");
-      expect(body).toHaveProperty("joinedAt");
       expect(body.joinedAt).toBeTruthy();
+      expect(Object.keys(body).sort()).toEqual([
+        "displayName",
+        "email",
+        "joinedAt",
+        "role",
+        "userId",
+      ]);
 
       // Persisted
       await assertDbHas(
@@ -340,7 +358,7 @@ describe("Organizations API", () => {
   });
 
   describe("PUT /api/orgs/:orgId/invitations/:invitationId", () => {
-    it("returns the full invitation DTO (not just {id, role})", async () => {
+    it("returns the bare invitation DTO (same shape as the invitations list)", async () => {
       const ctx = await createTestContext({ orgSlug: "invorg" });
       const invitation = await createInvitation({
         email: "invitee@test.com",
@@ -358,14 +376,20 @@ describe("Organizations API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      // Legacy fields preserved (superset)
+      // Bare invitation DTO — same shape as the invitations list in
+      // GET /api/orgs/:orgId (token kept: endpoint is owner-gated)
       expect(body.id).toBe(invitation.id);
       expect(body.role).toBe("admin");
-      // Full invitation DTO — same shape as the invitations list in GET /api/orgs/:orgId
       expect(body.email).toBe("invitee@test.com");
       expect(body.token).toBe(invitation.token);
-      expect(body).toHaveProperty("expiresAt");
-      expect(body).toHaveProperty("createdAt");
+      expect(Object.keys(body).sort()).toEqual([
+        "createdAt",
+        "email",
+        "expiresAt",
+        "id",
+        "role",
+        "token",
+      ]);
 
       // Persisted
       await assertDbHas(

--- a/apps/api/test/integration/routes/profile.test.ts
+++ b/apps/api/test/integration/routes/profile.test.ts
@@ -63,7 +63,7 @@ describe("Profile API", () => {
   });
 
   describe("PATCH /api/profile", () => {
-    it("updates language", async () => {
+    it("updates language and returns the full profile", async () => {
       const res = await app.request("/api/profile", {
         method: "PATCH",
         headers: { Cookie: ctx.cookie, "Content-Type": "application/json" },
@@ -71,9 +71,13 @@ describe("Profile API", () => {
       });
 
       expect(res.status).toBe(200);
+      // Bare updated resource — same serializer as GET /api/profile
       const body = (await res.json()) as any;
-      expect(body.ok).toBe(true);
+      expect(body.id).toBe(ctx.user.id);
       expect(body.language).toBe("en");
+      expect(body.email).toBe(ctx.user.email);
+      expect(body.name).toBe(ctx.user.name);
+      expect(body).not.toHaveProperty("ok");
 
       // Verify persistence
       const getRes = await app.request("/api/profile", {
@@ -83,7 +87,7 @@ describe("Profile API", () => {
       expect(profile.language).toBe("en");
     });
 
-    it("updates display name", async () => {
+    it("updates display name and returns the full profile", async () => {
       const res = await app.request("/api/profile", {
         method: "PATCH",
         headers: { Cookie: ctx.cookie, "Content-Type": "application/json" },
@@ -92,8 +96,16 @@ describe("Profile API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.ok).toBe(true);
+      expect(body.id).toBe(ctx.user.id);
       expect(body.displayName).toBe("New Name");
+      expect(body.email).toBe(ctx.user.email);
+      expect(body).not.toHaveProperty("ok");
+
+      // PATCH returns the exact same shape as GET /api/profile
+      const getRes = await app.request("/api/profile", {
+        headers: { Cookie: ctx.cookie },
+      });
+      expect(await getRes.json()).toEqual(body);
     });
 
     it("rejects invalid language", async () => {

--- a/apps/web/src/pages/invite-accept.tsx
+++ b/apps/web/src/pages/invite-accept.tsx
@@ -79,12 +79,14 @@ export function InviteAcceptPage() {
         const data = await res.json().catch(() => ({}));
         throw new Error(data.detail || t("invite.error"));
       }
+      // The accept endpoint returns the joined org resource (same shape as
+      // the GET /api/orgs list items).
       const data = await res.json();
       await refreshAuth();
       // Refetch orgs so the new org is in the cache BEFORE setId triggers useAutoSelect
       await queryClient.invalidateQueries({ queryKey: ["orgs"] });
-      if (data.orgId) {
-        orgStore.getState().setId(data.orgId);
+      if (data.id) {
+        orgStore.getState().setId(data.id);
       }
       navigate("/");
     },

--- a/apps/web/src/pages/onboarding/members-step.tsx
+++ b/apps/web/src/pages/onboarding/members-step.tsx
@@ -23,7 +23,7 @@ import { CopyLinkButton } from "../../components/copy-link-button";
 import { api } from "../../api";
 import { roleI18nKey, INVITE_ROLES } from "../../hooks/use-permissions";
 import { Spinner } from "../../components/spinner";
-import type { OrgInvitation } from "@appstrate/shared-types";
+import type { OrganizationMember, OrgInvitation } from "@appstrate/shared-types";
 
 export function OnboardingMembersStep() {
   const { t } = useTranslation(["settings", "common"]);
@@ -46,7 +46,7 @@ export function OnboardingMembersStep() {
 
   const addMemberMutation = useMutation({
     mutationFn: async ({ email, role }: { email: string; role: "viewer" | "member" | "admin" }) => {
-      return api<{ invited?: boolean; added?: boolean; token?: string }>(`/orgs/${orgId}/members`, {
+      return api<OrganizationMember | OrgInvitation>(`/orgs/${orgId}/members`, {
         method: "POST",
         body: JSON.stringify({ email, role }),
       });

--- a/apps/web/src/pages/org-settings/members.tsx
+++ b/apps/web/src/pages/org-settings/members.tsx
@@ -56,7 +56,9 @@ export function OrgSettingsMembersPage() {
 
   const addMemberMutation = useMutation({
     mutationFn: async ({ email, role }: { email: string; role: "viewer" | "member" | "admin" }) => {
-      return api<{ invited?: boolean; added?: boolean; token?: string }>(`/orgs/${orgId}/members`, {
+      // Polymorphic bare resource: the created member (has `userId`) or the
+      // created invitation (has `id` + `token`).
+      return api<OrganizationMember | OrgInvitation>(`/orgs/${orgId}/members`, {
         method: "POST",
         body: JSON.stringify({ email, role }),
       });


### PR DESCRIPTION
Refs #657 — batch **F**: orgs members/invitations + profile bare resources.

Mutating endpoints return the bare resource (same serializer as their list/GET counterparts), with operation scraps removed.

## Endpoint changes

| Endpoint | Before | After | Removed fields |
| --- | --- | --- | --- |
| `PUT /orgs/:orgId/members/:userId` | member DTO + legacy superset note | bare `OrgMember` (`userId`, `displayName`, `email`, `role`, `joinedAt`) | — (shape locked by test) |
| `PUT /orgs/:orgId/invitations/:invitationId` | invitation DTO + legacy superset note | bare `OrgInvitationInfo` (`id`, `email`, `role`, `token`, `expiresAt`, `createdAt`) | — (shape locked by test) |
| `POST /orgs/:orgId/members` | `{invited, email, role, token?}` or `{userId, role, added}` | **polymorphic 201** — bare `OrgInvitationInfo` when inviting, bare `OrgMember` when adding directly; documented as OpenAPI `oneOf` with named examples | `invited`, `added` |
| `PATCH /profile` | `{ok, language, displayName}` | bare full profile — same serializer as `GET /profile` (new `UserProfile` schema, shared `getProfileResource()`) | `ok` |
| `POST /invite/:token/accept` | `{success, is_new_user, orgId, requires_login?}` | joined-org resource (same shape as `GET /api/orgs` items: `id`, `name`, `slug`, `role`, `createdAt`); new-user flow still sets the session cookie via `Set-Cookie` | `success`, `is_new_user`, `orgId`, `requires_login` |

**Note on `token`**: invitation DTOs keep `token` — the invitations list in `GET /orgs/:orgId` already exposes it and all these endpoints are admin/owner-gated, so this is no new exposure.

**Polymorphic POST discrimination**: clients discriminate on field presence — `userId` ⇒ member added, `id` + `token` ⇒ invitation created. Both branches reuse the exact list serializers.

## Web consumers

- `apps/web/src/pages/invite-accept.tsx` — accept handler reads `data.id` (was `data.orgId`) to pin the org store; the register/login mode switch still comes from `/invite/:token/info` (`is_new_user` there is unchanged).
- `apps/web/src/pages/org-settings/members.tsx` — add-member mutation typed as `OrganizationMember | OrgInvitation`; response body was already unused beyond invalidation.
- Profile mutations (`use-profile.ts`) ignore the response body — no change needed.

## Scope hygiene

This worktree inherited hunks on `welcome.ts` (`welcome/setup` → 204) that belong to batch A (#659); they were **reverted to origin/main** here to avoid duplicate/conflicting changes.

## Baseline

`apps/api/src/openapi/baseline.json` regenerated via `bun scripts/detect-breaking-changes.ts --update-baseline` on a head rebased onto current main. ⚠️ Like the other #657 batch PRs, the baseline will conflict between open batches — regenerate at merge time.

## Validation

- `bun run check` — 29/29 tasks green (incl. OpenAPI verify: 222 endpoints)
- Touched suites: organizations (55-test trio incl. invitations + profile) all green; welcome suite re-run green after the revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)