### PR TITLE
refactor(api)!: bare Run resource from run mutations — drop runId alias, 201 on trigger (batch C, #657)

### DIFF
--- a/apps/api/src/modules/mcp/router.ts
+++ b/apps/api/src/modules/mcp/router.ts
@@ -126,7 +126,7 @@ Organization → Applications (id \`app_…\`, one default) → Agents → Runs.
 This MCP server is scoped to ONE organization — the one this endpoint serves — and every operation runs against it plus its default application; you never send those ids per call. To act in another organization, connect that organization's own MCP server (its URL carries its id). Within the org, operations use the default application unless an operation takes an explicit application id.
 
 ## Beyond the per-operation schemas
-- Runs are asynchronous: triggering one returns a runId, then it moves pending→running→success|failed|timeout|cancelled. To wait for completion, call the run get operation with \`query: { wait: true }\` — the server long-polls up to ~55 s and returns the run when it goes terminal; a still-non-terminal response just means call it again (no sleep needed).
+- Runs are asynchronous: triggering one returns the created run resource (use its \`id\`), then it moves pending→running→success|failed|timeout|cancelled. To wait for completion, call the run get operation with \`query: { wait: true }\` — the server long-polls up to ~55 s and returns the run when it goes terminal; a still-non-terminal response just means call it again (no sleep needed).
 - Streaming/SSE operations (live logs, realtime) cannot be called through this server; fetch logs or poll instead.
 - Wire JSON is snake_case, except universal id/timestamp fields (id, createdAt…) which stay camelCase.`;
 

--- a/apps/api/src/openapi/baseline.json
+++ b/apps/api/src/openapi/baseline.json
@@ -796,7 +796,7 @@
         },
         "responses": {
           "200": {
-            "description": "Agent proxy updated",
+            "description": "Agent proxy updated — returns the affected proxy setting",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -808,12 +808,28 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": ["proxyId", "resolved"],
+                      "properties": {
+                        "proxyId": {
+                          "type": ["string", "null"]
+                        },
+                        "resolved": {
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean"
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -1284,7 +1300,7 @@
         },
         "responses": {
           "200": {
-            "description": "Agent model updated",
+            "description": "Agent model updated — returns the affected model setting",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -1296,12 +1312,25 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": ["modelId"],
+                      "properties": {
+                        "modelId": {
+                          "type": ["string", "null"]
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean"
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -1513,7 +1542,7 @@
         "operationId": "runAgent",
         "tags": ["Runs"],
         "summary": "Execute an agent",
-        "description": "Start an agent run (fire-and-forget). Returns the run ID. Rate-limited to 20/min. Supports JSON body or multipart/form-data with file uploads.",
+        "description": "Start an agent run (fire-and-forget — the response does not wait for execution). Returns `201` + the created run resource — same shape as `GET /runs/{id}` — including the resolved `model_label` / `model_source`. Rate-limited to 20/min. The body is JSON. File-typed input fields (`format: uri` + `contentMediaType` in the agent's input schema) accept either of two forms: (1) an `upload://upl_xxx` reference from `createUpload` — stage the bytes first by PUTting them to the signed URL (see `createUpload` for the step-by-step recipe); or (2) an inline RFC 2397 data URI `data:<mime>;name=<filename>;base64,<payload>` with up to 4 MiB of decoded content (`name` is optional) — the single-call path for JSON-only clients such as MCP. Inline bytes are written to the run workspace as a document and the payload is stripped from the persisted run input (the stored value keeps only a `data:<mime>;name=<doc>;base64,` marker). Declared binary MIMEs are verified by magic-byte sniffing in both forms. Send `rerun_from` instead of `input` to replay a previous run's input — same documents, new overrides — without re-uploading. The effective model is resolved at run creation with precedence: request `modelId` > agent model setting > org default model > system default. Without an explicit `modelId`, a change to the org default model between triggers applies to the next run — send `modelId` to pin a specific model per run.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -1543,7 +1572,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Version query to execute (exact version, dist-tag, or semver range). When provided, the run uses the versioned manifest and prompt instead of the live agent."
+            "description": "Which agent definition to execute: `draft` (the live editor working copy), `published` (the latest published version — 404 `no_published_version` if nothing is published), or a version spec (exact version, dist-tag, or semver range; 3-step resolution). **Default when omitted: the latest published version when one exists, the draft otherwise** — programmatic callers (API, MCP, CLI, CI) run what was published unless they explicitly ask for the draft. The editor UI passes `version=draft` for test-runs. The run object's `version_ref` states which definition executed. Ignored for system agents."
           }
         ],
         "requestBody": {
@@ -1554,11 +1583,15 @@
                 "properties": {
                   "input": {
                     "type": "object",
-                    "description": "Run input values"
+                    "description": "Run input values, validated against the agent's input schema. File fields take `upload://upl_xxx` references (from `createUpload`) or inline `data:<mime>;name=<filename>;base64,<payload>` URIs (≤4 MiB decoded)."
+                  },
+                  "rerun_from": {
+                    "type": "string",
+                    "description": "Run id whose `input` to replay verbatim on this run. Mutually exclusive with `input` (400 if both are sent). The referenced run must be visible in the caller's org + application scope (404 otherwise; end-users can only replay their own runs) and must belong to the agent being triggered (409 `rerun_agent_mismatch`). File fields keep their `upload://` URIs in the stored input, and consumed uploads stay re-consumable for `UPLOAD_RETENTION_HOURS` (default 24 h) after their first consume — so a cancelled or completed run can be re-triggered with the same documents and different overrides (`modelId`, `config`, `?version`, `connection_overrides`) in a single call, without re-uploading. Returns 410 `upload_expired` when a referenced upload's reuse window has elapsed (re-upload required)."
                   },
                   "modelId": {
                     "type": "string",
-                    "description": "Model ID override for this run. Takes priority over agent and org defaults."
+                    "description": "Model ID override for this run — a system model key or an org-model UUID. Pins THIS run to that model, taking priority over the full resolution cascade (request `modelId` > agent model setting > org default model > system default). Without it, the org default is resolved at run creation — not ahead of time — so changing the org default between triggers silently changes the model used by subsequent runs. Returns 404 when the referenced model does not exist. The response echoes the resolved `model_label` + `model_source` so callers can verify which model the run actually uses."
                   },
                   "proxyId": {
                     "type": "string",
@@ -1585,28 +1618,12 @@
                   "dryRun": true
                 }
               }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "input": {
-                    "type": "string",
-                    "description": "JSON-encoded input values"
-                  },
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "File upload"
-                  }
-                }
-              }
             }
           }
         },
         "responses": {
-          "200": {
-            "description": "Run started",
+          "201": {
+            "description": "Run created (fire-and-forget — execution continues asynchronously). The body is the created run resource, same shape as `GET /runs/{id}`: resolved `model_label` / `model_source` (detect org-default drift at trigger time per #635), `status`, `version_ref`, `agent_scope`, etc., so no follow-up GET is needed.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -1627,15 +1644,13 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "runId": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/Run"
                 },
                 "example": {
-                  "runId": "run_cm1abc123def456"
+                  "id": "run_cm1abc123def456",
+                  "status": "pending",
+                  "model_label": "Claude Sonnet 4",
+                  "model_source": "org"
                 }
               }
             }
@@ -1667,7 +1682,29 @@
             "$ref": "#/components/responses/NotFound"
           },
           "409": {
-            "$ref": "#/components/responses/IdempotencyInProgress"
+            "description": "Concurrent request with the same Idempotency-Key still in flight, or the `rerun_from` run belongs to a different agent (`rerun_agent_mismatch`)",
+            "headers": {
+              "Request-Id": {
+                "$ref": "#/components/headers/RequestId"
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "A referenced upload has expired before consume, or its post-consume reuse window has elapsed (`upload_expired`) — stage a fresh upload and retry",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "412": {
             "description": "Missing integration connection (`missing_integration_connection`)",
@@ -1848,7 +1885,7 @@
         "operationId": "runInline",
         "tags": ["Runs"],
         "summary": "Execute an inline agent (no persisted package)",
-        "description": "Run an agent defined entirely in the request body. The platform creates a shadow `packages` row (ephemeral = true), runs it through the standard pipeline, and returns `202 { runId, packageId }`. Stream progress via `GET /api/realtime/runs/{id}`. See `docs/specs/INLINE_RUNS.md`.",
+        "description": "Run an agent defined entirely in the request body. The platform creates a shadow `packages` row (ephemeral = true), runs it through the standard pipeline, and returns `202` + the created run resource (same shape as `GET /runs/{id}`; the shadow package id is the resource's `packageId`). Stream progress via `GET /api/realtime/runs/{id}`. See `docs/specs/INLINE_RUNS.md`.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -1939,21 +1976,13 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": ["runId", "packageId"],
-                  "properties": {
-                    "runId": {
-                      "type": "string"
-                    },
-                    "packageId": {
-                      "type": "string",
-                      "description": "Shadow package id (reserved `@inline/r-<uuid>` scope). Hidden from catalog queries."
-                    }
-                  }
+                  "$ref": "#/components/schemas/Run",
+                  "description": "The created run resource — same shape as `GET /runs/{id}`. `packageId` is the shadow package id (reserved `@inline/r-<uuid>` scope, hidden from catalog queries)."
                 },
                 "example": {
-                  "runId": "run_cm1abc123",
-                  "packageId": "@inline/r-abc12345-..."
+                  "id": "run_cm1abc123",
+                  "packageId": "@inline/r-abc12345-...",
+                  "status": "pending"
                 }
               }
             }
@@ -2248,8 +2277,8 @@
       "get": {
         "operationId": "getRun",
         "tags": ["Runs"],
-        "summary": "Get run status/result",
-        "description": "Get run details including status, result, input, and duration.",
+        "summary": "Get run status/result (optionally long-poll until terminal)",
+        "description": "Get run details including status, result, input, and duration.\n\nPass `?wait=<seconds>` (or `?wait=true` for the maximum) to long-poll: the server holds the request until the run reaches a terminal status (`success`, `failed`, `timeout`, `cancelled`) or the wait elapses, then returns the current run object exactly as the plain call does. The wait is capped at **55 seconds** — deliberately below the 60 s idle timeouts that ship as defaults in common reverse proxies (nginx `proxy_read_timeout`, ALB idle timeout) so the long poll always completes with a real response instead of a proxy 504; values above the cap are clamped. A response with a non-terminal `status` simply means the wait timed out — issue the same call again to keep waiting. One long poll replaces N sleep+getRun round-trips, which is the recommended completion-wait pattern for MCP clients (the SSE stream is not reachable through the MCP server).",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -2264,6 +2293,25 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "boolean",
+                  "description": "`true` waits the maximum 55 s; `false` disables."
+                },
+                {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "Wait budget in seconds. Values above 55 are clamped to 55."
+                }
+              ]
+            },
+            "description": "Hold the request until the run reaches a terminal status or this many seconds elapse (capped at 55, see operation description), then return the run object. `0`/`false`/absent = return immediately (default). Negative, fractional, or non-numeric values return 400."
           }
         ],
         "responses": {
@@ -2293,8 +2341,11 @@
                     "maxEmails": 50
                   },
                   "result": {
-                    "processed": 42,
-                    "labeled": 38
+                    "output": {
+                      "processed": 42,
+                      "labeled": 38
+                    },
+                    "text": "## Inbox triage\nProcessed 42 emails, labeled 38."
                   },
                   "checkpoint": {
                     "lastProcessedId": "msg_99f2a"
@@ -2311,6 +2362,7 @@
                   "scheduleId": "sched_cm1abc456def789",
                   "version_label": "1.2.0",
                   "version_dirty": false,
+                  "version_ref": "1.2.0",
                   "proxy_label": null,
                   "model_label": "Claude Sonnet 4",
                   "model_source": "system",
@@ -2336,7 +2388,7 @@
         "operationId": "getRunLogs",
         "tags": ["Runs"],
         "summary": "Get run logs",
-        "description": "Get persisted log entries for a run. Pass `?since=<id>` to receive only entries with `id > since` — the cursor used by the CLI's polling tail to bound per-poll payload growth. `id` is a monotonic BIGSERIAL; an invalid cursor falls back to the full list rather than 400.",
+        "description": "Get persisted log entries for a run. Pass `?since=<id>` to receive only entries with `id > since` — the cursor used by the CLI's polling tail to bound per-poll payload growth, and the pagination cursor when combined with `?limit=`. Pass `?level=` to filter by minimum severity (`level=info` skips debug breadcrumbs). When `limit` is set and more entries follow, an RFC 5988 `Link: <…?since=<lastId>>; rel=\"next\"` response header points at the next page. `id` is a monotonic BIGSERIAL; invalid `since`/`level`/`limit` values fall back to the unfiltered default rather than 400 so a stale cursor never breaks a polling tail. Without query parameters the full chronological history is returned (backward-compatible default). Note: tool-result payloads inside `data` are truncated at write time by the runner (default 2048 bytes, operator-tunable via `TOOL_RESULT_BYTE_LIMIT`) — entries already persisted truncated cannot be recovered by this endpoint.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -2361,7 +2413,28 @@
               "format": "int64",
               "minimum": 0
             },
-            "description": "Return only log entries with `id > since`. Used by the CLI's `appstrate run` remote polling loop to fetch incremental tails without re-shipping the full history each poll."
+            "description": "Return only log entries with `id > since`. Used by the CLI's `appstrate run` remote polling loop to fetch incremental tails without re-shipping the full history each poll, and as the cursor in the `Link; rel=\"next\"` pagination header."
+          },
+          {
+            "name": "level",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["debug", "info", "warn", "error"]
+            },
+            "description": "Minimum severity to include (`debug < info < warn < error`). `level=info` returns info, warn and error entries. Defaults to `debug` (everything)."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000
+            },
+            "description": "Maximum number of entries to return. When more entries follow, the response carries a `Link; rel=\"next\"` header whose URL re-uses `since` as the cursor. Absent means no cap (full history)."
           }
         ],
         "responses": {
@@ -2373,6 +2446,9 @@
               },
               "Appstrate-Version": {
                 "$ref": "#/components/headers/AppstrateVersion"
+              },
+              "Link": {
+                "$ref": "#/components/headers/Link"
               }
             },
             "content": {
@@ -2397,7 +2473,7 @@
         "operationId": "cancelRun",
         "tags": ["Runs"],
         "summary": "Cancel a run",
-        "description": "Cancel a running or pending run.",
+        "description": "Cancel a running or pending run. Returns the updated run resource — same shape as `GET /runs/{id}` — read after the terminal pipeline ran, so `status` is `cancelled` and cost/duration reflect the final state.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -2416,7 +2492,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Run cancelled",
+            "description": "Run cancelled — the body is the updated run resource (`status: cancelled`)",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -2428,12 +2504,11 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "ok": {
-                      "type": "boolean"
-                    }
-                  }
+                  "$ref": "#/components/schemas/Run"
+                },
+                "example": {
+                  "id": "run_cm1abc123def456",
+                  "status": "cancelled"
                 }
               }
             }
@@ -2609,10 +2684,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["runId", "url", "finalize_url", "secret", "expiresAt"],
+                  "description": "Operation envelope (not the run resource): the one-time sink credentials plus the created run's `id`. Fetch the resource itself via `GET /runs/{id}`.",
+                  "required": ["id", "url", "finalize_url", "secret", "expiresAt"],
                   "properties": {
-                    "runId": {
-                      "type": "string"
+                    "id": {
+                      "type": "string",
+                      "description": "The created run's id."
                     },
                     "url": {
                       "type": "string",
@@ -2920,6 +2997,10 @@
                     "type": "number",
                     "minimum": 0,
                     "description": "Authoritative terminal run cost written to the `runs` row."
+                  },
+                  "report": {
+                    "type": "string",
+                    "description": "Aggregated markdown report — every `report.appended` event's content joined with `\\n` in call order. Persisted (capped at 256 KiB) as `runs.result.text` so getRun exposes the run's deliverable without log scraping."
                   }
                 }
               }
@@ -3319,10 +3400,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["runId", "expiresAt"],
+                  "description": "Operation result (not the run resource): `sink_expires_at` is internal sink state, deliberately not part of the public Run shape.",
+                  "required": ["id", "expiresAt"],
                   "properties": {
-                    "runId": {
-                      "type": "string"
+                    "id": {
+                      "type": "string",
+                      "description": "The run's id."
                     },
                     "expiresAt": {
                       "type": "string",
@@ -3621,7 +3704,7 @@
                   },
                   "version_override": {
                     "type": "string",
-                    "description": "Pin the agent version every run triggered by this schedule. Literal label or dist-tag."
+                    "description": "Which agent definition every run triggered by this schedule executes: `draft`, `published`, or a version spec (exact version, dist-tag, or semver range). Default when omitted: the latest published version when one exists, the draft otherwise. The pinned definition (manifest + prompt) is resolved at each fire."
                   },
                   "connection_overrides": {
                     "type": "object",
@@ -3823,7 +3906,8 @@
                     "type": ["string", "null"]
                   },
                   "version_override": {
-                    "type": ["string", "null"]
+                    "type": ["string", "null"],
+                    "description": "Version selector (`draft` | `published` | version spec). Pass `null` to clear (falls back to the default: latest published version when one exists, draft otherwise)."
                   },
                   "connection_overrides": {
                     "type": ["object", "null"],
@@ -4024,13 +4108,40 @@
         "operationId": "listIntegrations",
         "tags": ["Integrations"],
         "summary": "List available integrations",
-        "description": "List every AFPS integration accessible to the current org (own + system), enriched with `active` + `block_user_connections` flags for the current application.",
+        "description": "List every AFPS integration accessible to the current org (own + system), enriched with `active` + `block_user_connections` flags for the current application. Supports offset pagination (`limit`/`offset`) and a `fields` projection selector — request `?fields=id,source` to drop the heavy per-row `manifest` and fetch only what you need.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
           },
           {
             "$ref": "#/components/parameters/XAppId"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Comma-separated allowlist of fields to return per item (`id` is always included). Allowed: id, manifest, orgId, source, active, block_user_connections. An unknown field is a 400.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4402,7 +4513,7 @@
         },
         "responses": {
           "201": {
-            "description": "Activated",
+            "description": "Activated — returns the full integration detail",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -4414,17 +4525,182 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": ["active", "activated_at"],
-                  "properties": {
-                    "active": {
-                      "type": "boolean"
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": ["manifest", "auths", "tool_catalog", "allow_undeclared_tools"],
+                      "properties": {
+                        "manifest": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "auths": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "auth_key",
+                              "type",
+                              "required",
+                              "scopes",
+                              "resource",
+                              "connections",
+                              "has_oauth_client",
+                              "client_auto_provisioned"
+                            ],
+                            "properties": {
+                              "auth_key": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": ["oauth2", "api_key", "basic", "mtls", "custom"],
+                                "description": "Auth method type (AFPS §7.2). For `mtls`, client cert + key are supplied via `credentials.schema` and injected at runtime through `delivery.files`."
+                              },
+                              "required": {
+                                "type": "boolean"
+                              },
+                              "scopes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "resource": {
+                                "type": ["string", "null"],
+                                "description": "RFC 8707 resource indicator declared by the manifest (`auths.{key}.resource`). AFPS §7.3 name — matches the RFC."
+                              },
+                              "connections": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "id",
+                                    "packageId",
+                                    "auth_key",
+                                    "account_id",
+                                    "identity_claims",
+                                    "scopes_granted",
+                                    "needs_reconnection",
+                                    "expiresAt",
+                                    "owner_type",
+                                    "owner_id",
+                                    "createdAt",
+                                    "updatedAt"
+                                  ],
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "packageId": {
+                                      "type": "string"
+                                    },
+                                    "auth_key": {
+                                      "type": "string"
+                                    },
+                                    "account_id": {
+                                      "type": "string"
+                                    },
+                                    "identity_claims": {
+                                      "type": ["object", "null"],
+                                      "additionalProperties": true
+                                    },
+                                    "scopes_granted": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "needs_reconnection": {
+                                      "type": "boolean"
+                                    },
+                                    "expiresAt": {
+                                      "type": ["string", "null"],
+                                      "format": "date-time"
+                                    },
+                                    "owner_type": {
+                                      "type": "string",
+                                      "enum": ["user", "end_user"]
+                                    },
+                                    "owner_id": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "shared_with_org": {
+                                      "type": "boolean"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  }
+                                }
+                              },
+                              "has_oauth_client": {
+                                "type": "boolean"
+                              },
+                              "client_auto_provisioned": {
+                                "type": "boolean",
+                                "description": "True for an oauth2 auth on a remote MCP integration (`source.kind: \"remote\"`). Per the MCP Authorization spec the OAuth client is provisioned automatically at connect time — discovery of the authorization server (RFC 9728 → RFC 8414) plus client acquisition without manual pre-registration (CIMD when advertised, else RFC 7591 dynamic registration) — so no pre-registered client is required."
+                              }
+                            }
+                          }
+                        },
+                        "tool_catalog": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": ["name"],
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "policy": {
+                                "type": "object",
+                                "properties": {
+                                  "required_scopes": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "allow_undeclared_tools": {
+                          "type": "boolean"
+                        }
+                      }
                     },
-                    "activated_at": {
-                      "type": "string",
-                      "format": "date-time"
+                    {
+                      "type": "object",
+                      "required": ["active", "activated_at"],
+                      "properties": {
+                        "active": {
+                          "type": "boolean"
+                        },
+                        "activated_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -4470,7 +4746,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Deactivated",
+            "description": "Deactivated — returns the full integration detail",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -4482,13 +4758,178 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": ["active"],
-                  "properties": {
-                    "active": {
-                      "type": "boolean"
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": ["manifest", "auths", "tool_catalog", "allow_undeclared_tools"],
+                      "properties": {
+                        "manifest": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "auths": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "auth_key",
+                              "type",
+                              "required",
+                              "scopes",
+                              "resource",
+                              "connections",
+                              "has_oauth_client",
+                              "client_auto_provisioned"
+                            ],
+                            "properties": {
+                              "auth_key": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": ["oauth2", "api_key", "basic", "mtls", "custom"],
+                                "description": "Auth method type (AFPS §7.2). For `mtls`, client cert + key are supplied via `credentials.schema` and injected at runtime through `delivery.files`."
+                              },
+                              "required": {
+                                "type": "boolean"
+                              },
+                              "scopes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "resource": {
+                                "type": ["string", "null"],
+                                "description": "RFC 8707 resource indicator declared by the manifest (`auths.{key}.resource`). AFPS §7.3 name — matches the RFC."
+                              },
+                              "connections": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "id",
+                                    "packageId",
+                                    "auth_key",
+                                    "account_id",
+                                    "identity_claims",
+                                    "scopes_granted",
+                                    "needs_reconnection",
+                                    "expiresAt",
+                                    "owner_type",
+                                    "owner_id",
+                                    "createdAt",
+                                    "updatedAt"
+                                  ],
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "packageId": {
+                                      "type": "string"
+                                    },
+                                    "auth_key": {
+                                      "type": "string"
+                                    },
+                                    "account_id": {
+                                      "type": "string"
+                                    },
+                                    "identity_claims": {
+                                      "type": ["object", "null"],
+                                      "additionalProperties": true
+                                    },
+                                    "scopes_granted": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "needs_reconnection": {
+                                      "type": "boolean"
+                                    },
+                                    "expiresAt": {
+                                      "type": ["string", "null"],
+                                      "format": "date-time"
+                                    },
+                                    "owner_type": {
+                                      "type": "string",
+                                      "enum": ["user", "end_user"]
+                                    },
+                                    "owner_id": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "shared_with_org": {
+                                      "type": "boolean"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  }
+                                }
+                              },
+                              "has_oauth_client": {
+                                "type": "boolean"
+                              },
+                              "client_auto_provisioned": {
+                                "type": "boolean",
+                                "description": "True for an oauth2 auth on a remote MCP integration (`source.kind: \"remote\"`). Per the MCP Authorization spec the OAuth client is provisioned automatically at connect time — discovery of the authorization server (RFC 9728 → RFC 8414) plus client acquisition without manual pre-registration (CIMD when advertised, else RFC 7591 dynamic registration) — so no pre-registered client is required."
+                              }
+                            }
+                          }
+                        },
+                        "tool_catalog": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": ["name"],
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "policy": {
+                                "type": "object",
+                                "properties": {
+                                  "required_scopes": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "allow_undeclared_tools": {
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": ["active"],
+                      "properties": {
+                        "active": {
+                          "type": "boolean"
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -6207,7 +6648,7 @@
         },
         "responses": {
           "201": {
-            "description": "Model created",
+            "description": "Model created — the full created model resource (same shape as `GET`/`list`). `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -6219,15 +6660,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "example": {
-                  "id": "cm5mno345"
+                  "$ref": "#/components/schemas/OrgModel"
                 }
               }
             }
@@ -6274,7 +6707,7 @@
         },
         "responses": {
           "200": {
-            "description": "Default model updated",
+            "description": "Default model updated. Returns the new effective default model resource (same shape as `GET`/`list`) plus a legacy `success` flag. When the default is cleared (`modelId: null`) and no default remains in effect, only `{ success: true }` is returned.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -6286,12 +6719,20 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgModel"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Legacy acknowledgement flag, always `true`. Retained for backward compatibility; prefer reading the model fields."
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -6722,7 +7163,7 @@
         },
         "responses": {
           "200": {
-            "description": "Model updated",
+            "description": "Model updated — the full updated model resource (same shape as `GET`/`list`). `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -6734,12 +7175,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgModel"
                 }
               }
             }
@@ -6846,10 +7282,37 @@
         "operationId": "listModelProviderRegistry",
         "tags": ["Model Provider Credentials"],
         "summary": "List the in-code model provider registry",
-        "description": "Returns the catalog of LLM providers Appstrate knows how to talk to. The UI uses this to render the provider picker without hard-coding the catalog client-side.",
+        "description": "Returns the catalog of LLM providers Appstrate knows how to talk to. The UI uses this to render the provider picker without hard-coding the catalog client-side. Supports offset pagination (`limit`/`offset`) and a `fields` projection selector — request `?fields=providerId,authMode` to skip the heavy per-provider `models` catalog (the bulk of the payload) when you only need to know which providers exist.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Comma-separated allowlist of fields to return per provider (`providerId` is always included). Allowed: providerId, displayName, iconUrl, description, docsUrl, apiShape, defaultBaseUrl, baseUrlOverridable, authMode, featured, models. An unknown field is a 400.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -7124,7 +7587,7 @@
         },
         "responses": {
           "201": {
-            "description": "Model provider credential created",
+            "description": "Model provider credential created — the full created credential resource (same non-secret shape as `GET`/`list`). The api key / OAuth token is never echoed back. `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -7136,15 +7599,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "example": {
-                  "id": "cm7stu902"
+                  "$ref": "#/components/schemas/ModelProviderCredential"
                 }
               }
             }
@@ -7298,7 +7753,7 @@
         },
         "responses": {
           "200": {
-            "description": "Model provider credential updated",
+            "description": "Model provider credential updated — the full updated credential resource (same non-secret shape as `GET`/`list`). The api key / OAuth token is never echoed back. `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -7310,12 +7765,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ModelProviderCredential"
                 }
               }
             }
@@ -7858,15 +8308,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgProxy"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "The created proxy's id. Same value as the resource's `id`; retained as a top-level field for backward compatibility."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created proxy resource — same shape as the `GET /api/proxies` list items — so no follow-up GET is needed."
                 },
                 "example": {
-                  "id": "cm6pqr679"
+                  "id": "cm6pqr679",
+                  "label": "US Residential Proxy",
+                  "urlPrefix": "http://user:****@us-proxy.example.com:8080",
+                  "source": "custom",
+                  "enabled": true,
+                  "isDefault": false,
+                  "created_by": "usr_k7x9m2p4q1",
+                  "createdAt": "2026-01-10T08:00:00Z",
+                  "updatedAt": "2026-01-10T08:00:00Z"
                 }
               }
             }
@@ -7929,10 +8396,37 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["success", "proxy"],
                   "properties": {
                     "success": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "description": "Always true on success. Retained for backward compatibility."
+                    },
+                    "proxy": {
+                      "description": "The affected default proxy resource — same shape as the `GET /api/proxies` list items — or null when the default was unset (proxyId null).",
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/OrgProxy"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
                     }
+                  }
+                },
+                "example": {
+                  "success": true,
+                  "proxy": {
+                    "id": "cm6pqr679",
+                    "label": "US Residential Proxy",
+                    "urlPrefix": "http://user:****@us-proxy.example.com:8080",
+                    "source": "custom",
+                    "enabled": true,
+                    "isDefault": true,
+                    "created_by": "usr_k7x9m2p4q1",
+                    "createdAt": "2026-01-10T08:00:00Z",
+                    "updatedAt": "2026-01-10T08:00:00Z"
                   }
                 }
               }
@@ -8006,12 +8500,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgProxy"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "The updated proxy's id. Same value as the resource's `id`; retained as a top-level field for backward compatibility."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated proxy resource — same shape as the `GET /api/proxies` list items — so no follow-up GET is needed."
+                },
+                "example": {
+                  "id": "cm6pqr679",
+                  "label": "US Residential Proxy",
+                  "urlPrefix": "http://user:****@us-proxy.example.com:8080",
+                  "source": "custom",
+                  "enabled": true,
+                  "isDefault": false,
+                  "created_by": "usr_k7x9m2p4q1",
+                  "createdAt": "2026-01-10T08:00:00Z",
+                  "updatedAt": "2026-01-12T09:00:00Z"
                 }
               }
             }
@@ -8894,7 +9408,7 @@
         },
         "responses": {
           "200": {
-            "description": "Role updated",
+            "description": "Updated member — same shape as the members list in GET /api/orgs/{orgId}",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -8906,16 +9420,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "userId": {
-                      "type": "string"
-                    },
-                    "role": {
-                      "type": "string",
-                      "enum": ["viewer", "member", "admin"]
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgMember"
+                },
+                "example": {
+                  "userId": "usr_def456",
+                  "displayName": "Bob",
+                  "email": "bob@acme.com",
+                  "role": "admin",
+                  "joinedAt": "2026-01-12T10:00:00Z"
                 }
               }
             }
@@ -9033,7 +9545,7 @@
         },
         "responses": {
           "200": {
-            "description": "Invitation role updated",
+            "description": "Updated invitation — same shape as the invitations list in GET /api/orgs/{orgId}",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -9045,16 +9557,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "role": {
-                      "type": "string",
-                      "enum": ["viewer", "member", "admin"]
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgInvitationInfo"
+                },
+                "example": {
+                  "id": "inv_abc123",
+                  "email": "carol@acme.com",
+                  "role": "admin",
+                  "token": "tok_xyz789",
+                  "expiresAt": "2026-02-01T00:00:00Z",
+                  "createdAt": "2026-01-25T00:00:00Z"
                 }
               }
             }
@@ -10631,7 +11142,7 @@
         "operationId": "getMcpServerBundle",
         "tags": ["Internal"],
         "summary": "Fetch the AFPS bundle bytes for a referenced mcp-server package",
-        "description": "Container-to-host only. Auth via Bearer run token. Called by the sidecar's integrations-boot to materialise an integration's MCP server before spawning a runner container. In AFPS a local-source integration references a SEPARATE mcp-server package via `source.server.name`; this endpoint serves that package's bundle. It verifies that the run's agent declares an installed integration (in `dependencies.integrations`) that references this mcp-server — orthogonal access control to the credentials endpoint. Returns the raw ZIP archive (`application/zip`).",
+        "description": "Container-to-host only. Auth via Bearer run token. Called by the sidecar's integrations-boot to materialise an integration's MCP server before spawning a runner container. In AFPS a local-source integration references a SEPARATE mcp-server package via `source.server.name`; this endpoint serves that package's bundle. It verifies that the run's agent declares an installed integration (in `dependencies.integrations`) that references this mcp-server — orthogonal access control to the credentials endpoint. Returns the raw ZIP archive (`application/zip`). The sidecar passes `?version=` with the concrete version the spawn resolver pinned from `source.server.version` (#588) so the bytes match the manifest the resolver read; absent, the latest non-yanked version is served (back-compat).",
         "security": [
           {
             "bearerExecToken": []
@@ -10643,6 +11154,15 @@
           },
           {
             "$ref": "#/components/parameters/PackageName"
+          },
+          {
+            "name": "version",
+            "in": "query",
+            "required": false,
+            "description": "Concrete published version to serve (the version the spawn resolver pinned from `source.server.version`). When omitted, the latest non-yanked version is served.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -11571,23 +12091,36 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the created package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "Optimistic-lock token to send with the next update."
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
-                },
-                "example": {
-                  "packageId": "@acme/summarize",
-                  "lock_version": 1,
-                  "message": "Skill created"
+                  ],
+                  "description": "The created package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, `message`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -11767,18 +12300,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "version": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created version resource — same shape as the GET version detail (manifest, integrity, dist_tags, …) — plus a human-readable `message`. `id` (version row id) and `version` are part of the resource. No follow-up GET needed."
                 }
               }
             }
@@ -11838,18 +12374,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "restored_version": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "restored_version": {
+                          "type": "string",
+                          "description": "Legacy alias of the restored version's `version`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "The package's NEW optimistic-lock token after the draft was overwritten — not part of the version resource; read it back before the next draft edit."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The restored version resource — same shape as the GET version detail — plus the operation-result envelope (`message`, `restored_version` legacy alias of `version`, and the package's new `lock_version`)."
                 }
               }
             }
@@ -12122,15 +12669,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -12300,18 +12864,36 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/AgentDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the created package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "Optimistic-lock token to send with the next update."
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, `message`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -12431,15 +13013,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/AgentDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -12675,18 +13274,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "version": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created version resource — same shape as the GET version detail (manifest, integrity, dist_tags, …) — plus a human-readable `message`. `id` (version row id) and `version` are part of the resource. No follow-up GET needed."
                 }
               }
             }
@@ -12755,18 +13357,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "restored_version": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "restored_version": {
+                          "type": "string",
+                          "description": "Legacy alias of the restored version's `version`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "The package's NEW optimistic-lock token after the draft was overwritten — not part of the version resource; read it back before the next draft edit."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The restored version resource — same shape as the GET version detail — plus the operation-result envelope (`message`, `restored_version` legacy alias of `version`, and the package's new `lock_version`)."
                 }
               }
             }
@@ -12993,22 +13606,37 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": ["packageId", "type", "forked_from"],
-                  "properties": {
-                    "packageId": {
-                      "type": "string",
-                      "description": "New package ID under org scope"
+                  "allOf": [
+                    {
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/AgentDetail"
+                        },
+                        {
+                          "$ref": "#/components/schemas/OrgPackageItemDetail"
+                        }
+                      ]
                     },
-                    "type": {
-                      "type": "string",
-                      "enum": ["agent", "skill", "mcp-server", "integration"]
-                    },
-                    "forked_from": {
-                      "type": "string",
-                      "description": "Source package ID"
+                    {
+                      "type": "object",
+                      "required": ["packageId", "type", "forked_from"],
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "New package ID under org scope. Legacy alias of the forked resource's `id`."
+                        },
+                        "type": {
+                          "type": "string",
+                          "enum": ["agent", "skill", "mcp-server", "integration"]
+                        },
+                        "forked_from": {
+                          "type": "string",
+                          "description": "Source package ID"
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The forked package resource — same shape as the new package's GET detail (`AgentDetail` when `type` is `agent`, otherwise `OrgPackageItemDetail`) — merged with the fork operation envelope (`packageId` legacy alias of `id`, `type`, `forked_from`). No follow-up GET needed."
                 }
               }
             }
@@ -13147,15 +13775,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -13336,15 +13981,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/AgentDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -13530,18 +14192,36 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the created package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "Optimistic-lock token to send with the next update."
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, `message`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -13721,18 +14401,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "version": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created version resource — same shape as the GET version detail (manifest, integrity, dist_tags, …) — plus a human-readable `message`. `id` (version row id) and `version` are part of the resource. No follow-up GET needed."
                 }
               }
             }
@@ -13792,18 +14475,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "restored_version": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "restored_version": {
+                          "type": "string",
+                          "description": "Legacy alias of the restored version's `version`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "The package's NEW optimistic-lock token after the draft was overwritten — not part of the version resource; read it back before the next draft edit."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The restored version resource — same shape as the GET version detail — plus the operation-result envelope (`message`, `restored_version` legacy alias of `version`, and the package's new `lock_version`)."
                 }
               }
             }
@@ -14077,15 +14771,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -14265,15 +14976,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -14478,18 +15206,36 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the created package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "Optimistic-lock token to send with the next update."
+                        },
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, `message`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -14669,18 +15415,21 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "version": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created version resource — same shape as the GET version detail (manifest, integrity, dist_tags, …) — plus a human-readable `message`. `id` (version row id) and `version` are part of the resource. No follow-up GET needed."
                 }
               }
             }
@@ -14740,18 +15489,29 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/PackageVersionDetail"
                     },
-                    "restored_version": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "message": {
+                          "type": "string",
+                          "description": "Human-readable operation message."
+                        },
+                        "restored_version": {
+                          "type": "string",
+                          "description": "Legacy alias of the restored version's `version`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "The package's NEW optimistic-lock token after the draft was overwritten — not part of the version resource; read it back before the next draft edit."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The restored version resource — same shape as the GET version detail — plus the operation-result envelope (`message`, `restored_version` legacy alias of `version`, and the package's new `lock_version`)."
                 }
               }
             }
@@ -15025,15 +15785,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -15213,15 +15990,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     },
-                    "lock_version": {
-                      "type": "integer"
+                    {
+                      "type": "object",
+                      "properties": {
+                        "packageId": {
+                          "type": "string",
+                          "description": "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`."
+                        },
+                        "lock_version": {
+                          "type": "integer",
+                          "description": "New optimistic-lock token after this update — read it back before the next edit."
+                        },
+                        "warnings": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Non-blocking validation warnings (present only when any)."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed."
                 }
               }
             }
@@ -16536,7 +17330,7 @@
         "operationId": "createUpload",
         "tags": ["Uploads"],
         "summary": "Create a direct-upload descriptor",
-        "description": "Reserve an upload slot and return a signed URL the client PUTs the binary to. The returned `uri` (e.g. `upload://upl_xxx`) is embedded in agent `input` fields; the run pipeline resolves and consumes it atomically. Rate-limited to 20/min.",
+        "description": "Reserve an upload slot and return a signed URL the client PUTs the binary to. Full upload→run recipe: (1) POST /api/uploads with the file's `name`, exact `size` in bytes, and `mime` — the response carries a `uri` (e.g. `upload://upl_xxx`), a signed `url`, and `headers`. (2) PUT the raw file bytes (not multipart) to `url`, sending exactly the returned `headers` (typically just `Content-Type`). No other headers are required — in particular no checksum headers; the signed URL does not bind one. (3) Call `runAgent` with `uri` as the value of the file-typed input field. The actual byte count must equal the declared `size`, and binary MIMEs are verified by magic-byte sniffing. Consumed uploads are NOT single-use: the bytes stay retained — and the `uri` re-consumable — for `UPLOAD_RETENTION_HOURS` (default 24 h) after the first consume, so the same input can be re-run (e.g. via `rerun_from` after cancelling) without re-uploading. Unconsumed uploads expire with the signed URL. Small files (≤4 MiB decoded) can skip this flow entirely: inline the content directly in the `runAgent` input as `data:<mime>;name=<filename>;base64,<payload>`. Rate-limited to 20/min.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -16606,12 +17400,12 @@
                     },
                     "uri": {
                       "type": "string",
-                      "description": "Reference to embed in agent input (e.g. `upload://upl_xxx`)."
+                      "description": "Reference to embed in the agent's file-typed input field on `runAgent` (e.g. `upload://upl_xxx`)."
                     },
                     "url": {
                       "type": "string",
                       "format": "uri",
-                      "description": "Pre-signed PUT URL. Points at S3/MinIO directly, or at the platform FS sink."
+                      "description": "Pre-signed PUT URL. Points at S3/MinIO directly, or at the platform FS sink. PUT the raw binary body to it before the upload expires."
                     },
                     "method": {
                       "type": "string",
@@ -16622,7 +17416,7 @@
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Headers the client MUST forward on the PUT request."
+                      "description": "The complete set of headers the client MUST send verbatim on the PUT request (typically just `Content-Type`). Nothing else is required — no checksum headers."
                     },
                     "expiresAt": {
                       "type": "string",
@@ -18289,6 +19083,13 @@
         "schema": {
           "type": "integer"
         }
+      },
+      "Link": {
+        "description": "RFC 5988 pagination link(s), e.g. `<https://…?since=42&limit=100>; rel=\"next\"`. Present only when another page follows — absence means the listing is complete.",
+        "schema": {
+          "type": "string",
+          "example": "<https://example.com/api/runs/run_x/logs?since=42&limit=100>; rel=\"next\""
+        }
       }
     },
     "schemas": {
@@ -18639,7 +19440,7 @@
           },
           "scope": {
             "type": ["string", "null"],
-            "description": "Scope from manifest name (e.g. @myorg from @myorg/name)"
+            "description": "Scope from manifest name, including the leading `@` (e.g. `@myorg` from `@myorg/name`). Directly usable as the `{scope}` path parameter of package/agent operations."
           },
           "version": {
             "type": ["string", "null"],
@@ -18697,7 +19498,7 @@
           },
           "scope": {
             "type": ["string", "null"],
-            "description": "Scope from manifest name"
+            "description": "Scope from manifest name, including the leading `@` (e.g. `@myorg`). Directly usable as the `{scope}` path parameter of package/agent operations."
           },
           "version": {
             "type": ["string", "null"],
@@ -18925,9 +19726,68 @@
           }
         }
       },
+      "PackageVersionDetail": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Version row id"
+          },
+          "version": {
+            "type": "string",
+            "description": "Semver version string (e.g. 1.0.0)"
+          },
+          "manifest": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Full version manifest (AFPS)"
+          },
+          "content": {
+            "type": ["string", "null"],
+            "description": "Primary content file extracted from the version ZIP"
+          },
+          "source_code": {
+            "type": ["string", "null"],
+            "description": "Secondary source file content (e.g. .ts), when present"
+          },
+          "yanked": {
+            "type": "boolean",
+            "description": "Whether this version has been yanked"
+          },
+          "yanked_reason": {
+            "type": ["string", "null"]
+          },
+          "integrity": {
+            "type": "string",
+            "description": "SRI integrity hash (sha256-...)"
+          },
+          "artifact_size": {
+            "type": "integer",
+            "description": "Artifact ZIP size in bytes"
+          },
+          "createdAt": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "dist_tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "Run": {
         "type": "object",
-        "required": ["id", "orgId", "applicationId", "status", "version_dirty", "started_at"],
+        "required": [
+          "id",
+          "orgId",
+          "applicationId",
+          "status",
+          "version_dirty",
+          "version_ref",
+          "started_at"
+        ],
         "properties": {
           "id": {
             "type": "string"
@@ -18951,7 +19811,21 @@
             "type": "object"
           },
           "result": {
-            "type": "object"
+            "type": ["object", "null"],
+            "description": "What the run produced — the stable API contract for the run's deliverable, set when the run reaches a terminal status. `null` while the run is in flight, and on terminal runs that emitted neither structured output nor a report. Persisted even on failed runs (a run that reported and then failed keeps its partial deliverable).",
+            "properties": {
+              "output": {
+                "description": "Structured JSON emitted via the agent's `output` runtime tool. Validated against the agent's declared output schema when one exists — a schema mismatch flips the run to `failed` (with the validation errors in `error`) but the payload is still stored, never dropped."
+              },
+              "text": {
+                "type": "string",
+                "description": "Markdown report emitted via the agent's `report` runtime tool. Multiple report calls are concatenated in call order, joined with newlines. Capped at 256 KiB of UTF-8 — see `text_truncated`. The full untruncated report remains available as individual run-log entries (type='result', event='report')."
+              },
+              "text_truncated": {
+                "type": "boolean",
+                "description": "Present and `true` when `text` exceeded the 256 KiB cap and was truncated at a UTF-8 character boundary. Absent otherwise."
+              }
+            }
           },
           "checkpoint": {
             "type": "object"
@@ -18999,11 +19873,15 @@
           },
           "version_label": {
             "type": ["string", "null"],
-            "description": "Version label at run time (e.g. '1.0.0')"
+            "description": "Version label at run time (e.g. '1.0.0'). For draft runs this is the latest published version the draft sits on top of — read `version_ref` to know which definition actually executed."
           },
           "version_dirty": {
             "type": "boolean",
-            "description": "Whether the draft had unpublished changes at run time"
+            "description": "Whether the draft had unpublished changes at run time. Kept for backward compatibility — prefer `version_ref`, which states unambiguously what executed."
+          },
+          "version_ref": {
+            "type": "string",
+            "description": "Unambiguous reference to the agent definition the run executed: 'draft' when the mutable draft ran with unpublished changes (or the agent has no published version), or the concrete semver (e.g. '2.1.0') when the run executed that published definition (or a draft identical to it)."
           },
           "proxy_label": {
             "type": ["string", "null"],
@@ -19015,7 +19893,7 @@
           },
           "model_source": {
             "type": ["string", "null"],
-            "description": "Model source: 'system' (platform-provided) or 'org' (user-configured)"
+            "description": "Model source: 'system' (platform-provided) or 'org' (user-configured). Resolved at run creation — an org-default change between triggers applies to subsequent runs unless the run was pinned via the runAgent `modelId` override."
           },
           "cost": {
             "type": ["number", "null"],
@@ -19074,7 +19952,7 @@
           },
           "agent_scope": {
             "type": ["string", "null"],
-            "description": "Denormalized agent scope at run creation. Survives rename, delete, or shadow compaction — the global run view falls back to this when the source package is gone."
+            "description": "Denormalized agent scope at run creation, including the leading `@` (e.g. `@myorg`). Survives rename, delete, or shadow compaction — the global run view falls back to this when the source package is gone."
           },
           "agent_name": {
             "type": ["string", "null"],

--- a/apps/api/src/openapi/paths/runs.ts
+++ b/apps/api/src/openapi/paths/runs.ts
@@ -92,7 +92,7 @@ export const runsPaths = {
       responses: {
         "201": {
           description:
-            "Run created (fire-and-forget — execution continues asynchronously). The body is the created run resource, same shape as `GET /runs/{id}`: resolved `model_label` / `model_source` (detect org-default drift at trigger time per #635), `status`, `version_ref`, `agent_scope`, etc., so no follow-up GET is needed.",
+            "Run created (fire-and-forget — execution continues asynchronously). The body is the created run resource, same shape as `GET /runs/{id}`: resolved `model_label` / `model_source` (detect org-default drift at trigger time per #635), `status`, `version_ref`, `agent_scope`, etc., so no follow-up GET is needed. Under a rare concurrent-teardown race (the run is deleted between creation and serialization) the body may degrade to `{id}` only.",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
@@ -326,7 +326,8 @@ export const runsPaths = {
       },
       responses: {
         "202": {
-          description: "Inline run accepted — stream via SSE",
+          description:
+            "Inline run accepted — stream via SSE. The body is the created run resource (same shape as `GET /runs/{id}`); under a rare concurrent-teardown race (the run is deleted between creation and serialization) it may degrade to `{id}` only.",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },

--- a/apps/api/src/openapi/paths/runs.ts
+++ b/apps/api/src/openapi/paths/runs.ts
@@ -7,7 +7,7 @@ export const runsPaths = {
       tags: ["Runs"],
       summary: "Execute an agent",
       description:
-        "Start an agent run (fire-and-forget). Returns the created run resource — same shape as `GET /runs/{id}` — including the resolved `model_label` / `model_source`. Rate-limited to 20/min. " +
+        "Start an agent run (fire-and-forget — the response does not wait for execution). Returns `201` + the created run resource — same shape as `GET /runs/{id}` — including the resolved `model_label` / `model_source`. Rate-limited to 20/min. " +
         "The body is JSON. File-typed input fields (`format: uri` + `contentMediaType` in the " +
         "agent's input schema) accept either of two forms: " +
         "(1) an `upload://upl_xxx` reference from `createUpload` — stage the bytes first by " +
@@ -90,8 +90,9 @@ export const runsPaths = {
         },
       },
       responses: {
-        "200": {
-          description: "Run started",
+        "201": {
+          description:
+            "Run created (fire-and-forget — execution continues asynchronously). The body is the created run resource, same shape as `GET /runs/{id}`: resolved `model_label` / `model_source` (detect org-default drift at trigger time per #635), `status`, `version_ref`, `agent_scope`, etc., so no follow-up GET is needed.",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
@@ -101,26 +102,9 @@ export const runsPaths = {
           },
           content: {
             "application/json": {
-              schema: {
-                allOf: [
-                  { $ref: "#/components/schemas/Run" },
-                  {
-                    type: "object",
-                    properties: {
-                      runId: {
-                        type: "string",
-                        description:
-                          "Legacy alias of the run's `id`, kept for backward compatibility. Prefer `id`.",
-                      },
-                    },
-                  },
-                ],
-                description:
-                  "The created run resource — same shape as `GET /runs/{id}`. Includes the resolved `model_label` / `model_source` (detect org-default drift at trigger time per #635), `status`, `version_ref`, `agent_scope`, etc., so no follow-up GET is needed. `runId` is a legacy alias of `id`.",
-              },
+              schema: { $ref: "#/components/schemas/Run" },
               example: {
                 id: "run_cm1abc123def456",
-                runId: "run_cm1abc123def456",
                 status: "pending",
                 model_label: "Claude Sonnet 4",
                 model_source: "org",
@@ -286,7 +270,7 @@ export const runsPaths = {
       tags: ["Runs"],
       summary: "Execute an inline agent (no persisted package)",
       description:
-        "Run an agent defined entirely in the request body. The platform creates a shadow `packages` row (ephemeral = true), runs it through the standard pipeline, and returns `202 { runId, packageId }`. Stream progress via `GET /api/realtime/runs/{id}`. See `docs/specs/INLINE_RUNS.md`.",
+        "Run an agent defined entirely in the request body. The platform creates a shadow `packages` row (ephemeral = true), runs it through the standard pipeline, and returns `202` + the created run resource (same shape as `GET /runs/{id}`; the shadow package id is the resource's `packageId`). Stream progress via `GET /api/realtime/runs/{id}`. See `docs/specs/INLINE_RUNS.md`.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -353,18 +337,15 @@ export const runsPaths = {
           content: {
             "application/json": {
               schema: {
-                type: "object",
-                required: ["runId", "packageId"],
-                properties: {
-                  runId: { type: "string" },
-                  packageId: {
-                    type: "string",
-                    description:
-                      "Shadow package id (reserved `@inline/r-<uuid>` scope). Hidden from catalog queries.",
-                  },
-                },
+                $ref: "#/components/schemas/Run",
+                description:
+                  "The created run resource — same shape as `GET /runs/{id}`. `packageId` is the shadow package id (reserved `@inline/r-<uuid>` scope, hidden from catalog queries).",
               },
-              example: { runId: "run_cm1abc123", packageId: "@inline/r-abc12345-..." },
+              example: {
+                id: "run_cm1abc123",
+                packageId: "@inline/r-abc12345-...",
+                status: "pending",
+              },
             },
           },
         },
@@ -679,7 +660,8 @@ export const runsPaths = {
       operationId: "cancelRun",
       tags: ["Runs"],
       summary: "Cancel a run",
-      description: "Cancel a running or pending run.",
+      description:
+        "Cancel a running or pending run. Returns the updated run resource — same shape as `GET /runs/{id}` — read after the terminal pipeline ran, so `status` is `cancelled` and cost/duration reflect the final state.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -687,14 +669,15 @@ export const runsPaths = {
       ],
       responses: {
         "200": {
-          description: "Run cancelled",
+          description: "Run cancelled — the body is the updated run resource (`status: cancelled`)",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
           },
           content: {
             "application/json": {
-              schema: { type: "object", properties: { ok: { type: "boolean" } } },
+              schema: { $ref: "#/components/schemas/Run" },
+              example: { id: "run_cm1abc123def456", status: "cancelled" },
             },
           },
         },
@@ -831,9 +814,11 @@ export const runsPaths = {
             "application/json": {
               schema: {
                 type: "object",
-                required: ["runId", "url", "finalize_url", "secret", "expiresAt"],
+                description:
+                  "Operation envelope (not the run resource): the one-time sink credentials plus the created run's `id`. Fetch the resource itself via `GET /runs/{id}`.",
+                required: ["id", "url", "finalize_url", "secret", "expiresAt"],
                 properties: {
-                  runId: { type: "string" },
+                  id: { type: "string", description: "The created run's id." },
                   url: {
                     type: "string",
                     format: "uri",
@@ -1249,9 +1234,11 @@ export const runsPaths = {
             "application/json": {
               schema: {
                 type: "object",
-                required: ["runId", "expiresAt"],
+                description:
+                  "Operation result (not the run resource): `sink_expires_at` is internal sink state, deliberately not part of the public Run shape.",
+                required: ["id", "expiresAt"],
                 properties: {
-                  runId: { type: "string" },
+                  id: { type: "string", description: "The run's id." },
                   expiresAt: { type: "string", format: "date-time" },
                 },
               },

--- a/apps/api/src/routes/runs-remote.ts
+++ b/apps/api/src/routes/runs-remote.ts
@@ -320,9 +320,12 @@ export function createRunsRemoteRouter() {
         versionLabel: overrideVersionLabel ?? null,
       });
 
+      // Operation envelope (legit exception under #657: one-time sink
+      // credentials are not part of the run resource). The run id field is
+      // `id` — the legacy `runId` alias was removed with the strict rule.
       c.status(201);
       return c.json({
-        runId: result.runId,
+        id: result.runId,
         ...result.sinkCredentials,
       });
     },
@@ -376,7 +379,14 @@ export function createRunsRemoteRouter() {
         throw notFound(`run ${runId} not found or sink already closed`);
       }
 
-      return c.json({ runId, expiresAt: newExpiresAt.toISOString() });
+      // Operation result, not a resource: `sink_expires_at` is internal
+      // server state deliberately NOT projected on the Run DTO (see
+      // runRowToWireDto), so a full Run fetch here would not even carry the
+      // value the caller asked to extend. No first-party client reads this
+      // body today (the CLI/runtime keep-alive is POST /events/heartbeat);
+      // the field naming is aligned with the resource convention (`id`,
+      // no `runId` alias — #657) for third-party runners.
+      return c.json({ id: runId, expiresAt: newExpiresAt.toISOString() });
     },
   );
 

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -160,21 +160,20 @@ export function createRunsRouter() {
           runnerKind: runner.kind,
         });
 
-        // Return the created run resource — same DTO and serializer as
+        // 201 + the bare created run resource — same DTO and serializer as
         // GET /runs/:id — so callers see the full launched state (resolved
         // `model_label` / `model_source` for org-default drift detection per
         // #635, plus status, version_ref, agent_scope, …) without a follow-up
-        // GET. The run row exists once `prepareAndExecuteRun` resolves. The
-        // legacy `runId` field is kept alongside the DTO's `id` for backward
-        // compatibility with existing clients.
+        // GET. The run row exists once `prepareAndExecuteRun` resolves.
+        // No legacy `runId` alias (#657): the run id is `id`.
         const row = await getRunFull(getAppScope(c), runId);
         if (!row) {
           // The run was just created above; a miss here means a concurrent
-          // teardown raced us. Fall back to the minimal id-only contract
+          // teardown raced us. Fall back to a minimal id-only resource
           // rather than 500-ing a successfully launched run.
-          return c.json({ runId });
+          return c.json({ id: runId }, 201);
         }
-        return c.json({ runId, ...row });
+        return c.json(row, 201);
       } catch (err) {
         // Roll back any input documents streamed into the run workspace before
         // the run launched (size/MIME mismatch, failed preflight, …). Once
@@ -372,14 +371,25 @@ export function createRunsRouter() {
       error: { message: "Cancelled by user" },
     });
 
-    return c.json({ ok: true });
+    // Return the bare updated run resource — read AFTER synthesiseFinalize so
+    // the response reflects the terminal state (`status: "cancelled"`, cost,
+    // completed_at). Same DTO and serializer as GET /runs/:id (#657).
+    const row = await getRunFull(scope, runId);
+    if (!row) {
+      // The run was readable above; a miss here means a concurrent delete
+      // raced the finalize. The resource is gone — surface the same 404 a
+      // fresh read would.
+      throw notFound("Run not found");
+    }
+    return c.json(row);
   });
 
   // POST /api/runs/inline — execute an inline (no persisted package) agent.
   // See docs/specs/INLINE_RUNS.md. The manifest + prompt travel in the
   // request body; the platform creates a transient shadow package
   // (ephemeral = true), runs it through the existing pipeline, and
-  // returns 202 { runId } immediately. The client streams progress via
+  // returns 202 + the bare created run resource (the shadow package id is
+  // the run's `packageId` field). The client streams progress via
   // GET /api/realtime/runs/:id (existing SSE endpoint).
   router.post(
     "/runs/inline",
@@ -396,7 +406,7 @@ export function createRunsRouter() {
 
       const body = await c.req.json<InlineRunBody>();
 
-      const { runId, packageId } = await triggerInlineRun({
+      const { runId } = await triggerInlineRun({
         orgId,
         applicationId,
         actor,
@@ -405,8 +415,18 @@ export function createRunsRouter() {
         traceparent: runTraceparent(c),
       });
 
-      c.status(202);
-      return c.json({ runId, packageId });
+      // 202 + the bare created run resource (#657) — same DTO and serializer
+      // as GET /runs/:id. The shadow package id callers used to read from
+      // the `packageId` envelope field is the resource's own `packageId`.
+      // The run row exists once `triggerInlineRun` resolves
+      // (`prepareAndExecuteRun` inserts it before returning).
+      const row = await getRunFull(getAppScope(c), runId);
+      if (!row) {
+        // Concurrent teardown raced us — fall back to a minimal id-only
+        // resource rather than 500-ing a successfully launched run.
+        return c.json({ id: runId }, 202);
+      }
+      return c.json(row, 202);
     },
   );
 

--- a/apps/api/test/integration/routes/runs-cancel-convergence.test.ts
+++ b/apps/api/test/integration/routes/runs-cancel-convergence.test.ts
@@ -138,6 +138,12 @@ describe("POST /api/runs/:id/cancel — terminal-state convergence", () => {
       headers: authHeaders(ctx),
     });
     expect(res.status).toBe(200);
+    // The response is the bare updated Run resource read AFTER the terminal
+    // pipeline (#657) — it already reflects the cancelled state + final cost.
+    const body = (await res.json()) as { id?: string; status?: string; cost?: number | null };
+    expect(body.id).toBe(runId);
+    expect(body.status).toBe("cancelled");
+    expect(body.cost).toBeCloseTo(0.0551, 4);
 
     expect(spy.callCount()).toBe(1);
     const params = spy.lastParams()!;

--- a/apps/api/test/integration/routes/runs-remote-registry.test.ts
+++ b/apps/api/test/integration/routes/runs-remote-registry.test.ts
@@ -104,11 +104,13 @@ describe("POST /api/runs/remote — kind: registry", () => {
     });
 
     expect(res.status).toBe(201);
-    const body = (await res.json()) as { runId: string };
-    expect(body.runId).toBeString();
+    const body = (await res.json()) as { id: string; runId?: unknown };
+    expect(body.id).toBeString();
+    // Legacy `runId` alias removed (#657) — the envelope carries `id`.
+    expect(body.runId).toBeUndefined();
 
     // Run is attributed to the real package, not a shadow row.
-    const [run] = await db.select().from(runs).where(eq(runs.id, body.runId)).limit(1);
+    const [run] = await db.select().from(runs).where(eq(runs.id, body.id)).limit(1);
     expect(run).toBeDefined();
     expect(run!.packageId).toBe("@acme/briefing");
     expect(run!.versionLabel).toBe("1.2.3");
@@ -131,8 +133,8 @@ describe("POST /api/runs/remote — kind: registry", () => {
     });
 
     expect(res.status).toBe(201);
-    const body = (await res.json()) as { runId: string };
-    const [run] = await db.select().from(runs).where(eq(runs.id, body.runId)).limit(1);
+    const body = (await res.json()) as { id: string };
+    const [run] = await db.select().from(runs).where(eq(runs.id, body.id)).limit(1);
     expect(run!.versionLabel).toBe("1.0.0");
   });
 
@@ -161,8 +163,8 @@ describe("POST /api/runs/remote — kind: registry", () => {
     });
 
     expect(res.status).toBe(201);
-    const body = (await res.json()) as { runId: string };
-    const [run] = await db.select().from(runs).where(eq(runs.id, body.runId)).limit(1);
+    const body = (await res.json()) as { id: string };
+    const [run] = await db.select().from(runs).where(eq(runs.id, body.id)).limit(1);
     expect(run!.packageId).toBe("@acme/draft-only");
     expect(run!.versionLabel).toBe("draft");
   });

--- a/apps/api/test/integration/routes/runs.test.ts
+++ b/apps/api/test/integration/routes/runs.test.ts
@@ -449,7 +449,7 @@ describe("Runs API", () => {
         body: JSON.stringify({ input: {} }),
       });
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       const body = (await res.json()) as {
         id?: string;
         runId?: string;
@@ -458,17 +458,17 @@ describe("Runs API", () => {
         model_label?: string | null;
         model_source?: string | null;
       };
-      // The trigger response is the full Run DTO (same shape as GET /runs/:id)
-      // plus a legacy `runId` alias of `id`.
-      expect(body.runId).toStartWith("run_");
-      expect(body.id).toBe(body.runId!);
+      // The trigger response is the bare Run DTO (same shape as GET /runs/:id).
+      // The legacy `runId` alias was removed with the strict rule (#657).
+      expect(body.id).toStartWith("run_");
+      expect(body.runId).toBeUndefined();
       expect(body.status).toBeString();
       expect(body.agent_scope).toContain("runorg");
       expect(body.model_label).toBe("Echo Default GPT");
       expect(body.model_source).toBe("org");
 
       // The echo must match the persisted run-row snapshot — same source of truth.
-      const [row] = await db.select().from(runs).where(eq(runs.id, body.runId!));
+      const [row] = await db.select().from(runs).where(eq(runs.id, body.id!));
       expect(row!.modelLabel).toBe("Echo Default GPT");
       expect(row!.modelSource).toBe("org");
 
@@ -487,9 +487,8 @@ describe("Runs API", () => {
         body: JSON.stringify({ input: {}, modelId: pinnedId }),
       });
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(201);
       const body = (await res.json()) as {
-        runId?: string;
         model_label?: string | null;
         model_source?: string | null;
       };
@@ -989,8 +988,12 @@ describe("Runs API", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as any;
-      expect(body.ok).toBe(true);
+      // The response is the bare updated Run resource (same shape as
+      // GET /runs/:id), read after the terminal pipeline — not `{ok}` (#657).
+      const body = (await res.json()) as { id?: string; ok?: unknown; status?: string };
+      expect(body.ok).toBeUndefined();
+      expect(body.id).toBe(run.id);
+      expect(body.status).toBe("cancelled");
 
       // Convergence assertion — the cancel route flowed through finalizeRun
       // (status flipped to cancelled, sink closed). See `runs-cancel-
@@ -1021,8 +1024,9 @@ describe("Runs API", () => {
       });
 
       expect(res.status).toBe(200);
-      const body = (await res.json()) as any;
-      expect(body.ok).toBe(true);
+      const body = (await res.json()) as { id?: string; status?: string };
+      expect(body.id).toBe(run.id);
+      expect(body.status).toBe("cancelled");
 
       const final = await db.select({ status: runs.status }).from(runs).where(eq(runs.id, run.id));
       expect(final[0]!.status).toBe("cancelled");

--- a/apps/cli/src/commands/run/remote-runner.ts
+++ b/apps/cli/src/commands/run/remote-runner.ts
@@ -3,9 +3,10 @@
 /**
  * `runRemote` — remote execution path for `appstrate run`.
  *
- * Trigger: `POST /api/agents/:scope/:name/run` returns `{ runId }` and
- * the platform spawns a Pi container (same path as the dashboard "Run"
- * button). The CLI then tails the run by polling two endpoints:
+ * Trigger: `POST /api/agents/:scope/:name/run` returns `201` + the bare
+ * created run resource (same shape as `GET /runs/:id` — we read its `id`)
+ * and the platform spawns a Pi container (same path as the dashboard
+ * "Run" button). The CLI then tails the run by polling two endpoints:
  *
  *   - `GET /api/runs/:runId/logs?since=<lastId>` — append-only run-log
  *     entries with `id > since`. The cursor is required for bounded
@@ -481,26 +482,28 @@ async function triggerRun(opts: RunRemoteOptions, deps: HttpDeps): Promise<strin
     });
   }
 
-  // The server's contract is `{ runId: string }` (apps/api/src/routes/runs.ts
-  // → `c.json({ runId })`). We accept *only* that shape — falling back to
-  // alternate keys (`{ id }`, `{ run.id }`, …) would silently mask a
-  // contract drift instead of failing fast at the boundary. The error
-  // body carries the unexpected payload so the user can debug a server
-  // mismatch without re-running with extra logging.
-  const payload = (await res.json().catch(() => null)) as { runId?: unknown } | null;
+  // The server's contract is `201` + the bare created run resource
+  // (apps/api/src/routes/runs.ts → `c.json(row, 201)`, same DTO as
+  // `GET /runs/:id`). We read *only* its `id` — falling back to alternate
+  // keys (`{ runId }`, `{ run.id }`, …) would silently mask a contract
+  // drift instead of failing fast at the boundary (#657 removed the
+  // legacy `runId` alias). The error body carries the unexpected payload
+  // so the user can debug a server mismatch without re-running with
+  // extra logging.
+  const payload = (await res.json().catch(() => null)) as { id?: unknown } | null;
   if (!payload || typeof payload !== "object") {
     throw new RemoteRunError("Trigger returned a non-JSON response", {
       body: payload,
-      hint: "The server should return `{ runId: string }`. Check the platform version on the pinned instance.",
+      hint: "The server should return the created run resource (`{ id: string, ... }`). Check the platform version on the pinned instance.",
     });
   }
-  if (typeof payload.runId !== "string" || payload.runId.length === 0) {
-    throw new RemoteRunError("Trigger response missing `runId` string", {
+  if (typeof payload.id !== "string" || payload.id.length === 0) {
+    throw new RemoteRunError("Trigger response missing `id` string", {
       body: payload,
-      hint: "Expected `{ runId: string }`. The platform may be incompatible with this CLI version.",
+      hint: "Expected the created run resource (`{ id: string, ... }`). The platform may be incompatible with this CLI version.",
     });
   }
-  return payload.runId;
+  return payload.id;
 }
 
 async function fetchRunRecord(

--- a/apps/cli/src/commands/run/report.ts
+++ b/apps/cli/src/commands/run/report.ts
@@ -193,8 +193,10 @@ export async function startReportSession(
     );
   }
 
+  // Operation envelope: one-time sink credentials + the created run's `id`
+  // (the legacy `runId` alias was removed — #657).
   const payload = (await res.json()) as {
-    runId: string;
+    id: string;
     url: string;
     finalize_url: string;
     secret: string;
@@ -208,9 +210,9 @@ export async function startReportSession(
   });
 
   return {
-    runId: payload.runId,
+    runId: payload.id,
     httpSink,
-    proxyHeaders: { "X-Run-Id": payload.runId },
+    proxyHeaders: { "X-Run-Id": payload.id },
     sinkUrl: payload.url,
     runSecret: payload.secret,
   };

--- a/apps/cli/test/run-remote-runner.test.ts
+++ b/apps/cli/test/run-remote-runner.test.ts
@@ -180,8 +180,8 @@ describe("runRemote — URL encoding (regression #355)", () => {
     const fetchImpl = makeFetchImpl(
       {
         "POST /api/agents/@pierre-cabriere/hello-world/run": {
-          status: 200,
-          body: { runId: "run_url" },
+          status: 201,
+          body: { id: "run_url" },
         },
         "GET /api/runs/run_url/logs": { status: 200, body: [] },
         "GET /api/runs/run_url": {
@@ -215,8 +215,8 @@ describe("runRemote — happy path", () => {
     const fetchImpl = makeFetchImpl(
       {
         "POST /api/agents/@system/hello-world/run": {
-          status: 200,
-          body: { runId: "run_test_1" },
+          status: 201,
+          body: { id: "run_test_1" },
         },
         "GET /api/runs/run_test_1/logs": [
           {
@@ -294,7 +294,7 @@ describe("runRemote — happy path", () => {
     const calls: FetchCall[] = [];
     const fetchImpl = makeFetchImpl(
       {
-        "POST /api/agents/@scope/agent/run": { status: 200, body: { runId: "run_2" } },
+        "POST /api/agents/@scope/agent/run": { status: 201, body: { id: "run_2" } },
         "GET /api/runs/run_2/logs": { status: 200, body: [] },
         "GET /api/runs/run_2": {
           status: 200,
@@ -328,7 +328,7 @@ describe("runRemote — happy path", () => {
     const calls: FetchCall[] = [];
     const fetchImpl = makeFetchImpl(
       {
-        "POST /api/agents/@system/hello-world/run": { status: 200, body: { runId: "run_3" } },
+        "POST /api/agents/@system/hello-world/run": { status: 201, body: { id: "run_3" } },
         "GET /api/runs/run_3/logs": { status: 200, body: [] },
         "GET /api/runs/run_3": {
           status: 200,
@@ -349,7 +349,7 @@ describe("runRemote — happy path", () => {
     const calls: FetchCall[] = [];
     const fetchImpl = makeFetchImpl(
       {
-        "POST /api/agents/@system/hello-world/run": { status: 200, body: { runId: "run_4" } },
+        "POST /api/agents/@system/hello-world/run": { status: 201, body: { id: "run_4" } },
         "GET /api/runs/run_4/logs": { status: 200, body: [] },
         "GET /api/runs/run_4": {
           status: 200,
@@ -385,7 +385,7 @@ describe("runRemote — happy path", () => {
     const calls: FetchCall[] = [];
     const fetchImpl = makeFetchImpl(
       {
-        "POST /api/agents/@system/hello-world/run": { status: 200, body: { runId: "run_4e" } },
+        "POST /api/agents/@system/hello-world/run": { status: 201, body: { id: "run_4e" } },
         "GET /api/runs/run_4e/logs": { status: 200, body: [] },
         "GET /api/runs/run_4e": {
           status: 200,
@@ -419,7 +419,7 @@ describe("runRemote — happy path", () => {
     const calls: FetchCall[] = [];
     const fetchImpl = makeFetchImpl(
       {
-        "POST /api/agents/@system/hello-world/run": { status: 200, body: { runId: "run_5" } },
+        "POST /api/agents/@system/hello-world/run": { status: 201, body: { id: "run_5" } },
         "GET /api/runs/run_5/logs": {
           status: 200,
           body: [
@@ -483,7 +483,7 @@ describe("runRemote — non-success terminals", () => {
     const calls: FetchCall[] = [];
     const fetchImpl = makeFetchImpl(
       {
-        "POST /api/agents/@system/hello-world/run": { status: 200, body: { runId: "run_f" } },
+        "POST /api/agents/@system/hello-world/run": { status: 201, body: { id: "run_f" } },
         "GET /api/runs/run_f/logs": { status: 200, body: [] },
         "GET /api/runs/run_f": {
           status: 200,
@@ -506,7 +506,7 @@ describe("runRemote — non-success terminals", () => {
     const calls: FetchCall[] = [];
     const fetchImpl = makeFetchImpl(
       {
-        "POST /api/agents/@system/hello-world/run": { status: 200, body: { runId: "run_t" } },
+        "POST /api/agents/@system/hello-world/run": { status: 201, body: { id: "run_t" } },
         "GET /api/runs/run_t/logs": { status: 200, body: [] },
         "GET /api/runs/run_t": {
           status: 200,
@@ -531,7 +531,7 @@ describe("runRemote — cancellation", () => {
     let recordHits = 0;
     const fetchImpl = makeFetchImpl(
       {
-        "POST /api/agents/@system/hello-world/run": { status: 200, body: { runId: "run_c" } },
+        "POST /api/agents/@system/hello-world/run": { status: 201, body: { id: "run_c" } },
         "GET /api/runs/run_c/logs": { status: 200, body: [] },
         "GET /api/runs/run_c": [
           { status: 200, body: recordSummary({ id: "run_c", status: "running" }) },
@@ -579,7 +579,7 @@ describe("runRemote — cancellation", () => {
     const calls: FetchCall[] = [];
     const fetchImpl = makeFetchImpl(
       {
-        "POST /api/agents/@system/hello-world/run": { status: 200, body: { runId: "run_dc" } },
+        "POST /api/agents/@system/hello-world/run": { status: 201, body: { id: "run_dc" } },
         "GET /api/runs/run_dc/logs": { status: 200, body: [] },
         "GET /api/runs/run_dc": {
           status: 200,
@@ -648,12 +648,12 @@ describe("runRemote — error paths", () => {
     }
   });
 
-  it("throws RemoteRunError when trigger response lacks runId", async () => {
+  it("throws RemoteRunError when trigger response lacks an id", async () => {
     const calls: FetchCall[] = [];
     const fetchImpl = makeFetchImpl(
       {
         "POST /api/agents/@system/hello-world/run": {
-          status: 200,
+          status: 201,
           body: { somethingElse: true },
         },
       },
@@ -669,7 +669,7 @@ describe("runRemote — error paths", () => {
     const calls: FetchCall[] = [];
     const fetchImpl = makeFetchImpl(
       {
-        "POST /api/agents/@system/hello-world/run": { status: 200, body: { runId: "run_ll" } },
+        "POST /api/agents/@system/hello-world/run": { status: 201, body: { id: "run_ll" } },
         "GET /api/runs/run_ll/logs": { status: 500, body: { error: "transient" } },
         "GET /api/runs/run_ll": {
           status: 200,
@@ -704,7 +704,7 @@ describe("runRemote — log dedup", () => {
     // catch a server that fails to honor the cursor.
     const fetchImpl = makeFetchImpl(
       {
-        "POST /api/agents/@system/hello-world/run": { status: 200, body: { runId: "run_dd" } },
+        "POST /api/agents/@system/hello-world/run": { status: 201, body: { id: "run_dd" } },
         "GET /api/runs/run_dd/logs": [
           { status: 200, body: [log(1, "a")] },
           { status: 200, body: [log(1, "a"), log(2, "b")] },
@@ -748,8 +748,8 @@ describe("runRemote — log cursor (?since=)", () => {
     const fetchImpl = makeFetchImpl(
       {
         "POST /api/agents/@system/hello-world/run": {
-          status: 200,
-          body: { runId: "run_cursor" },
+          status: 201,
+          body: { id: "run_cursor" },
         },
         "GET /api/runs/run_cursor/logs": [
           { status: 200, body: [log(1), log(2)] },
@@ -797,7 +797,7 @@ describe("runRemote — log cursor (?since=)", () => {
     });
     const fetchImpl = makeFetchImpl(
       {
-        "POST /api/agents/@system/hello-world/run": { status: 200, body: { runId: "run_tail" } },
+        "POST /api/agents/@system/hello-world/run": { status: 201, body: { id: "run_tail" } },
         "GET /api/runs/run_tail/logs": [
           { status: 200, body: [log(1)] },
           // After terminal, the post-terminal "tail" fetch picks up a
@@ -841,7 +841,7 @@ describe("runRemote — record-poll cadence", () => {
     // to log-activity-driven refresh.
     const fetchImpl = makeFetchImpl(
       {
-        "POST /api/agents/@system/hello-world/run": { status: 200, body: { runId: "run_quiet" } },
+        "POST /api/agents/@system/hello-world/run": { status: 201, body: { id: "run_quiet" } },
         "GET /api/runs/run_quiet/logs": { status: 200, body: [] },
         "GET /api/runs/run_quiet": [
           { status: 200, body: recordSummary({ id: "run_quiet", status: "running" }) },
@@ -874,12 +874,12 @@ describe("runRemote — record-poll cadence", () => {
 });
 
 describe("runRemote — trigger response shape", () => {
-  it("rejects a 200 response that is not a JSON object", async () => {
+  it("rejects a 201 response that is not a JSON object", async () => {
     const calls: FetchCall[] = [];
     const fetchImpl = makeFetchImpl(
       {
         "POST /api/agents/@system/hello-world/run": {
-          status: 200,
+          status: 201,
           contentType: "text/plain",
           body: "ok",
         },
@@ -899,13 +899,13 @@ describe("runRemote — trigger response shape", () => {
     }
   });
 
-  it("rejects a 200 response where runId is not a string", async () => {
+  it("rejects a 201 response where id is not a string", async () => {
     const calls: FetchCall[] = [];
     const fetchImpl = makeFetchImpl(
       {
         "POST /api/agents/@system/hello-world/run": {
-          status: 200,
-          body: { runId: 12345 },
+          status: 201,
+          body: { id: 12345 },
         },
       },
       calls,
@@ -919,18 +919,18 @@ describe("runRemote — trigger response shape", () => {
       throw new Error("expected throw");
     } catch (err) {
       if (!(err instanceof RemoteRunError)) throw err;
-      expect(err.message).toMatch(/runId/);
+      expect(err.message).toMatch(/`id`/);
       expect(err.hint).toBeDefined();
     }
   });
 
-  it("rejects a 200 response with empty-string runId", async () => {
+  it("rejects a 201 response with empty-string id", async () => {
     const calls: FetchCall[] = [];
     const fetchImpl = makeFetchImpl(
       {
         "POST /api/agents/@system/hello-world/run": {
-          status: 200,
-          body: { runId: "" },
+          status: 201,
+          body: { id: "" },
         },
       },
       calls,
@@ -944,7 +944,7 @@ describe("runRemote — trigger response shape", () => {
       throw new Error("expected throw");
     } catch (err) {
       if (!(err instanceof RemoteRunError)) throw err;
-      expect(err.message).toMatch(/runId/);
+      expect(err.message).toMatch(/`id`/);
     }
   });
 });
@@ -962,7 +962,7 @@ describe("runRemote — trigger retry on transient 5xx", () => {
       {
         "POST /api/agents/@system/hello-world/run": [
           { status: 503, body: { error: "service unavailable" } },
-          { status: 200, body: { runId: "run_retry_1" } },
+          { status: 201, body: { id: "run_retry_1" } },
         ],
         "GET /api/runs/run_retry_1/logs": { status: 200, body: [] },
         "GET /api/runs/run_retry_1": {
@@ -991,7 +991,7 @@ describe("runRemote — trigger retry on transient 5xx", () => {
         "POST /api/agents/@system/hello-world/run": [
           { status: 502, body: { error: "bad gateway" } },
           { status: 504, body: { error: "gateway timeout" } },
-          { status: 200, body: { runId: "run_retry_2" } },
+          { status: 201, body: { id: "run_retry_2" } },
         ],
         "GET /api/runs/run_retry_2/logs": { status: 200, body: [] },
         "GET /api/runs/run_retry_2": {
@@ -1064,7 +1064,7 @@ describe("runRemote — record-poll resilience", () => {
     const calls: FetchCall[] = [];
     const fetchImpl = makeFetchImpl(
       {
-        "POST /api/agents/@system/hello-world/run": { status: 200, body: { runId: "run_rec_5xx" } },
+        "POST /api/agents/@system/hello-world/run": { status: 201, body: { id: "run_rec_5xx" } },
         "GET /api/runs/run_rec_5xx/logs": { status: 200, body: [] },
         "GET /api/runs/run_rec_5xx": [
           // First poll fails — the runner must NOT crash.
@@ -1110,8 +1110,8 @@ describe("runRemote — record-poll resilience", () => {
       const method = (init?.method ?? "GET").toUpperCase();
       calls.push({ url, method, headers: {}, body: undefined });
       if (url.endsWith("/run") && method === "POST") {
-        return new Response(JSON.stringify({ runId: "run_final_5xx" }), {
-          status: 200,
+        return new Response(JSON.stringify({ id: "run_final_5xx" }), {
+          status: 201,
           headers: { "Content-Type": "application/json" },
         });
       }

--- a/apps/cli/test/run-report-source.test.ts
+++ b/apps/cli/test/run-report-source.test.ts
@@ -35,7 +35,7 @@ const SNAPSHOT = {
 };
 
 const SUCCESS_BODY = {
-  runId: "run_test_1234567890",
+  id: "run_test_1234567890",
   url: "https://app.example.com/api/runs/run_test/events",
   finalize_url: "https://app.example.com/api/runs/run_test/events/finalize",
   secret: "ZWZmZWN0aXZlbHkgYW55dGhpbmc=",

--- a/apps/web/src/hooks/use-mutations.ts
+++ b/apps/web/src/hooks/use-mutations.ts
@@ -3,6 +3,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
+import type { EnrichedRun } from "@appstrate/shared-types";
 import i18n from "../i18n";
 import { api, ApiError, buildQs, uploadFormData } from "../api";
 import { PACKAGE_CONFIG, type PackageType } from "./use-packages";
@@ -67,7 +68,9 @@ export function useRunAgent(packageId: string) {
       const body: Record<string, unknown> = {};
       if (input !== undefined) body.input = input;
       if (connectionOverrides !== undefined) body.connection_overrides = connectionOverrides;
-      return api<{ runId: string }>(`/agents/${packageId}/run${qs}`, {
+      // 201 + the bare created Run resource (same shape as GET /runs/:id) —
+      // the legacy `runId` alias was removed (#657).
+      return api<EnrichedRun>(`/agents/${packageId}/run${qs}`, {
         method: "POST",
         body: JSON.stringify(body),
       });
@@ -75,7 +78,7 @@ export function useRunAgent(packageId: string) {
     onSuccess: (data) => {
       qc.invalidateQueries({ queryKey: ["runs"] });
       qc.invalidateQueries({ queryKey: ["paginated-runs"] });
-      navigate(`/agents/${packageId}/runs/${data.runId}`);
+      navigate(`/agents/${packageId}/runs/${data.id}`);
     },
     onError: onMutationError,
   });

--- a/e2e/tests/uploads/upload-flow.api.spec.ts
+++ b/e2e/tests/uploads/upload-flow.api.spec.ts
@@ -79,7 +79,7 @@ test.describe("upload:// protocol", () => {
     const runRes = await apiClient.post(`/agents/${scope}/${agentName}/run`, {
       input: { doc: descriptor.uri },
     });
-    expect(runRes.status()).toBe(200);
+    expect(runRes.status()).toBe(201);
   });
 
   test("consume rejects a file whose magic bytes don't match contentMediaType", async ({
@@ -142,7 +142,7 @@ test.describe("upload:// protocol", () => {
     const first = await apiClient.post(`/agents/${scope}/${agentName}/run`, {
       input: { doc: descriptor.uri },
     });
-    expect(first.status()).toBe(200);
+    expect(first.status()).toBe(201);
 
     const second = await apiClient.post(`/agents/${scope}/${agentName}/run`, {
       input: { doc: descriptor.uri },

--- a/e2e/tests/uploads/upload-flow.api.spec.ts
+++ b/e2e/tests/uploads/upload-flow.api.spec.ts
@@ -117,17 +117,19 @@ test.describe("upload:// protocol", () => {
     expect(body.toLowerCase()).toContain("mime");
   });
 
-  test("reusing an upload:// URI twice fails with 409", async ({
+  test("reusing an upload:// URI within the retention window starts a second run", async ({
     apiClient,
     browserCtx,
     request,
   }) => {
+    // Consumed uploads are retained for UPLOAD_RETENTION_HOURS (default 24h),
+    // so the same URI is re-consumable — each trigger creates a distinct run.
     const scope = `@${browserCtx.org.orgSlug}`;
-    const agentName = `upload-once-${Date.now()}`;
+    const agentName = `upload-reuse-${Date.now()}`;
     await createAgentWithFileInput(apiClient, scope, agentName);
 
     const createRes = await apiClient.post("/uploads", {
-      name: "once.pdf",
+      name: "reuse.pdf",
       size: PDF_MAGIC.length,
       mime: "application/pdf",
     });
@@ -143,10 +145,13 @@ test.describe("upload:// protocol", () => {
       input: { doc: descriptor.uri },
     });
     expect(first.status()).toBe(201);
+    const firstRun = await first.json();
 
     const second = await apiClient.post(`/agents/${scope}/${agentName}/run`, {
       input: { doc: descriptor.uri },
     });
-    expect([404, 409, 410]).toContain(second.status());
+    expect(second.status()).toBe(201);
+    const secondRun = await second.json();
+    expect(secondRun.id).not.toBe(firstRun.id);
   });
 });


### PR DESCRIPTION
Refs #657 — batch **C (runs)** of the strict bare-resource rule. Deliberate **breaking wire changes** (no prod data).

## Endpoint changes

| Endpoint | Before | After |
|---|---|---|
| `POST /agents/{scope}/{name}/run` | `200` + `allOf:[Run, {runId}]` | **`201`** + bare `Run` resource (same serializer as `GET /runs/{id}`, direct `$ref`) |
| `POST /runs/{id}/cancel` | `200 {ok: true}` | `200` + the **updated Run resource**, read AFTER `synthesiseFinalize` — `status: cancelled`, final `cost`/`completed_at` |
| `POST /runs/inline` | `202 {runId, packageId}` | `202` + bare `Run` resource (the shadow package id is the resource's own `packageId` field) |
| `POST /runs/remote` | `201 {runId, ...sink credentials}` | envelope **kept** (one-time sink credentials are legit operation data, #657 exception) but `runId` → **`id`** |
| `PATCH /runs/{runId}/sink/extend` | `200 {runId, expiresAt}` | `200 {id, expiresAt}` — operation result, not a resource: `sink_expires_at` is deliberately not on the Run DTO, and no first-party client reads this body (runtime keep-alive is `POST /events/heartbeat`) |
| `POST /runs/inline/validate` | `{ok: true}` | unchanged — legit dry-run operation result (noted only) |

## Removed fields / status changes

- **Removed**: `runId` alias (trigger, inline, remote, sink/extend), `ok` boolean (cancel), the `allOf:[Run,{runId}]` compat envelope, the inline `{runId, packageId}` envelope.
- **Status codes**: trigger `200` → `201` (created). Inline stays `202` (accepted, async), cancel stays `200` (update), remote stays `201`.

## Consumers updated (same PR)

- **web**: `useRunAgent` — `api<EnrichedRun>`, `data.runId` → `data.id` (only `.runId` response read in apps/web).
- **CLI**: `remote-runner.ts` `triggerRun` parses the bare resource's `id` (strict, fail-fast on alternate keys, hints updated); `report.ts` `startReportSession` reads the remote envelope's `id`.
- **MCP**: server instructions no longer say "returns a runId" — now "returns the created run resource (use its `id`)".
- **github-action**: separate PR in `appstrate/github-action` (reads `data.runId`) — linked below.

## Tests replaced

- `runs.test.ts`: trigger echo tests expect `201`, `body.id`, `body.runId` undefined; cancel tests assert the bare updated Run (`id`, `status: cancelled`) instead of `{ok}`.
- `runs-cancel-convergence.test.ts`: pins that the response body carries the post-finalize state (`status: cancelled` + final `cost`).
- `runs-remote-registry.test.ts`: envelope `id` + `runId` removal pinned.
- CLI `run-remote-runner.test.ts`: trigger mocks `201` + `{id}`, shape-rejection tests renamed/retargeted; `run-report-source.test.ts` envelope fixture updated.

## Baseline

`apps/api/src/openapi/baseline.json` regenerated via `bun scripts/detect-breaking-changes.ts --update-baseline`. Against the committed baseline the script reports exactly the 5 intended BREAKING entries above (plus pre-existing non-breaking drift from already-merged PRs — the committed baseline was stale).

⚠️ **The regenerated baseline will conflict with the other open #657 batch PRs** — regenerate at merge time on whichever lands last.

## Validation

- `bun run check`: 29/29 tasks green (incl. OpenAPI verify, 203 endpoints).
- Touched API integration tests: 162 pass / 0 fail (runs, cancel-convergence, remote-registry, inline-run, inline-run-validate, version-selection, events-ingestion, run-wait).
- CLI tests: 42 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)