### PR TITLE
refactor(api)!: bare package/version resources from package mutations (batch D, #657)

### DIFF
--- a/apps/api/src/openapi/baseline.json
+++ b/apps/api/src/openapi/baseline.json
@@ -796,7 +796,7 @@
         },
         "responses": {
           "200": {
-            "description": "Agent proxy updated",
+            "description": "Agent proxy updated — returns the affected proxy setting",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -808,12 +808,28 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": ["proxyId", "resolved"],
+                      "properties": {
+                        "proxyId": {
+                          "type": ["string", "null"]
+                        },
+                        "resolved": {
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean"
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -1284,7 +1300,7 @@
         },
         "responses": {
           "200": {
-            "description": "Agent model updated",
+            "description": "Agent model updated — returns the affected model setting",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -1296,12 +1312,25 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": ["modelId"],
+                      "properties": {
+                        "modelId": {
+                          "type": ["string", "null"]
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean"
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -1372,21 +1401,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
-                    },
-                    "skillIds": {
-                      "type": "array",
-                      "items": {
-                        "type": "string"
-                      }
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/AgentDetail",
+                  "description": "The updated agent resource — same shape as the GET agent detail. The new skill references appear in `dependencies.skills`. No follow-up GET needed."
                 }
               }
             }
@@ -1513,7 +1529,7 @@
         "operationId": "runAgent",
         "tags": ["Runs"],
         "summary": "Execute an agent",
-        "description": "Start an agent run (fire-and-forget). Returns the run ID. Rate-limited to 20/min. Supports JSON body or multipart/form-data with file uploads.",
+        "description": "Start an agent run (fire-and-forget). Returns the created run resource — same shape as `GET /runs/{id}` — including the resolved `model_label` / `model_source`. Rate-limited to 20/min. The body is JSON. File-typed input fields (`format: uri` + `contentMediaType` in the agent's input schema) accept either of two forms: (1) an `upload://upl_xxx` reference from `createUpload` — stage the bytes first by PUTting them to the signed URL (see `createUpload` for the step-by-step recipe); or (2) an inline RFC 2397 data URI `data:<mime>;name=<filename>;base64,<payload>` with up to 4 MiB of decoded content (`name` is optional) — the single-call path for JSON-only clients such as MCP. Inline bytes are written to the run workspace as a document and the payload is stripped from the persisted run input (the stored value keeps only a `data:<mime>;name=<doc>;base64,` marker). Declared binary MIMEs are verified by magic-byte sniffing in both forms. Send `rerun_from` instead of `input` to replay a previous run's input — same documents, new overrides — without re-uploading. The effective model is resolved at run creation with precedence: request `modelId` > agent model setting > org default model > system default. Without an explicit `modelId`, a change to the org default model between triggers applies to the next run — send `modelId` to pin a specific model per run.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -1543,7 +1559,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Version query to execute (exact version, dist-tag, or semver range). When provided, the run uses the versioned manifest and prompt instead of the live agent."
+            "description": "Which agent definition to execute: `draft` (the live editor working copy), `published` (the latest published version — 404 `no_published_version` if nothing is published), or a version spec (exact version, dist-tag, or semver range; 3-step resolution). **Default when omitted: the latest published version when one exists, the draft otherwise** — programmatic callers (API, MCP, CLI, CI) run what was published unless they explicitly ask for the draft. The editor UI passes `version=draft` for test-runs. The run object's `version_ref` states which definition executed. Ignored for system agents."
           }
         ],
         "requestBody": {
@@ -1554,11 +1570,15 @@
                 "properties": {
                   "input": {
                     "type": "object",
-                    "description": "Run input values"
+                    "description": "Run input values, validated against the agent's input schema. File fields take `upload://upl_xxx` references (from `createUpload`) or inline `data:<mime>;name=<filename>;base64,<payload>` URIs (≤4 MiB decoded)."
+                  },
+                  "rerun_from": {
+                    "type": "string",
+                    "description": "Run id whose `input` to replay verbatim on this run. Mutually exclusive with `input` (400 if both are sent). The referenced run must be visible in the caller's org + application scope (404 otherwise; end-users can only replay their own runs) and must belong to the agent being triggered (409 `rerun_agent_mismatch`). File fields keep their `upload://` URIs in the stored input, and consumed uploads stay re-consumable for `UPLOAD_RETENTION_HOURS` (default 24 h) after their first consume — so a cancelled or completed run can be re-triggered with the same documents and different overrides (`modelId`, `config`, `?version`, `connection_overrides`) in a single call, without re-uploading. Returns 410 `upload_expired` when a referenced upload's reuse window has elapsed (re-upload required)."
                   },
                   "modelId": {
                     "type": "string",
-                    "description": "Model ID override for this run. Takes priority over agent and org defaults."
+                    "description": "Model ID override for this run — a system model key or an org-model UUID. Pins THIS run to that model, taking priority over the full resolution cascade (request `modelId` > agent model setting > org default model > system default). Without it, the org default is resolved at run creation — not ahead of time — so changing the org default between triggers silently changes the model used by subsequent runs. Returns 404 when the referenced model does not exist. The response echoes the resolved `model_label` + `model_source` so callers can verify which model the run actually uses."
                   },
                   "proxyId": {
                     "type": "string",
@@ -1583,22 +1603,6 @@
                 },
                 "config": {
                   "dryRun": true
-                }
-              }
-            },
-            "multipart/form-data": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "input": {
-                    "type": "string",
-                    "description": "JSON-encoded input values"
-                  },
-                  "file": {
-                    "type": "string",
-                    "format": "binary",
-                    "description": "File upload"
-                  }
                 }
               }
             }
@@ -1627,15 +1631,28 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "runId": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/Run"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "runId": {
+                          "type": "string",
+                          "description": "Legacy alias of the run's `id`, kept for backward compatibility. Prefer `id`."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created run resource — same shape as `GET /runs/{id}`. Includes the resolved `model_label` / `model_source` (detect org-default drift at trigger time per #635), `status`, `version_ref`, `agent_scope`, etc., so no follow-up GET is needed. `runId` is a legacy alias of `id`."
                 },
                 "example": {
-                  "runId": "run_cm1abc123def456"
+                  "id": "run_cm1abc123def456",
+                  "runId": "run_cm1abc123def456",
+                  "status": "pending",
+                  "model_label": "Claude Sonnet 4",
+                  "model_source": "org"
                 }
               }
             }
@@ -1667,7 +1684,29 @@
             "$ref": "#/components/responses/NotFound"
           },
           "409": {
-            "$ref": "#/components/responses/IdempotencyInProgress"
+            "description": "Concurrent request with the same Idempotency-Key still in flight, or the `rerun_from` run belongs to a different agent (`rerun_agent_mismatch`)",
+            "headers": {
+              "Request-Id": {
+                "$ref": "#/components/headers/RequestId"
+              }
+            },
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "A referenced upload has expired before consume, or its post-consume reuse window has elapsed (`upload_expired`) — stage a fresh upload and retry",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           },
           "412": {
             "description": "Missing integration connection (`missing_integration_connection`)",
@@ -2248,8 +2287,8 @@
       "get": {
         "operationId": "getRun",
         "tags": ["Runs"],
-        "summary": "Get run status/result",
-        "description": "Get run details including status, result, input, and duration.",
+        "summary": "Get run status/result (optionally long-poll until terminal)",
+        "description": "Get run details including status, result, input, and duration.\n\nPass `?wait=<seconds>` (or `?wait=true` for the maximum) to long-poll: the server holds the request until the run reaches a terminal status (`success`, `failed`, `timeout`, `cancelled`) or the wait elapses, then returns the current run object exactly as the plain call does. The wait is capped at **55 seconds** — deliberately below the 60 s idle timeouts that ship as defaults in common reverse proxies (nginx `proxy_read_timeout`, ALB idle timeout) so the long poll always completes with a real response instead of a proxy 504; values above the cap are clamped. A response with a non-terminal `status` simply means the wait timed out — issue the same call again to keep waiting. One long poll replaces N sleep+getRun round-trips, which is the recommended completion-wait pattern for MCP clients (the SSE stream is not reachable through the MCP server).",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -2264,6 +2303,25 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "wait",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "oneOf": [
+                {
+                  "type": "boolean",
+                  "description": "`true` waits the maximum 55 s; `false` disables."
+                },
+                {
+                  "type": "integer",
+                  "minimum": 0,
+                  "description": "Wait budget in seconds. Values above 55 are clamped to 55."
+                }
+              ]
+            },
+            "description": "Hold the request until the run reaches a terminal status or this many seconds elapse (capped at 55, see operation description), then return the run object. `0`/`false`/absent = return immediately (default). Negative, fractional, or non-numeric values return 400."
           }
         ],
         "responses": {
@@ -2293,8 +2351,11 @@
                     "maxEmails": 50
                   },
                   "result": {
-                    "processed": 42,
-                    "labeled": 38
+                    "output": {
+                      "processed": 42,
+                      "labeled": 38
+                    },
+                    "text": "## Inbox triage\nProcessed 42 emails, labeled 38."
                   },
                   "checkpoint": {
                     "lastProcessedId": "msg_99f2a"
@@ -2311,6 +2372,7 @@
                   "scheduleId": "sched_cm1abc456def789",
                   "version_label": "1.2.0",
                   "version_dirty": false,
+                  "version_ref": "1.2.0",
                   "proxy_label": null,
                   "model_label": "Claude Sonnet 4",
                   "model_source": "system",
@@ -2336,7 +2398,7 @@
         "operationId": "getRunLogs",
         "tags": ["Runs"],
         "summary": "Get run logs",
-        "description": "Get persisted log entries for a run. Pass `?since=<id>` to receive only entries with `id > since` — the cursor used by the CLI's polling tail to bound per-poll payload growth. `id` is a monotonic BIGSERIAL; an invalid cursor falls back to the full list rather than 400.",
+        "description": "Get persisted log entries for a run. Pass `?since=<id>` to receive only entries with `id > since` — the cursor used by the CLI's polling tail to bound per-poll payload growth, and the pagination cursor when combined with `?limit=`. Pass `?level=` to filter by minimum severity (`level=info` skips debug breadcrumbs). When `limit` is set and more entries follow, an RFC 5988 `Link: <…?since=<lastId>>; rel=\"next\"` response header points at the next page. `id` is a monotonic BIGSERIAL; invalid `since`/`level`/`limit` values fall back to the unfiltered default rather than 400 so a stale cursor never breaks a polling tail. Without query parameters the full chronological history is returned (backward-compatible default). Note: tool-result payloads inside `data` are truncated at write time by the runner (default 2048 bytes, operator-tunable via `TOOL_RESULT_BYTE_LIMIT`) — entries already persisted truncated cannot be recovered by this endpoint.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -2361,7 +2423,28 @@
               "format": "int64",
               "minimum": 0
             },
-            "description": "Return only log entries with `id > since`. Used by the CLI's `appstrate run` remote polling loop to fetch incremental tails without re-shipping the full history each poll."
+            "description": "Return only log entries with `id > since`. Used by the CLI's `appstrate run` remote polling loop to fetch incremental tails without re-shipping the full history each poll, and as the cursor in the `Link; rel=\"next\"` pagination header."
+          },
+          {
+            "name": "level",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["debug", "info", "warn", "error"]
+            },
+            "description": "Minimum severity to include (`debug < info < warn < error`). `level=info` returns info, warn and error entries. Defaults to `debug` (everything)."
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000
+            },
+            "description": "Maximum number of entries to return. When more entries follow, the response carries a `Link; rel=\"next\"` header whose URL re-uses `since` as the cursor. Absent means no cap (full history)."
           }
         ],
         "responses": {
@@ -2373,6 +2456,9 @@
               },
               "Appstrate-Version": {
                 "$ref": "#/components/headers/AppstrateVersion"
+              },
+              "Link": {
+                "$ref": "#/components/headers/Link"
               }
             },
             "content": {
@@ -2920,6 +3006,10 @@
                     "type": "number",
                     "minimum": 0,
                     "description": "Authoritative terminal run cost written to the `runs` row."
+                  },
+                  "report": {
+                    "type": "string",
+                    "description": "Aggregated markdown report — every `report.appended` event's content joined with `\\n` in call order. Persisted (capped at 256 KiB) as `runs.result.text` so getRun exposes the run's deliverable without log scraping."
                   }
                 }
               }
@@ -3621,7 +3711,7 @@
                   },
                   "version_override": {
                     "type": "string",
-                    "description": "Pin the agent version every run triggered by this schedule. Literal label or dist-tag."
+                    "description": "Which agent definition every run triggered by this schedule executes: `draft`, `published`, or a version spec (exact version, dist-tag, or semver range). Default when omitted: the latest published version when one exists, the draft otherwise. The pinned definition (manifest + prompt) is resolved at each fire."
                   },
                   "connection_overrides": {
                     "type": "object",
@@ -3823,7 +3913,8 @@
                     "type": ["string", "null"]
                   },
                   "version_override": {
-                    "type": ["string", "null"]
+                    "type": ["string", "null"],
+                    "description": "Version selector (`draft` | `published` | version spec). Pass `null` to clear (falls back to the default: latest published version when one exists, draft otherwise)."
                   },
                   "connection_overrides": {
                     "type": ["object", "null"],
@@ -4024,13 +4115,40 @@
         "operationId": "listIntegrations",
         "tags": ["Integrations"],
         "summary": "List available integrations",
-        "description": "List every AFPS integration accessible to the current org (own + system), enriched with `active` + `block_user_connections` flags for the current application.",
+        "description": "List every AFPS integration accessible to the current org (own + system), enriched with `active` + `block_user_connections` flags for the current application. Supports offset pagination (`limit`/`offset`) and a `fields` projection selector — request `?fields=id,source` to drop the heavy per-row `manifest` and fetch only what you need.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
           },
           {
             "$ref": "#/components/parameters/XAppId"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Comma-separated allowlist of fields to return per item (`id` is always included). Allowed: id, manifest, orgId, source, active, block_user_connections. An unknown field is a 400.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -4402,7 +4520,7 @@
         },
         "responses": {
           "201": {
-            "description": "Activated",
+            "description": "Activated — returns the full integration detail",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -4414,17 +4532,182 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": ["active", "activated_at"],
-                  "properties": {
-                    "active": {
-                      "type": "boolean"
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": ["manifest", "auths", "tool_catalog", "allow_undeclared_tools"],
+                      "properties": {
+                        "manifest": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "auths": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "auth_key",
+                              "type",
+                              "required",
+                              "scopes",
+                              "resource",
+                              "connections",
+                              "has_oauth_client",
+                              "client_auto_provisioned"
+                            ],
+                            "properties": {
+                              "auth_key": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": ["oauth2", "api_key", "basic", "mtls", "custom"],
+                                "description": "Auth method type (AFPS §7.2). For `mtls`, client cert + key are supplied via `credentials.schema` and injected at runtime through `delivery.files`."
+                              },
+                              "required": {
+                                "type": "boolean"
+                              },
+                              "scopes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "resource": {
+                                "type": ["string", "null"],
+                                "description": "RFC 8707 resource indicator declared by the manifest (`auths.{key}.resource`). AFPS §7.3 name — matches the RFC."
+                              },
+                              "connections": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "id",
+                                    "packageId",
+                                    "auth_key",
+                                    "account_id",
+                                    "identity_claims",
+                                    "scopes_granted",
+                                    "needs_reconnection",
+                                    "expiresAt",
+                                    "owner_type",
+                                    "owner_id",
+                                    "createdAt",
+                                    "updatedAt"
+                                  ],
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "packageId": {
+                                      "type": "string"
+                                    },
+                                    "auth_key": {
+                                      "type": "string"
+                                    },
+                                    "account_id": {
+                                      "type": "string"
+                                    },
+                                    "identity_claims": {
+                                      "type": ["object", "null"],
+                                      "additionalProperties": true
+                                    },
+                                    "scopes_granted": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "needs_reconnection": {
+                                      "type": "boolean"
+                                    },
+                                    "expiresAt": {
+                                      "type": ["string", "null"],
+                                      "format": "date-time"
+                                    },
+                                    "owner_type": {
+                                      "type": "string",
+                                      "enum": ["user", "end_user"]
+                                    },
+                                    "owner_id": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "shared_with_org": {
+                                      "type": "boolean"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  }
+                                }
+                              },
+                              "has_oauth_client": {
+                                "type": "boolean"
+                              },
+                              "client_auto_provisioned": {
+                                "type": "boolean",
+                                "description": "True for an oauth2 auth on a remote MCP integration (`source.kind: \"remote\"`). Per the MCP Authorization spec the OAuth client is provisioned automatically at connect time — discovery of the authorization server (RFC 9728 → RFC 8414) plus client acquisition without manual pre-registration (CIMD when advertised, else RFC 7591 dynamic registration) — so no pre-registered client is required."
+                              }
+                            }
+                          }
+                        },
+                        "tool_catalog": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": ["name"],
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "policy": {
+                                "type": "object",
+                                "properties": {
+                                  "required_scopes": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "allow_undeclared_tools": {
+                          "type": "boolean"
+                        }
+                      }
                     },
-                    "activated_at": {
-                      "type": "string",
-                      "format": "date-time"
+                    {
+                      "type": "object",
+                      "required": ["active", "activated_at"],
+                      "properties": {
+                        "active": {
+                          "type": "boolean"
+                        },
+                        "activated_at": {
+                          "type": "string",
+                          "format": "date-time"
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -4470,7 +4753,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Deactivated",
+            "description": "Deactivated — returns the full integration detail",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -4482,13 +4765,178 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": ["active"],
-                  "properties": {
-                    "active": {
-                      "type": "boolean"
+                  "allOf": [
+                    {
+                      "type": "object",
+                      "required": ["manifest", "auths", "tool_catalog", "allow_undeclared_tools"],
+                      "properties": {
+                        "manifest": {
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "auths": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "auth_key",
+                              "type",
+                              "required",
+                              "scopes",
+                              "resource",
+                              "connections",
+                              "has_oauth_client",
+                              "client_auto_provisioned"
+                            ],
+                            "properties": {
+                              "auth_key": {
+                                "type": "string"
+                              },
+                              "type": {
+                                "type": "string",
+                                "enum": ["oauth2", "api_key", "basic", "mtls", "custom"],
+                                "description": "Auth method type (AFPS §7.2). For `mtls`, client cert + key are supplied via `credentials.schema` and injected at runtime through `delivery.files`."
+                              },
+                              "required": {
+                                "type": "boolean"
+                              },
+                              "scopes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "resource": {
+                                "type": ["string", "null"],
+                                "description": "RFC 8707 resource indicator declared by the manifest (`auths.{key}.resource`). AFPS §7.3 name — matches the RFC."
+                              },
+                              "connections": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "required": [
+                                    "id",
+                                    "packageId",
+                                    "auth_key",
+                                    "account_id",
+                                    "identity_claims",
+                                    "scopes_granted",
+                                    "needs_reconnection",
+                                    "expiresAt",
+                                    "owner_type",
+                                    "owner_id",
+                                    "createdAt",
+                                    "updatedAt"
+                                  ],
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "packageId": {
+                                      "type": "string"
+                                    },
+                                    "auth_key": {
+                                      "type": "string"
+                                    },
+                                    "account_id": {
+                                      "type": "string"
+                                    },
+                                    "identity_claims": {
+                                      "type": ["object", "null"],
+                                      "additionalProperties": true
+                                    },
+                                    "scopes_granted": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "needs_reconnection": {
+                                      "type": "boolean"
+                                    },
+                                    "expiresAt": {
+                                      "type": ["string", "null"],
+                                      "format": "date-time"
+                                    },
+                                    "owner_type": {
+                                      "type": "string",
+                                      "enum": ["user", "end_user"]
+                                    },
+                                    "owner_id": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": ["string", "null"]
+                                    },
+                                    "shared_with_org": {
+                                      "type": "boolean"
+                                    },
+                                    "createdAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    },
+                                    "updatedAt": {
+                                      "type": "string",
+                                      "format": "date-time"
+                                    }
+                                  }
+                                }
+                              },
+                              "has_oauth_client": {
+                                "type": "boolean"
+                              },
+                              "client_auto_provisioned": {
+                                "type": "boolean",
+                                "description": "True for an oauth2 auth on a remote MCP integration (`source.kind: \"remote\"`). Per the MCP Authorization spec the OAuth client is provisioned automatically at connect time — discovery of the authorization server (RFC 9728 → RFC 8414) plus client acquisition without manual pre-registration (CIMD when advertised, else RFC 7591 dynamic registration) — so no pre-registered client is required."
+                              }
+                            }
+                          }
+                        },
+                        "tool_catalog": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": ["name"],
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "description": {
+                                "type": "string"
+                              },
+                              "policy": {
+                                "type": "object",
+                                "properties": {
+                                  "required_scopes": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "allow_undeclared_tools": {
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "required": ["active"],
+                      "properties": {
+                        "active": {
+                          "type": "boolean"
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -6207,7 +6655,7 @@
         },
         "responses": {
           "201": {
-            "description": "Model created",
+            "description": "Model created — the full created model resource (same shape as `GET`/`list`). `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -6219,15 +6667,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "example": {
-                  "id": "cm5mno345"
+                  "$ref": "#/components/schemas/OrgModel"
                 }
               }
             }
@@ -6274,7 +6714,7 @@
         },
         "responses": {
           "200": {
-            "description": "Default model updated",
+            "description": "Default model updated. Returns the new effective default model resource (same shape as `GET`/`list`) plus a legacy `success` flag. When the default is cleared (`modelId: null`) and no default remains in effect, only `{ success: true }` is returned.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -6286,12 +6726,20 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgModel"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "description": "Legacy acknowledgement flag, always `true`. Retained for backward compatibility; prefer reading the model fields."
+                        }
+                      }
                     }
-                  }
+                  ]
                 }
               }
             }
@@ -6722,7 +7170,7 @@
         },
         "responses": {
           "200": {
-            "description": "Model updated",
+            "description": "Model updated — the full updated model resource (same shape as `GET`/`list`). `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -6734,12 +7182,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgModel"
                 }
               }
             }
@@ -6846,10 +7289,37 @@
         "operationId": "listModelProviderRegistry",
         "tags": ["Model Provider Credentials"],
         "summary": "List the in-code model provider registry",
-        "description": "Returns the catalog of LLM providers Appstrate knows how to talk to. The UI uses this to render the provider picker without hard-coding the catalog client-side.",
+        "description": "Returns the catalog of LLM providers Appstrate knows how to talk to. The UI uses this to render the provider picker without hard-coding the catalog client-side. Supports offset pagination (`limit`/`offset`) and a `fields` projection selector — request `?fields=providerId,authMode` to skip the heavy per-provider `models` catalog (the bulk of the payload) when you only need to know which providers exist.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Comma-separated allowlist of fields to return per provider (`providerId` is always included). Allowed: providerId, displayName, iconUrl, description, docsUrl, apiShape, defaultBaseUrl, baseUrlOverridable, authMode, featured, models. An unknown field is a 400.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -7124,7 +7594,7 @@
         },
         "responses": {
           "201": {
-            "description": "Model provider credential created",
+            "description": "Model provider credential created — the full created credential resource (same non-secret shape as `GET`/`list`). The api key / OAuth token is never echoed back. `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -7136,15 +7606,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "example": {
-                  "id": "cm7stu902"
+                  "$ref": "#/components/schemas/ModelProviderCredential"
                 }
               }
             }
@@ -7298,7 +7760,7 @@
         },
         "responses": {
           "200": {
-            "description": "Model provider credential updated",
+            "description": "Model provider credential updated — the full updated credential resource (same non-secret shape as `GET`/`list`). The api key / OAuth token is never echoed back. `id` is part of the resource, so callers reading the legacy `{ id }` stub are unaffected.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -7310,12 +7772,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/ModelProviderCredential"
                 }
               }
             }
@@ -7858,15 +8315,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgProxy"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "The created proxy's id. Same value as the resource's `id`; retained as a top-level field for backward compatibility."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The created proxy resource — same shape as the `GET /api/proxies` list items — so no follow-up GET is needed."
                 },
                 "example": {
-                  "id": "cm6pqr679"
+                  "id": "cm6pqr679",
+                  "label": "US Residential Proxy",
+                  "urlPrefix": "http://user:****@us-proxy.example.com:8080",
+                  "source": "custom",
+                  "enabled": true,
+                  "isDefault": false,
+                  "created_by": "usr_k7x9m2p4q1",
+                  "createdAt": "2026-01-10T08:00:00Z",
+                  "updatedAt": "2026-01-10T08:00:00Z"
                 }
               }
             }
@@ -7929,10 +8403,37 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "required": ["success", "proxy"],
                   "properties": {
                     "success": {
-                      "type": "boolean"
+                      "type": "boolean",
+                      "description": "Always true on success. Retained for backward compatibility."
+                    },
+                    "proxy": {
+                      "description": "The affected default proxy resource — same shape as the `GET /api/proxies` list items — or null when the default was unset (proxyId null).",
+                      "oneOf": [
+                        {
+                          "$ref": "#/components/schemas/OrgProxy"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
                     }
+                  }
+                },
+                "example": {
+                  "success": true,
+                  "proxy": {
+                    "id": "cm6pqr679",
+                    "label": "US Residential Proxy",
+                    "urlPrefix": "http://user:****@us-proxy.example.com:8080",
+                    "source": "custom",
+                    "enabled": true,
+                    "isDefault": true,
+                    "created_by": "usr_k7x9m2p4q1",
+                    "createdAt": "2026-01-10T08:00:00Z",
+                    "updatedAt": "2026-01-10T08:00:00Z"
                   }
                 }
               }
@@ -8006,12 +8507,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/OrgProxy"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string",
+                          "description": "The updated proxy's id. Same value as the resource's `id`; retained as a top-level field for backward compatibility."
+                        }
+                      }
                     }
-                  }
+                  ],
+                  "description": "The updated proxy resource — same shape as the `GET /api/proxies` list items — so no follow-up GET is needed."
+                },
+                "example": {
+                  "id": "cm6pqr679",
+                  "label": "US Residential Proxy",
+                  "urlPrefix": "http://user:****@us-proxy.example.com:8080",
+                  "source": "custom",
+                  "enabled": true,
+                  "isDefault": false,
+                  "created_by": "usr_k7x9m2p4q1",
+                  "createdAt": "2026-01-10T08:00:00Z",
+                  "updatedAt": "2026-01-12T09:00:00Z"
                 }
               }
             }
@@ -8894,7 +9415,7 @@
         },
         "responses": {
           "200": {
-            "description": "Role updated",
+            "description": "Updated member — same shape as the members list in GET /api/orgs/{orgId}",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -8906,16 +9427,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "userId": {
-                      "type": "string"
-                    },
-                    "role": {
-                      "type": "string",
-                      "enum": ["viewer", "member", "admin"]
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgMember"
+                },
+                "example": {
+                  "userId": "usr_def456",
+                  "displayName": "Bob",
+                  "email": "bob@acme.com",
+                  "role": "admin",
+                  "joinedAt": "2026-01-12T10:00:00Z"
                 }
               }
             }
@@ -9033,7 +9552,7 @@
         },
         "responses": {
           "200": {
-            "description": "Invitation role updated",
+            "description": "Updated invitation — same shape as the invitations list in GET /api/orgs/{orgId}",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -9045,16 +9564,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "role": {
-                      "type": "string",
-                      "enum": ["viewer", "member", "admin"]
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgInvitationInfo"
+                },
+                "example": {
+                  "id": "inv_abc123",
+                  "email": "carol@acme.com",
+                  "role": "admin",
+                  "token": "tok_xyz789",
+                  "expiresAt": "2026-02-01T00:00:00Z",
+                  "createdAt": "2026-01-25T00:00:00Z"
                 }
               }
             }
@@ -10631,7 +11149,7 @@
         "operationId": "getMcpServerBundle",
         "tags": ["Internal"],
         "summary": "Fetch the AFPS bundle bytes for a referenced mcp-server package",
-        "description": "Container-to-host only. Auth via Bearer run token. Called by the sidecar's integrations-boot to materialise an integration's MCP server before spawning a runner container. In AFPS a local-source integration references a SEPARATE mcp-server package via `source.server.name`; this endpoint serves that package's bundle. It verifies that the run's agent declares an installed integration (in `dependencies.integrations`) that references this mcp-server — orthogonal access control to the credentials endpoint. Returns the raw ZIP archive (`application/zip`).",
+        "description": "Container-to-host only. Auth via Bearer run token. Called by the sidecar's integrations-boot to materialise an integration's MCP server before spawning a runner container. In AFPS a local-source integration references a SEPARATE mcp-server package via `source.server.name`; this endpoint serves that package's bundle. It verifies that the run's agent declares an installed integration (in `dependencies.integrations`) that references this mcp-server — orthogonal access control to the credentials endpoint. Returns the raw ZIP archive (`application/zip`). The sidecar passes `?version=` with the concrete version the spawn resolver pinned from `source.server.version` (#588) so the bytes match the manifest the resolver read; absent, the latest non-yanked version is served (back-compat).",
         "security": [
           {
             "bearerExecToken": []
@@ -10643,6 +11161,15 @@
           },
           {
             "$ref": "#/components/parameters/PackageName"
+          },
+          {
+            "name": "version",
+            "in": "query",
+            "required": false,
+            "description": "Concrete published version to serve (the version the spawn resolver pinned from `source.server.version`). When omitted, the latest non-yanked version is served.",
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -11571,23 +12098,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  }
-                },
-                "example": {
-                  "packageId": "@acme/summarize",
-                  "lock_version": 1,
-                  "message": "Skill created"
+                  "$ref": "#/components/schemas/OrgPackageItemDetail",
+                  "description": "The created package resource — same shape as its GET detail. The resource carries `lock_version`, the optimistic-lock token to send with the next update. No follow-up GET needed."
                 }
               }
             }
@@ -11767,18 +12279,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
-                    },
-                    "version": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/PackageVersionDetail",
+                  "description": "The created version resource — same shape as the GET version detail (manifest, integrity, dist_tags, …). `id` (version row id) and `version` are part of the resource. No follow-up GET needed."
                 }
               }
             }
@@ -11838,18 +12340,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    },
-                    "restored_version": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgPackageItemDetail",
+                  "description": "The updated package resource after the restore — same shape as the package GET detail. The restored version is reflected in `version` / `manifest` / `content`, and the resource carries the package's NEW `lock_version` — read it back before the next draft edit."
                 }
               }
             }
@@ -12122,15 +12614,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgPackageItemDetail",
+                  "description": "The updated package resource — same shape as its GET detail. The resource carries the NEW `lock_version` — read it back before the next edit. No follow-up GET needed."
                 }
               }
             }
@@ -12300,18 +12785,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/AgentDetail",
+                  "description": "The created package resource — same shape as its GET detail. The resource carries `lock_version`, the optimistic-lock token to send with the next update. No follow-up GET needed."
                 }
               }
             }
@@ -12431,15 +12906,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    }
-                  }
+                  "$ref": "#/components/schemas/AgentDetail",
+                  "description": "The updated package resource — same shape as its GET detail. The resource carries the NEW `lock_version` — read it back before the next edit. No follow-up GET needed."
                 }
               }
             }
@@ -12675,18 +13143,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
-                    },
-                    "version": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/PackageVersionDetail",
+                  "description": "The created version resource — same shape as the GET version detail (manifest, integrity, dist_tags, …). `id` (version row id) and `version` are part of the resource. No follow-up GET needed."
                 }
               }
             }
@@ -12755,18 +13213,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    },
-                    "restored_version": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    }
-                  }
+                  "$ref": "#/components/schemas/AgentDetail",
+                  "description": "The updated package resource after the restore — same shape as the package GET detail. The restored version is reflected in `version` / `manifest` / `content`, and the resource carries the package's NEW `lock_version` — read it back before the next draft edit."
                 }
               }
             }
@@ -12993,22 +13441,15 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "required": ["packageId", "type", "forked_from"],
-                  "properties": {
-                    "packageId": {
-                      "type": "string",
-                      "description": "New package ID under org scope"
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/AgentDetail"
                     },
-                    "type": {
-                      "type": "string",
-                      "enum": ["agent", "skill", "mcp-server", "integration"]
-                    },
-                    "forked_from": {
-                      "type": "string",
-                      "description": "Source package ID"
+                    {
+                      "$ref": "#/components/schemas/OrgPackageItemDetail"
                     }
-                  }
+                  ],
+                  "description": "The forked package resource — same shape as the new package's GET detail (`AgentDetail` for agents, otherwise `OrgPackageItemDetail`). The resource's `id` is the new package ID under org scope and `forked_from` carries the source package ID. No follow-up GET needed."
                 }
               }
             }
@@ -13147,15 +13588,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgPackageItemDetail",
+                  "description": "The updated package resource — same shape as its GET detail. The resource carries the NEW `lock_version` — read it back before the next edit. No follow-up GET needed."
                 }
               }
             }
@@ -13336,15 +13770,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    }
-                  }
+                  "$ref": "#/components/schemas/AgentDetail",
+                  "description": "The updated package resource — same shape as its GET detail. The resource carries the NEW `lock_version` — read it back before the next edit. No follow-up GET needed."
                 }
               }
             }
@@ -13530,18 +13957,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgPackageItemDetail",
+                  "description": "The created package resource — same shape as its GET detail. The resource carries `lock_version`, the optimistic-lock token to send with the next update. No follow-up GET needed."
                 }
               }
             }
@@ -13721,18 +14138,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
-                    },
-                    "version": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/PackageVersionDetail",
+                  "description": "The created version resource — same shape as the GET version detail (manifest, integrity, dist_tags, …). `id` (version row id) and `version` are part of the resource. No follow-up GET needed."
                 }
               }
             }
@@ -13792,18 +14199,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    },
-                    "restored_version": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgPackageItemDetail",
+                  "description": "The updated package resource after the restore — same shape as the package GET detail. The restored version is reflected in `version` / `manifest` / `content`, and the resource carries the package's NEW `lock_version` — read it back before the next draft edit."
                 }
               }
             }
@@ -14077,15 +14474,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgPackageItemDetail",
+                  "description": "The updated package resource — same shape as its GET detail. The resource carries the NEW `lock_version` — read it back before the next edit. No follow-up GET needed."
                 }
               }
             }
@@ -14265,15 +14655,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgPackageItemDetail",
+                  "description": "The updated package resource — same shape as its GET detail. The resource carries the NEW `lock_version` — read it back before the next edit. No follow-up GET needed."
                 }
               }
             }
@@ -14478,18 +14861,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgPackageItemDetail",
+                  "description": "The created package resource — same shape as its GET detail. The resource carries `lock_version`, the optimistic-lock token to send with the next update. No follow-up GET needed."
                 }
               }
             }
@@ -14669,18 +15042,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "integer"
-                    },
-                    "version": {
-                      "type": "string"
-                    },
-                    "message": {
-                      "type": "string"
-                    }
-                  }
+                  "$ref": "#/components/schemas/PackageVersionDetail",
+                  "description": "The created version resource — same shape as the GET version detail (manifest, integrity, dist_tags, …). `id` (version row id) and `version` are part of the resource. No follow-up GET needed."
                 }
               }
             }
@@ -14740,18 +15103,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "message": {
-                      "type": "string"
-                    },
-                    "restored_version": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgPackageItemDetail",
+                  "description": "The updated package resource after the restore — same shape as the package GET detail. The restored version is reflected in `version` / `manifest` / `content`, and the resource carries the package's NEW `lock_version` — read it back before the next draft edit."
                 }
               }
             }
@@ -15025,15 +15378,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgPackageItemDetail",
+                  "description": "The updated package resource — same shape as its GET detail. The resource carries the NEW `lock_version` — read it back before the next edit. No follow-up GET needed."
                 }
               }
             }
@@ -15213,15 +15559,8 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "packageId": {
-                      "type": "string"
-                    },
-                    "lock_version": {
-                      "type": "integer"
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgPackageItemDetail",
+                  "description": "The updated package resource — same shape as its GET detail. The resource carries the NEW `lock_version` — read it back before the next edit. No follow-up GET needed."
                 }
               }
             }
@@ -16536,7 +16875,7 @@
         "operationId": "createUpload",
         "tags": ["Uploads"],
         "summary": "Create a direct-upload descriptor",
-        "description": "Reserve an upload slot and return a signed URL the client PUTs the binary to. The returned `uri` (e.g. `upload://upl_xxx`) is embedded in agent `input` fields; the run pipeline resolves and consumes it atomically. Rate-limited to 20/min.",
+        "description": "Reserve an upload slot and return a signed URL the client PUTs the binary to. Full upload→run recipe: (1) POST /api/uploads with the file's `name`, exact `size` in bytes, and `mime` — the response carries a `uri` (e.g. `upload://upl_xxx`), a signed `url`, and `headers`. (2) PUT the raw file bytes (not multipart) to `url`, sending exactly the returned `headers` (typically just `Content-Type`). No other headers are required — in particular no checksum headers; the signed URL does not bind one. (3) Call `runAgent` with `uri` as the value of the file-typed input field. The actual byte count must equal the declared `size`, and binary MIMEs are verified by magic-byte sniffing. Consumed uploads are NOT single-use: the bytes stay retained — and the `uri` re-consumable — for `UPLOAD_RETENTION_HOURS` (default 24 h) after the first consume, so the same input can be re-run (e.g. via `rerun_from` after cancelling) without re-uploading. Unconsumed uploads expire with the signed URL. Small files (≤4 MiB decoded) can skip this flow entirely: inline the content directly in the `runAgent` input as `data:<mime>;name=<filename>;base64,<payload>`. Rate-limited to 20/min.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -16606,12 +16945,12 @@
                     },
                     "uri": {
                       "type": "string",
-                      "description": "Reference to embed in agent input (e.g. `upload://upl_xxx`)."
+                      "description": "Reference to embed in the agent's file-typed input field on `runAgent` (e.g. `upload://upl_xxx`)."
                     },
                     "url": {
                       "type": "string",
                       "format": "uri",
-                      "description": "Pre-signed PUT URL. Points at S3/MinIO directly, or at the platform FS sink."
+                      "description": "Pre-signed PUT URL. Points at S3/MinIO directly, or at the platform FS sink. PUT the raw binary body to it before the upload expires."
                     },
                     "method": {
                       "type": "string",
@@ -16622,7 +16961,7 @@
                       "additionalProperties": {
                         "type": "string"
                       },
-                      "description": "Headers the client MUST forward on the PUT request."
+                      "description": "The complete set of headers the client MUST send verbatim on the PUT request (typically just `Content-Type`). Nothing else is required — no checksum headers."
                     },
                     "expiresAt": {
                       "type": "string",
@@ -18289,6 +18628,13 @@
         "schema": {
           "type": "integer"
         }
+      },
+      "Link": {
+        "description": "RFC 5988 pagination link(s), e.g. `<https://…?since=42&limit=100>; rel=\"next\"`. Present only when another page follows — absence means the listing is complete.",
+        "schema": {
+          "type": "string",
+          "example": "<https://example.com/api/runs/run_x/logs?since=42&limit=100>; rel=\"next\""
+        }
       }
     },
     "schemas": {
@@ -18639,7 +18985,7 @@
           },
           "scope": {
             "type": ["string", "null"],
-            "description": "Scope from manifest name (e.g. @myorg from @myorg/name)"
+            "description": "Scope from manifest name, including the leading `@` (e.g. `@myorg` from `@myorg/name`). Directly usable as the `{scope}` path parameter of package/agent operations."
           },
           "version": {
             "type": ["string", "null"],
@@ -18697,7 +19043,7 @@
           },
           "scope": {
             "type": ["string", "null"],
-            "description": "Scope from manifest name"
+            "description": "Scope from manifest name, including the leading `@` (e.g. `@myorg`). Directly usable as the `{scope}` path parameter of package/agent operations."
           },
           "version": {
             "type": ["string", "null"],
@@ -18925,9 +19271,68 @@
           }
         }
       },
+      "PackageVersionDetail": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Version row id"
+          },
+          "version": {
+            "type": "string",
+            "description": "Semver version string (e.g. 1.0.0)"
+          },
+          "manifest": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Full version manifest (AFPS)"
+          },
+          "content": {
+            "type": ["string", "null"],
+            "description": "Primary content file extracted from the version ZIP"
+          },
+          "source_code": {
+            "type": ["string", "null"],
+            "description": "Secondary source file content (e.g. .ts), when present"
+          },
+          "yanked": {
+            "type": "boolean",
+            "description": "Whether this version has been yanked"
+          },
+          "yanked_reason": {
+            "type": ["string", "null"]
+          },
+          "integrity": {
+            "type": "string",
+            "description": "SRI integrity hash (sha256-...)"
+          },
+          "artifact_size": {
+            "type": "integer",
+            "description": "Artifact ZIP size in bytes"
+          },
+          "createdAt": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "dist_tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "Run": {
         "type": "object",
-        "required": ["id", "orgId", "applicationId", "status", "version_dirty", "started_at"],
+        "required": [
+          "id",
+          "orgId",
+          "applicationId",
+          "status",
+          "version_dirty",
+          "version_ref",
+          "started_at"
+        ],
         "properties": {
           "id": {
             "type": "string"
@@ -18951,7 +19356,21 @@
             "type": "object"
           },
           "result": {
-            "type": "object"
+            "type": ["object", "null"],
+            "description": "What the run produced — the stable API contract for the run's deliverable, set when the run reaches a terminal status. `null` while the run is in flight, and on terminal runs that emitted neither structured output nor a report. Persisted even on failed runs (a run that reported and then failed keeps its partial deliverable).",
+            "properties": {
+              "output": {
+                "description": "Structured JSON emitted via the agent's `output` runtime tool. Validated against the agent's declared output schema when one exists — a schema mismatch flips the run to `failed` (with the validation errors in `error`) but the payload is still stored, never dropped."
+              },
+              "text": {
+                "type": "string",
+                "description": "Markdown report emitted via the agent's `report` runtime tool. Multiple report calls are concatenated in call order, joined with newlines. Capped at 256 KiB of UTF-8 — see `text_truncated`. The full untruncated report remains available as individual run-log entries (type='result', event='report')."
+              },
+              "text_truncated": {
+                "type": "boolean",
+                "description": "Present and `true` when `text` exceeded the 256 KiB cap and was truncated at a UTF-8 character boundary. Absent otherwise."
+              }
+            }
           },
           "checkpoint": {
             "type": "object"
@@ -18999,11 +19418,15 @@
           },
           "version_label": {
             "type": ["string", "null"],
-            "description": "Version label at run time (e.g. '1.0.0')"
+            "description": "Version label at run time (e.g. '1.0.0'). For draft runs this is the latest published version the draft sits on top of — read `version_ref` to know which definition actually executed."
           },
           "version_dirty": {
             "type": "boolean",
-            "description": "Whether the draft had unpublished changes at run time"
+            "description": "Whether the draft had unpublished changes at run time. Kept for backward compatibility — prefer `version_ref`, which states unambiguously what executed."
+          },
+          "version_ref": {
+            "type": "string",
+            "description": "Unambiguous reference to the agent definition the run executed: 'draft' when the mutable draft ran with unpublished changes (or the agent has no published version), or the concrete semver (e.g. '2.1.0') when the run executed that published definition (or a draft identical to it)."
           },
           "proxy_label": {
             "type": ["string", "null"],
@@ -19015,7 +19438,7 @@
           },
           "model_source": {
             "type": ["string", "null"],
-            "description": "Model source: 'system' (platform-provided) or 'org' (user-configured)"
+            "description": "Model source: 'system' (platform-provided) or 'org' (user-configured). Resolved at run creation — an org-default change between triggers applies to subsequent runs unless the run was pinned via the runAgent `modelId` override."
           },
           "cost": {
             "type": ["number", "null"],
@@ -19074,7 +19497,7 @@
           },
           "agent_scope": {
             "type": ["string", "null"],
-            "description": "Denormalized agent scope at run creation. Survives rename, delete, or shadow compaction — the global run view falls back to this when the source package is gone."
+            "description": "Denormalized agent scope at run creation, including the leading `@` (e.g. `@myorg`). Survives rename, delete, or shadow compaction — the global run view falls back to this when the source package is gone."
           },
           "agent_name": {
             "type": ["string", "null"],

--- a/apps/api/src/openapi/paths/agents.ts
+++ b/apps/api/src/openapi/paths/agents.ts
@@ -589,12 +589,11 @@ export const agentsPaths = {
           content: {
             "application/json": {
               schema: {
-                type: "object",
-                properties: {
-                  packageId: { type: "string" },
-                  skillIds: { type: "array", items: { type: "string" } },
-                  message: { type: "string" },
-                },
+                // The updated agent resource, bare (issue #657) — the new
+                // skill references appear in `dependencies.skills`.
+                $ref: "#/components/schemas/AgentDetail",
+                description:
+                  "The updated agent resource — same shape as the GET agent detail. The new skill references appear in `dependencies.skills`. No follow-up GET needed.",
               },
             },
           },

--- a/apps/api/src/openapi/paths/packages.ts
+++ b/apps/api/src/openapi/paths/packages.ts
@@ -1,119 +1,53 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Mutation response schemas (issue #646)
+// Mutation response schemas (issue #657)
 //
-// Mutating package endpoints return the affected resource — the same shape as
-// the corresponding GET detail — composed with `allOf` so the operation-result
-// envelope (`packageId` / `lock_version` / `message` / `warnings` /
-// `restored_version`) is preserved ADDITIVELY. The legacy stub fields are kept
-// as top-level aliases for backward compatibility. `detect-breaking-changes.ts`
-// flattens `allOf`, so these read as supersets of the previous shapes (0 removed
-// fields → additive).
+// Mutating package endpoints return the affected resource BARE — the exact
+// shape of the corresponding GET detail, `$ref`'d directly. No operation
+// envelope: the optimistic-lock token (`lock_version`) and fork provenance
+// (`forked_from`) are resource state and live INSIDE the detail DTOs.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** `POST /packages/{type}` → created package resource + create envelope. */
+/** `POST /packages/{type}` → the created package resource, bare. */
 function packageCreateResponseSchema(detailRef: string) {
   return {
-    allOf: [
-      { $ref: detailRef },
-      {
-        type: "object",
-        properties: {
-          packageId: {
-            type: "string",
-            description:
-              "Legacy alias of the created package's `id`, kept for backward compatibility. Prefer `id`.",
-          },
-          lock_version: {
-            type: "integer",
-            description: "Optimistic-lock token to send with the next update.",
-          },
-          message: { type: "string", description: "Human-readable operation message." },
-          warnings: {
-            type: "array",
-            items: { type: "string" },
-            description: "Non-blocking validation warnings (present only when any).",
-          },
-        },
-      },
-    ],
+    $ref: detailRef,
     description:
-      "The created package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, `message`, optional `warnings`). No follow-up GET needed.",
+      "The created package resource — same shape as its GET detail. The resource carries `lock_version`, the optimistic-lock token to send with the next update. No follow-up GET needed.",
   };
 }
 
-/** `PUT /packages/{type}/...` → updated package resource + update envelope. */
+/** `PUT /packages/{type}/...` → the updated package resource, bare. */
 function packageUpdateResponseSchema(detailRef: string) {
   return {
-    allOf: [
-      { $ref: detailRef },
-      {
-        type: "object",
-        properties: {
-          packageId: {
-            type: "string",
-            description:
-              "Legacy alias of the updated package's `id`, kept for backward compatibility. Prefer `id`.",
-          },
-          lock_version: {
-            type: "integer",
-            description:
-              "New optimistic-lock token after this update — read it back before the next edit.",
-          },
-          warnings: {
-            type: "array",
-            items: { type: "string" },
-            description: "Non-blocking validation warnings (present only when any).",
-          },
-        },
-      },
-    ],
+    $ref: detailRef,
     description:
-      "The updated package resource — same shape as its GET detail — plus the operation-result envelope (`packageId` legacy alias of `id`, `lock_version`, optional `warnings`). No follow-up GET needed.",
+      "The updated package resource — same shape as its GET detail. The resource carries the NEW `lock_version` — read it back before the next edit. No follow-up GET needed.",
   };
 }
 
-/** `POST /packages/{type}/.../versions` → created version resource + `message`. */
+/** `POST /packages/{type}/.../versions` → the created version resource, bare. */
 function versionCreateResponseSchema() {
   return {
-    allOf: [
-      { $ref: "#/components/schemas/PackageVersionDetail" },
-      {
-        type: "object",
-        properties: {
-          message: { type: "string", description: "Human-readable operation message." },
-        },
-      },
-    ],
+    $ref: "#/components/schemas/PackageVersionDetail",
     description:
-      "The created version resource — same shape as the GET version detail (manifest, integrity, dist_tags, …) — plus a human-readable `message`. `id` (version row id) and `version` are part of the resource. No follow-up GET needed.",
+      "The created version resource — same shape as the GET version detail (manifest, integrity, dist_tags, …). `id` (version row id) and `version` are part of the resource. No follow-up GET needed.",
   };
 }
 
-/** `POST /packages/.../versions/{v}/restore` → restored version resource + envelope. */
-function versionRestoreResponseSchema() {
+/**
+ * `POST /packages/.../versions/{v}/restore` → the updated PACKAGE resource,
+ * bare. A restore mutates the package draft, so the response is the package
+ * detail (not the version detail): the restored version is reflected in the
+ * resource's `version` / `manifest` / `content`, and the resource carries the
+ * package's NEW `lock_version`.
+ */
+function versionRestoreResponseSchema(detailRef: string) {
   return {
-    allOf: [
-      { $ref: "#/components/schemas/PackageVersionDetail" },
-      {
-        type: "object",
-        properties: {
-          message: { type: "string", description: "Human-readable operation message." },
-          restored_version: {
-            type: "string",
-            description: "Legacy alias of the restored version's `version`.",
-          },
-          lock_version: {
-            type: "integer",
-            description:
-              "The package's NEW optimistic-lock token after the draft was overwritten — not part of the version resource; read it back before the next draft edit.",
-          },
-        },
-      },
-    ],
+    $ref: detailRef,
     description:
-      "The restored version resource — same shape as the GET version detail — plus the operation-result envelope (`message`, `restored_version` legacy alias of `version`, and the package's new `lock_version`).",
+      "The updated package resource after the restore — same shape as the package GET detail. The restored version is reflected in `version` / `manifest` / `content`, and the resource carries the package's NEW `lock_version` — read it back before the next draft edit.",
   };
 }
 
@@ -715,7 +649,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: versionRestoreResponseSchema(),
+              schema: versionRestoreResponseSchema("#/components/schemas/OrgPackageItemDetail"),
             },
           },
         },
@@ -1267,7 +1201,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: versionRestoreResponseSchema(),
+              schema: versionRestoreResponseSchema("#/components/schemas/AgentDetail"),
             },
           },
         },
@@ -1406,36 +1340,17 @@ export const packagesPaths = {
           content: {
             "application/json": {
               schema: {
-                allOf: [
-                  {
-                    // The forked package resource — same shape as the new
-                    // package's GET detail, selected by `type` at runtime
-                    // (issue #646). Fields vary by type, so they are documented
-                    // as a `oneOf` rather than statically merged.
-                    oneOf: [
-                      { $ref: "#/components/schemas/AgentDetail" },
-                      { $ref: "#/components/schemas/OrgPackageItemDetail" },
-                    ],
-                  },
-                  {
-                    type: "object",
-                    required: ["packageId", "type", "forked_from"],
-                    properties: {
-                      packageId: {
-                        type: "string",
-                        description:
-                          "New package ID under org scope. Legacy alias of the forked resource's `id`.",
-                      },
-                      type: {
-                        type: "string",
-                        enum: ["agent", "skill", "mcp-server", "integration"],
-                      },
-                      forked_from: { type: "string", description: "Source package ID" },
-                    },
-                  },
+                // The forked package resource, bare — same shape as the new
+                // package's GET detail, selected by the source package type at
+                // runtime (issue #657). Fields vary by type, so the response is
+                // a `oneOf`. Fork provenance is resource state: `forked_from`
+                // is part of both detail DTOs.
+                oneOf: [
+                  { $ref: "#/components/schemas/AgentDetail" },
+                  { $ref: "#/components/schemas/OrgPackageItemDetail" },
                 ],
                 description:
-                  "The forked package resource — same shape as the new package's GET detail (`AgentDetail` when `type` is `agent`, otherwise `OrgPackageItemDetail`) — merged with the fork operation envelope (`packageId` legacy alias of `id`, `type`, `forked_from`). No follow-up GET needed.",
+                  "The forked package resource — same shape as the new package's GET detail (`AgentDetail` for agents, otherwise `OrgPackageItemDetail`). The resource's `id` is the new package ID under org scope and `forked_from` carries the source package ID. No follow-up GET needed.",
               },
             },
           },
@@ -1958,7 +1873,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: versionRestoreResponseSchema(),
+              schema: versionRestoreResponseSchema("#/components/schemas/OrgPackageItemDetail"),
             },
           },
         },
@@ -2563,7 +2478,7 @@ export const packagesPaths = {
           },
           content: {
             "application/json": {
-              schema: versionRestoreResponseSchema(),
+              schema: versionRestoreResponseSchema("#/components/schemas/OrgPackageItemDetail"),
             },
           },
         },

--- a/apps/api/src/routes/agent-detail-handler.ts
+++ b/apps/api/src/routes/agent-detail-handler.ts
@@ -31,8 +31,8 @@ import { getAppScope } from "../lib/scope.ts";
  * gate must not 404 a successful write that was not auto-installed.
  *
  * Returns `null` when the agent is not found (or not accessible under
- * `requireAccess`), so the GET wrapper can map it to a 404 and mutation callers
- * can fall back to the legacy envelope.
+ * `requireAccess`), so the GET wrapper can map it to a 404 and mutation
+ * callers to a 500 (a just-written agent must be re-readable).
  */
 export async function buildAgentDetailDto(
   c: Context<AppEnv>,

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -505,7 +505,7 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
         });
       }
 
-      const item = await createOrgItem(
+      await createOrgItem(
         orgId,
         { id: packageId, content, createdBy: user.id },
         rcfg.cfg,
@@ -548,22 +548,15 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
         );
       }
 
-      // Return the created package resource — same DTO/serializer as the GET
-      // detail — so callers see the launched state without a follow-up GET
-      // (issue #646). `packageId` (legacy alias of the DTO's `id`),
-      // `lock_version` (optimistic-lock token), and `message` are retained
-      // additively as operation-result envelope. Defensive fallback to the
-      // legacy stub if the just-created row can't be re-read.
+      // Return the created package resource bare — same DTO/serializer as the
+      // GET detail (issue #657). `id` and `lock_version` (the optimistic-lock
+      // token of the draft) are part of the resource; no operation envelope.
       const detail = await loadPackageDetailDto(c, rcfg, packageId, orgId);
-      return c.json(
-        {
-          ...(detail ?? {}),
-          packageId,
-          lock_version: item.lockVersion,
-          message: `${rcfg.cfg.label.slice(0, -1)} created`,
-        },
-        201,
-      );
+      if (!detail) {
+        logger.error("Created package could not be re-read", { packageId, orgId });
+        throw internalError();
+      }
+      return c.json(detail, 201);
     }
 
     // Skill/Tool create — uses parsePackageUpload (ZIP or JSON body)
@@ -587,7 +580,6 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
       );
     }
 
-    let warnings: string[] = [];
     if (rcfg.validateContent) {
       const validation = rcfg.validateContent(parsed.content);
       if (!validation.valid) {
@@ -600,7 +592,6 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
           })),
         );
       }
-      warnings = validation.warnings;
     }
 
     // Merge user-specified version into manifest for createOrgItem
@@ -664,19 +655,14 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
       );
     }
 
-    // Return the created package resource (same serializer as GET detail) with
-    // the operation envelope retained additively (issue #646).
+    // Return the created package resource bare — same serializer as the GET
+    // detail (issue #657). `id` and `lock_version` are part of the resource.
     const detail = await loadPackageDetailDto(c, rcfg, item.id, orgId);
-    return c.json(
-      {
-        ...(detail ?? {}),
-        packageId: item.id,
-        lock_version: item.lockVersion,
-        message: `${rcfg.cfg.label.slice(0, -1)} created`,
-        ...(warnings.length > 0 ? { warnings } : {}),
-      },
-      201,
-    );
+    if (!detail) {
+      logger.error("Created package could not be re-read", { packageId: item.id, orgId });
+      throw internalError();
+    }
+    return c.json(detail, 201);
   };
 }
 
@@ -822,7 +808,6 @@ function makeUpdateHandler(rcfg: PackageRouteConfig) {
     }
 
     // Content validation
-    let warnings: string[] = [];
     if (rcfg.validateContent && content) {
       const validation = rcfg.validateContent(content);
       if (!validation.valid) {
@@ -835,7 +820,6 @@ function makeUpdateHandler(rcfg: PackageRouteConfig) {
           })),
         );
       }
-      warnings = validation.warnings;
     }
 
     // Source validation (tools)
@@ -889,17 +873,15 @@ function makeUpdateHandler(rcfg: PackageRouteConfig) {
       });
     }
 
-    // Return the updated package resource (same serializer as GET detail) with
-    // the operation envelope retained additively — `packageId` (legacy alias of
-    // `id`), `lock_version` (the new optimistic-lock token consumers must read
-    // back for the next edit), and `warnings` (issue #646).
+    // Return the updated package resource bare — same serializer as the GET
+    // detail (issue #657). The resource carries `lock_version`, the NEW
+    // optimistic-lock token consumers must read back for the next edit.
     const detail = await loadPackageDetailDto(c, rcfg, itemId, orgId);
-    return c.json({
-      ...(detail ?? {}),
-      packageId: updated.id,
-      lock_version: updated.lockVersion,
-      ...(warnings.length > 0 ? { warnings } : {}),
-    });
+    if (!detail) {
+      logger.error("Updated package could not be re-read", { packageId: itemId, orgId });
+      throw internalError();
+    }
+    return c.json(detail);
   };
 }
 
@@ -1084,21 +1066,16 @@ function makeCreateVersionHandler(rcfg: PackageRouteConfig) {
       throw invalidRequest("Failed to create version (invalid or duplicate)");
     }
 
-    // Return the created version resource — same DTO/serializer as the GET
-    // version detail — so callers see the snapshot (manifest, integrity,
-    // dist_tags, …) without a follow-up GET (issue #646). `id` (version row id)
-    // and `version` are already part of the resource; `message` is retained
-    // additively as operation-result envelope.
+    // Return the created version resource bare — same DTO/serializer as the
+    // GET version detail — so callers see the snapshot (manifest, integrity,
+    // dist_tags, …) without a follow-up GET (issue #657). `id` (version row
+    // id) and `version` are part of the resource.
     const detail = await buildVersionDetailDto(rcfg, itemId, result.version);
-    return c.json(
-      {
-        ...(detail ?? {}),
-        id: result.id,
-        version: result.version,
-        message: `Version ${result.version} created`,
-      },
-      201,
-    );
+    if (!detail) {
+      logger.error("Created version could not be re-read", { packageId: itemId, orgId });
+      throw internalError();
+    }
+    return c.json(detail, 201);
   };
 }
 
@@ -1184,19 +1161,17 @@ function makeRestoreVersionHandler(rcfg: PackageRouteConfig) {
       });
     }
 
-    // Return the restored version resource — same DTO/serializer as the GET
-    // version detail (issue #646). The operation envelope is retained
-    // additively: `message`, `restored_version` (legacy alias of the resource's
-    // `version`), and `lock_version` — the package's NEW optimistic-lock token
-    // (not part of the version resource), which consumers must read back before
-    // the next draft edit.
-    const versionDto = await buildVersionDetailDto(rcfg, itemId, detail.version);
-    return c.json({
-      ...(versionDto ?? {}),
-      message: `Version ${detail.version} restored`,
-      restored_version: detail.version,
-      lock_version: updated.lockVersion,
-    });
+    // Restore mutates the package draft — return the updated PACKAGE resource
+    // bare, same DTO/serializer as the package GET detail (issue #657). The
+    // restored version info is reflected in the resource itself (`version`,
+    // `manifest`, `content`), and the resource carries `lock_version`, the
+    // package's NEW optimistic-lock token to read back before the next edit.
+    const packageDto = await loadPackageDetailDto(c, rcfg, itemId, orgId);
+    if (!packageDto) {
+      logger.error("Restored package could not be re-read", { packageId: itemId, orgId });
+      throw internalError();
+    }
+    return c.json(packageDto);
   };
 }
 
@@ -1343,24 +1318,22 @@ export function createPackagesRouter() {
       );
     }
 
-    // Return the forked package resource — same DTO/serializer as the new
-    // package's GET detail, selected by its type (issue #646). The fork
-    // operation fields (`packageId` legacy alias of `id`, `type`, `forked_from`)
-    // are retained additively. Falls back to the fork-result stub if the
-    // freshly-forked row can't be re-read.
+    // Return the forked package resource bare — same DTO/serializer as the new
+    // package's GET detail, selected by its type (issue #657). The fork
+    // provenance is resource state: `forked_from` is part of the detail DTO.
     const forkedRcfg = ROUTE_CONFIGS[result.type as PackageType];
     const detail = forkedRcfg
       ? await loadPackageDetailDto(c, forkedRcfg, result.packageId, orgId)
       : null;
-    return c.json(
-      {
-        ...(detail ?? {}),
+    if (!detail) {
+      logger.error("Forked package could not be re-read", {
         packageId: result.packageId,
         type: result.type,
-        forked_from: result.forked_from,
-      },
-      201,
-    );
+        orgId,
+      });
+      throw internalError();
+    }
+    return c.json(detail, 201);
   });
 
   // --- Package import/download/publish routes ---

--- a/apps/api/src/routes/user-agents.ts
+++ b/apps/api/src/routes/user-agents.ts
@@ -9,7 +9,8 @@ import type { AppEnv } from "../types/index.ts";
 import { scopedNameRegex } from "@appstrate/core/validation";
 import { caretRange } from "@appstrate/core/semver";
 import { requireOrgAgent, requireMutableAgent } from "../middleware/guards.ts";
-import { invalidRequest, parseBody } from "../lib/errors.ts";
+import { buildAgentDetailDto } from "./agent-detail-handler.ts";
+import { internalError, invalidRequest, parseBody } from "../lib/errors.ts";
 import { asRecord } from "@appstrate/core/safe-json";
 import { orgOrSystemFilter } from "../lib/package-helpers.ts";
 export const updateSkillsSchema = z.object({
@@ -85,7 +86,16 @@ export function createUserAgentsRouter() {
 
       await updateManifestDeps(c.get("orgId"), packageId, skillIds);
 
-      return c.json({ packageId, skillIds, message: "Skill references updated" });
+      // Return the updated agent resource bare — same serializer as the GET
+      // agent detail (issue #657). The new skill references appear in
+      // `dependencies.skills`. `requireAccess: false`: the caller just wrote
+      // this agent in their org, so the app-install gate must not 404 a
+      // successful write.
+      const detail = await buildAgentDetailDto(c, { itemId: packageId, requireAccess: false });
+      if (!detail) {
+        throw internalError();
+      }
+      return c.json(detail);
     },
   );
 

--- a/apps/api/src/routes/user-agents.ts
+++ b/apps/api/src/routes/user-agents.ts
@@ -11,6 +11,7 @@ import { caretRange } from "@appstrate/core/semver";
 import { requireOrgAgent, requireMutableAgent } from "../middleware/guards.ts";
 import { buildAgentDetailDto } from "./agent-detail-handler.ts";
 import { internalError, invalidRequest, parseBody } from "../lib/errors.ts";
+import { logger } from "../lib/logger.ts";
 import { asRecord } from "@appstrate/core/safe-json";
 import { orgOrSystemFilter } from "../lib/package-helpers.ts";
 export const updateSkillsSchema = z.object({
@@ -93,6 +94,10 @@ export function createUserAgentsRouter() {
       // successful write.
       const detail = await buildAgentDetailDto(c, { itemId: packageId, requireAccess: false });
       if (!detail) {
+        logger.error("Updated agent could not be re-read", {
+          packageId,
+          orgId: c.get("orgId"),
+        });
         throw internalError();
       }
       return c.json(detail);

--- a/apps/api/test/integration/routes/packages.test.ts
+++ b/apps/api/test/integration/routes/packages.test.ts
@@ -346,9 +346,13 @@ describe("Packages API", () => {
       });
 
       expect(res.status).toBe(201);
+      // Bare created resource (issue #657): `id` + `lock_version` are resource
+      // state; no `packageId`/`message` envelope.
       const body = (await res.json()) as any;
-      expect(body.packageId).toBe("@pkgorg/new-agent");
+      expect(body.id).toBe("@pkgorg/new-agent");
       expect(body.lock_version).toBeNumber();
+      expect(body.packageId).toBeUndefined();
+      expect(body.message).toBeUndefined();
 
       await assertDbHas(packages, eq(packages.id, "@pkgorg/new-agent"));
     });
@@ -440,8 +444,8 @@ describe("Packages API", () => {
 
       // The package is created under the caller's org regardless of its scope name.
       expect(res.status).toBe(201);
-      const body = (await res.json()) as { packageId: string };
-      expect(body.packageId).toBe("@otherscope/foreign-agent");
+      const body = (await res.json()) as { id: string };
+      expect(body.id).toBe("@otherscope/foreign-agent");
     });
   });
 
@@ -495,8 +499,9 @@ describe("Packages API", () => {
 
       expect(res.status).toBe(201);
       const body = (await res.json()) as any;
-      expect(body.packageId).toBe("@pkgorg/new-integration");
+      expect(body.id).toBe("@pkgorg/new-integration");
       expect(body.lock_version).toBeNumber();
+      expect(body.packageId).toBeUndefined();
 
       await assertDbHas(packages, eq(packages.id, "@pkgorg/new-integration"));
     });
@@ -581,8 +586,9 @@ describe("Packages API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.packageId).toBe("@pkgorg/update-agent");
+      expect(body.id).toBe("@pkgorg/update-agent");
       expect(body.lock_version).toBeGreaterThan(agent.lockVersion!);
+      expect(body.packageId).toBeUndefined();
     });
 
     it("returns 400 when lockVersion is missing", async () => {
@@ -1269,11 +1275,12 @@ describe("Packages API", () => {
   });
 
   // ═══════════════════════════════════════════════
-  // Issue #646 — mutating endpoints return the affected resource (same shape as
-  // the GET detail) while retaining the operation envelope additively.
+  // Issue #657 — mutating endpoints return the affected resource BARE (same
+  // shape as the GET detail). No operation envelope: `lock_version` and
+  // `forked_from` are resource state inside the detail DTO.
   // ═══════════════════════════════════════════════
 
-  describe("issue #646 — mutating package endpoints return the resource", () => {
+  describe("issue #657 — mutating package endpoints return the bare resource", () => {
     const agentManifest = (name: string, version = "0.1.0") => ({
       name,
       version,
@@ -1283,7 +1290,7 @@ describe("Packages API", () => {
       description: "Returns the full resource on mutation",
     });
 
-    it("POST create agent returns the Agent detail DTO + create envelope", async () => {
+    it("POST create agent returns the bare Agent detail DTO", async () => {
       const res = await app.request("/api/packages/agents", {
         method: "POST",
         headers: authHeaders(ctx, { "Content-Type": "application/json" }),
@@ -1295,19 +1302,21 @@ describe("Packages API", () => {
 
       expect(res.status).toBe(201);
       const body = (await res.json()) as any;
-      // Operation envelope retained additively.
-      expect(body.packageId).toBe("@pkgorg/res-agent");
-      expect(body.lock_version).toBeNumber();
-      expect(body.message).toBeString();
       // Full Agent detail resource (same serializer as GET detail).
       expect(body.id).toBe("@pkgorg/res-agent");
       expect(body.display_name).toBe("Resource Agent");
       expect(body.dependencies).toBeDefined();
       expect(body.config).toBeDefined();
       expect(body.version_count).toBeNumber();
+      // `lock_version` is resource state (draft optimistic-lock token).
+      expect(body.lock_version).toBeNumber();
+      // No operation envelope.
+      expect(body.packageId).toBeUndefined();
+      expect(body.message).toBeUndefined();
+      expect(body.warnings).toBeUndefined();
     });
 
-    it("POST create integration returns the package detail DTO + create envelope", async () => {
+    it("POST create integration returns the bare package detail DTO", async () => {
       const res = await app.request("/api/packages/integrations", {
         method: "POST",
         headers: authHeaders(ctx, { "Content-Type": "application/json" }),
@@ -1350,16 +1359,18 @@ describe("Packages API", () => {
 
       expect(res.status).toBe(201);
       const body = (await res.json()) as any;
-      expect(body.packageId).toBe("@pkgorg/res-integration");
-      expect(body.lock_version).toBeNumber();
-      // Full OrgPackageItemDetail resource.
+      // Full OrgPackageItemDetail resource, bare.
       expect(body.id).toBe("@pkgorg/res-integration");
+      expect(body.lock_version).toBeNumber();
       expect(body.manifest).toBeDefined();
       expect(body.version_count).toBeNumber();
       expect(body.has_unarchived_changes).toBeBoolean();
+      // No operation envelope.
+      expect(body.packageId).toBeUndefined();
+      expect(body.message).toBeUndefined();
     });
 
-    it("PUT update agent returns the Agent detail DTO + lock_version envelope", async () => {
+    it("PUT update agent returns the bare Agent detail DTO with the new lock_version", async () => {
       const create = await app.request("/api/packages/agents", {
         method: "POST",
         headers: authHeaders(ctx, { "Content-Type": "application/json" }),
@@ -1382,16 +1393,18 @@ describe("Packages API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      // Envelope retained — new lock token consumers read back.
-      expect(body.packageId).toBe("@pkgorg/upd-res-agent");
-      expect(body.lock_version).toBeGreaterThan(created.lock_version);
-      // Full Agent detail resource.
+      // Full Agent detail resource, bare. The resource carries the NEW
+      // `lock_version` consumers read back before the next edit.
       expect(body.id).toBe("@pkgorg/upd-res-agent");
+      expect(body.lock_version).toBeGreaterThan(created.lock_version);
       expect(body.dependencies).toBeDefined();
       expect(body.config).toBeDefined();
+      // No operation envelope.
+      expect(body.packageId).toBeUndefined();
+      expect(body.warnings).toBeUndefined();
     });
 
-    it("POST create version returns the version detail DTO + message envelope", async () => {
+    it("POST create version returns the bare version detail DTO", async () => {
       const create = await app.request("/api/packages/agents", {
         method: "POST",
         headers: authHeaders(ctx, { "Content-Type": "application/json" }),
@@ -1421,17 +1434,18 @@ describe("Packages API", () => {
 
       expect(res.status).toBe(201);
       const body = (await res.json()) as any;
-      // Envelope retained.
+      // Full version detail resource, bare (same serializer as GET version
+      // detail). `id` (version row id) and `version` are part of the resource.
       expect(body.id).toBeNumber();
       expect(body.version).toBe("0.2.0");
-      expect(body.message).toBeString();
-      // Full version detail resource (same serializer as GET version detail).
       expect(body.manifest).toBeDefined();
       expect(body.integrity).toBeString();
       expect(Array.isArray(body.dist_tags)).toBe(true);
+      // No operation envelope.
+      expect(body.message).toBeUndefined();
     });
 
-    it("POST restore version returns the version detail DTO + restore envelope", async () => {
+    it("POST restore version returns the bare updated PACKAGE detail DTO", async () => {
       const create = await app.request("/api/packages/agents", {
         method: "POST",
         headers: authHeaders(ctx, { "Content-Type": "application/json" }),
@@ -1452,14 +1466,17 @@ describe("Packages API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      // Operation envelope retained additively.
-      expect(body.message).toBeString();
-      expect(body.restored_version).toBe("0.1.0");
-      expect(body.lock_version).toBeGreaterThan(created.lock_version);
-      // Full version detail resource for the restored version.
+      // A restore mutates the package draft — the response is the updated
+      // PACKAGE resource (Agent detail), bare. The restored version is
+      // reflected in the resource, and the resource carries the package's NEW
+      // `lock_version`.
+      expect(body.id).toBe("@pkgorg/restore-res-agent");
       expect(body.version).toBe("0.1.0");
       expect(body.manifest).toBeDefined();
-      expect(Array.isArray(body.dist_tags)).toBe(true);
+      expect(body.lock_version).toBeGreaterThan(created.lock_version);
+      // No operation envelope.
+      expect(body.message).toBeUndefined();
+      expect(body.restored_version).toBeUndefined();
     });
   });
 });

--- a/apps/api/test/integration/routes/packages.test.ts
+++ b/apps/api/test/integration/routes/packages.test.ts
@@ -1478,5 +1478,85 @@ describe("Packages API", () => {
       expect(body.message).toBeUndefined();
       expect(body.restored_version).toBeUndefined();
     });
+
+    it("POST fork returns the bare forked AGENT detail DTO (oneOf agent arm)", async () => {
+      // Fork requires a source in ANOTHER org with a published version whose
+      // ZIP exists in storage — go through the API end to end.
+      const srcCtx = await createTestContext({ orgSlug: "forksrc" });
+      const create = await app.request("/api/packages/agents", {
+        method: "POST",
+        headers: authHeaders(srcCtx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          manifest: agentManifest("@forksrc/forkable-agent"),
+          content: "source prompt",
+        }),
+      });
+      expect(create.status).toBe(201);
+      const pub = await app.request("/api/packages/agents/@forksrc/forkable-agent/versions", {
+        method: "POST",
+        headers: authHeaders(srcCtx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({ version: "0.1.0" }),
+      });
+      expect(pub.status).toBe(201);
+
+      const res = await app.request("/api/packages/@forksrc/forkable-agent/fork", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({}),
+      });
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as any;
+      // Bare forked Agent detail DTO — fork provenance is resource state.
+      expect(body.id).toBe("@pkgorg/forkable-agent");
+      expect(body.forked_from).toBe("@forksrc/forkable-agent");
+      expect(body.manifest).toBeDefined();
+      expect(body.lock_version).toBeDefined();
+      // No operation envelope.
+      expect(body.packageId).toBeUndefined();
+      expect(body.type).toBeUndefined();
+    });
+
+    it("POST fork returns the bare forked SKILL detail DTO (oneOf non-agent arm)", async () => {
+      const srcCtx = await createTestContext({ orgSlug: "forksrc2" });
+      const create = await app.request("/api/packages/skills", {
+        method: "POST",
+        headers: authHeaders(srcCtx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          manifest: {
+            name: "@forksrc2/forkable-skill",
+            version: "0.1.0",
+            type: "skill",
+            schema_version: "0.1",
+            display_name: "Forkable Skill",
+            description: "Skill arm of the fork oneOf",
+          },
+          content: "# Skill\nDo the thing.",
+        }),
+      });
+      expect(create.status).toBe(201);
+      const pub = await app.request("/api/packages/skills/@forksrc2/forkable-skill/versions", {
+        method: "POST",
+        headers: authHeaders(srcCtx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({ version: "0.1.0" }),
+      });
+      expect(pub.status).toBe(201);
+
+      const res = await app.request("/api/packages/@forksrc2/forkable-skill/fork", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({}),
+      });
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as any;
+      // Bare forked OrgPackageItem detail DTO.
+      expect(body.id).toBe("@pkgorg/forkable-skill");
+      expect(body.forked_from).toBe("@forksrc2/forkable-skill");
+      expect(body.lock_version).toBeDefined();
+      // No operation envelope.
+      expect(body.packageId).toBeUndefined();
+      expect(body.type).toBeUndefined();
+    });
   });
 });

--- a/apps/api/test/integration/routes/user-agents.test.ts
+++ b/apps/api/test/integration/routes/user-agents.test.ts
@@ -82,6 +82,15 @@ describe("User Agents API", () => {
       });
 
       expect(res.status).toBe(200);
+      // Bare updated agent resource (issue #657) — same shape as the GET agent
+      // detail. The new skill references appear in `dependencies.skills`; no
+      // `packageId`/`skillIds`/`message` envelope.
+      const body = (await res.json()) as any;
+      expect(body.id).toBe("@myorg/skills-agent");
+      expect(body.dependencies.skills).toEqual([expect.objectContaining({ id: "@myorg/skill-a" })]);
+      expect(body.packageId).toBeUndefined();
+      expect(body.skillIds).toBeUndefined();
+      expect(body.message).toBeUndefined();
 
       // Verify manifest was updated
       const [row] = await db

--- a/apps/web/src/components/agent-editor/resource-section.tsx
+++ b/apps/web/src/components/agent-editor/resource-section.tsx
@@ -150,7 +150,7 @@ export function ResourceSection({
 
     try {
       const result = await upload.mutateAsync(file);
-      const newId = result.packageId;
+      const newId = result.id;
       const newVersion = result.version;
       if (!newVersion) return;
 

--- a/apps/web/src/components/fork-package-modal.tsx
+++ b/apps/web/src/components/fork-package-modal.tsx
@@ -65,7 +65,7 @@ export function ForkPackageModal({ open, onClose, packageId, defaultName, type }
       {
         onSuccess: (result) => {
           handleClose();
-          navigate(packageDetailPath(type, result.packageId));
+          navigate(packageDetailPath(type, result.id));
         },
         onError: (err) => {
           const code = err instanceof ApiError ? err.code : "";

--- a/apps/web/src/hooks/use-editor-state.ts
+++ b/apps/web/src/hooks/use-editor-state.ts
@@ -140,6 +140,11 @@ export function useEditorState<S extends EditorStateBase>(
       allowNavigation();
       const body = toWireBody(state);
       if (isEdit) {
+        // Unlike saveDraft, this path does NOT read back the response's
+        // lock_version: useUpdatePackage.onSuccess navigates away and the
+        // editor unmounts, so the stale token can never be reused. If that
+        // navigation is ever removed, read the token back here too or the
+        // next save will 409.
         updatePkg.mutate(
           {
             ...(body as Parameters<typeof updatePkg.mutate>[0]),

--- a/apps/web/src/hooks/use-editor-state.ts
+++ b/apps/web/src/hooks/use-editor-state.ts
@@ -102,13 +102,16 @@ export function useEditorState<S extends EditorStateBase>(
   const saveDraft = useCallback(async () => {
     if (!isEdit || !packageId) return;
     const cfg = PACKAGE_CONFIG[packageType];
-    await api(`/packages/${cfg.path}/${packageId}`, {
+    // PUT returns the updated package resource bare (issue #657) — read back
+    // the NEW `lock_version` so a subsequent save doesn't go stale.
+    const updated = await api<{ lock_version: number }>(`/packages/${cfg.path}/${packageId}`, {
       method: "PUT",
       body: JSON.stringify({
         ...toWireBody(state),
         lock_version: state.lock_version!,
       }),
     });
+    setState((s) => ({ ...s, lock_version: updated.lock_version }));
     qc.invalidateQueries({ queryKey: ["packages"] });
     qc.invalidateQueries({ queryKey: ["version-info"] });
     if (packageType === "agent") {

--- a/apps/web/src/hooks/use-mutations.ts
+++ b/apps/web/src/hooks/use-mutations.ts
@@ -236,7 +236,8 @@ export function useCreatePackage(type: PackageType) {
       content: string;
       source_code?: string;
     }) => {
-      return api<{ packageId: string }>(`/packages/${cfg.path}`, {
+      // 201 → the created package resource, bare (issue #657).
+      return api<{ id: string }>(`/packages/${cfg.path}`, {
         method: "POST",
         body: JSON.stringify(body),
       });
@@ -245,8 +246,8 @@ export function useCreatePackage(type: PackageType) {
       qc.invalidateQueries({ queryKey: ["packages"] });
       if (type === "agent") qc.invalidateQueries({ queryKey: ["agents"] });
       if (type === "integration") qc.invalidateQueries({ queryKey: ["integrations"] });
-      if (data.packageId) {
-        navigate(packageDetailPath(type, data.packageId));
+      if (data.id) {
+        navigate(packageDetailPath(type, data.id));
       }
     },
     onError: onMutationError,
@@ -264,7 +265,9 @@ export function useUpdatePackage(type: PackageType, packageId: string) {
       source_code?: string;
       lock_version: number;
     }) => {
-      return api<{ lock_version: number }>(`/packages/${cfg.path}/${packageId}`, {
+      // 200 → the updated package resource, bare (issue #657). The resource
+      // carries the NEW `lock_version` optimistic-lock token.
+      return api<{ id: string; lock_version: number }>(`/packages/${cfg.path}/${packageId}`, {
         method: "PUT",
         body: JSON.stringify(body),
       });

--- a/apps/web/src/hooks/use-packages.ts
+++ b/apps/web/src/hooks/use-packages.ts
@@ -67,7 +67,9 @@ function useUploadPackage(type: PackageType) {
     mutationFn: async (file: File) => {
       const fd = new FormData();
       fd.append("file", file);
-      return uploadFormData<{ packageId: string; version?: string }>(`/packages/${cfg.path}`, fd);
+      // 201 → the created package resource, bare (issue #657). `version` is
+      // the manifest version of the created draft.
+      return uploadFormData<{ id: string; version: string | null }>(`/packages/${cfg.path}`, fd);
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["packages", cfg.path] });
@@ -214,13 +216,11 @@ export function useCreateVersion(type: PackageType, packageId: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (version?: string) => {
-      return api<{ id: number; version: string; message: string }>(
-        `${packageBasePath(type, packageId)}/versions`,
-        {
-          method: "POST",
-          body: version ? JSON.stringify({ version }) : undefined,
-        },
-      );
+      // 201 → the created version resource, bare (issue #657).
+      return api<{ id: number; version: string }>(`${packageBasePath(type, packageId)}/versions`, {
+        method: "POST",
+        body: version ? JSON.stringify({ version }) : undefined,
+      });
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["package-versions"] });
@@ -251,7 +251,10 @@ export function useRestoreVersion(type: PackageType, packageId: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (version: string) =>
-      api<{ message: string; restored_version: string; lock_version: number }>(
+      // 200 → the updated PACKAGE resource, bare (issue #657): the restore is
+      // reflected in `version`/`manifest`/`content` and the resource carries
+      // the package's NEW `lock_version`.
+      api<{ id: string; version: string | null; lock_version: number }>(
         `${packageBasePath(type, packageId)}/versions/${version}/restore`,
         { method: "POST" },
       ),
@@ -281,14 +284,13 @@ export function useForkPackage() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async ({ packageId, name }: { packageId: string; name?: string }) => {
-      return api<{ packageId: string; type: string; forkedFrom: string }>(
-        `/packages/${packageId}/fork`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(name ? { name } : {}),
-        },
-      );
+      // 201 → the forked package resource, bare (issue #657): `id` is the new
+      // package ID under org scope, `forked_from` the source package ID.
+      return api<{ id: string; forked_from: string | null }>(`/packages/${packageId}/fork`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(name ? { name } : {}),
+      });
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["agents"] });


### PR DESCRIPTION
Refs #657 — batch **D (packages family)**, the largest batch. Strips the additive compat envelope kept by #651: every package-family mutation now returns the affected resource **bare** — the exact shape of the corresponding GET detail, `$ref`'d directly in OpenAPI (no `allOf`). Deliberate breaking wire change; no prod data.

## Per-endpoint final shape (factories expand ×4 types: skills / agents / integrations / mcp-servers)

| Endpoint | Now returns | Removed |
|---|---|---|
| `POST /packages/{type}` | **201** + bare detail (`AgentDetail` for agents, `OrgPackageItemDetail` otherwise) | `packageId`, `message`, `warnings` |
| `PUT /packages/{type}/{scope}/{name}` + by-id `PUT /packages/{type}/{id}` | **200** + bare detail | `packageId`, `warnings` |
| `POST .../versions` | **201** + bare `PackageVersionDetail` | `message` |
| `POST .../versions/{v}/restore` | **200** + bare **updated PACKAGE detail** (a restore mutates the package draft — the restored version is reflected in the resource's `version`/`manifest`/`content`) | `message`, `restored_version` |
| `POST /packages/{scope}/{name}/fork` | **201** + bare forked detail (`oneOf AgentDetail \| OrgPackageItemDetail`, selected by source type) | top-level `packageId`, `type`, `forked_from` envelope |
| `PUT /agents/{scope}/{name}/skills` | **200** + bare updated `AgentDetail` (skill refs visible in `dependencies.skills`) | `packageId`, `skillIds`, `message` |

Mutation echoes that fail to re-read the just-written row now **500** (`internalError`) instead of silently degrading to the legacy stub — a just-written resource must be re-readable.

## Judgment call 1 — `lock_version` is resource state (kept INSIDE the DTO)

The web editor genuinely round-trips it: `package-editor.tsx` seeds editor state from the GET detail's `lock_version`, and `use-editor-state.ts` appends it to every `PUT` (submit + save-draft). It is the draft's optimistic-concurrency token — state of the draft, not an operation scrap. Both detail serializers (`getOrgItem` → `OrgPackageItemDetail`, `buildAgentDetailDto` → `AgentDetail`) already emit it and both OpenAPI detail schemas already declare it (since #651), so **every read AND mutation response carries it uniformly** — nothing stapled on mutation responses. Bonus: `saveDraft` now reads the NEW `lock_version` back from the bare PUT response, so consecutive draft saves can't go stale.

## Judgment call 2 — `warnings` dropped (no named exception needed)

Audited `apps/web`: the only `warnings` consumer is the **import** flow (`useImportPackage` surfaces AFPS §7.7 install warnings as toasts) — and import endpoints keep their operation-report shape under the issue's documented *multi-entity import report* exception, untouched here. Nothing reads `warnings` from create/update responses, so they are removed without a carve-out; the non-blocking validation warnings computed in the create/update handlers were dropped along with the envelope. `message` dies everywhere.

## `forked_from` provenance

Already part of both detail DTOs (serializers + OpenAPI schemas), so the fork response needed no schema addition — the bare resource carries `id` (new package ID) and `forked_from` (source package ID).

## Consumers (same PR)

- `apps/web/src/hooks/use-mutations.ts` — `useCreatePackage` (`data.packageId` → `data.id`), `useUpdatePackage` (typed to the bare resource)
- `apps/web/src/hooks/use-packages.ts` — `useUploadPackage` (`packageId` → `id`), `useCreateVersion` (drop `message`), `useRestoreVersion` (bare package detail), `useForkPackage` (`{packageId,type,forkedFrom}` → `{id,forked_from}`)
- `apps/web/src/components/fork-package-modal.tsx` — navigate on `result.id`
- `apps/web/src/components/agent-editor/resource-section.tsx` — ZIP upload reads `result.id`
- `apps/web/src/hooks/use-editor-state.ts` — `saveDraft` reads back the new `lock_version`
- CLI (`apps/cli`) is a generic curl-style client — no publish flow reads these envelopes (verified by grep); `github-action` untouched; e2e seed helpers already consume `id`.

## Tests

- `packages.test.ts`: create/update assertions flipped to `id` + bare-shape negatives; the #646 envelope suite **replaced** by a #657 bare-resource suite (create agent/integration, update, version create, restore-returns-package-detail)
- `user-agents.test.ts`: skills PUT now asserts the bare `AgentDetail` (skill ref in `dependencies.skills`, no `packageId`/`skillIds`/`message`)
- Adjacent suites (agents, guards, multi-tenancy, mcp-server import, openapi-response-validation, integrations) re-run green — import endpoints intentionally unchanged.

## Baseline

`bun scripts/detect-breaking-changes.ts --update-baseline` committed — 34 breaking entries, all listed above. **Cross-PR note**: the regenerated baseline also absorbs ~499 non-breaking additive entries from earlier merged PRs (#638–#651 era: `proxyId`/`resolved`/`modelId` echoes, run fields, …) that never regenerated the baseline — expect baseline conflicts with any in-flight batch (B/C/E/F) PR that also regenerates it; regenerate on top of whichever merges first.

## Validation

- `bun run check`: **29/29** (incl. OpenAPI verification, after rebase on main)
- Touched integration suites: packages (60), user-agents (5), agents/guards/multi-tenancy/mcp-server (59), openapi-response-validation + integrations (58) — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)