### PR TITLE
fix(api)!: align last four mutation responses with the GET-detail serializer (#657 follow-up)

### DIFF
--- a/apps/api/src/openapi/baseline.json
+++ b/apps/api/src/openapi/baseline.json
@@ -1817,7 +1817,7 @@
         "operationId": "runInline",
         "tags": ["Runs"],
         "summary": "Execute an inline agent (no persisted package)",
-        "description": "Run an agent defined entirely in the request body. The platform creates a shadow `packages` row (ephemeral = true), runs it through the standard pipeline, and returns `202` + the created run resource (same shape as `GET /runs/{id}`; the shadow package id is the resource's `packageId`). Stream progress via `GET /api/realtime/runs/{id}`. See `docs/specs/INLINE_RUNS.md`.",
+        "description": "Run an agent defined entirely in the request body. The platform creates a shadow `packages` row (ephemeral = true), runs it through the standard pipeline, and returns `201` + the created run resource (same shape as `GET /runs/{id}`; the shadow package id is the resource's `packageId`). Stream progress via `GET /api/realtime/runs/{id}`. See `docs/specs/INLINE_RUNS.md`.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -1886,8 +1886,8 @@
           }
         },
         "responses": {
-          "202": {
-            "description": "Inline run accepted — stream via SSE. The body is the created run resource (same shape as `GET /runs/{id}`); under a rare concurrent-teardown race (the run is deleted between creation and serialization) it may degrade to `{id}` only.",
+          "201": {
+            "description": "Inline run created — stream via SSE. The body is the created run resource (same shape as `GET /runs/{id}`); under a rare concurrent-teardown race (the run is deleted between creation and serialization) it may degrade to `{id}` only.",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -9049,7 +9049,7 @@
         },
         "responses": {
           "200": {
-            "description": "Organization updated",
+            "description": "Updated organization — same OrgDetail shape as GET /api/orgs/{orgId}",
             "headers": {
               "Request-Id": {
                 "$ref": "#/components/headers/RequestId"
@@ -9061,29 +9061,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "name": {
-                      "type": "string"
-                    },
-                    "slug": {
-                      "type": "string"
-                    },
-                    "created_by": {
-                      "type": "string"
-                    },
-                    "createdAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    },
-                    "updatedAt": {
-                      "type": "string",
-                      "format": "date-time"
-                    }
-                  }
+                  "$ref": "#/components/schemas/OrgDetail"
                 }
               }
             }
@@ -9096,6 +9074,9 @@
           },
           "403": {
             "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
           }
         }
       },

--- a/apps/api/src/openapi/paths/organizations.ts
+++ b/apps/api/src/openapi/paths/organizations.ts
@@ -174,30 +174,21 @@ export const organizationsPaths = {
       },
       responses: {
         "200": {
-          description: "Organization updated",
+          description: "Updated organization — same OrgDetail shape as GET /api/orgs/{orgId}",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
           },
           content: {
             "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  id: { type: "string" },
-                  name: { type: "string" },
-                  slug: { type: "string" },
-                  created_by: { type: "string" },
-                  createdAt: { type: "string", format: "date-time" },
-                  updatedAt: { type: "string", format: "date-time" },
-                },
-              },
+              schema: { $ref: "#/components/schemas/OrgDetail" },
             },
           },
         },
         "400": { $ref: "#/components/responses/ValidationError" },
         "401": { $ref: "#/components/responses/Unauthorized" },
         "403": { $ref: "#/components/responses/Forbidden" },
+        "404": { $ref: "#/components/responses/NotFound" },
       },
     },
     delete: {

--- a/apps/api/src/openapi/paths/runs.ts
+++ b/apps/api/src/openapi/paths/runs.ts
@@ -277,7 +277,7 @@ export const runsPaths = {
       tags: ["Runs"],
       summary: "Execute an inline agent (no persisted package)",
       description:
-        "Run an agent defined entirely in the request body. The platform creates a shadow `packages` row (ephemeral = true), runs it through the standard pipeline, and returns `202` + the created run resource (same shape as `GET /runs/{id}`; the shadow package id is the resource's `packageId`). Stream progress via `GET /api/realtime/runs/{id}`. See `docs/specs/INLINE_RUNS.md`.",
+        "Run an agent defined entirely in the request body. The platform creates a shadow `packages` row (ephemeral = true), runs it through the standard pipeline, and returns `201` + the created run resource (same shape as `GET /runs/{id}`; the shadow package id is the resource's `packageId`). Stream progress via `GET /api/realtime/runs/{id}`. See `docs/specs/INLINE_RUNS.md`.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -332,9 +332,9 @@ export const runsPaths = {
         },
       },
       responses: {
-        "202": {
+        "201": {
           description:
-            "Inline run accepted — stream via SSE. The body is the created run resource (same shape as `GET /runs/{id}`); under a rare concurrent-teardown race (the run is deleted between creation and serialization) it may degrade to `{id}` only.",
+            "Inline run created — stream via SSE. The body is the created run resource (same shape as `GET /runs/{id}`); under a rare concurrent-teardown race (the run is deleted between creation and serialization) it may degrade to `{id}` only.",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -172,16 +172,9 @@ router.post("/", async (c) => {
 
 // --- Routes below require org context (orgId from params, verified via membership) ---
 
-// GET /api/orgs/:orgId — org details + members
-router.get("/:orgId", async (c) => {
-  const user = c.get("user");
-  const orgId = c.req.param("orgId");
-
-  const member = await getOrgMember(orgId, user.id);
-  if (!member) {
-    throw forbidden("Not a member of this organization");
-  }
-
+// OrgDetail serializer — shared by GET /:orgId and PUT /:orgId so the update
+// response is the exact same resource shape as the detail read.
+async function buildOrgDetail(orgId: string) {
   const [org, members, invitations] = await Promise.all([
     getOrgById(orgId),
     getOrgMembers(orgId),
@@ -191,7 +184,7 @@ router.get("/:orgId", async (c) => {
     throw notFound("Organization not found");
   }
 
-  return c.json({
+  return {
     id: org.id,
     name: org.name,
     slug: org.slug,
@@ -211,7 +204,20 @@ router.get("/:orgId", async (c) => {
       expiresAt: inv.expiresAt?.toISOString(),
       createdAt: inv.createdAt?.toISOString(),
     })),
-  });
+  };
+}
+
+// GET /api/orgs/:orgId — org details + members
+router.get("/:orgId", async (c) => {
+  const user = c.get("user");
+  const orgId = c.req.param("orgId");
+
+  const member = await getOrgMember(orgId, user.id);
+  if (!member) {
+    throw forbidden("Not a member of this organization");
+  }
+
+  return c.json(await buildOrgDetail(orgId));
 });
 
 // PUT /api/orgs/:orgId — update name/slug (owner only — org routes skip org context)
@@ -235,7 +241,7 @@ router.put("/:orgId", async (c) => {
     }
   }
 
-  const updated = await updateOrganization(orgId, {
+  await updateOrganization(orgId, {
     ...(data.name?.trim() ? { name: data.name.trim() } : {}),
     ...(data.slug ? { slug: data.slug } : {}),
   });
@@ -248,8 +254,8 @@ router.put("/:orgId", async (c) => {
     orgIdOverride: orgId,
   });
 
-  const { createdBy, ...updatedRest } = updated;
-  return c.json({ ...updatedRest, created_by: createdBy });
+  // Bare updated resource — same OrgDetail serializer as GET /:orgId.
+  return c.json(await buildOrgDetail(orgId));
 });
 
 // DELETE /api/orgs/:orgId — delete organization and all related data (owner only)

--- a/apps/api/src/routes/runs.ts
+++ b/apps/api/src/routes/runs.ts
@@ -388,7 +388,7 @@ export function createRunsRouter() {
   // See docs/specs/INLINE_RUNS.md. The manifest + prompt travel in the
   // request body; the platform creates a transient shadow package
   // (ephemeral = true), runs it through the existing pipeline, and
-  // returns 202 + the bare created run resource (the shadow package id is
+  // returns 201 + the bare created run resource (the shadow package id is
   // the run's `packageId` field). The client streams progress via
   // GET /api/realtime/runs/:id (existing SSE endpoint).
   router.post(
@@ -415,18 +415,19 @@ export function createRunsRouter() {
         traceparent: runTraceparent(c),
       });
 
-      // 202 + the bare created run resource (#657) — same DTO and serializer
-      // as GET /runs/:id. The shadow package id callers used to read from
-      // the `packageId` envelope field is the resource's own `packageId`.
-      // The run row exists once `triggerInlineRun` resolves
+      // 201 + the bare created run resource (#657) — same DTO and serializer
+      // as GET /runs/:id, same status code as the sibling trigger
+      // POST /agents/{scope}/{name}/run. The shadow package id callers used
+      // to read from the `packageId` envelope field is the resource's own
+      // `packageId`. The run row exists once `triggerInlineRun` resolves
       // (`prepareAndExecuteRun` inserts it before returning).
       const row = await getRunFull(getAppScope(c), runId);
       if (!row) {
         // Concurrent teardown raced us — fall back to a minimal id-only
         // resource rather than 500-ing a successfully launched run.
-        return c.json({ id: runId }, 202);
+        return c.json({ id: runId }, 201);
       }
-      return c.json(row, 202);
+      return c.json(row, 201);
     },
   );
 

--- a/apps/api/src/services/scheduler.ts
+++ b/apps/api/src/services/scheduler.ts
@@ -556,7 +556,7 @@ export async function createSchedule(
     versionOverride?: string | null;
     connectionOverrides?: Record<string, string> | null;
   },
-): Promise<ScheduleWireDto> {
+): Promise<EnrichedSchedule> {
   const id = `sched_${crypto.randomUUID()}`;
   const tz = data.timezone || "UTC";
 
@@ -593,7 +593,10 @@ export async function createSchedule(
 
   await upsertScheduleJob(schedule, scope.orgId);
 
-  return schedule;
+  // Same EnrichedSchedule serializer as getSchedule/listSchedules, so the
+  // create response matches the GET detail shape (actor_name/actor_type).
+  const [enriched] = await enrichSchedules([schedule], scope.orgId);
+  return enriched ?? { ...schedule, actor_name: null, actor_type: null };
 }
 
 export async function updateSchedule(
@@ -611,7 +614,7 @@ export async function updateSchedule(
     versionOverride?: string | null;
     connectionOverrides?: Record<string, string> | null;
   },
-): Promise<ScheduleWireDto | null> {
+): Promise<EnrichedSchedule | null> {
   const existing = await getSchedule(id, scope);
   if (!existing) return null;
 
@@ -662,7 +665,10 @@ export async function updateSchedule(
     await removeScheduleJob(id);
   }
 
-  return schedule;
+  // Same EnrichedSchedule serializer as getSchedule/listSchedules, so the
+  // update response matches the GET detail shape (actor_name/actor_type).
+  const [enriched] = await enrichSchedules([schedule], scope.orgId);
+  return enriched ?? { ...schedule, actor_name: null, actor_type: null };
 }
 
 export async function deleteSchedule(scope: AppScope, id: string): Promise<boolean> {

--- a/apps/api/test/integration/routes/inline-run.test.ts
+++ b/apps/api/test/integration/routes/inline-run.test.ts
@@ -139,7 +139,7 @@ describe("POST /api/runs/inline — dependency resolution", () => {
   }
 
   // Success path of dep resolution is covered in inline-run-validate.test.ts
-  // (same preflight function), and asserting 202 here would fire
+  // (same preflight function), and asserting 201 here would fire
   // `executeAgentInBackground()` whose async tail would keep writing to the
   // runs/run_logs tables past the end of the test — a source of flakiness
   // when the next test's `truncateAll()` races the background work.
@@ -186,7 +186,7 @@ describe("POST /api/runs/inline — rate limiting", () => {
     const headers = { ...authHeaders(ctx), "Content-Type": "application/json" };
 
     // First two requests consume the quota. Status doesn't matter here —
-    // whatever the outcome (validation pass or fail, 202 or 500), the
+    // whatever the outcome (validation pass or fail, 201 or 500), the
     // rate-limit middleware has already decremented the bucket.
     await limitedApp.request("/api/runs/inline", { method: "POST", headers, body });
     await limitedApp.request("/api/runs/inline", { method: "POST", headers, body });

--- a/apps/api/test/integration/routes/organizations.test.ts
+++ b/apps/api/test/integration/routes/organizations.test.ts
@@ -242,6 +242,29 @@ describe("Organizations API", () => {
     });
   });
 
+  describe("PUT /api/orgs/:orgId", () => {
+    it("returns the bare OrgDetail (same serializer as GET /api/orgs/:orgId)", async () => {
+      const ctx = await createTestContext({ orgSlug: "renameorg" });
+
+      const res = await app.request(`/api/orgs/${ctx.orgId}`, {
+        method: "PUT",
+        headers: { Cookie: ctx.cookie, "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Renamed Org" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.id).toBe(ctx.orgId);
+      expect(body.name).toBe("Renamed Org");
+      expect(body.members).toBeArray();
+      expect(body.members).toHaveLength(1);
+      expect(body.invitations).toBeArray();
+      // No serializer drift: the divergent pre-#657 shape is gone.
+      expect(body).not.toHaveProperty("created_by");
+      expect(body).not.toHaveProperty("updatedAt");
+    });
+  });
+
   describe("POST /api/orgs/:orgId/members", () => {
     it("adds existing user directly when SMTP is disabled", async () => {
       const ctx = await createTestContext({ orgSlug: "memberorg" });

--- a/apps/api/test/integration/routes/schedules.test.ts
+++ b/apps/api/test/integration/routes/schedules.test.ts
@@ -174,6 +174,9 @@ describe("Schedules API", () => {
       expect(body.timezone).toBe("Europe/Paris");
       // Schedule runs as the creating member.
       expect(body.userId).toBe(ctx.user.id);
+      // EnrichedSchedule — same serializer as GET /schedules/:id (#657).
+      expect(body.actor_type).toBe("user");
+      expect(body).toHaveProperty("actor_name");
     });
 
     it("rejects invalid cron expression", async () => {
@@ -289,6 +292,9 @@ describe("Schedules API", () => {
       const body = (await res.json()) as any;
       expect(body.name).toBe("New Name");
       expect(body.cron_expression).toBe("0 12 * * *");
+      // EnrichedSchedule — same serializer as GET /schedules/:id (#657).
+      expect(body.actor_type).toBe("user");
+      expect(body).toHaveProperty("actor_name");
     });
   });
 


### PR DESCRIPTION
## Context

After merging the six #657 sweep PRs (#659–#664), a fresh full-codebase audit (25-agent Opus workflow, 131 mutating endpoints discovered, grep-reconciled to 100% coverage) found **four remaining serializer drifts**. Everything else is conformant: zero legacy aliases, zero `{success}` envelopes, zero `allOf` compat members left.

## Fixes

| Endpoint | Was | Now |
|---|---|---|
| `PUT /api/orgs/:orgId` | a third org shape (`{id,name,slug,createdAt,updatedAt,created_by}` — no `members`/`invitations`, divergent from both GET detail and the list) | the same `OrgDetail` payload as `GET /api/orgs/:orgId`, via a shared `buildOrgDetail` serializer extracted from the GET handler |
| `POST /api/agents/:scope/:name/schedules` | bare `ScheduleWireDto` (missing `actor_name`/`actor_type` that GET detail returns) | `EnrichedSchedule` — `createSchedule` enriches before returning |
| `PUT /api/schedules/:id` | same drift (mirror) | `EnrichedSchedule` — `updateSchedule` enriches before returning |
| `POST /api/runs/inline` | `202` (inconsistent with the sibling trigger `POST /agents/{scope}/{name}/run` → `201`; the run row exists at response time) | `201` |

## Notes

- OpenAPI: PUT org response collapses to a direct `$ref OrgDetail` (+404 documented); inline run `202`→`201`. Schedule create/update specs already `$ref Schedule` (which declares the actor fields) — handler now actually matches.
- Frontend: `general.tsx` ignores the PUT org response body; no consumer read `created_by`/`updatedAt` from it. No inline-run consumer asserts the status code numerically (e2e and tests verified).
- Tests: new regression tests for the OrgDetail PUT shape and the enriched schedule create/update responses; stale `202` comments refreshed. 115/115 on the four touched suites.
- Breaking on the wire — no production data; baseline regenerated (`detect:breaking --update-baseline`).

Follow-up to #657 (closed). `bun run check` 29/29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)