### PR TITLE
fix(api): close PR #670 documented follow-ups — SSRF DNS layer, import audit trail, DinD skip warning

### DIFF
--- a/apps/api/src/openapi/paths/packages.ts
+++ b/apps/api/src/openapi/paths/packages.ts
@@ -115,6 +115,11 @@ export const packagesPaths = {
                           type: ["integer", "null"],
                           description: "DB row id for the version; null for system packages.",
                         },
+                        type: {
+                          type: "string",
+                          description:
+                            "Package type (agent, skill, mcp-server, integration). Present on `inserted` entries only.",
+                        },
                       },
                     },
                   },

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -12,6 +12,7 @@ import { db } from "@appstrate/db/client";
 import { listResponse } from "../lib/list-response.ts";
 import { postInstallPackage } from "../services/post-install-package.ts";
 import { handleImportBundle } from "../services/bundle-import.ts";
+import { parsePackageIdentity } from "@appstrate/afps-runtime/bundle";
 import { installPackage, hasPackageAccess } from "../services/application-packages.ts";
 import { parseManifestBytesSafe } from "../lib/manifest-parser.ts";
 import { getAllPackageIds } from "../services/package-catalog.ts";
@@ -1436,6 +1437,7 @@ export function createPackagesRouter() {
     parsed: ReturnType<typeof parsePackageZip>,
     buffer: Buffer,
     force: boolean,
+    source: "zip" | "github",
   ) {
     const user = c.get("user");
     const orgId = c.get("orgId");
@@ -1600,6 +1602,17 @@ export function createPackagesRouter() {
 
     logger.info("Package imported", { packageId, type: packageType, orgId });
     const importedVersion = (manifest as Record<string, unknown>).version as string | undefined;
+    await recordAuditFromContext(c, {
+      action: existing ? "package.updated" : "package.created",
+      resourceType: "package",
+      resourceId: packageId,
+      after: {
+        type: packageType,
+        version: importedVersion ?? null,
+        via: `import:${source}`,
+        force,
+      },
+    });
     // Surface engine-subset limitations for integration manifests as
     // non-blocking warnings (AFPS §7.7). Publishers learn
     // about unsupported `connect.login` selectors / criteria at install
@@ -1661,6 +1674,22 @@ export function createPackagesRouter() {
         detail: message,
       });
     }
+    // One audit event per package version actually written — "reused"
+    // entries changed no state. `recordAudit*` never throws.
+    for (const entry of result.imported) {
+      if (entry.status !== "inserted") continue;
+      const identity = parsePackageIdentity(entry.identity);
+      await recordAuditFromContext(c, {
+        action: "package.version_created",
+        resourceType: "package",
+        resourceId: identity?.packageId ?? entry.identity,
+        after: {
+          version: identity?.version ?? null,
+          via: "import:bundle",
+          root: entry.identity === `${result.root_package_id}@${result.root_version}`,
+        },
+      });
+    }
     return c.json(result, 201);
   });
 
@@ -1680,7 +1709,7 @@ export function createPackagesRouter() {
 
     const parsed = await parseZipWithSkillFallback(zipBytes, c.get("orgSlug"));
 
-    return handleImport(c, parsed, buffer, c.req.query("force") === "true");
+    return handleImport(c, parsed, buffer, c.req.query("force") === "true", "zip");
   });
 
   // POST /api/packages/import-github — import a package from a GitHub URL
@@ -1707,7 +1736,7 @@ export function createPackagesRouter() {
 
     const parsed = await parseZipWithSkillFallback(zipBytes, c.get("orgSlug"));
 
-    return handleImport(c, parsed, buffer, false);
+    return handleImport(c, parsed, buffer, false, "github");
   });
 
   // GET /api/packages/:scope/:name/:version/download — download a versioned package ZIP

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -1684,6 +1684,7 @@ export function createPackagesRouter() {
         resourceType: "package",
         resourceId: identity?.packageId ?? entry.identity,
         after: {
+          type: entry.type ?? null,
           version: identity?.version ?? null,
           via: "import:bundle",
           root: entry.identity === `${result.root_package_id}@${result.root_version}`,

--- a/apps/api/src/services/bundle-import.ts
+++ b/apps/api/src/services/bundle-import.ts
@@ -207,6 +207,12 @@ export interface ImportedPackageResult {
   identity: string;
   status: "inserted" | "reused";
   version_id: number | null;
+  /**
+   * Package type, present on `inserted` entries only (the reuse paths
+   * never parse the ZIP, so the type is not known there without an
+   * extra read). Consumed by the route's audit events.
+   */
+  type?: string;
 }
 
 export interface ImportBundleResult {
@@ -362,6 +368,7 @@ export async function importBundle(
       identity,
       status: "inserted",
       version_id: newVer?.id ?? null,
+      type: parsedZip.type,
     });
   }
 

--- a/apps/api/test/helpers/tier.ts
+++ b/apps/api/test/helpers/tier.ts
@@ -38,6 +38,18 @@ const hasExternalDb = !!process.env.DATABASE_URL;
 // exercise it are slow — opt-in locally (TEST_DOCKER=1), always on in CI.
 const hasDocker = !isTier0 && (process.env.TEST_DOCKER === "1" || process.env.CI === "true");
 
+// Third-party CI systems often set `CI=1` (or another truthy value) where
+// GitHub Actions sets `CI=true` — under those, DinD tests silently skip and
+// the run looks green while exercising less. Surface the gap once so a fork's
+// CI maintainer knows to set TEST_DOCKER=1 (console is fine here: this is
+// test-harness diagnostics for a human terminal, not platform runtime code).
+if (!isTier0 && !hasDocker && process.env.CI && process.env.CI !== "true") {
+  console.warn(
+    `⚠ CI=${process.env.CI} detected (not "true") — Docker/DinD tests will be SKIPPED. ` +
+      "Set TEST_DOCKER=1 to run them in this CI system.",
+  );
+}
+
 /** `describe`/`it` that skip unless a real Redis is configured. */
 export const describeRequiresRedis = describe.skipIf(!hasRedis);
 export const itRequiresRedis = it.skipIf(!hasRedis);

--- a/apps/api/test/helpers/tier.ts
+++ b/apps/api/test/helpers/tier.ts
@@ -43,7 +43,15 @@ const hasDocker = !isTier0 && (process.env.TEST_DOCKER === "1" || process.env.CI
 // the run looks green while exercising less. Surface the gap once so a fork's
 // CI maintainer knows to set TEST_DOCKER=1 (console is fine here: this is
 // test-harness diagnostics for a human terminal, not platform runtime code).
-if (!isTier0 && !hasDocker && process.env.CI && process.env.CI !== "true") {
+// `CI=false`/`CI=0`/empty mean "explicitly NOT CI" (CRA-style opt-out) — no warn.
+const ciDisabledValues = ["", "0", "false"];
+if (
+  !isTier0 &&
+  !hasDocker &&
+  process.env.CI !== undefined &&
+  process.env.CI !== "true" &&
+  !ciDisabledValues.includes(process.env.CI.toLowerCase())
+) {
   console.warn(
     `⚠ CI=${process.env.CI} detected (not "true") — Docker/DinD tests will be SKIPPED. ` +
       "Set TEST_DOCKER=1 to run them in this CI system.",

--- a/apps/api/test/integration/routes/packages-import-bundle.test.ts
+++ b/apps/api/test/integration/routes/packages-import-bundle.test.ts
@@ -294,7 +294,9 @@ describe("POST /api/packages/import-bundle — import", () => {
       expect(row.after).toMatchObject({ via: "import:bundle" });
     }
     const rootRow = auditRows.find((r) => r.resourceId === "@srcorg/agent-root");
-    expect(rootRow?.after).toMatchObject({ version: "1.0.0", root: true });
+    expect(rootRow?.after).toMatchObject({ type: "agent", version: "1.0.0", root: true });
+    const skillRow = auditRows.find((r) => r.resourceId === "@srcorg/skill-a");
+    expect(skillRow?.after).toMatchObject({ type: "skill", root: false });
   });
 
   it("accepts a raw .afps and promotes it to a bundle-of-one", async () => {

--- a/apps/api/test/integration/routes/packages-import-bundle.test.ts
+++ b/apps/api/test/integration/routes/packages-import-bundle.test.ts
@@ -22,6 +22,7 @@ import { getTestApp } from "../../helpers/app.ts";
 import { installPackage } from "../../../src/services/application-packages.ts";
 import {
   applicationPackages,
+  auditEvents,
   packageDistTags,
   packageVersions,
   packages,
@@ -279,6 +280,21 @@ describe("POST /api/packages/import-bundle — import", () => {
       )
       .limit(1);
     expect(installed).toBeDefined();
+
+    // Each inserted package version leaves an audit trail.
+    const auditRows = await db
+      .select()
+      .from(auditEvents)
+      .where(eq(auditEvents.action, "package.version_created"));
+    expect(auditRows).toHaveLength(3);
+    for (const row of auditRows) {
+      expect(row.orgId).toBe(ctx.orgId);
+      expect(row.resourceType).toBe("package");
+      expect(row.actorType).toBe("user");
+      expect(row.after).toMatchObject({ via: "import:bundle" });
+    }
+    const rootRow = auditRows.find((r) => r.resourceId === "@srcorg/agent-root");
+    expect(rootRow?.after).toMatchObject({ version: "1.0.0", root: true });
   });
 
   it("accepts a raw .afps and promotes it to a bundle-of-one", async () => {
@@ -364,6 +380,13 @@ describe("POST /api/packages/import-bundle — import", () => {
     };
     expect(body2.imported).toHaveLength(3);
     expect(body2.imported.every((i) => i.status === "reused")).toBe(true);
+
+    // Reused entries changed no state — only the first import audited.
+    const auditRows = await db
+      .select()
+      .from(auditEvents)
+      .where(eq(auditEvents.action, "package.version_created"));
+    expect(auditRows).toHaveLength(3);
   });
 
   it("reports a bundle_conflict 409 when a version exists with different content", async () => {

--- a/apps/api/test/integration/routes/packages.test.ts
+++ b/apps/api/test/integration/routes/packages.test.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeEach } from "bun:test";
+import { zipSync } from "fflate";
 import { getTestApp } from "../../helpers/app.ts";
 import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
@@ -1101,6 +1102,53 @@ describe("Packages API", () => {
   // ═══════════════════════════════════════════════
 
   describe("POST /api/packages/import", () => {
+    it("imports a valid .afps and records an audit event", async () => {
+      const enc = (s: string) => new TextEncoder().encode(s);
+      const afps = zipSync({
+        "manifest.json": enc(
+          JSON.stringify({
+            name: "@pkgorg/imported-agent",
+            version: "1.0.0",
+            type: "agent",
+            schema_version: "0.1",
+            display_name: "Imported Agent",
+            description: "Imported via ZIP",
+          }),
+        ),
+        "prompt.md": enc("You are an imported agent."),
+      });
+      const formData = new FormData();
+      formData.append("file", new File([new Uint8Array(afps)], "agent.afps"));
+
+      const res = await app.request("/api/packages/import", {
+        method: "POST",
+        headers: authHeaders(ctx),
+        body: formData,
+      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as any;
+      expect(body.packageId).toBe("@pkgorg/imported-agent");
+
+      const auditRows = await db
+        .select()
+        .from(auditEvents)
+        .where(
+          and(
+            eq(auditEvents.action, "package.created"),
+            eq(auditEvents.resourceId, "@pkgorg/imported-agent"),
+          ),
+        );
+      expect(auditRows).toHaveLength(1);
+      expect(auditRows[0]!.orgId).toBe(ctx.orgId);
+      expect(auditRows[0]!.actorType).toBe("user");
+      expect(auditRows[0]!.after).toMatchObject({
+        type: "agent",
+        version: "1.0.0",
+        via: "import:zip",
+        force: false,
+      });
+    });
+
     it("returns 400 when no file is provided", async () => {
       const formData = new FormData();
 

--- a/runtime-pi/sidecar/credential-proxy.ts
+++ b/runtime-pi/sidecar/credential-proxy.ts
@@ -200,10 +200,14 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
   // 4. Validate URL against authorizedUris (or block internal
   //    targets when allowAllUris is set). The SSRF branches add the
   //    DNS-resolving rebind layer over the literal blocklist (see
-  //    `refuseSsrfTarget`); the allowlist branch stays literal-only —
-  //    `authorizedUris` is the operator-declared trust boundary, and a
-  //    matched allowlist host resolving internally is that operator's
-  //    own network topology, not an agent-reachable pivot.
+  //    `refuseSsrfTarget`). On the allowlist branch, the SSRF gate
+  //    applies UNLESS some entry pins this exact host literally —
+  //    a named host resolving internally is the operator's declared
+  //    topology (on-prem APIs are legitimate allowlist targets), but
+  //    the AFPS glob grammar lets `**` span the host (`https://**`),
+  //    and a glob-matched host is agent-chosen, not operator-chosen —
+  //    without the gate that branch would be strictly weaker than
+  //    allow_all.
   if (creds.allowAllUris) {
     const refusal = await refuseSsrfTarget(resolvedUrl, deps.resolveHost);
     if (refusal) return refusal;
@@ -214,6 +218,10 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
         status: 403,
         error: `URL not authorized for integration "${integrationId}". Allowed: ${creds.authorizedUris.join(", ")}`,
       };
+    }
+    if (!hostLiterallyAllowlisted(resolvedUrl, creds.authorizedUris)) {
+      const refusal = await refuseSsrfTarget(resolvedUrl, deps.resolveHost);
+      if (refusal) return refusal;
     }
   } else {
     // No authorizedUris and no allowAllUris — apply the SSRF safety net.
@@ -477,8 +485,40 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
 }
 
 /**
- * SSRF gate for the non-allowlisted branches: the literal blocklist
- * first (IP literals, known-internal names), then resolve every A/AAAA
+ * True when some allowlist entry names the URL's host with a literal
+ * (wildcard-free) host component. Only then is the allowlist a
+ * host-level trust declaration that exempts the target from the SSRF
+ * gate: the operator wrote that exact host down, so an internal
+ * address behind it is their declared topology. Entries whose host
+ * segment contains a glob (`https://**`, `https://*.example.com/…`)
+ * never pin — the concrete host is then chosen by the agent at call
+ * time, and the SSRF gate must still apply.
+ *
+ * The host comparison is authority-only (userinfo and port stripped),
+ * case-insensitive, matching how `matchesAuthorizedUriSpec` treats the
+ * pattern as an opaque string while WHATWG URL lowercases hostnames.
+ */
+function hostLiterallyAllowlisted(url: string, specs: string[]): boolean {
+  let host: string;
+  try {
+    host = new URL(url).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+  for (const spec of specs) {
+    const m = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/([^/?#]+)/.exec(spec.trim());
+    if (!m) continue;
+    const hostPart = m[1]!.replace(/^[^@]*@/, "").replace(/:\d+$/, "");
+    if (hostPart.includes("*")) continue;
+    if (hostPart.toLowerCase() === host) return true;
+  }
+  return false;
+}
+
+/**
+ * SSRF gate for every branch without a literal operator host pin
+ * (allow_all, no allowlist, glob-matched allowlist): the literal
+ * blocklist first (IP literals, known-internal names), then resolve every A/AAAA
  * record and refuse if ANY lands in a blocked range. A DNS name whose
  * record points inside (10.x, 169.254.169.254, …) passes `isBlockedUrl`
  * alone — this closes the rebind-to-internal vector.

--- a/runtime-pi/sidecar/credential-proxy.ts
+++ b/runtime-pi/sidecar/credential-proxy.ts
@@ -35,9 +35,11 @@ import {
   normalizeAuthScheme,
   substituteVars,
   findUnresolvedPlaceholders,
+  resolveAndCheckHost,
   OUTBOUND_TIMEOUT_MS,
   INTEGRATION_ID_RE,
   type CredentialsResponse,
+  type HostResolver,
   type SidecarConfig,
 } from "./helpers.ts";
 import {
@@ -146,6 +148,11 @@ export interface ApiCallDeps {
    * 401-retry path skips the refresh after the first failure.
    */
   reportedAuthFailures: Set<string>;
+  /**
+   * DNS resolver for the SSRF rebind check — injectable for tests.
+   * Production callers omit it (system resolver via `node:dns`).
+   */
+  resolveHost?: HostResolver;
 }
 
 /**
@@ -191,11 +198,15 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
   }
 
   // 4. Validate URL against authorizedUris (or block internal
-  //    targets when allowAllUris is set).
+  //    targets when allowAllUris is set). The SSRF branches add the
+  //    DNS-resolving rebind layer over the literal blocklist (see
+  //    `refuseSsrfTarget`); the allowlist branch stays literal-only —
+  //    `authorizedUris` is the operator-declared trust boundary, and a
+  //    matched allowlist host resolving internally is that operator's
+  //    own network topology, not an agent-reachable pivot.
   if (creds.allowAllUris) {
-    if (isBlockedUrl(resolvedUrl)) {
-      return { ok: false, status: 403, error: "URL targets a blocked network range" };
-    }
+    const refusal = await refuseSsrfTarget(resolvedUrl, deps.resolveHost);
+    if (refusal) return refusal;
   } else if (creds.authorizedUris && creds.authorizedUris.length) {
     if (!matchesAuthorizedUri(resolvedUrl, creds.authorizedUris)) {
       return {
@@ -206,9 +217,8 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
     }
   } else {
     // No authorizedUris and no allowAllUris — apply the SSRF safety net.
-    if (isBlockedUrl(resolvedUrl)) {
-      return { ok: false, status: 403, error: "URL targets a blocked network range" };
-    }
+    const refusal = await refuseSsrfTarget(resolvedUrl, deps.resolveHost);
+    if (refusal) return refusal;
   }
 
   // 5b. Pre-substitute headers with the *initial* creds so we can
@@ -464,6 +474,54 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
   });
 
   return { ok: true, response: upstream, finalUrl: upstreamFinalUrl, authRefreshed };
+}
+
+/**
+ * SSRF gate for the non-allowlisted branches: the literal blocklist
+ * first (IP literals, known-internal names), then resolve every A/AAAA
+ * record and refuse if ANY lands in a blocked range. A DNS name whose
+ * record points inside (10.x, 169.254.169.254, …) passes `isBlockedUrl`
+ * alone — this closes the rebind-to-internal vector.
+ *
+ * The outbound connection is delegated to `fetch`, which re-resolves —
+ * so this is fail-closed defence-in-depth with a documented residual
+ * TOCTOU, not a full resolve-and-pin (same posture as the MITM upstream
+ * fetch and the platform CIMD guard; only the raw-socket egress
+ * listeners can pin). Resolution failure maps to 502 — the same outcome
+ * the subsequent fetch would have produced for an unresolvable host —
+ * while a blocked answer is the policy 403.
+ *
+ * Returns the structured failure, or `null` when the target is clear.
+ */
+async function refuseSsrfTarget(
+  url: string,
+  resolveHost?: HostResolver,
+): Promise<ApiCallFailure | null> {
+  const blockedFailure: ApiCallFailure = {
+    ok: false,
+    status: 403,
+    error: "URL targets a blocked network range",
+  };
+  if (isBlockedUrl(url)) return blockedFailure;
+  let hostname: string;
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    return blockedFailure;
+  }
+  const check = await resolveAndCheckHost(hostname, { resolve: resolveHost });
+  if (!check.blocked) return null;
+  if (check.reason === "resolution-failed") {
+    return {
+      ok: false,
+      status: 502,
+      error: `Target host could not be resolved (${redactHost(url)})`,
+    };
+  }
+  logger.warn("api_call refused: target resolves into a blocked network range", {
+    host: redactHost(url),
+  });
+  return blockedFailure;
 }
 
 function wrapFetchError(err: unknown, label: string, url: string): ApiCallFailure {

--- a/runtime-pi/sidecar/test/credential-proxy.test.ts
+++ b/runtime-pi/sidecar/test/credential-proxy.test.ts
@@ -1435,7 +1435,7 @@ describe("executeApiCall — SSRF DNS-rebind layer", () => {
     expect(fetchFn).toHaveBeenCalledTimes(1);
   });
 
-  it("does NOT run the DNS layer on the allowlist branch (operator trust boundary)", async () => {
+  it("does NOT run the DNS layer when the allowlist pins the host literally", async () => {
     const resolveHost = mock(async () => ["203.0.113.7"]);
     const fetchFn = mock(async () => new Response("ok", { status: 200 }));
     const result = await call(
@@ -1443,6 +1443,114 @@ describe("executeApiCall — SSRF DNS-rebind layer", () => {
       "https://api.example.com/x",
     );
     expect(result.ok).toBe(true);
+    expect(resolveHost).not.toHaveBeenCalled();
+  });
+
+  it("literal-host allowlist exempts an internal-resolving host (operator topology)", async () => {
+    // On-prem case: the operator explicitly named the host; it resolving
+    // into a private range is their declared network, not an agent pivot.
+    const fetchFn = mock(async () => new Response("ok", { status: 200 }));
+    const result = await call(
+      makeDeps({
+        fetchFn: fetchFn as unknown as typeof fetch,
+        fetchCredentials: mock(
+          async (): Promise<CredentialsResponse> => ({
+            credentials: { access_token: "tok" },
+            authorizedUris: ["https://intranet.corp.example/**"],
+            allowAllUris: false,
+            credentialHeaderName: "Authorization",
+            credentialHeaderPrefix: "Bearer",
+            credentialFieldName: "access_token",
+          }),
+        ),
+        resolveHost: async () => ["10.0.0.5"],
+      }),
+      "https://intranet.corp.example/api/x",
+    );
+    expect(result.ok).toBe(true);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  for (const [label, pattern] of [
+    ["host-spanning **", "https://**"],
+    ["wildcard subdomain", "https://*.example.com/**"],
+  ] as const) {
+    it(`glob-matched allowlist host stays behind the SSRF gate (${label})`, async () => {
+      // `https://**` (and any glob in the host segment) means the concrete
+      // host is agent-chosen — without the gate the allowlist branch would
+      // be strictly weaker than allow_all.
+      const fetchFn = mock(async () => new Response("leaked", { status: 200 }));
+      const result = await call(
+        makeDeps({
+          fetchFn: fetchFn as unknown as typeof fetch,
+          fetchCredentials: mock(
+            async (): Promise<CredentialsResponse> => ({
+              credentials: { access_token: "tok" },
+              authorizedUris: [pattern],
+              allowAllUris: false,
+              credentialHeaderName: "Authorization",
+              credentialHeaderPrefix: "Bearer",
+              credentialFieldName: "access_token",
+            }),
+          ),
+          resolveHost: async () => ["169.254.169.254"],
+        }),
+        "https://rebind.example.com/x",
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.status).toBe(403);
+        expect(result.error).toMatch(/blocked network range/);
+      }
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+  }
+
+  it("glob-matched allowlist host resolving public proceeds normally", async () => {
+    const fetchFn = mock(async () => new Response("ok", { status: 200 }));
+    const result = await call(
+      makeDeps({
+        fetchFn: fetchFn as unknown as typeof fetch,
+        fetchCredentials: mock(
+          async (): Promise<CredentialsResponse> => ({
+            credentials: { access_token: "tok" },
+            authorizedUris: ["https://**"],
+            allowAllUris: false,
+            credentialHeaderName: "Authorization",
+            credentialHeaderPrefix: "Bearer",
+            credentialFieldName: "access_token",
+          }),
+        ),
+        resolveHost: async () => ["203.0.113.7"],
+      }),
+      "https://anything.example.net/x",
+    );
+    expect(result.ok).toBe(true);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("glob allowlist + IP-literal internal target is literal-blocked before DNS", async () => {
+    // `https://**` matches `https://169.254.169.254/...` in the allowlist
+    // matcher — the literal blocklist inside the gate must still refuse it.
+    const resolveHost = mock(async () => ["203.0.113.7"]);
+    const result = await call(
+      makeDeps({
+        fetchCredentials: mock(
+          async (): Promise<CredentialsResponse> => ({
+            credentials: { access_token: "tok" },
+            authorizedUris: ["https://**"],
+            allowAllUris: false,
+            credentialHeaderName: "Authorization",
+            credentialHeaderPrefix: "Bearer",
+            credentialFieldName: "access_token",
+          }),
+        ),
+        resolveHost,
+      }),
+      "https://169.254.169.254/latest/meta-data",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(403);
     expect(resolveHost).not.toHaveBeenCalled();
   });
 

--- a/runtime-pi/sidecar/test/credential-proxy.test.ts
+++ b/runtime-pi/sidecar/test/credential-proxy.test.ts
@@ -34,6 +34,9 @@ function makeDeps(overrides: Partial<ApiCallDeps> = {}): ApiCallDeps {
       }),
     ),
     reportedAuthFailures: new Set<string>(),
+    // Deterministic public answer so the SSRF DNS-rebind layer never
+    // does real DNS in tests. Rebind-specific tests override this.
+    resolveHost: async () => ["203.0.113.7"],
     ...overrides,
   };
 }
@@ -1322,5 +1325,135 @@ describe("executeApiCall — debug diagnostic envelope (#404)", () => {
     expect(envelope!.authMode).toBe("none");
     expect(envelope!.injectedHeader).toBeNull();
     expect(envelope!.urlPolicy).toBe("allow_all");
+  });
+});
+
+describe("executeApiCall — SSRF DNS-rebind layer", () => {
+  const call = (deps: ApiCallDeps, targetUrl = "https://rebind.example.com/x") =>
+    executeApiCall(
+      {
+        integrationId: "demo",
+        targetUrl,
+        method: "GET",
+        callerHeaders: {},
+        body: { kind: "none" },
+      },
+      deps,
+    );
+
+  const ssrfGuardCreds = mock(
+    async (): Promise<CredentialsResponse> => ({
+      credentials: { access_token: "tok" },
+      authorizedUris: null,
+      allowAllUris: false,
+      credentialHeaderName: "Authorization",
+      credentialHeaderPrefix: "Bearer",
+      credentialFieldName: "access_token",
+    }),
+  );
+
+  const allowAllCreds = mock(
+    async (): Promise<CredentialsResponse> => ({
+      credentials: { access_token: "tok" },
+      authorizedUris: null,
+      allowAllUris: true,
+      credentialHeaderName: "Authorization",
+      credentialHeaderPrefix: "Bearer",
+      credentialFieldName: "access_token",
+    }),
+  );
+
+  for (const [label, fetchCredentials] of [
+    ["ssrf_guard (no allowlist)", ssrfGuardCreds],
+    ["allow_all", allowAllCreds],
+  ] as const) {
+    it(`refuses a hostname resolving into a blocked range — ${label}`, async () => {
+      const fetchFn = mock(async () => new Response("leaked", { status: 200 }));
+      const result = await call(
+        makeDeps({
+          fetchFn: fetchFn as unknown as typeof fetch,
+          fetchCredentials,
+          resolveHost: async () => ["169.254.169.254"],
+        }),
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.status).toBe(403);
+        expect(result.error).toMatch(/blocked network range/);
+      }
+      // The request never went out — fail happened pre-fetch.
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+
+    it(`fails closed on DNS resolution failure — ${label}`, async () => {
+      const fetchFn = mock(async () => new Response("leaked", { status: 200 }));
+      const result = await call(
+        makeDeps({
+          fetchFn: fetchFn as unknown as typeof fetch,
+          fetchCredentials,
+          resolveHost: async () => {
+            throw new Error("ENOTFOUND");
+          },
+        }),
+      );
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.status).toBe(502);
+        expect(result.error).toMatch(/could not be resolved/);
+        // Host only — never the full URL (may encode capabilities).
+        expect(result.error).toContain("rebind.example.com");
+        expect(result.error).not.toContain("/x");
+      }
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+  }
+
+  it("refuses when ANY resolved record is blocked (multi-record rebind)", async () => {
+    const fetchFn = mock(async () => new Response("leaked", { status: 200 }));
+    const result = await call(
+      makeDeps({
+        fetchCredentials: ssrfGuardCreds,
+        fetchFn: fetchFn as unknown as typeof fetch,
+        resolveHost: async () => ["203.0.113.7", "10.0.0.5"],
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(403);
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("allows a hostname resolving to public addresses only", async () => {
+    const fetchFn = mock(async () => new Response("ok", { status: 200 }));
+    const result = await call(
+      makeDeps({
+        fetchCredentials: ssrfGuardCreds,
+        fetchFn: fetchFn as unknown as typeof fetch,
+        resolveHost: async () => ["203.0.113.7"],
+      }),
+    );
+    expect(result.ok).toBe(true);
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT run the DNS layer on the allowlist branch (operator trust boundary)", async () => {
+    const resolveHost = mock(async () => ["203.0.113.7"]);
+    const fetchFn = mock(async () => new Response("ok", { status: 200 }));
+    const result = await call(
+      makeDeps({ fetchFn: fetchFn as unknown as typeof fetch, resolveHost }),
+      "https://api.example.com/x",
+    );
+    expect(result.ok).toBe(true);
+    expect(resolveHost).not.toHaveBeenCalled();
+  });
+
+  it("IP-literal targets skip resolution but stay literal-blocked", async () => {
+    const resolveHost = mock(async () => ["203.0.113.7"]);
+    const result = await call(
+      makeDeps({ fetchCredentials: ssrfGuardCreds, resolveHost }),
+      "https://169.254.169.254/latest/meta-data",
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(403);
+    expect(resolveHost).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Closes the three "Known follow-ups" documented in #670's PR body.

### 1. Credential-proxy SSRF: DNS-rebind layer (`runtime-pi/sidecar/credential-proxy.ts`)

The `allowAllUris` and no-allowlist branches used the literal-only `isBlockedUrl` check before fetch — a DNS name whose A/AAAA record points at an internal address (10.x, `169.254.169.254`, …) passed it. Both branches now run `resolveAndCheckHost` (the shared layer from #670): every resolved record is checked, fail-closed on resolution failure.

- **Posture**: fail-closed defence-in-depth with a documented residual TOCTOU — the connection is delegated to `fetch`, which re-resolves; only the raw-socket egress listeners can fully pin. Same documented posture as the MITM upstream fetch and the platform CIMD guard (`apps/api/src/lib/ssrf-dns.ts`).
- **Error mapping**: blocked answer → 403 `URL targets a blocked network range` (policy, unchanged message); resolution failure → 502 `Target host could not be resolved (<host>)` — the same outcome the subsequent fetch would have produced for an unresolvable host, so no behavior change for typo'd hostnames.
- The allowlist branch deliberately stays literal-only: `authorizedUris` is the operator-declared trust boundary, and a matched allowlist host resolving internally is that operator's own topology, not an agent-reachable pivot.
- Resolver injectable via `ApiCallDeps.resolveHost` (tests); production uses the system resolver.
- Out of scope, still literal-only: the per-hop redirect check in `@appstrate/afps-runtime` `fetchFollowingRedirectsCapturingCookies` (portable engine, no core dependency) — noted for a future pass.

### 2. Audit trail on package import routes (`apps/api/src/routes/packages.ts`)

| Route | Event |
|---|---|
| `POST /packages/import` | `package.created` / `package.updated` (existing draft), `after.via = "import:zip"`, `after.force` |
| `POST /packages/import-github` | same, `after.via = "import:github"` |
| `POST /packages/import-bundle` | `package.version_created` per **inserted** entry, `after.via = "import:bundle"`, `after.root` flag — `reused` entries changed no state and are not audited |

Reuses the existing lifecycle action vocabulary (`package.created`/`updated`/`version_created`) with a `via` discriminator rather than inventing a parallel `package.imported` verb — audit consumers filtering on lifecycle actions see imports without a new case.

### 3. DinD skip warning (`apps/api/test/helpers/tier.ts`)

Third-party CI systems often set `CI=1` where GitHub Actions sets `CI=true` — under those, Docker/DinD tests silently skipped and the run looked green while exercising less. The tier helper now warns once (`CI=<value> detected (not "true") — Docker/DinD tests will be SKIPPED. Set TEST_DOCKER=1 …`) when that exact gap is hit. No behavior change for GitHub Actions or local runs.

## Validation

- `bun run check` — 29/29 tasks, OpenAPI clean
- `runtime-pi/sidecar/test/` — 593 pass / 0 fail (incl. 7 new DNS-rebind cases: blocked record, multi-record rebind, resolution failure fail-closed, allowlist branch untouched, IP-literal short-circuit)
- `packages.test.ts` + `packages-import-bundle.test.ts` — 71 pass / 0 fail (new: happy-path `/import` audit assertion, bundle per-package audit rows, reused-import records nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review pass (multi-agent: security / audit contracts / test integrity)

Three findings fixed in the follow-up commit:

- **Glob-matched allowlist hosts now behind the SSRF gate** (security, IMPORTANT): the allowlist branch had no SSRF check at all, and the AFPS glob grammar permits `**` to span the host (`https://**`) — making that branch strictly weaker than the hardened `allow_all`. The gate (literal + DNS) now applies unless an allowlist entry pins the exact host with a wildcard-free host component; literal on-prem declarations (`https://intranet.corp/**` resolving 10.x) remain exempt as operator-declared topology.
- **Bundle audit events carry `after.type`**: parity with every other `package.*` event. `ImportedPackageResult` gains optional `type` on `inserted` entries (additive wire field, OpenAPI updated).
- **DinD warning skips `CI=false`/`0`/empty** (explicit not-CI convention).

Accepted residuals (documented, not fixed here): redirect hops stay literal-only in the portable `afps-runtime` engine; zip-vs-bundle audit vocabulary asymmetry (`package.created`+`updated` vs `package.version_created`) left as a vocabulary decision for a follow-up.
