### PR TITLE
refactor(api)!: schedules list envelope + snake_case query-param convergence

### DIFF
--- a/apps/api/src/openapi/baseline.json
+++ b/apps/api/src/openapi/baseline.json
@@ -2161,7 +2161,7 @@
             }
           },
           {
-            "name": "startDate",
+            "name": "start_date",
             "in": "query",
             "schema": {
               "type": "string",
@@ -2169,7 +2169,7 @@
             }
           },
           {
-            "name": "endDate",
+            "name": "end_date",
             "in": "query",
             "schema": {
               "type": "string",
@@ -2367,7 +2367,7 @@
         "operationId": "getRunLogs",
         "tags": ["Runs"],
         "summary": "Get run logs",
-        "description": "Get persisted log entries for a run, wrapped in the standard list envelope `{ object: \"list\", data, hasMore }`. Pass `?since=<id>` to receive only entries with `id > since` — the cursor used by the CLI's polling tail to bound per-poll payload growth, and the pagination cursor when combined with `?limit=`. Pass `?level=` to filter by minimum severity (`level=info` skips debug breadcrumbs). When `limit` is set and more entries follow, `hasMore` is `true` and an RFC 5988 `Link: <…?since=<lastId>>; rel=\"next\"` response header points at the next page. `id` is a monotonic BIGSERIAL; invalid `since`/`level`/`limit` values fall back to the unfiltered default rather than 400 so a stale cursor never breaks a polling tail. Without query parameters the full chronological history is returned. Rate-limited to 120/min per identity. Note: tool-result payloads inside `data` are truncated at write time by the runner (default 2048 bytes, operator-tunable via `TOOL_RESULT_BYTE_LIMIT`) — entries already persisted truncated cannot be recovered by this endpoint.",
+        "description": "Get persisted log entries for a run, wrapped in the standard list envelope `{ object: \"list\", data, hasMore }`. Pass `?since=<id>` to receive only entries with `id > since` — the cursor used by the CLI's polling tail to bound per-poll payload growth, and the pagination cursor when combined with `?limit=`. Pass `?level=` to filter by minimum severity (`level=info` skips debug breadcrumbs). `limit` defaults to 1000 when omitted — the response is never unbounded; when more entries follow, `hasMore` is `true` and an RFC 5988 `Link: <…?since=<lastId>>; rel=\"next\"` response header points at the next page. `id` is a monotonic BIGSERIAL; invalid `since`/`level`/`limit` values fall back to the default rather than 400 so a stale cursor never breaks a polling tail. Rate-limited to 120/min per identity. Note: tool-result payloads inside `data` are truncated at write time by the runner (default 2048 bytes, operator-tunable via `TOOL_RESULT_BYTE_LIMIT`) — entries already persisted truncated cannot be recovered by this endpoint.",
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
@@ -2411,9 +2411,10 @@
             "schema": {
               "type": "integer",
               "minimum": 1,
-              "maximum": 1000
+              "maximum": 1000,
+              "default": 1000
             },
-            "description": "Maximum number of entries to return. When more entries follow, the response carries a `Link; rel=\"next\"` header whose URL re-uses `since` as the cursor. Absent means no cap (full history)."
+            "description": "Maximum number of entries to return. Defaults to 1000 when omitted. When more entries follow, the response carries a `Link; rel=\"next\"` header whose URL re-uses `since` as the cursor — page with it to read longer histories."
           }
         ],
         "responses": {
@@ -2454,7 +2455,7 @@
                     },
                     "hasMore": {
                       "type": "boolean",
-                      "description": "True when `?limit=` was set and more entries follow — the `Link; rel=\"next\"` header carries the next page's URL."
+                      "description": "True when more entries follow the current page (the server caps each page at `limit`, default 1000) — the `Link; rel=\"next\"` header carries the next page's URL."
                     }
                   }
                 }
@@ -3606,9 +3607,22 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Schedule"
+                  "type": "object",
+                  "required": ["object", "data", "hasMore"],
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Schedule"
+                      }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
+                    }
                   }
                 }
               }
@@ -3654,9 +3668,22 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Schedule"
+                  "type": "object",
+                  "required": ["object", "data", "hasMore"],
+                  "properties": {
+                    "object": {
+                      "type": "string",
+                      "enum": ["list"]
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Schedule"
+                      }
+                    },
+                    "hasMore": {
+                      "type": "boolean"
+                    }
                   }
                 }
               }
@@ -10130,7 +10157,7 @@
             "$ref": "#/components/parameters/XAppId"
           },
           {
-            "name": "agentPackageId",
+            "name": "agent_package_id",
             "in": "query",
             "required": true,
             "schema": {
@@ -10264,7 +10291,7 @@
             "$ref": "#/components/parameters/XAppId"
           },
           {
-            "name": "agentPackageId",
+            "name": "agent_package_id",
             "in": "query",
             "required": true,
             "schema": {
@@ -10272,7 +10299,7 @@
             }
           },
           {
-            "name": "integrationPackageId",
+            "name": "integration_package_id",
             "in": "query",
             "required": true,
             "schema": {
@@ -10285,7 +10312,7 @@
             "description": "Pin cleared (or never existed)"
           },
           "400": {
-            "description": "Missing required query param (agentPackageId or integrationPackageId)."
+            "description": "Missing required query param (agent_package_id or integration_package_id)."
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"
@@ -11482,6 +11509,10 @@
                           "version_id": {
                             "type": ["integer", "null"],
                             "description": "DB row id for the version; null for system packages."
+                          },
+                          "type": {
+                            "type": "string",
+                            "description": "Package type (agent, skill, mcp-server, integration). Present on `inserted` entries only."
                           }
                         }
                       }

--- a/apps/api/src/openapi/paths/me.ts
+++ b/apps/api/src/openapi/paths/me.ts
@@ -199,7 +199,7 @@ export const mePaths = {
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
         {
-          name: "agentPackageId",
+          name: "agent_package_id",
           in: "query",
           required: true,
           schema: { type: "string" },
@@ -297,13 +297,13 @@ export const mePaths = {
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
         {
-          name: "agentPackageId",
+          name: "agent_package_id",
           in: "query",
           required: true,
           schema: { type: "string" },
         },
         {
-          name: "integrationPackageId",
+          name: "integration_package_id",
           in: "query",
           required: true,
           schema: { type: "string" },
@@ -312,7 +312,7 @@ export const mePaths = {
       responses: {
         "204": { description: "Pin cleared (or never existed)" },
         "400": {
-          description: "Missing required query param (agentPackageId or integrationPackageId).",
+          description: "Missing required query param (agent_package_id or integration_package_id).",
         },
         "401": { $ref: "#/components/responses/Unauthorized" },
         "403": { $ref: "#/components/responses/Forbidden" },

--- a/apps/api/src/openapi/paths/runs.ts
+++ b/apps/api/src/openapi/paths/runs.ts
@@ -512,8 +512,8 @@ export const runsPaths = {
           schema: { type: "string", enum: ["all", "package", "inline"] },
         },
         { name: "status", in: "query", schema: { type: "string" } },
-        { name: "startDate", in: "query", schema: { type: "string", format: "date-time" } },
-        { name: "endDate", in: "query", schema: { type: "string", format: "date-time" } },
+        { name: "start_date", in: "query", schema: { type: "string", format: "date-time" } },
+        { name: "end_date", in: "query", schema: { type: "string", format: "date-time" } },
       ],
       responses: {
         "200": {

--- a/apps/api/src/openapi/paths/schedules.ts
+++ b/apps/api/src/openapi/paths/schedules.ts
@@ -21,8 +21,16 @@ export const schedulesPaths = {
           content: {
             "application/json": {
               schema: {
-                type: "array",
-                items: { $ref: "#/components/schemas/Schedule" },
+                type: "object",
+                required: ["object", "data", "hasMore"],
+                properties: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
+                    type: "array",
+                    items: { $ref: "#/components/schemas/Schedule" },
+                  },
+                  hasMore: { type: "boolean" },
+                },
               },
             },
           },
@@ -53,8 +61,16 @@ export const schedulesPaths = {
           content: {
             "application/json": {
               schema: {
-                type: "array",
-                items: { $ref: "#/components/schemas/Schedule" },
+                type: "object",
+                required: ["object", "data", "hasMore"],
+                properties: {
+                  object: { type: "string", enum: ["list"] },
+                  data: {
+                    type: "array",
+                    items: { $ref: "#/components/schemas/Schedule" },
+                  },
+                  hasMore: { type: "boolean" },
+                },
               },
             },
           },

--- a/apps/api/src/routes/me.ts
+++ b/apps/api/src/routes/me.ts
@@ -175,7 +175,7 @@ router.get("/integration-pins", requireAppContext(), async (c) => {
     // than 403 so the picker can render without special-casing the actor.
     return c.json(listResponse([]));
   }
-  const agentPackageId = c.req.query("agentPackageId");
+  const agentPackageId = c.req.query("agent_package_id");
   if (!agentPackageId) {
     return c.json(listResponse([]));
   }
@@ -215,10 +215,10 @@ router.delete("/integration-pins", requireAppContext(), async (c) => {
     throw unauthorized("End-user cannot clear a member-scope pin");
   }
   const scope = getAppScope(c);
-  const agentPackageId = c.req.query("agentPackageId");
-  const integrationId = c.req.query("integrationPackageId");
+  const agentPackageId = c.req.query("agent_package_id");
+  const integrationId = c.req.query("integration_package_id");
   if (!agentPackageId || !integrationId) {
-    throw invalidRequest("agentPackageId and integrationPackageId query params are required");
+    throw invalidRequest("agent_package_id and integration_package_id query params are required");
   }
   const result = await deleteMemberPin(scope, agentPackageId, integrationId, user.id);
   if (result.deleted) {

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -56,7 +56,7 @@ export function createNotificationsRouter() {
 
   // GET /api/runs — global paginated run list across the application.
   // Supports filtering by ?user=me (self-owned runs), ?kind=inline|package|all
-  // for inline-run filtering, ?status, ?startDate/?endDate.
+  // for inline-run filtering, ?status, ?start_date/?end_date.
   router.get("/runs", async (c) => {
     const actor = getActor(c);
     const scope = getAppScope(c);
@@ -89,15 +89,15 @@ export function createNotificationsRouter() {
         ? (rawKind as GlobalRunKind)
         : undefined;
     const status = c.req.query("status");
-    const startDateRaw = c.req.query("startDate");
-    const endDateRaw = c.req.query("endDate");
+    const startDateRaw = c.req.query("start_date");
+    const endDateRaw = c.req.query("end_date");
     const startDate = startDateRaw ? new Date(startDateRaw) : undefined;
     const endDate = endDateRaw ? new Date(endDateRaw) : undefined;
     if (startDate && Number.isNaN(startDate.getTime())) {
-      throw invalidRequest("startDate is not a valid ISO date", "startDate");
+      throw invalidRequest("start_date is not a valid ISO date", "start_date");
     }
     if (endDate && Number.isNaN(endDate.getTime())) {
-      throw invalidRequest("endDate is not a valid ISO date", "endDate");
+      throw invalidRequest("end_date is not a valid ISO date", "end_date");
     }
 
     const result = await listGlobalRuns(scope, {

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -24,6 +24,7 @@ import { asJSONSchemaObject, schemaHasFileFields } from "@appstrate/core/form";
 import { listScheduleRuns } from "../services/state/runs.ts";
 import { recordAuditFromContext } from "../services/audit.ts";
 import { setOffsetLinkHeader } from "../lib/pagination-link.ts";
+import { listResponse } from "../lib/list-response.ts";
 import { runConfigOverrideSchema, scheduleInputSchema } from "../lib/jsonb-schemas.ts";
 
 // Per-integration connection picks frozen on the schedule row (cascade
@@ -68,7 +69,7 @@ export function createSchedulesRouter() {
   router.get("/schedules", async (c) => {
     const scope = getAppScope(c);
     const schedules = await listSchedules(scope);
-    return c.json(schedules);
+    return c.json(listResponse(schedules));
   });
 
   // GET /api/agents/:scope/:name/schedules — list schedules for an agent
@@ -76,7 +77,7 @@ export function createSchedulesRouter() {
     const scope = getAppScope(c);
     const agent = c.get("package");
     const schedules = await listPackageSchedules(scope, agent.id);
-    return c.json(schedules);
+    return c.json(listResponse(schedules));
   });
 
   // POST /api/agents/:scope/:name/schedules — create a schedule

--- a/apps/api/test/integration/routes/me-integration-pins.test.ts
+++ b/apps/api/test/integration/routes/me-integration-pins.test.ts
@@ -208,7 +208,7 @@ describe("/api/me/integration-pins", () => {
       expect(putRes.status).toBe(200);
 
       const res = await app.request(
-        `/api/me/integration-pins?agentPackageId=${encodeURIComponent(AGENT)}`,
+        `/api/me/integration-pins?agent_package_id=${encodeURIComponent(AGENT)}`,
         { headers: authHeaders(ctx) },
       );
 
@@ -251,8 +251,8 @@ describe("/api/me/integration-pins", () => {
       });
 
       const qs = new URLSearchParams({
-        agentPackageId: AGENT,
-        integrationPackageId: INTEGRATION,
+        agent_package_id: AGENT,
+        integration_package_id: INTEGRATION,
       });
       const res = await app.request(`/api/me/integration-pins?${qs.toString()}`, {
         method: "DELETE",
@@ -263,7 +263,7 @@ describe("/api/me/integration-pins", () => {
 
       // Subsequent GET returns empty list.
       const list = await app.request(
-        `/api/me/integration-pins?agentPackageId=${encodeURIComponent(AGENT)}`,
+        `/api/me/integration-pins?agent_package_id=${encodeURIComponent(AGENT)}`,
         { headers: authHeaders(ctx) },
       );
       const body = (await list.json()) as { data: unknown[] };
@@ -332,8 +332,8 @@ describe("/api/me/integration-pins", () => {
       });
 
       const qs = new URLSearchParams({
-        agentPackageId: AGENT,
-        integrationPackageId: INTEGRATION,
+        agent_package_id: AGENT,
+        integration_package_id: INTEGRATION,
       });
       const res = await app.request(`/api/me/integration-pins?${qs.toString()}`, {
         method: "DELETE",
@@ -361,7 +361,7 @@ describe("/api/me/integration-pins", () => {
       });
 
       const res = await app.request(
-        `/api/me/integration-pins?agentPackageId=${encodeURIComponent(AGENT)}`,
+        `/api/me/integration-pins?agent_package_id=${encodeURIComponent(AGENT)}`,
         {
           headers: {
             Authorization: `Bearer ${apiKey.rawKey}`,

--- a/apps/api/test/integration/routes/openapi-response-validation.test.ts
+++ b/apps/api/test/integration/routes/openapi-response-validation.test.ts
@@ -420,7 +420,8 @@ describe("OpenAPI response validation", () => {
       }
 
       expect(result.valid).toBe(true);
-      expect(body).toBeArray();
+      expect((body as any).object).toBe("list");
+      expect((body as any).data).toBeArray();
     });
   });
 

--- a/apps/api/test/integration/routes/schedules.test.ts
+++ b/apps/api/test/integration/routes/schedules.test.ts
@@ -29,8 +29,9 @@ describe("Schedules API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body).toBeArray();
-      expect(body).toHaveLength(0);
+      expect(body.object).toBe("list");
+      expect(body.data).toBeArray();
+      expect(body.data).toHaveLength(0);
     });
 
     it("returns schedules for the org", async () => {
@@ -51,8 +52,9 @@ describe("Schedules API", () => {
 
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
-      expect(body.length).toBeGreaterThanOrEqual(1);
-      expect(body[0].name).toBe("Hourly");
+      expect(body.object).toBe("list");
+      expect(body.data.length).toBeGreaterThanOrEqual(1);
+      expect(body.data[0].name).toBe("Hourly");
     });
   });
 

--- a/apps/web/src/hooks/use-member-integration-pins.ts
+++ b/apps/web/src/hooks/use-member-integration-pins.ts
@@ -74,8 +74,8 @@ export function useDeleteMemberIntegrationPin() {
   return useMutation({
     mutationFn: (input: DeleteMemberPinInput) => {
       const qs = new URLSearchParams({
-        agentPackageId: input.agentPackageId,
-        integrationPackageId: input.integrationId,
+        agent_package_id: input.agentPackageId,
+        integration_package_id: input.integrationId,
       }).toString();
       return api<void>(`/me/integration-pins?${qs}`, { method: "DELETE" });
     },

--- a/apps/web/src/hooks/use-schedules.ts
+++ b/apps/web/src/hooks/use-schedules.ts
@@ -26,9 +26,7 @@ export function useAllSchedules() {
   const applicationId = useCurrentApplicationId();
   return useQuery({
     queryKey: ["schedules", orgId, applicationId],
-    queryFn: async () => {
-      return api<EnrichedSchedule[]>("/schedules");
-    },
+    queryFn: () => apiList<EnrichedSchedule>("/schedules"),
     enabled: !!orgId && !!applicationId,
   });
 }
@@ -50,9 +48,7 @@ export function useSchedules(packageId: string | undefined) {
   const applicationId = useCurrentApplicationId();
   return useQuery({
     queryKey: ["schedules", orgId, applicationId, packageId],
-    queryFn: async () => {
-      return api<EnrichedSchedule[]>(`/agents/${packageId}/schedules`);
-    },
+    queryFn: () => apiList<EnrichedSchedule>(`/agents/${packageId}/schedules`),
     enabled: !!packageId && !!applicationId,
   });
 }

--- a/docs/CASING_CONVENTIONS.md
+++ b/docs/CASING_CONVENTIONS.md
@@ -335,17 +335,6 @@ Query params are wire surface. They follow the **same rule as wire JSON (Zone 1)
 
 Conforming snake_case examples: `?actor_type=&actor_id=` on the persistence routes (`routes/agents.ts:360`); OAuth 2.0 wire params `?client_id=`, `?post_logout_redirect_uri=` (RFC 6749, Zone 1). Single bare tokens (`limit`, `kind`, `status`, `q`, `since`) are trivially conforming.
 
-### Legacy exceptions (closed list — converge at the next API-version date)
-
-Four camelCase domain query params predate this rule. They are **exceptions, not precedent** — this list MUST NOT grow. Rename them to snake_case behind the next dated API version (`Appstrate-Version`):
-
-| Param                  | Route                                           | Target name                                              |
-| ---------------------- | ----------------------------------------------- | -------------------------------------------------------- |
-| `startDate`            | global runs feed (`routes/notifications.ts:92`) | `start_date` (domain timestamp — Carve-out 4b flips)     |
-| `endDate`              | global runs feed (`routes/notifications.ts:93`) | `end_date`                                               |
-| `agentPackageId`       | `/me/integration-pins` (`routes/me.ts:178,218`) | `agent_package_id` (already the wire-DTO spelling)       |
-| `integrationPackageId` | `/me/integration-pins` (`routes/me.ts:219`)     | `integration_package_id` (already the wire-DTO spelling) |
-
 A new camelCase domain query param is a bug, same as a camelCase domain wire field.
 
 ### Pagination styles (which one to use)


### PR DESCRIPTION
## Summary

The two breaking normalizations deferred from #673 (post-merge analysis findings). No production data — clean break, no compat window.

### 1. Schedules lists join the canonical envelope

`GET /schedules` and `GET /agents/{scope}/{name}/schedules` were the last two list endpoints returning a raw array — they escaped #670's envelope conversion and contradicted `lib/list-response.ts`'s "every list-shaped response" claim. Both now return `{ object: "list", data, hasMore }`.

- Web: `useAllSchedules` / `useSchedules` switched to `apiList` — the hook's return shape is unchanged (`apiList` unwraps to the array), so no component edits.
- OpenAPI: both operations now declare the envelope schema (same shape as api-keys/logs).
- `GET /schedules/{id}/runs` was already enveloped; this closes the route file's internal inconsistency.

### 2. Casing convergence — "Legacy exceptions" list emptied

The 4 camelCase domain query params documented as a closed list in `docs/CASING_CONVENTIONS.md` are renamed to snake_case. The deferral rationale ("converge at the next API-version date") protected nobody — verified zero client usage for the dates, one web hook for the pins.

| Before | After | Clients touched |
|---|---|---|
| `?startDate=` / `?endDate=` (global runs feed) | `?start_date=` / `?end_date=` | none (no web/CLI/action caller) |
| `?agentPackageId=` (GET/DELETE /me/integration-pins) | `?agent_package_id=` | `use-member-integration-pins.ts` (updated) |
| `?integrationPackageId=` (DELETE /me/integration-pins) | `?integration_package_id=` | same hook (updated) |

The pins params now match their own PUT-body wire spelling (`agent_package_id` / `integration_package_id`) — the route was already half-snake_case. The "Legacy exceptions" table is deleted from CASING_CONVENTIONS.md; the rule is now exception-free.

`detect:breaking` baseline updated (the renames + envelope are intentional breaks).

## Validation

- `bun run check` — 29/29, OpenAPI clean
- Affected route tests: schedules + me-integration-pins + notifications — 54 pass / 0 fail
- Web unit tests — 95 pass / 0 fail; web typecheck clean

⚠️ Merge order: this PR assumes #673 is merged first (branched from it conceptually but based on main — no actual dependency; CI will confirm).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
