### PR TITLE
fix(mcp): advertise the AS issuer in protected-resource metadata (OAuth discovery)

### DIFF
--- a/apps/api/src/modules/mcp/router.ts
+++ b/apps/api/src/modules/mcp/router.ts
@@ -101,13 +101,23 @@ export function createMcpRouter(): Hono<AppEnv> {
   // it must match the AS `validAudiences` (also APP_URL-derived) and the
   // resource-server audience check. Behind a reverse proxy where the public
   // origin differs from an internal request host, an origin-derived value would
-  // silently break audience binding. `authorization_servers` / doc URLs derive
-  // from the same APP_URL base so discovery stays consistent.
+  // silently break audience binding. Doc URLs derive from the same APP_URL base
+  // so discovery stays consistent.
+  //
+  // `authorization_servers` MUST be the AS *issuer identifier*, not the bare
+  // origin. Better Auth mounts the OAuth AS at `basePath: "/api/auth"` (see
+  // `packages/db/src/auth.ts`), so every metadata document it serves
+  // (`/.well-known/oauth-authorization-server`, `/api/auth/.well-known/openid-
+  // configuration`) advertises `issuer = APP_URL/api/auth`. RFC 8414 §3.3
+  // requires the `issuer` a client reads back to be byte-identical to the AS
+  // identifier it started from; advertising the bare origin here made strict
+  // clients (the claude.ai connector) reject discovery on issuer mismatch and
+  // fail the whole OAuth handshake. Point at the real issuer.
   const protectedResourceMetadata = (c: Context<AppEnv>) => {
     const appBase = getEnv().APP_URL.replace(/\/+$/, "");
     return c.json({
       resource: getMcpResourceUri(),
-      authorization_servers: [appBase],
+      authorization_servers: [`${appBase}/api/auth`],
       scopes_supported: [...MCP_SCOPES],
       bearer_methods_supported: ["header"],
       resource_documentation: `${appBase}/api/docs`,

--- a/apps/api/src/modules/mcp/test/integration/mcp.test.ts
+++ b/apps/api/src/modules/mcp/test/integration/mcp.test.ts
@@ -84,6 +84,10 @@ describe("mcp discovery + auth gate", () => {
       const body = (await res.json()) as Record<string, unknown>;
       expect((body.resource as string).endsWith("/api/mcp")).toBe(true);
       expect(Array.isArray(body.authorization_servers)).toBe(true);
+      // Must be the AS *issuer identifier* (`APP_URL/api/auth`), not the bare
+      // origin — otherwise RFC 8414 §3.3 issuer matching fails and strict
+      // OAuth clients (the claude.ai connector) reject discovery. See router.ts.
+      expect((body.authorization_servers as string[])[0]?.endsWith("/api/auth")).toBe(true);
       expect(body.scopes_supported).toEqual(["mcp:read", "mcp:invoke"]);
     }
   });

--- a/apps/api/src/modules/mcp/test/integration/mcp.test.ts
+++ b/apps/api/src/modules/mcp/test/integration/mcp.test.ts
@@ -92,6 +92,32 @@ describe("mcp discovery + auth gate", () => {
     }
   });
 
+  it("advertises an authorization_servers entry that byte-matches the live AS issuer (RFC 8414 §3.3)", async () => {
+    // Cross-document contract: the `authorization_servers` entry in the
+    // protected-resource metadata is an AS *issuer identifier*. A strict client
+    // (the claude.ai connector) discovers the AS metadata from it and rejects
+    // the handshake unless the `issuer` it reads back is byte-identical
+    // (RFC 8414 §3.3). The two surfaces were previously verified in isolation —
+    // the AS issuer was `${APP_URL}/api/auth`, the PRM advertised the bare
+    // origin, and nothing asserted they matched, so the mismatch shipped.
+    //
+    // Assert equality against the issuer the AS actually serves at its
+    // well-known (proxied from Better Auth) rather than a hard-coded suffix, so
+    // the contract holds even if Better Auth's `basePath` ever moves.
+    const prmRes = await app.request("/.well-known/oauth-protected-resource/api/mcp");
+    expect(prmRes.status).toBe(200);
+    const prm = (await prmRes.json()) as { authorization_servers: string[] };
+    const advertisedAs = prm.authorization_servers[0];
+    expect(typeof advertisedAs).toBe("string");
+
+    const asRes = await app.request("/.well-known/oauth-authorization-server");
+    expect(asRes.status).toBe(200);
+    const asMeta = (await asRes.json()) as { issuer: string };
+    expect(typeof asMeta.issuer).toBe("string");
+
+    expect(advertisedAs).toBe(asMeta.issuer);
+  });
+
   it("rejects unauthenticated /api/mcp with 401 + RFC 9728 WWW-Authenticate challenge", async () => {
     const res = await app.request("/api/mcp", {
       method: "POST",


### PR DESCRIPTION
## Problème

Brancher la passerelle MCP per-org (`/api/mcp/o/{org}`) comme **connecteur custom dans claude.ai** échoue à l'OAuth :

> Authorization with the MCP server failed. You can check your credentials and permissions.

Reproduit sur `app.appstrate.com`.

## Cause

La metadata RFC 9728 (protected-resource) annonce :

```jsonc
"authorization_servers": ["https://app.appstrate.com"]   // origine nue
```

Or Better Auth monte le serveur d'autorisation sur `basePath: "/api/auth"` (`packages/db/src/auth.ts`). **Tous** les documents de metadata qu'il sert
(`/.well-known/oauth-authorization-server`, `/api/auth/.well-known/openid-configuration`) déclarent donc :

```jsonc
"issuer": "https://app.appstrate.com/api/auth"
```

RFC 8414 §3.3 exige que l'`issuer` relu par le client soit **identique** à l'identifiant d'AS depuis lequel il a démarré la découverte. `…/api/auth` ≠ `…` → un client OAuth strict (le connecteur claude.ai) **rejette la découverte** et fait échouer tout le handshake.

## Correctif

Pointer `authorization_servers` sur l'issuer réel `${APP_URL}/api/auth`, + une assertion de test anti-régression.

```diff
-      authorization_servers: [appBase],
+      authorization_servers: [`${appBase}/api/auth`],
```

## Vérification

- `bun test …/mcp/test/integration/mcp.test.ts -t "RFC 9728"` → 2 pass / 0 fail
- `bun run --filter @appstrate/api typecheck` → OK
- Découverte OIDC `…/api/auth/.well-known/openid-configuration` déjà servie et auto-cohérente → suffit aux clients qui font la découverte OIDC.

## Note de suivi (hors scope de cette PR)

La variante RFC 8414 *path-insertion* `…/.well-known/oauth-authorization-server/api/auth` renvoie un 404 HTML (limitation Better Auth). Les clients qui ne tentent **que** cette URL (sans fallback OIDC) resteraient bloqués. À traiter séparément si besoin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)