### PR TITLE
test(core-providers): fix catalog snapshot broken by #675

### DIFF
--- a/apps/api/src/modules/core-providers/test/unit/providers.test.ts
+++ b/apps/api/src/modules/core-providers/test/unit/providers.test.ts
@@ -12,13 +12,18 @@ describe("core-providers module", () => {
     expect(ids).toEqual([
       "anthropic",
       "cerebras",
+      "deepseek",
+      "fireworks-ai",
       "google-ai",
       "groq",
       "mistral",
+      "moonshot",
       "openai",
       "openai-compatible",
       "openrouter",
+      "together-ai",
       "xai",
+      "zai",
     ]);
   });
 


### PR DESCRIPTION
## Problem

Test CI is red on `main`. PR #675 (DeepSeek, Moonshot, Together AI, Fireworks AI, Z.ai) added 5 API-key providers to the core-providers catalog but did not update the snapshot test in `apps/api/src/modules/core-providers/test/unit/providers.test.ts`.

```
(fail) core-providers module > declares the canonical API-key provider catalog
  + "deepseek"
  + "fireworks-ai"
  + "moonshot"
  + "together-ai"
  + "zai"
```

## Fix

Add the 5 new provider IDs (sorted) to the `toEqual` expected catalog.

## Verification

```
$ bun test src/modules/core-providers/test/unit/providers.test.ts
 5 pass / 0 fail
```

## Note

A second unrelated failure was observed on the same run — `API Keys API > GET /api/api-keys` failing with `PostgresError: deadlock detected` during test-cleanup truncate. That is a parallel-cleanup flake, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)