### PR TITLE
fix(api): always dedupe model-provider credential labels

### DIFF
--- a/apps/api/src/routes/model-provider-credentials.ts
+++ b/apps/api/src/routes/model-provider-credentials.ts
@@ -16,8 +16,8 @@ import { requirePermission } from "../middleware/require-permission.ts";
 import { isSystemModelProviderKey } from "../services/model-registry.ts";
 import {
   createApiKeyCredential,
+  dedupeCredentialLabel,
   deleteModelProviderCredential,
-  deriveCredentialLabel,
   getOrgModelProviderCredential,
   listOrgModelProviderCredentials,
   loadInferenceCredentials,
@@ -45,8 +45,8 @@ import { recordAuditFromContext } from "../services/audit.ts";
 export const createSchema = z.object({
   /**
    * Optional. When omitted, the server derives the label from the provider's
-   * `displayName` and dedupes against existing org credentials. See
-   * {@link deriveCredentialLabel}.
+   * `displayName`. Either way it is deduped against existing org credentials
+   * (suffixed ` (2)`, ` (3)`, … on collision). See {@link dedupeCredentialLabel}.
    */
   label: z.string().min(1).optional(),
   providerId: z.string().min(1, "providerId is required"),
@@ -196,7 +196,9 @@ export function createModelProviderCredentialsRouter() {
       );
     }
 
-    const label = data.label ?? (await deriveCredentialLabel(orgId, providerId));
+    // Always dedupe — a user-supplied label is suffixed on collision too, so
+    // labels stay unique within the org (same scheme as org models).
+    const label = await dedupeCredentialLabel(orgId, data.label?.trim() || cfg.displayName);
 
     try {
       const id = await createApiKeyCredential({

--- a/apps/api/src/services/model-providers/credentials.ts
+++ b/apps/api/src/services/model-providers/credentials.ts
@@ -334,18 +334,14 @@ export async function updateModelProviderCredential(
 // ─── Label derivation ──────────────────────────────────────────────────────
 
 /**
- * Derive a credential label when the caller doesn't supply one. Picks the
- * provider's `displayName` (registry) and dedupes against existing labels
- * in the same org by appending ` (2)`, ` (3)`, … on collision, resolved
- * server-side so automation (CLI, connect-helper, OAuth import) doesn't have
- * to invent a name.
- *
- * Unknown providerIds fall back to the literal id — defensive only;
- * upstream callers reject unknown ids before we get here.
+ * Make `base` unique within an org's credential labels by appending ` (2)`,
+ * ` (3)`, … on collision (same suffix scheme as org models). Always run a
+ * label through this before persisting — including caller-supplied ones —
+ * so two connections to the same provider never share a name. The
+ * `connect-helper` CLI sends a default label (`ChatGPT`, `Claude`) on every
+ * redeem, so deriving only when the label is absent would never dedupe.
  */
-export async function deriveCredentialLabel(orgId: string, providerId: string): Promise<string> {
-  const provider = getModelProvider(providerId);
-  const base = provider?.displayName ?? providerId;
+export async function dedupeCredentialLabel(orgId: string, base: string): Promise<string> {
   const rows = await db
     .select({ label: modelProviderCredentials.label })
     .from(modelProviderCredentials)
@@ -354,6 +350,20 @@ export async function deriveCredentialLabel(orgId: string, providerId: string): 
     base,
     rows.map((r) => r.label),
   );
+}
+
+/**
+ * Derive a credential label when the caller doesn't supply one. Picks the
+ * provider's `displayName` (registry) and dedupes against existing labels in
+ * the same org, resolved server-side so automation doesn't have to invent a
+ * name.
+ *
+ * Unknown providerIds fall back to the literal id — defensive only;
+ * upstream callers reject unknown ids before we get here.
+ */
+export async function deriveCredentialLabel(orgId: string, providerId: string): Promise<string> {
+  const provider = getModelProvider(providerId);
+  return dedupeCredentialLabel(orgId, provider?.displayName ?? providerId);
 }
 
 /**

--- a/apps/api/src/services/model-providers/oauth-flow.ts
+++ b/apps/api/src/services/model-providers/oauth-flow.ts
@@ -25,7 +25,7 @@
 
 import {
   createOAuthCredential,
-  deriveCredentialLabel,
+  dedupeCredentialLabel,
   findMissingIdentityClaims,
   type CreateOAuthCredentialInput,
 } from "./credentials.ts";
@@ -71,9 +71,12 @@ export async function importOAuthModelProviderConnection(
   if (!input.accessToken || !input.refreshToken) {
     throw invalidRequest("`accessToken` and `refreshToken` are required");
   }
-  const label = input.label?.trim()
-    ? input.label.trim()
-    : await deriveCredentialLabel(input.orgId, input.providerId);
+  // Always dedupe, even when the caller (the connect-helper CLI) supplies a
+  // label — its default (`ChatGPT`, `Claude`) is the same on every redeem, so
+  // honouring it verbatim would name every connection identically. The base
+  // is the supplied label, else the provider's displayName.
+  const base = input.label?.trim() || config.displayName || config.providerId;
+  const label = await dedupeCredentialLabel(input.orgId, base);
 
   // Identity extraction is delegated to the provider's module via the
   // `extractTokenIdentity` hook, which maps provider-specific claims into

--- a/apps/api/test/integration/services/label-derivation.test.ts
+++ b/apps/api/test/integration/services/label-derivation.test.ts
@@ -5,15 +5,19 @@
  * providers cleanup (follow-up to #437). Both `POST /api/models` and
  * `POST /api/model-provider-credentials` accept an optional `label` field
  * and fall back to these helpers when omitted; the connect-helper /
- * `pair/redeem` route relies on `deriveCredentialLabel` for the same
- * reason. The matrix below pins:
+ * `pair/redeem` route runs every label (including the CLI-supplied default)
+ * through `dedupeCredentialLabel`. The matrix below pins:
  *   1. `displayName` / catalog-label is the base.
  *   2. Subsequent rows get ` (2)`, ` (3)`, … on collision.
- *   3. Unknown providers / models fall back to the literal id.
+ *   3. A caller-supplied label is deduped too (not honoured verbatim).
+ *   4. Unknown providers / models fall back to the literal id.
  */
 
 import { describe, it, expect, beforeEach } from "bun:test";
-import { deriveCredentialLabel } from "../../../src/services/model-providers/credentials.ts";
+import {
+  deriveCredentialLabel,
+  dedupeCredentialLabel,
+} from "../../../src/services/model-providers/credentials.ts";
 import { deriveModelLabel } from "../../../src/services/org-models.ts";
 import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
@@ -54,6 +58,40 @@ describe("deriveCredentialLabel", () => {
       apiKey: "sk-test-2",
     });
     expect(await deriveCredentialLabel(ctx.orgId, "openai")).toBe("OpenAI (3)");
+  });
+});
+
+describe("dedupeCredentialLabel", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "labelorg" });
+  });
+
+  it("returns the base verbatim when free", async () => {
+    expect(await dedupeCredentialLabel(ctx.orgId, "ChatGPT")).toBe("ChatGPT");
+  });
+
+  it("suffixes a caller-supplied label on collision (CLI default-label case)", async () => {
+    // The connect-helper sends the same default label ("ChatGPT") on every
+    // redeem; without deduping the supplied label every connection collides.
+    await seedOrgModelProviderKey({
+      orgId: ctx.orgId,
+      label: "ChatGPT",
+      apiShape: "openai-completions",
+      baseUrl: "https://api.openai.com/v1",
+      apiKey: "sk-test-1",
+    });
+    expect(await dedupeCredentialLabel(ctx.orgId, "ChatGPT")).toBe("ChatGPT (2)");
+    await seedOrgModelProviderKey({
+      orgId: ctx.orgId,
+      label: "ChatGPT (2)",
+      apiShape: "openai-completions",
+      baseUrl: "https://api.openai.com/v1",
+      apiKey: "sk-test-2",
+    });
+    expect(await dedupeCredentialLabel(ctx.orgId, "ChatGPT")).toBe("ChatGPT (3)");
   });
 });
 


### PR DESCRIPTION
## Problem

Connecting two subscription providers of the same kind (two Codex accounts, or Codex + a second Claude Code) produced credentials with the **identical label** — "ChatGPT", "Claude" — with no auto-incrementing suffix, unlike org models which already get "Name", "Name (2)", "Name (3)".

**Root cause:** the `@appstrate/connect-helper` CLI sends a default label (`provider.defaultLabel`) on **every** `/pair/redeem`, and `importOAuthModelProviderConnection` only derived+deduped a label when one was *absent* — so the supplied default was honoured verbatim every time. The dedup machinery (`dedupeLabel` from `@appstrate/core`, shared with org models) never ran.

## Fix

Always run the credential label through dedup, regardless of source:

- Extract **`dedupeCredentialLabel(orgId, base)`** — the org-scoped dedup half of `deriveCredentialLabel` — and apply it to the caller-supplied label too.
- **OAuth import** (`oauth-flow.ts`): base = supplied label, else `config.displayName`, else providerId → always deduped.
- **API-key create** (`POST /api/model-provider-credentials`): same — `data.label ?? displayName`, always deduped.
- Result: second+ connection becomes "ChatGPT (2)", "ChatGPT (3)", … — same scheme as org models.

A user-supplied label is deduped too (the server can't distinguish an explicit `--label` from the CLI default), so labels stay unique within the org.

## Companion change

The connect-helper CLI is being updated (separate repo/PR) to stop inventing a default label and only forward `--label` when explicitly passed — then the server auto-names from the provider display name. **This PR does not depend on that release**: it already fixes the symptom for users on the current CLI by deduping the default label it sends.

## Testing

- `dedupeCredentialLabel` unit/integration: base verbatim when free; caller-supplied label suffixed `(2)`, `(3)` on collision (the CLI-default case). Existing `deriveCredentialLabel` matrix kept. 8 tests pass.
- `tsc --noEmit` ✅ · `eslint` ✅ · `prettier` ✅.

Backend-only. No schema/migration — labels were never DB-unique, dedup is an application-layer convention. Pre-existing limitation unchanged: two truly-concurrent redeems can still collide on the same `(2)` (same as org models).

🤖 Generated with [Claude Code](https://claude.com/claude-code)