### PR TITLE
fix(web): drop misleading Bun install hint from OAuth pairing UI

### DIFF
--- a/apps/web/src/components/oauth-pairing-body.tsx
+++ b/apps/web/src/components/oauth-pairing-body.tsx
@@ -191,7 +191,6 @@ export function OAuthPairingBody({ providerId, onConnected, onBusyChange }: OAut
               </span>
             </Button>
           </div>
-          <p className="text-muted-foreground text-xs">{t("credentials.oauth.cliHint")}</p>
           <div className="text-muted-foreground flex items-center gap-2 text-xs">
             <Spinner />
             <span>{t("credentials.oauth.cliWaiting")}</span>

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -545,7 +545,6 @@
   "credentials.oauth.callbackSuccess": "OAuth provider connected successfully",
   "credentials.oauth.cliStageTitle": "Connect via CLI",
   "credentials.oauth.cliInstructions": "Run this command in your terminal to complete the connection:",
-  "credentials.oauth.cliHint": "If you don't have Bun yet, install it via: curl -fsSL https://bun.sh/install | bash",
   "credentials.oauth.cliWaiting": "Waiting for the connection…",
   "credentials.oauth.dismissConfirmTitle": "Close the connection window?",
   "credentials.oauth.dismissConfirmDescription": "The displayed command will disappear. A connection in progress will still finish in the background.",

--- a/apps/web/src/locales/fr/settings.json
+++ b/apps/web/src/locales/fr/settings.json
@@ -545,7 +545,6 @@
   "credentials.oauth.callbackSuccess": "Provider OAuth connecté avec succès",
   "credentials.oauth.cliStageTitle": "Connecter via la CLI",
   "credentials.oauth.cliInstructions": "Exécutez cette commande dans votre terminal pour terminer la connexion :",
-  "credentials.oauth.cliHint": "Si vous n'avez pas encore Bun, l'installer via : curl -fsSL https://bun.sh/install | bash",
   "credentials.oauth.cliWaiting": "En attente de la connexion…",
   "credentials.oauth.dismissConfirmTitle": "Fermer la fenêtre de connexion ?",
   "credentials.oauth.dismissConfirmDescription": "La commande affichée disparaîtra. Une connexion en cours se terminera quand même en arrière-plan.",


### PR DESCRIPTION
## Problem

The model-provider OAuth pairing modal (`OAuthPairingBody`) shows a hint telling users to install **Bun**:

> If you don't have Bun yet, install it via: `curl -fsSL https://bun.sh/install | bash`

But the command it surfaces is **`npx @appstrate/connect-helper@latest <token>`** (`routes/model-providers-oauth.ts:204`) — that's Node, not Bun.

## Why the hint is wrong

The published `@appstrate/connect-helper` is a **single-file Node bundle** (`dist/cli.js`, shebang `#!/usr/bin/env node`, all deps inlined via `bun build --target=node`). It:

- runs under **Node ≥20** (`npx` ships with Node/npm)
- installs **zero transitive deps** (all runtime deps live in `devDependencies`)
- is CI-smoke-tested under Node, never Bun

So **Bun is never needed at runtime**. The hint was a stale leftover (command was likely `bunx` before the Node bundle) and actively misled users into installing Bun for nothing.

## Change

Remove the `cliHint` paragraph from `OAuthPairingBody` and its `fr`/`en` locale keys. `npx` is assumed present (comes with Node), consistent with every other npm-distributed CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)