### PR TITLE
test(api): isolate FS storage between test files + deterministic latest version resolution

### DIFF
--- a/apps/api/src/routes/internal.ts
+++ b/apps/api/src/routes/internal.ts
@@ -454,7 +454,11 @@ export function createInternalRouter() {
         .where(
           and(eq(packageVersions.packageId, mcpServerId), sql`${packageVersions.yanked} = false`),
         )
-        .orderBy(sql`${packageVersions.createdAt} DESC`)
+        // Tiebreak by the serial `id` (insertion order) so two versions
+        // published in the same `createdAt` tick still resolve "latest"
+        // deterministically — without it the ORDER BY is non-deterministic on
+        // a tie and the most-recently-inserted version is not guaranteed.
+        .orderBy(sql`${packageVersions.createdAt} DESC, ${packageVersions.id} DESC`)
         .limit(1);
       if (!resolved) throw notFound(`No published version for '${mcpServerId}'`);
     }

--- a/apps/api/test/helpers/db.ts
+++ b/apps/api/test/helpers/db.ts
@@ -9,9 +9,42 @@
 import { db, closeDb } from "@appstrate/db/client";
 import { sql } from "drizzle-orm";
 import type { Db } from "@appstrate/db/client";
+import { readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
 
 export { db, closeDb };
 export type { Db };
+
+/**
+ * Reset the filesystem storage namespace between tests (tier0 / FS mode).
+ *
+ * tier0 points `FS_STORAGE_PATH` at one per-process temp dir shared by every
+ * test FILE (see `test/setup/preload.ts`). `truncateAll` resets the DB but the
+ * storage bucket files (`<bucket>/<pkg>/<version>.afps`, run workspaces, …)
+ * persisted across files — so a stale artifact uploaded by file A under a
+ * fixed package id (e.g. `@mcporg/local-server`) leaked into file B that
+ * reused the same id, making whole-suite runs flaky in a way isolated runs
+ * never showed. Wiping the storage root's contents alongside the DB delete
+ * makes storage isolation match DB isolation.
+ *
+ * No-op when S3 storage is configured (tier3 / MinIO) — there is no FS path to
+ * clear, and the bucket lifecycle is owned by Docker Compose, not the test
+ * harness. Best-effort: a teardown failure must never mask the test outcome.
+ */
+function resetFsStorage(): void {
+  if (process.env.S3_BUCKET) return; // S3 mode — not filesystem-backed.
+  const root = process.env.FS_STORAGE_PATH;
+  if (!root) return;
+  try {
+    // Remove the bucket subtrees but keep the root dir itself (the storage
+    // adapter recreates bucket dirs lazily on the next upload).
+    for (const entry of readdirSync(root)) {
+      rmSync(join(root, entry), { recursive: true, force: true });
+    }
+  } catch {
+    // Root may not exist yet (no upload happened) — nothing to clear.
+  }
+}
 
 /**
  * Core table names in dependency-safe order (children first, parents last).
@@ -98,9 +131,13 @@ function buildTruncateSql(): string {
  * Order is children → parents (module tables first, since they reference
  * core tables).
  *
+ * Also resets the filesystem storage namespace (tier0 / FS mode) so storage
+ * isolation between test files matches DB isolation — see {@link resetFsStorage}.
+ *
  * Call this in beforeEach() for full test isolation.
  */
 export async function truncateAll(): Promise<void> {
   cachedTruncateSql ??= buildTruncateSql();
   await db.execute(sql.raw(cachedTruncateSql));
+  resetFsStorage();
 }


### PR DESCRIPTION
## Problem

Whole-suite `TEST_TIER=0` runs flaked on `internal-mcp-server-bundle.test.ts` (the `?version=` exact / "latest" byte assertions). Isolated runs never reproduced it — classic cross-file pollution.

Two independent root causes, both fixed here.

### 1. FS storage leaked across test files

tier0 points `FS_STORAGE_PATH` at a single per-process temp dir shared by every test file (`test/setup/preload.ts`). `truncateAll` (the universal `beforeEach`) reset the **DB only** — the storage bucket files (`<bucket>/<pkg>/<version>.afps`, run workspaces) persisted across files. An artifact uploaded by file A under a fixed package id (e.g. `@mcporg/local-server`) leaked into file B that reused the same id.

Fix: `truncateAll` now also wipes the FS storage root's contents — FS mode only (no-op under S3 / tier3, where the bucket lifecycle is owned by Docker Compose). Storage isolation now matches DB isolation. Scanned the suite first: no test combines `beforeAll` with a storage upload, so a per-test wipe is safe.

### 2. "latest" version resolution was non-deterministic

`GET /internal/mcp-server-bundle` resolved the no-`?version=` case via `ORDER BY created_at DESC LIMIT 1`. Two versions published in the same `created_at` tick (back-to-back inserts, common in tests and fast publishes) tie, and the tiebreak is arbitrary — so "latest" could return the older version. Fix: tiebreak by the serial `id` (insertion order), so the most-recently-inserted version wins deterministically.

## Verification

- The previously-flaky pair (`internal-integration-credentials` + `internal-mcp-server-bundle`) → green.
- Full `apps/api/test` under `TEST_TIER=0`, **two consecutive runs**: the `@mcporg` flake is gone in both (2389 pass).
- `bun run check` green.

### Out of scope (pre-existing)

One unrelated test — `model-provider-credentials … returns 409 CREDENTIAL_IN_USE` — fails under `TEST_TIER=0` **even in isolation on clean `main`** (verified by stashing this branch's changes). It's a pre-existing tier0-only limitation (the 409 path likely relies on Postgres behavior PGlite differs on), not a regression from this PR and not related to storage pollution. Left for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)