### PR TITLE
fix(oidc): serve OAuth discovery at RFC 8414 path-inserted URLs

### DIFF
--- a/apps/api/src/modules/mcp/test/integration/mcp.test.ts
+++ b/apps/api/src/modules/mcp/test/integration/mcp.test.ts
@@ -122,7 +122,7 @@ describe("mcp discovery + auth gate", () => {
     const prmRes = await app.request(`/.well-known/oauth-protected-resource/api/mcp/o/${orgId}`);
     expect(prmRes.status).toBe(200);
     const prm = (await prmRes.json()) as { authorization_servers: string[] };
-    const advertisedAs = prm.authorization_servers[0];
+    const advertisedAs = prm.authorization_servers[0]!;
     expect(typeof advertisedAs).toBe("string");
 
     // RFC 8414 §3.1 path-insertion: `https://host/path` → `https://host/.well-known/oauth-authorization-server/path`.

--- a/apps/api/src/modules/mcp/test/integration/mcp.test.ts
+++ b/apps/api/src/modules/mcp/test/integration/mcp.test.ts
@@ -110,9 +110,14 @@ describe("mcp discovery + auth gate", () => {
     // the AS issuer was `${APP_URL}/api/auth`, the PRM advertised the bare
     // origin, and nothing asserted they matched, so the mismatch shipped.
     //
-    // Assert equality against the issuer the AS actually serves at its
-    // well-known (proxied from Better Auth) rather than a hard-coded suffix, so
-    // the contract holds even if Better Auth's `basePath` ever moves.
+    // Derive the discovery URL exactly as a strict RFC 8414 client does — by
+    // inserting the issuer's path component after `.well-known` — rather than
+    // fetching the origin-root form. Fetching the root form here would mask a
+    // path-insertion gap: the advertised issuer carries a `/api/auth` path, so
+    // a real client requests `/.well-known/oauth-authorization-server/api/auth`,
+    // NOT the bare root. (That gap shipped once: the root form returned JSON, the
+    // path-inserted form fell through to the SPA `/*` catch-all and returned
+    // `index.html`, so the connector's `JSON.parse` failed on the leading `<`.)
     const orgId = "00000000-0000-0000-0000-0000000000ae";
     const prmRes = await app.request(`/.well-known/oauth-protected-resource/api/mcp/o/${orgId}`);
     expect(prmRes.status).toBe(200);
@@ -120,11 +125,19 @@ describe("mcp discovery + auth gate", () => {
     const advertisedAs = prm.authorization_servers[0];
     expect(typeof advertisedAs).toBe("string");
 
-    const asRes = await app.request("/.well-known/oauth-authorization-server");
+    // RFC 8414 §3.1 path-insertion: `https://host/path` → `https://host/.well-known/oauth-authorization-server/path`.
+    const issuerPath = new URL(advertisedAs).pathname.replace(/\/$/, "");
+    const discoveryUrl = `/.well-known/oauth-authorization-server${issuerPath}`;
+    const asRes = await app.request(discoveryUrl);
+    // The derived URL MUST resolve to the metadata document — not a 404 and not
+    // the SPA shell. A non-JSON body here is exactly the failure that broke the
+    // Claude MCP connector.
     expect(asRes.status).toBe(200);
+    expect(asRes.headers.get("content-type") ?? "").toContain("json");
     const asMeta = (await asRes.json()) as { issuer: string };
     expect(typeof asMeta.issuer).toBe("string");
 
+    // Byte-match against the issuer served at the client-derived URL (RFC 8414 §3.3).
     expect(advertisedAs).toBe(asMeta.issuer);
   });
 

--- a/apps/api/src/modules/oidc/auth/plugins.ts
+++ b/apps/api/src/modules/oidc/auth/plugins.ts
@@ -248,9 +248,12 @@ export function oidcBetterAuthPlugins(opts: OidcBetterAuthPluginsOptions = {}): 
       loginPage: "/api/oauth/login",
       consentPage: "/api/oauth/consent",
       // basePath is `/api/auth` (not `/`), so BA advises ensuring the
-      // discovery doc at `/.well-known/oauth-authorization-server/api/auth`
-      // is served — which this plugin itself serves. The warning is purely
-      // advisory for the non-root basePath; clear it via the documented flag.
+      // discovery doc at `/.well-known/oauth-authorization-server/api/auth` is
+      // served. BA itself only exposes the suffix form
+      // (`/api/auth/.well-known/...`); the RFC 8414 path-inserted form at the
+      // origin root is served by this module's router (see `routes.ts` OIDC
+      // discovery). The warning is purely advisory for the non-root basePath;
+      // clear it via the documented flag.
       silenceWarnings: { oauthAuthServerConfig: true },
       // OIDC scope vocabulary (identity scopes + OIDC_ALLOWED_SCOPES). Owned
       // wholly by this module — there is no cross-module scope contribution

--- a/apps/api/src/modules/oidc/openapi/paths.ts
+++ b/apps/api/src/modules/oidc/openapi/paths.ts
@@ -527,6 +527,26 @@ export const oidcPaths = {
       responses: { "200": { description: "Authorization server metadata document." } },
     },
   },
+  "/.well-known/openid-configuration/api/auth": {
+    get: {
+      operationId: "oidcDiscoveryPathInserted",
+      tags: ["OAuth Clients"],
+      summary: "OpenID Connect discovery document (RFC 8414 path-inserted)",
+      description:
+        "Same document as `/.well-known/openid-configuration`. The advertised issuer is `${APP_URL}/api/auth`, so RFC 8414 path-aware clients insert the issuer path after `.well-known` and request the discovery document here.",
+      responses: { "200": { description: "OpenID Configuration document." } },
+    },
+  },
+  "/.well-known/oauth-authorization-server/api/auth": {
+    get: {
+      operationId: "oauthServerMetadataPathInserted",
+      tags: ["OAuth Clients"],
+      summary: "OAuth 2.0 Authorization Server Metadata (RFC 8414 path-inserted)",
+      description:
+        "Same document as `/.well-known/oauth-authorization-server`. The advertised issuer is `${APP_URL}/api/auth`, so RFC 8414 path-aware clients insert the issuer path after `.well-known` and request the metadata document here.",
+      responses: { "200": { description: "Authorization server metadata document." } },
+    },
+  },
 
   // ─── Logout ─────────────────────────────────────────────────────────────
 

--- a/apps/api/src/modules/oidc/routes.ts
+++ b/apps/api/src/modules/oidc/routes.ts
@@ -2316,16 +2316,30 @@ export function createOidcRouter() {
 
   // ── OIDC discovery ──────────────────────────────────────────────────────────
 
-  router.get("/.well-known/openid-configuration", async (c: Context<AppEnv>) => {
+  const serveOpenIdConfig = async (c: Context<AppEnv>) => {
     const payload = await getOidcAuthApi().getOpenIdConfig({ headers: c.req.raw.headers });
     c.header("cache-control", "public, max-age=3600");
     return c.json(payload as never);
-  });
-  router.get("/.well-known/oauth-authorization-server", async (c: Context<AppEnv>) => {
+  };
+  const serveOAuthServerConfig = async (c: Context<AppEnv>) => {
     const payload = await getOidcAuthApi().getOAuthServerConfig({ headers: c.req.raw.headers });
     c.header("cache-control", "public, max-age=3600");
     return c.json(payload as never);
-  });
+  };
+
+  // Origin-root form (RFC 5785 / RFC 8414) — OIDC client libraries that apply no
+  // path-insertion look here.
+  router.get("/.well-known/openid-configuration", serveOpenIdConfig);
+  router.get("/.well-known/oauth-authorization-server", serveOAuthServerConfig);
+  // Path-inserted form — the advertised authorization-server identifier is
+  // `${APP_URL}/api/auth` (issuer carries the `/api/auth` path), so RFC 8414
+  // path-aware clients (e.g. the Claude MCP SDK, reached via the
+  // `oauth-protected-resource` `authorization_servers` entry) build the discovery
+  // URL by inserting the issuer path after `.well-known`. Without these aliases
+  // the request falls through to the SPA `/*` catch-all and is answered with
+  // `index.html`, so the client's `JSON.parse` fails on the leading `<`.
+  router.get("/.well-known/openid-configuration/api/auth", serveOpenIdConfig);
+  router.get("/.well-known/oauth-authorization-server/api/auth", serveOAuthServerConfig);
 
   // ── Phase 3 admin oversight (#251) ─────────────────────────────────────────
   //

--- a/apps/api/src/modules/oidc/test/integration/routes/discovery.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/routes/discovery.test.ts
@@ -138,4 +138,42 @@ describe("OIDC discovery — RFC 8414 + OpenID Connect Discovery", () => {
       expect(headers.get("cache-control") ?? "").toContain("max-age=3600");
     });
   });
+
+  // The advertised authorization-server identifier is `${APP_URL}/api/auth`
+  // (issuer carries the `/api/auth` path). RFC 8414 path-aware clients (the
+  // Claude MCP SDK, reached via the `oauth-protected-resource`
+  // `authorization_servers` entry) build the discovery URL by inserting that
+  // path after `.well-known`. These aliases must return the same JSON document
+  // as the origin-root form — otherwise the request falls through to the SPA
+  // `/*` catch-all and the client's `JSON.parse` chokes on the leading `<` of
+  // `index.html`.
+  describe("RFC 8414 path-inserted discovery URLs", () => {
+    it("serves openid-configuration at the path-inserted URL", async () => {
+      const { status, body } = await fetchJson<OpenIdConfigShape>(
+        "/.well-known/openid-configuration/api/auth",
+      );
+      expect(status).toBe(200);
+      expect(body.authorization_endpoint).toContain("/oauth2/authorize");
+      expect(body.token_endpoint).toContain("/oauth2/token");
+      expect(body.code_challenge_methods_supported).toContain("S256");
+    });
+
+    it("serves oauth-authorization-server at the path-inserted URL", async () => {
+      const { status, body } = await fetchJson<OpenIdConfigShape>(
+        "/.well-known/oauth-authorization-server/api/auth",
+      );
+      expect(status).toBe(200);
+      expect(body.authorization_endpoint).toContain("/oauth2/authorize");
+      expect(body.token_endpoint).toContain("/oauth2/token");
+      expect(body.response_types_supported).toContain("code");
+    });
+
+    it("returns the same document at the path-inserted and origin-root URLs", async () => {
+      const root = await fetchJson<OpenIdConfigShape>("/.well-known/oauth-authorization-server");
+      const inserted = await fetchJson<OpenIdConfigShape>(
+        "/.well-known/oauth-authorization-server/api/auth",
+      );
+      expect(inserted.body).toEqual(root.body);
+    });
+  });
 });

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -21,6 +21,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/.well-known/oauth-authorization-server/api/auth": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * OAuth 2.0 Authorization Server Metadata (RFC 8414 path-inserted)
+         * @description Same document as `/.well-known/oauth-authorization-server`. The advertised issuer is `${APP_URL}/api/auth`, so RFC 8414 path-aware clients insert the issuer path after `.well-known` and request the metadata document here.
+         */
+        get: operations["oauthServerMetadataPathInserted"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/.well-known/oauth-protected-resource/api/mcp/o/{org}": {
         parameters: {
             query?: never;
@@ -53,6 +73,26 @@ export interface paths {
          * @description RFC-compliant discovery endpoint. Mounted at the HTTP origin root (NOT under `/api`) per OIDC Discovery 1.0 §4.
          */
         get: operations["oidcDiscovery"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/.well-known/openid-configuration/api/auth": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * OpenID Connect discovery document (RFC 8414 path-inserted)
+         * @description Same document as `/.well-known/openid-configuration`. The advertised issuer is `${APP_URL}/api/auth`, so RFC 8414 path-aware clients insert the issuer path after `.well-known` and request the discovery document here.
+         */
+        get: operations["oidcDiscoveryPathInserted"];
         put?: never;
         post?: never;
         delete?: never;
@@ -5337,6 +5377,24 @@ export interface operations {
             };
         };
     };
+    oauthServerMetadataPathInserted: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Authorization server metadata document. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
     mcpProtectedResourceMetadata: {
         parameters: {
             query?: never;
@@ -5369,6 +5427,24 @@ export interface operations {
         };
     };
     oidcDiscovery: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OpenID Configuration document. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    oidcDiscoveryPathInserted: {
         parameters: {
             query?: never;
             header?: never;

--- a/e2e/tests/mcp/mcp.api.spec.ts
+++ b/e2e/tests/mcp/mcp.api.spec.ts
@@ -200,8 +200,11 @@ test.describe("MCP over a self-service OAuth client (DCR + PKCE)", () => {
   const REDIRECT = "http://localhost:9931/callback";
 
   /** Register a public self-service client via RFC 7591 DCR. */
-  async function registerDcrClient(request: APIRequestContext): Promise<string> {
-    const res = await request.post(`${BASE}/api/auth/oauth2/register`, {
+  async function registerDcrClient(
+    request: APIRequestContext,
+    registrationEndpoint = `${BASE}/api/auth/oauth2/register`,
+  ): Promise<string> {
+    const res = await request.post(registrationEndpoint, {
       headers: { "Content-Type": "application/json" },
       data: {
         client_name: "Claude Code (e2e)",
@@ -223,11 +226,12 @@ test.describe("MCP over a self-service OAuth client (DCR + PKCE)", () => {
     request: APIRequestContext,
     cookie: string,
     clientId: string,
+    authorizationEndpoint = `${BASE}/api/auth/oauth2/authorize`,
   ): Promise<{ code: string; verifier: string }> {
     const verifier = randomVerifier();
     const challenge = await sha256Base64Url(verifier);
     const authorizeUrl =
-      `${BASE}/api/auth/oauth2/authorize?` +
+      `${authorizationEndpoint}?` +
       new URLSearchParams({
         response_type: "code",
         client_id: clientId,
@@ -286,8 +290,9 @@ test.describe("MCP over a self-service OAuth client (DCR + PKCE)", () => {
     code: string,
     verifier: string,
     resource: string,
+    tokenEndpoint = `${BASE}/api/auth/oauth2/token`,
   ) {
-    const res = await request.post(`${BASE}/api/auth/oauth2/token`, {
+    const res = await request.post(tokenEndpoint, {
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
       form: {
         grant_type: "authorization_code",
@@ -431,6 +436,85 @@ test.describe("MCP over a self-service OAuth client (DCR + PKCE)", () => {
         headers: { ...headers, "X-Application-Id": orgContext.org.defaultAppId },
       });
       expect(lifted.status()).toBe(401);
+    } finally {
+      await anon.dispose();
+    }
+  });
+
+  // This is the one test that exercises the discovery chain the way a strict
+  // RFC 9728 → RFC 8414 client (the Claude / claude.ai MCP connector) does:
+  // start from the 401 challenge, follow `resource_metadata` to the PRM, take
+  // `authorization_servers[0]`, and DERIVE the AS-metadata URL by inserting the
+  // issuer's path after `.well-known` — instead of hard-coding `/api/auth/...`.
+  // Crucially it runs against the FULL booted server, which has the SPA `/*`
+  // catch-all. The in-process bun:test harness has no SPA fallback, so an
+  // unmounted well-known there 404s; only here does it fall through to
+  // `index.html`. That is exactly the bug that shipped: the path-inserted
+  // discovery URL returned the SPA shell, so the connector's `JSON.parse` failed
+  // with "Unrecognized token '<'" and onboarding never started. This test
+  // onboards end-to-end using ONLY discovered endpoints, so it fails if any of
+  // them is unreachable or non-JSON.
+  test("onboards via the full discovery chain using only discovered endpoints", async ({
+    playwright,
+    orgContext,
+  }) => {
+    const anon = await playwright.request.newContext();
+    try {
+      const mcpUrl = mcpUrlForOrg(orgContext.org.orgId);
+
+      // 1. Tokenless initialize → 401 + RFC 9728 challenge carrying the PRM URL.
+      const challengeRes = await anon.post(mcpUrl, {
+        headers: { "Content-Type": "application/json", Accept: MCP_ACCEPT },
+        data: INIT,
+      });
+      expect(challengeRes.status()).toBe(401);
+      const challenge = challengeRes.headers()["www-authenticate"] ?? "";
+      const prmUrl = challenge.match(/resource_metadata="([^"]+)"/)?.[1];
+      expect(prmUrl, "challenge advertises resource_metadata").toBeTruthy();
+
+      // 2. PRM → authorization_servers[0] (the AS issuer identifier).
+      const prmRes = await anon.get(prmUrl!);
+      expect(prmRes.status()).toBe(200);
+      expect(prmRes.headers()["content-type"] ?? "").toContain("json");
+      const prm = (await prmRes.json()) as { authorization_servers: string[] };
+      const issuer = prm.authorization_servers[0]!;
+      expect(typeof issuer).toBe("string");
+
+      // 3. RFC 8414 §3.1 path-insertion — the step that broke. The derived URL
+      //    MUST return the metadata document as JSON, not the SPA shell.
+      const issuerUrl = new URL(issuer);
+      const discoveryUrl = `${issuerUrl.origin}/.well-known/oauth-authorization-server${issuerUrl.pathname.replace(/\/$/, "")}`;
+      const asRes = await anon.get(discoveryUrl);
+      expect(asRes.status(), `discovery URL ${discoveryUrl} must resolve`).toBe(200);
+      expect(
+        asRes.headers()["content-type"] ?? "",
+        "path-inserted discovery URL must be JSON, not the SPA shell",
+      ).toContain("json");
+      const asMeta = (await asRes.json()) as {
+        issuer: string;
+        registration_endpoint: string;
+        authorization_endpoint: string;
+        token_endpoint: string;
+      };
+      expect(asMeta.issuer).toBe(issuer); // RFC 8414 §3.3 byte-match
+
+      // 4. Onboard using ONLY the discovered endpoints (DCR → PKCE → token).
+      const clientId = await registerDcrClient(anon, asMeta.registration_endpoint);
+      const { code, verifier } = await authorizeToCode(
+        anon,
+        orgContext.auth.cookie,
+        clientId,
+        asMeta.authorization_endpoint,
+      );
+      const minted = await exchange(anon, clientId, code, verifier, mcpUrl, asMeta.token_endpoint);
+      expect(minted.status).toBe(200);
+      const accessToken = minted.body.access_token as string;
+      expect(typeof accessToken).toBe("string");
+
+      // 5. The discovered-and-minted token drives the org's MCP endpoint.
+      const init = await mcpRpc(anon, mcpUrl, { Authorization: `Bearer ${accessToken}` }, INIT);
+      expect(init.status).toBe(200);
+      expect(init.envelope.result?.serverInfo).toBeTruthy();
     } finally {
       await anon.dispose();
     }

--- a/scripts/verify-openapi.ts
+++ b/scripts/verify-openapi.ts
@@ -1389,6 +1389,11 @@ const RESPONSE_SCHEMA_ALLOWLIST = new Set<string>([
   // by the SPA's typed client.
   "GET /.well-known/oauth-authorization-server 200",
   "GET /.well-known/openid-configuration 200",
+  // RFC 8414 path-inserted variants — same Better-Auth-owned document, served
+  // for clients that derive the discovery URL from the `${APP_URL}/api/auth`
+  // issuer path (e.g. the Claude MCP SDK).
+  "GET /.well-known/oauth-authorization-server/api/auth 200",
+  "GET /.well-known/openid-configuration/api/auth 200",
   "GET /api/auth/oauth2/authorize 200",
   "GET /api/auth/oauth2/userinfo 200",
   "POST /api/auth/oauth2/revoke 200",


### PR DESCRIPTION
## Problem

`claude mcp add --transport http <name> https://app.appstrate.com/api/mcp/o/<id>` adds the server but the connection fails:

```
Status: ✘ failed
Issue:  JSON Parse error: Unrecognized token '<'
Auth:   ✘ not authenticated
SDK auth failed: Failed to parse JSON
```

## Root cause

The `oauth-protected-resource` metadata advertises the authorization-server identifier as `${APP_URL}/api/auth` — an issuer whose path component is `/api/auth`. RFC 8414 path-aware clients (the Claude MCP SDK) derive the discovery URL by **inserting** that path after `.well-known`:

```
https://app.appstrate.com/.well-known/oauth-authorization-server/api/auth
```

The OIDC module only mounted discovery at the bare origin root, so the path-inserted request fell through to the SPA `/*` catch-all and was answered with `index.html` (HTTP 200). The client's `JSON.parse` then choked on the leading `<` → discovery + auth never started.

| URL | Before |
|---|---|
| `/.well-known/oauth-authorization-server/api/auth` | **200 HTML** ✗ |
| `/.well-known/openid-configuration/api/auth` | **200 HTML** ✗ |
| `/.well-known/oauth-authorization-server` (origin root) | 200 JSON ✓ |
| `/api/auth/.well-known/oauth-authorization-server` (Better Auth suffix) | 200 JSON ✓ |

## Fix

- Serve both discovery documents at the RFC 8414 path-inserted URLs, in addition to the origin-root form (`routes.ts`).
- Correct the stale `plugins.ts` comment that claimed Better Auth already served the path-inserted doc (it serves only the `/api/auth/.well-known/...` suffix form).
- Document the new paths in the OIDC OpenAPI spec + add them to the `verify-openapi` response-schema allowlist; regenerate SPA API types.
- Add discovery tests for the new URLs, including document-equality with the origin-root form.

## Test

```
bun test apps/api/src/modules/oidc/test/integration/routes/discovery.test.ts  # 8 pass
bun run verify:openapi                                                         # ALL CHECKS PASSED
cd apps/api && bunx tsc --noEmit                                               # clean
```

After deploy, existing failed registrations should `claude mcp remove <name>` then re-add — the SDK caches a failed discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)