### PR TITLE
feat(runs): honor integration manifest pins across all run origins (#686)

### DIFF
--- a/apps/api/src/openapi/paths/runs.ts
+++ b/apps/api/src/openapi/paths/runs.ts
@@ -998,6 +998,12 @@ export const runsPaths = {
                 },
                 applicationId: { type: "string", minLength: 1 },
                 input: { type: "object" },
+                dependency_overrides: {
+                  type: "object",
+                  description:
+                    'Per-run dependency version overrides (#666/#686). Flat map `{ "@scope/dep": "draft" | "<semver|dist-tag>" }`; keys may name a declared skill OR integration. `"draft"` opts that dependency into its working copy; any other value replaces the manifest pin. An unsatisfiable pin aborts the run with `dependency_unresolved` (422).',
+                  additionalProperties: { type: "string" },
+                },
                 contextSnapshot: {
                   type: "object",
                   description:

--- a/apps/api/src/openapi/paths/schedules.ts
+++ b/apps/api/src/openapi/paths/schedules.ts
@@ -131,6 +131,12 @@ export const schedulesPaths = {
                     'Per-integration connection picks frozen on the schedule row (flat-connections mechanism #3). Shape: `{ "@scope/integration": "<connection_id>" }`. Loses to admin pins (#1), beats actor-fallback (#4). Stored on `package_schedules.connection_overrides` and replayed on every fire.',
                   additionalProperties: { type: "string" },
                 },
+                dependency_overrides: {
+                  type: "object",
+                  description:
+                    'Per-dependency version overrides frozen on the schedule row (#666/#686). Shape: `{ "@scope/dep": "draft" | "<semver|dist-tag>" }`; keys may name a declared skill OR integration. Forwarded to each fired run so it resolves dependencies exactly as the schedule froze them.',
+                  additionalProperties: { type: "string" },
+                },
               },
             },
           },
@@ -163,6 +169,7 @@ export const schedulesPaths = {
                 proxy_id_override: null,
                 version_override: null,
                 connection_overrides: null,
+                dependency_overrides: null,
                 last_run_at: null,
                 next_run_at: "2026-01-16T09:00:00Z",
                 createdAt: "2026-01-15T10:30:00Z",
@@ -226,6 +233,7 @@ export const schedulesPaths = {
                 proxy_id_override: null,
                 version_override: "1.2.0",
                 connection_overrides: null,
+                dependency_overrides: null,
                 last_run_at: "2026-01-15T09:00:00Z",
                 next_run_at: "2026-01-16T09:00:00Z",
                 createdAt: "2026-01-14T14:00:00Z",
@@ -277,6 +285,12 @@ export const schedulesPaths = {
                   type: ["object", "null"],
                   description:
                     "Per-integration connection picks frozen on the schedule. Pass `null` to clear.",
+                  additionalProperties: { type: "string" },
+                },
+                dependency_overrides: {
+                  type: ["object", "null"],
+                  description:
+                    'Per-dependency version overrides frozen on the schedule (#666/#686). Shape: `{ "@scope/dep": "draft" | "<semver|dist-tag>" }`; skill or integration ids. Pass `null` to clear.',
                   additionalProperties: { type: "string" },
                 },
               },

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -818,6 +818,7 @@ export const schemas = {
       "proxy_id_override",
       "version_override",
       "connection_overrides",
+      "dependency_overrides",
       "last_run_at",
       "next_run_at",
       "createdAt",
@@ -848,6 +849,12 @@ export const schemas = {
         type: ["object", "null"],
         description:
           'Per-integration connection picks frozen on the schedule row (flat-connections mechanism #3). Flat map: `{ "@scope/integration": "<connection_id>" }`. Replayed on every fire; loses to admin pins (#1), beats actor-fallback (#4).',
+        additionalProperties: { type: "string" },
+      },
+      dependency_overrides: {
+        type: ["object", "null"],
+        description:
+          'Per-dependency version overrides frozen on the schedule row (#666/#686). Flat map: `{ "@scope/dep": "draft" | "<semver|dist-tag>" }`; keys may name a declared skill OR integration. Forwarded to each fired run\'s `dependency_overrides` so a scheduled run resolves its dependencies exactly as the schedule froze them.',
         additionalProperties: { type: "string" },
       },
       last_run_at: { type: ["string", "null"], format: "date-time" },

--- a/apps/api/src/routes/internal.ts
+++ b/apps/api/src/routes/internal.ts
@@ -51,7 +51,11 @@ import {
   resolveLiveIntegrationCredentials,
   serializeIntegrationCredentialsWire,
 } from "../services/integration-credentials-resolver.ts";
-import { fetchIntegrationManifest } from "../services/integration-service.ts";
+import {
+  fetchIntegrationManifest,
+  readIntegrationManifestAt,
+  resolvedIntegrationVersionToDescriptor,
+} from "../services/integration-service.ts";
 import { getLocalServerRef } from "../services/integration-manifest-helpers.ts";
 
 /**
@@ -75,6 +79,16 @@ async function verifyRunToken(c: Context): Promise<{
      * per-run overrides past the kickoff handoff.
      */
     resolvedConnections: Record<string, { connectionId: string; source: string }> | null;
+    /**
+     * Snapshot of each declared integration's resolved manifest version frozen
+     * at run kickoff (#686). The credentials resolver reads the integration
+     * manifest AT this version so a mid-run MITM refresh sees the same
+     * delivery/auth plan the spawn used.
+     */
+    resolvedIntegrationVersions: Record<
+      string,
+      { version: string | null; source: "version" | "draft" | "system" }
+    > | null;
   };
 }> {
   const authHeader = c.req.header("Authorization");
@@ -104,6 +118,7 @@ async function verifyRunToken(c: Context): Promise<{
       modelCredentialId: runs.modelCredentialId,
       runOrigin: runs.runOrigin,
       resolvedConnections: runs.resolvedConnections,
+      resolvedIntegrationVersions: runs.resolvedIntegrationVersions,
     })
     .from(runs)
     .where(eq(runs.id, runId))
@@ -130,6 +145,7 @@ async function verifyRunToken(c: Context): Promise<{
       modelCredentialId: run.modelCredentialId ?? null,
       runOrigin: run.runOrigin,
       resolvedConnections: run.resolvedConnections ?? null,
+      resolvedIntegrationVersions: run.resolvedIntegrationVersions ?? null,
     },
   };
 }
@@ -340,6 +356,7 @@ export function createInternalRouter() {
       agentPackageId: run.packageId,
       actor,
       resolvedConnections: run.resolvedConnections,
+      resolvedIntegrationVersions: run.resolvedIntegrationVersions,
     });
     logger.info("Integration credentials delivered", {
       runId,
@@ -378,6 +395,7 @@ export function createInternalRouter() {
           agentPackageId: run.packageId,
           actor,
           resolvedConnections: run.resolvedConnections,
+          resolvedIntegrationVersions: run.resolvedIntegrationVersions,
         },
         { forceRefresh: true },
       );
@@ -483,7 +501,15 @@ export function createInternalRouter() {
    */
   async function assertAgentReferencesMcpServer(
     mcpServerId: string,
-    run: { packageId: string; orgId: string; applicationId: string },
+    run: {
+      packageId: string;
+      orgId: string;
+      applicationId: string;
+      resolvedIntegrationVersions: Record<
+        string,
+        { version: string | null; source: "version" | "draft" | "system" }
+      > | null;
+    },
     runId: string,
   ): Promise<void> {
     const agent = await getPackage(run.packageId, run.orgId, { includeEphemeral: true });
@@ -502,7 +528,16 @@ export function createInternalRouter() {
         )
         .limit(1);
       if (!installRow) continue;
-      const res = await fetchIntegrationManifest(integrationId);
+      // Read the integration manifest AT the version frozen for this run
+      // (#686) so the authz check sees the same `source.server.name` the spawn
+      // resolver did. No frozen entry (soft-resolved / legacy run) → draft.
+      const frozen = run.resolvedIntegrationVersions?.[integrationId];
+      const res = frozen
+        ? await readIntegrationManifestAt(
+            integrationId,
+            resolvedIntegrationVersionToDescriptor(frozen),
+          )
+        : await fetchIntegrationManifest(integrationId);
       if (!res.ok) continue;
       const ref = getLocalServerRef(res.manifest);
       if (ref?.name === mcpServerId) return;

--- a/apps/api/src/routes/internal.ts
+++ b/apps/api/src/routes/internal.ts
@@ -51,11 +51,7 @@ import {
   resolveLiveIntegrationCredentials,
   serializeIntegrationCredentialsWire,
 } from "../services/integration-credentials-resolver.ts";
-import {
-  fetchIntegrationManifest,
-  readIntegrationManifestAt,
-  resolvedIntegrationVersionToDescriptor,
-} from "../services/integration-service.ts";
+import { readIntegrationManifestForRun } from "../services/integration-service.ts";
 import { getLocalServerRef } from "../services/integration-manifest-helpers.ts";
 
 /**
@@ -531,13 +527,10 @@ export function createInternalRouter() {
       // Read the integration manifest AT the version frozen for this run
       // (#686) so the authz check sees the same `source.server.name` the spawn
       // resolver did. No frozen entry (soft-resolved / legacy run) → draft.
-      const frozen = run.resolvedIntegrationVersions?.[integrationId];
-      const res = frozen
-        ? await readIntegrationManifestAt(
-            integrationId,
-            resolvedIntegrationVersionToDescriptor(frozen),
-          )
-        : await fetchIntegrationManifest(integrationId);
+      const res = await readIntegrationManifestForRun(
+        integrationId,
+        run.resolvedIntegrationVersions?.[integrationId],
+      );
       if (!res.ok) continue;
       const ref = getLocalServerRef(res.manifest);
       if (ref?.name === mcpServerId) return;

--- a/apps/api/src/routes/runs-remote.ts
+++ b/apps/api/src/routes/runs-remote.ts
@@ -32,6 +32,7 @@ import { getActor } from "../lib/actor.ts";
 import { recordAuditFromContext } from "../services/audit.ts";
 import { getPlatformRunLimits } from "../services/run-limits.ts";
 import { runInlinePreflight } from "../services/inline-run-preflight.ts";
+import { isValidDependencyOverride } from "../services/input-parser.ts";
 import { insertShadowPackage, buildShadowLoadedPackage } from "../services/inline-run.ts";
 import { createRun } from "../services/run-creation.ts";
 import { resolveRunnerContext } from "../lib/runner-context.ts";
@@ -99,6 +100,18 @@ const CreateRemoteRunBodySchema = z
     ]),
     applicationId: z.string().min(1),
     input: z.record(z.string(), z.unknown()).optional().default({}),
+    // Per-run dependency version overrides (#666/#686) — run-level, applies to
+    // both source shapes. `"draft"` opts a declared skill/integration into its
+    // working copy; any other value replaces the manifest pin. Mirrors the
+    // platform run route's value gate (`isValidDependencyOverride`); the KEY
+    // gate + pin resolution happen in `freezeRunSpawnDependencies`.
+    dependency_overrides: z
+      .record(z.string(), z.string())
+      .optional()
+      .refine(
+        (m) => !m || Object.values(m).every(isValidDependencyOverride),
+        '`dependency_overrides` values must be "draft" or a valid version spec (semver range or dist-tag)',
+      ),
     contextSnapshot: z
       .record(z.string(), z.unknown())
       .optional()
@@ -285,6 +298,12 @@ export function createRunsRemoteRouter() {
         config: effectiveConfig,
         modelId: modelIdOverride,
         proxyId: proxyIdOverride,
+        // Normalize an empty map to null (mirrors the platform run route): a
+        // non-null map on the row means the run carried explicit overrides.
+        dependencyOverrides:
+          body.dependency_overrides && Object.keys(body.dependency_overrides).length > 0
+            ? body.dependency_overrides
+            : null,
         apiKeyId: c.get("apiKeyId") ?? undefined,
         sink: body.sink ? { ttlSeconds: body.sink.ttl_seconds } : undefined,
         contextSnapshot: body.contextSnapshot,

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -32,6 +32,11 @@ import { runConfigOverrideSchema, scheduleInputSchema } from "../lib/jsonb-schem
 // loses to admin pins at fire time. Shape: { "@scope/integration": "<connection_id>" }.
 const connectionOverridesSchema = z.record(z.string(), z.string());
 
+// Per-dependency version overrides frozen on the schedule row (#666/#686).
+// Same wire shape as the run-route's dependency_overrides; keys may name a
+// declared skill OR integration. Shape: { "@scope/dep": "draft" | "<spec>" }.
+const dependencyOverridesSchema = z.record(z.string(), z.string());
+
 export const createScheduleSchema = z.object({
   name: z.string().optional(),
   cron_expression: z.string().min(1, "cron_expression is required"),
@@ -46,6 +51,7 @@ export const createScheduleSchema = z.object({
   proxy_id_override: z.string().optional(),
   version_override: z.string().optional(),
   connection_overrides: connectionOverridesSchema.optional(),
+  dependency_overrides: dependencyOverridesSchema.optional(),
 });
 
 export const updateScheduleSchema = z.object({
@@ -60,6 +66,7 @@ export const updateScheduleSchema = z.object({
   proxy_id_override: z.string().nullable().optional(),
   version_override: z.string().nullable().optional(),
   connection_overrides: connectionOverridesSchema.nullable().optional(),
+  dependency_overrides: dependencyOverridesSchema.nullable().optional(),
 });
 
 export function createSchedulesRouter() {
@@ -135,6 +142,7 @@ export function createSchedulesRouter() {
         proxyIdOverride: data.proxy_id_override ?? null,
         versionOverride: data.version_override ?? null,
         connectionOverrides: data.connection_overrides ?? null,
+        dependencyOverrides: data.dependency_overrides ?? null,
       });
       await recordAuditFromContext(c, {
         action: "schedule.created",
@@ -193,6 +201,7 @@ export function createSchedulesRouter() {
       proxyIdOverride: data.proxy_id_override,
       versionOverride: data.version_override,
       connectionOverrides: data.connection_overrides,
+      dependencyOverrides: data.dependency_overrides,
     });
     // Mirror schedule.created: explicit camelCase keys (dominant audit
     // convention — see api-keys.ts, modules/webhooks/routes.ts). Only
@@ -210,6 +219,8 @@ export function createSchedulesRouter() {
     if (data.version_override !== undefined) auditAfter.versionOverride = data.version_override;
     if (data.connection_overrides !== undefined)
       auditAfter.connectionOverrides = data.connection_overrides;
+    if (data.dependency_overrides !== undefined)
+      auditAfter.dependencyOverrides = data.dependency_overrides;
     await recordAuditFromContext(c, {
       action: "schedule.updated",
       resourceType: "schedule",

--- a/apps/api/src/services/integration-credentials-resolver.ts
+++ b/apps/api/src/services/integration-credentials-resolver.ts
@@ -47,9 +47,7 @@ import {
 } from "./integration-connections.ts";
 import { computeRequiredScopes } from "./integration-scope-resolver.ts";
 import {
-  fetchIntegrationManifest,
-  readIntegrationManifestAt,
-  resolvedIntegrationVersionToDescriptor,
+  readIntegrationManifestForRun,
   type ResolvedIntegrationVersion,
 } from "./integration-service.ts";
 
@@ -367,12 +365,7 @@ async function loadIntegrationManifest(
 ): Promise<IntegrationManifest> {
   // Read AT the version frozen for this run (#686) so the delivery/auth plan
   // matches the spawn. No frozen entry → draft (legacy / soft-resolved).
-  const res = frozenVersion
-    ? await readIntegrationManifestAt(
-        integrationId,
-        resolvedIntegrationVersionToDescriptor(frozenVersion),
-      )
-    : await fetchIntegrationManifest(integrationId);
+  const res = await readIntegrationManifestForRun(integrationId, frozenVersion);
   if (res.ok) return res.manifest;
   switch (res.failure.kind) {
     case "not_found":

--- a/apps/api/src/services/integration-credentials-resolver.ts
+++ b/apps/api/src/services/integration-credentials-resolver.ts
@@ -46,7 +46,12 @@ import {
   markIntegrationConnectionNeedsReconnection,
 } from "./integration-connections.ts";
 import { computeRequiredScopes } from "./integration-scope-resolver.ts";
-import { fetchIntegrationManifest } from "./integration-service.ts";
+import {
+  fetchIntegrationManifest,
+  readIntegrationManifestAt,
+  resolvedIntegrationVersionToDescriptor,
+  type ResolvedIntegrationVersion,
+} from "./integration-service.ts";
 
 /** Mutable builder for the wire payload (returned widened to the readonly wire type). */
 interface MutableCredentialsWire {
@@ -90,6 +95,13 @@ export async function resolveLiveIntegrationCredentials(
      * declaration is materialised.
      */
     resolvedConnections?: Record<string, { connectionId: string; source: string }> | null;
+    /**
+     * Snapshot from `runs.resolved_integration_versions` (#686). When present,
+     * `[integrationId]` pins the manifest VERSION this resolver reads — so the
+     * delivery/auth plan a mid-run MITM refresh injects matches the version the
+     * spawn resolver used at kickoff. Absent (legacy / soft-resolved) → draft.
+     */
+    resolvedIntegrationVersions?: Record<string, ResolvedIntegrationVersion> | null;
   },
   options: ResolveLiveCredentialsOptions = {},
 ): Promise<IntegrationCredentialsWire> {
@@ -99,7 +111,10 @@ export async function resolveLiveIntegrationCredentials(
     throw notFound(`Integration '${integrationId}' has no actor-scoped connection for this run`);
   }
 
-  const manifest = await loadIntegrationManifest(integrationId);
+  const manifest = await loadIntegrationManifest(
+    integrationId,
+    context.resolvedIntegrationVersions?.[integrationId] ?? null,
+  );
   await assertIntegrationActive(integrationId, context.applicationId);
 
   const auths = (manifest.auths ?? {}) as Record<string, AfpsManifestAuth>;
@@ -346,8 +361,18 @@ export async function resolveLiveIntegrationCredentials(
 // Helpers
 // ─────────────────────────────────────────────
 
-async function loadIntegrationManifest(integrationId: string): Promise<IntegrationManifest> {
-  const res = await fetchIntegrationManifest(integrationId);
+async function loadIntegrationManifest(
+  integrationId: string,
+  frozenVersion: ResolvedIntegrationVersion | null,
+): Promise<IntegrationManifest> {
+  // Read AT the version frozen for this run (#686) so the delivery/auth plan
+  // matches the spawn. No frozen entry → draft (legacy / soft-resolved).
+  const res = frozenVersion
+    ? await readIntegrationManifestAt(
+        integrationId,
+        resolvedIntegrationVersionToDescriptor(frozenVersion),
+      )
+    : await fetchIntegrationManifest(integrationId);
   if (res.ok) return res.manifest;
   switch (res.failure.kind) {
     case "not_found":

--- a/apps/api/src/services/integration-service.ts
+++ b/apps/api/src/services/integration-service.ts
@@ -367,6 +367,27 @@ export async function readIntegrationManifestAt(
   return { ok: true, manifest: parsed.data };
 }
 
+/**
+ * Read an integration manifest for a RUN, honoring the version frozen on
+ * `runs.resolved_integration_versions` (#686). The single decision point for
+ * "frozen version vs draft" — used by every run-scoped reader (credentials
+ * resolver, byte-route authz) so the "no frozen entry → draft" fallback lives
+ * in ONE place instead of a ternary duplicated per call site.
+ *
+ *   - `frozen` present → read AT that descriptor (the spawn used the same).
+ *   - `frozen` absent (legacy run / soft-resolved integration) → draft, via the
+ *     shared per-call-graph `cache` when provided.
+ */
+export function readIntegrationManifestForRun(
+  packageId: string,
+  frozen: ResolvedIntegrationVersion | null | undefined,
+  cache?: IntegrationManifestCache,
+): Promise<IntegrationManifestLoadResult> {
+  return frozen
+    ? readIntegrationManifestAt(packageId, resolvedIntegrationVersionToDescriptor(frozen))
+    : fetchIntegrationManifest(packageId, cache);
+}
+
 export type RunIntegrationVersionsResult =
   | { ok: true; versions: ResolvedIntegrationVersionMap }
   | { ok: false; unresolved: Array<{ name: string; versionSpec: string }> };

--- a/apps/api/src/services/integration-service.ts
+++ b/apps/api/src/services/integration-service.ts
@@ -14,10 +14,12 @@ import { packages, packageVersions, packageDistTags } from "@appstrate/db/schema
 import { integrationManifestSchema } from "@appstrate/core/integration";
 import type { IntegrationManifest } from "@appstrate/core/integration";
 import { mcpServerManifestSchema, type McpServerManifest } from "@appstrate/core/mcp-server";
+import { parseManifestIntegrations } from "@appstrate/core/dependencies";
 import { getSystemPackages } from "./system-packages.ts";
 import type { IntegrationSummary } from "@appstrate/shared-types";
 import { orgOrSystemFilter, notEphemeralFilter } from "../lib/package-helpers.ts";
 import { pickVersion } from "./run-launcher/db-package-catalog.ts";
+import { VERSION_SELECTOR_DRAFT } from "./agent-version-resolver.ts";
 import { logger } from "../lib/logger.ts";
 
 export type { IntegrationSummary };
@@ -133,48 +135,37 @@ export async function fetchMcpServerManifest(packageId: string): Promise<McpServ
   return parsed.data;
 }
 
+// ---------------------------------------------------------------------------
+// Spawn-time package version resolution (single kernel)
+// ---------------------------------------------------------------------------
+
 /**
- * Discriminated failure modes for {@link resolveMcpServerForSpawn} — distinct
- * from "package missing" so the spawn resolver can log WHY an integration was
- * skipped (a leaked diagnosis cycle in prod traced to the silent
- * stale-draft/latest-bytes split; see issue #588).
+ * Discriminated failure modes shared by every spawn-time package resolution.
+ * Distinct from "package missing" so callers can log WHY a package was skipped
+ * (a leaked diagnosis cycle in prod traced to the silent stale-draft/latest-bytes
+ * split; see issue #588).
  */
-export type McpServerResolveFailure =
+export type PublishedManifestFailure =
   | "not_found"
-  | "not_mcp_server"
+  | "wrong_type"
   | "invalid_manifest"
-  /** A published version exists, but none satisfied `source.server.version`. */
+  /** A published version exists, but none satisfied the pin. */
   | "unsatisfiable_pin"
   /** The package exists but has no published version to run. */
   | "no_published_version";
 
-export type McpServerResolution =
-  | {
-      ok: true;
-      manifest: McpServerManifest;
-      /**
-       * The CONCRETE version the spawn will run. `null` for system
-       * mcp-servers (single version served from the boot registry — no
-       * `package_versions` row, no `?version=` needed on the byte route).
-       */
-      version: string | null;
-      /** `"system"` → boot registry bytes; `"version"` → published `.afps`. */
-      source: "system" | "version";
-    }
-  | { ok: false; reason: McpServerResolveFailure };
+type PublishedManifestResolution =
+  | { ok: true; rawManifest: unknown; version: string | null; source: "system" | "version" }
+  | { ok: false; reason: PublishedManifestFailure };
 
 /**
- * Resolve a referenced `mcp-server` package to a CONCRETE version, honoring the
- * `source.server.version` pin, and return that version's manifest.
- *
- * This is the single resolution contract for the local-source spawn path. It
- * replaces the previous split where the manifest was read from
- * `packages.draft_manifest` (version-blind) while the runnable bytes came from
- * the latest non-yanked `package_versions` row (pin-blind, and independent of
- * the manifest version) — so a `publish` that didn't also overwrite the draft
- * left the run executing one version's bytes under another version's manifest
- * (issue #588). Here the manifest comes from `package_versions.manifest` for the
- * SAME `version` the byte route is told to serve, so they can never skew.
+ * Resolve a package to a CONCRETE published version honoring its pin, and
+ * return that version's RAW manifest (unparsed — the caller validates with the
+ * schema for its package type). This is the single version-resolution kernel
+ * behind both the mcp-server spawn path (#588) and the integration spawn path
+ * (#686): the manifest comes from `package_versions.manifest` for the SAME
+ * `version` the byte route is told to serve, so manifest and bytes can never
+ * skew.
  *
  * Resolution order mirrors every other platform catalog: exact → dist-tag →
  * semver range (yanked versions visible only to an exact pin). A missing /
@@ -184,22 +175,18 @@ export type McpServerResolution =
  * Unscoped (no orgId filter) — callers already hold an auth context (run token
  * / service-internal call), matching {@link fetchMcpServerManifest}.
  */
-export async function resolveMcpServerForSpawn(
+async function resolvePublishedManifest(
   packageId: string,
+  expectedType: "integration" | "mcp-server",
   pin?: string | null,
-): Promise<McpServerResolution> {
-  // System mcp-servers are loaded once at boot and served from the in-memory
+): Promise<PublishedManifestResolution> {
+  // System packages are loaded once at boot and served from the in-memory
   // registry by id — there is no `package_versions` row to pin against, and the
   // byte route resolves them the same way (issue #588 only concerns
   // separately-versioned local packages).
   const sys = getSystemPackages().get(packageId);
   if (sys) {
-    const parsed = mcpServerManifestSchema.safeParse(sys.manifest);
-    if (!parsed.success) {
-      logger.warn("system mcp-server manifest failed validation", { packageId });
-      return { ok: false, reason: "invalid_manifest" };
-    }
-    return { ok: true, manifest: parsed.data, version: null, source: "system" };
+    return { ok: true, rawManifest: sys.manifest, version: null, source: "system" };
   }
 
   const [pkgRow] = await db
@@ -207,17 +194,8 @@ export async function resolveMcpServerForSpawn(
     .from(packages)
     .where(eq(packages.id, packageId))
     .limit(1);
-  if (!pkgRow) {
-    logger.info("referenced mcp-server package not found", { packageId });
-    return { ok: false, reason: "not_found" };
-  }
-  if (pkgRow.type !== "mcp-server") {
-    logger.warn("referenced package is not an mcp-server", {
-      packageId,
-      actualType: pkgRow.type,
-    });
-    return { ok: false, reason: "not_mcp_server" };
-  }
+  if (!pkgRow) return { ok: false, reason: "not_found" };
+  if (pkgRow.type !== expectedType) return { ok: false, reason: "wrong_type" };
 
   const [versionRows, tagRows] = await Promise.all([
     db
@@ -237,40 +215,233 @@ export async function resolveMcpServerForSpawn(
       .where(eq(packageDistTags.packageId, packageId)),
   ]);
 
-  if (versionRows.length === 0) {
-    logger.warn("referenced mcp-server has no published version", { packageId, pin });
-    return { ok: false, reason: "no_published_version" };
-  }
+  if (versionRows.length === 0) return { ok: false, reason: "no_published_version" };
 
-  // Missing/empty pin → "latest" (the working-copy default; the org run path
-  // treats `source.server.version` as advisory). `pickVersion` applies the
-  // canonical exact → dist-tag → range resolution and the yanked-visibility
-  // rule shared with `DbPackageCatalog`.
+  // Missing/empty pin → "latest". `pickVersion` applies the canonical
+  // exact → dist-tag → range resolution and the yanked-visibility rule shared
+  // with `DbPackageCatalog`.
   const spec = pin && pin.trim().length > 0 ? pin.trim() : "latest";
   const picked = pickVersion(
     spec,
     versionRows.map((v) => ({ version: v.version, integrity: v.integrity, yanked: v.yanked })),
     tagRows,
   );
-  if (!picked) {
-    logger.warn("source.server.version pin could not be satisfied for mcp-server", {
-      packageId,
-      pin: spec,
-      available: versionRows.map((v) => v.version),
-    });
-    return { ok: false, reason: "unsatisfiable_pin" };
-  }
+  if (!picked) return { ok: false, reason: "unsatisfiable_pin" };
 
   const row = versionRows.find((v) => v.version === picked.version);
-  const parsed = mcpServerManifestSchema.safeParse(row?.manifest);
+  return { ok: true, rawManifest: row?.manifest, version: picked.version, source: "version" };
+}
+
+/**
+ * Discriminated failure modes for {@link resolveMcpServerForSpawn}. Mirrors
+ * {@link PublishedManifestFailure} with the mcp-server-specific `not_mcp_server`
+ * name preserved for existing call-site logging.
+ */
+export type McpServerResolveFailure =
+  | "not_found"
+  | "not_mcp_server"
+  | "invalid_manifest"
+  | "unsatisfiable_pin"
+  | "no_published_version";
+
+export type McpServerResolution =
+  | {
+      ok: true;
+      manifest: McpServerManifest;
+      /**
+       * The CONCRETE version the spawn will run. `null` for system
+       * mcp-servers (single version served from the boot registry — no
+       * `package_versions` row, no `?version=` needed on the byte route).
+       */
+      version: string | null;
+      /** `"system"` → boot registry bytes; `"version"` → published `.afps`. */
+      source: "system" | "version";
+    }
+  | { ok: false; reason: McpServerResolveFailure };
+
+/**
+ * Resolve a referenced `mcp-server` package to a CONCRETE version, honoring the
+ * `source.server.version` pin, and return that version's manifest. Thin wrapper
+ * over {@link resolvePublishedManifest} + MCPB schema validation.
+ */
+export async function resolveMcpServerForSpawn(
+  packageId: string,
+  pin?: string | null,
+): Promise<McpServerResolution> {
+  const res = await resolvePublishedManifest(packageId, "mcp-server", pin);
+  if (!res.ok) {
+    const reason: McpServerResolveFailure =
+      res.reason === "wrong_type" ? "not_mcp_server" : res.reason;
+    logger.warn("mcp-server could not be resolved for spawn", { packageId, pin, reason });
+    return { ok: false, reason };
+  }
+  const parsed = mcpServerManifestSchema.safeParse(res.rawManifest);
   if (!parsed.success) {
-    logger.warn("mcp-server version manifest failed validation", {
-      packageId,
-      version: picked.version,
-    });
+    logger.warn("mcp-server manifest failed validation", { packageId, version: res.version });
     return { ok: false, reason: "invalid_manifest" };
   }
-  return { ok: true, manifest: parsed.data, version: picked.version, source: "version" };
+  return { ok: true, manifest: parsed.data, version: res.version, source: res.source };
+}
+
+// ---------------------------------------------------------------------------
+// Integration manifest version resolution (#686)
+// ---------------------------------------------------------------------------
+
+/**
+ * Which concrete source an integration manifest is read from for a run. Frozen
+ * at kickoff (per declared integration) and reused by every later reader so the
+ * spawn spec and the long-lived runtime credential path can never skew.
+ *
+ *   - `draft`   → the mutable working copy (`packages.draft_manifest`) — opted
+ *                 into per-run via `dependency_overrides[id] === "draft"`.
+ *   - `system`  → the in-memory boot registry (system integrations).
+ *   - `version` → a published `package_versions` row (the pinned version).
+ */
+export type SpawnVersionDescriptor =
+  | { kind: "draft" }
+  | { kind: "system" }
+  | { kind: "version"; version: string };
+
+/** Frozen resolution recorded on `runs.resolved_integration_versions`. */
+export interface ResolvedIntegrationVersion {
+  version: string | null;
+  source: "version" | "draft" | "system";
+}
+export type ResolvedIntegrationVersionMap = Record<string, ResolvedIntegrationVersion>;
+
+function descriptorToResolved(d: SpawnVersionDescriptor): ResolvedIntegrationVersion {
+  return d.kind === "version"
+    ? { version: d.version, source: "version" }
+    : { version: null, source: d.kind };
+}
+
+/** Map a frozen snapshot entry back into the descriptor the readers consume. */
+export function resolvedIntegrationVersionToDescriptor(
+  entry: ResolvedIntegrationVersion,
+): SpawnVersionDescriptor {
+  switch (entry.source) {
+    case "draft":
+      return { kind: "draft" };
+    case "system":
+      return { kind: "system" };
+    case "version":
+      // A `version` source always froze a concrete version; fall back to the
+      // latest published only if the snapshot is somehow malformed.
+      return entry.version ? { kind: "version", version: entry.version } : { kind: "draft" };
+  }
+}
+
+/**
+ * Read an integration manifest AT a specific resolved version. The single
+ * manifest reader for a pinned integration — used both when seeding the
+ * kickoff cache and on the runtime credential path (which reads the frozen
+ * descriptor off the run row).
+ */
+export async function readIntegrationManifestAt(
+  packageId: string,
+  descriptor: SpawnVersionDescriptor,
+): Promise<IntegrationManifestLoadResult> {
+  if (descriptor.kind === "draft") return fetchIntegrationManifestUncached(packageId);
+
+  if (descriptor.kind === "system") {
+    const sys = getSystemPackages().get(packageId);
+    if (!sys) return { ok: false, failure: { kind: "not_found" } };
+    const parsed = integrationManifestSchema.safeParse(sys.manifest);
+    if (!parsed.success) return { ok: false, failure: { kind: "invalid_manifest" } };
+    return { ok: true, manifest: parsed.data };
+  }
+
+  const [row] = await db
+    .select({ manifest: packageVersions.manifest })
+    .from(packageVersions)
+    .where(
+      and(
+        eq(packageVersions.packageId, packageId),
+        eq(packageVersions.version, descriptor.version),
+      ),
+    )
+    .limit(1);
+  if (!row) return { ok: false, failure: { kind: "not_found" } };
+  const parsed = integrationManifestSchema.safeParse(row.manifest);
+  if (!parsed.success) return { ok: false, failure: { kind: "invalid_manifest" } };
+  return { ok: true, manifest: parsed.data };
+}
+
+export type RunIntegrationVersionsResult =
+  | { ok: true; versions: ResolvedIntegrationVersionMap }
+  | { ok: false; unresolved: Array<{ name: string; versionSpec: string }> };
+
+/**
+ * Resolve EVERY declared integration to a concrete manifest version for a run,
+ * honoring each `dependencies.integrations.<id>` pin (and any per-run
+ * `dependency_overrides`) against PUBLISHED versions — the integration-axis
+ * sibling of `RunPackageCatalog` (#666) and the connection cascade snapshot
+ * (#199). This is the single point the pin is enforced:
+ *
+ *   - Seeds the shared `manifestCache` with the resolved manifest keyed by
+ *     packageId, so every kickoff reader threading that cache (connection
+ *     cascade, spawn resolver, pin checks) honors the pin with NO per-caller
+ *     change.
+ *   - Returns the frozen `{ version, source }` map to persist on
+ *     `runs.resolved_integration_versions`, which the runtime credential path
+ *     reads back so a mid-run MITM refresh resolves the SAME version.
+ *
+ * An unsatisfiable pin (incl. a never-published dependency) is reported as
+ * `unresolved` so the caller fails loud with a structured `dependency_unresolved`
+ * (422) rather than silently spawning the draft. Soft failures (package
+ * missing / wrong type / invalid manifest) are left unseeded — the spawn
+ * resolver already drops such integrations with a warning, and the runtime
+ * reader falls back to the draft, matching pre-#686 behavior.
+ */
+export async function resolveRunIntegrationVersions(params: {
+  agentManifest: Record<string, unknown>;
+  dependencyOverrides?: Record<string, string> | null;
+  manifestCache?: IntegrationManifestCache;
+}): Promise<RunIntegrationVersionsResult> {
+  const entries = parseManifestIntegrations(params.agentManifest);
+  const versions: ResolvedIntegrationVersionMap = {};
+  const unresolved: Array<{ name: string; versionSpec: string }> = [];
+
+  for (const entry of entries) {
+    const override = params.dependencyOverrides?.[entry.id];
+    let descriptor: SpawnVersionDescriptor;
+
+    if (override === VERSION_SELECTOR_DRAFT) {
+      descriptor = { kind: "draft" };
+    } else {
+      // A non-draft override replaces the manifest pin; otherwise the pin wins.
+      const spec = override ?? entry.version;
+      const res = await resolvePublishedManifest(entry.id, "integration", spec);
+      if (res.ok) {
+        descriptor =
+          res.source === "system" ? { kind: "system" } : { kind: "version", version: res.version! };
+      } else if (res.reason === "unsatisfiable_pin" || res.reason === "no_published_version") {
+        // A real pin that cannot be met — fail loud, never fall back to draft.
+        unresolved.push({ name: entry.id, versionSpec: spec || "*" });
+        continue;
+      } else {
+        // not_found / wrong_type / invalid — soft. Leave the cache unseeded so
+        // the spawn resolver's own miss-handling skips the integration and the
+        // runtime reader falls back to draft (pre-#686 behavior).
+        logger.info("integration version left unresolved; falling back to draft", {
+          integrationId: entry.id,
+          reason: res.reason,
+        });
+        continue;
+      }
+    }
+
+    // Seed the shared per-run manifest cache so every kickoff reader gets the
+    // pinned manifest transparently (one entry per integration, overwriting any
+    // draft entry an earlier readiness pass may have memoized).
+    if (params.manifestCache) {
+      params.manifestCache.set(entry.id, readIntegrationManifestAt(entry.id, descriptor));
+    }
+    versions[entry.id] = descriptorToResolved(descriptor);
+  }
+
+  if (unresolved.length > 0) return { ok: false, unresolved };
+  return { ok: true, versions };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/api/src/services/integration-spawn-resolver.ts
+++ b/apps/api/src/services/integration-spawn-resolver.ts
@@ -152,12 +152,14 @@ async function resolveOne(
   requiredAuthKey: string | undefined,
   manifestCache?: IntegrationManifestCache,
 ): Promise<IntegrationSpawnSpec | null> {
-  // (a) Package exists + integration type — read the latest manifest
-  // straight off `packages.draft_manifest`. System integrations have
-  // `source = 'system'`; org integrations have `org_id` set to the
-  // run's org. The runtime never resolves against a yanked version —
-  // we always use the package's draft manifest, which the publish path
-  // keeps pinned to the live "latest" snapshot.
+  // (a) Package exists + integration type. The manifest is read through the
+  // per-run `manifestCache`, which `resolveRunIntegrationVersions` seeds at
+  // kickoff (#686) with the manifest AT the version the
+  // `dependencies.integrations.<id>` pin resolved to (published / system /
+  // draft-override). So this read honors the pin transparently; only when no
+  // entry was seeded (soft-resolved or non-run callers) does it fall back to
+  // `packages.draft_manifest`. An unsatisfiable integration pin already failed
+  // the run loud upstream, before we get here.
   const res = await fetchIntegrationManifest(integrationId, manifestCache);
   if (!res.ok) {
     switch (res.failure.kind) {

--- a/apps/api/src/services/integration-spawn-resolver.ts
+++ b/apps/api/src/services/integration-spawn-resolver.ts
@@ -49,6 +49,7 @@ import {
 } from "@appstrate/core/mcp-server";
 import type { IntegrationSpawnSpec, ApiCallSpec } from "@appstrate/core/sidecar-types";
 
+import { BundleError } from "@appstrate/afps-runtime/bundle";
 import { logger } from "../lib/logger.ts";
 import type { Actor } from "../lib/actor.ts";
 import { isIntegrationActive, selectAccessibleConnection } from "./integration-connections.ts";
@@ -125,6 +126,13 @@ export async function resolveIntegrationSpawns(
       );
       if (spec) out.push(spec);
     } catch (err) {
+      // An unsatisfiable referenced-mcp-server pin is a hard failure: the run
+      // must NOT silently spawn without the integration's tools. resolveOne
+      // raises a DEPENDENCY_UNRESOLVED BundleError for it; let it propagate so
+      // the pipeline maps it to a structured 422 (#686), matching the skill
+      // closure (#666). Every other failure (not installed / not connected /
+      // missing referenced package) stays a per-integration warn-and-skip.
+      if (err instanceof BundleError && err.code === "DEPENDENCY_UNRESOLVED") throw err;
       logger.warn("integration resolve failed; skipping", {
         integrationId: entry.id,
         applicationId,
@@ -272,6 +280,22 @@ async function resolveOne(
     // whatever bytes happen to be latest.
     const resolution = await resolveMcpServerForSpawn(ref.name, ref.version);
     if (!resolution.ok) {
+      // A real `source.server.version` pin that cannot be met (unsatisfiable
+      // range / never-published) fails the run LOUDLY (#686) — a pinned run
+      // must never silently spawn without the integration. A
+      // missing/wrong/invalid referenced package stays a soft skip: the
+      // integration is mis-declared, not the run's pin, so the run proceeds
+      // without it (the sidecar surfaces the gap from its side too).
+      if (
+        resolution.reason === "unsatisfiable_pin" ||
+        resolution.reason === "no_published_version"
+      ) {
+        throw new BundleError(
+          "DEPENDENCY_UNRESOLVED",
+          `Referenced mcp-server '${ref.name}@${ref.version ?? "latest"}' could not be resolved against published versions (${resolution.reason})`,
+          { missing: [{ name: ref.name, versionSpec: ref.version ?? "latest" }] },
+        );
+      }
       logger.warn("referenced mcp-server could not be resolved; skipping integration", {
         integrationId,
         mcpServerId: ref.name,

--- a/apps/api/src/services/run-creation.ts
+++ b/apps/api/src/services/run-creation.ts
@@ -22,9 +22,14 @@ import { getEnv } from "@appstrate/env";
 import { mintSinkCredentials, type SinkCredentials } from "../lib/mint-sink-credentials.ts";
 import type { LoadedPackage } from "../types/index.ts";
 import type { Actor } from "../lib/actor.ts";
-import { extractRunAgentDenorm } from "./run-pipeline.ts";
+import { extractRunAgentDenorm, freezeRunSpawnDependencies } from "./run-pipeline.ts";
 import { validateAgentReadiness } from "./agent-readiness.ts";
 import { resolveRunConnectionsOrError } from "./integration-connection-resolver.ts";
+import {
+  type IntegrationManifestCache,
+  type ResolvedIntegrationVersionMap,
+} from "./integration-service.ts";
+import { ApiError } from "../lib/errors.ts";
 import type { ResolvedConnectionMap } from "@appstrate/core/integration";
 import { createRun as createRunRow } from "./state/runs.ts";
 import { runPreflightGates } from "./run-preflight-gates.ts";
@@ -64,6 +69,13 @@ export interface CreateRunInput {
    * persisted on `runs.connection_overrides` for audit + replay.
    */
   connectionOverrides?: Record<string, string> | null;
+  /**
+   * Per-dependency version overrides for THIS run (#666/#686). `"draft"` opts a
+   * declared skill/integration into its working copy; any other value replaces
+   * the manifest pin. Persisted on `runs.dependency_overrides` and enforced by
+   * `freezeRunSpawnDependencies` — an unsatisfiable pin aborts the run.
+   */
+  dependencyOverrides?: Record<string, string> | null;
   /** Client-requested sink TTL. */
   sink?: SinkRequest;
   /** CLI-provided execution environment metadata (os, cli version, git sha, ...). */
@@ -140,6 +152,30 @@ export async function createRun(input: CreateRunInput): Promise<CreateRunResult>
   if (!gates.ok) return { ok: false, error: gates.error };
   const { agent } = gates;
 
+  // --- Freeze integration manifest versions (#686, remote-path mirror of
+  //     run-pipeline Step 2a). MUST run before the connection cascade so the
+  //     cascade reads the pinned manifests, and before the row insert so the
+  //     frozen map persists — the runtime credential path (origin-agnostic,
+  //     served the same to remote runs) reads it back. Without this a remote
+  //     run silently served the mutable draft and never failed loud on an
+  //     unsatisfiable pin. A shared `manifestCache` dedupes the cascade reads.
+  const manifestCache: IntegrationManifestCache = new Map();
+  let resolvedIntegrationVersions: ResolvedIntegrationVersionMap;
+  try {
+    resolvedIntegrationVersions = await freezeRunSpawnDependencies({
+      agent,
+      dependencyOverrides: input.dependencyOverrides ?? null,
+      manifestCache,
+    });
+  } catch (err) {
+    // Remote callers get a flat error they can surface verbatim. Preserve the
+    // ApiError's code/status (invalid_request 400 / dependency_unresolved 422).
+    if (err instanceof ApiError) {
+      return { ok: false, error: { code: err.code, message: err.message, status: err.status } };
+    }
+    throw err;
+  }
+
   // --- Snapshot the connection cascade (#199, remote-path mirror of
   //     run-pipeline). Readiness above ran with the same overrides, so a
   //     failure here is either the caller's pick pointing at an inaccessible
@@ -157,6 +193,9 @@ export async function createRun(input: CreateRunInput): Promise<CreateRunResult>
       // Remote runs are never scheduled, so there is no frozen schedule
       // override on this path (mechanism #3 applies to platform runs only).
       scheduleOverrides: null,
+      // Reads the pinned manifests frozen just above (auth keys / scopes match
+      // what the spawn will use).
+      manifestCache,
     });
     if (!outcome.ok) {
       // Remote runners get a flat `agent_not_ready` they can surface verbatim
@@ -207,6 +246,8 @@ export async function createRun(input: CreateRunInput): Promise<CreateRunResult>
       sinkExpiresAt: new Date(credentials.expiresAt),
       connectionOverrides: input.connectionOverrides ?? null,
       resolvedConnections,
+      dependencyOverrides: input.dependencyOverrides ?? null,
+      resolvedIntegrationVersions,
       ...(overrideVersionLabel ? { versionLabel: overrideVersionLabel } : {}),
       ...(contextSnapshot !== undefined ? { contextSnapshot } : {}),
       runnerName: input.runnerName ?? null,

--- a/apps/api/src/services/run-pipeline.ts
+++ b/apps/api/src/services/run-pipeline.ts
@@ -22,10 +22,9 @@ import {
   type IntegrationManifestCache,
   type ResolvedIntegrationVersionMap,
 } from "./integration-service.ts";
-import { parseManifestIntegrations } from "@appstrate/core/dependencies";
+import { collectOverridableDependencyIds } from "@appstrate/core/dependencies";
 import type { ConnectionOverrides, ResolvedConnectionMap } from "@appstrate/core/integration";
 import { parseScopedName } from "@appstrate/core/naming";
-import { extractSkillIdsFromManifest } from "../lib/manifest-utils.ts";
 import { mintSinkCredentials } from "../lib/mint-sink-credentials.ts";
 import { encrypt } from "@appstrate/connect";
 import { getEnv } from "@appstrate/env";
@@ -201,6 +200,70 @@ export async function resolveRunPreflight(params: {
 }
 
 // ---------------------------------------------------------------------------
+// Spawn-dependency freeze (#686) — shared across origins
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate `dependency_overrides` keys and freeze every declared integration's
+ * manifest version against PUBLISHED versions honoring its pin (+ overrides).
+ *
+ * The single point the integration pin is enforced for a run, shared by EVERY
+ * origin — platform (`prepareAndExecuteRun`), scheduled (same), and remote
+ * (`run-creation.createRun`). Extracting it is what closes the remote-origin
+ * gap: before, only the platform path froze versions, so a remote run silently
+ * served the mutable draft on the credential path (the exact #686 bug class on
+ * a different origin).
+ *
+ *   - Rejects an override KEY that names no declared skill/integration with a
+ *     400 (the "fails silently on the key axis" trap the value gate can't see).
+ *   - Seeds the shared `manifestCache` (when given) so every kickoff reader
+ *     threading it honors the pin with no per-caller change.
+ *   - Throws a structured `dependency_unresolved` (422) on an unsatisfiable /
+ *     never-published pin — never a silent draft fallback.
+ *
+ * Returns the frozen `{ version, source }` map to persist on
+ * `runs.resolved_integration_versions`.
+ */
+export async function freezeRunSpawnDependencies(params: {
+  agent: LoadedPackage;
+  dependencyOverrides?: Record<string, string> | null;
+  manifestCache?: IntegrationManifestCache;
+}): Promise<ResolvedIntegrationVersionMap> {
+  if (params.dependencyOverrides) {
+    const declaredDeps = collectOverridableDependencyIds(
+      params.agent.manifest as Record<string, unknown>,
+    );
+    const unknownKey = Object.keys(params.dependencyOverrides).find(
+      (key) => !declaredDeps.has(key),
+    );
+    if (unknownKey) {
+      throw new ApiError({
+        status: 400,
+        code: "invalid_request",
+        title: "Bad Request",
+        detail: `\`dependency_overrides["${unknownKey}"]\` is not a declared skill or integration dependency of this agent`,
+      });
+    }
+  }
+
+  const resolved = await resolveRunIntegrationVersions({
+    agentManifest: params.agent.manifest as Record<string, unknown>,
+    dependencyOverrides: params.dependencyOverrides ?? null,
+    manifestCache: params.manifestCache,
+  });
+  if (!resolved.ok) {
+    const list = resolved.unresolved.map((m) => `'${m.name}@${m.versionSpec}'`).join(", ");
+    throw new ApiError({
+      status: 422,
+      code: "dependency_unresolved",
+      title: "Dependency Unresolved",
+      detail: `Could not resolve ${list} against published versions — publish the integration, fix the pin, or pass \`dependency_overrides\` to run a working copy.`,
+    });
+  }
+  return resolved.versions;
+}
+
+// ---------------------------------------------------------------------------
 // Pipeline
 // ---------------------------------------------------------------------------
 
@@ -249,59 +312,22 @@ export async function prepareAndExecuteRun(params: RunPipelineParams): Promise<R
   }
   const { agent } = gates;
 
-  // Reject `dependency_overrides` keys that name a package the agent does not
-  // declare as a dependency (#666/#686). The run-route value gate only checks
-  // each override VALUE; an override KEY that isn't a declared dependency is
-  // never consulted by the resolution and would silently do nothing — the exact
-  // "fails silently" trap the value gate exists to avoid, on the key axis. The
-  // manifest isn't in scope at parse time, so the key check lives here (the
-  // first point with both the parsed overrides and the agent). Bundled skills
-  // (`buildAgentPackage`) AND spawned integrations (`resolveRunIntegrationVersions`)
-  // both honor overrides, so both id sets are valid keys.
-  if (params.dependencyOverrides) {
-    const declaredDeps = new Set<string>(extractSkillIdsFromManifest(agent.manifest));
-    for (const entry of parseManifestIntegrations(agent.manifest as Record<string, unknown>)) {
-      declaredDeps.add(entry.id);
-    }
-    const unknownKey = Object.keys(params.dependencyOverrides).find(
-      (key) => !declaredDeps.has(key),
-    );
-    if (unknownKey) {
-      throw new ApiError({
-        status: 400,
-        code: "invalid_request",
-        title: "Bad Request",
-        detail: `\`dependency_overrides["${unknownKey}"]\` is not a declared skill or integration dependency of this agent`,
-      });
-    }
-  }
-
   // --- Step 2a: Integration manifest version snapshot (#686) ---
   //
-  // Resolve every declared integration's manifest version against PUBLISHED
-  // versions honoring its `dependencies.integrations.<id>` pin (+ any
-  // `dependency_overrides`), BEFORE the connection cascade and the spawn
-  // resolver run. Seeding the shared `manifestCache` makes both honor the pin
-  // transparently; the frozen map is persisted so the runtime credential path
-  // resolves the SAME version. An unsatisfiable pin fails loud here (422),
-  // never a silent draft spawn — the integration-axis mirror of #666.
-  const integrationVersions = await resolveRunIntegrationVersions({
-    agentManifest: agent.manifest as Record<string, unknown>,
-    dependencyOverrides: params.dependencyOverrides ?? null,
-    manifestCache,
-  });
-  if (!integrationVersions.ok) {
-    const list = integrationVersions.unresolved
-      .map((m) => `'${m.name}@${m.versionSpec}'`)
-      .join(", ");
-    throw new ApiError({
-      status: 422,
-      code: "dependency_unresolved",
-      title: "Dependency Unresolved",
-      detail: `Could not resolve ${list} against published versions — publish the integration, fix the pin, or pass \`dependency_overrides\` to run a working copy.`,
+  // Validate `dependency_overrides` keys and freeze every declared
+  // integration's manifest version against PUBLISHED versions honoring its
+  // `dependencies.integrations.<id>` pin (+ any `dependency_overrides`), BEFORE
+  // the connection cascade and the spawn resolver run. Seeding the shared
+  // `manifestCache` makes both honor the pin transparently; the frozen map is
+  // persisted so the runtime credential path resolves the SAME version. An
+  // unsatisfiable pin fails loud (422), never a silent draft spawn. Shared with
+  // the remote origin (`run-creation.ts`) via `freezeRunSpawnDependencies`.
+  const resolvedIntegrationVersions: ResolvedIntegrationVersionMap =
+    await freezeRunSpawnDependencies({
+      agent,
+      dependencyOverrides: params.dependencyOverrides ?? null,
+      manifestCache,
     });
-  }
-  const resolvedIntegrationVersions: ResolvedIntegrationVersionMap = integrationVersions.versions;
 
   // --- Step 2b: Connection resolution snapshot (#199) ---
   //

--- a/apps/api/src/services/run-pipeline.ts
+++ b/apps/api/src/services/run-pipeline.ts
@@ -17,7 +17,12 @@ import { getPackageConfig } from "./application-packages.ts";
 import { executeAgentInBackground } from "./run-launcher/execute-background.ts";
 import { validateAgentReadiness } from "./agent-readiness.ts";
 import { resolveRunConnectionsOrError } from "./integration-connection-resolver.ts";
-import type { IntegrationManifestCache } from "./integration-service.ts";
+import {
+  resolveRunIntegrationVersions,
+  type IntegrationManifestCache,
+  type ResolvedIntegrationVersionMap,
+} from "./integration-service.ts";
+import { parseManifestIntegrations } from "@appstrate/core/dependencies";
 import type { ConnectionOverrides, ResolvedConnectionMap } from "@appstrate/core/integration";
 import { parseScopedName } from "@appstrate/core/naming";
 import { extractSkillIdsFromManifest } from "../lib/manifest-utils.ts";
@@ -245,29 +250,60 @@ export async function prepareAndExecuteRun(params: RunPipelineParams): Promise<R
   const { agent } = gates;
 
   // Reject `dependency_overrides` keys that name a package the agent does not
-  // declare as a skill dependency (#666). The run-route value gate only checks
-  // each override VALUE; an override KEY that isn't in `dependencies.skills` is
-  // never consulted by the closure walk and would silently do nothing — the
-  // exact "fails silently" trap the value gate exists to avoid, on the key
-  // axis. The manifest isn't in scope at parse time, so the key check lives
-  // here (the first point with both the parsed overrides and the agent). Skills
-  // are the only bundled dependency type, matching `buildAgentPackage`.
+  // declare as a dependency (#666/#686). The run-route value gate only checks
+  // each override VALUE; an override KEY that isn't a declared dependency is
+  // never consulted by the resolution and would silently do nothing — the exact
+  // "fails silently" trap the value gate exists to avoid, on the key axis. The
+  // manifest isn't in scope at parse time, so the key check lives here (the
+  // first point with both the parsed overrides and the agent). Bundled skills
+  // (`buildAgentPackage`) AND spawned integrations (`resolveRunIntegrationVersions`)
+  // both honor overrides, so both id sets are valid keys.
   if (params.dependencyOverrides) {
-    const declaredSkills = new Set(extractSkillIdsFromManifest(agent.manifest));
+    const declaredDeps = new Set<string>(extractSkillIdsFromManifest(agent.manifest));
+    for (const entry of parseManifestIntegrations(agent.manifest as Record<string, unknown>)) {
+      declaredDeps.add(entry.id);
+    }
     const unknownKey = Object.keys(params.dependencyOverrides).find(
-      (key) => !declaredSkills.has(key),
+      (key) => !declaredDeps.has(key),
     );
     if (unknownKey) {
       throw new ApiError({
         status: 400,
         code: "invalid_request",
         title: "Bad Request",
-        detail: `\`dependency_overrides["${unknownKey}"]\` is not a declared skill dependency of this agent`,
+        detail: `\`dependency_overrides["${unknownKey}"]\` is not a declared skill or integration dependency of this agent`,
       });
     }
   }
 
-  // --- Step 2: Connection resolution snapshot (#199) ---
+  // --- Step 2a: Integration manifest version snapshot (#686) ---
+  //
+  // Resolve every declared integration's manifest version against PUBLISHED
+  // versions honoring its `dependencies.integrations.<id>` pin (+ any
+  // `dependency_overrides`), BEFORE the connection cascade and the spawn
+  // resolver run. Seeding the shared `manifestCache` makes both honor the pin
+  // transparently; the frozen map is persisted so the runtime credential path
+  // resolves the SAME version. An unsatisfiable pin fails loud here (422),
+  // never a silent draft spawn — the integration-axis mirror of #666.
+  const integrationVersions = await resolveRunIntegrationVersions({
+    agentManifest: agent.manifest as Record<string, unknown>,
+    dependencyOverrides: params.dependencyOverrides ?? null,
+    manifestCache,
+  });
+  if (!integrationVersions.ok) {
+    const list = integrationVersions.unresolved
+      .map((m) => `'${m.name}@${m.versionSpec}'`)
+      .join(", ");
+    throw new ApiError({
+      status: 422,
+      code: "dependency_unresolved",
+      title: "Dependency Unresolved",
+      detail: `Could not resolve ${list} against published versions — publish the integration, fix the pin, or pass \`dependency_overrides\` to run a working copy.`,
+    });
+  }
+  const resolvedIntegrationVersions: ResolvedIntegrationVersionMap = integrationVersions.versions;
+
+  // --- Step 2b: Connection resolution snapshot (#199) ---
   //
   // Apply the 4-mechanism cascade once at kickoff so:
   //  - the spawn loader (run-context-builder) pins the same row admin/run intended,
@@ -280,7 +316,8 @@ export async function prepareAndExecuteRun(params: RunPipelineParams): Promise<R
   // state — any error here is hard 412: either the override points at an
   // invalid id (caller's mistake), or a race after readiness mutated DB
   // state (connection deleted / pin shifted). Either way the caller
-  // needs structured feedback, not a silent fallback.
+  // needs structured feedback, not a silent fallback. The cascade reads the
+  // pinned manifests seeded by Step 2a (auth keys / scopes match the spawn).
   let resolvedConnections: ResolvedConnectionMap | null = null;
   if (actor) {
     const outcome = await resolveRunConnectionsOrError({
@@ -424,6 +461,7 @@ export async function prepareAndExecuteRun(params: RunPipelineParams): Promise<R
       sinkExpiresAt: new Date(sinkCredentials.expiresAt),
       connectionOverrides: params.connectionOverrides ?? null,
       resolvedConnections,
+      resolvedIntegrationVersions,
       runnerName: params.runnerName ?? null,
       runnerKind: params.runnerKind ?? null,
       modelCredentialId: plan.llmConfig.credentialId ?? null,

--- a/apps/api/src/services/scheduler.ts
+++ b/apps/api/src/services/scheduler.ts
@@ -58,6 +58,13 @@ interface ScheduleJobData {
    * with the scheduler's intent. Loses to admin pins.
    */
   connectionOverrides?: Record<string, string>;
+  /**
+   * Frozen per-dependency version overrides (#666/#686). Loaded from
+   * `package_schedules.dependency_overrides`, forwarded into
+   * `runs.dependency_overrides` at fire time so a scheduled run resolves its
+   * skill / integration dependencies exactly as the schedule froze them.
+   */
+  dependencyOverrides?: Record<string, string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -87,6 +94,7 @@ function toSchedule(row: typeof schedules.$inferSelect): ScheduleWireDto {
     proxy_id_override: row.proxyIdOverride,
     version_override: row.versionOverride,
     connection_overrides: (row.connectionOverrides as Record<string, string> | null) ?? null,
+    dependency_overrides: (row.dependencyOverrides as Record<string, string> | null) ?? null,
     last_run_at: row.lastRunAt ? row.lastRunAt.toISOString() : null,
     next_run_at: row.nextRunAt ? row.nextRunAt.toISOString() : null,
     createdAt: row.createdAt!.toISOString(),
@@ -124,6 +132,7 @@ async function upsertScheduleJob(schedule: ScheduleWireDto, orgId: string): Prom
     proxyIdOverride: schedule.proxy_id_override ?? undefined,
     versionOverride: schedule.version_override ?? undefined,
     connectionOverrides: schedule.connection_overrides ?? undefined,
+    dependencyOverrides: schedule.dependency_overrides ?? undefined,
   };
 
   await (
@@ -155,6 +164,7 @@ async function handleScheduleJob(job: QueueJob<ScheduleJobData>): Promise<void> 
     proxyIdOverride,
     versionOverride,
     connectionOverrides,
+    dependencyOverrides,
   } = job.data;
 
   await triggerScheduledRun(
@@ -164,7 +174,14 @@ async function handleScheduleJob(job: QueueJob<ScheduleJobData>): Promise<void> 
     orgId,
     applicationId,
     input,
-    { configOverride, modelIdOverride, proxyIdOverride, versionOverride, connectionOverrides },
+    {
+      configOverride,
+      modelIdOverride,
+      proxyIdOverride,
+      versionOverride,
+      connectionOverrides,
+      dependencyOverrides,
+    },
   );
 
   // Update schedule timestamps
@@ -265,6 +282,7 @@ export async function triggerScheduledRun(
     proxyIdOverride?: string;
     versionOverride?: string;
     connectionOverrides?: Record<string, string>;
+    dependencyOverrides?: Record<string, string>;
   } = {},
 ) {
   // Populated once the agent loads so every failSchedule() call can
@@ -439,6 +457,7 @@ export async function triggerScheduledRun(
         scheduleId,
         applicationId,
         scheduleConnectionOverrides: overrides.connectionOverrides ?? null,
+        dependencyOverrides: overrides.dependencyOverrides ?? null,
       });
     } catch (err) {
       if (err instanceof ApiError) {
@@ -576,6 +595,7 @@ export async function createSchedule(
     proxyIdOverride?: string | null;
     versionOverride?: string | null;
     connectionOverrides?: Record<string, string> | null;
+    dependencyOverrides?: Record<string, string> | null;
   },
 ): Promise<EnrichedSchedule> {
   const id = `sched_${crypto.randomUUID()}`;
@@ -603,6 +623,7 @@ export async function createSchedule(
       proxyIdOverride: data.proxyIdOverride ?? null,
       versionOverride: data.versionOverride ?? null,
       connectionOverrides: data.connectionOverrides ?? null,
+      dependencyOverrides: data.dependencyOverrides ?? null,
       nextRunAt: nextRun ?? null,
     })
     .returning();
@@ -634,6 +655,7 @@ export async function updateSchedule(
     proxyIdOverride?: string | null;
     versionOverride?: string | null;
     connectionOverrides?: Record<string, string> | null;
+    dependencyOverrides?: Record<string, string> | null;
   },
 ): Promise<EnrichedSchedule | null> {
   const existing = await getSchedule(id, scope);
@@ -662,6 +684,8 @@ export async function updateSchedule(
   if (data.versionOverride !== undefined) payload.versionOverride = data.versionOverride;
   if (data.connectionOverrides !== undefined)
     payload.connectionOverrides = data.connectionOverrides;
+  if (data.dependencyOverrides !== undefined)
+    payload.dependencyOverrides = data.dependencyOverrides;
 
   const [row] = await db
     .update(schedules)

--- a/apps/api/src/services/state/runs.ts
+++ b/apps/api/src/services/state/runs.ts
@@ -355,6 +355,15 @@ interface CreateRunParams {
     { connectionId: string; source: string; label?: string | null; accountId?: string | null }
   > | null;
   /**
+   * Snapshot of each declared integration's resolved manifest version at
+   * kickoff (#686). Persisted on `runs.resolved_integration_versions` so the
+   * runtime credential path reads the SAME version the spawn resolver used.
+   */
+  resolvedIntegrationVersions?: Record<
+    string,
+    { version: string | null; source: "version" | "draft" | "system" }
+  > | null;
+  /**
    * `model_provider_credentials.id` snapshotted at run creation. Pinned
    * here so the OAuth model token resolver can reject any other
    * credentialId requested via the run's signed token. Set only for
@@ -406,6 +415,9 @@ export async function createRun(scope: AppScope, params: CreateRunParams): Promi
       : {}),
     ...(params.resolvedConnections !== undefined
       ? { resolvedConnections: params.resolvedConnections }
+      : {}),
+    ...(params.resolvedIntegrationVersions !== undefined
+      ? { resolvedIntegrationVersions: params.resolvedIntegrationVersions }
       : {}),
   });
 }

--- a/apps/api/test/integration/routes/runs-remote-registry.test.ts
+++ b/apps/api/test/integration/routes/runs-remote-registry.test.ts
@@ -299,6 +299,97 @@ describe("POST /api/runs/remote — kind: registry", () => {
     expect(body.code).toBe("draft_with_spec");
   });
 
+  it("rejects a dependency_overrides key the agent does not declare (400)", async () => {
+    await seedPublishedAgent(ctx, "1.2.3");
+
+    const res = await post({
+      source: { kind: "registry", packageId: "@acme/briefing", stage: "published", spec: "1.2.3" },
+      applicationId: ctx.defaultAppId,
+      input: {},
+      // Mirrors the platform run route: the freeze KEY gate runs on remote too.
+      dependency_overrides: { "@acme/not-a-dep": "draft" },
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a malformed dependency_overrides value (400)", async () => {
+    await seedPublishedAgent(ctx, "1.2.3");
+
+    const res = await post({
+      source: { kind: "registry", packageId: "@acme/briefing", stage: "published", spec: "1.2.3" },
+      applicationId: ctx.defaultAppId,
+      input: {},
+      dependency_overrides: { "@acme/briefing": "not a version!!" },
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("forwards a declared dependency_overrides onto the run row", async () => {
+    // Skill the agent depends on — must exist + be installed so readiness
+    // passes and the run reaches the dependency-freeze + row insert.
+    await seedPackage({
+      orgId: ctx.orgId,
+      id: "@acme/helper",
+      type: "skill",
+      draftManifest: {
+        name: "@acme/helper",
+        display_name: "Helper",
+        version: "1.0.0",
+        type: "skill",
+        schema_version: "0.1",
+        author: "tester",
+      } as unknown as Record<string, unknown>,
+      draftContent: "helper",
+    });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, "@acme/helper");
+
+    // Agent declaring a skill dependency — its id is a valid override KEY.
+    const manifest = {
+      name: "@acme/briefing",
+      display_name: "Briefing Agent",
+      version: "2.0.0",
+      type: "agent",
+      description: "Test agent",
+      schema_version: "0.1",
+      author: "tester",
+      timeout: 300,
+      dependencies: { skills: { "@acme/helper": "^1.0.0" }, mcp_servers: {}, integrations: {} },
+    } as unknown as Record<string, unknown>;
+    await seedPackage({
+      orgId: ctx.orgId,
+      id: "@acme/briefing",
+      type: "agent",
+      draftManifest: manifest,
+      draftContent: PROMPT,
+    });
+    const versionRow = await seedPackageVersion({
+      packageId: "@acme/briefing",
+      version: "2.0.0",
+      integrity: "sha256-test",
+      artifactSize: 1024,
+      manifest,
+    });
+    await db
+      .insert(packageDistTags)
+      .values({ packageId: "@acme/briefing", tag: "latest", versionId: versionRow.id });
+    await uploadPackageZip("@acme/briefing", "2.0.0", buildMinimalZip(manifest, PROMPT));
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, "@acme/briefing");
+
+    const res = await post({
+      source: { kind: "registry", packageId: "@acme/briefing", stage: "published", spec: "2.0.0" },
+      applicationId: ctx.defaultAppId,
+      input: {},
+      dependency_overrides: { "@acme/helper": "draft" },
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { id: string };
+    const [run] = await db.select().from(runs).where(eq(runs.id, body.id)).limit(1);
+    expect(run!.dependencyOverrides).toEqual({ "@acme/helper": "draft" });
+  });
+
   it("accepts an integrity hint without rejecting on drift", async () => {
     await seedPublishedAgent(ctx, "1.2.3");
     const res = await post({

--- a/apps/api/test/integration/services/integration-spawn-resolver-version-pin.test.ts
+++ b/apps/api/test/integration/services/integration-spawn-resolver-version-pin.test.ts
@@ -19,8 +19,10 @@
  *   - pin honored: a `^1.0.0` pin resolves to the highest matching version and
  *     EXCLUDES a newer out-of-range version (2.0.0), even though it is latest.
  *   - manifest follows the resolved version, NOT the draft (distinct entry_point).
- *   - unsatisfiable pin → integration skipped (loud), not silently run on stale bytes.
- *   - no published version → integration skipped (unrunnable; byte route 404s).
+ *   - unsatisfiable pin → run fails loud (`DEPENDENCY_UNRESOLVED`), never a
+ *     silent degrade (#686 tightened this from the old warn-and-skip).
+ *   - no published version → same loud failure (unrunnable byte route would
+ *     otherwise 404 mid-run).
  *   - incident regression: publishing a new in-range version makes the run pick
  *     it up WITHOUT overwriting the draft.
  */
@@ -160,8 +162,10 @@ describe("resolveIntegrationSpawns — source.server.version pin (#588)", () => 
     expect(server.entry_point).toBe("./v1_5.js");
   });
 
-  it("skips the integration when the pin cannot be satisfied (no silent stale bytes)", async () => {
-    // Integration pins `^3.0.0`; only 1.0.0 is published → unsatisfiable.
+  it("fails loud when the server pin cannot be satisfied (no silent degrade, #686)", async () => {
+    // Integration pins `^3.0.0`; only 1.0.0 is published → unsatisfiable. The
+    // run must abort with DEPENDENCY_UNRESOLVED, never spawn without the
+    // integration's tools.
     await seedPackage({
       id: INTEG,
       orgId: ctx.orgId,
@@ -180,11 +184,10 @@ describe("resolveIntegrationSpawns — source.server.version pin (#588)", () => 
     await seedServerVersion("1.0.0", "./v1.js");
     await seedConnection(ctx);
 
-    const specs = await resolve(ctx);
-    expect(specs.length).toBe(0);
+    expect(resolve(ctx)).rejects.toMatchObject({ code: "DEPENDENCY_UNRESOLVED" });
   });
 
-  it("skips the integration when the mcp-server has no published version", async () => {
+  it("fails loud when the mcp-server has no published version (#686)", async () => {
     await seedPackage({
       id: INTEG,
       orgId: ctx.orgId,
@@ -203,8 +206,7 @@ describe("resolveIntegrationSpawns — source.server.version pin (#588)", () => 
     // No seedPackageVersion → draft-only, unrunnable.
     await seedConnection(ctx);
 
-    const specs = await resolve(ctx);
-    expect(specs.length).toBe(0);
+    expect(resolve(ctx)).rejects.toMatchObject({ code: "DEPENDENCY_UNRESOLVED" });
   });
 
   it("regression: publishing a new in-range version is picked up WITHOUT overwriting the draft", async () => {

--- a/apps/api/test/integration/services/integration-version-pin.test.ts
+++ b/apps/api/test/integration/services/integration-version-pin.test.ts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration manifest version resolution on the run path (issue #686).
+ *
+ * `resolveRunIntegrationVersions` resolves every declared integration's
+ * manifest against PUBLISHED versions honoring its `dependencies.integrations.<id>`
+ * pin (and per-run `dependency_overrides`), the integration-axis mirror of the
+ * skill closure fix (#666) and `resolveMcpServerForSpawn` (#588). It:
+ *   - seeds the shared manifest cache with the PINNED manifest so every kickoff
+ *     reader (connection cascade, spawn resolver) honors the pin transparently,
+ *   - returns the frozen `{ version, source }` map persisted on the run row,
+ *   - fails loud (`unresolved`) on an unsatisfiable / never-published pin
+ *     instead of silently falling back to the mutable draft.
+ *
+ * `readIntegrationManifestAt` is the single manifest reader used both when
+ * seeding the cache and on the runtime credential path, so a mid-run MITM
+ * refresh reads the SAME version the spawn used. This suite locks both.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+
+import {
+  resolveRunIntegrationVersions,
+  readIntegrationManifestAt,
+  resolvedIntegrationVersionToDescriptor,
+  type IntegrationManifestCache,
+} from "../../../src/services/integration-service.ts";
+import { truncateAll } from "../../helpers/db.ts";
+import { createTestContext, type TestContext } from "../../helpers/auth.ts";
+import { seedPackage, seedPackageVersion } from "../../helpers/seed.ts";
+import { localIntegrationManifest } from "../../helpers/integration-manifests.ts";
+
+const INTEG = "@pinorg/integ";
+const SERVER = "@pinorg/server";
+
+/** A valid integration manifest stamped with `version` so a test can prove
+ *  WHICH version's manifest was read (published vs the draft marker). */
+function integManifest(version: string) {
+  return localIntegrationManifest({
+    name: INTEG,
+    version,
+    serverName: SERVER,
+    auths: {
+      key: {
+        type: "api_key",
+        authorizedUris: ["https://api.example.com/**"],
+        credentialFields: ["api_key"],
+        delivery: { env: { API_KEY: { value: "{$credential.api_key}", sensitive: true } } },
+      },
+    },
+    tools_policy: { search: {} },
+  });
+}
+
+/** Agent declaring INTEG at `pin`. */
+function agentManifest(pin: string): Record<string, unknown> {
+  return {
+    schema_version: "0.2",
+    type: "agent",
+    name: "@pinorg/agent",
+    version: "1.0.0",
+    display_name: "Agent",
+    dependencies: { integrations: { [INTEG]: pin } },
+    integrations_configuration: { [INTEG]: { tools: ["search"] } },
+  };
+}
+
+/** Seed the integration package with a DRAFT manifest carrying a sentinel
+ *  version (9.9.9) that no published version uses — any reader that returns
+ *  9.9.9 read the draft, not the pinned published version. */
+async function seedDraft(ctx: TestContext) {
+  await seedPackage({
+    id: INTEG,
+    orgId: ctx.orgId,
+    type: "integration",
+    source: "local",
+    draftManifest: integManifest("9.9.9"),
+  });
+}
+
+async function seedPublished(version: string) {
+  await seedPackageVersion({
+    packageId: INTEG,
+    version,
+    manifest: integManifest(version),
+  });
+}
+
+describe("resolveRunIntegrationVersions — integration manifest pin (#686)", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "pinorg" });
+  });
+
+  it("resolves the pin to the highest in-range published version, NOT the draft", async () => {
+    await seedDraft(ctx);
+    await seedPublished("1.0.0");
+    await seedPublished("1.5.0");
+    await seedPublished("2.0.0"); // out of `^1.0.0` range
+
+    const cache: IntegrationManifestCache = new Map();
+    const res = await resolveRunIntegrationVersions({
+      agentManifest: agentManifest("^1.0.0"),
+      manifestCache: cache,
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    // Highest satisfying `^1.0.0` is 1.5.0 — never 2.0.0 (latest) or 9.9.9 (draft).
+    expect(res.versions[INTEG]).toEqual({ version: "1.5.0", source: "version" });
+
+    // The shared cache is seeded with the PUBLISHED manifest, so every kickoff
+    // reader threading it (connection cascade, spawn resolver) gets the pin.
+    const cached = await cache.get(INTEG);
+    expect(cached?.ok).toBe(true);
+    if (cached?.ok) expect(cached.manifest.version).toBe("1.5.0");
+  });
+
+  it("exact pin selects that version", async () => {
+    await seedDraft(ctx);
+    await seedPublished("1.0.0");
+    await seedPublished("1.5.0");
+
+    const res = await resolveRunIntegrationVersions({ agentManifest: agentManifest("1.0.0") });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.versions[INTEG]).toEqual({ version: "1.0.0", source: "version" });
+  });
+
+  it("`dependency_overrides[id] = draft` routes the integration to its working copy", async () => {
+    await seedDraft(ctx);
+    await seedPublished("1.0.0");
+
+    const cache: IntegrationManifestCache = new Map();
+    const res = await resolveRunIntegrationVersions({
+      agentManifest: agentManifest("^1.0.0"),
+      dependencyOverrides: { [INTEG]: "draft" },
+      manifestCache: cache,
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.versions[INTEG]).toEqual({ version: null, source: "draft" });
+    // The cache now serves the DRAFT manifest (sentinel 9.9.9), not 1.0.0.
+    const cached = await cache.get(INTEG);
+    expect(cached?.ok).toBe(true);
+    if (cached?.ok) expect(cached.manifest.version).toBe("9.9.9");
+  });
+
+  it("a non-draft `dependency_overrides[id]` replaces the manifest pin", async () => {
+    await seedDraft(ctx);
+    await seedPublished("1.0.0");
+    await seedPublished("2.0.0");
+
+    // Manifest pins `^1.0.0` (would pick 1.0.0), override forces 2.0.0.
+    const res = await resolveRunIntegrationVersions({
+      agentManifest: agentManifest("^1.0.0"),
+      dependencyOverrides: { [INTEG]: "2.0.0" },
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.versions[INTEG]).toEqual({ version: "2.0.0", source: "version" });
+  });
+
+  it("an unsatisfiable pin fails loud (unresolved), never a silent draft fallback", async () => {
+    await seedDraft(ctx);
+    await seedPublished("1.0.0"); // only 1.0.0; pin wants ^3.0.0
+
+    const res = await resolveRunIntegrationVersions({ agentManifest: agentManifest("^3.0.0") });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.unresolved).toEqual([{ name: INTEG, versionSpec: "^3.0.0" }]);
+  });
+
+  it("a never-published integration with a pin is unresolved", async () => {
+    await seedDraft(ctx); // draft only, no published versions
+
+    const res = await resolveRunIntegrationVersions({ agentManifest: agentManifest("^1.0.0") });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.unresolved[0]?.name).toBe(INTEG);
+  });
+
+  it("runtime parity: readIntegrationManifestAt reads the SAME version the snapshot froze", async () => {
+    await seedDraft(ctx);
+    await seedPublished("1.0.0");
+    await seedPublished("1.5.0");
+
+    const res = await resolveRunIntegrationVersions({ agentManifest: agentManifest("^1.0.0") });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const frozen = res.versions[INTEG]!;
+
+    // The runtime credential path reads the manifest AT the frozen descriptor —
+    // it must see 1.5.0, identical to what the spawn cache was seeded with.
+    const manifest = await readIntegrationManifestAt(
+      INTEG,
+      resolvedIntegrationVersionToDescriptor(frozen),
+    );
+    expect(manifest.ok).toBe(true);
+    if (manifest.ok) expect(manifest.manifest.version).toBe("1.5.0");
+  });
+});

--- a/apps/api/test/integration/services/integration-version-pin.test.ts
+++ b/apps/api/test/integration/services/integration-version-pin.test.ts
@@ -26,6 +26,9 @@ import {
   resolvedIntegrationVersionToDescriptor,
   type IntegrationManifestCache,
 } from "../../../src/services/integration-service.ts";
+import { freezeRunSpawnDependencies } from "../../../src/services/run-pipeline.ts";
+import { ApiError } from "../../../src/lib/errors.ts";
+import type { LoadedPackage } from "../../../src/types/index.ts";
 import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
 import { seedPackage, seedPackageVersion } from "../../helpers/seed.ts";
@@ -180,6 +183,47 @@ describe("resolveRunIntegrationVersions — integration manifest pin (#686)", ()
     expect(res.ok).toBe(false);
     if (res.ok) return;
     expect(res.unresolved[0]?.name).toBe(INTEG);
+  });
+
+  // freezeRunSpawnDependencies is the shared kickoff unit BOTH origins use —
+  // platform (`prepareAndExecuteRun`) and remote (`run-creation.createRun`).
+  // Locking it here covers the remote path's enforcement without standing up
+  // the readiness/connection cascade: remote calls the identical function.
+  describe("freezeRunSpawnDependencies — shared origin gate", () => {
+    function agentPkg(pin: string): LoadedPackage {
+      return { manifest: agentManifest(pin) } as unknown as LoadedPackage;
+    }
+
+    it("freezes the satisfiable pin to the published version", async () => {
+      await seedDraft(ctx);
+      await seedPublished("1.0.0");
+      await seedPublished("1.5.0");
+
+      const versions = await freezeRunSpawnDependencies({ agent: agentPkg("^1.0.0") });
+      expect(versions[INTEG]).toEqual({ version: "1.5.0", source: "version" });
+    });
+
+    it("throws dependency_unresolved (422) on an unsatisfiable pin — same as remote", async () => {
+      await seedDraft(ctx);
+      await seedPublished("1.0.0");
+
+      const err = await freezeRunSpawnDependencies({ agent: agentPkg("^3.0.0") }).catch((e) => e);
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).status).toBe(422);
+      expect((err as ApiError).code).toBe("dependency_unresolved");
+    });
+
+    it("throws 400 on a dependency_overrides key the agent does not declare", async () => {
+      await seedDraft(ctx);
+      await seedPublished("1.0.0");
+
+      const err = await freezeRunSpawnDependencies({
+        agent: agentPkg("^1.0.0"),
+        dependencyOverrides: { "@pinorg/not-declared": "draft" },
+      }).catch((e) => e);
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).status).toBe(400);
+    });
   });
 
   it("runtime parity: readIntegrationManifestAt reads the SAME version the snapshot froze", async () => {

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -4824,6 +4824,10 @@ export interface components {
             connection_overrides: {
                 [key: string]: string;
             } | null;
+            /** @description Per-dependency version overrides frozen on the schedule row (#666/#686). Flat map: `{ "@scope/dep": "draft" | "<semver|dist-tag>" }`; keys may name a declared skill OR integration. Forwarded to each fired run's `dependency_overrides` so a scheduled run resolves its dependencies exactly as the schedule froze them. */
+            dependency_overrides: {
+                [key: string]: string;
+            } | null;
             /** Format: date-time */
             last_run_at: string | null;
             /** Format: date-time */
@@ -6403,6 +6407,10 @@ export interface operations {
                     connection_overrides?: {
                         [key: string]: string;
                     };
+                    /** @description Per-dependency version overrides frozen on the schedule row (#666/#686). Shape: `{ "@scope/dep": "draft" | "<semver|dist-tag>" }`; keys may name a declared skill OR integration. Forwarded to each fired run so it resolves dependencies exactly as the schedule froze them. */
+                    dependency_overrides?: {
+                        [key: string]: string;
+                    };
                 };
             };
         };
@@ -6436,6 +6444,7 @@ export interface operations {
                      *       "proxy_id_override": null,
                      *       "version_override": null,
                      *       "connection_overrides": null,
+                     *       "dependency_overrides": null,
                      *       "last_run_at": null,
                      *       "next_run_at": "2026-01-16T09:00:00Z",
                      *       "createdAt": "2026-01-15T10:30:00Z",
@@ -16976,6 +16985,7 @@ export interface operations {
                      *       "proxy_id_override": null,
                      *       "version_override": "1.2.0",
                      *       "connection_overrides": null,
+                     *       "dependency_overrides": null,
                      *       "last_run_at": "2026-01-15T09:00:00Z",
                      *       "next_run_at": "2026-01-16T09:00:00Z",
                      *       "createdAt": "2026-01-14T14:00:00Z",
@@ -17021,6 +17031,10 @@ export interface operations {
                     version_override?: string | null;
                     /** @description Per-integration connection picks frozen on the schedule. Pass `null` to clear. */
                     connection_overrides?: {
+                        [key: string]: string;
+                    } | null;
+                    /** @description Per-dependency version overrides frozen on the schedule (#666/#686). Shape: `{ "@scope/dep": "draft" | "<semver|dist-tag>" }`; skill or integration ids. Pass `null` to clear. */
+                    dependency_overrides?: {
                         [key: string]: string;
                     } | null;
                 };

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -16168,6 +16168,10 @@ export interface operations {
                     };
                     applicationId: string;
                     input?: Record<string, never>;
+                    /** @description Per-run dependency version overrides (#666/#686). Flat map `{ "@scope/dep": "draft" | "<semver|dist-tag>" }`; keys may name a declared skill OR integration. `"draft"` opts that dependency into its working copy; any other value replaces the manifest pin. An unsatisfiable pin aborts the run with `dependency_unresolved` (422). */
+                    dependency_overrides?: {
+                        [key: string]: string;
+                    };
                     /** @description Caller-provided execution-environment metadata (os, cli version, git sha). Capped at 16 KiB serialised. */
                     contextSnapshot?: Record<string, never>;
                     sink?: {

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -210,6 +210,32 @@ export function parseManifestIntegrations(
 }
 
 /**
+ * Collect the ids of every dependency a run may legitimately override via
+ * `dependency_overrides` — bundled **skills** (`buildAgentPackage`) and spawned
+ * **integrations** (`resolveRunIntegrationVersions`). The single source of truth
+ * for the run-path override KEY gate, so skills and integrations are never
+ * enumerated independently at the call site (#666/#686).
+ *
+ * Intentionally LENIENT (mirrors the two underlying readers): skills come from
+ * `dependencies.skills` keys verbatim, integrations from
+ * {@link parseManifestIntegrations}. `mcp_servers` are deliberately excluded —
+ * an mcp-server is pinned via its integration's `source.server.version`, not a
+ * `dependency_overrides` key (the byte route serves system/published only), so
+ * an mcp-server override key must stay an unknown-key 400.
+ */
+export function collectOverridableDependencyIds(manifest: Record<string, unknown>): Set<string> {
+  const deps = (manifest.dependencies ?? {}) as { skills?: Record<string, unknown> };
+  const ids = new Set<string>();
+  for (const id of Object.keys(deps.skills ?? {})) {
+    if (id) ids.add(id);
+  }
+  for (const entry of parseManifestIntegrations(manifest)) {
+    ids.add(entry.id);
+  }
+  return ids;
+}
+
+/**
  * Write integration entries back to a manifest in the AFPS split form:
  * the semver range goes to `dependencies.integrations.<id>` (a bare string,
  * §4.1) and the per-integration configuration goes to

--- a/packages/db/drizzle/0012_amusing_gressill.sql
+++ b/packages/db/drizzle/0012_amusing_gressill.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "runs" ADD COLUMN "resolved_integration_versions" jsonb;--> statement-breakpoint
+ALTER TABLE "package_schedules" ADD COLUMN "dependency_overrides" jsonb;

--- a/packages/db/drizzle/meta/0012_snapshot.json
+++ b/packages/db/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,7059 @@
+{
+  "id": "695ee164-9a0b-4405-9fe6-508d69c1f8e3",
+  "prevId": "932ea6cb-110e-4b41-8ff4-de6baeca3589",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realm": {
+          "name": "realm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'platform'"
+        }
+      },
+      "indexes": {
+        "session_realm_idx": {
+          "name": "session_realm_idx",
+          "columns": [
+            {
+              "expression": "realm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "realm": {
+          "name": "realm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'platform'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_realm_idx": {
+          "name": "user_realm_idx",
+          "columns": [
+            {
+              "expression": "realm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_api_keys_org_id": {
+          "name": "idx_api_keys_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_keys_application_id": {
+          "name": "idx_api_keys_application_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_keys_key_hash": {
+          "name": "idx_api_keys_key_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_api_keys_key_prefix": {
+          "name": "idx_api_keys_key_prefix",
+          "columns": [
+            {
+              "expression": "key_prefix",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_org_id_organizations_id_fk": {
+          "name": "api_keys_org_id_organizations_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_application_id_applications_id_fk": {
+          "name": "api_keys_application_id_applications_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "api_keys_created_by_user_id_fk": {
+          "name": "api_keys_created_by_user_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider_credentials": {
+      "name": "model_provider_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credentials_encrypted": {
+          "name": "credentials_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_url_override": {
+          "name": "base_url_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_failure_count": {
+          "name": "refresh_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_refresh_failure_at": {
+          "name": "last_refresh_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_model_ids": {
+          "name": "available_model_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_provider_credentials_org_id": {
+          "name": "idx_model_provider_credentials_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_credentials_org_provider": {
+          "name": "idx_model_provider_credentials_org_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_credentials_expires_at_oauth": {
+          "name": "idx_model_provider_credentials_expires_at_oauth",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"model_provider_credentials\".\"expires_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_provider_credentials_org_id_organizations_id_fk": {
+          "name": "model_provider_credentials_org_id_organizations_id_fk",
+          "tableFrom": "model_provider_credentials",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_credentials_created_by_user_id_fk": {
+          "name": "model_provider_credentials_created_by_user_id_fk",
+          "tableFrom": "model_provider_credentials",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.model_provider_pairings": {
+      "name": "model_provider_pairings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_from_ip": {
+          "name": "consumed_from_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_model_provider_pairings_org_id": {
+          "name": "idx_model_provider_pairings_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_model_provider_pairings_expires_at": {
+          "name": "idx_model_provider_pairings_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "consumed_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "model_provider_pairings_user_id_user_id_fk": {
+          "name": "model_provider_pairings_user_id_user_id_fk",
+          "tableFrom": "model_provider_pairings",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_pairings_org_id_organizations_id_fk": {
+          "name": "model_provider_pairings_org_id_organizations_id_fk",
+          "tableFrom": "model_provider_pairings",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "model_provider_pairings_credential_id_model_provider_credentials_id_fk": {
+          "name": "model_provider_pairings_credential_id_model_provider_credentials_id_fk",
+          "tableFrom": "model_provider_pairings",
+          "tableTo": "model_provider_credentials",
+          "columnsFrom": ["credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "model_provider_pairings_token_hash_unique": {
+          "name": "model_provider_pairings_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_invitations": {
+      "name": "org_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accepted_by": {
+          "name": "accepted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_invitations_token": {
+          "name": "idx_org_invitations_token",
+          "columns": [
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_invitations_org_id": {
+          "name": "idx_org_invitations_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_invitations_email": {
+          "name": "idx_org_invitations_email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_invitations_org_id_organizations_id_fk": {
+          "name": "org_invitations_org_id_organizations_id_fk",
+          "tableFrom": "org_invitations",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_invitations_invited_by_user_id_fk": {
+          "name": "org_invitations_invited_by_user_id_fk",
+          "tableFrom": "org_invitations",
+          "tableTo": "user",
+          "columnsFrom": ["invited_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "org_invitations_accepted_by_user_id_fk": {
+          "name": "org_invitations_accepted_by_user_id_fk",
+          "tableFrom": "org_invitations",
+          "tableTo": "user",
+          "columnsFrom": ["accepted_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "org_invitations_token_unique": {
+          "name": "org_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org_models": {
+      "name": "org_models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_window": {
+          "name": "context_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_tokens": {
+          "name": "max_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_models_org_id": {
+          "name": "idx_org_models_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_models_one_default": {
+          "name": "idx_org_models_one_default",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"org_models\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_models_org_id_organizations_id_fk": {
+          "name": "org_models_org_id_organizations_id_fk",
+          "tableFrom": "org_models",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_models_credential_id_model_provider_credentials_id_fk": {
+          "name": "org_models_credential_id_model_provider_credentials_id_fk",
+          "tableFrom": "org_models",
+          "tableTo": "model_provider_credentials",
+          "columnsFrom": ["credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "org_models_created_by_user_id_fk": {
+          "name": "org_models_created_by_user_id_fk",
+          "tableFrom": "org_models",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "org_models_source_valid": {
+          "name": "org_models_source_valid",
+          "value": "source IN ('built-in', 'custom')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_proxies": {
+      "name": "org_proxies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url_encrypted": {
+          "name": "url_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'custom'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_proxies_org_id": {
+          "name": "idx_org_proxies_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_org_proxies_one_default": {
+          "name": "idx_org_proxies_one_default",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"org_proxies\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_proxies_org_id_organizations_id_fk": {
+          "name": "org_proxies_org_id_organizations_id_fk",
+          "tableFrom": "org_proxies",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_proxies_created_by_user_id_fk": {
+          "name": "org_proxies_created_by_user_id_fk",
+          "tableFrom": "org_proxies",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "org_proxies_source_valid": {
+          "name": "org_proxies_source_valid",
+          "value": "source IN ('built-in', 'custom')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.org_members": {
+      "name": "org_members",
+      "schema": "",
+      "columns": {
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "org_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_org_members_user_id": {
+          "name": "idx_org_members_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "org_members_org_id_organizations_id_fk": {
+          "name": "org_members_org_id_organizations_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "org_members_user_id_user_id_fk": {
+          "name": "org_members_user_id_user_id_fk",
+          "tableFrom": "org_members",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "org_members_org_id_user_id_pk": {
+          "name": "org_members_org_id_user_id_pk",
+          "columns": ["org_id", "user_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_settings": {
+          "name": "org_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organizations_created_by_user_id_fk": {
+          "name": "organizations_created_by_user_id_fk",
+          "tableFrom": "organizations",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_applications_org_id": {
+          "name": "idx_applications_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_applications_one_default": {
+          "name": "idx_applications_one_default",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"applications\".\"is_default\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "applications_org_id_organizations_id_fk": {
+          "name": "applications_org_id_organizations_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "applications_created_by_user_id_fk": {
+          "name": "applications_created_by_user_id_fk",
+          "tableFrom": "applications",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.end_users": {
+      "name": "end_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_end_users_external_id": {
+          "name": "idx_end_users_external_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"end_users\".\"external_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_end_users_app_email": {
+          "name": "idx_end_users_app_email",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "email IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_end_users_application_id": {
+          "name": "idx_end_users_application_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_end_users_org_id": {
+          "name": "idx_end_users_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "end_users_application_id_applications_id_fk": {
+          "name": "end_users_application_id_applications_id_fk",
+          "tableFrom": "end_users",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "end_users_org_id_organizations_id_fk": {
+          "name": "end_users_org_id_organizations_id_fk",
+          "tableFrom": "end_users",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_id_user_id_fk": {
+          "name": "profiles_id_user_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "user",
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "language_check": {
+          "name": "language_check",
+          "value": "\"profiles\".\"language\" IN ('fr', 'en')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.application_packages": {
+      "name": "application_packages",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_id": {
+          "name": "proxy_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "block_user_connections": {
+          "name": "block_user_connections",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_application_packages_package_id": {
+          "name": "idx_application_packages_package_id",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_application_packages_app_id": {
+          "name": "idx_application_packages_app_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "application_packages_application_id_applications_id_fk": {
+          "name": "application_packages_application_id_applications_id_fk",
+          "tableFrom": "application_packages",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_packages_package_id_packages_id_fk": {
+          "name": "application_packages_package_id_packages_id_fk",
+          "tableFrom": "application_packages",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "application_packages_version_id_package_versions_id_fk": {
+          "name": "application_packages_version_id_package_versions_id_fk",
+          "tableFrom": "application_packages",
+          "tableTo": "package_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "application_packages_application_id_package_id_pk": {
+          "name": "application_packages_application_id_package_id_pk",
+          "columns": ["application_id", "package_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.package_dist_tags": {
+      "name": "package_dist_tags",
+      "schema": "",
+      "columns": {
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "package_dist_tags_package_id_packages_id_fk": {
+          "name": "package_dist_tags_package_id_packages_id_fk",
+          "tableFrom": "package_dist_tags",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_dist_tags_version_id_package_versions_id_fk": {
+          "name": "package_dist_tags_version_id_package_versions_id_fk",
+          "tableFrom": "package_dist_tags",
+          "tableTo": "package_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "package_dist_tags_package_id_tag_pk": {
+          "name": "package_dist_tags_package_id_tag_pk",
+          "columns": ["package_id", "tag"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.package_version_dependencies": {
+      "name": "package_version_dependencies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dep_scope": {
+          "name": "dep_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dep_name": {
+          "name": "dep_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dep_type": {
+          "name": "dep_type",
+          "type": "package_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version_range": {
+          "name": "version_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pkg_ver_deps_unique": {
+          "name": "pkg_ver_deps_unique",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dep_scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dep_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dep_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pkg_ver_deps_version_id": {
+          "name": "idx_pkg_ver_deps_version_id",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_version_dependencies_version_id_package_versions_id_fk": {
+          "name": "package_version_dependencies_version_id_package_versions_id_fk",
+          "tableFrom": "package_version_dependencies",
+          "tableTo": "package_versions",
+          "columnsFrom": ["version_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.package_versions": {
+      "name": "package_versions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integrity": {
+          "name": "integrity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artifact_size": {
+          "name": "artifact_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manifest": {
+          "name": "manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "yanked": {
+          "name": "yanked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "yanked_reason": {
+          "name": "yanked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "package_versions_pkg_version_unique": {
+          "name": "package_versions_pkg_version_unique",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_package_versions_package_id": {
+          "name": "idx_package_versions_package_id",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_versions_package_id_packages_id_fk": {
+          "name": "package_versions_package_id_packages_id_fk",
+          "tableFrom": "package_versions",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_versions_created_by_user_id_fk": {
+          "name": "package_versions_created_by_user_id_fk",
+          "tableFrom": "package_versions",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "package_versions_manifest_v0": {
+          "name": "package_versions_manifest_v0",
+          "value": "\"manifest\" IS NULL OR (\"manifest\" ->> 'schema_version') IS NULL OR (\"manifest\" ->> 'schema_version') LIKE '0.%'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.packages": {
+      "name": "packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "package_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "package_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'local'"
+        },
+        "draft_manifest": {
+          "name": "draft_manifest",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_content": {
+          "name": "draft_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_installed": {
+          "name": "auto_installed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ephemeral": {
+          "name": "ephemeral",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "lock_version": {
+          "name": "lock_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "forked_from": {
+          "name": "forked_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_packages_org_id": {
+          "name": "idx_packages_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_packages_type": {
+          "name": "idx_packages_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_packages_org_type": {
+          "name": "idx_packages_org_type",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_packages_ephemeral_created": {
+          "name": "idx_packages_ephemeral_created",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"packages\".\"ephemeral\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "packages_org_id_organizations_id_fk": {
+          "name": "packages_org_id_organizations_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "packages_created_by_user_id_fk": {
+          "name": "packages_created_by_user_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "packages_id_format": {
+          "name": "packages_id_format",
+          "value": "\"packages\".\"id\" ~ '^@[a-z0-9][a-z0-9-]*/[a-z0-9][a-z0-9-]*$'"
+        },
+        "packages_draft_manifest_v0": {
+          "name": "packages_draft_manifest_v0",
+          "value": "\"draft_manifest\" IS NULL OR (\"draft_manifest\" ->> 'schema_version') IS NULL OR (\"draft_manifest\" ->> 'schema_version') LIKE '0.%'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.credential_proxy_usage": {
+      "name": "credential_proxy_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_host": {
+          "name": "target_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "http_status": {
+          "name": "http_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_credential_proxy_usage_org_id": {
+          "name": "idx_credential_proxy_usage_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credential_proxy_usage_run_id": {
+          "name": "idx_credential_proxy_usage_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credential_proxy_usage_org_created": {
+          "name": "idx_credential_proxy_usage_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credential_proxy_usage_api_key_id": {
+          "name": "idx_credential_proxy_usage_api_key_id",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credential_proxy_usage_user_id": {
+          "name": "idx_credential_proxy_usage_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_credential_proxy_usage_application_id": {
+          "name": "idx_credential_proxy_usage_application_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credential_proxy_usage_org_id_organizations_id_fk": {
+          "name": "credential_proxy_usage_org_id_organizations_id_fk",
+          "tableFrom": "credential_proxy_usage",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "credential_proxy_usage_api_key_id_api_keys_id_fk": {
+          "name": "credential_proxy_usage_api_key_id_api_keys_id_fk",
+          "tableFrom": "credential_proxy_usage",
+          "tableTo": "api_keys",
+          "columnsFrom": ["api_key_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credential_proxy_usage_user_id_user_id_fk": {
+          "name": "credential_proxy_usage_user_id_user_id_fk",
+          "tableFrom": "credential_proxy_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credential_proxy_usage_run_id_runs_id_fk": {
+          "name": "credential_proxy_usage_run_id_runs_id_fk",
+          "tableFrom": "credential_proxy_usage",
+          "tableTo": "runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "credential_proxy_usage_application_id_applications_id_fk": {
+          "name": "credential_proxy_usage_application_id_applications_id_fk",
+          "tableFrom": "credential_proxy_usage",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "credential_proxy_usage_request_id_unique": {
+          "name": "credential_proxy_usage_request_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["request_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "credential_proxy_usage_principal_single": {
+          "name": "credential_proxy_usage_principal_single",
+          "value": "api_key_id IS NULL OR user_id IS NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.llm_usage": {
+      "name": "llm_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "llm_usage_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "real_model": {
+          "name": "real_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api": {
+          "name": "api",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_llm_usage_org_id": {
+          "name": "idx_llm_usage_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_usage_api_key_id": {
+          "name": "idx_llm_usage_api_key_id",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_usage_user_id": {
+          "name": "idx_llm_usage_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_usage_run_id": {
+          "name": "idx_llm_usage_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_llm_usage_org_created": {
+          "name": "idx_llm_usage_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_llm_usage_proxy_request_id": {
+          "name": "uq_llm_usage_proxy_request_id",
+          "columns": [
+            {
+              "expression": "request_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "source = 'proxy' AND request_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_llm_usage_runner_run_id": {
+          "name": "uq_llm_usage_runner_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "source = 'runner' AND run_id IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "llm_usage_org_id_organizations_id_fk": {
+          "name": "llm_usage_org_id_organizations_id_fk",
+          "tableFrom": "llm_usage",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "llm_usage_api_key_id_api_keys_id_fk": {
+          "name": "llm_usage_api_key_id_api_keys_id_fk",
+          "tableFrom": "llm_usage",
+          "tableTo": "api_keys",
+          "columnsFrom": ["api_key_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "llm_usage_user_id_user_id_fk": {
+          "name": "llm_usage_user_id_user_id_fk",
+          "tableFrom": "llm_usage",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "llm_usage_run_id_runs_id_fk": {
+          "name": "llm_usage_run_id_runs_id_fk",
+          "tableFrom": "llm_usage",
+          "tableTo": "runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "llm_usage_principal_single": {
+          "name": "llm_usage_principal_single",
+          "value": "api_key_id IS NULL OR user_id IS NULL"
+        },
+        "llm_usage_proxy_has_request_id": {
+          "name": "llm_usage_proxy_has_request_id",
+          "value": "source <> 'proxy' OR request_id IS NOT NULL"
+        },
+        "llm_usage_runner_has_run_id": {
+          "name": "llm_usage_runner_has_run_id",
+          "value": "source <> 'runner' OR run_id IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.package_persistence": {
+      "name": "package_persistence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "pkp_key_unique": {
+          "name": "pkp_key_unique",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(COALESCE(\"actor_id\", '__shared__'))",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "key IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pkp_lookup": {
+          "name": "pkp_lookup",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pinned",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pkp_org": {
+          "name": "pkp_org",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pkp_run_id": {
+          "name": "pkp_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"package_persistence\".\"run_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_persistence_package_id_packages_id_fk": {
+          "name": "package_persistence_package_id_packages_id_fk",
+          "tableFrom": "package_persistence",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_persistence_application_id_applications_id_fk": {
+          "name": "package_persistence_application_id_applications_id_fk",
+          "tableFrom": "package_persistence",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_persistence_org_id_organizations_id_fk": {
+          "name": "package_persistence_org_id_organizations_id_fk",
+          "tableFrom": "package_persistence",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_persistence_run_id_runs_id_fk": {
+          "name": "package_persistence_run_id_runs_id_fk",
+          "tableFrom": "package_persistence",
+          "tableTo": "runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "pkp_actor_type_valid": {
+          "name": "pkp_actor_type_valid",
+          "value": "actor_type IN ('user', 'end_user', 'shared')"
+        },
+        "pkp_actor_id_shape": {
+          "name": "pkp_actor_id_shape",
+          "value": "(actor_type = 'shared' AND actor_id IS NULL) OR (actor_type <> 'shared' AND actor_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.run_logs": {
+      "name": "run_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'progress'"
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'debug'"
+        },
+        "event": {
+          "name": "event",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_run_logs_run_id": {
+          "name": "idx_run_logs_run_id",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_logs_lookup": {
+          "name": "idx_run_logs_lookup",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_run_logs_org_id": {
+          "name": "idx_run_logs_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "run_logs_run_id_runs_id_fk": {
+          "name": "run_logs_run_id_runs_id_fk",
+          "tableFrom": "run_logs",
+          "tableTo": "runs",
+          "columnsFrom": ["run_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "run_logs_org_id_organizations_id_fk": {
+          "name": "run_logs_org_id_organizations_id_fk",
+          "tableFrom": "run_logs",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "run_logs_level_valid": {
+          "name": "run_logs_level_valid",
+          "value": "level IN ('debug', 'info', 'warn', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.runs": {
+      "name": "runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checkpoint": {
+          "name": "checkpoint",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_usage": {
+          "name": "token_usage",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule_id": {
+          "name": "schedule_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_label": {
+          "name": "version_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_dirty": {
+          "name": "version_dirty",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_label": {
+          "name": "proxy_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_label": {
+          "name": "model_label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_source": {
+          "name": "model_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cost": {
+          "name": "cost",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_number": {
+          "name": "run_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_overrides": {
+          "name": "connection_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_connections": {
+          "name": "resolved_connections",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_integration_versions": {
+          "name": "resolved_integration_versions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_key_id": {
+          "name": "api_key_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_override": {
+          "name": "config_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependency_overrides": {
+          "name": "dependency_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_scope": {
+          "name": "agent_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_origin": {
+          "name": "run_origin",
+          "type": "run_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'platform'"
+        },
+        "sink_secret_encrypted": {
+          "name": "sink_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sink_expires_at": {
+          "name": "sink_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sink_closed_at": {
+          "name": "sink_closed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_sequence": {
+          "name": "last_event_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_heartbeat_at": {
+          "name": "last_heartbeat_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "context_snapshot": {
+          "name": "context_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_name": {
+          "name": "runner_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runner_kind": {
+          "name": "runner_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_credential_id": {
+          "name": "model_credential_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_runs_package_id": {
+          "name": "idx_runs_package_id",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_status": {
+          "name": "idx_runs_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_user_id": {
+          "name": "idx_runs_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_end_user_id": {
+          "name": "idx_runs_end_user_id",
+          "columns": [
+            {
+              "expression": "end_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_package_started": {
+          "name": "idx_runs_package_started",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_schedule_id": {
+          "name": "idx_runs_schedule_id",
+          "columns": [
+            {
+              "expression": "schedule_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"schedule_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_app_status_started": {
+          "name": "idx_runs_app_status_started",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_app_started": {
+          "name": "idx_runs_app_started",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_package_run_number": {
+          "name": "idx_runs_package_run_number",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_api_key_id": {
+          "name": "idx_runs_api_key_id",
+          "columns": [
+            {
+              "expression": "api_key_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"api_key_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_model_credential_id": {
+          "name": "idx_runs_model_credential_id",
+          "columns": [
+            {
+              "expression": "model_credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"model_credential_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_org_id": {
+          "name": "idx_runs_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_notification": {
+          "name": "idx_runs_notification",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notified_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_unread": {
+          "name": "idx_runs_unread",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"notified_at\" IS NOT NULL AND \"runs\".\"read_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_sink_expires_at": {
+          "name": "idx_runs_sink_expires_at",
+          "columns": [
+            {
+              "expression": "sink_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"sink_expires_at\" IS NOT NULL AND \"runs\".\"sink_closed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_runs_stall_sweep": {
+          "name": "idx_runs_stall_sweep",
+          "columns": [
+            {
+              "expression": "last_heartbeat_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runs\".\"sink_closed_at\" IS NULL AND \"runs\".\"sink_expires_at\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "runs_package_id_packages_id_fk": {
+          "name": "runs_package_id_packages_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runs_user_id_user_id_fk": {
+          "name": "runs_user_id_user_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runs_end_user_id_end_users_id_fk": {
+          "name": "runs_end_user_id_end_users_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "end_users",
+          "columnsFrom": ["end_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runs_application_id_applications_id_fk": {
+          "name": "runs_application_id_applications_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_org_id_organizations_id_fk": {
+          "name": "runs_org_id_organizations_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "runs_schedule_id_package_schedules_id_fk": {
+          "name": "runs_schedule_id_package_schedules_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "package_schedules",
+          "columnsFrom": ["schedule_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runs_api_key_id_api_keys_id_fk": {
+          "name": "runs_api_key_id_api_keys_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "api_keys",
+          "columnsFrom": ["api_key_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "runs_model_credential_id_model_provider_credentials_id_fk": {
+          "name": "runs_model_credential_id_model_provider_credentials_id_fk",
+          "tableFrom": "runs",
+          "tableTo": "model_provider_credentials",
+          "columnsFrom": ["model_credential_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "runs_at_most_one_actor": {
+          "name": "runs_at_most_one_actor",
+          "value": "NOT (user_id IS NOT NULL AND end_user_id IS NOT NULL)"
+        },
+        "runs_open_sink_has_secret": {
+          "name": "runs_open_sink_has_secret",
+          "value": "sink_expires_at IS NULL OR sink_secret_encrypted IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.package_schedules": {
+      "name": "package_schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_override": {
+          "name": "config_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_id_override": {
+          "name": "model_id_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proxy_id_override": {
+          "name": "proxy_id_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_override": {
+          "name": "version_override",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_overrides": {
+          "name": "connection_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dependency_overrides": {
+          "name": "dependency_overrides",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_schedules_package_id": {
+          "name": "idx_schedules_package_id",
+          "columns": [
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_user_id": {
+          "name": "idx_schedules_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_schedules_end_user_id": {
+          "name": "idx_schedules_end_user_id",
+          "columns": [
+            {
+              "expression": "end_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_package_schedules_org_id": {
+          "name": "idx_package_schedules_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_package_schedules_app_id": {
+          "name": "idx_package_schedules_app_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "package_schedules_package_id_packages_id_fk": {
+          "name": "package_schedules_package_id_packages_id_fk",
+          "tableFrom": "package_schedules",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_schedules_user_id_user_id_fk": {
+          "name": "package_schedules_user_id_user_id_fk",
+          "tableFrom": "package_schedules",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_schedules_end_user_id_end_users_id_fk": {
+          "name": "package_schedules_end_user_id_end_users_id_fk",
+          "tableFrom": "package_schedules",
+          "tableTo": "end_users",
+          "columnsFrom": ["end_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_schedules_org_id_organizations_id_fk": {
+          "name": "package_schedules_org_id_organizations_id_fk",
+          "tableFrom": "package_schedules",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "package_schedules_application_id_applications_id_fk": {
+          "name": "package_schedules_application_id_applications_id_fk",
+          "tableFrom": "package_schedules",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "package_schedules_at_most_one_actor": {
+          "name": "package_schedules_at_most_one_actor",
+          "value": "NOT (user_id IS NOT NULL AND end_user_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "integration_package_id": {
+          "name": "integration_package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credentials_encrypted": {
+          "name": "credentials_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "identity_claims": {
+          "name": "identity_claims",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes_granted": {
+          "name": "scopes_granted",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "needs_reconnection": {
+          "name": "needs_reconnection",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_failure_count": {
+          "name": "refresh_failure_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_refresh_failure_at": {
+          "name": "last_refresh_failure_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_with_org": {
+          "name": "shared_with_org",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integration_conn_lookup": {
+          "name": "idx_integration_conn_lookup",
+          "columns": [
+            {
+              "expression": "integration_package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auth_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_conn_user": {
+          "name": "idx_integration_conn_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"integration_connections\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_conn_end_user": {
+          "name": "idx_integration_conn_end_user",
+          "columns": [
+            {
+              "expression": "end_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"integration_connections\".\"end_user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_conn_app": {
+          "name": "idx_integration_conn_app",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_conn_shared": {
+          "name": "idx_integration_conn_shared",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auth_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"integration_connections\".\"shared_with_org\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_connections_integration_package_id_packages_id_fk": {
+          "name": "integration_connections_integration_package_id_packages_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "packages",
+          "columnsFrom": ["integration_package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_application_id_applications_id_fk": {
+          "name": "integration_connections_application_id_applications_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_user_id_user_id_fk": {
+          "name": "integration_connections_user_id_user_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_connections_end_user_id_end_users_id_fk": {
+          "name": "integration_connections_end_user_id_end_users_id_fk",
+          "tableFrom": "integration_connections",
+          "tableTo": "end_users",
+          "columnsFrom": ["end_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "integration_conn_exactly_one_owner": {
+          "name": "integration_conn_exactly_one_owner",
+          "value": "(user_id IS NOT NULL AND end_user_id IS NULL) OR (user_id IS NULL AND end_user_id IS NOT NULL)"
+        },
+        "integration_connections_auth_key_valid": {
+          "name": "integration_connections_auth_key_valid",
+          "value": "\"auth_key\" ~ '^[a-z][a-z0-9_]*$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.integration_oauth_clients": {
+      "name": "integration_oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_package_id": {
+          "name": "integration_package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_encrypted": {
+          "name": "client_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integration_oauth_clients_unique": {
+          "name": "idx_integration_oauth_clients_unique",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "auth_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_oauth_clients_app": {
+          "name": "idx_integration_oauth_clients_app",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_oauth_clients_package": {
+          "name": "idx_integration_oauth_clients_package",
+          "columns": [
+            {
+              "expression": "integration_package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_oauth_clients_application_id_applications_id_fk": {
+          "name": "integration_oauth_clients_application_id_applications_id_fk",
+          "tableFrom": "integration_oauth_clients",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_oauth_clients_integration_package_id_packages_id_fk": {
+          "name": "integration_oauth_clients_integration_package_id_packages_id_fk",
+          "tableFrom": "integration_oauth_clients",
+          "tableTo": "packages",
+          "columnsFrom": ["integration_package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_pins": {
+      "name": "integration_pins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_package_id": {
+          "name": "integration_package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integration_pins_unique": {
+          "name": "idx_integration_pins_unique",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "coalesce(\"user_id\", '')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_pins_app_pkg": {
+          "name": "idx_integration_pins_app_pkg",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_pins_connection": {
+          "name": "idx_integration_pins_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_pins_user": {
+          "name": "idx_integration_pins_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"integration_pins\".\"user_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_pins_application_id_applications_id_fk": {
+          "name": "integration_pins_application_id_applications_id_fk",
+          "tableFrom": "integration_pins",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_pins_package_id_packages_id_fk": {
+          "name": "integration_pins_package_id_packages_id_fk",
+          "tableFrom": "integration_pins",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_pins_integration_package_id_packages_id_fk": {
+          "name": "integration_pins_integration_package_id_packages_id_fk",
+          "tableFrom": "integration_pins",
+          "tableTo": "packages",
+          "columnsFrom": ["integration_package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_pins_user_id_user_id_fk": {
+          "name": "integration_pins_user_id_user_id_fk",
+          "tableFrom": "integration_pins",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_pins_connection_id_integration_connections_id_fk": {
+          "name": "integration_pins_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_pins",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_pins_created_by_user_id_fk": {
+          "name": "integration_pins_created_by_user_id_fk",
+          "tableFrom": "integration_pins",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_org_defaults": {
+      "name": "integration_org_defaults",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "integration_package_id": {
+          "name": "integration_package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enforce": {
+          "name": "enforce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_integration_org_defaults_unique": {
+          "name": "idx_integration_org_defaults_unique",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "integration_package_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_org_defaults_app": {
+          "name": "idx_integration_org_defaults_app",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_integration_org_defaults_connection": {
+          "name": "idx_integration_org_defaults_connection",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "integration_org_defaults_application_id_applications_id_fk": {
+          "name": "integration_org_defaults_application_id_applications_id_fk",
+          "tableFrom": "integration_org_defaults",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_org_defaults_integration_package_id_packages_id_fk": {
+          "name": "integration_org_defaults_integration_package_id_packages_id_fk",
+          "tableFrom": "integration_org_defaults",
+          "tableTo": "packages",
+          "columnsFrom": ["integration_package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_org_defaults_connection_id_integration_connections_id_fk": {
+          "name": "integration_org_defaults_connection_id_integration_connections_id_fk",
+          "tableFrom": "integration_org_defaults",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "integration_org_defaults_created_by_user_id_fk": {
+          "name": "integration_org_defaults_created_by_user_id_fk",
+          "tableFrom": "integration_org_defaults",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploads": {
+      "name": "uploads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime": {
+          "name": "mime",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_uploads_app": {
+          "name": "idx_uploads_app",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uploads_expires_unconsumed": {
+          "name": "idx_uploads_expires_unconsumed",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"uploads\".\"consumed_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploads_org_id_organizations_id_fk": {
+          "name": "uploads_org_id_organizations_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploads_application_id_applications_id_fk": {
+          "name": "uploads_application_id_applications_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploads_created_by_user_id_fk": {
+          "name": "uploads_created_by_user_id_fk",
+          "tableFrom": "uploads",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_events": {
+      "name": "audit_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_type": {
+          "name": "resource_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "before": {
+          "name": "before",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "after": {
+          "name": "after",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip": {
+          "name": "ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_audit_events_org_created": {
+          "name": "idx_audit_events_org_created",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_events_resource": {
+          "name": "idx_audit_events_resource",
+          "columns": [
+            {
+              "expression": "resource_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_events_actor": {
+          "name": "idx_audit_events_actor",
+          "columns": [
+            {
+              "expression": "actor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_events_application_id_applications_id_fk": {
+          "name": "audit_events_application_id_applications_id_fk",
+          "tableFrom": "audit_events",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency": {
+          "name": "latency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt": {
+          "name": "attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_webhook_deliveries_webhook_id": {
+          "name": "idx_webhook_deliveries_webhook_id",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_webhook_deliveries_event_id": {
+          "name": "idx_webhook_deliveries_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_webhook_deliveries_status": {
+          "name": "idx_webhook_deliveries_status",
+          "columns": [
+            {
+              "expression": "webhook_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhook_deliveries_webhook_id_webhooks_id_fk": {
+          "name": "webhook_deliveries_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_deliveries",
+          "tableTo": "webhooks",
+          "columnsFrom": ["webhook_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhooks": {
+      "name": "webhooks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "events": {
+          "name": "events",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload_mode": {
+          "name": "payload_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'full'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret_next": {
+          "name": "secret_next",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secret_next_expires_at": {
+          "name": "secret_next_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_webhooks_org_id": {
+          "name": "idx_webhooks_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_webhooks_application_id": {
+          "name": "idx_webhooks_application_id",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_webhooks_app_enabled": {
+          "name": "idx_webhooks_app_enabled",
+          "columns": [
+            {
+              "expression": "application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "webhooks_org_id_organizations_id_fk": {
+          "name": "webhooks_org_id_organizations_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "organizations",
+          "columnsFrom": ["org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhooks_application_id_applications_id_fk": {
+          "name": "webhooks_application_id_applications_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "webhooks_package_id_packages_id_fk": {
+          "name": "webhooks_package_id_packages_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "packages",
+          "columnsFrom": ["package_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "webhooks_level_values": {
+          "name": "webhooks_level_values",
+          "value": "level IN ('org', 'application')"
+        },
+        "webhooks_level_check": {
+          "name": "webhooks_level_check",
+          "value": "(level = 'org' AND application_id IS NULL) OR (level = 'application' AND application_id IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.application_smtp_configs": {
+      "name": "application_smtp_configs",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pass_encrypted": {
+          "name": "pass_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_address": {
+          "name": "from_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_name": {
+          "name": "from_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "secure_mode": {
+          "name": "secure_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'auto'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_smtp_configs_application_id_applications_id_fk": {
+          "name": "application_smtp_configs_application_id_applications_id_fk",
+          "tableFrom": "application_smtp_configs",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "application_smtp_configs_secure_mode_check": {
+          "name": "application_smtp_configs_secure_mode_check",
+          "value": "secure_mode IN ('auto', 'tls', 'starttls', 'none')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.application_social_providers": {
+      "name": "application_social_providers",
+      "schema": "",
+      "columns": {
+        "application_id": {
+          "name": "application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret_encrypted": {
+          "name": "client_secret_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "application_social_providers_application_id_applications_id_fk": {
+          "name": "application_social_providers_application_id_applications_id_fk",
+          "tableFrom": "application_social_providers",
+          "tableTo": "applications",
+          "columnsFrom": ["application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "application_social_providers_application_id_provider_pk": {
+          "name": "application_social_providers_application_id_provider_pk",
+          "columns": ["application_id", "provider"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "application_social_providers_provider_check": {
+          "name": "application_social_providers_provider_check",
+          "value": "provider IN ('google', 'github')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.cli_refresh_tokens": {
+      "name": "cli_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_reason": {
+          "name": "revoked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_ip": {
+          "name": "created_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_ip": {
+          "name": "last_used_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_cli_refresh_tokens_family": {
+          "name": "idx_cli_refresh_tokens_family",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_cli_refresh_tokens_user": {
+          "name": "idx_cli_refresh_tokens_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cli_refresh_tokens_user_id_user_id_fk": {
+          "name": "cli_refresh_tokens_user_id_user_id_fk",
+          "tableFrom": "cli_refresh_tokens",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cli_refresh_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "cli_refresh_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "cli_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "cli_refresh_tokens_parent_id_fkey": {
+          "name": "cli_refresh_tokens_parent_id_fkey",
+          "tableFrom": "cli_refresh_tokens",
+          "tableTo": "cli_refresh_tokens",
+          "columnsFrom": ["parent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cli_refresh_tokens_token_hash_unique": {
+          "name": "cli_refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.device_codes": {
+      "name": "device_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "device_code": {
+          "name": "device_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_code": {
+          "name": "user_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "polling_interval": {
+          "name": "polling_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "device_codes_user_id_user_id_fk": {
+          "name": "device_codes_user_id_user_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "device_codes_client_id_oauth_clients_client_id_fk": {
+          "name": "device_codes_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "device_codes",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "device_codes_device_code_unique": {
+          "name": "device_codes_device_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["device_code"]
+        },
+        "device_codes_user_code_unique": {
+          "name": "device_codes_user_code_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_code"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.jwks": {
+      "name": "jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "private_key": {
+          "name": "private_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_access_tokens": {
+      "name": "oauth_access_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_id": {
+          "name": "refresh_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_access_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_access_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_session_id_session_id_fk": {
+          "name": "oauth_access_tokens_session_id_session_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_user_id_user_id_fk": {
+          "name": "oauth_access_tokens_user_id_user_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk": {
+          "name": "oauth_access_tokens_refresh_id_oauth_refresh_tokens_id_fk",
+          "tableFrom": "oauth_access_tokens",
+          "tableTo": "oauth_refresh_tokens",
+          "columnsFrom": ["refresh_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_access_tokens_token_unique": {
+          "name": "oauth_access_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_clients": {
+      "name": "oauth_clients",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled": {
+          "name": "disabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "is_first_party": {
+          "name": "is_first_party",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "enable_end_session": {
+          "name": "enable_end_session",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_type": {
+          "name": "subject_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uri": {
+          "name": "uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "contacts": {
+          "name": "contacts",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tos": {
+          "name": "tos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "policy": {
+          "name": "policy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_id": {
+          "name": "software_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_statement": {
+          "name": "software_statement",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_logout_redirect_uris": {
+          "name": "post_logout_redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_endpoint_auth_method": {
+          "name": "token_endpoint_auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_types": {
+          "name": "grant_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "response_types": {
+          "name": "response_types",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "require_pkce": {
+          "name": "require_pkce",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'instance'"
+        },
+        "referenced_org_id": {
+          "name": "referenced_org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "referenced_application_id": {
+          "name": "referenced_application_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allow_signup": {
+          "name": "allow_signup",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "signup_role": {
+          "name": "signup_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        }
+      },
+      "indexes": {
+        "idx_oauth_clients_org": {
+          "name": "idx_oauth_clients_org",
+          "columns": [
+            {
+              "expression": "referenced_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_clients_app": {
+          "name": "idx_oauth_clients_app",
+          "columns": [
+            {
+              "expression": "referenced_application_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_clients_user_id_user_id_fk": {
+          "name": "oauth_clients_user_id_user_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_clients_referenced_org_id_organizations_id_fk": {
+          "name": "oauth_clients_referenced_org_id_organizations_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "organizations",
+          "columnsFrom": ["referenced_org_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_clients_referenced_application_id_applications_id_fk": {
+          "name": "oauth_clients_referenced_application_id_applications_id_fk",
+          "tableFrom": "oauth_clients",
+          "tableTo": "applications",
+          "columnsFrom": ["referenced_application_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_clients_client_id_unique": {
+          "name": "oauth_clients_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["client_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "oauth_clients_level_check": {
+          "name": "oauth_clients_level_check",
+          "value": "(level = 'org' AND referenced_org_id IS NOT NULL AND referenced_application_id IS NULL) OR (level = 'application' AND referenced_application_id IS NOT NULL AND referenced_org_id IS NULL) OR (level = 'instance' AND referenced_org_id IS NULL AND referenced_application_id IS NULL)"
+        },
+        "oauth_clients_signup_role_check": {
+          "name": "oauth_clients_signup_role_check",
+          "value": "signup_role IN ('admin', 'member', 'viewer')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.oauth_consents": {
+      "name": "oauth_consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_consents_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_consents_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_consents_user_id_user_id_fk": {
+          "name": "oauth_consents_user_id_user_id_fk",
+          "tableFrom": "oauth_consents",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_refresh_tokens": {
+      "name": "oauth_refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_time": {
+          "name": "auth_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resources": {
+          "name": "resources",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk": {
+          "name": "oauth_refresh_tokens_client_id_oauth_clients_client_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "oauth_clients",
+          "columnsFrom": ["client_id"],
+          "columnsTo": ["client_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_session_id_session_id_fk": {
+          "name": "oauth_refresh_tokens_session_id_session_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "oauth_refresh_tokens_user_id_user_id_fk": {
+          "name": "oauth_refresh_tokens_user_id_user_id_fk",
+          "tableFrom": "oauth_refresh_tokens",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "oauth_refresh_tokens_token_unique": {
+          "name": "oauth_refresh_tokens_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oidc_end_user_profiles": {
+      "name": "oidc_end_user_profiles",
+      "schema": "",
+      "columns": {
+        "end_user_id": {
+          "name": "end_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "auth_user_id": {
+          "name": "auth_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_oidc_profiles_auth_user": {
+          "name": "idx_oidc_profiles_auth_user",
+          "columns": [
+            {
+              "expression": "auth_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oidc_end_user_profiles_end_user_id_end_users_id_fk": {
+          "name": "oidc_end_user_profiles_end_user_id_end_users_id_fk",
+          "tableFrom": "oidc_end_user_profiles",
+          "tableTo": "end_users",
+          "columnsFrom": ["end_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oidc_end_user_profiles_auth_user_id_user_id_fk": {
+          "name": "oidc_end_user_profiles_auth_user_id_user_id_fk",
+          "tableFrom": "oidc_end_user_profiles",
+          "tableTo": "user",
+          "columnsFrom": ["auth_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.invitation_status": {
+      "name": "invitation_status",
+      "schema": "public",
+      "values": ["pending", "accepted", "expired", "cancelled"]
+    },
+    "public.llm_usage_source": {
+      "name": "llm_usage_source",
+      "schema": "public",
+      "values": ["proxy", "runner"]
+    },
+    "public.org_role": {
+      "name": "org_role",
+      "schema": "public",
+      "values": ["owner", "admin", "member", "viewer"]
+    },
+    "public.package_source": {
+      "name": "package_source",
+      "schema": "public",
+      "values": ["local", "system"]
+    },
+    "public.package_type": {
+      "name": "package_type",
+      "schema": "public",
+      "values": ["agent", "skill", "integration", "mcp-server"]
+    },
+    "public.run_origin": {
+      "name": "run_origin",
+      "schema": "public",
+      "values": ["platform", "remote"]
+    },
+    "public.run_status": {
+      "name": "run_status",
+      "schema": "public",
+      "values": ["pending", "running", "success", "failed", "timeout", "cancelled"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1781594303211,
       "tag": "0011_aromatic_korvac",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1781698915475,
+      "tag": "0012_amusing_gressill",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/runs.ts
+++ b/packages/db/src/schema/runs.ts
@@ -125,6 +125,18 @@ export const runs = pgTable(
           { connectionId: string; source: string; label?: string | null; accountId?: string | null }
         >
       >(),
+    // Snapshot of the integration manifest VERSION resolved per declared
+    // integration at run kickoff (#686). Shape:
+    // { "@scope/integration": { version: "1.4.2" | null, source: "version" | "draft" | "system" } }.
+    // Frozen here so every manifest read for THIS run — the kickoff spawn
+    // spec AND the long-lived runtime credential/MITM-refresh path — resolves
+    // the same version, never re-deriving against a catalog that may gain a
+    // newer published version mid-run. `version: null` for `draft`/`system`
+    // sources (no `package_versions` row). The sibling of `resolvedConnections`
+    // for the manifest-version axis; absent integrations fall back to draft.
+    resolvedIntegrationVersions: jsonb("resolved_integration_versions").$type<
+      Record<string, { version: string | null; source: "version" | "draft" | "system" }>
+    >(),
     apiKeyId: text("api_key_id").references(() => apiKeys.id, {
       onDelete: "set null",
     }),
@@ -589,6 +601,13 @@ export const schedules = pgTable(
     // creation/edit (mirrors `configOverride`). Same shape as
     // `runs.connectionOverrides`. Loses to admin pin at fire time.
     connectionOverrides: jsonb("connection_overrides").$type<Record<string, string>>(),
+    // Per-schedule dependency version overrides — frozen at schedule
+    // creation/edit, forwarded to each fired run's `runs.dependencyOverrides`
+    // (#666/#686). Shape: { "@scope/dep": "draft" | "<semver|dist-tag>" }.
+    // Keys may name a declared skill OR integration dependency; `"draft"` opts
+    // that dependency into its working copy for the dev edit loop, any other
+    // value replaces the manifest pin. Mirrors `runs.dependencyOverrides`.
+    dependencyOverrides: jsonb("dependency_overrides").$type<Record<string, string>>(),
     lastRunAt: timestamp("last_run_at", { withTimezone: true }),
     nextRunAt: timestamp("next_run_at", { withTimezone: true }),
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -270,6 +270,7 @@ export interface ScheduleWireDto {
   proxy_id_override: string | null;
   version_override: string | null;
   connection_overrides: Record<string, string> | null;
+  dependency_overrides: Record<string, string> | null;
   last_run_at: string | null;
   next_run_at: string | null;
   createdAt: string;


### PR DESCRIPTION
Closes #686. Extends the #666 published-version-pin contract from the bundled skill closure to **spawned integrations / mcp-servers**, and enforces it across **every run origin** (platform, scheduled, remote).

## Problem

Every run-path read of an integration manifest went through `fetchIntegrationManifest → packages.draft_manifest` (version-blind). So a mid-edit draft flowed into consumer runs and the `dependencies.integrations.<id>` pin was advisory — **at kickoff** (spawn spec) **and on the long-lived runtime credential path** (the MITM refresh re-reads the manifest on every call). Pinning only spawn would have created a new manifest/manifest skew across the run lifecycle; pinning only the platform origin would have left remote runs (CLI / GitHub Action) on the draft.

## Design — single source of truth, no duplication

- **One version-resolution kernel.** `resolvePublishedManifest` (system short-circuit → shared `pickVersion` → `package_versions.manifest`) now backs both `resolveMcpServerForSpawn` (#588) and the new integration resolution. `readIntegrationManifestAt` is the single manifest reader for a pinned integration, used when seeding the kickoff cache **and** on the runtime credential path.
- **One frozen descriptor per run.** `resolveRunIntegrationVersions` resolves every declared integration against published versions honoring its pin (+ `dependency_overrides`), **seeds the shared per-run `manifestCache`** so every kickoff reader (connection cascade, spawn resolver, pin checks) honors the pin with *no per-caller change*, and returns the `{ version, source }` map persisted on the new `runs.resolved_integration_versions` column. The credentials resolver reads that frozen map back via the run token, so a mid-run MITM refresh resolves the **same** version the spawn used.
- **Fail loud.** An unsatisfiable / never-published integration pin aborts the run with a structured `dependency_unresolved` (422) instead of silently spawning the draft; same for an unsatisfiable referenced-mcp-server pin (tightened from the old warn-and-skip). "Declared-but-not-connected" stays a soft skip.
- **`dependency_overrides` accepts integration ids** (not just skills); `"draft"` opts one integration into its working copy for the dev edit loop. **Schedules gain a `dependency_overrides` column**, forwarded to each fired run — run + schedule contracts are now symmetric.

The keystone: the per-run `manifestCache` (already threaded into readiness, the connection cascade, and the spawn resolver) becomes the kickoff seam — seeding it with the pinned manifest makes all six existing readers honor the pin transparently.

## Cross-origin coverage + unification

The enforcement is now origin-complete and the read/resolve surface is deduplicated:

- **Remote runs no longer bypass the pin.** The freeze moved into a shared `freezeRunSpawnDependencies` (key-gate + published-version resolution + loud 422), called by the platform pipeline (`prepareAndExecuteRun`) **and** `run-creation.createRun`. Remote runs now seed the connection cascade, persist `resolved_integration_versions` + `dependency_overrides`, and fail loud on an unsatisfiable pin — previously a remote run silently served the mutable draft on the credential path (the #686 bug class on a different origin).
- **`POST /api/runs/remote` accepts `dependency_overrides`** (run-level, both `inline` and `registry` source shapes), value-gated by the shared `isValidDependencyOverride` and key-gated by the freeze. run + schedule + remote contracts are now symmetric.
- **One run-time manifest reader** — `readIntegrationManifestForRun` replaces the `frozen ? readIntegrationManifestAt : fetchIntegrationManifest` ternary that was duplicated in the credentials resolver and the byte-route authz check.
- **One source for override-able ids** — `collectOverridableDependencyIds` (`@appstrate/core/dependencies`) backs the override KEY gate instead of enumerating skills + integrations independently at the call site.

## Scoped out (documented boundaries)

- **mcp-server ids as `dependency_overrides` keys** — no draft-bytes fetch path (the byte route serves system/published only); the referenced server is already pinned via `source.server.version` (#588).
- **Freezing the resolved mcp-server version on the run row** — `resolveMcpServerForSpawn` runs once at kickoff and no later reader re-resolves it, so there is no live skew to close (YAGNI).
- **External credential-proxy reads** (no run row to freeze against) stay on draft. Config-time readers (connection picker, scope validation) intentionally keep reading the draft (you configure against the working copy).

## Migration

`0012` — two additive nullable columns: `runs.resolved_integration_versions`, `package_schedules.dependency_overrides`. No backfill (legacy runs fall back to draft). Column name kept integration-specific because that is all it stores (skills are frozen by their bundled bytes, not a version map).

## Tests

- `integration-version-pin.test.ts`: pin honored (published ≠ draft) incl. seeded-cache assertion; exact pin; `dependency_overrides="draft"` → working copy; non-draft override replaces pin; unsatisfiable pin → `unresolved`; never-published → `unresolved`; **runtime parity** (`readIntegrationManifestAt` reads the version the snapshot froze); **shared gate** — `freezeRunSpawnDependencies` satisfiable freeze / 422 unsatisfiable pin / 400 unknown override key.
- `runs-remote-registry.test.ts`: remote `dependency_overrides` — undeclared key → 400, malformed value → 400, declared override persisted on the run row.
- Updated `integration-spawn-resolver-version-pin.test.ts` (#588): unsatisfiable / no-published referenced-server pin now asserts the loud `DEPENDENCY_UNRESOLVED` (was silent skip).
- `bun run check` green (tsc + verify-openapi + verify:api-types + type-coverage + prettier); full run/remote/schedule/credentials/internal/pin sweep + unit green (1072 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
