### PR TITLE
feat(cli): detect + repair outdated compose env block (#515)

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -31,7 +31,7 @@
 // curl-installed standalone binary crashes at startup with ENOENT.
 import "./lib/pi-binary-shim.ts";
 import { Command, InvalidArgumentError } from "commander";
-import { installCommand } from "./commands/install.ts";
+import { composeUpgradeCommand, installCommand } from "./commands/install.ts";
 import { loginCommand } from "./commands/login.ts";
 import { logoutCommand } from "./commands/logout.ts";
 import { whoamiCommand } from "./commands/whoami.ts";
@@ -200,7 +200,19 @@ program
     "-y, --yes",
     "Skip all prompts and accept smart defaults (Docker-aware tier from #180, default directory, auto-start dev server). Required for curl|bash, CI, Dockerfile RUN, cloud-init. Equivalent to APPSTRATE_YES=1. Per-field flags (--tier, --dir, --port) still override the defaults.",
   )
+  .option(
+    "--upgrade-compose",
+    "Maintenance only: strip stale duplicated env defaults from an existing install's docker-compose.yml (issue #515). Backs up the file, preserves your edits, does not touch .env or run Docker. Use --dir to point at a non-default install. Skips the normal install flow.",
+  )
   .action(async (opts) => {
+    // --upgrade-compose is a standalone maintenance op — short-circuit
+    // before the tier/dir/port resolution of the normal install flow.
+    if (opts.upgradeCompose === true) {
+      await composeUpgradeCommand({
+        dir: typeof opts.dir === "string" ? opts.dir : undefined,
+      });
+      return;
+    }
     // Env var fallback mirrors Homebrew's NONINTERACTIVE=1 / rustup-init's
     // RUSTUP_INIT_SKIP_PATH_CHECK pattern — useful for Dockerfile `ENV` and
     // cloud-init `environment:` blocks where appending argv is awkward.

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -55,5 +55,6 @@ function serializeReport(report: DoctorReport): unknown {
     dualInstall: report.dualInstall,
     multiSource: report.multiSource,
     localInstall: report.localInstall,
+    composeDrift: report.composeDrift,
   };
 }

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -60,6 +60,12 @@ import {
   readProjectFile,
   writeProjectFile,
 } from "../lib/install/project.ts";
+import {
+  formatComposeUpgradeResult,
+  resolveComposeUpgradeDir,
+  runComposeUpgrade,
+  type ComposeUpgradeDeps,
+} from "../lib/install/compose-upgrade.ts";
 import { CLI_VERSION } from "../lib/version.ts";
 
 export interface InstallOptions {
@@ -262,6 +268,45 @@ export async function installCommand(opts: InstallOptions): Promise<void> {
         autoConfirm,
         bootstrap,
       });
+    }
+  } catch (err) {
+    exitWithError(err);
+  }
+}
+
+/**
+ * `appstrate install --upgrade-compose` (issue #515) — surgically strip
+ * stale duplicated env defaults from an existing install's
+ * `docker-compose.yml`. Standalone maintenance op: no tier prompt, no
+ * `.env` touch, no Docker. The flag short-circuits the normal install
+ * flow in `cli.ts` so the heavy interactive path never runs.
+ *
+ * `deps` is a DI seam for tests — production wires the real filesystem
+ * I/O inside `runComposeUpgrade`.
+ */
+export async function composeUpgradeCommand(
+  opts: { dir?: string },
+  deps: ComposeUpgradeDeps = {},
+): Promise<void> {
+  intro("Appstrate compose upgrade");
+  try {
+    const dir = resolveComposeUpgradeDir(opts.dir);
+    const outcome = await runComposeUpgrade(dir, deps);
+    clack.note(formatComposeUpgradeResult(outcome), "docker-compose.yml");
+    switch (outcome.status) {
+      case "no-install":
+        // A wrong --dir (or no install) is a user-actionable failure —
+        // exit non-zero so scripts notice instead of assuming success.
+        throw new Error(`No docker-compose.yml found under ${dir}.`);
+      case "clean":
+        outro("Already up to date — nothing to upgrade.");
+        return;
+      case "refused-only":
+        outro("No automatic changes made — see the manual edits above.");
+        return;
+      case "upgraded":
+        outro("Compose file upgraded. Restart the stack to apply.");
+        return;
     }
   } catch (err) {
     exitWithError(err);

--- a/apps/cli/src/lib/compose-defaults.ts
+++ b/apps/cli/src/lib/compose-defaults.ts
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared knowledge about env defaults that the self-hosting compose
+ * files MUST NOT re-declare, plus the pure analysis + repair routines
+ * that operate on a compose file's text.
+ *
+ * Two consumers:
+ *   1. `scripts/verify-compose-defaults.ts` — PR-time guard that fails
+ *      CI when a tracked compose template mirrors a code default (the
+ *      #513 `MODULES` drift class).
+ *   2. `apps/cli` — the runtime side (issue #515): `appstrate doctor`
+ *      flags an operator's *on-disk* `docker-compose.yml` when it still
+ *      carries stale duplicated defaults, and `appstrate install
+ *      --upgrade-compose` surgically strips them.
+ *
+ * Keeping the table + extraction in one module means the CI guard and
+ * the runtime check can never disagree about what counts as a
+ * duplication.
+ *
+ * ─── Why a hand-maintained table (not parsed from the Zod schema) ────
+ *
+ * The schema's `.default(...)` calls in `packages/env/src/index.ts` are
+ * interleaved with transforms and refinements that are non-trivial to
+ * extract statically. A hand list paired with the CI guard's coverage
+ * is enough to catch the regression — a typo in the table just fails to
+ * catch one duplication, it never introduces one. Keep this list in
+ * sync with `packages/env/src/index.ts` when adding new vars.
+ */
+
+/** Source-of-truth file the defaults mirror — referenced in messages. */
+export const SCHEMA_SOURCE = "packages/env/src/index.ts";
+
+// ─── Code defaults (mirror of `packages/env/src/index.ts`) ───────────
+//
+// String values are the literal default the Zod schema resolves to
+// BEFORE transformation (compose passes raw env vars, the schema parses
+// JSON / coerces booleans afterward). Keep this list in sync.
+export const CODE_DEFAULTS: Record<string, string> = {
+  APP_URL: "http://localhost:3000",
+  AUTH_DISABLE_SIGNUP: "false",
+  AUTH_DISABLE_ORG_CREATION: "false",
+  AUTH_PLATFORM_ADMIN_EMAILS: "",
+  AUTH_ALLOWED_SIGNUP_DOMAINS: "",
+  AUTH_BOOTSTRAP_OWNER_EMAIL: "",
+  AUTH_BOOTSTRAP_ORG_NAME: "Default",
+  AUTH_BOOTSTRAP_TOKEN: "",
+  AFPS_TRUST_ROOT: "[]",
+  AFPS_SIGNATURE_POLICY: "off",
+  BETTER_AUTH_ACTIVE_KID: "k1",
+  BETTER_AUTH_SECRETS: "{}",
+  CONNECTION_ENCRYPTION_KEY_ID: "k1",
+  CONNECTION_ENCRYPTION_KEYS: "{}",
+  LOG_LEVEL: "info",
+  OTEL_ENABLED: "false",
+  OTEL_SERVICE_NAME: "appstrate-api",
+  OTEL_TRUST_INCOMING_TRACE: "false",
+  MODULES: "oidc,webhooks,mcp,core-providers,@appstrate/module-codex,@appstrate/module-claude-code",
+  OAUTH_REFRESH_WORKER_ENABLED: "false",
+  INTEGRATION_REFRESH_MAX_FAILURES: "5",
+  INTEGRATION_REFRESH_GRACE_SECONDS: "3600",
+  REMOTE_RUN_SINK_DEFAULT_TTL_SECONDS: "7200",
+  REMOTE_RUN_SINK_MAX_TTL_SECONDS: "86400",
+  REMOTE_RUN_REPLAY_WINDOW_SECONDS: "600",
+  REMOTE_RUN_BUFFER_FLUSH_MS: "5000",
+  REMOTE_RUN_EVENT_LIMITS: "{}",
+  RUN_HEARTBEAT_INTERVAL_SECONDS: "15",
+  RUN_STALL_THRESHOLD_SECONDS: "60",
+  RUN_WATCHDOG_INTERVAL_SECONDS: "15",
+  SIDECAR_MAX_REQUEST_BODY_BYTES: "10485760",
+  SIDECAR_MAX_MCP_ENVELOPE_BYTES: "16777216",
+  SYSTEM_PROVIDER_KEYS: "[]",
+  SYSTEM_PROXIES: "[]",
+  TRUST_PROXY: "false",
+  WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS: "300",
+  // `RUN_TOKEN_SECRET` is `.optional()` — its absence equals empty
+  // string in compose, so a `${RUN_TOKEN_SECRET:-}` is a duplication.
+  RUN_TOKEN_SECRET: "",
+  // `PORT` default is the number 3000; compose stores strings.
+  PORT: "3000",
+  // `DOCKER_SOCKET` is a code default but compose mirrors the YAML
+  // volume mount (intentional override territory — see ALLOWLIST).
+  DOCKER_SOCKET: "/var/run/docker.sock",
+  // `RUN_ADAPTER` code default is `process`; compose intentionally
+  // overrides to `docker` (see ALLOWLIST).
+  RUN_ADAPTER: "process",
+  // Sidecar integration runtime pinned by the Docker orchestrator
+  // (operator override; the process orchestrator reads the raw env).
+  INTEGRATION_RUNTIME_ADAPTER: "docker",
+  // `TRUSTED_ORIGINS` code default is the dev localhost CSV; compose
+  // intentionally overrides to empty (see ALLOWLIST).
+  TRUSTED_ORIGINS: "http://localhost:3000,http://localhost:5173",
+  // `PI_IMAGE` / `SIDECAR_IMAGE` code default is Docker Hub `:latest`;
+  // compose intentionally overrides to GHCR (see ALLOWLIST).
+  PI_IMAGE: "appstrate-pi:latest",
+  SIDECAR_IMAGE: "appstrate-sidecar:latest",
+  // `PGLITE_DATA_DIR` / `FS_STORAGE_PATH` defaults exist but compose
+  // doesn't usually reference them with a default.
+  PGLITE_DATA_DIR: "./data/pglite",
+  FS_STORAGE_PATH: "./data/storage",
+  // `NODE_ENV` defaults to `development`; compose-driven prod usually
+  // sets it explicitly via `.env`, no default-mirroring expected.
+  NODE_ENV: "development",
+  API_BODY_LIMIT_BYTES: "10485760",
+  SMTP_PORT: "587",
+  LLM_PROXY_CACHE_MODE: "off",
+  LLM_PROXY_CACHE_MAX_AGE: "3600",
+  PLATFORM_RUN_LIMITS: "{}",
+  INLINE_RUN_LIMITS: "{}",
+  LLM_PROXY_LIMITS: "{}",
+  CREDENTIAL_PROXY_LIMITS: "{}",
+  OIDC_INSTANCE_CLIENTS: "[]",
+};
+
+// ─── Allowlist — intentional overrides (reason required) ─────────────
+//
+// Each entry's value is the YAML default and the operator-visible
+// rationale for differing from the code default. When the YAML default
+// CHANGES, update the rationale (or remove the entry if the override
+// is no longer intentional).
+export const ALLOWLIST: Record<string, { yamlDefault: string; reason: string }> = {
+  RUN_ADAPTER: {
+    yamlDefault: "docker",
+    reason:
+      "Code default `process` is for OSS dev; containerized self-host requires Docker isolation.",
+  },
+  TRUSTED_ORIGINS: {
+    yamlDefault: "",
+    reason:
+      "Code default includes dev localhost ports; prod self-host correctly defaults to empty so operator opts in to their public domain explicitly.",
+  },
+  S3_BUCKET: {
+    yamlDefault: "appstrate",
+    reason:
+      "Environment-specific — switches the platform into S3 mode. Bare name aligns with the MinIO bucket created by minio-init.",
+  },
+  S3_REGION: {
+    yamlDefault: "us-east-1",
+    reason:
+      "Environment-specific. MinIO ignores this but the AWS SDK requires it to be non-empty when S3_BUCKET is set.",
+  },
+  PORT: {
+    yamlDefault: "3000",
+    reason: "Mirrors the YAML `ports:` mapping — keep coupled.",
+  },
+  DOCKER_SOCKET: {
+    yamlDefault: "/var/run/docker.sock",
+    reason: "Mirrors the YAML `volumes:` mount — keep coupled.",
+  },
+  PI_IMAGE: {
+    yamlDefault: "ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-latest}",
+    reason:
+      "Override to GHCR registry + APPSTRATE_VERSION coupling (code default points at Docker Hub).",
+  },
+  SIDECAR_IMAGE: {
+    yamlDefault: "ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-latest}",
+    reason:
+      "Override to GHCR registry + APPSTRATE_VERSION coupling (code default points at Docker Hub).",
+  },
+  BETTER_AUTH_SECRETS: {
+    yamlDefault: "",
+    reason:
+      "Empty string (NOT `{}`) is load-bearing — neutralizes better-auth 1.6+'s own CSV parser that crashes boot on a non-CSV `{}` value. See compose comment block.",
+  },
+};
+
+// ─── Compose default extraction ──────────────────────────────────────
+
+export interface ComposeDefaultMatch {
+  /** 1-based line number within the analyzed content. */
+  line: number;
+  varName: string;
+  /** The `default` captured from `${NAME:-default}`. */
+  yamlDefault: string;
+  /** The full source line the match was found on (verbatim). */
+  raw: string;
+}
+
+// Match `${NAME:-default}` where default can be anything except `}`.
+// The pattern handles nested braces poorly, but compose files don't
+// use them — this is sufficient for the env vars we care about.
+//
+// Re-created per call (not a module-level singleton) so the stateful
+// `lastIndex` of a `/g` regex can never leak between callers.
+function defaultPattern(): RegExp {
+  return /\$\{([A-Z_][A-Z0-9_]*):-([^}]*)\}/g;
+}
+
+/**
+ * Extract every `${NAME:-default}` occurrence from a compose file's text.
+ * Pure — takes the file content, returns one match per occurrence.
+ */
+export function extractComposeDefaults(content: string): ComposeDefaultMatch[] {
+  const lines = content.split("\n");
+  const matches: ComposeDefaultMatch[] = [];
+  const pattern = defaultPattern();
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    pattern.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = pattern.exec(line)) !== null) {
+      const [, varName, yamlDefault] = m;
+      if (!varName) continue;
+      matches.push({ line: i + 1, varName, yamlDefault: yamlDefault ?? "", raw: line });
+    }
+  }
+
+  return matches;
+}
+
+// ─── Findings ────────────────────────────────────────────────────────
+
+export interface ComposeDuplicateFinding {
+  kind: "duplicate";
+  line: number;
+  varName: string;
+  yamlDefault: string;
+  codeDefault: string;
+  raw: string;
+}
+
+export interface ComposeAllowlistDriftFinding {
+  kind: "allowlist-drift";
+  line: number;
+  varName: string;
+  yamlDefault: string;
+  expectedYamlDefault: string;
+  raw: string;
+}
+
+export type ComposeFinding = ComposeDuplicateFinding | ComposeAllowlistDriftFinding;
+
+/**
+ * Analyze a compose file's text against {@link CODE_DEFAULTS} /
+ * {@link ALLOWLIST}. Returns findings in line order:
+ *
+ *   - `duplicate`       — a `${VAR:-x}` whose `x` equals the code default
+ *                         (the #513 drift class — safe-but-stale, the
+ *                         YAML value masks future schema changes).
+ *   - `allowlist-drift` — an intentional override whose recorded
+ *                         yamlDefault no longer matches the file.
+ *
+ * Pure: no filesystem, no globals. Callers (CI guard, doctor) wrap it.
+ */
+export function analyzeComposeDefaults(content: string): ComposeFinding[] {
+  const findings: ComposeFinding[] = [];
+
+  for (const match of extractComposeDefaults(content)) {
+    const codeDefault = CODE_DEFAULTS[match.varName];
+    if (codeDefault === undefined) continue; // not tracked, skip
+
+    const allowed = ALLOWLIST[match.varName];
+    if (allowed) {
+      // Allowed — but sanity-check the recorded yamlDefault still
+      // matches what the file actually says. Catch silent drift.
+      if (allowed.yamlDefault !== match.yamlDefault) {
+        findings.push({
+          kind: "allowlist-drift",
+          line: match.line,
+          varName: match.varName,
+          yamlDefault: match.yamlDefault,
+          expectedYamlDefault: allowed.yamlDefault,
+          raw: match.raw,
+        });
+      }
+      continue;
+    }
+
+    if (match.yamlDefault === codeDefault) {
+      findings.push({
+        kind: "duplicate",
+        line: match.line,
+        varName: match.varName,
+        yamlDefault: match.yamlDefault,
+        codeDefault,
+        raw: match.raw,
+      });
+    }
+  }
+
+  return findings;
+}
+
+// ─── In-place repair (`appstrate install --upgrade-compose`) ─────────
+
+/** A duplicated-default line that was rewritten to a bare passthrough. */
+export interface ComposeFixApplied {
+  line: number;
+  varName: string;
+  before: string;
+  after: string;
+}
+
+/** A finding that could not be auto-fixed — operator must act by hand. */
+export interface ComposeFixRefused {
+  line: number;
+  varName: string;
+  reason: string;
+  raw: string;
+}
+
+export interface ComposeFixResult {
+  /** True when at least one line was rewritten. */
+  changed: boolean;
+  /** The repaired file content (identical to input when `changed` is false). */
+  newContent: string;
+  applied: ComposeFixApplied[];
+  refused: ComposeFixRefused[];
+}
+
+// A duplicated default in the shipped templates always lives as a YAML
+// *sequence* entry — `      - VAR=${VAR:-default}`. The fix is to drop
+// the `=${VAR:-default}` so the entry becomes a bare passthrough
+// (`      - VAR`), letting the Zod schema's default win at boot. This
+// regex is deliberately strict: it only matches that exact shape so we
+// never mangle a mapping entry, an inline-interpolation, or a line that
+// also carries a trailing comment.
+function listEntryPattern(varName: string): RegExp {
+  const v = escapeRegExp(varName);
+  return new RegExp(`^(\\s*-\\s*)${v}=\\$\\{${v}:-[^}]*\\}\\s*$`);
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Strip stale duplicated env defaults from a compose file's text,
+ * preserving every other line verbatim (operator-added services,
+ * volumes, comments are untouched — the rewrite only ever shortens the
+ * specific `- VAR=${VAR:-default}` lines that mirror a code default).
+ *
+ * `allowlist-drift` findings are intentionally LEFT ALONE: a divergent
+ * intentional-override default may be the operator's own deliberate
+ * choice, not the #513 bug — they surface in `appstrate doctor` for a
+ * human to judge, but are never auto-edited here.
+ *
+ * Any duplicated-default occurrence that is NOT in the canonical
+ * sequence-entry shape (a hand-written mapping form, or two defaults on
+ * one line) is reported as `refused` rather than guessed at — the
+ * caller prints it for manual follow-up.
+ *
+ * Pure + idempotent: re-running on the result yields zero changes.
+ */
+export function rewriteStaleComposeDefaults(content: string): ComposeFixResult {
+  const findings = analyzeComposeDefaults(content);
+  const duplicates = findings.filter((f): f is ComposeDuplicateFinding => f.kind === "duplicate");
+
+  if (duplicates.length === 0) {
+    return { changed: false, newContent: content, applied: [], refused: [] };
+  }
+
+  const lines = content.split("\n");
+  const applied: ComposeFixApplied[] = [];
+  const refused: ComposeFixRefused[] = [];
+
+  for (const dup of duplicates) {
+    const idx = dup.line - 1;
+    const original = lines[idx];
+    if (original === undefined) continue; // unreachable — line came from this content
+    const m = listEntryPattern(dup.varName).exec(original);
+    if (!m) {
+      refused.push({
+        line: dup.line,
+        varName: dup.varName,
+        reason:
+          "duplicated default is not a bare `- VAR=${VAR:-default}` sequence entry " +
+          "(mapping form, inline interpolation, or trailing comment) — edit by hand",
+        raw: original,
+      });
+      continue;
+    }
+    const prefix = m[1] ?? "";
+    const after = `${prefix}${dup.varName}`;
+    lines[idx] = after;
+    applied.push({ line: dup.line, varName: dup.varName, before: original, after });
+  }
+
+  return {
+    changed: applied.length > 0,
+    newContent: applied.length > 0 ? lines.join("\n") : content,
+    applied,
+    refused,
+  };
+}

--- a/apps/cli/src/lib/doctor.ts
+++ b/apps/cli/src/lib/doctor.ts
@@ -13,6 +13,8 @@
  * `probeBinary` to assert the rendered output without spawning anything.
  */
 
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 import { runCommand } from "./install/os.ts";
 import {
   defaultPathScanFs,
@@ -22,6 +24,7 @@ import {
 } from "./path-scan.ts";
 import { upgradeHint, type InstallSource } from "./install-source.ts";
 import { defaultInstallDir, readProjectFile } from "./install/project.ts";
+import { analyzeComposeDefaults, type ComposeFinding } from "./compose-defaults.ts";
 
 export interface InstallationInfo {
   /** PATH directory containing the binary. */
@@ -61,6 +64,18 @@ export interface DoctorReport {
    * the user doesn't have to memorize the derived project hash.
    */
   localInstall?: LocalInstallInfo;
+  /**
+   * Drift findings against the on-disk `<dir>/docker-compose.yml` of a
+   * detected local install (issue #515). Only populated when a local
+   * install is present AND its compose file carries stale duplicated
+   * env defaults (or an intentional override that no longer matches).
+   * Absent/empty for a healthy or freshly-installed compose file.
+   *
+   * Each finding masks the Zod schema's single source of truth the same
+   * way the #513 `MODULES` drift did — `appstrate install
+   * --upgrade-compose` strips the safe-to-remove duplicates.
+   */
+  composeDrift?: ComposeFinding[];
 }
 
 export interface ProbeBinary {
@@ -121,6 +136,13 @@ export interface RunDoctorOptions {
   probeLocalInstall?: (dir: string) => Promise<LocalInstallInfo | null>;
   /** Override the install dir probed (defaults to `~/appstrate`). */
   installDir?: string;
+  /**
+   * Read `<dir>/docker-compose.yml` for the compose-drift check (#515).
+   * Returns the file content, or `null` when there is no compose file.
+   * Defaults to a real `readFile`. Injected by tests to assert drift
+   * formatting without touching disk.
+   */
+  readComposeFile?: (dir: string) => Promise<string | null>;
 }
 
 /**
@@ -197,13 +219,50 @@ export async function runDoctor(opts: RunDoctorOptions = {}): Promise<DoctorRepo
     // intentional swallow — sidecar absence is not a doctor finding.
   }
 
+  // Compose-drift check (#515) — only meaningful for a detected local
+  // install: the on-disk compose file is what an operator's stack
+  // actually boots from, so stale duplicated defaults there silently
+  // mask the schema's source of truth. Soft-fails on any read error
+  // (unreadable / absent file) so it never perturbs the rest of the
+  // report — a missing compose file is the normal state for the common
+  // "no local install" case, already gated by `localInstall`.
+  let composeDrift: ComposeFinding[] | undefined;
+  if (localInstall) {
+    const readCompose = opts.readComposeFile ?? defaultReadComposeFile;
+    try {
+      const content = await readCompose(localInstall.dir);
+      if (content !== null) {
+        const findings = analyzeComposeDefaults(content);
+        if (findings.length > 0) composeDrift = findings;
+      }
+    } catch {
+      // intentional swallow — drift detection is best-effort.
+    }
+  }
+
   return {
     installations,
     runningIndex,
     dualInstall: installations.length > 1,
     multiSource: sources.size > 1,
     ...(localInstall ? { localInstall } : {}),
+    ...(composeDrift ? { composeDrift } : {}),
   };
+}
+
+/**
+ * Default compose reader — reads `<dir>/docker-compose.yml`. Returns
+ * `null` (not a throw) when the file is missing so `runDoctor` can
+ * skip the drift section cleanly; other I/O errors propagate to the
+ * caller's soft-fail catch.
+ */
+async function defaultReadComposeFile(dir: string): Promise<string | null> {
+  try {
+    return await readFile(join(dir, "docker-compose.yml"), "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return null;
+    throw err;
+  }
 }
 
 /**
@@ -273,6 +332,10 @@ export function formatDoctorReport(report: DoctorReport, runningExecPath: string
     lines.push(`  • appstrate uninstall --purge   (down -v + rm <dir>, destructive)`);
   }
 
+  if (report.composeDrift && report.composeDrift.length > 0) {
+    lines.push(...formatComposeDrift(report.composeDrift));
+  }
+
   if (report.dualInstall) {
     lines.push(``);
     lines.push(`Multiple installations detected.`);
@@ -296,6 +359,51 @@ export function formatDoctorReport(report: DoctorReport, runningExecPath: string
   }
 
   return lines.join("\n");
+}
+
+/**
+ * Render the compose-drift section (#515). Splits the findings into the
+ * two classes so the operator sees which lines are safe to auto-strip
+ * (`appstrate install --upgrade-compose`) versus which need a human eye
+ * (an intentional override whose recorded default drifted).
+ */
+function formatComposeDrift(findings: ComposeFinding[]): string[] {
+  const lines: string[] = [];
+  const duplicates = findings.filter((f) => f.kind === "duplicate");
+  const drifts = findings.filter((f) => f.kind === "allowlist-drift");
+
+  lines.push(``);
+  lines.push(
+    `Compose drift: ${findings.length} env default(s) in your on-disk docker-compose.yml ` +
+      `mirror or diverge from the platform schema.`,
+  );
+
+  if (duplicates.length > 0) {
+    lines.push(``);
+    lines.push(
+      `  Stale duplicated defaults (safe to remove — they mask schema updates, the #513 class):`,
+    );
+    for (const f of duplicates) {
+      lines.push(`    • line ${f.line}: ${f.varName}=${JSON.stringify(f.yamlDefault)}`);
+    }
+    lines.push(``);
+    lines.push(`  Fix automatically (backs up the file first, preserves your edits):`);
+    lines.push(`    • appstrate install --upgrade-compose`);
+  }
+
+  if (drifts.length > 0) {
+    lines.push(``);
+    lines.push(`  Intentional overrides whose value diverged from the shipped template:`);
+    for (const f of drifts) {
+      lines.push(
+        `    • line ${f.line}: ${f.varName}=${JSON.stringify(f.yamlDefault)} ` +
+          `(template default ${JSON.stringify(f.expectedYamlDefault)})`,
+      );
+    }
+    lines.push(`  Left untouched by --upgrade-compose — review by hand if unexpected.`);
+  }
+
+  return lines;
 }
 
 function upgradeHintRemoval(source: InstallSource): string {

--- a/apps/cli/src/lib/install/compose-upgrade.ts
+++ b/apps/cli/src/lib/install/compose-upgrade.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `appstrate install --upgrade-compose` (issue #515) — strip stale
+ * duplicated env defaults from an operator's on-disk
+ * `<dir>/docker-compose.yml` without touching `.env`, without running
+ * Docker, and without disturbing any operator-added blocks.
+ *
+ * The repair itself is pure (`rewriteStaleComposeDefaults` in
+ * `../compose-defaults.ts`): it only ever shortens the specific
+ * `- VAR=${VAR:-default}` lines that mirror a code default, so services,
+ * volumes, comments, and any hand-added env are preserved verbatim.
+ * Anything that can't be cleanly auto-fixed is REFUSED (reported, not
+ * guessed at) — the "refuses with a diff if it can't cleanly merge"
+ * half of the issue's proposal.
+ *
+ * This module is the thin I/O wrapper around that pure core: read the
+ * file, back it up, atomically rewrite. All side effects are injectable
+ * so the orchestration is unit-testable without a real install dir.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { defaultInstallDir } from "./project.ts";
+import { atomicReplace, backupFiles } from "./upgrade.ts";
+import {
+  rewriteStaleComposeDefaults,
+  type ComposeFixApplied,
+  type ComposeFixRefused,
+} from "../compose-defaults.ts";
+
+/** Compose file name relative to the install dir — single source. */
+const COMPOSE_FILE = "docker-compose.yml";
+
+export type ComposeUpgradeStatus =
+  /** No `<dir>/docker-compose.yml` — nothing to upgrade (likely Tier 0 or wrong dir). */
+  | "no-install"
+  /** File is already clean of removable duplicated defaults. */
+  | "clean"
+  /** Duplicated defaults were found and stripped (file rewritten + backed up). */
+  | "upgraded"
+  /** Duplicated defaults exist but NONE were auto-fixable — file left untouched. */
+  | "refused-only";
+
+export interface ComposeUpgradeOutcome {
+  status: ComposeUpgradeStatus;
+  /** Absolute path to the compose file that was (or would be) rewritten. */
+  composePath: string;
+  /** Lines rewritten to bare passthroughs. */
+  applied: ComposeFixApplied[];
+  /** Duplicated defaults that need a human edit (mapping form, etc.). */
+  refused: ComposeFixRefused[];
+  /** Absolute path to the `.backup` written before an upgrade, if any. */
+  backupPath?: string;
+}
+
+export interface ComposeUpgradeDeps {
+  /** Read the compose file content, or `null` when it does not exist. */
+  readComposeFile?: (path: string) => Promise<string | null>;
+  /** Copy `<dir>/<name>` → `<dir>/<name>.backup`; returns names backed up. */
+  backup?: (dir: string, files: string[]) => Promise<string[]>;
+  /** Atomically replace the compose file with new content. */
+  writeComposeFile?: (path: string, body: string) => Promise<void>;
+}
+
+/** Default reader — `null` on ENOENT, rethrow other I/O errors. */
+async function defaultReadComposeFile(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+/**
+ * Run the compose upgrade for an install rooted at `dir`.
+ *
+ * Never runs Docker and never writes `.env` — applying the refreshed
+ * compose to a running stack is left to the operator (`docker compose
+ * up -d` / `appstrate restart`), surfaced by `formatComposeUpgradeResult`.
+ */
+export async function runComposeUpgrade(
+  dir: string,
+  deps: ComposeUpgradeDeps = {},
+): Promise<ComposeUpgradeOutcome> {
+  const absDir = resolve(dir);
+  const composePath = join(absDir, COMPOSE_FILE);
+  const read = deps.readComposeFile ?? defaultReadComposeFile;
+  const backup = deps.backup ?? backupFiles;
+  const write = deps.writeComposeFile ?? atomicReplace;
+
+  const content = await read(composePath);
+  if (content === null) {
+    return { status: "no-install", composePath, applied: [], refused: [] };
+  }
+
+  const result = rewriteStaleComposeDefaults(content);
+
+  if (!result.changed) {
+    return {
+      status: result.refused.length > 0 ? "refused-only" : "clean",
+      composePath,
+      applied: [],
+      refused: result.refused,
+    };
+  }
+
+  // Back up BEFORE the write so a crashed/killed process can never
+  // leave the operator without a recoverable previous generation.
+  const backedUp = await backup(absDir, [COMPOSE_FILE]);
+  await write(composePath, result.newContent);
+
+  return {
+    status: "upgraded",
+    composePath,
+    applied: result.applied,
+    refused: result.refused,
+    ...(backedUp.includes(COMPOSE_FILE)
+      ? { backupPath: join(absDir, `${COMPOSE_FILE}.backup`) }
+      : {}),
+  };
+}
+
+/**
+ * Render a `ComposeUpgradeOutcome` as plain-text lines (the command
+ * file frames it with clack). Mirrors `formatDoctorReport`'s "lib owns
+ * the words, command owns the I/O" split.
+ */
+export function formatComposeUpgradeResult(outcome: ComposeUpgradeOutcome): string {
+  const lines: string[] = [];
+
+  switch (outcome.status) {
+    case "no-install":
+      lines.push(`No ${COMPOSE_FILE} found at ${outcome.composePath}.`);
+      lines.push(``);
+      lines.push(
+        `--upgrade-compose only applies to a Docker-tier install. Pass --dir <path> if your`,
+      );
+      lines.push(`install lives elsewhere, or run \`appstrate install\` to create one.`);
+      return lines.join("\n");
+
+    case "clean":
+      lines.push(`${outcome.composePath} is already clean — no stale duplicated defaults.`);
+      return lines.join("\n");
+
+    case "refused-only":
+      lines.push(
+        `Found ${outcome.refused.length} duplicated default(s) in ${outcome.composePath},`,
+      );
+      lines.push(`but none could be auto-fixed safely. Edit these lines by hand:`);
+      for (const r of outcome.refused) {
+        lines.push(`  • line ${r.line}: ${r.varName} — ${r.reason}`);
+        lines.push(`      ${r.raw.trim()}`);
+      }
+      return lines.join("\n");
+
+    case "upgraded":
+      lines.push(
+        `Rewrote ${outcome.composePath} — stripped ${outcome.applied.length} stale default(s):`,
+      );
+      for (const a of outcome.applied) {
+        lines.push(`  • line ${a.line}: ${a.before.trim()}  →  ${a.after.trim()}`);
+      }
+      if (outcome.backupPath) {
+        lines.push(``);
+        lines.push(`Previous version saved to ${outcome.backupPath}.`);
+      }
+      if (outcome.refused.length > 0) {
+        lines.push(``);
+        lines.push(`${outcome.refused.length} default(s) need a manual edit (not auto-fixable):`);
+        for (const r of outcome.refused) {
+          lines.push(`  • line ${r.line}: ${r.varName} — ${r.reason}`);
+        }
+      }
+      lines.push(``);
+      lines.push(
+        `Apply to a running stack:  cd ${resolve(outcome.composePath, "..")} && docker compose up -d`,
+      );
+      lines.push(`(or: appstrate restart)`);
+      return lines.join("\n");
+  }
+}
+
+/** Resolve the upgrade-compose target dir: `--dir` or `~/appstrate`. */
+export function resolveComposeUpgradeDir(rawDir: string | undefined): string {
+  return resolve(rawDir ?? defaultInstallDir());
+}

--- a/apps/cli/test/compose-defaults.test.ts
+++ b/apps/cli/test/compose-defaults.test.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "bun:test";
+import {
+  analyzeComposeDefaults,
+  extractComposeDefaults,
+  rewriteStaleComposeDefaults,
+  CODE_DEFAULTS,
+  ALLOWLIST,
+} from "../src/lib/compose-defaults.ts";
+
+/**
+ * Unit coverage for the shared compose-default knowledge (#515). Pure
+ * string-in/findings-out — no filesystem. Mirrors the contract the CI
+ * guard (`scripts/verify-compose-defaults.ts`) and the runtime checks
+ * (`appstrate doctor` / `--upgrade-compose`) both rely on.
+ */
+
+// MODULES is a tracked, NON-allowlisted code default — the canonical
+// #513 drift var. Its code default is the literal CSV below.
+const MODULES_DEFAULT = CODE_DEFAULTS.MODULES!;
+
+describe("extractComposeDefaults", () => {
+  it("captures var name, default, line, and raw text per occurrence", () => {
+    const content = [
+      "services:",
+      "  api:",
+      "    environment:",
+      "      - MODULES=${MODULES:-a,b}",
+    ].join("\n");
+    const matches = extractComposeDefaults(content);
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      line: 4,
+      varName: "MODULES",
+      yamlDefault: "a,b",
+      raw: "      - MODULES=${MODULES:-a,b}",
+    });
+  });
+
+  it("finds multiple occurrences on the same line", () => {
+    const content =
+      "      - DATABASE_URL=postgres://${POSTGRES_USER:-appstrate}:${POSTGRES_PASSWORD:-x}@db";
+    const matches = extractComposeDefaults(content);
+    expect(matches.map((m) => m.varName)).toEqual(["POSTGRES_USER", "POSTGRES_PASSWORD"]);
+  });
+
+  it("does not leak regex state across calls (lastIndex reset)", () => {
+    const content = "      - MODULES=${MODULES:-x}";
+    expect(extractComposeDefaults(content)).toHaveLength(1);
+    expect(extractComposeDefaults(content)).toHaveLength(1);
+  });
+});
+
+describe("analyzeComposeDefaults", () => {
+  it("flags a duplicated code default", () => {
+    const content = `      - MODULES=\${MODULES:-${MODULES_DEFAULT}}`;
+    const findings = analyzeComposeDefaults(content);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      kind: "duplicate",
+      varName: "MODULES",
+      yamlDefault: MODULES_DEFAULT,
+      codeDefault: MODULES_DEFAULT,
+      line: 1,
+    });
+  });
+
+  it("ignores a YAML default that differs from the code default", () => {
+    // An operator who genuinely wants a different default is not the
+    // #513 bug — only an EXACT mirror is flagged.
+    const content = "      - MODULES=${MODULES:-only,webhooks}";
+    expect(analyzeComposeDefaults(content)).toEqual([]);
+  });
+
+  it("ignores untracked variables entirely", () => {
+    const content = "      - SOME_RANDOM_VAR=${SOME_RANDOM_VAR:-whatever}";
+    expect(analyzeComposeDefaults(content)).toEqual([]);
+  });
+
+  it("does not flag an allowlisted var at its sanctioned default", () => {
+    // RUN_ADAPTER is allowlisted with yamlDefault "docker".
+    const content = "      - RUN_ADAPTER=${RUN_ADAPTER:-docker}";
+    expect(analyzeComposeDefaults(content)).toEqual([]);
+  });
+
+  it("flags allowlist drift when an override's default changed", () => {
+    const content = "      - RUN_ADAPTER=${RUN_ADAPTER:-process}";
+    const findings = analyzeComposeDefaults(content);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      kind: "allowlist-drift",
+      varName: "RUN_ADAPTER",
+      yamlDefault: "process",
+      expectedYamlDefault: ALLOWLIST.RUN_ADAPTER!.yamlDefault,
+    });
+  });
+
+  it("returns findings in line order for a mixed file", () => {
+    const content = [
+      "      - SOME_RANDOM_VAR=${SOME_RANDOM_VAR:-x}", // ignored
+      `      - MODULES=\${MODULES:-${MODULES_DEFAULT}}`, // duplicate
+      "      - RUN_ADAPTER=${RUN_ADAPTER:-process}", // allowlist-drift
+    ].join("\n");
+    const findings = analyzeComposeDefaults(content);
+    expect(findings.map((f) => [f.line, f.kind])).toEqual([
+      [2, "duplicate"],
+      [3, "allowlist-drift"],
+    ]);
+  });
+});
+
+describe("rewriteStaleComposeDefaults", () => {
+  it("returns unchanged for a clean file", () => {
+    const content = ["      - MODULES", "      - APP_URL"].join("\n");
+    const result = rewriteStaleComposeDefaults(content);
+    expect(result.changed).toBe(false);
+    expect(result.newContent).toBe(content);
+    expect(result.applied).toEqual([]);
+    expect(result.refused).toEqual([]);
+  });
+
+  it("strips a stale sequence-entry default to a bare passthrough", () => {
+    const content = [
+      "    environment:",
+      `      - MODULES=\${MODULES:-${MODULES_DEFAULT}}`,
+      "      - APP_URL",
+    ].join("\n");
+    const result = rewriteStaleComposeDefaults(content);
+    expect(result.changed).toBe(true);
+    expect(result.applied).toHaveLength(1);
+    expect(result.applied[0]).toMatchObject({
+      line: 2,
+      varName: "MODULES",
+      after: "      - MODULES",
+    });
+    expect(result.newContent.split("\n")[1]).toBe("      - MODULES");
+    expect(result.refused).toEqual([]);
+  });
+
+  it("preserves operator-added lines verbatim", () => {
+    const content = [
+      "    environment:",
+      `      - MODULES=\${MODULES:-${MODULES_DEFAULT}}`,
+      "      - MY_CUSTOM_OPERATOR_VAR=hello",
+      "    volumes:",
+      "      - ./my-extra-mount:/data",
+    ].join("\n");
+    const result = rewriteStaleComposeDefaults(content);
+    const lines = result.newContent.split("\n");
+    expect(lines[1]).toBe("      - MODULES");
+    expect(lines[2]).toBe("      - MY_CUSTOM_OPERATOR_VAR=hello");
+    expect(lines[4]).toBe("      - ./my-extra-mount:/data");
+  });
+
+  it("is idempotent — a second pass changes nothing", () => {
+    const content = `      - MODULES=\${MODULES:-${MODULES_DEFAULT}}`;
+    const once = rewriteStaleComposeDefaults(content);
+    const twice = rewriteStaleComposeDefaults(once.newContent);
+    expect(twice.changed).toBe(false);
+    expect(twice.newContent).toBe(once.newContent);
+  });
+
+  it("refuses (does not guess) a duplicated default in mapping form", () => {
+    // Hand-written `VAR: ${VAR:-default}` cannot become a bare
+    // passthrough without changing YAML structure → reported, not edited.
+    const content = `      MODULES: \${MODULES:-${MODULES_DEFAULT}}`;
+    const result = rewriteStaleComposeDefaults(content);
+    expect(result.changed).toBe(false);
+    expect(result.newContent).toBe(content);
+    expect(result.refused).toHaveLength(1);
+    expect(result.refused[0]).toMatchObject({ line: 1, varName: "MODULES" });
+  });
+
+  it("leaves allowlist-drift lines untouched (not the #513 class)", () => {
+    const content = "      - RUN_ADAPTER=${RUN_ADAPTER:-process}";
+    const result = rewriteStaleComposeDefaults(content);
+    expect(result.changed).toBe(false);
+    expect(result.applied).toEqual([]);
+    expect(result.refused).toEqual([]);
+  });
+
+  it("preserves indentation of the rewritten entry", () => {
+    const content = `        - MODULES=\${MODULES:-${MODULES_DEFAULT}}`;
+    const result = rewriteStaleComposeDefaults(content);
+    expect(result.newContent).toBe("        - MODULES");
+  });
+});

--- a/apps/cli/test/compose-upgrade.test.ts
+++ b/apps/cli/test/compose-upgrade.test.ts
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "bun:test";
+import {
+  runComposeUpgrade,
+  formatComposeUpgradeResult,
+  resolveComposeUpgradeDir,
+  type ComposeUpgradeDeps,
+  type ComposeUpgradeOutcome,
+} from "../src/lib/install/compose-upgrade.ts";
+import { CODE_DEFAULTS } from "../src/lib/compose-defaults.ts";
+import { defaultInstallDir } from "../src/lib/install/project.ts";
+
+/**
+ * `appstrate install --upgrade-compose` orchestration (#515). All
+ * filesystem effects are injected, so these assert the read → analyze →
+ * backup → write sequencing without an install dir on disk.
+ */
+
+const MODULES_DEFAULT = CODE_DEFAULTS.MODULES!;
+const STALE_LINE = `      - MODULES=\${MODULES:-${MODULES_DEFAULT}}`;
+
+/** Recording deps: capture what was read/backed-up/written. */
+function deps(content: string | null) {
+  const calls = {
+    backedUp: [] as { dir: string; files: string[] }[],
+    writes: [] as { path: string; body: string }[],
+  };
+  const d: ComposeUpgradeDeps = {
+    readComposeFile: async () => content,
+    backup: async (dir, files) => {
+      calls.backedUp.push({ dir, files });
+      return files; // pretend all existed and were copied
+    },
+    writeComposeFile: async (path, body) => {
+      calls.writes.push({ path, body });
+    },
+  };
+  return { d, calls };
+}
+
+describe("runComposeUpgrade", () => {
+  it("reports no-install when the compose file is absent", async () => {
+    const { d, calls } = deps(null);
+    const out = await runComposeUpgrade("/tmp/nope", d);
+    expect(out.status).toBe("no-install");
+    expect(out.composePath).toBe("/tmp/nope/docker-compose.yml");
+    expect(calls.writes).toHaveLength(0);
+    expect(calls.backedUp).toHaveLength(0);
+  });
+
+  it("reports clean when there is nothing to strip", async () => {
+    const { d, calls } = deps(
+      ["    environment:", "      - MODULES", "      - APP_URL"].join("\n"),
+    );
+    const out = await runComposeUpgrade("/srv/appstrate", d);
+    expect(out.status).toBe("clean");
+    expect(calls.writes).toHaveLength(0);
+    expect(calls.backedUp).toHaveLength(0);
+  });
+
+  it("backs up then writes when it strips a stale default", async () => {
+    const content = ["    environment:", STALE_LINE, "      - APP_URL"].join("\n");
+    const { d, calls } = deps(content);
+    const out = await runComposeUpgrade("/srv/appstrate", d);
+
+    expect(out.status).toBe("upgraded");
+    expect(out.applied).toHaveLength(1);
+    expect(out.applied[0]!.varName).toBe("MODULES");
+    expect(out.backupPath).toBe("/srv/appstrate/docker-compose.yml.backup");
+
+    // Backup happens BEFORE the write — assert ordering and content.
+    expect(calls.backedUp).toEqual([{ dir: "/srv/appstrate", files: ["docker-compose.yml"] }]);
+    expect(calls.writes).toHaveLength(1);
+    expect(calls.writes[0]!.path).toBe("/srv/appstrate/docker-compose.yml");
+    expect(calls.writes[0]!.body.split("\n")[1]).toBe("      - MODULES");
+  });
+
+  it("does not write when a duplicate exists but is not auto-fixable", async () => {
+    const content = `      MODULES: \${MODULES:-${MODULES_DEFAULT}}`; // mapping form
+    const { d, calls } = deps(content);
+    const out = await runComposeUpgrade("/srv/appstrate", d);
+    expect(out.status).toBe("refused-only");
+    expect(out.refused).toHaveLength(1);
+    expect(calls.writes).toHaveLength(0);
+    expect(calls.backedUp).toHaveLength(0);
+  });
+
+  it("omits backupPath when the backup helper reports nothing copied", async () => {
+    const content = STALE_LINE;
+    const d: ComposeUpgradeDeps = {
+      readComposeFile: async () => content,
+      backup: async () => [], // nothing actually existed to copy
+      writeComposeFile: async () => {},
+    };
+    const out = await runComposeUpgrade("/srv/appstrate", d);
+    expect(out.status).toBe("upgraded");
+    expect(out.backupPath).toBeUndefined();
+  });
+});
+
+describe("formatComposeUpgradeResult", () => {
+  function fmt(o: Partial<ComposeUpgradeOutcome> & { status: ComposeUpgradeOutcome["status"] }) {
+    return formatComposeUpgradeResult({
+      composePath: "/srv/appstrate/docker-compose.yml",
+      applied: [],
+      refused: [],
+      ...o,
+    });
+  }
+
+  it("no-install points at --dir", () => {
+    const text = fmt({ status: "no-install" });
+    expect(text).toContain("No docker-compose.yml found");
+    expect(text).toContain("--dir");
+  });
+
+  it("clean says already clean", () => {
+    expect(fmt({ status: "clean" })).toContain("already clean");
+  });
+
+  it("upgraded lists the stripped lines, backup, and restart hint", () => {
+    const text = fmt({
+      status: "upgraded",
+      applied: [
+        {
+          line: 2,
+          varName: "MODULES",
+          before: "      - MODULES=${MODULES:-x}",
+          after: "      - MODULES",
+        },
+      ],
+      backupPath: "/srv/appstrate/docker-compose.yml.backup",
+    });
+    expect(text).toContain("stripped 1 stale default");
+    expect(text).toContain("MODULES");
+    expect(text).toContain(".backup");
+    expect(text).toContain("docker compose up -d");
+  });
+
+  it("refused-only explains the manual edits", () => {
+    const text = fmt({
+      status: "refused-only",
+      refused: [
+        {
+          line: 5,
+          varName: "MODULES",
+          reason: "mapping form",
+          raw: "      MODULES: ${MODULES:-x}",
+        },
+      ],
+    });
+    expect(text).toContain("none could be auto-fixed");
+    expect(text).toContain("line 5");
+  });
+});
+
+describe("resolveComposeUpgradeDir", () => {
+  it("defaults to the standard install dir", () => {
+    expect(resolveComposeUpgradeDir(undefined)).toBe(defaultInstallDir());
+  });
+
+  it("resolves an explicit --dir to absolute", () => {
+    expect(resolveComposeUpgradeDir("/srv/appstrate")).toBe("/srv/appstrate");
+  });
+});

--- a/apps/cli/test/doctor.test.ts
+++ b/apps/cli/test/doctor.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect } from "bun:test";
 import { formatDoctorReport, runDoctor, type ProbeBinary } from "../src/lib/doctor.ts";
 import { type PathScanFs } from "../src/lib/path-scan.ts";
 import { buildInternalInfoPayload, type InternalInfoPayload } from "../src/commands/internal.ts";
+import { CODE_DEFAULTS } from "../src/lib/compose-defaults.ts";
 
 /**
  * Phase 3 — `appstrate doctor` (issue #249).
@@ -335,6 +336,173 @@ describe("local Docker-tier install probe (#343)", () => {
     );
     expect(text).not.toContain("Local Docker-tier install detected");
     expect(text).not.toContain("appstrate logs -f");
+  });
+});
+
+describe("compose-drift check (#515)", () => {
+  const onPath = {
+    pathEnv: "/usr/local/bin",
+    pathScanFs: fs({ "/usr/local/bin/appstrate": { exec: true } }),
+    probeBinary: probe({
+      "/usr/local/bin/appstrate": { version: "1.2.3", source: "curl" as const },
+    }),
+    execPath: "/usr/local/bin/appstrate",
+  };
+  const localInstall = async (dir: string) => ({ dir, projectName: "appstrate-prod-cafebabe" });
+  const MODULES_DEFAULT = CODE_DEFAULTS.MODULES!;
+  const STALE_COMPOSE = [
+    "    environment:",
+    `      - MODULES=\${MODULES:-${MODULES_DEFAULT}}`,
+  ].join("\n");
+
+  it("attaches composeDrift when a local install's compose has a stale default", async () => {
+    const report = await runDoctor({
+      ...onPath,
+      probeLocalInstall: localInstall,
+      installDir: "/srv/appstrate",
+      readComposeFile: async () => STALE_COMPOSE,
+    });
+    expect(report.composeDrift).toBeDefined();
+    expect(report.composeDrift).toHaveLength(1);
+    expect(report.composeDrift![0]).toMatchObject({ kind: "duplicate", varName: "MODULES" });
+  });
+
+  it("omits composeDrift when the compose file is clean", async () => {
+    const report = await runDoctor({
+      ...onPath,
+      probeLocalInstall: localInstall,
+      installDir: "/srv/appstrate",
+      readComposeFile: async () => "    environment:\n      - MODULES",
+    });
+    expect(report.composeDrift).toBeUndefined();
+  });
+
+  it("does NOT read the compose file when there is no local install", async () => {
+    let read = false;
+    const report = await runDoctor({
+      ...onPath,
+      probeLocalInstall: async () => null,
+      readComposeFile: async () => {
+        read = true;
+        return STALE_COMPOSE;
+      },
+    });
+    expect(read).toBe(false);
+    expect(report.composeDrift).toBeUndefined();
+  });
+
+  it("omits composeDrift when the compose file is absent (reader returns null)", async () => {
+    const report = await runDoctor({
+      ...onPath,
+      probeLocalInstall: localInstall,
+      installDir: "/srv/appstrate",
+      readComposeFile: async () => null,
+    });
+    expect(report.composeDrift).toBeUndefined();
+  });
+
+  it("fails soft (no composeDrift) when the reader throws", async () => {
+    const report = await runDoctor({
+      ...onPath,
+      probeLocalInstall: localInstall,
+      installDir: "/srv/appstrate",
+      readComposeFile: async () => {
+        throw new Error("permission denied");
+      },
+    });
+    // The local install is still reported — only the drift section is skipped.
+    expect(report.localInstall).toBeDefined();
+    expect(report.composeDrift).toBeUndefined();
+  });
+
+  it("renders the drift section with the --upgrade-compose hint", () => {
+    const text = formatDoctorReport(
+      {
+        installations: [
+          {
+            pathEntry: "/usr/local/bin",
+            binary: "/usr/local/bin/appstrate",
+            realPath: "/usr/local/bin/appstrate",
+            version: "1.2.3",
+            source: "curl",
+          },
+        ],
+        runningIndex: 0,
+        dualInstall: false,
+        multiSource: false,
+        localInstall: { dir: "/srv/appstrate", projectName: "appstrate-prod-cafebabe" },
+        composeDrift: [
+          {
+            kind: "duplicate",
+            line: 2,
+            varName: "MODULES",
+            yamlDefault: "a,b",
+            codeDefault: "a,b",
+            raw: "      - MODULES=${MODULES:-a,b}",
+          },
+        ],
+      },
+      "/usr/local/bin/appstrate",
+    );
+    expect(text).toContain("Compose drift");
+    expect(text).toContain("MODULES");
+    expect(text).toContain("appstrate install --upgrade-compose");
+  });
+
+  it("renders allowlist-drift findings as manual-review, not auto-fixable", () => {
+    const text = formatDoctorReport(
+      {
+        installations: [
+          {
+            pathEntry: "/usr/local/bin",
+            binary: "/usr/local/bin/appstrate",
+            realPath: "/usr/local/bin/appstrate",
+            version: "1.2.3",
+            source: "curl",
+          },
+        ],
+        runningIndex: 0,
+        dualInstall: false,
+        multiSource: false,
+        localInstall: { dir: "/srv/appstrate", projectName: "appstrate-prod-cafebabe" },
+        composeDrift: [
+          {
+            kind: "allowlist-drift",
+            line: 9,
+            varName: "RUN_ADAPTER",
+            yamlDefault: "process",
+            expectedYamlDefault: "docker",
+            raw: "      - RUN_ADAPTER=${RUN_ADAPTER:-process}",
+          },
+        ],
+      },
+      "/usr/local/bin/appstrate",
+    );
+    expect(text).toContain("Intentional overrides");
+    expect(text).toContain("RUN_ADAPTER");
+    expect(text).toContain("review by hand");
+  });
+
+  it("does NOT render a drift section when composeDrift is absent", () => {
+    const text = formatDoctorReport(
+      {
+        installations: [
+          {
+            pathEntry: "/usr/local/bin",
+            binary: "/usr/local/bin/appstrate",
+            realPath: "/usr/local/bin/appstrate",
+            version: "1.2.3",
+            source: "curl",
+          },
+        ],
+        runningIndex: 0,
+        dualInstall: false,
+        multiSource: false,
+        localInstall: { dir: "/srv/appstrate", projectName: "appstrate-prod-cafebabe" },
+      },
+      "/usr/local/bin/appstrate",
+    );
+    expect(text).not.toContain("Compose drift");
   });
 });
 

--- a/examples/self-hosting/README.md
+++ b/examples/self-hosting/README.md
@@ -297,6 +297,23 @@ docker compose up -d
 
 Migrations run automatically on startup via the `appstrate-migrate` service.
 
+### Keeping `docker-compose.yml` in sync
+
+Env defaults live in the platform's schema, not the compose file. An older
+on-disk `docker-compose.yml` can still pin a stale default (e.g. `MODULES`)
+that masks newer schema values. `appstrate doctor` flags this under a
+**Compose drift** section when it detects a local install. To strip the
+stale duplicated defaults — backing up the file first and preserving any
+edits you made (extra services, mounts, comments) — run:
+
+```bash
+appstrate install --upgrade-compose          # ~/appstrate
+appstrate install --upgrade-compose --dir /srv/appstrate
+```
+
+It never touches `.env` or runs Docker; restart the stack afterwards
+(`docker compose up -d`) to apply.
+
 ## Configuration
 
 See `.env.example` for all available environment variables. Key settings:

--- a/scripts/verify-compose-defaults.ts
+++ b/scripts/verify-compose-defaults.ts
@@ -9,24 +9,21 @@
  * model providers for weeks). This guard catches the same class of bug
  * at PR time.
  *
- * Approach (intentionally simple): regex-parse the 4 compose files for
- * `${NAME:-DEFAULT}` patterns; cross-check each match against the
- * hand-maintained `CODE_DEFAULTS` table below. Flag any YAML default
- * that mirrors the code default, unless the variable is on the
- * `ALLOWLIST` (intentional override, with a documented reason).
- *
- * Trade-off: the table here is hand-maintained, not parsed from the
- * Zod schema. The schema's `.default(...)` calls are mixed with
- * transforms and refinements that are non-trivial to extract
- * statically, and a hand list paired with this same guard's coverage
- * is enough to catch the regression — a typo in the table would just
- * fail to catch one duplication, not introduce one. Keep the table in
- * sync with `packages/env/src/index.ts` when adding new vars.
+ * The table + extraction + analysis live in
+ * `apps/cli/src/lib/compose-defaults.ts` so this PR-time guard and the
+ * runtime checks (`appstrate doctor` / `appstrate install
+ * --upgrade-compose`, issue #515) share one source of truth and can
+ * never disagree about what counts as a duplication.
  *
  * Usage: bun scripts/verify-compose-defaults.ts
  */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import {
+  analyzeComposeDefaults,
+  SCHEMA_SOURCE,
+  type ComposeFinding,
+} from "../apps/cli/src/lib/compose-defaults.ts";
 
 const REPO_ROOT = join(import.meta.dir, "..");
 
@@ -37,235 +34,16 @@ const COMPOSE_FILES = [
   "examples/self-hosting/docker-compose.tier3.yml",
 ];
 
-const SCHEMA_SOURCE = "packages/env/src/index.ts";
-
-// ─── Code defaults (mirror of `packages/env/src/index.ts`) ───────────
-//
-// String values are the literal default the Zod schema resolves to
-// BEFORE transformation (compose passes raw env vars, the schema parses
-// JSON / coerces booleans afterward). Keep this list in sync.
-const CODE_DEFAULTS: Record<string, string> = {
-  APP_URL: "http://localhost:3000",
-  AUTH_DISABLE_SIGNUP: "false",
-  AUTH_DISABLE_ORG_CREATION: "false",
-  AUTH_PLATFORM_ADMIN_EMAILS: "",
-  AUTH_ALLOWED_SIGNUP_DOMAINS: "",
-  AUTH_BOOTSTRAP_OWNER_EMAIL: "",
-  AUTH_BOOTSTRAP_ORG_NAME: "Default",
-  AUTH_BOOTSTRAP_TOKEN: "",
-  AFPS_TRUST_ROOT: "[]",
-  AFPS_SIGNATURE_POLICY: "off",
-  BETTER_AUTH_ACTIVE_KID: "k1",
-  BETTER_AUTH_SECRETS: "{}",
-  CONNECTION_ENCRYPTION_KEY_ID: "k1",
-  CONNECTION_ENCRYPTION_KEYS: "{}",
-  LOG_LEVEL: "info",
-  OTEL_ENABLED: "false",
-  OTEL_SERVICE_NAME: "appstrate-api",
-  OTEL_TRUST_INCOMING_TRACE: "false",
-  MODULES: "oidc,webhooks,mcp,core-providers,@appstrate/module-codex,@appstrate/module-claude-code",
-  OAUTH_REFRESH_WORKER_ENABLED: "false",
-  INTEGRATION_REFRESH_MAX_FAILURES: "5",
-  INTEGRATION_REFRESH_GRACE_SECONDS: "3600",
-  REMOTE_RUN_SINK_DEFAULT_TTL_SECONDS: "7200",
-  REMOTE_RUN_SINK_MAX_TTL_SECONDS: "86400",
-  REMOTE_RUN_REPLAY_WINDOW_SECONDS: "600",
-  REMOTE_RUN_BUFFER_FLUSH_MS: "5000",
-  REMOTE_RUN_EVENT_LIMITS: "{}",
-  RUN_HEARTBEAT_INTERVAL_SECONDS: "15",
-  RUN_STALL_THRESHOLD_SECONDS: "60",
-  RUN_WATCHDOG_INTERVAL_SECONDS: "15",
-  SIDECAR_MAX_REQUEST_BODY_BYTES: "10485760",
-  SIDECAR_MAX_MCP_ENVELOPE_BYTES: "16777216",
-  SYSTEM_PROVIDER_KEYS: "[]",
-  SYSTEM_PROXIES: "[]",
-  TRUST_PROXY: "false",
-  WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS: "300",
-  // `RUN_TOKEN_SECRET` is `.optional()` — its absence equals empty
-  // string in compose, so a `${RUN_TOKEN_SECRET:-}` is a duplication.
-  RUN_TOKEN_SECRET: "",
-  // `PORT` default is the number 3000; compose stores strings.
-  PORT: "3000",
-  // `DOCKER_SOCKET` is a code default but compose mirrors the YAML
-  // volume mount (intentional override territory — see ALLOWLIST).
-  DOCKER_SOCKET: "/var/run/docker.sock",
-  // `RUN_ADAPTER` code default is `process`; compose intentionally
-  // overrides to `docker` (see ALLOWLIST).
-  RUN_ADAPTER: "process",
-  // Sidecar integration runtime pinned by the Docker orchestrator
-  // (operator override; the process orchestrator reads the raw env).
-  INTEGRATION_RUNTIME_ADAPTER: "docker",
-  // `TRUSTED_ORIGINS` code default is the dev localhost CSV; compose
-  // intentionally overrides to empty (see ALLOWLIST).
-  TRUSTED_ORIGINS: "http://localhost:3000,http://localhost:5173",
-  // `PI_IMAGE` / `SIDECAR_IMAGE` code default is Docker Hub `:latest`;
-  // compose intentionally overrides to GHCR (see ALLOWLIST).
-  PI_IMAGE: "appstrate-pi:latest",
-  SIDECAR_IMAGE: "appstrate-sidecar:latest",
-  // `PGLITE_DATA_DIR` / `FS_STORAGE_PATH` defaults exist but compose
-  // doesn't usually reference them with a default.
-  PGLITE_DATA_DIR: "./data/pglite",
-  FS_STORAGE_PATH: "./data/storage",
-  // `NODE_ENV` defaults to `development`; compose-driven prod usually
-  // sets it explicitly via `.env`, no default-mirroring expected.
-  NODE_ENV: "development",
-  API_BODY_LIMIT_BYTES: "10485760",
-  SMTP_PORT: "587",
-  LLM_PROXY_CACHE_MODE: "off",
-  LLM_PROXY_CACHE_MAX_AGE: "3600",
-  PLATFORM_RUN_LIMITS: "{}",
-  INLINE_RUN_LIMITS: "{}",
-  LLM_PROXY_LIMITS: "{}",
-  CREDENTIAL_PROXY_LIMITS: "{}",
-  OIDC_INSTANCE_CLIENTS: "[]",
-};
-
-// ─── Allowlist — intentional overrides (reason required) ─────────────
-//
-// Each entry's value is the YAML default and the operator-visible
-// rationale for differing from the code default. When the YAML default
-// CHANGES, update the rationale (or remove the entry if the override
-// is no longer intentional).
-const ALLOWLIST: Record<string, { yamlDefault: string; reason: string }> = {
-  RUN_ADAPTER: {
-    yamlDefault: "docker",
-    reason:
-      "Code default `process` is for OSS dev; containerized self-host requires Docker isolation.",
-  },
-  TRUSTED_ORIGINS: {
-    yamlDefault: "",
-    reason:
-      "Code default includes dev localhost ports; prod self-host correctly defaults to empty so operator opts in to their public domain explicitly.",
-  },
-  S3_BUCKET: {
-    yamlDefault: "appstrate",
-    reason:
-      "Environment-specific — switches the platform into S3 mode. Bare name aligns with the MinIO bucket created by minio-init.",
-  },
-  S3_REGION: {
-    yamlDefault: "us-east-1",
-    reason:
-      "Environment-specific. MinIO ignores this but the AWS SDK requires it to be non-empty when S3_BUCKET is set.",
-  },
-  PORT: {
-    yamlDefault: "3000",
-    reason: "Mirrors the YAML `ports:` mapping — keep coupled.",
-  },
-  DOCKER_SOCKET: {
-    yamlDefault: "/var/run/docker.sock",
-    reason: "Mirrors the YAML `volumes:` mount — keep coupled.",
-  },
-  PI_IMAGE: {
-    yamlDefault: "ghcr.io/appstrate/appstrate-pi:${APPSTRATE_VERSION:-latest}",
-    reason:
-      "Override to GHCR registry + APPSTRATE_VERSION coupling (code default points at Docker Hub).",
-  },
-  SIDECAR_IMAGE: {
-    yamlDefault: "ghcr.io/appstrate/appstrate-sidecar:${APPSTRATE_VERSION:-latest}",
-    reason:
-      "Override to GHCR registry + APPSTRATE_VERSION coupling (code default points at Docker Hub).",
-  },
-  BETTER_AUTH_SECRETS: {
-    yamlDefault: "",
-    reason:
-      "Empty string (NOT `{}`) is load-bearing — neutralizes better-auth 1.6+'s own CSV parser that crashes boot on a non-CSV `{}` value. See compose comment block.",
-  },
-};
-
-// ─── Compose default extraction ──────────────────────────────────────
-
-interface Match {
-  file: string;
-  line: number;
-  varName: string;
-  yamlDefault: string;
-}
-
-// Match `${NAME:-default}` where default can be anything except `}`.
-// The pattern handles nested braces poorly, but compose files don't
-// use them — this is sufficient for the env vars we care about.
-const DEFAULT_PATTERN = /\$\{([A-Z_][A-Z0-9_]*):-([^}]*)\}/g;
-
-function extractDefaults(filePath: string): Match[] {
-  const absPath = join(REPO_ROOT, filePath);
-  const content = readFileSync(absPath, "utf-8");
-  const lines = content.split("\n");
-  const matches: Match[] = [];
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i] ?? "";
-    DEFAULT_PATTERN.lastIndex = 0;
-    let m: RegExpExecArray | null;
-    while ((m = DEFAULT_PATTERN.exec(line)) !== null) {
-      const [, varName, yamlDefault] = m;
-      if (!varName) continue;
-      matches.push({
-        file: filePath,
-        line: i + 1,
-        varName,
-        yamlDefault: yamlDefault ?? "",
-      });
-    }
-  }
-
-  return matches;
-}
-
-// ─── Main ────────────────────────────────────────────────────────────
-
-type Finding =
-  | {
-      kind: "duplicate";
-      file: string;
-      line: number;
-      varName: string;
-      yamlDefault: string;
-      codeDefault: string;
-    }
-  | {
-      kind: "allowlist-drift";
-      file: string;
-      line: number;
-      varName: string;
-      yamlDefault: string;
-      expectedYamlDefault: string;
-    };
+/** A finding tagged with the file it came from (the lib is per-content). */
+type FileFinding = ComposeFinding & { file: string };
 
 function main(): number {
-  const findings: Finding[] = [];
+  const findings: FileFinding[] = [];
 
   for (const file of COMPOSE_FILES) {
-    for (const match of extractDefaults(file)) {
-      const codeDefault = CODE_DEFAULTS[match.varName];
-      if (codeDefault === undefined) continue; // not in our table, skip
-
-      const allowed = ALLOWLIST[match.varName];
-      if (allowed) {
-        // Allowed — but sanity-check the recorded yamlDefault still
-        // matches what the file actually says. Catch silent drift.
-        if (allowed.yamlDefault !== match.yamlDefault) {
-          findings.push({
-            kind: "allowlist-drift",
-            file: match.file,
-            line: match.line,
-            varName: match.varName,
-            yamlDefault: match.yamlDefault,
-            expectedYamlDefault: allowed.yamlDefault,
-          });
-        }
-        continue;
-      }
-
-      if (match.yamlDefault === codeDefault) {
-        findings.push({
-          kind: "duplicate",
-          file: match.file,
-          line: match.line,
-          varName: match.varName,
-          yamlDefault: match.yamlDefault,
-          codeDefault,
-        });
-      }
+    const content = readFileSync(join(REPO_ROOT, file), "utf-8");
+    for (const finding of analyzeComposeDefaults(content)) {
+      findings.push({ ...finding, file });
     }
   }
 
@@ -290,7 +68,7 @@ function main(): number {
       `Compose files should not mirror defaults already defined in ${SCHEMA_SOURCE}.\n` +
         `Drop the YAML default and rely on the Zod schema's single source of truth — or, if the\n` +
         `override is deliberate, add the variable to the ALLOWLIST in\n` +
-        `scripts/verify-compose-defaults.ts with a documented reason.\n` +
+        `apps/cli/src/lib/compose-defaults.ts with a documented reason.\n` +
         `This was the root cause of #513 (MODULES drift → no model providers).\n`,
     );
     for (const f of duplicates) {
@@ -308,7 +86,7 @@ function main(): number {
     console.error(`\x1b[1m── Class 2: ALLOWLIST drift ──\x1b[0m`);
     console.error(
       `The ALLOWLIST entry's recorded yamlDefault no longer matches the compose file.\n` +
-        `Either update the ALLOWLIST entry in scripts/verify-compose-defaults.ts (when the\n` +
+        `Either update the ALLOWLIST entry in apps/cli/src/lib/compose-defaults.ts (when the\n` +
         `change is intentional — also revise the documented reason) or revert the compose\n` +
         `change. Silent drift would let an intentional override quietly change semantics.\n`,
     );


### PR DESCRIPTION
Closes #515.

## Context

#514 made the Zod schema (`packages/env`) the single source of truth for env defaults and added a PR-time CI guard (`verify:compose-defaults`). But operators who installed **before** #514 keep a `docker-compose.yml` that still re-declares those defaults. A stale YAML default silently masks newer schema values — the exact #513 `MODULES` class — and nothing surfaced it at runtime. This adds the runtime side.

## What's in here

**`appstrate doctor` — drift detection**
Reads a detected local install's on-disk `docker-compose.yml` and reports a **Compose drift** section:
- *Stale duplicated defaults* — safe to strip (mask schema updates).
- *Intentional overrides whose value diverged* from the shipped template — flagged for manual review, never auto-touched.

Soft-fails: a missing/unreadable compose file (the normal "no local install" state) never perturbs the rest of the report. Gated on a detected local install. Also surfaced in `doctor --json`.

**`appstrate install --upgrade-compose` — surgical repair**
Rewrites only the specific `- VAR=${VAR:-default}` sequence entries that mirror a code default → bare `- VAR` passthrough (schema default wins). 
- Backs the file up first; preserves **every** operator-added block verbatim (extra services, mounts, comments, custom env).
- A duplicated default not in that canonical shape (hand-written mapping form, etc.) is **refused** and reported for a manual edit — the "refuses with a diff if it can't cleanly merge" path — rather than guessed at.
- Never touches `.env`, never runs Docker. Idempotent.

**Single source of truth**
The `CODE_DEFAULTS` / `ALLOWLIST` tables + extraction + analysis move to `apps/cli/src/lib/compose-defaults.ts`. The PR-time guard (`scripts/verify-compose-defaults.ts`) now imports from it, so CI and the runtime checks can never disagree about what counts as a duplication.

## Out of scope (per the issue)

No new CI guard — #514's `verify:compose-defaults` already catches regressions at PR time. This is purely the runtime/operator migration side.

## Testing

- `compose-defaults.test.ts` — analysis (duplicate / allowlist-drift / untracked), surgical repair, idempotency, refusal of non-canonical shapes, operator-line + indentation preservation.
- `compose-upgrade.test.ts` — read → backup → write sequencing via injected I/O; clean / upgraded / refused-only / no-install; backupPath presence.
- `doctor.test.ts` — drift attach, local-install gating (no read when no install), null/throw soft-fail, rendering of both finding classes.
- Full repo `bun run check` green (31/31). Manual end-to-end run confirmed: stale `MODULES` stripped, operator lines + volumes preserved, backup written, re-run reports clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)