### PR TITLE
fix(e2e): match new dependency-override error wording

### DIFF
--- a/e2e/tests/runs/dependency-overrides.api.spec.ts
+++ b/e2e/tests/runs/dependency-overrides.api.spec.ts
@@ -112,7 +112,9 @@ test.describe("Run dependency resolution (#666)", () => {
     });
 
     expect(res.status()).toBe(400);
-    expect(JSON.stringify(await res.json()).toLowerCase()).toContain("declared skill dependency");
+    expect(JSON.stringify(await res.json()).toLowerCase()).toContain(
+      "declared skill or integration dependency",
+    );
   });
 
   test("fails loud with 422 for an unsatisfiable manifest pin", async ({


### PR DESCRIPTION
## Problem

The `e2e` job has been red on every push to `main` since #703 (#686 "honor integration manifest pins") landed. One spec fails:

`e2e/tests/runs/dependency-overrides.api.spec.ts:115`

## Cause

#686 changed the run-pipeline validation error in `apps/api/src/services/run-pipeline.ts:244`:

- before: `... is not a declared skill dependency of this agent`
- after: `... is not a declared skill or integration dependency of this agent`

The assertion (added in #666) still matched the old contiguous substring `"declared skill dependency"`; the inserted `or integration ` splits it, so `.toContain` fails. Source behaviour is correct — only the test was stale.

## Fix

Assertion now matches the current wording (`"declared skill or integration dependency"`). No source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)