### PR TITLE
feat(invitations): delegate invite auth to standard login/signup + session-only accept

### DIFF
--- a/apps/api/src/modules/oidc/pages/login.ts
+++ b/apps/api/src/modules/oidc/pages/login.ts
@@ -41,6 +41,14 @@ export interface LoginPageProps {
    * these buttons is safe.
    */
   allowSignup: boolean;
+  /**
+   * Lock the email field (read-only, pre-filled from `email`). Set when the
+   * authorize request carried an OIDC `login_hint` — the invitation flow
+   * pins the invited address so the user cannot accidentally sign in with a
+   * different account. UX only: the invitation accept endpoint re-checks the
+   * session email server-side.
+   */
+  lockEmail?: boolean;
 }
 
 export function renderLoginPage(props: LoginPageProps): RawHtml {
@@ -77,10 +85,16 @@ export function renderLoginPage(props: LoginPageProps): RawHtml {
         name="email"
         placeholder="Email"
         required
-        autofocus
+        ${props.lockEmail ? html`readonly` : html`autofocus`}
         value="${props.email ?? ""}"
       />
-      <input type="password" name="password" placeholder="Mot de passe" required />
+      <input
+        type="password"
+        name="password"
+        placeholder="Mot de passe"
+        required
+        ${props.lockEmail ? html`autofocus` : null}
+      />
       <button type="submit">Se connecter</button>
     </form>
     ${renderSocialButtons({

--- a/apps/api/src/modules/oidc/pages/register.ts
+++ b/apps/api/src/modules/oidc/pages/register.ts
@@ -29,6 +29,13 @@ export interface RegisterPageProps {
    * in that case instead of calling this function.
    */
   allowSignup?: boolean;
+  /**
+   * Lock the email field (read-only, pre-filled from `email`). Set when the
+   * authorize request carried an OIDC `login_hint` — the invitation flow
+   * pins the invited address. UX only: the invitation accept endpoint
+   * re-checks the session email server-side.
+   */
+  lockEmail?: boolean;
 }
 
 export function renderRegisterPage(props: RegisterPageProps): RawHtml {
@@ -58,7 +65,14 @@ export function renderRegisterPage(props: RegisterPageProps): RawHtml {
         autofocus
         value="${props.name ?? ""}"
       />
-      <input type="email" name="email" placeholder="Email" required value="${props.email ?? ""}" />
+      <input
+        type="email"
+        name="email"
+        placeholder="Email"
+        required
+        ${props.lockEmail ? html`readonly` : null}
+        value="${props.email ?? ""}"
+      />
       <input
         type="password"
         name="password"

--- a/apps/api/src/modules/oidc/routes.ts
+++ b/apps/api/src/modules/oidc/routes.ts
@@ -803,6 +803,8 @@ export function createOidcRouter() {
     // banner instead of silently rendering a blank login page.
     const errorCode = url.searchParams.get("error");
     const errorMessage = errorCode ? mapLoginErrorCode(errorCode) : undefined;
+    // OIDC `login_hint` pins the email (invitation flow) — pre-fill + lock it.
+    const loginHint = url.searchParams.get("login_hint")?.toLowerCase().trim() || undefined;
     const body = renderLoginPage({
       queryString: stripErrorFromQueryString(url.search),
       branding: ctx.branding,
@@ -811,6 +813,8 @@ export function createOidcRouter() {
       smtpEnabled: ctx.features.smtp,
       allowSignup: allowSignupForClient(ctx.client),
       error: errorMessage,
+      email: loginHint,
+      lockEmail: !!loginHint,
     });
     return c.html(body.value);
   });
@@ -1093,12 +1097,16 @@ export function createOidcRouter() {
     // Same pending-client cookie as GET /api/oauth/login — covers the social
     // sign-in buttons surfaced on the register page.
     issuePendingClientCookie(c, ctx.client.clientId);
+    // OIDC `login_hint` pins the email (invitation flow) — pre-fill + lock it.
+    const loginHint = url.searchParams.get("login_hint")?.toLowerCase().trim() || undefined;
     const body = renderRegisterPage({
       queryString: url.search,
       branding: ctx.branding,
       csrfToken: ctx.csrfToken,
       socialProviders: ctx.socialProviders,
       allowSignup: true,
+      email: loginHint,
+      lockEmail: !!loginHint,
     });
     return c.html(body.value);
   });

--- a/apps/api/src/modules/oidc/test/integration/routes/oauth-login-hint.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/routes/oauth-login-hint.test.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration tests for the OIDC `login_hint` plumbing on the server-rendered
+ * login and register pages.
+ *
+ * This closes the gap the unit tests can't reach: `pages.test.ts` proves the
+ * templates honour `lockEmail`, but only this level proves the public route
+ * actually READS `login_hint` from the query and pins + locks the email field.
+ * The invite flow depends on it end-to-end (SPA → authorize → login_hint →
+ * locked email), so a regression that drops the param must fail a test here.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { getTestApp } from "../../../../../../test/helpers/app.ts";
+import { truncateAll } from "../../../../../../test/helpers/db.ts";
+import {
+  createTestContext,
+  authHeaders,
+  type TestContext,
+} from "../../../../../../test/helpers/auth.ts";
+import oidcModule from "../../../index.ts";
+
+const app = getTestApp({ modules: [oidcModule] });
+
+async function registerClient(ctx: TestContext): Promise<{ clientId: string }> {
+  const res = await app.request("/api/oauth/clients", {
+    method: "POST",
+    headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+    body: JSON.stringify({
+      level: "application" as const,
+      name: "Login-hint Test App",
+      redirectUris: ["https://acme.example.com/oauth/callback"],
+      referencedApplicationId: ctx.defaultAppId,
+      allowSignup: true,
+    }),
+  });
+  return (await res.json()) as { clientId: string };
+}
+
+/** The readonly attribute must apply specifically to the email field. */
+function emailFieldIsReadonly(html: string): boolean {
+  const match = html.match(/<input[^>]*\bname="email"[^>]*>/);
+  return !!match && /\breadonly\b/.test(match[0]);
+}
+
+describe("OIDC login_hint pins + locks the email field", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "oidchint" });
+  });
+
+  it("GET /login pre-fills and locks the email when login_hint is present", async () => {
+    const { clientId } = await registerClient(ctx);
+    const qs = `?client_id=${encodeURIComponent(clientId)}&login_hint=${encodeURIComponent("Invited@Acme.com")}`;
+    const res = await app.request(`/api/oauth/login${qs}`);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    // Normalized (lowercased) hint is reflected into the value.
+    expect(html).toContain('value="invited@acme.com"');
+    expect(emailFieldIsReadonly(html)).toBe(true);
+  });
+
+  it("GET /login leaves the email editable without login_hint", async () => {
+    const { clientId } = await registerClient(ctx);
+    const res = await app.request(`/api/oauth/login?client_id=${encodeURIComponent(clientId)}`);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(emailFieldIsReadonly(html)).toBe(false);
+  });
+
+  it("GET /register pre-fills and locks the email when login_hint is present", async () => {
+    const { clientId } = await registerClient(ctx);
+    const qs = `?client_id=${encodeURIComponent(clientId)}&login_hint=${encodeURIComponent("newbie@acme.com")}`;
+    const res = await app.request(`/api/oauth/register${qs}`);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('value="newbie@acme.com"');
+    expect(emailFieldIsReadonly(html)).toBe(true);
+  });
+
+  it("GET /register leaves the email editable without login_hint", async () => {
+    const { clientId } = await registerClient(ctx);
+    const res = await app.request(`/api/oauth/register?client_id=${encodeURIComponent(clientId)}`);
+
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(emailFieldIsReadonly(html)).toBe(false);
+  });
+});

--- a/apps/api/src/modules/oidc/test/unit/pages.test.ts
+++ b/apps/api/src/modules/oidc/test/unit/pages.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect } from "bun:test";
 import { renderLoginPage } from "../../pages/login.ts";
+import { renderRegisterPage } from "../../pages/register.ts";
 import { renderConsentPage } from "../../pages/consent.ts";
 import { renderMagicLinkPage } from "../../pages/magic-link.ts";
 import { renderForgotPasswordPage } from "../../pages/forgot-password.ts";
@@ -43,6 +44,50 @@ describe("renderLoginPage", () => {
     }).value;
     expect(out).not.toContain(`<script>x()</script>`);
     expect(out).toContain("&quot;&gt;&lt;script&gt;x()&lt;/script&gt;");
+  });
+
+  it("locks the email field (readonly) and moves autofocus to password when lockEmail is set", () => {
+    const out = renderLoginPage({
+      ...DEFAULT_PROPS,
+      queryString: "",
+      email: "invited@acme.com",
+      lockEmail: true,
+    }).value;
+    expect(out).toContain('value="invited@acme.com"');
+    expect(out).toContain("readonly");
+    // The locked field gives up autofocus; the only autofocus is on password.
+    expect(out.match(/autofocus/g)).toHaveLength(1);
+  });
+
+  it("keeps the email field editable (no readonly) by default", () => {
+    const out = renderLoginPage({
+      ...DEFAULT_PROPS,
+      queryString: "",
+      email: "x@y.com",
+    }).value;
+    expect(out).not.toContain("readonly");
+  });
+});
+
+describe("renderRegisterPage", () => {
+  it("locks the email field (readonly) when lockEmail is set", () => {
+    const out = renderRegisterPage({
+      ...DEFAULT_PROPS,
+      queryString: "",
+      email: "invited@acme.com",
+      lockEmail: true,
+    }).value;
+    expect(out).toContain('value="invited@acme.com"');
+    expect(out).toContain("readonly");
+  });
+
+  it("keeps the email field editable (no readonly) by default", () => {
+    const out = renderRegisterPage({
+      ...DEFAULT_PROPS,
+      queryString: "",
+      email: "x@y.com",
+    }).value;
+    expect(out).not.toContain("readonly");
   });
 });
 

--- a/apps/api/src/openapi/baseline.json
+++ b/apps/api/src/openapi/baseline.json
@@ -10746,8 +10746,8 @@
               }
             }
           },
-          "400": {
-            "$ref": "#/components/responses/ValidationError"
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           },
           "403": {
             "description": "Invitation email does not match the authenticated session",

--- a/apps/api/src/openapi/info.ts
+++ b/apps/api/src/openapi/info.ts
@@ -43,7 +43,7 @@ export const openApiInfo = {
     { name: "Organizations", description: "Organization and member management" },
     { name: "Profile", description: "User profile management" },
     { name: "Realtime", description: "Server-Sent Events (SSE) for real-time updates" },
-    { name: "Invitations", description: "Organization invitation magic links" },
+    { name: "Invitations", description: "Organization invitation acceptance" },
     { name: "Welcome", description: "Post-invite profile setup" },
     { name: "Health", description: "Health check" },
     { name: "Internal", description: "Container-to-host internal routes" },

--- a/apps/api/src/openapi/paths/invitations.ts
+++ b/apps/api/src/openapi/paths/invitations.ts
@@ -82,30 +82,13 @@ export const invitationsPaths = {
       tags: ["Invitations"],
       summary: "Accept invitation",
       description:
-        "Accept an invitation. Creates user account if new, adds to org, sets session cookie.",
-      security: [],
+        "Accept an invitation. Requires an authenticated Better Auth session whose email matches the invitation; adds the user to the org and returns the joined organization. Account creation happens beforehand through the standard login/signup flow, never here.",
+      security: [{ cookieAuth: [] }],
       parameters: [{ name: "token", in: "path", required: true, schema: { type: "string" } }],
-      requestBody: {
-        content: {
-          "application/json": {
-            schema: {
-              type: "object",
-              properties: {
-                password: {
-                  type: "string",
-                  minLength: 8,
-                  description: "Password (required for new users, minimum 8 characters)",
-                },
-                displayName: { type: "string" },
-              },
-            },
-          },
-        },
-      },
       responses: {
         "200": {
           description:
-            "Invitation accepted — returns the joined organization (same shape as the items in GET /api/orgs, with `role` set to the invitation role). For new users a session cookie is set via Set-Cookie.",
+            "Invitation accepted — returns the joined organization (same shape as the items in GET /api/orgs, with `role` set to the invitation role).",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
@@ -123,7 +106,7 @@ export const invitationsPaths = {
             },
           },
         },
-        "400": { $ref: "#/components/responses/ValidationError" },
+        "401": { $ref: "#/components/responses/Unauthorized" },
         "403": {
           description: "Invitation email does not match the authenticated session",
           content: {

--- a/apps/api/src/openapi/paths/organizations.ts
+++ b/apps/api/src/openapi/paths/organizations.ts
@@ -214,11 +214,11 @@ export const organizationsPaths = {
   },
   "/api/orgs/{orgId}/members": {
     post: {
-      operationId: "addOrInviteMember",
+      operationId: "inviteMember",
       tags: ["Organizations"],
-      summary: "Add or invite a member",
+      summary: "Invite a member",
       description:
-        "Add a user to the org (if they exist) or create an invitation with a magic link token.",
+        "Create a pending invitation for the given email (new and existing users alike). The invitee joins by opening the invite link, authenticating through the standard login/signup flow, then explicitly accepting. When SMTP is configured an invitation email is sent; otherwise the admin shares the returned token out of band.",
       parameters: [{ name: "orgId", in: "path", required: true, schema: { type: "string" } }],
       requestBody: {
         required: true,
@@ -238,41 +238,21 @@ export const organizationsPaths = {
       responses: {
         "201": {
           description:
-            "Polymorphic bare resource: when the user already exists (and no invitation flow applies) they are added directly and the created member is returned (OrgMember — discriminate on `userId`); otherwise an invitation is created and returned (OrgInvitationInfo — discriminate on `id` + `token`). Both use the same serializers as the lists in GET /api/orgs/{orgId}.",
+            "Invitation created — bare OrgInvitationInfo (same shape as the items in the invitations list in GET /api/orgs/{orgId}).",
           headers: {
             "Request-Id": { $ref: "#/components/headers/RequestId" },
             "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
           },
           content: {
             "application/json": {
-              schema: {
-                oneOf: [
-                  { $ref: "#/components/schemas/OrgMember" },
-                  { $ref: "#/components/schemas/OrgInvitationInfo" },
-                ],
-              },
-              examples: {
-                memberAdded: {
-                  summary: "Existing user added directly",
-                  value: {
-                    userId: "usr_def456",
-                    displayName: "Bob",
-                    email: "bob@acme.com",
-                    role: "member",
-                    joinedAt: "2026-01-12T10:00:00Z",
-                  },
-                },
-                invitationCreated: {
-                  summary: "Invitation created",
-                  value: {
-                    id: "inv_abc123",
-                    email: "newuser@example.com",
-                    role: "member",
-                    token: "inv_abc123def456",
-                    expiresAt: "2026-02-01T00:00:00Z",
-                    createdAt: "2026-01-25T00:00:00Z",
-                  },
-                },
+              schema: { $ref: "#/components/schemas/OrgInvitationInfo" },
+              example: {
+                id: "inv_abc123",
+                email: "newuser@example.com",
+                role: "member",
+                token: "inv_abc123def456",
+                expiresAt: "2026-02-01T00:00:00Z",
+                createdAt: "2026-01-25T00:00:00Z",
               },
             },
           },

--- a/apps/api/src/routes/invitations.ts
+++ b/apps/api/src/routes/invitations.ts
@@ -118,8 +118,23 @@ router.post("/:token/accept", async (c) => {
     });
   }
 
-  await addMember(invitation.orgId, session.user.id, invitation.role as AssignableRole);
-  await markInvitationAccepted(invitation.id, session.user.id);
+  // Claim the single-use token and add the membership in ONE transaction so
+  // the two writes can never half-apply (user joined but invite still pending,
+  // or vice versa). The claim is conditional on `status = 'pending'`, so two
+  // concurrent accepts can't both succeed — the loser sees 0 rows claimed and
+  // is reported as already-accepted. `addMember` is idempotent (it swallows the
+  // unique violation), so an existing membership keeps the claim valid.
+  const claimed = await db.transaction(async (tx) => {
+    const won = await markInvitationAccepted(invitation.id, session.user.id, tx);
+    if (!won) return false;
+    await addMember(invitation.orgId, session.user.id, invitation.role as AssignableRole, tx);
+    return true;
+  });
+
+  if (!claimed) {
+    // A concurrent accept consumed the token between our read and our claim.
+    throw gone("invitation_accepted", "Invitation already accepted");
+  }
 
   // Bare joined-org resource — same shape as the items in GET /api/orgs
   // (issue #657). The web accept page reads `id` to pin the org store.

--- a/apps/api/src/routes/invitations.ts
+++ b/apps/api/src/routes/invitations.ts
@@ -5,8 +5,7 @@ import { db } from "@appstrate/db/client";
 import { user } from "@appstrate/db/schema";
 import { eq } from "drizzle-orm";
 import { getAuth } from "@appstrate/db/auth";
-import { logger } from "../lib/logger.ts";
-import { ApiError, invalidRequest, internalError, gone } from "../lib/errors.ts";
+import { ApiError, gone } from "../lib/errors.ts";
 import {
   getInvitationByToken,
   markInvitationAccepted,
@@ -14,7 +13,6 @@ import {
   getOrgName,
   type AssignableRole,
 } from "../services/invitations.ts";
-import { getErrorMessage } from "@appstrate/core/errors";
 import { addMember, getOrgById } from "../services/organizations.ts";
 
 const router = new Hono();
@@ -67,15 +65,49 @@ router.get("/:token/info", async (c) => {
   });
 });
 
-// POST /invite/:token/accept — accept invitation (public)
+// POST /invite/:token/accept — authenticated user joins the org.
+//
+// Public route (registered before the platform auth middleware) but a valid
+// Better Auth session is REQUIRED: the caller authenticates first through the
+// platform-standard path (OIDC when the module is loaded, otherwise the
+// built-in email/password + social forms), then accepts. Account creation
+// never happens here — this endpoint has a single responsibility: bind an
+// already-authenticated user to the org named by the invitation token.
+//
+// Accept is a deliberate, session-bound POST: it is never a GET (no
+// state-change on link prefetch) and never auto-fires, so an email-client
+// prefetch or a logged-in stranger cannot silently join the org.
 router.post("/:token/accept", async (c) => {
   const token = c.req.param("token");
   const invitation = await getInvitationByToken(token);
   assertInvitationExists(invitation);
   assertInvitationUsable(invitation);
 
-  // Bare joined-org resource — same shape as the items in GET /api/orgs
-  // (issue #657). The web accept page reads `id` to pin the org store.
+  const session = await getAuth()
+    .api.getSession({ headers: c.req.raw.headers })
+    .catch(() => null);
+
+  if (!session?.user) {
+    throw new ApiError({
+      status: 401,
+      code: "authentication_required",
+      title: "Unauthorized",
+      detail: "Authentication is required to accept an invitation",
+    });
+  }
+
+  // The invitation is bound to a single email; the session must own it.
+  // This is also the security backstop for the email pinned client-side on
+  // the login/signup forms — a tampered email field cannot escape it.
+  if (session.user.email.toLowerCase() !== invitation.email.toLowerCase()) {
+    throw new ApiError({
+      status: 403,
+      code: "email_mismatch",
+      title: "Email mismatch",
+      detail: `This invitation is for ${invitation.email}`,
+    });
+  }
+
   const org = await getOrgById(invitation.orgId);
   if (!org) {
     throw new ApiError({
@@ -85,100 +117,19 @@ router.post("/:token/accept", async (c) => {
       detail: "Organization not found",
     });
   }
-  const joinedOrg = {
+
+  await addMember(invitation.orgId, session.user.id, invitation.role as AssignableRole);
+  await markInvitationAccepted(invitation.id, session.user.id);
+
+  // Bare joined-org resource — same shape as the items in GET /api/orgs
+  // (issue #657). The web accept page reads `id` to pin the org store.
+  return c.json({
     id: org.id,
     name: org.name,
     slug: org.slug,
     role: invitation.role,
     createdAt: org.createdAt,
-  };
-
-  // Check if user already exists
-  const [existingUser] = await db
-    .select({ id: user.id })
-    .from(user)
-    .where(eq(user.email, invitation.email))
-    .limit(1);
-
-  if (!existingUser) {
-    // --- NEW USER: create account via Better Auth ---
-    const body = await c.req
-      .json<{ password?: string; displayName?: string }>()
-      .catch((): { password?: string; displayName?: string } => ({}));
-
-    if (!body.password || body.password.length < 8) {
-      throw invalidRequest("Password is required and must be at least 8 characters");
-    }
-
-    try {
-      // Sign up — creates user + account + profile (via databaseHook)
-      const signupRes = await getAuth().api.signUpEmail({
-        body: {
-          email: invitation.email,
-          password: body.password,
-          name: body.displayName?.trim() || invitation.email,
-        },
-      });
-
-      if (!signupRes?.user?.id) {
-        logger.error("Invitation signup failed — no user returned", {
-          email: invitation.email,
-        });
-        throw internalError();
-      }
-
-      const newUserId = signupRes.user.id;
-
-      // Sign in to get session cookie
-      const signinRes = await getAuth().api.signInEmail({
-        body: { email: invitation.email, password: body.password },
-        asResponse: true,
-      });
-
-      // Add member to org
-      await addMember(invitation.orgId, newUserId, invitation.role as AssignableRole);
-
-      await markInvitationAccepted(invitation.id, newUserId);
-
-      // Forward Set-Cookie from signin response
-      const setCookieHeader = signinRes.headers.get("set-cookie");
-      const headers = new Headers();
-      headers.set("Content-Type", "application/json");
-      if (setCookieHeader) {
-        headers.set("Set-Cookie", setCookieHeader);
-      }
-
-      return new Response(JSON.stringify(joinedOrg), { status: 200, headers });
-    } catch (err) {
-      if (err instanceof ApiError) throw err;
-      logger.error("Invitation accept failed (new user)", {
-        error: getErrorMessage(err),
-        email: invitation.email,
-      });
-      throw internalError();
-    }
-  } else {
-    // --- EXISTING USER ---
-    const session = await getAuth()
-      .api.getSession({ headers: c.req.raw.headers })
-      .catch(() => null);
-
-    // Prevent a logged-in user from accepting an invitation meant for a different email
-    if (session?.user && session.user.email.toLowerCase() !== invitation.email.toLowerCase()) {
-      throw new ApiError({
-        status: 403,
-        code: "email_mismatch",
-        title: "Email mismatch",
-        detail: `This invitation is for ${invitation.email}`,
-      });
-    }
-
-    await addMember(invitation.orgId, existingUser.id, invitation.role as AssignableRole);
-
-    await markInvitationAccepted(invitation.id, existingUser.id);
-
-    return c.json(joinedOrg);
-  }
+  });
 });
 
 export default router;

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -13,10 +13,8 @@ import {
   getOrgMembers,
   getOrgMember,
   getOrgMemberWithProfile,
-  addMember,
   removeMember,
   updateMemberRole,
-  findUserByEmail,
   isSlugAvailable,
   getOrgSettings,
   updateOrgSettings,
@@ -28,13 +26,11 @@ import { ApiError, forbidden, invalidRequest, notFound, parseBody } from "../lib
 import { listResponse } from "../lib/list-response.ts";
 import {
   createInvitation,
-  sendMagicLinkInvitation,
   getOrgInvitations,
   cancelInvitation,
   updateInvitationRole,
   ASSIGNABLE_ROLES,
 } from "../services/invitations.ts";
-import { getAppConfig } from "../lib/app-config.ts";
 import { provisionDefaultAgentForOrg } from "../services/default-agent.ts";
 import { getEnv } from "@appstrate/env";
 import { isPlatformAdmin } from "@appstrate/db/auth-policy";
@@ -288,6 +284,13 @@ router.delete("/:orgId", async (c) => {
 });
 
 // POST /api/orgs/:orgId/members — invite a member (admin+)
+//
+// Always creates a pending invitation — for new and existing users alike.
+// The invitee joins by opening the invite link, authenticating through the
+// standard login/signup flow, then explicitly accepting. This keeps a single,
+// consent-explicit join path: no silent direct-add of existing users, no
+// magic-link side channel. When SMTP is configured the invitation email is
+// sent; otherwise the admin shares the returned token/link out of band.
 router.post("/:orgId/members", async (c) => {
   const user = c.get("user");
   const orgId = c.req.param("orgId");
@@ -301,81 +304,8 @@ router.post("/:orgId/members", async (c) => {
 
   const body = await c.req.json();
   const data = parseBody(addMemberSchema, body);
-
   const role = data.role;
 
-  const targetUser = await findUserByEmail(data.email.trim());
-
-  // Polymorphic response (documented as oneOf in OpenAPI): the operation
-  // either creates an invitation (201 + bare OrgInvitationInfo — has `id` +
-  // `token`) or adds an existing user directly (201 + bare OrgMember — has
-  // `userId`). Both DTOs use the same serializers as the lists in
-  // GET /orgs/:orgId. The `token` is exposed because this endpoint is
-  // admin-gated, consistent with the invitations list.
-  const serializeInvitation = (inv: Awaited<ReturnType<typeof createInvitation>>) => ({
-    id: inv.id,
-    email: inv.email,
-    role: inv.role,
-    token: inv.token,
-    expiresAt: inv.expiresAt?.toISOString(),
-    createdAt: inv.createdAt?.toISOString(),
-  });
-
-  if (targetUser) {
-    if (getAppConfig().features.smtp) {
-      // User exists + SMTP → create invitation with magic link (auto-auth on click)
-      const invitation = await createInvitation({
-        email: data.email.trim(),
-        orgId,
-        role,
-        invitedBy: user.id,
-        skipEmail: true,
-      });
-      void sendMagicLinkInvitation(invitation);
-      await recordAuditFromContext(c, {
-        action: "org.invitation_created",
-        resourceType: "invitation",
-        resourceId: invitation.id,
-        after: { email: invitation.email, role },
-        orgIdOverride: orgId,
-      });
-      return c.json(serializeInvitation(invitation), 201);
-    }
-    // User exists + no SMTP → add directly
-    try {
-      await addMember(orgId, targetUser.id, role);
-    } catch (err) {
-      throw new ApiError({
-        status: 400,
-        code: "add_member_failed",
-        title: "Bad Request",
-        detail: err instanceof Error ? err.message : "Failed to add member",
-      });
-    }
-    await recordAuditFromContext(c, {
-      action: "org.member_added",
-      resourceType: "member",
-      resourceId: targetUser.id,
-      after: { email: data.email.trim(), role },
-      orgIdOverride: orgId,
-    });
-    const member = await getOrgMemberWithProfile(orgId, targetUser.id);
-    if (!member) {
-      throw notFound("Member not found");
-    }
-    return c.json(
-      {
-        userId: member.userId,
-        role: member.role,
-        joinedAt: member.joinedAt,
-        displayName: member.displayName,
-        email: member.email,
-      },
-      201,
-    );
-  }
-
-  // User doesn't exist — create invitation
   try {
     const invitation = await createInvitation({
       email: data.email.trim(),
@@ -391,7 +321,21 @@ router.post("/:orgId/members", async (c) => {
       after: { email: invitation.email, role },
       orgIdOverride: orgId,
     });
-    return c.json(serializeInvitation(invitation), 201);
+
+    // Bare OrgInvitationInfo — same shape as the items in the invitations
+    // list in GET /orgs/:orgId. The `token` is exposed because this endpoint
+    // is admin-gated (it lets a no-SMTP admin copy the invite link).
+    return c.json(
+      {
+        id: invitation.id,
+        email: invitation.email,
+        role: invitation.role,
+        token: invitation.token,
+        expiresAt: invitation.expiresAt?.toISOString(),
+        createdAt: invitation.createdAt?.toISOString(),
+      },
+      201,
+    );
   } catch (err) {
     throw new ApiError({
       status: 500,

--- a/apps/api/src/services/invitations.ts
+++ b/apps/api/src/services/invitations.ts
@@ -6,10 +6,7 @@ import { eq, and, lt, desc } from "drizzle-orm";
 import { getEnv } from "@appstrate/env";
 import { getAppConfig } from "../lib/app-config.ts";
 import { sendEmail } from "./email.ts";
-import { getAuth } from "@appstrate/db/auth";
-import { logger } from "../lib/logger.ts";
 import { scopedWhere } from "../lib/db-helpers.ts";
-import { getErrorMessage } from "@appstrate/core/errors";
 
 /** Roles assignable via invitation (excludes owner — transferred, not invited). */
 export const ASSIGNABLE_ROLES = ["viewer", "member", "admin"] as const;
@@ -77,7 +74,7 @@ export async function createInvitation({
       getOrgName(orgId),
       getInviterName(invitedBy),
     ]);
-    const inviteUrl = `${getEnv().APP_URL}/invite/${token}/accept`;
+    const inviteUrl = `${getEnv().APP_URL}/invite/${token}`;
     void sendEmail("invitation", {
       to: normalizedEmail,
       email: normalizedEmail,
@@ -162,33 +159,6 @@ export async function getInviterName(userId: string): Promise<string> {
     .where(eq(user.id, userId))
     .limit(1);
   return row?.displayName || row?.name || "Un membre";
-}
-
-/**
- * Trigger Better Auth magic link for an existing user invitation.
- * The callbackURL contains the invitation token — the sendMagicLink callback
- * in auth.ts detects this and sends the invitation email instead of the generic one.
- */
-export async function sendMagicLinkInvitation(invitation: {
-  id: string;
-  token: string;
-  email: string;
-}) {
-  try {
-    await getAuth().api.signInMagicLink({
-      body: {
-        email: invitation.email,
-        callbackURL: `/invite/${invitation.token}/accept`,
-      },
-      headers: new Headers(),
-    });
-  } catch (err) {
-    logger.error("Failed to send magic link invitation", {
-      error: getErrorMessage(err),
-      email: invitation.email,
-      invitationId: invitation.id,
-    });
-  }
 }
 
 export async function expireOldInvitations() {

--- a/apps/api/src/services/invitations.ts
+++ b/apps/api/src/services/invitations.ts
@@ -8,6 +8,9 @@ import { getAppConfig } from "../lib/app-config.ts";
 import { sendEmail } from "./email.ts";
 import { scopedWhere } from "../lib/db-helpers.ts";
 
+/** Accepts either the base client or an open transaction handle. */
+type DbOrTx = typeof db | Parameters<Parameters<typeof db.transaction>[0]>[0];
+
 /** Roles assignable via invitation (excludes owner — transferred, not invited). */
 export const ASSIGNABLE_ROLES = ["viewer", "member", "admin"] as const;
 export type AssignableRole = (typeof ASSIGNABLE_ROLES)[number];
@@ -31,13 +34,11 @@ export async function createInvitation({
   orgId,
   role,
   invitedBy,
-  skipEmail,
 }: {
   email: string;
   orgId: string;
   role: AssignableRole;
   invitedBy: string;
-  skipEmail?: boolean;
 }) {
   const normalizedEmail = email.toLowerCase().trim();
 
@@ -69,7 +70,7 @@ export async function createInvitation({
 
   if (!invitation) throw new Error("Failed to create invitation");
 
-  if (!skipEmail && getAppConfig().features.smtp) {
+  if (getAppConfig().features.smtp) {
     const [orgName, inviterName] = await Promise.all([
       getOrgName(orgId),
       getInviterName(invitedBy),
@@ -107,11 +108,24 @@ export async function getOrgInvitations(orgId: string) {
     .orderBy(desc(orgInvitations.createdAt));
 }
 
-export async function markInvitationAccepted(invitationId: string, userId: string) {
-  await db
+/**
+ * Atomically claim a single-use invitation: flips `pending → accepted` only if
+ * it is still pending, in one conditional UPDATE. Returns `true` if THIS call
+ * won the claim, `false` if the row was already consumed (lost a concurrent
+ * race). The `WHERE status = 'pending'` guard is what makes two simultaneous
+ * accepts safe — the row lock lets exactly one UPDATE match.
+ */
+export async function markInvitationAccepted(
+  invitationId: string,
+  userId: string,
+  tx: DbOrTx = db,
+): Promise<boolean> {
+  const claimed = await tx
     .update(orgInvitations)
     .set({ status: "accepted", acceptedBy: userId, acceptedAt: new Date() })
-    .where(eq(orgInvitations.id, invitationId));
+    .where(and(eq(orgInvitations.id, invitationId), eq(orgInvitations.status, "pending")))
+    .returning({ id: orgInvitations.id });
+  return claimed.length > 0;
 }
 
 export async function cancelInvitation(invitationId: string, orgId: string) {

--- a/apps/api/src/services/organizations.ts
+++ b/apps/api/src/services/organizations.ts
@@ -17,6 +17,9 @@ import { and, eq, inArray, count, sql } from "drizzle-orm";
 import type { OrgRole } from "../types/index.ts";
 import { scopedWhere } from "../lib/db-helpers.ts";
 
+/** Accepts either the base client or an open transaction handle. */
+type DbOrTx = typeof db | Parameters<Parameters<typeof db.transaction>[0]>[0];
+
 interface OrgResult {
   id: string;
   name: string;
@@ -209,50 +212,19 @@ export async function getOrgMemberWithProfile(orgId: string, userId: string) {
   };
 }
 
-export async function findUserByEmail(email: string): Promise<{ id: string } | null> {
-  const [row] = await db.select({ id: user.id }).from(user).where(eq(user.email, email)).limit(1);
-
-  return row ?? null;
-}
-
 export async function addMember(
   orgId: string,
   userId: string,
   role: OrgRole = "member",
+  tx: DbOrTx = db,
 ): Promise<void> {
-  try {
-    await db.insert(organizationMembers).values({
-      orgId,
-      userId,
-      role,
-    });
-  } catch (err: unknown) {
-    // Drizzle wraps the postgres driver error in `DrizzleQueryError` whose
-    // `message` only says "Failed query: …" — the unique-violation details
-    // live on `err.cause` (with PG `code === "23505"`). Walk the cause chain
-    // so we match both the wrapped and the raw error shape.
-    if (isUniqueViolation(err)) {
-      // User is already a member — idempotent, silently ignore
-      return;
-    }
-    throw err;
-  }
-}
-
-function isUniqueViolation(err: unknown): boolean {
-  // Cap depth to defend against pathological / circular `cause` chains.
-  // Drizzle wraps once, postgres.js wraps once — 8 hops is generous.
-  let cur: unknown = err;
-  for (let depth = 0; cur != null && depth < 8; depth++) {
-    if (typeof cur === "object") {
-      const e = cur as { code?: unknown; message?: unknown };
-      if (e.code === "23505") return true;
-      const msg = typeof e.message === "string" ? e.message : "";
-      if (msg.includes("duplicate key") || msg.includes("unique constraint")) return true;
-    }
-    cur = (cur as { cause?: unknown }).cause;
-  }
-  return false;
+  // ON CONFLICT DO NOTHING makes this idempotent AND transaction-safe. A plain
+  // INSERT that hits the (org_id, user_id) PK would raise — and inside an
+  // enclosing transaction a raised statement ABORTS the whole transaction, so
+  // a caught-and-swallowed error would still poison the surrounding tx. The
+  // conflict clause turns "already a member" into a clean no-op (the existing
+  // row, and its role, are left untouched — no silent downgrade).
+  await tx.insert(organizationMembers).values({ orgId, userId, role }).onConflictDoNothing();
 }
 
 export async function removeMember(orgId: string, userId: string): Promise<void> {

--- a/apps/api/test/helpers/auth.ts
+++ b/apps/api/test/helpers/auth.ts
@@ -112,7 +112,9 @@ function randomSessionToken(): string {
  * production cookie — signature check + session row lookup).
  *
  * Rows seeded (mirrors what a real sign-up produces in SMTP-off mode):
- *   - `user`     — emailVerified=false, realm="platform"
+ *   - `user`     — emailVerified=false (pass `emailVerified: true` to mirror a
+ *                  social-login outcome, where BA's OAuth callback marks the
+ *                  brand-new row verified), realm="platform"
  *   - `profiles` — inserted by the BA `user.create.after` hook in prod
  *   - `account`  — providerId="credential" with the AUTH_FAST_TEST_HASH
  *                  SHA-256 password hash, so HTTP sign-in with the same
@@ -123,11 +125,17 @@ function randomSessionToken(): string {
  * `/api/auth/sign-up/email` directly.
  */
 export async function createTestUser(
-  overrides: Partial<{ email: string; name: string; password: string }> = {},
+  overrides: Partial<{
+    email: string;
+    name: string;
+    password: string;
+    emailVerified: boolean;
+  }> = {},
 ): Promise<TestUser & { cookie: string }> {
   const email = (overrides.email ?? `test-${nextId()}@test.com`).toLowerCase();
   const name = overrides.name ?? `Test User ${nextId()}`;
   const password = overrides.password ?? "TestPassword123!";
+  const emailVerified = overrides.emailVerified ?? false;
 
   const userId = crypto.randomUUID();
   const token = randomSessionToken();
@@ -136,7 +144,7 @@ export async function createTestUser(
   // with this password verifies against the account row.
   const passwordHash = new Bun.CryptoHasher("sha256").update(password).digest("hex");
 
-  await db.insert(userTable).values({ id: userId, name, email, realm: "platform" });
+  await db.insert(userTable).values({ id: userId, name, email, emailVerified, realm: "platform" });
   await Promise.all([
     db.insert(profiles).values({ id: userId, displayName: name || email, language: "fr" }),
     db.insert(accountTable).values({

--- a/apps/api/test/integration/routes/auth-signup-gate.test.ts
+++ b/apps/api/test/integration/routes/auth-signup-gate.test.ts
@@ -78,6 +78,29 @@ describe("Platform signup gate — issue #228", () => {
     });
   });
 
+  describe("invited-email auto-verification", () => {
+    it("marks the email verified when a pending invitation exists (any signup method)", async () => {
+      const ctx: TestContext = await createTestContext({ orgSlug: "verifyorg" });
+      await seedInvitation({
+        orgId: ctx.orgId,
+        email: "invited-verify@example.com",
+        invitedBy: ctx.user.id,
+      });
+
+      const res = await attemptSignup("invited-verify@example.com");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { user?: { emailVerified?: boolean } };
+      expect(body.user?.emailVerified).toBe(true);
+    });
+
+    it("leaves the email unverified for a non-invited signup", async () => {
+      const res = await attemptSignup("solo-unverified@example.com");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { user?: { emailVerified?: boolean } };
+      expect(body.user?.emailVerified).toBe(false);
+    });
+  });
+
   describe("AUTH_DISABLE_SIGNUP=true", () => {
     beforeEach(() => {
       setAuthEnv({ AUTH_DISABLE_SIGNUP: "true" });

--- a/apps/api/test/integration/routes/auth-signup-gate.test.ts
+++ b/apps/api/test/integration/routes/auth-signup-gate.test.ts
@@ -78,8 +78,14 @@ describe("Platform signup gate — issue #228", () => {
     });
   });
 
-  describe("invited-email auto-verification", () => {
-    it("marks the email verified when a pending invitation exists (any signup method)", async () => {
+  describe("invitation never auto-verifies the email", () => {
+    // SECURITY: a pending invitation is matched on email ALONE (the invite
+    // token is not available at signup), so it is NOT proof of inbox ownership.
+    // It overrides the signup GATE (so an invited user can register when signup
+    // is locked down) but must NEVER grant emailVerified — otherwise anyone
+    // could mint a verified account for any unclaimed address, and the OIDC
+    // end-user adopter's `emailVerified === true` takeover guard would fall.
+    it("leaves the email unverified even when a pending invitation exists", async () => {
       const ctx: TestContext = await createTestContext({ orgSlug: "verifyorg" });
       await seedInvitation({
         orgId: ctx.orgId,
@@ -90,7 +96,7 @@ describe("Platform signup gate — issue #228", () => {
       const res = await attemptSignup("invited-verify@example.com");
       expect(res.status).toBe(200);
       const body = (await res.json()) as { user?: { emailVerified?: boolean } };
-      expect(body.user?.emailVerified).toBe(true);
+      expect(body.user?.emailVerified).toBe(false);
     });
 
     it("leaves the email unverified for a non-invited signup", async () => {

--- a/apps/api/test/integration/routes/invitations.test.ts
+++ b/apps/api/test/integration/routes/invitations.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, beforeEach } from "bun:test";
 import { and, eq } from "drizzle-orm";
-import { organizationMembers, orgInvitations } from "@appstrate/db/schema";
+import { organizationMembers, orgInvitations, user } from "@appstrate/db/schema";
 import { getTestApp } from "../../helpers/app.ts";
 import { truncateAll } from "../../helpers/db.ts";
 import {
@@ -299,6 +299,75 @@ describe("Invitations API", () => {
         headers: { Cookie: member.cookie },
       });
       expect(res.status).toBe(404);
+    });
+  });
+
+  // When an invited user authenticates via a social provider (Google/GitHub) on
+  // the invite page, Better Auth's OAuth callback marks the brand-new account
+  // `emailVerified = true` (see shouldAutoVerifyEmailOnCreate + its unit test
+  // auth-social-email-verify.test.ts — that path can't be driven end-to-end here
+  // because the harness intentionally runs no fake OAuth2 server against BA).
+  // These tests pin what the accept endpoint actually guarantees for that case:
+  // ownership is enforced by the session-email ↔ invitation-email match (the
+  // session email is the provider-asserted address), NOT by the platform's
+  // `emailVerified` flag — the accept route never reads it. A provider-verified
+  // session is represented by `createTestUser({ emailVerified: true })`.
+  describe("POST /invite/:token/accept — social-login invitee (provider-verified session)", () => {
+    it("a provider-verified session joins on email match and stays verified", async () => {
+      const social = await createTestUser({
+        email: "social-invitee@test.com",
+        emailVerified: true,
+      });
+
+      const inv = await seedInvitation({
+        orgId: ctx.orgId,
+        email: "social-invitee@test.com",
+        role: "member",
+        invitedBy: ctx.user.id,
+      });
+
+      const res = await app.request(`/invite/${inv.token}/accept`, {
+        method: "POST",
+        headers: { Cookie: social.cookie },
+      });
+
+      expect(res.status).toBe(200);
+      await assertDbHas(
+        organizationMembers,
+        and(eq(organizationMembers.orgId, ctx.orgId), eq(organizationMembers.userId, social.id))!,
+      );
+      // Accept must not disturb the provider-established verification.
+      const userRow = await getDbRow(user, eq(user.id, social.id));
+      expect(userRow?.emailVerified).toBe(true);
+    });
+
+    it("rejects a provider-verified session whose email does not match the invite", async () => {
+      // Logged in with a (verified) Google identity, but for a different address
+      // than the one invited — the provider identity is the gate, so 403.
+      const social = await createTestUser({
+        email: "other-google@test.com",
+        emailVerified: true,
+      });
+
+      const inv = await seedInvitation({
+        orgId: ctx.orgId,
+        email: "invited-target@test.com",
+        invitedBy: ctx.user.id,
+      });
+
+      const res = await app.request(`/invite/${inv.token}/accept`, {
+        method: "POST",
+        headers: { Cookie: social.cookie },
+      });
+
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as any;
+      expect(body.code).toBe("email_mismatch");
+      await assertDbCount(
+        organizationMembers,
+        and(eq(organizationMembers.orgId, ctx.orgId), eq(organizationMembers.userId, social.id))!,
+        0,
+      );
     });
   });
 

--- a/apps/api/test/integration/routes/invitations.test.ts
+++ b/apps/api/test/integration/routes/invitations.test.ts
@@ -1,10 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, beforeEach } from "bun:test";
+import { and, eq } from "drizzle-orm";
+import { organizationMembers, orgInvitations } from "@appstrate/db/schema";
 import { getTestApp } from "../../helpers/app.ts";
 import { truncateAll } from "../../helpers/db.ts";
-import { createTestContext, createTestUser, type TestContext } from "../../helpers/auth.ts";
+import {
+  addOrgMember,
+  createTestContext,
+  createTestUser,
+  type TestContext,
+} from "../../helpers/auth.ts";
 import { seedInvitation } from "../../helpers/seed.ts";
+import { assertDbHas, assertDbCount, getDbRow } from "../../helpers/assertions.ts";
 
 const app = getTestApp();
 
@@ -87,6 +95,21 @@ describe("Invitations API", () => {
       expect(body.slug).toBe("inviteorg");
       expect(body.role).toBe("admin");
       expect(body).not.toHaveProperty("success");
+
+      // The membership row is actually written (not just a 200 body), with the
+      // invitation's role, and the invitation is flipped to accepted.
+      await assertDbHas(
+        organizationMembers,
+        and(
+          eq(organizationMembers.orgId, ctx.orgId),
+          eq(organizationMembers.userId, member.id),
+          eq(organizationMembers.role, "admin"),
+        )!,
+      );
+      const row = await getDbRow(orgInvitations, eq(orgInvitations.id, inv.id));
+      expect(row?.status).toBe("accepted");
+      expect(row?.acceptedBy).toBe(member.id);
+      expect(row?.acceptedAt).not.toBeNull();
     });
 
     it("marks the invitation accepted (and rejects a second accept with 410)", async () => {
@@ -130,16 +153,21 @@ describe("Invitations API", () => {
       expect(body.code).toBe("email_mismatch");
     });
 
-    it("is idempotent when the user is already a member", async () => {
+    it("is idempotent when the user is already a member (keeps their existing role)", async () => {
       const member = await createTestUser({ email: "idempotent@test.com" });
-      const { addOrgMember } = await import("../../helpers/auth.ts");
 
-      // Pre-add the user as member (simulates double-click / race).
-      await addOrgMember(ctx.orgId, member.id, "member");
+      // Pre-add the user as viewer (simulates double-click / race), then invite
+      // them as admin. Accepting must NOT silently downgrade or upgrade an
+      // existing membership — the safe default is to keep the current role and
+      // simply consume the invitation. (Re-inviting an existing member at a new
+      // role is intentionally a no-op on the role to avoid an owner being
+      // demoted by a stray viewer invite.)
+      await addOrgMember(ctx.orgId, member.id, "viewer");
 
       const inv = await seedInvitation({
         orgId: ctx.orgId,
         email: "idempotent@test.com",
+        role: "admin",
         invitedBy: ctx.user.id,
       });
 
@@ -148,10 +176,120 @@ describe("Invitations API", () => {
         headers: { Cookie: member.cookie },
       });
 
-      // Should succeed (idempotent), not 500.
+      // Succeeds (idempotent), not 500.
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
       expect(body.id).toBe(ctx.orgId);
+
+      // Exactly one membership row, role unchanged, invitation consumed.
+      await assertDbCount(
+        organizationMembers,
+        and(eq(organizationMembers.orgId, ctx.orgId), eq(organizationMembers.userId, member.id))!,
+        1,
+      );
+      const memberRow = await getDbRow(
+        organizationMembers,
+        and(eq(organizationMembers.orgId, ctx.orgId), eq(organizationMembers.userId, member.id))!,
+      );
+      expect(memberRow?.role).toBe("viewer");
+      const invRow = await getDbRow(orgInvitations, eq(orgInvitations.id, inv.id));
+      expect(invRow?.status).toBe("accepted");
+    });
+
+    it("accepts a case-insensitive email match", async () => {
+      const member = await createTestUser({ email: "Mixed.Case@Test.com" });
+
+      const inv = await seedInvitation({
+        orgId: ctx.orgId,
+        // Invitation stores the normalized (lowercased) address.
+        email: "mixed.case@test.com",
+        invitedBy: ctx.user.id,
+      });
+
+      const res = await app.request(`/invite/${inv.token}/accept`, {
+        method: "POST",
+        headers: { Cookie: member.cookie },
+      });
+
+      expect(res.status).toBe(200);
+      await assertDbHas(
+        organizationMembers,
+        and(eq(organizationMembers.orgId, ctx.orgId), eq(organizationMembers.userId, member.id))!,
+      );
+    });
+
+    it("returns 410 when accepting an expired invitation", async () => {
+      const member = await createTestUser({ email: "late@test.com" });
+
+      const inv = await seedInvitation({
+        orgId: ctx.orgId,
+        email: "late@test.com",
+        invitedBy: ctx.user.id,
+        expiresAt: new Date(Date.now() - 1000), // already expired
+      });
+
+      const res = await app.request(`/invite/${inv.token}/accept`, {
+        method: "POST",
+        headers: { Cookie: member.cookie },
+      });
+
+      expect(res.status).toBe(410);
+      const body = (await res.json()) as any;
+      expect(body.code).toBe("invitation_expired");
+      // Nothing was written.
+      await assertDbCount(
+        organizationMembers,
+        and(eq(organizationMembers.orgId, ctx.orgId), eq(organizationMembers.userId, member.id))!,
+        0,
+      );
+    });
+
+    it("returns 410 when accepting a cancelled invitation", async () => {
+      const member = await createTestUser({ email: "revoked@test.com" });
+
+      const inv = await seedInvitation({
+        orgId: ctx.orgId,
+        email: "revoked@test.com",
+        invitedBy: ctx.user.id,
+        status: "cancelled",
+      });
+
+      const res = await app.request(`/invite/${inv.token}/accept`, {
+        method: "POST",
+        headers: { Cookie: member.cookie },
+      });
+
+      expect(res.status).toBe(410);
+      const body = (await res.json()) as any;
+      expect(body.code).toBe("invitation_cancelled");
+    });
+
+    it("survives two concurrent accepts: one joins, the other is 410, single membership row", async () => {
+      const member = await createTestUser({ email: "race@test.com" });
+
+      const inv = await seedInvitation({
+        orgId: ctx.orgId,
+        email: "race@test.com",
+        invitedBy: ctx.user.id,
+      });
+
+      const fire = () =>
+        app.request(`/invite/${inv.token}/accept`, {
+          method: "POST",
+          headers: { Cookie: member.cookie },
+        });
+
+      const [a, b] = await Promise.all([fire(), fire()]);
+      const statuses = [a.status, b.status].sort();
+      // The single-use token is claimed atomically: exactly one 200, one 410.
+      expect(statuses).toEqual([200, 410]);
+
+      // No double membership, no 500.
+      await assertDbCount(
+        organizationMembers,
+        and(eq(organizationMembers.orgId, ctx.orgId), eq(organizationMembers.userId, member.id))!,
+        1,
+      );
     });
 
     it("returns 404 for an unknown token", async () => {

--- a/apps/api/test/integration/routes/invitations.test.ts
+++ b/apps/api/test/integration/routes/invitations.test.ts
@@ -50,62 +50,23 @@ describe("Invitations API", () => {
     });
   });
 
-  describe("POST /invite/:token/accept (public)", () => {
-    it("accepts invitation for new user", async () => {
+  describe("POST /invite/:token/accept (session required)", () => {
+    it("returns 401 when there is no authenticated session", async () => {
       const inv = await seedInvitation({
         orgId: ctx.orgId,
-        email: "joining@test.com",
+        email: "anon@test.com",
         invitedBy: ctx.user.id,
       });
 
-      const res = await app.request(`/invite/${inv.token}/accept`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          password: "SecurePass123!",
-          displayName: "New Member",
-        }),
-      });
+      const res = await app.request(`/invite/${inv.token}/accept`, { method: "POST" });
 
-      expect(res.status).toBe(200);
-      // Bare joined-org resource — same shape as the items in GET /api/orgs
+      expect(res.status).toBe(401);
       const body = (await res.json()) as any;
-      expect(body.id).toBe(ctx.orgId);
-      expect(body.name).toBeTruthy();
-      expect(body.slug).toBe("inviteorg");
-      expect(body.role).toBe("member");
-      expect(body.createdAt).toBeTruthy();
-      expect(body).not.toHaveProperty("success");
-      // New-user flow sets the session cookie on the response
-      expect(res.headers.get("set-cookie")).toBeTruthy();
+      expect(body.code).toBe("authentication_required");
     });
 
-    it("rejects already accepted invitation", async () => {
-      const inv = await seedInvitation({
-        orgId: ctx.orgId,
-        email: "double@test.com",
-        invitedBy: ctx.user.id,
-      });
-
-      // Accept first time
-      await app.request(`/invite/${inv.token}/accept`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ password: "SecurePass123!" }),
-      });
-
-      // Try to accept again
-      const res = await app.request(`/invite/${inv.token}/accept`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ password: "SecurePass123!" }),
-      });
-
-      expect(res.status).toBe(410);
-    });
-
-    it("accepts invitation for existing user when authenticated with matching email", async () => {
-      const existingUser = await createTestUser({ email: "existing@test.com" });
+    it("joins the org for an authenticated user whose email matches", async () => {
+      const member = await createTestUser({ email: "existing@test.com" });
 
       const inv = await seedInvitation({
         orgId: ctx.orgId,
@@ -116,46 +77,95 @@ describe("Invitations API", () => {
 
       const res = await app.request(`/invite/${inv.token}/accept`, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Cookie: existingUser.cookie,
-        },
-        body: JSON.stringify({}),
+        headers: { Cookie: member.cookie },
       });
 
       expect(res.status).toBe(200);
-      // Bare joined-org resource with the invitation's role
+      // Bare joined-org resource with the invitation's role.
       const body = (await res.json()) as any;
       expect(body.id).toBe(ctx.orgId);
       expect(body.slug).toBe("inviteorg");
       expect(body.role).toBe("admin");
       expect(body).not.toHaveProperty("success");
-      expect(body).not.toHaveProperty("requires_login");
     });
 
-    it("accepts for an unauthenticated existing user and returns the joined org", async () => {
-      await createTestUser({ email: "noauth@test.com" });
+    it("marks the invitation accepted (and rejects a second accept with 410)", async () => {
+      const member = await createTestUser({ email: "double@test.com" });
 
       const inv = await seedInvitation({
         orgId: ctx.orgId,
-        email: "noauth@test.com",
+        email: "double@test.com",
         invitedBy: ctx.user.id,
       });
 
-      // Accept without session cookie
-      const res = await app.request(`/invite/${inv.token}/accept`, {
+      const first = await app.request(`/invite/${inv.token}/accept`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
+        headers: { Cookie: member.cookie },
+      });
+      expect(first.status).toBe(200);
+
+      const second = await app.request(`/invite/${inv.token}/accept`, {
+        method: "POST",
+        headers: { Cookie: member.cookie },
+      });
+      expect(second.status).toBe(410);
+    });
+
+    it("returns 403 when the session email does not match the invitation", async () => {
+      const wrongUser = await createTestUser({ email: "wrong@test.com" });
+
+      const inv = await seedInvitation({
+        orgId: ctx.orgId,
+        email: "target@test.com",
+        invitedBy: ctx.user.id,
       });
 
+      const res = await app.request(`/invite/${inv.token}/accept`, {
+        method: "POST",
+        headers: { Cookie: wrongUser.cookie },
+      });
+
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as any;
+      expect(body.code).toBe("email_mismatch");
+    });
+
+    it("is idempotent when the user is already a member", async () => {
+      const member = await createTestUser({ email: "idempotent@test.com" });
+      const { addOrgMember } = await import("../../helpers/auth.ts");
+
+      // Pre-add the user as member (simulates double-click / race).
+      await addOrgMember(ctx.orgId, member.id, "member");
+
+      const inv = await seedInvitation({
+        orgId: ctx.orgId,
+        email: "idempotent@test.com",
+        invitedBy: ctx.user.id,
+      });
+
+      const res = await app.request(`/invite/${inv.token}/accept`, {
+        method: "POST",
+        headers: { Cookie: member.cookie },
+      });
+
+      // Should succeed (idempotent), not 500.
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
       expect(body.id).toBe(ctx.orgId);
-      expect(body.role).toBe(inv.role);
     });
 
-    it("reports isNewUser=false in info when user exists", async () => {
+    it("returns 404 for an unknown token", async () => {
+      const member = await createTestUser({ email: "whoever@test.com" });
+      const res = await app.request(`/invite/nonexistent-token/accept`, {
+        method: "POST",
+        headers: { Cookie: member.cookie },
+      });
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe("GET /invite/:token/info — is_new_user", () => {
+    it("reports is_new_user=false when the invited email already has an account", async () => {
       await createTestUser({ email: "known@test.com" });
 
       const inv = await seedInvitation({
@@ -170,58 +180,6 @@ describe("Invitations API", () => {
       const body = (await res.json()) as any;
       expect(body.is_new_user).toBe(false);
       expect(body.email).toBe("known@test.com");
-    });
-
-    it("returns 403 when authenticated user's email does not match invitation", async () => {
-      const wrongUser = await createTestUser({ email: "wrong@test.com" });
-      await createTestUser({ email: "target@test.com" });
-
-      const inv = await seedInvitation({
-        orgId: ctx.orgId,
-        email: "target@test.com",
-        invitedBy: ctx.user.id,
-      });
-
-      const res = await app.request(`/invite/${inv.token}/accept`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Cookie: wrongUser.cookie,
-        },
-        body: JSON.stringify({}),
-      });
-
-      expect(res.status).toBe(403);
-      const body = (await res.json()) as any;
-      expect(body.code).toBe("email_mismatch");
-    });
-
-    it("accepts invitation when existing user re-accepts (idempotent addMember)", async () => {
-      const existingUser = await createTestUser({ email: "idempotent@test.com" });
-      const { addOrgMember } = await import("../../helpers/auth.ts");
-
-      // Pre-add the user as member (simulates double-click / race)
-      await addOrgMember(ctx.orgId, existingUser.id, "member");
-
-      const inv = await seedInvitation({
-        orgId: ctx.orgId,
-        email: "idempotent@test.com",
-        invitedBy: ctx.user.id,
-      });
-
-      const res = await app.request(`/invite/${inv.token}/accept`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Cookie: existingUser.cookie,
-        },
-        body: JSON.stringify({}),
-      });
-
-      // Should succeed (idempotent), not 500
-      expect(res.status).toBe(200);
-      const body = (await res.json()) as any;
-      expect(body.id).toBe(ctx.orgId);
     });
   });
 });

--- a/apps/api/test/integration/routes/organizations.test.ts
+++ b/apps/api/test/integration/routes/organizations.test.ts
@@ -390,7 +390,6 @@ describe("Organizations API", () => {
         orgId: ctx.orgId,
         role: "member",
         invitedBy: ctx.user.id,
-        skipEmail: true,
       });
 
       const res = await app.request(`/api/orgs/${ctx.orgId}/invitations/${invitation.id}`, {
@@ -456,7 +455,6 @@ describe("Organizations API", () => {
         orgId: ctx.orgId,
         role: "member",
         invitedBy: ctx.user.id,
-        skipEmail: true,
       });
 
       const res = await app.request(`/api/orgs/${ctx.orgId}/invitations/${invitation.id}`, {

--- a/apps/api/test/integration/routes/organizations.test.ts
+++ b/apps/api/test/integration/routes/organizations.test.ts
@@ -14,7 +14,7 @@ import {
 } from "../../helpers/auth.ts";
 import { createInvitation } from "../../../src/services/invitations.ts";
 import { seedApiKey } from "../../helpers/seed.ts";
-import { assertDbHas } from "../../helpers/assertions.ts";
+import { assertDbHas, assertDbMissing } from "../../helpers/assertions.ts";
 import {
   organizations,
   orgInvitations,
@@ -266,7 +266,7 @@ describe("Organizations API", () => {
   });
 
   describe("POST /api/orgs/:orgId/members", () => {
-    it("adds existing user directly when SMTP is disabled", async () => {
+    it("creates an invitation even for an existing user (no silent direct-add)", async () => {
       const ctx = await createTestContext({ orgSlug: "memberorg" });
       const member = await createTestUser({ email: "member@test.com" });
 
@@ -278,17 +278,17 @@ describe("Organizations API", () => {
 
       expect(res.status).toBe(201);
       const body = (await res.json()) as any;
-      // Bare created member — same shape as the members list in GET /api/orgs/:orgId
-      expect(body.userId).toBe(member.id);
-      expect(body.role).toBe("member");
+      // Always a bare invitation — never a direct member add (the invitee
+      // must accept first, so consent is explicit).
+      expect(body.id).toBeTruthy();
+      expect(body.token).toBeTruthy();
       expect(body.email).toBe("member@test.com");
-      expect(body.joinedAt).toBeTruthy();
-      // No operation scraps
-      expect(body).not.toHaveProperty("added");
-      expect(body).not.toHaveProperty("invited");
+      expect(body.role).toBe("member");
+      expect(body).not.toHaveProperty("userId");
 
-      // Verify membership in DB
-      await assertDbHas(organizationMembers, eq(organizationMembers.userId, member.id));
+      // The invitation exists; no membership has been created yet.
+      await assertDbHas(orgInvitations, eq(orgInvitations.email, "member@test.com"));
+      await assertDbMissing(organizationMembers, eq(organizationMembers.userId, member.id));
     });
 
     it("creates invitation for non-existing user", async () => {
@@ -328,7 +328,7 @@ describe("Organizations API", () => {
       expect(res.status).toBe(400);
     });
 
-    it("handles adding already existing member gracefully", async () => {
+    it("creates an invitation even when the email already belongs to a member", async () => {
       const ctx = await createTestContext({ orgSlug: "memberorg" });
       const member = await createTestUser({ email: "already@test.com" });
       await addOrgMember(ctx.orgId, member.id, "member");
@@ -339,8 +339,10 @@ describe("Organizations API", () => {
         body: JSON.stringify({ email: "already@test.com" }),
       });
 
-      // addMember is idempotent — duplicate silently ignored, returns 201
+      // Re-inviting an existing member just creates a fresh pending invitation.
       expect(res.status).toBe(201);
+      const body = (await res.json()) as any;
+      expect(body.token).toBeTruthy();
     });
   });
 

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -2335,10 +2335,10 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Add or invite a member
-         * @description Add a user to the org (if they exist) or create an invitation with a magic link token.
+         * Invite a member
+         * @description Create a pending invitation for the given email (new and existing users alike). The invitee joins by opening the invite link, authenticating through the standard login/signup flow, then explicitly accepting. When SMTP is configured an invitation email is sent; otherwise the admin shares the returned token out of band.
          */
-        post: operations["addOrInviteMember"];
+        post: operations["inviteMember"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4068,7 +4068,7 @@ export interface paths {
         put?: never;
         /**
          * Accept invitation
-         * @description Accept an invitation. Creates user account if new, adds to org, sets session cookie.
+         * @description Accept an invitation. Requires an authenticated Better Auth session whose email matches the invitation; adds the user to the org and returns the joined organization. Account creation happens beforehand through the standard login/signup flow, never here.
          */
         post: operations["acceptInvitation"];
         delete?: never;
@@ -12668,7 +12668,7 @@ export interface operations {
             404: components["responses"]["NotFound"];
         };
     };
-    addOrInviteMember: {
+    inviteMember: {
         parameters: {
             query?: never;
             header?: never;
@@ -12691,7 +12691,7 @@ export interface operations {
             };
         };
         responses: {
-            /** @description Polymorphic bare resource: when the user already exists (and no invitation flow applies) they are added directly and the created member is returned (OrgMember — discriminate on `userId`); otherwise an invitation is created and returned (OrgInvitationInfo — discriminate on `id` + `token`). Both use the same serializers as the lists in GET /api/orgs/{orgId}. */
+            /** @description Invitation created — bare OrgInvitationInfo (same shape as the items in the invitations list in GET /api/orgs/{orgId}). */
             201: {
                 headers: {
                     "Request-Id": components["headers"]["RequestId"];
@@ -12699,7 +12699,17 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["OrgMember"] | components["schemas"]["OrgInvitationInfo"];
+                    /**
+                     * @example {
+                     *       "id": "inv_abc123",
+                     *       "email": "newuser@example.com",
+                     *       "role": "member",
+                     *       "token": "inv_abc123def456",
+                     *       "expiresAt": "2026-02-01T00:00:00Z",
+                     *       "createdAt": "2026-01-25T00:00:00Z"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["OrgInvitationInfo"];
                 };
             };
             400: components["responses"]["ValidationError"];
@@ -18211,17 +18221,9 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    /** @description Password (required for new users, minimum 8 characters) */
-                    password?: string;
-                    displayName?: string;
-                };
-            };
-        };
+        requestBody?: never;
         responses: {
-            /** @description Invitation accepted — returns the joined organization (same shape as the items in GET /api/orgs, with `role` set to the invitation role). For new users a session cookie is set via Set-Cookie. */
+            /** @description Invitation accepted — returns the joined organization (same shape as the items in GET /api/orgs, with `role` set to the invitation role). */
             200: {
                 headers: {
                     "Request-Id": components["headers"]["RequestId"];
@@ -18241,7 +18243,7 @@ export interface operations {
                     "application/json": components["schemas"]["Organization"];
                 };
             };
-            400: components["responses"]["ValidationError"];
+            401: components["responses"]["Unauthorized"];
             /** @description Invitation email does not match the authenticated session */
             403: {
                 headers: {

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -388,7 +388,6 @@ export function App() {
           <Route path="/reset-password" element={<ResetPasswordPage />} />
           <Route path="/magic-link" element={<MagicLinkPage />} />
           <Route path="/invite/:token" element={<InviteAcceptPage />} />
-          <Route path="/invite/:token/accept" element={<InviteAcceptPage />} />
           <Route path="*" element={<Navigate to="/login" replace />} />
         </Routes>
       </ErrorBoundary>
@@ -443,7 +442,6 @@ export function App() {
             />
           )}
           <Route path="/invite/:token" element={<InviteAcceptPage />} />
-          <Route path="/invite/:token/accept" element={<InviteAcceptPage />} />
           <Route
             path="/welcome"
             element={

--- a/apps/web/src/components/register-form.tsx
+++ b/apps/web/src/components/register-form.tsx
@@ -22,11 +22,6 @@ type RegisterFormData = {
 
 interface RegisterFormProps extends React.ComponentPropsWithoutRef<"div"> {
   fixedEmail?: string;
-  onSubmitOverride?: (data: {
-    email: string;
-    password: string;
-    displayName: string;
-  }) => Promise<void>;
   header?: ReactNode | null;
   footer?: ReactNode | null;
   switchAuthSlot?: ReactNode;
@@ -51,7 +46,6 @@ interface RegisterFormProps extends React.ComponentPropsWithoutRef<"div"> {
 export function RegisterForm({
   className,
   fixedEmail,
-  onSubmitOverride,
   header,
   footer,
   switchAuthSlot,
@@ -78,23 +72,11 @@ export function RegisterForm({
 
   const onSubmit = async (data: RegisterFormData) => {
     try {
-      if (onSubmitOverride) {
-        await onSubmitOverride({
-          email: fixedEmail ?? data.email,
-          password: data.password,
-          displayName: data.displayName.trim() || "",
-        });
+      const result = await signup(data.email, data.password, data.displayName.trim() || undefined);
+      if (result.emailVerificationRequired) {
+        navigate("/verify-email", { state: { email: data.email } });
       } else {
-        const result = await signup(
-          data.email,
-          data.password,
-          data.displayName.trim() || undefined,
-        );
-        if (result.emailVerificationRequired) {
-          navigate("/verify-email", { state: { email: data.email } });
-        } else {
-          navigate(redirectAfterSignup);
-        }
+        navigate(redirectAfterSignup);
       }
     } catch (err) {
       setError("root", {

--- a/apps/web/src/modules/oidc/lib/oidc.ts
+++ b/apps/web/src/modules/oidc/lib/oidc.ts
@@ -62,6 +62,7 @@ const OIDC_REDIRECT_KEY = "appstrate_oidc_redirect";
 async function initPkceFlow(
   config: OidcConfig,
   redirectTo: string | undefined,
+  loginHint?: string,
 ): Promise<URLSearchParams> {
   const state = generateState();
   const codeVerifier = generateCodeVerifier();
@@ -76,7 +77,7 @@ async function initPkceFlow(
   // `validAudiences` (`${APP_URL}/api/auth`). The SPA never consumes the
   // minted tokens — the BA session cookie is the real auth — but the
   // grant still has to succeed, so `resource` is non-negotiable.
-  return new URLSearchParams({
+  const params = new URLSearchParams({
     response_type: "code",
     client_id: config.clientId,
     redirect_uri: config.callbackUrl,
@@ -89,6 +90,16 @@ async function initPkceFlow(
     code_challenge_method: "S256",
     resource: config.issuer,
   });
+
+  // OIDC `login_hint` (standard param) — the oauth-provider carries it
+  // through (signed) to the server-rendered login/register pages, which
+  // pre-fill and lock the email field. Used by the invitation flow to pin
+  // the invited address. Purely UX: the accept endpoint re-checks that the
+  // session email matches the invitation server-side, so a tampered field
+  // cannot escape it.
+  if (loginHint) params.set("login_hint", loginHint);
+
+  return params;
 }
 
 /**
@@ -98,12 +109,12 @@ async function initPkceFlow(
  * handles authentication. On success the browser lands on `/auth/callback`
  * with an authorization code.
  */
-export async function startOidcLogin(redirectTo?: string): Promise<void> {
+export async function startOidcLogin(redirectTo?: string, loginHint?: string): Promise<void> {
   const config = getOidcConfig();
   if (!config) {
     throw new Error("OIDC not configured — window.__APP_CONFIG__.oidc is missing");
   }
-  const params = await initPkceFlow(config, redirectTo);
+  const params = await initPkceFlow(config, redirectTo, loginHint);
   window.location.assign(`/api/auth/oauth2/authorize?${params.toString()}`);
 }
 
@@ -114,12 +125,12 @@ export async function startOidcLogin(redirectTo?: string): Promise<void> {
  * reusing the same `state`/`code_challenge`/`resource` that were generated
  * here, so the callback handler cannot tell login and signup apart.
  */
-export async function startOidcSignup(redirectTo?: string): Promise<void> {
+export async function startOidcSignup(redirectTo?: string, loginHint?: string): Promise<void> {
   const config = getOidcConfig();
   if (!config) {
     throw new Error("OIDC not configured — window.__APP_CONFIG__.oidc is missing");
   }
-  const params = await initPkceFlow(config, redirectTo);
+  const params = await initPkceFlow(config, redirectTo, loginHint);
   window.location.assign(`/api/oauth/register?${params.toString()}`);
 }
 

--- a/apps/web/src/pages/invite-accept.tsx
+++ b/apps/web/src/pages/invite-accept.tsx
@@ -19,6 +19,27 @@ import { orgKeys } from "../lib/query-keys";
 type InviteInfo =
   paths["/invite/{token}/info"]["get"]["responses"]["200"]["content"]["application/json"];
 
+/** Whether the instance is running an OIDC IdP (the platform's own login flow). */
+function hasOidc(): boolean {
+  return !!(window.__APP_CONFIG__ as unknown as Record<string, unknown>)?.oidc;
+}
+
+/**
+ * Invitation acceptance — a single route (`/invite/:token`) that is, in
+ * order: a loader, then an authentication delegator, then an explicit accept.
+ *
+ * Authentication is never performed inline by this page; it delegates to the
+ * platform-standard path so an invited user is created exactly like any other
+ * user:
+ *   - OIDC instance → redirect into the OIDC login/signup flow, carrying the
+ *     invite as `redirectTo` and the invited email as `login_hint` (pinned).
+ *   - OSS instance  → the built-in email/password + social forms, email pinned.
+ *
+ * On return the user is authenticated and lands back here; acceptance is then
+ * a single explicit, session-bound POST ("Rejoindre {org}") — the same button
+ * for everyone (post-OIDC, post-OSS-login, post-OSS-signup, already-authed).
+ * That uniform explicit step is the consent + email-mismatch chokepoint.
+ */
 export function InviteAcceptPage() {
   const { t } = useTranslation(["settings", "common"]);
   const { token } = useParams<{ token: string }>();
@@ -31,6 +52,8 @@ export function InviteAcceptPage() {
   const [accepting, setAccepting] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
   const [mode, setMode] = useState<"register" | "login">("register");
+
+  const oidc = hasOidc();
 
   useEffect(() => {
     if (!token) return;
@@ -57,36 +80,39 @@ export function InviteAcceptPage() {
       });
   }, [token, t]);
 
-  /** POST accept + handle success (shared by all accept flows) */
-  const postAccept = useCallback(
-    async (body: { password?: string; displayName?: string } = {}) => {
-      // Non-2xx throws ApiError (RFC 9457 detail) via the client middleware.
-      // The accept endpoint returns the joined org resource (same shape as
-      // the GET /api/orgs list items).
-      const { data } = await client.POST("/invite/{token}/accept", {
-        params: { path: { token: token ?? "" } },
-        body,
-      });
-      await refreshAuth();
-      // Refetch orgs so the new org is in the cache BEFORE setId triggers useAutoSelect
-      await queryClient.invalidateQueries({ queryKey: orgKeys.all });
-      if (data?.id) {
-        orgStore.getState().setId(data.id);
+  // OIDC delegation: once the invite is loaded and the visitor is not yet
+  // authenticated, redirect into the standard OIDC flow. The invite token
+  // rides as `redirectTo` (the browser returns to this page authenticated);
+  // the invited email rides as `login_hint` so the server-rendered login /
+  // register page pins it. Acceptance happens on return, in the authed branch.
+  useEffect(() => {
+    if (!info || user || !oidc || !token) return;
+    const redirectTo = `/invite/${token}`;
+    void import("../modules/oidc/lib/oidc").then(({ startOidcLogin, startOidcSignup }) => {
+      if (info.is_new_user) {
+        void startOidcSignup(redirectTo, info.email);
+      } else {
+        void startOidcLogin(redirectTo, info.email);
       }
-      navigate("/");
-    },
-    [token, navigate, queryClient],
-  );
+    });
+  }, [info, user, oidc, token]);
 
-  const handleRegisterAndAccept = useCallback(
-    async (formData: { email: string; password: string; displayName: string }) => {
-      await postAccept({
-        password: formData.password,
-        displayName: formData.displayName || undefined,
-      });
-    },
-    [postAccept],
-  );
+  /** POST accept (session-bound, no body) + handle success. */
+  const postAccept = useCallback(async () => {
+    // Non-2xx throws ApiError (RFC 9457 detail) via the client middleware.
+    // The accept endpoint returns the joined org resource (same shape as the
+    // GET /api/orgs list items).
+    const { data } = await client.POST("/invite/{token}/accept", {
+      params: { path: { token: token ?? "" } },
+    });
+    await refreshAuth();
+    // Refetch orgs so the new org is in the cache BEFORE setId triggers useAutoSelect.
+    await queryClient.invalidateQueries({ queryKey: orgKeys.all });
+    if (data?.id) {
+      orgStore.getState().setId(data.id);
+    }
+    navigate("/");
+  }, [token, navigate, queryClient]);
 
   if (loading) {
     return (
@@ -140,7 +166,7 @@ export function InviteAcceptPage() {
     </div>
   );
 
-  // Authenticated user: check email match then show accept button
+  // Authenticated: the explicit accept step (consent + email-mismatch guard).
   if (user) {
     const emailMatches = user.email.toLowerCase() === info.email.toLowerCase();
 
@@ -187,7 +213,22 @@ export function InviteAcceptPage() {
     );
   }
 
-  // Unauthenticated: register or login mode
+  // Unauthenticated + OIDC: the delegation effect above is redirecting away.
+  // Render a spinner for that brief window.
+  if (oidc) {
+    return (
+      <AuthLayout>
+        <div className="flex items-center justify-center py-8">
+          <Spinner />
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  // Unauthenticated + OSS: inline email/password + social forms, email pinned.
+  // These run the platform-standard signup/login (no accept coupling). On
+  // success the auth context updates and this page re-renders into the
+  // authenticated branch above, where the user explicitly accepts.
   const switchToLogin = (
     <span className="text-muted-foreground text-center text-sm">
       {t("invite.hasAccount")}{" "}
@@ -228,16 +269,16 @@ export function InviteAcceptPage() {
         {mode === "register" ? (
           <RegisterForm
             fixedEmail={info.email}
-            onSubmitOverride={handleRegisterAndAccept}
             header={null}
             footer={null}
             switchAuthSlot={switchToLogin}
             socialCallbackURL={`/invite/${token}`}
+            redirectAfterSignup={`/invite/${token}`}
           />
         ) : (
           <LoginForm
             fixedEmail={info.email}
-            onSuccess={postAccept}
+            onSuccess={refreshAuth}
             header={null}
             footer={null}
             switchAuthSlot={switchToRegister}

--- a/apps/web/src/pages/invite-accept.tsx
+++ b/apps/web/src/pages/invite-accept.tsx
@@ -24,6 +24,20 @@ function hasOidc(): boolean {
   return !!(window.__APP_CONFIG__ as unknown as Record<string, unknown>)?.oidc;
 }
 
+/** Map an invitation ApiError code to a translation key, falling back to `fallback`. */
+function inviteErrorKey(code: string | null, fallback: string): string {
+  switch (code) {
+    case "invitation_expired":
+      return "invite.expired";
+    case "invitation_accepted":
+      return "invite.alreadyAccepted";
+    case "invitation_cancelled":
+      return "invite.cancelled";
+    default:
+      return fallback;
+  }
+}
+
 /**
  * Invitation acceptance — a single route (`/invite/:token`) that is, in
  * order: a loader, then an authentication delegator, then an explicit accept.
@@ -66,16 +80,8 @@ export function InviteAcceptPage() {
         setLoading(false);
       })
       .catch((err: unknown) => {
-        const code = err instanceof ApiError ? err.code : "invitation_not_found";
-        if (code === "invitation_expired") {
-          setServerError(t("invite.expired"));
-        } else if (code === "invitation_accepted") {
-          setServerError(t("invite.alreadyAccepted"));
-        } else if (code === "invitation_cancelled") {
-          setServerError(t("invite.cancelled"));
-        } else {
-          setServerError(t("invite.invalid"));
-        }
+        const code = err instanceof ApiError ? err.code : null;
+        setServerError(t(inviteErrorKey(code, "invite.invalid")));
         setLoading(false);
       });
   }, [token, t]);
@@ -88,14 +94,16 @@ export function InviteAcceptPage() {
   useEffect(() => {
     if (!info || user || !oidc || !token) return;
     const redirectTo = `/invite/${token}`;
-    void import("../modules/oidc/lib/oidc").then(({ startOidcLogin, startOidcSignup }) => {
-      if (info.is_new_user) {
-        void startOidcSignup(redirectTo, info.email);
-      } else {
-        void startOidcLogin(redirectTo, info.email);
-      }
-    });
-  }, [info, user, oidc, token]);
+    void import("../modules/oidc/lib/oidc")
+      .then(({ startOidcLogin, startOidcSignup }) =>
+        info.is_new_user
+          ? startOidcSignup(redirectTo, info.email)
+          : startOidcLogin(redirectTo, info.email),
+      )
+      // If the dynamic import or the redirect fails, surface an error instead
+      // of leaving the OIDC branch stuck on an indefinite spinner.
+      .catch(() => setServerError(t("invite.error")));
+  }, [info, user, oidc, token, t]);
 
   /** POST accept (session-bound, no body) + handle success. */
   const postAccept = useCallback(async () => {
@@ -195,7 +203,8 @@ export function InviteAcceptPage() {
       try {
         await postAccept();
       } catch (err) {
-        setServerError(err instanceof Error ? err.message : t("invite.error"));
+        const code = err instanceof ApiError ? err.code : null;
+        setServerError(t(inviteErrorKey(code, "invite.error")));
         setAccepting(false);
       }
     };
@@ -214,8 +223,22 @@ export function InviteAcceptPage() {
   }
 
   // Unauthenticated + OIDC: the delegation effect above is redirecting away.
-  // Render a spinner for that brief window.
+  // Render a spinner for that brief window — unless the redirect failed, in
+  // which case show the error instead of spinning forever.
   if (oidc) {
+    if (serverError) {
+      return (
+        <AuthLayout>
+          <div className="flex flex-col gap-6">
+            {inviteBanner}
+            <p className="text-destructive text-center text-sm">{serverError}</p>
+            <Button className="w-full" onClick={() => navigate("/")}>
+              {t("invite.goHome")}
+            </Button>
+          </div>
+        </AuthLayout>
+      );
+    }
     return (
       <AuthLayout>
         <div className="flex items-center justify-center py-8">

--- a/e2e/tests/organizations/invite-flow.ui.spec.ts
+++ b/e2e/tests/organizations/invite-flow.ui.spec.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Browser E2E for the organization invitation flow.
+ *
+ * The accept step (and the email-mismatch guard) are mode-independent: they
+ * only require an authenticated session, so we inject the invitee's cookie and
+ * drive the page directly — no login UI involved. The inline signup-via-invite
+ * form only exists in OSS mode (an OIDC instance redirects unauthenticated
+ * visitors to its own IdP), so that test self-skips when an OIDC instance
+ * client is configured.
+ *
+ * @tags @critical
+ */
+
+import { test, expect } from "../../fixtures/browser.fixture.ts";
+import { registerUser } from "../../helpers/seed.ts";
+import type { Browser } from "@playwright/test";
+
+function uid() {
+  return Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
+}
+
+/** A browser context carrying only the given Better Auth session cookie. */
+async function contextWithCookie(browser: Browser, cookie: string) {
+  const context = await browser.newContext();
+  const match = cookie.match(/better-auth\.session_token=([^;]+)/);
+  if (match) {
+    await context.addCookies([
+      {
+        name: "better-auth.session_token",
+        value: match[1],
+        domain: "localhost",
+        path: "/",
+      },
+    ]);
+  }
+  return context;
+}
+
+test.describe("Organization invitation flow", () => {
+  test("an authenticated invitee joins via the explicit accept button @critical", async ({
+    request,
+    browser,
+    browserCtx,
+    orgOnlyClient,
+  }) => {
+    const invitedEmail = `e2e-invitee-${uid()}@test.com`;
+    // The invitee already has an account (the mode-independent path).
+    const invitee = await registerUser(request, { email: invitedEmail });
+
+    const inviteRes = await orgOnlyClient.post(`/orgs/${browserCtx.org.orgId}/members`, {
+      email: invitedEmail,
+      role: "member",
+    });
+    expect(inviteRes.status()).toBe(201);
+    const { token } = (await inviteRes.json()) as { token: string };
+
+    const ctx = await contextWithCookie(browser, invitee.cookie);
+    const page = await ctx.newPage();
+    await page.goto(`/invite/${token}`);
+
+    // Authenticated + email matches → the explicit "Rejoindre {org}" button.
+    const joinButton = page.getByRole("button", { name: /Rejoindre/i });
+    await expect(joinButton).toBeVisible({ timeout: 10_000 });
+    await joinButton.click();
+
+    // Accept resolved → the page navigates off /invite.
+    await page.waitForURL((url) => !url.pathname.startsWith("/invite"), { timeout: 10_000 });
+
+    // Acceptance persisted: re-opening the link now reports it consumed.
+    await page.goto(`/invite/${token}`);
+    await expect(page.getByText(/déjà été acceptée/i)).toBeVisible({ timeout: 10_000 });
+
+    await ctx.close();
+  });
+
+  test("the page blocks a logged-in account whose email does not match", async ({
+    request,
+    browser,
+    browserCtx,
+    orgOnlyClient,
+  }) => {
+    // Logged in as one account, but the invitation targets a different email.
+    const wrongUser = await registerUser(request);
+    const inviteRes = await orgOnlyClient.post(`/orgs/${browserCtx.org.orgId}/members`, {
+      email: `e2e-target-${uid()}@test.com`,
+      role: "member",
+    });
+    expect(inviteRes.status()).toBe(201);
+    const { token } = (await inviteRes.json()) as { token: string };
+
+    const ctx = await contextWithCookie(browser, wrongUser.cookie);
+    const page = await ctx.newPage();
+    await page.goto(`/invite/${token}`);
+
+    await expect(page.getByText(/cette invitation est destinée à/i)).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByRole("button", { name: /Se déconnecter et réessayer/i })).toBeVisible();
+    // No join button is offered on a mismatch.
+    await expect(page.getByRole("button", { name: /Rejoindre/i })).toHaveCount(0);
+
+    await ctx.close();
+  });
+
+  test("a new invitee signs up inline and joins (OSS mode)", async ({
+    browser,
+    browserCtx,
+    orgOnlyClient,
+  }) => {
+    const invitedEmail = `e2e-newinvitee-${uid()}@test.com`;
+    const inviteRes = await orgOnlyClient.post(`/orgs/${browserCtx.org.orgId}/members`, {
+      email: invitedEmail,
+      role: "member",
+    });
+    expect(inviteRes.status()).toBe(201);
+    const { token } = (await inviteRes.json()) as { token: string };
+
+    const ctx = await browser.newContext(); // anonymous
+    const page = await ctx.newPage();
+    await page.goto(`/invite/${token}`);
+
+    // The inline form only exists in OSS mode; an OIDC instance redirects
+    // unauthenticated visitors to its own server-rendered pages instead.
+    const oidc = await page.evaluate(
+      () => !!(window as unknown as { __APP_CONFIG__?: { oidc?: unknown } }).__APP_CONFIG__?.oidc,
+    );
+    test.skip(oidc, "OIDC instance — inline signup form is not rendered on the invite page");
+
+    // The register form is shown with the invited email pinned (read-only).
+    const emailField = page.locator("#email");
+    await expect(emailField).toHaveValue(invitedEmail);
+    await expect(emailField).toHaveJSProperty("readOnly", true);
+
+    await page.locator("#displayName").fill("E2E Invitee");
+    await page.locator("#password").fill("TestPassword123!");
+    await page.getByRole("button", { name: /Créer un compte/i }).click();
+
+    // The invited email is auto-verified (a pending invitation proves
+    // ownership), so signup establishes a session and the page re-renders
+    // into the authenticated branch with the explicit join button.
+    const joinButton = page.getByRole("button", { name: /Rejoindre/i });
+    await expect(joinButton).toBeVisible({ timeout: 15_000 });
+    await joinButton.click();
+
+    await page.waitForURL((url) => !url.pathname.startsWith("/invite"), { timeout: 10_000 });
+
+    await page.goto(`/invite/${token}`);
+    await expect(page.getByText(/déjà été acceptée/i)).toBeVisible({ timeout: 10_000 });
+
+    await ctx.close();
+  });
+});

--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -14,7 +14,7 @@ const logger = createLogger("info");
 import type { BeforeSignupContext, AfterSignupContext } from "@appstrate/core/module";
 import { db } from "./client.ts";
 import * as schema from "./schema.ts";
-import { profiles, orgInvitations, organizations, user } from "./schema.ts";
+import { profiles, orgInvitations, user } from "./schema.ts";
 import { getEnv } from "@appstrate/env";
 import {
   evaluateSignupPolicy,
@@ -372,10 +372,6 @@ function buildBasePlugins(
               try {
                 const normalizedEmail = email.toLowerCase().trim();
 
-                // Parse callbackURL from the magic link to determine context
-                const callbackURL = new URL(rawUrl).searchParams.get("callbackURL") ?? "";
-                const isInvitation = callbackURL.startsWith("/invite/");
-
                 // Rewrite the verify URL to route through the OIDC module's
                 // confirmation interstitial so that one-shot token consumption
                 // is gated behind an explicit click. Without this, email
@@ -409,65 +405,16 @@ function buildBasePlugins(
                 }
                 const url = rewritten.toString();
 
-                let subject: string;
-                let html: string;
-
-                if (isInvitation) {
-                  // Extract invitation token from callbackURL: /invite/{token}/accept
-                  const invitationToken = callbackURL.split("/")[2];
-                  const [invitation] = invitationToken
-                    ? await db
-                        .select({
-                          orgId: orgInvitations.orgId,
-                          role: orgInvitations.role,
-                          invitedBy: orgInvitations.invitedBy,
-                        })
-                        .from(orgInvitations)
-                        .where(eq(orgInvitations.token, invitationToken))
-                        .limit(1)
-                    : [];
-
-                  if (invitation) {
-                    const [orgRow, inviterRow] = await Promise.all([
-                      db
-                        .select({ name: organizations.name })
-                        .from(organizations)
-                        .where(eq(organizations.id, invitation.orgId))
-                        .limit(1)
-                        .then(([r]) => r),
-                      invitation.invitedBy
-                        ? db
-                            .select({ displayName: profiles.displayName, name: user.name })
-                            .from(user)
-                            .leftJoin(profiles, eq(profiles.id, user.id))
-                            .where(eq(user.id, invitation.invitedBy))
-                            .limit(1)
-                            .then(([r]) => r)
-                        : null,
-                    ]);
-
-                    ({ subject, html } = renderEmail("invitation", {
-                      email: normalizedEmail,
-                      inviteUrl: url,
-                      orgName: orgRow?.name ?? "Organisation",
-                      inviterName: inviterRow?.displayName || inviterRow?.name || "Un membre",
-                      role: invitation.role,
-                      locale: "fr",
-                    }));
-                  } else {
-                    ({ subject, html } = renderEmail("magic-link", {
-                      email: normalizedEmail,
-                      url,
-                      locale: "fr",
-                    }));
-                  }
-                } else {
-                  ({ subject, html } = renderEmail("magic-link", {
-                    email: normalizedEmail,
-                    url,
-                    locale: "fr",
-                  }));
-                }
+                // Magic-link is now a pure passwordless-login channel. The
+                // invitation flow no longer rides on magic-link: an invited
+                // user opens the `/invite/{token}` page and authenticates
+                // through the standard login/signup path, then accepts. So a
+                // single generic template covers every magic-link send.
+                const { subject, html } = renderEmail("magic-link", {
+                  email: normalizedEmail,
+                  url,
+                  locale: "fr",
+                });
 
                 const override = getSmtpOverride();
                 const transport = override?.transport ?? smtpTransport!;
@@ -788,14 +735,8 @@ function buildAuth(extraPlugins: BetterAuthPluginList = []) {
             const headers = ctx?.headers ?? ctx?.request?.headers ?? null;
             // Platform-level signup gate (self-hosting lockdown). Runs FIRST
             // so the cheapest, most specific decision wins before any module
-            // hook. Skipped entirely when neither restriction is configured
-            // (open mode = single env read, no policy eval, no DB query).
-            //
-            // The invitation lookup is always performed when at least one
-            // restriction is active, because a pending invitation overrides
-            // BOTH closed mode and the domain allowlist. The lookup is
-            // index-covered (`idx_org_invitations_email`) — negligible cost
-            // for the only path where a restriction applies.
+            // hook. A pending invitation overrides BOTH closed mode and the
+            // domain allowlist (see `invited` below).
             const envForGate = getEnv();
             // Bootstrap-token redemption (#344 Layer 2b) — explicitly
             // bypasses the `AUTH_DISABLE_SIGNUP` gate. The redeem route
@@ -814,12 +755,20 @@ function buildAuth(extraPlugins: BetterAuthPluginList = []) {
             // both gates (Infisical-style breakage avoidance), matching
             // the non-bypass evaluator's logic.
             const bootstrapTokenBypass = isBootstrapTokenRedemptionActive();
+            // A pending invitation for this exact email proves the recipient
+            // owns the inbox the inviter sent the token to. It serves two
+            // purposes below: it overrides the signup gate, AND it auto-verifies
+            // the email so an invited user never hits the verification screen —
+            // regardless of signup method (email/password, OIDC, social,
+            // magic-link). One generic rule, no per-flow special-casing. The
+            // lookup is index-covered (`idx_org_invitations_email`); signups
+            // are infrequent, so the unconditional query is negligible.
+            const invited = await hasPendingInvitationByEmail(user.email);
             const gateActive =
               envForGate.AUTH_DISABLE_SIGNUP || envForGate.AUTH_ALLOWED_SIGNUP_DOMAINS.length > 0;
             if (gateActive) {
-              const hasInvite = await hasPendingInvitationByEmail(user.email);
               if (bootstrapTokenBypass) {
-                if (envForGate.AUTH_ALLOWED_SIGNUP_DOMAINS.length > 0 && !hasInvite) {
+                if (envForGate.AUTH_ALLOWED_SIGNUP_DOMAINS.length > 0 && !invited) {
                   if (!isAllowedSignupDomain(user.email)) {
                     logger.info("auth: bootstrap-token bypass blocked by domain allowlist", {
                       email: user.email,
@@ -831,7 +780,7 @@ function buildAuth(extraPlugins: BetterAuthPluginList = []) {
                   }
                 }
               } else {
-                const decision = evaluateSignupPolicy(user.email, hasInvite);
+                const decision = evaluateSignupPolicy(user.email, invited);
                 if (!decision.allowed) {
                   logger.info("auth: platform signup gate blocked signup", {
                     email: user.email,
@@ -862,9 +811,12 @@ function buildAuth(extraPlugins: BetterAuthPluginList = []) {
               : _realmResolver
                 ? await _realmResolver(headers)
                 : "platform";
+            // Auto-verify when a trusted social provider produced the row
+            // (the BA OAuth callback path) OR when the email is invited — both
+            // are independent proofs of ownership.
             const autoVerify = shouldAutoVerifyEmailOnCreate(ctx);
             const data: Record<string, unknown> = { realm };
-            if (autoVerify) data.emailVerified = true;
+            if (autoVerify || invited) data.emailVerified = true;
             return { data };
           },
           after: async (user, context) => {

--- a/packages/db/src/auth.ts
+++ b/packages/db/src/auth.ts
@@ -755,14 +755,15 @@ function buildAuth(extraPlugins: BetterAuthPluginList = []) {
             // both gates (Infisical-style breakage avoidance), matching
             // the non-bypass evaluator's logic.
             const bootstrapTokenBypass = isBootstrapTokenRedemptionActive();
-            // A pending invitation for this exact email proves the recipient
-            // owns the inbox the inviter sent the token to. It serves two
-            // purposes below: it overrides the signup gate, AND it auto-verifies
-            // the email so an invited user never hits the verification screen —
-            // regardless of signup method (email/password, OIDC, social,
-            // magic-link). One generic rule, no per-flow special-casing. The
-            // lookup is index-covered (`idx_org_invitations_email`); signups
-            // are infrequent, so the unconditional query is negligible.
+            // A pending invitation for this exact email overrides the signup
+            // gate (Infisical-style breakage avoidance) so an invited user can
+            // complete signup even when signup is locked down. It is matched on
+            // EMAIL ALONE — the invitation token is not available at signup —
+            // so it is NOT proof of inbox ownership (it only means an org admin
+            // typed this address) and must NEVER auto-verify the email. See the
+            // `emailVerified` decision below. The lookup is index-covered
+            // (`idx_org_invitations_email`); signups are infrequent, so the
+            // unconditional query is negligible.
             const invited = await hasPendingInvitationByEmail(user.email);
             const gateActive =
               envForGate.AUTH_DISABLE_SIGNUP || envForGate.AUTH_ALLOWED_SIGNUP_DOMAINS.length > 0;
@@ -811,12 +812,17 @@ function buildAuth(extraPlugins: BetterAuthPluginList = []) {
               : _realmResolver
                 ? await _realmResolver(headers)
                 : "platform";
-            // Auto-verify when a trusted social provider produced the row
-            // (the BA OAuth callback path) OR when the email is invited — both
-            // are independent proofs of ownership.
+            // Auto-verify ONLY when a trusted social provider produced the row
+            // (the BA OAuth callback path). A pending invitation is deliberately
+            // NOT a verification signal: it is matched on email alone, so
+            // granting `emailVerified` here would let anyone mint a verified
+            // account for any unclaimed address (create org → self-invite that
+            // email → sign up) AND would defeat the OIDC end-user adopter's
+            // `emailVerified === true` takeover guard. Invited users verify
+            // their inbox through the normal flow, like everyone else.
             const autoVerify = shouldAutoVerifyEmailOnCreate(ctx);
             const data: Record<string, unknown> = { realm };
-            if (autoVerify || invited) data.emailVerified = true;
+            if (autoVerify) data.emailVerified = true;
             return { data };
           },
           after: async (user, context) => {


### PR DESCRIPTION
## Problem

`/invite/:token` embedded its own email/password + social forms and `POST .../accept` created the account **inline** via Better Auth — bypassing the OIDC module entirely and running a second, parallel signup path. Invited users got plain BA sessions while everyone else got OIDC realm-tagged sessions. Three auth surfaces (invite forms, `/login`, magic-link invitation) had drifted out of sync.

## Approach (Big-Bang, no backward compat — DB reset)

The invite page is now purely **load → delegate auth → explicit accept**. Authentication always goes through the platform-standard path; the invite token only rides as `redirectTo`.

### Backend
- **`POST /invite/:token/accept` is session-only, single responsibility**: `401` without a session, `403` on email mismatch, else claim-the-invitation + `addMember`. No account creation here — drops the `password`/`displayName` body and the `signUpEmail`/`signInEmail`/`Set-Cookie` branch. Accept is a deliberate session-bound POST (never a GET, never auto-fires → no prefetch/stranger auto-join).
- **Accept is atomic + single-use-safe**: the claim (`UPDATE … WHERE status = 'pending'`) and the membership insert run in one transaction, so two concurrent accepts can't both succeed (loser → `410`) and the two writes can never half-apply. `addMember` uses `ON CONFLICT DO NOTHING` — transaction-safe idempotency, existing member keeps their role (no silent downgrade).
- **A pending invitation overrides the signup _gate_ only** (Infisical-style breakage avoidance, so an invited user can register when signup is locked down). It is matched on **email alone** — the invite token is not available at signup — so it is **not** treated as inbox-ownership proof and **never** sets `emailVerified`. Invited users verify their inbox through the normal flow, like everyone else (GitHub/Slack/Clerk model). _(See the security note below — this is the fix for an email-verification bypass.)_
- **`POST /orgs/:orgId/members` always creates a pending invitation** (new + existing users alike). Drops the silent direct-add and the magic-link side channel; join is consent-explicit.
- Removes `sendMagicLinkInvitation` and the invitation branch in the magic-link sender (magic-link is now a pure passwordless-login channel). Invite email URL → `/invite/:token`.

### OIDC
- **`login_hint`** threaded from the SPA through the authorize flow to the server-rendered login/register pages, which pre-fill and **lock** the email field. Purely UX — the accept endpoint re-checks the session email server-side, so a tampered field can't escape it. (Verified the oauth-provider carries `login_hint`, signed, to the login/register pages.)

### Frontend
- `invite-accept.tsx` rewritten as a state machine: OIDC instances redirect into the standard OIDC login/signup (invite as `redirectTo` + email as `login_hint`); OSS instances render the built-in forms (email pinned). On return the user is authenticated and explicitly accepts via one uniform **"Rejoindre {org}"** button — the consent + email-mismatch chokepoint (GitHub/Slack-style). The OIDC redirect catches failures (no infinite spinner) and accept errors map `err.code` → localized strings.
- Single canonical route `/invite/:token` (drops the `/accept` alias).

## Security (adversarial-review follow-up)

The first pass auto-verified an invited user's email (`pending invitation ⇒ emailVerified=true`). Because the lookup matches on **email alone**, this let anyone mint a verified account for any unclaimed address (create org → self-invite that email → sign up) **and** defeated the OIDC end-user adopter's `emailVerified === true` takeover guard, enabling cross-tenant end-user account adoption. **Fixed**: a pending invitation no longer touches `emailVerified` (gate override kept). Pinned by a regression test.

## Tests
- **Accept**: `401`/`403`/`200` with DB-state assertions, single-use (`410` on re-accept), expired/cancelled accept → `410`, case-insensitive email match, **concurrent double-accept** (one `200`, one `410`, single membership row), existing-member keeps role + invite consumed, `404` unknown token.
- **Security pin**: an invited email is **not** auto-verified; the signup-gate bypass still works.
- **Members**: always-invitation (existing user not direct-added, no membership until accept).
- **OIDC `login_hint`**: new integration test — `GET /api/oauth/login|register?login_hint=…` pre-fills and **locks** the email field (covers the route-level plumbing the page unit test can't reach). Unit test still asserts the templates honour `lockEmail`.
- **Browser e2e** (`e2e/tests/organizations/invite-flow.ui.spec.ts`): authed invitee joins via the button; email-mismatch is blocked; new invitee signs up inline (OSS mode) and joins. Verified passing in both OIDC and OSS boots.

`bun run check` green (31 tasks). Touched API tests + full OIDC suite (457) pass.

## Notes
- OpenAPI baseline updated for the intentional removal of the accept `400` response (surgical edit, not a full regen, to keep the diff reviewable).
- **Behavior changes** (intentional): no-SMTP admins now share invite links out of band instead of auto-adding existing users; existing-user invites require an explicit accept; members-POST response is invitation-only. Invited users in SMTP mode verify their inbox like any other signup (no longer skipped).
- Dead code removed from the Big-Bang: `onSubmitOverride` (RegisterForm), `findUserByEmail`, the `skipEmail` param on `createInvitation`.
- **Known low-severity residuals** (not blocking): `login_hint` could leak the invited email to a social IdP via `Referer` on the OIDC page (mitigate with `Referrer-Policy`); the `403` mismatch body echoes the invited address (acceptable while the token is the secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)