### PR TITLE
refactor(auth): single auth seam (useAuth) + unified OIDC render gate + lint guard

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -21,6 +21,7 @@ import { ForgotPasswordPage } from "./pages/forgot-password";
 import { ResetPasswordPage } from "./pages/reset-password";
 import { MagicLinkPage } from "./pages/magic-link";
 import { ErrorBoundary } from "./components/error-boundary";
+import { HostedAuthGate } from "./components/hosted-auth-gate";
 import { AppSidebar } from "./components/app-sidebar";
 import { NotificationBell } from "./components/notification-bell";
 import { LoadingState } from "./components/page-states";
@@ -345,7 +346,22 @@ export function App() {
     return (
       <ErrorBoundary>
         <Routes>
-          <Route path="/login" element={<LoginPage />} />
+          {/*
+           * The auth-entry routes are wrapped in `HostedAuthGate`: in OIDC
+           * mode it redirects to the hosted login/register page before the
+           * native form mounts (one mechanism, no per-page `useEffect`
+           * check to forget); in OSS mode it renders the form below. The
+           * ESLint `auth-client` ban (eslint.config.mjs) backs this up by
+           * stopping any of these pages from calling Better Auth directly.
+           */}
+          <Route
+            path="/login"
+            element={
+              <HostedAuthGate starter="login">
+                <LoginPage />
+              </HostedAuthGate>
+            }
+          />
           {/*
            * `/register` stays mounted even when `signupDisabled` is true so
            * the closed-mode bootstrap owner (and any
@@ -356,7 +372,14 @@ export function App() {
            * `RegisterPage` surfaces. The signup link is still hidden from
            * `/login` to avoid public discoverability.
            */}
-          <Route path="/register" element={<RegisterPage />} />
+          <Route
+            path="/register"
+            element={
+              <HostedAuthGate starter="signup">
+                <RegisterPage />
+              </HostedAuthGate>
+            }
+          />
           {/*
            * Server-rendered flows outside the SPA (e.g. the device-flow
            * `/activate` page) redirect unauthenticated visitors here with
@@ -383,10 +406,44 @@ export function App() {
               }
             />
           )}
-          <Route path="/verify-email" element={<VerifyEmailPage />} />
-          <Route path="/forgot-password" element={<ForgotPasswordPage />} />
-          <Route path="/reset-password" element={<ResetPasswordPage />} />
-          <Route path="/magic-link" element={<MagicLinkPage />} />
+          <Route
+            path="/verify-email"
+            element={
+              <HostedAuthGate starter="login">
+                <VerifyEmailPage />
+              </HostedAuthGate>
+            }
+          />
+          <Route
+            path="/forgot-password"
+            element={
+              <HostedAuthGate starter="login">
+                <ForgotPasswordPage />
+              </HostedAuthGate>
+            }
+          />
+          <Route
+            path="/reset-password"
+            element={
+              <HostedAuthGate starter="login">
+                <ResetPasswordPage />
+              </HostedAuthGate>
+            }
+          />
+          <Route
+            path="/magic-link"
+            element={
+              <HostedAuthGate starter="login">
+                <MagicLinkPage />
+              </HostedAuthGate>
+            }
+          />
+          {/*
+           * `/invite/:token` is NOT wrapped: it loads invite data first, then
+           * drives `useHostedAuthRedirect` directly with a starter (login vs
+           * signup) and login-hint derived from that data. Same seam, dynamic
+           * inputs — see invite-accept.tsx.
+           */}
           <Route path="/invite/:token" element={<InviteAcceptPage />} />
           <Route path="*" element={<Navigate to="/login" replace />} />
         </Routes>

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -406,14 +406,15 @@ export function App() {
               }
             />
           )}
-          <Route
-            path="/verify-email"
-            element={
-              <HostedAuthGate starter="login">
-                <VerifyEmailPage />
-              </HostedAuthGate>
-            }
-          />
+          {/*
+           * `/verify-email` is deliberately NOT gated: it is a post-signup
+           * interstitial (and verification-error display), not a login entry
+           * point. In OIDC + SMTP mode the server-rendered register flow can
+           * route an unauthenticated visitor here with `?email=` / `?error=`
+           * (see verify-email.tsx) — redirecting it to the hosted login would
+           * break that flow. It renders natively in both modes.
+           */}
+          <Route path="/verify-email" element={<VerifyEmailPage />} />
           <Route
             path="/forgot-password"
             element={

--- a/apps/web/src/components/hosted-auth-gate.tsx
+++ b/apps/web/src/components/hosted-auth-gate.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useLocation } from "react-router-dom";
+import { useHostedAuthRedirect } from "../hooks/use-hosted-auth-redirect";
+import { Spinner } from "./spinner";
+
+/**
+ * Render gate for the unauthenticated auth-entry routes.
+ *
+ * In OIDC mode it redirects to the hosted login / register page (via the
+ * shared `useHostedAuthRedirect` seam) and shows a spinner while the browser
+ * navigates away — the wrapped native form never renders. In OSS mode it is a
+ * pass-through and renders the form.
+ *
+ * Wrapping the routes here (rather than per-page `useEffect` checks copied into
+ * every auth page) is the structural guarantee that a new auth route cannot
+ * forget the OIDC redirect: it inherits the gate from `app.tsx`, and the
+ * ESLint `auth-client` ban stops it from calling Better Auth directly.
+ *
+ * For `starter="login"`, the post-callback destination is read from
+ * `location.state.from` — the same hand-off the server-side
+ * `/auth/login?returnTo=…` bridge populates — so a deep link survives the
+ * round-trip. Other starters have no `from`, which is a harmless `undefined`.
+ */
+export function HostedAuthGate({
+  starter = "login",
+  children,
+}: {
+  starter?: "login" | "signup";
+  children: React.ReactNode;
+}) {
+  const location = useLocation();
+  const from = starter === "login" ? (location.state as { from?: string } | null)?.from : undefined;
+
+  const { redirecting } = useHostedAuthRedirect({ starter, redirectTo: from });
+
+  if (redirecting) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spinner />
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/src/components/login-form.tsx
+++ b/apps/web/src/components/login-form.tsx
@@ -42,7 +42,7 @@ export function LoginForm({
   const { t } = useTranslation(["settings", "common"]);
   const navigate = useNavigate();
   const { resolvedTheme } = useTheme();
-  const { loginDirect } = useAuth();
+  const { login } = useAuth();
   const { features } = useAppConfig();
 
   const {
@@ -58,7 +58,7 @@ export function LoginForm({
 
   const onSubmit = async (data: LoginFormData) => {
     try {
-      await loginDirect(fixedEmail ?? data.email, data.password);
+      await login(fixedEmail ?? data.email, data.password);
       if (onSuccess) {
         await onSuccess();
       }

--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -105,6 +105,22 @@ export class AuthRefreshError extends Error {
 }
 
 /**
+ * Thrown by `changeEmail()` so the caller can distinguish a 409 address
+ * collision (a dedicated "email already in use" message) from any other
+ * failure without reaching into the raw Better Auth result shape — the
+ * seam is the only place that touches `authClient`.
+ */
+export class EmailChangeError extends Error {
+  constructor(
+    public conflict: boolean,
+    message: string,
+  ) {
+    super(message);
+    this.name = "EmailChangeError";
+  }
+}
+
+/**
  * Resync auth state from the server cookie and assert that a user was
  * established. Use after any flow that should have left a valid session
  * behind (OIDC callback, invite accept, email change). On the no-user
@@ -258,6 +274,52 @@ export function useAuth() {
     if (result.error) throw new Error(result.error.message);
   }, []);
 
+  // ─── Password recovery / passwordless (OSS-only at runtime) ─────────────
+  //
+  // These recovery flows have no OIDC branch on purpose: when the OIDC module
+  // is configured, `HostedAuthGate` / `useHostedAuthRedirect` redirect the
+  // forgot-password / reset-password / magic-link routes to the hosted IdP
+  // *before* their forms ever render, so these methods are only reachable in
+  // OSS mode. They live on the seam (not inline in the pages) solely so the
+  // ESLint `auth-client` ban can guarantee no page bypasses that redirect.
+
+  const requestPasswordReset = useCallback(async (email: string) => {
+    const result = await authClient.requestPasswordReset({
+      email,
+      redirectTo: "/reset-password",
+    });
+    if (result.error) throw new Error(result.error.message);
+  }, []);
+
+  const resetPassword = useCallback(async (token: string, newPassword: string) => {
+    const result = await authClient.resetPassword({ newPassword, token });
+    if (result.error) throw new Error(result.error.message);
+  }, []);
+
+  const startMagicLink = useCallback(async (email: string) => {
+    const result = await authClient.signIn.magicLink({ email, callbackURL: "/" });
+    if (result.error) throw new Error(result.error.message);
+  }, []);
+
+  // ─── Authenticated account management (no OIDC entry redirect) ───────────
+  //
+  // changeEmail / listLinkedAccounts operate on the *existing* session from
+  // inside the dashboard — they are not unauthenticated entry points, so they
+  // run natively in both modes. Routed through the seam only for the ban.
+
+  const changeEmail = useCallback(async (newEmail: string) => {
+    const result = await authClient.changeEmail({ newEmail });
+    if (result.error) {
+      throw new EmailChangeError(result.error.status === 409, result.error.message ?? "");
+    }
+  }, []);
+
+  const listLinkedAccounts = useCallback(async () => {
+    const result = await authClient.listAccounts();
+    if (result.error) throw new Error(result.error.message);
+    return result.data ?? [];
+  }, []);
+
   return {
     user: state.user,
     profile: state.profile,
@@ -273,5 +335,10 @@ export function useAuth() {
     linkGithub,
     unlinkAccount,
     resendVerificationEmail,
+    requestPasswordReset,
+    resetPassword,
+    startMagicLink,
+    changeEmail,
+    listLinkedAccounts,
   };
 }

--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -144,33 +144,12 @@ export function useAuth() {
   const state = useStore(authStore);
 
   /**
-   * Login — redirects to the OIDC authorize endpoint which shows the
-   * shared server-rendered login page. After authentication, the browser
-   * is redirected back to /auth/callback with an authorization code.
-   *
-   * The optional `redirectTo` is saved for after the callback completes.
-   *
-   * The single-argument shape (vs. the old `(email, password)`) is
-   * deliberate — any remaining inline email/password caller must use
-   * `loginDirect` explicitly and the compiler flags the miswire rather
-   * than silently coercing an email into `redirectTo`.
+   * Email/password login — used by the OSS login form and the invite
+   * acceptance flow, which authenticate inline without redirecting. In OIDC
+   * mode these forms never render (`HostedAuthGate` redirects first), so
+   * there is no redirect variant here — the gate owns that path.
    */
-  const login = useCallback((redirectTo?: string): Promise<void> => {
-    const oidcConfig = (window.__APP_CONFIG__ as unknown as Record<string, unknown>)?.oidc;
-    if (oidcConfig) {
-      return import("../modules/oidc/lib/oidc").then(({ startOidcLogin }) =>
-        startOidcLogin(redirectTo),
-      );
-    }
-    window.location.assign("/login");
-    return Promise.resolve();
-  }, []);
-
-  /**
-   * Direct email/password login — used by invite acceptance flow
-   * where the user must authenticate inline without redirecting.
-   */
-  const loginDirect = useCallback(async (email: string, password: string) => {
+  const login = useCallback(async (email: string, password: string) => {
     const result = await authClient.signIn.email({ email, password });
     if (result.error) throw new Error(result.error.message);
     const profile = await fetchProfile();
@@ -185,22 +164,9 @@ export function useAuth() {
       password: string,
       displayName?: string,
     ): Promise<{ emailVerificationRequired: boolean }> => {
-      // When OIDC is loaded, signup must traverse the same server-rendered
-      // flow as login so that (a) both events go through the centralized
-      // branded page and (b) the resulting BA session is established under
-      // the same cookie domain as the authorize callback. The server-side
-      // `/api/oauth/register` handler forwards to `/oauth2/authorize` on
-      // success, so the callback lands on `/auth/callback` like any login.
-      const oidcConfig = (window.__APP_CONFIG__ as unknown as Record<string, unknown>)?.oidc;
-      if (oidcConfig) {
-        const { startOidcSignup } = await import("../modules/oidc/lib/oidc");
-        await startOidcSignup();
-        // Page is navigating away — return a never-resolving promise so
-        // callers (`onSuccess` handlers, route navigations) cannot fire
-        // mid-unload and trigger a no-op state update on a detached tree.
-        return new Promise<never>(() => {});
-      }
-
+      // Native email/password signup (OSS). In OIDC mode the register form
+      // never renders — `HostedAuthGate` redirects to the hosted register
+      // page first — so signup has no OIDC branch; the gate owns that path.
       const result = await authClient.signUp.email({
         email,
         password,
@@ -325,7 +291,6 @@ export function useAuth() {
     profile: state.profile,
     loading: state.loading,
     login,
-    loginDirect,
     signup,
     logout,
     updatePassword,

--- a/apps/web/src/hooks/use-hosted-auth-redirect.ts
+++ b/apps/web/src/hooks/use-hosted-auth-redirect.ts
@@ -38,7 +38,7 @@ interface HostedAuthRedirectOptions {
 }
 
 /** Whether this instance runs the OIDC IdP (the hosted login flow). */
-function isHostedAuthEnabled(): boolean {
+export function isHostedAuthEnabled(): boolean {
   return !!(window.__APP_CONFIG__ as unknown as Record<string, unknown>)?.oidc;
 }
 

--- a/apps/web/src/hooks/use-hosted-auth-redirect.ts
+++ b/apps/web/src/hooks/use-hosted-auth-redirect.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect } from "react";
+
+/**
+ * The single seam through which the SPA hands an unauthenticated visitor to
+ * the OIDC hosted login / register pages.
+ *
+ * When the instance runs the OIDC module (`window.__APP_CONFIG__.oidc`
+ * present), every auth-entry route funnels through here instead of rendering
+ * a native Better Auth form — so a page can never silently bypass the IdP by
+ * forgetting its own redirect (the bug class this exists to kill). When OIDC
+ * is absent (OSS mode) it is a no-op and the caller renders its built-in form.
+ *
+ * `<HostedAuthGate>` wraps the simple auth routes (login / register / forgot /
+ * reset / magic-link / verify-email) on top of this hook; the invitation page
+ * calls the hook directly because its starter (login vs signup) and login-hint
+ * depend on invite data loaded asynchronously. Both share this one mechanism.
+ */
+
+type HostedAuthStarter = "login" | "signup";
+
+interface HostedAuthRedirectOptions {
+  /** Which OIDC hosted flow to start. Defaults to `"login"`. */
+  starter?: HostedAuthStarter;
+  /** Post-callback destination, persisted across the PKCE round-trip. */
+  redirectTo?: string;
+  /** OIDC `login_hint` — pins / pre-fills the email on the hosted page. */
+  loginHint?: string;
+  /**
+   * Gate the redirect. Default `true`. Callers pass `false` while async data
+   * is still loading or when the visitor is already authenticated, so the
+   * redirect fires exactly once with the right parameters.
+   */
+  enabled?: boolean;
+  /** Surface a dynamic-import / redirect failure instead of spinning forever. */
+  onError?: (error: unknown) => void;
+}
+
+/** Whether this instance runs the OIDC IdP (the hosted login flow). */
+function isHostedAuthEnabled(): boolean {
+  return !!(window.__APP_CONFIG__ as unknown as Record<string, unknown>)?.oidc;
+}
+
+/**
+ * Returns `{ redirecting }` — `true` while an OIDC redirect is in flight, so
+ * callers render a spinner for the brief navigation window instead of flashing
+ * the native form. In OSS mode it is always `false`.
+ */
+export function useHostedAuthRedirect(options: HostedAuthRedirectOptions = {}): {
+  redirecting: boolean;
+} {
+  const { starter = "login", redirectTo, loginHint, enabled = true, onError } = options;
+  const active = isHostedAuthEnabled() && enabled;
+
+  useEffect(() => {
+    if (!active) return;
+    void import("../modules/oidc/lib/oidc")
+      .then(({ startOidcLogin, startOidcSignup }) =>
+        starter === "signup"
+          ? startOidcSignup(redirectTo, loginHint)
+          : startOidcLogin(redirectTo, loginHint),
+      )
+      .catch((err) => onError?.(err));
+    // `onError` is intentionally excluded — callers pass an inline closure that
+    // would otherwise re-fire the redirect on every render. The redirect inputs
+    // (starter / redirectTo / loginHint / active) are the only real triggers.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [active, starter, redirectTo, loginHint]);
+
+  return { redirecting: active };
+}

--- a/apps/web/src/pages/forgot-password.tsx
+++ b/apps/web/src/pages/forgot-password.tsx
@@ -9,10 +9,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AuthLayout } from "../components/auth-layout";
 import { AuthSuccessState } from "../components/auth-success-state";
-import { authClient } from "../lib/auth-client";
+import { useAuth } from "../hooks/use-auth";
 
 export function ForgotPasswordPage() {
   const { t } = useTranslation(["settings", "common"]);
+  const { requestPasswordReset } = useAuth();
   const [email, setEmail] = useState("");
   const [state, setState] = useState<"form" | "submitting" | "sent">("form");
   const [error, setError] = useState<string | null>(null);
@@ -23,10 +24,7 @@ export function ForgotPasswordPage() {
     setState("submitting");
     setError(null);
     try {
-      await authClient.requestPasswordReset({
-        email: email.trim(),
-        redirectTo: "/reset-password",
-      });
+      await requestPasswordReset(email.trim());
       setState("sent");
     } catch {
       setError(t("forgotPassword.error"));

--- a/apps/web/src/pages/invite-accept.tsx
+++ b/apps/web/src/pages/invite-accept.tsx
@@ -7,7 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { ApiError, client, type paths } from "../api/client";
 import { refreshAuth, useAuth } from "../hooks/use-auth";
-import { useHostedAuthRedirect } from "../hooks/use-hosted-auth-redirect";
+import { useHostedAuthRedirect, isHostedAuthEnabled } from "../hooks/use-hosted-auth-redirect";
 import { orgStore } from "../stores/org-store";
 import { Spinner } from "../components/spinner";
 import { AuthLayout } from "../components/auth-layout";
@@ -19,11 +19,6 @@ import { orgKeys } from "../lib/query-keys";
 /** Spec response of GET /invite/{token}/info (all fields required, role is an org-role enum). */
 type InviteInfo =
   paths["/invite/{token}/info"]["get"]["responses"]["200"]["content"]["application/json"];
-
-/** Whether the instance is running an OIDC IdP (the platform's own login flow). */
-function hasOidc(): boolean {
-  return !!(window.__APP_CONFIG__ as unknown as Record<string, unknown>)?.oidc;
-}
 
 /** Map an invitation ApiError code to a translation key, falling back to `fallback`. */
 function inviteErrorKey(code: string | null, fallback: string): string {
@@ -68,7 +63,7 @@ export function InviteAcceptPage() {
   const [serverError, setServerError] = useState<string | null>(null);
   const [mode, setMode] = useState<"register" | "login">("register");
 
-  const oidc = hasOidc();
+  const oidc = isHostedAuthEnabled();
 
   useEffect(() => {
     if (!token) return;

--- a/apps/web/src/pages/invite-accept.tsx
+++ b/apps/web/src/pages/invite-accept.tsx
@@ -7,6 +7,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { ApiError, client, type paths } from "../api/client";
 import { refreshAuth, useAuth } from "../hooks/use-auth";
+import { useHostedAuthRedirect } from "../hooks/use-hosted-auth-redirect";
 import { orgStore } from "../stores/org-store";
 import { Spinner } from "../components/spinner";
 import { AuthLayout } from "../components/auth-layout";
@@ -87,23 +88,20 @@ export function InviteAcceptPage() {
   }, [token, t]);
 
   // OIDC delegation: once the invite is loaded and the visitor is not yet
-  // authenticated, redirect into the standard OIDC flow. The invite token
-  // rides as `redirectTo` (the browser returns to this page authenticated);
-  // the invited email rides as `login_hint` so the server-rendered login /
-  // register page pins it. Acceptance happens on return, in the authed branch.
-  useEffect(() => {
-    if (!info || user || !oidc || !token) return;
-    const redirectTo = `/invite/${token}`;
-    void import("../modules/oidc/lib/oidc")
-      .then(({ startOidcLogin, startOidcSignup }) =>
-        info.is_new_user
-          ? startOidcSignup(redirectTo, info.email)
-          : startOidcLogin(redirectTo, info.email),
-      )
-      // If the dynamic import or the redirect fails, surface an error instead
-      // of leaving the OIDC branch stuck on an indefinite spinner.
-      .catch(() => setServerError(t("invite.error")));
-  }, [info, user, oidc, token, t]);
+  // authenticated, redirect into the standard OIDC flow through the same
+  // `useHostedAuthRedirect` seam every other auth route uses. Unlike the
+  // simple routes (wrapped by `HostedAuthGate`), the invite chooses its
+  // starter and login-hint from data loaded asynchronously, so it drives the
+  // hook directly: the token rides as `redirectTo` (the browser returns here
+  // authenticated) and the invited email as `login_hint` (pinned on the hosted
+  // page). Acceptance happens on return, in the authed branch.
+  useHostedAuthRedirect({
+    enabled: !!info && !user && !!token,
+    starter: info?.is_new_user ? "signup" : "login",
+    redirectTo: token ? `/invite/${token}` : undefined,
+    loginHint: info?.email,
+    onError: () => setServerError(t("invite.error")),
+  });
 
   /** POST accept (session-bound, no body) + handle success. */
   const postAccept = useCallback(async () => {

--- a/apps/web/src/pages/login.tsx
+++ b/apps/web/src/pages/login.tsx
@@ -1,40 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Login page — redirects to the OIDC authorize flow when configured,
- * falls back to the built-in LoginForm when OIDC is not available.
+ * Login page — the built-in email/password form (OSS mode).
+ *
+ * In OIDC mode this component never renders: `HostedAuthGate` (wired in
+ * `app.tsx`) redirects to the hosted login page before it mounts. The page is
+ * therefore a pure OSS fallback with no auth logic of its own.
  */
 
-import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
 import { AuthLayout } from "../components/auth-layout";
 import { LoginForm } from "../components/login-form";
-import { Spinner } from "../components/spinner";
 
 export function LoginPage() {
-  const location = useLocation();
-  const oidcConfig = (window.__APP_CONFIG__ as unknown as Record<string, unknown>)?.oidc;
-
-  useEffect(() => {
-    if (oidcConfig) {
-      // Redirect to OIDC authorize — the server-rendered login page handles auth
-      const redirectTo = location.state?.from ?? "/";
-      import("../modules/oidc/lib/oidc").then(({ startOidcLogin }) => {
-        startOidcLogin(redirectTo);
-      });
-    }
-  }, [oidcConfig, location.state?.from]);
-
-  // OIDC configured: show spinner while redirect happens
-  if (oidcConfig) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
-  }
-
-  // Fallback: OIDC not configured (module not loaded) — use built-in form
   return (
     <AuthLayout>
       <LoginForm />

--- a/apps/web/src/pages/magic-link.tsx
+++ b/apps/web/src/pages/magic-link.tsx
@@ -9,10 +9,11 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { AuthLayout } from "../components/auth-layout";
 import { AuthSuccessState } from "../components/auth-success-state";
-import { authClient } from "../lib/auth-client";
+import { useAuth } from "../hooks/use-auth";
 
 export function MagicLinkPage() {
   const { t } = useTranslation(["settings", "common"]);
+  const { startMagicLink } = useAuth();
   const location = useLocation();
   const prefillEmail = (location.state as { email?: string })?.email ?? "";
 
@@ -26,7 +27,7 @@ export function MagicLinkPage() {
     setState("submitting");
     setError(null);
     try {
-      await authClient.signIn.magicLink({ email: email.trim(), callbackURL: "/" });
+      await startMagicLink(email.trim());
       setState("sent");
     } catch {
       setError(t("magicLink.error"));

--- a/apps/web/src/pages/preferences/general.tsx
+++ b/apps/web/src/pages/preferences/general.tsx
@@ -7,9 +7,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useUpdateDisplayName } from "../../hooks/use-profile";
-import { useAuth, refreshAuth } from "../../hooks/use-auth";
+import { useAuth, refreshAuth, EmailChangeError } from "../../hooks/use-auth";
 import { useAppConfig } from "../../hooks/use-app-config";
-import { authClient } from "../../lib/auth-client";
 import { CheckCircle2, AlertCircle } from "lucide-react";
 
 function EmailVerificationBadge() {
@@ -64,7 +63,7 @@ function EmailVerificationBadge() {
 
 function EmailChangeForm() {
   const { t } = useTranslation(["settings", "common"]);
-  const { user } = useAuth();
+  const { user, changeEmail } = useAuth();
   const { features } = useAppConfig();
   const [success, setSuccess] = useState("");
   const [verificationPendingEmail, setVerificationPendingEmail] = useState("");
@@ -89,24 +88,21 @@ function EmailChangeForm() {
     setSuccess("");
     setVerificationPendingEmail("");
     try {
-      const result = await authClient.changeEmail({ newEmail: data.newEmail.trim() });
-      if (result.error) {
-        if (result.error.status === 409) {
-          setError("root", { message: t("preferences.emailConflict") });
-        } else {
-          setError("root", { message: result.error.message || t("login.error") });
-        }
+      await changeEmail(data.newEmail.trim());
+      reset();
+      if (features.smtp) {
+        setVerificationPendingEmail(data.newEmail.trim());
       } else {
-        reset();
-        if (features.smtp) {
-          setVerificationPendingEmail(data.newEmail.trim());
-        } else {
-          setSuccess(t("preferences.emailChanged"));
-          await refreshAuth();
-        }
+        setSuccess(t("preferences.emailChanged"));
+        await refreshAuth();
       }
-    } catch {
-      setError("root", { message: t("login.error") });
+    } catch (err) {
+      if (err instanceof EmailChangeError && err.conflict) {
+        setError("root", { message: t("preferences.emailConflict") });
+      } else {
+        const message = err instanceof Error && err.message ? err.message : t("login.error");
+        setError("root", { message });
+      }
     }
   };
 

--- a/apps/web/src/pages/preferences/security.tsx
+++ b/apps/web/src/pages/preferences/security.tsx
@@ -12,23 +12,18 @@ import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import { useAuth } from "../../hooks/use-auth";
 import { useAppConfig } from "../../hooks/use-app-config";
-import { authClient } from "../../lib/auth-client";
 import { GoogleIcon, GitHubIcon } from "../../components/icons";
 
 function LinkedAccountsSection() {
   const { t } = useTranslation(["settings", "common"]);
   const { features } = useAppConfig();
-  const { linkGoogle, linkGithub, unlinkAccount } = useAuth();
+  const { linkGoogle, linkGithub, unlinkAccount, listLinkedAccounts } = useAuth();
   const [unlinking, setUnlinking] = useState<string | false>(false);
   const [linking, setLinking] = useState<string | false>(false);
 
   const { data: accounts, refetch } = useQuery({
     queryKey: ["linked-accounts"],
-    queryFn: async () => {
-      const result = await authClient.listAccounts();
-      if (result.error) throw new Error(result.error.message);
-      return result.data ?? [];
-    },
+    queryFn: () => listLinkedAccounts(),
   });
 
   if (!features.googleAuth && !features.githubAuth) return null;

--- a/apps/web/src/pages/register.tsx
+++ b/apps/web/src/pages/register.tsx
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Register page — redirects to the OIDC signup flow when configured, falls
- * back to the built-in RegisterForm when the OIDC module is not loaded.
+ * Register page — the built-in email/password form (OSS mode).
+ *
+ * In OIDC mode this component never renders: `HostedAuthGate` (wired in
+ * `app.tsx`) redirects to the hosted register page before it mounts.
  *
  * In closed mode (issue #228), if `AUTH_BOOTSTRAP_OWNER_EMAIL` is set
  * server-side, the email field is pre-filled and locked so the bootstrap
@@ -10,34 +12,15 @@
  * server-side signup gate is the real authority — this is just UX.
  */
 
-import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { AuthLayout } from "../components/auth-layout";
 import { RegisterForm } from "../components/register-form";
-import { Spinner } from "../components/spinner";
 import { useAppConfig } from "../hooks/use-app-config";
 import { deriveDisplayNameFromEmail } from "../lib/derive-display-name";
 
 export function RegisterPage() {
   const { t } = useTranslation(["settings"]);
   const { bootstrapOwnerEmail } = useAppConfig();
-  const oidcConfig = (window.__APP_CONFIG__ as unknown as Record<string, unknown>)?.oidc;
-
-  useEffect(() => {
-    if (oidcConfig) {
-      import("../modules/oidc/lib/oidc").then(({ startOidcSignup }) => {
-        startOidcSignup();
-      });
-    }
-  }, [oidcConfig]);
-
-  if (oidcConfig) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
-  }
 
   return (
     <AuthLayout>

--- a/apps/web/src/pages/reset-password.tsx
+++ b/apps/web/src/pages/reset-password.tsx
@@ -10,10 +10,11 @@ import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import { AuthLayout } from "../components/auth-layout";
 import { AuthSuccessState } from "../components/auth-success-state";
-import { authClient } from "../lib/auth-client";
+import { useAuth } from "../hooks/use-auth";
 
 export function ResetPasswordPage() {
   const { t } = useTranslation(["settings", "common"]);
+  const { resetPassword } = useAuth();
   const [searchParams] = useSearchParams();
   const token = searchParams.get("token");
 
@@ -56,12 +57,7 @@ export function ResetPasswordPage() {
 
     setState("submitting");
     try {
-      const result = await authClient.resetPassword({ newPassword: password, token });
-      if (result.error) {
-        setError(t("resetPassword.invalidToken"));
-        setState("form");
-        return;
-      }
+      await resetPassword(token, password);
       setState("success");
     } catch {
       setError(t("resetPassword.invalidToken"));

--- a/e2e/tests/auth/hosted-auth-gate.ui.spec.ts
+++ b/e2e/tests/auth/hosted-auth-gate.ui.spec.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Browser E2E for the single auth seam (`HostedAuthGate` / `useHostedAuthRedirect`).
+ *
+ * The whole point of the refactor is that EVERY auth-entry route funnels
+ * through one OIDC redirect mechanism — no page can render a native Better Auth
+ * form when the instance runs the OIDC IdP. These tests assert that invariant
+ * against whichever mode the server booted in (the suite is run twice — OIDC
+ * and OSS — in CI):
+ *
+ *   - OIDC instance → the route leaves the SPA and lands on a server-rendered
+ *     `/api/*` hosted page (login / register / authorize).
+ *   - OSS instance  → the route stays on the SPA and renders its native form.
+ *
+ * Mode is read from the injected `window.__APP_CONFIG__` in the served
+ * index.html (via a plain GET, before any SPA redirect can fire) so detection
+ * never races the redirect it is testing.
+ *
+ * @tags @critical
+ */
+
+import { test, expect } from "../../fixtures/browser.fixture.ts";
+import type { APIRequestContext, Page } from "@playwright/test";
+
+function uid() {
+  return Math.random().toString(36).slice(2, 10) + Date.now().toString(36);
+}
+
+/**
+ * The auth-entry routes wrapped by `HostedAuthGate` in app.tsx. `reset-password`
+ * carries a token so its OSS form renders (a tokenless visit shows the
+ * "request a new link" message instead, which has no form).
+ */
+const GATED_ROUTES = [
+  "/login",
+  "/register",
+  "/forgot-password",
+  "/reset-password?token=probe-token",
+  "/magic-link",
+];
+
+/**
+ * Read the boot mode from the served HTML, not the live SPA: a GET of `/`
+ * returns index.html with the injected `window.__APP_CONFIG__`, which only
+ * carries an `oidc` object when the OIDC module is loaded. This sidesteps the
+ * race where reading the flag from a live page happens after the gate already
+ * navigated away.
+ */
+async function serverIsOidc(request: APIRequestContext): Promise<boolean> {
+  const html = await (await request.get("/")).text();
+  return /"oidc"\s*:\s*\{/.test(html);
+}
+
+/** Assert the browser left the SPA for a server-rendered hosted auth page. */
+async function expectRedirectedToHostedPage(page: Page) {
+  await page.waitForURL((url) => url.pathname.startsWith("/api/"), { timeout: 15_000 });
+  expect(new URL(page.url()).pathname.startsWith("/api/")).toBe(true);
+}
+
+test.describe("Hosted auth gate — single entry point", () => {
+  test("every auth-entry route funnels through one OIDC redirect (or renders natively in OSS) @critical", async ({
+    browser,
+    request,
+  }) => {
+    const oidc = await serverIsOidc(request);
+    const ctx = await browser.newContext(); // anonymous — no session cookie
+    const page = await ctx.newPage();
+
+    for (const route of GATED_ROUTES) {
+      await page.goto(route);
+
+      if (oidc) {
+        await expectRedirectedToHostedPage(page);
+      } else {
+        // OSS: the gate is a pass-through — the SPA route renders its form.
+        const path = route.split("?")[0];
+        await expect(page).toHaveURL(new RegExp(`${path}(?:\\?|$)`));
+        await expect(page.locator("form input").first()).toBeVisible({ timeout: 10_000 });
+      }
+    }
+
+    await ctx.close();
+  });
+
+  test("an unauthenticated invite uses the same hosted gate (OIDC mode)", async ({
+    browser,
+    request,
+    browserCtx,
+    orgOnlyClient,
+  }) => {
+    const oidc = await serverIsOidc(request);
+    test.skip(
+      !oidc,
+      "OSS instance — the invite renders the inline form (covered by invite-flow spec)",
+    );
+
+    const invitedEmail = `e2e-gate-${uid()}@test.com`;
+    const inviteRes = await orgOnlyClient.post(`/orgs/${browserCtx.org.orgId}/members`, {
+      email: invitedEmail,
+      role: "member",
+    });
+    expect(inviteRes.status()).toBe(201);
+    const { token } = (await inviteRes.json()) as { token: string };
+
+    const ctx = await browser.newContext(); // anonymous
+    const page = await ctx.newPage();
+    await page.goto(`/invite/${token}`);
+
+    // The invite drives `useHostedAuthRedirect` directly (dynamic starter +
+    // login-hint), so it must leave the SPA for the hosted page just like the
+    // wrapped routes — proving both paths share one mechanism.
+    await expectRedirectedToHostedPage(page);
+
+    await ctx.close();
+  });
+});

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -139,10 +139,21 @@ export default tseslint.config(
     },
   },
   {
-    // Typed-client guard: all web API calls go through the typed OpenAPI
-    // client (src/api/client.ts — `$api`/`client`). The legacy fetch barrel
-    // (src/api.ts) is deleted; this rule keeps it from coming back under the
-    // old import specifiers (relative or aliased).
+    // Two web import guards live in one rule on purpose: ESLint flat config
+    // does NOT merge the options of the same rule id across blocks — a later
+    // block setting `no-restricted-imports` for the same files fully replaces
+    // this one. So both patterns must sit together here, and the seam
+    // exemption below re-declares the rule rather than adding to it.
+    //
+    //   1. Typed-client guard: all web API calls go through the typed OpenAPI
+    //      client (src/api/client.ts — `$api`/`client`). The legacy fetch
+    //      barrel (src/api.ts) is deleted; this keeps it from coming back
+    //      under the old import specifiers (relative or aliased).
+    //   2. Auth seam guard: every Better Auth call funnels through the single
+    //      seam (hooks/use-auth.ts) so a page can't bypass the OIDC hosted-
+    //      login redirect (`HostedAuthGate` / `useHostedAuthRedirect`) by
+    //      calling `auth-client` directly — the bug class this exists to kill.
+    //      Exempted for the seam file itself in the next block.
     files: ["apps/web/src/**/*.{ts,tsx}"],
     rules: {
       "no-restricted-imports": [
@@ -154,6 +165,35 @@ export default tseslint.config(
               // the typed-client modules ("./api/client", "@/api/errors", …).
               // gitignore-style `group` can't re-include children of an
               // excluded directory, so use a regex on the specifier instead.
+              regex: "^(?:(?:\\.{1,2}/)+|@/)api$",
+              message:
+                "Use the typed OpenAPI client from src/api/client.ts ($api / client) — the legacy fetch helpers are gone.",
+            },
+            {
+              // Matches "../lib/auth-client", "../../lib/auth-client" and
+              // "@/lib/auth-client". Only hooks/use-auth.ts (the seam) may
+              // import it — see the override block below.
+              regex: "(?:^|/)lib/auth-client$",
+              message:
+                "Auth flows must go through useAuth() (hooks/use-auth.ts) — the single seam that routes login/recovery/account actions through the OIDC hosted-login redirect when configured. Never import auth-client directly.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // Seam exemption: hooks/use-auth.ts is the one sanctioned importer of
+    // `auth-client`. Re-declare the web ban here WITHOUT the auth-client
+    // pattern (the api.ts guard still applies) — a later, narrower flat-config
+    // block fully replaces the rule for this file.
+    files: ["apps/web/src/hooks/use-auth.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
               regex: "^(?:(?:\\.{1,2}/)+|@/)api$",
               message:
                 "Use the typed OpenAPI client from src/api/client.ts ($api / client) — the legacy fetch helpers are gone.",

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,27 @@ import reactRefresh from "eslint-plugin-react-refresh";
 import tseslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier";
 
+// Shared web import-ban patterns (single source of truth). The general web
+// block bans both; the seam exemption (hooks/use-auth.ts) re-uses
+// API_BARREL_BAN alone. Defined here so the api.ts regex can never drift
+// between the two blocks — ESLint flat config replaces (not merges) a rule
+// across blocks, so the exemption must re-declare it.
+const API_BARREL_BAN = {
+  // Matches "./api", "../api" (any depth) and "@/api" — but not the
+  // typed-client modules ("./api/client", "@/api/errors", …). gitignore-style
+  // `group` can't re-include children of an excluded directory, so use a regex.
+  regex: "^(?:(?:\\.{1,2}/)+|@/)api$",
+  message:
+    "Use the typed OpenAPI client from src/api/client.ts ($api / client) — the legacy fetch helpers are gone.",
+};
+const AUTH_CLIENT_BAN = {
+  // Matches "../lib/auth-client", "../../lib/auth-client" and
+  // "@/lib/auth-client". Only hooks/use-auth.ts (the seam) may import it.
+  regex: "(?:^|/)lib/auth-client$",
+  message:
+    "Auth flows must go through useAuth() (hooks/use-auth.ts) — the single seam that routes login/recovery/account actions through the OIDC hosted-login redirect when configured. Never import auth-client directly.",
+};
+
 export default tseslint.config(
   {
     ignores: [
@@ -156,30 +177,7 @@ export default tseslint.config(
     //      Exempted for the seam file itself in the next block.
     files: ["apps/web/src/**/*.{ts,tsx}"],
     rules: {
-      "no-restricted-imports": [
-        "error",
-        {
-          patterns: [
-            {
-              // Matches "./api", "../api" (any depth) and "@/api" — but not
-              // the typed-client modules ("./api/client", "@/api/errors", …).
-              // gitignore-style `group` can't re-include children of an
-              // excluded directory, so use a regex on the specifier instead.
-              regex: "^(?:(?:\\.{1,2}/)+|@/)api$",
-              message:
-                "Use the typed OpenAPI client from src/api/client.ts ($api / client) — the legacy fetch helpers are gone.",
-            },
-            {
-              // Matches "../lib/auth-client", "../../lib/auth-client" and
-              // "@/lib/auth-client". Only hooks/use-auth.ts (the seam) may
-              // import it — see the override block below.
-              regex: "(?:^|/)lib/auth-client$",
-              message:
-                "Auth flows must go through useAuth() (hooks/use-auth.ts) — the single seam that routes login/recovery/account actions through the OIDC hosted-login redirect when configured. Never import auth-client directly.",
-            },
-          ],
-        },
-      ],
+      "no-restricted-imports": ["error", { patterns: [API_BARREL_BAN, AUTH_CLIENT_BAN] }],
     },
   },
   {
@@ -189,18 +187,7 @@ export default tseslint.config(
     // block fully replaces the rule for this file.
     files: ["apps/web/src/hooks/use-auth.ts"],
     rules: {
-      "no-restricted-imports": [
-        "error",
-        {
-          patterns: [
-            {
-              regex: "^(?:(?:\\.{1,2}/)+|@/)api$",
-              message:
-                "Use the typed OpenAPI client from src/api/client.ts ($api / client) — the legacy fetch helpers are gone.",
-            },
-          ],
-        },
-      ],
+      "no-restricted-imports": ["error", { patterns: [API_BARREL_BAN] }],
     },
   },
   {


### PR DESCRIPTION
## Problem

Auth flows in the SPA could silently bypass the OIDC module. The previous design relied on each auth page copy-pasting an inline `useEffect` that redirects to the hosted IdP when OIDC is configured. Any page that forgot it (or any new auth route) would render a native Better Auth form and create a session **outside** the hosted flow — the exact hole patched per-page in #708 for `/invite`.

This makes the **SPA** bypass structurally impossible (the redirect is inherited from a gate + enforced by lint) instead of relying on every page remembering. It does **not** close the native server endpoints — see *Residual* below.

## Approach (industry-standard, fitted to our BFF/cookie posture)

Appstrate is already a BFF/token-handler: the Hono backend is the OAuth client and the SPA holds only a Better Auth cookie (`handleOidcCallback` discards the OIDC tokens). So the remaining holes were **consistency/routing**, not token security. The fix is right-sized — a client seam + a single render gate + a lint fitness function — not a server rewrite.

Three pieces:

1. **One auth seam (`useAuth`)** — all Better Auth calls funnel through `hooks/use-auth.ts`. Added the methods that previously lived inline in pages: `requestPasswordReset`, `resetPassword`, `startMagicLink`, `changeEmail`, `listLinkedAccounts` (+ `EmailChangeError`).
2. **One redirect mechanism** — `useHostedAuthRedirect` + the `HostedAuthGate` wrapper. `app.tsx` wraps the auth-entry routes (login, register, forgot/reset-password, magic-link); in OIDC mode the gate redirects to the hosted page before the native form mounts, in OSS mode it renders the form. `login.tsx`/`register.tsx` lose their duplicated effect. **The invitation flow drives the same hook directly** (its starter + login-hint depend on async invite data), so there is now exactly **one** OIDC redirect path in the app.
3. **One guarantee (ESLint)** — `no-restricted-imports` bans `lib/auth-client` everywhere under `apps/web` except the seam. A page calling Better Auth directly now fails `bun run check`. Mirrors the existing `api.ts` barrel ban.

## Not gated: `/verify-email`

`/verify-email` is a post-signup interstitial / verification-error display, **not** a login entry point. In OIDC + SMTP mode the server-rendered register flow can route an unauthenticated visitor to the SPA route with `?email=` / `?error=`, so redirecting it to the hosted login would break that flow. It renders natively in both modes.

## Why no server-side 302

The OIDC login flow is initiated by **client-side PKCE** (`code_verifier` in `sessionStorage`); the server can't start it. A server 302 to `/authorize` is therefore impossible without the client generating PKCE first — the client gate is the only clean mechanism. No backend↔SPA route coupling.

## Residual (server-side, out of scope)

The native endpoints `/api/auth/sign-in|sign-up/email` stay **enabled in OIDC mode** (`emailAndPassword.enabled: true`, unconditional) — by necessity: the OIDC hosted login page itself authenticates through them. So a deliberate direct POST to `/api/auth/sign-in/email` still mints a valid **platform-realm** session, skipping the hosted UI. This is **not a security hole**: same realm, same user table, same credentials, and the server-side policies (`signup_disabled` hook, `requireEmailVerification`) apply path-independently. It is a governance/consistency gap — true server-side enforcement would need an origin/referer check (or a hosted-page-only flag) on the native endpoints and is left for a follow-up. The gate + lint close the *SPA* surface, which was the actual recurring bug.

## Tests

- New e2e double-boot spec (`e2e/tests/auth/hosted-auth-gate.ui.spec.ts`): OIDC boot → all gated routes + an unauthenticated invite leave the SPA for `/api/*`; OSS boot → they render native forms. Boot mode read from served `__APP_CONFIG__` so it never races the redirect.
- The ESLint guard is CI-verified: a reintroduced `auth-client` import fails `bun run check` (probe-tested locally).
- `bun run check` green (31/31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)