### PR TITLE
fix(invite): preserve the invitation across a wrong-account logout

### DIFF
--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -184,7 +184,15 @@ export function useAuth() {
     [],
   );
 
-  const logout = useCallback(async () => {
+  /**
+   * Log out. `redirectTo`, when given, is where the user should land after
+   * they sign in again — used by the invite "log out and retry" flow so a
+   * wrong-account user returns to the invitation. In OIDC mode it is stashed
+   * for the post-re-login callback (see `startOidcLogout`); in OSS mode the
+   * page that called logout stays mounted (e.g. /invite re-renders into its
+   * login form), so no explicit navigation is needed.
+   */
+  const logout = useCallback(async (redirectTo?: string) => {
     const oidcConfig = (window.__APP_CONFIG__ as unknown as Record<string, unknown>)?.oidc;
     if (oidcConfig) {
       // Navigate to the server-side logout endpoint FIRST — it clears the
@@ -194,7 +202,7 @@ export function useAuth() {
       // which starts a new OIDC login flow before the browser can follow
       // the logout redirect — effectively re-logging the user in.
       const { startOidcLogout } = await import("../modules/oidc/lib/oidc");
-      startOidcLogout();
+      startOidcLogout(redirectTo);
     } else {
       await authClient.signOut();
       clearAuth();

--- a/apps/web/src/modules/oidc/lib/oidc.ts
+++ b/apps/web/src/modules/oidc/lib/oidc.ts
@@ -205,9 +205,23 @@ export async function handleOidcCallback(): Promise<{ redirectTo: string }> {
 /**
  * OIDC logout — redirect through the server-side logout endpoint.
  * Clears the BA session cookie + the OIDC session on the IdP side.
+ *
+ * The post-logout redirect always lands on `/login` (the only URI the
+ * server validates against the client's registered `postLogoutRedirectUris`
+ * — an exact-match check, so a dynamic path like `/invite/:token` can't be
+ * passed there). To still return the user somewhere specific after they
+ * re-authenticate, `postLoginRedirect` is stashed in the same
+ * `OIDC_REDIRECT_KEY` that `handleOidcCallback` consumes: logout → `/login`
+ * → the gate re-runs `startOidcLogin(undefined)` (which does NOT overwrite
+ * the key) → the callback reads the stash and returns there. Used by the
+ * invite "log out and retry" path so a wrong-account user lands back on the
+ * invitation after signing in with the correct account.
  */
-export function startOidcLogout(): void {
+export function startOidcLogout(postLoginRedirect?: string): void {
   const config = getOidcConfig();
+  if (postLoginRedirect) {
+    sessionStorage.setItem(OIDC_REDIRECT_KEY, postLoginRedirect);
+  }
   if (!config) {
     window.location.assign("/login");
     return;

--- a/apps/web/src/pages/invite-accept.tsx
+++ b/apps/web/src/pages/invite-accept.tsx
@@ -182,7 +182,11 @@ export function InviteAcceptPage() {
                 inviteEmail: info.email,
               })}
             </p>
-            <Button variant="outline" className="w-full" onClick={logout}>
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={() => void logout(token ? `/invite/${token}` : undefined)}
+            >
               {t("invite.logoutAndRetry")}
             </Button>
           </div>

--- a/e2e/tests/organizations/invite-flow.ui.spec.ts
+++ b/e2e/tests/organizations/invite-flow.ui.spec.ts
@@ -104,6 +104,45 @@ test.describe("Organization invitation flow", () => {
     await ctx.close();
   });
 
+  test("logging out from a wrong-account invite preserves the return path (OIDC)", async ({
+    request,
+    browser,
+    browserCtx,
+    orgOnlyClient,
+  }) => {
+    // OIDC-only: the OSS logout keeps the /invite page mounted (it re-renders
+    // into its own login form), so there is no post-logout redirect to
+    // preserve. In OIDC mode logout leaves the SPA for the IdP and only lands
+    // back on /login, so the return path must be stashed for the callback.
+    const html = await (await request.get("/")).text();
+    test.skip(!/"oidc"\s*:\s*\{/.test(html), "OSS instance — logout keeps /invite mounted");
+
+    const wrongUser = await registerUser(request);
+    const inviteRes = await orgOnlyClient.post(`/orgs/${browserCtx.org.orgId}/members`, {
+      email: `e2e-target-${uid()}@test.com`,
+      role: "member",
+    });
+    expect(inviteRes.status()).toBe(201);
+    const { token } = (await inviteRes.json()) as { token: string };
+
+    const ctx = await contextWithCookie(browser, wrongUser.cookie);
+    const page = await ctx.newPage();
+    // Abort the server-side logout navigation so the page stays put and we can
+    // inspect what `startOidcLogout` stashed for the post-re-login callback.
+    await page.route("**/api/oauth/logout*", (route) => route.abort());
+    await page.goto(`/invite/${token}`);
+
+    await page.getByRole("button", { name: /Se déconnecter et réessayer/i }).click();
+
+    // The invite path is stashed in the same key handleOidcCallback consumes,
+    // so after re-login the user returns to the invitation (not onboarding).
+    await expect
+      .poll(() => page.evaluate(() => sessionStorage.getItem("appstrate_oidc_redirect")))
+      .toBe(`/invite/${token}`);
+
+    await ctx.close();
+  });
+
   test("a new invitee signs up inline and joins (OSS mode)", async ({
     browser,
     browserCtx,


### PR DESCRIPTION
## Bug

Invite link → user signs in with the **wrong** account → the recap page correctly shows the email-mismatch screen with "log out and retry". But after logging out and signing back in with the **correct** account, the user lands on **onboarding** instead of the join-organization page — the invitation is lost.

## Cause

In OIDC mode, `startOidcLogout()` redirected to `/login` with no memory of the invite. The OIDC logout endpoint (`/api/oauth/logout`) exact-matches `post_logout_redirect_uri` against the client's registered URIs (`routes.ts:2299`), so a dynamic `/invite/:token` can't be passed there. After logout → `/login` → re-login, `redirectTo` defaults to `/` → no org → onboarding.

## Fix

Stash the invite path in the same `OIDC_REDIRECT_KEY` that `handleOidcCallback` already consumes, before the logout navigation:

1. `startOidcLogout(postLoginRedirect?)` — `sessionStorage.setItem(OIDC_REDIRECT_KEY, postLoginRedirect)` then logs out.
2. `useAuth().logout(redirectTo?)` — threads it through.
3. invite-accept's mismatch button passes `/invite/${token}`.

Flow: logout stashes `/invite/:token` → `/login` → the gate re-runs `startOidcLogin(undefined)`, which does **not** overwrite the key → IdP login as the correct account → `/auth/callback` reads the stash → returns to `/invite/:token` → email matches → join button. `sessionStorage` survives the same-origin round-trip, exactly like the existing PKCE state/verifier.

OSS mode is unchanged: logout keeps the `/invite` page mounted (it re-renders into its own login form), so there is nothing to preserve.

## Test

`e2e/tests/organizations/invite-flow.ui.spec.ts` — OIDC-mode test aborts the `/api/oauth/logout` navigation so the page stays put, then asserts `sessionStorage[appstrate_oidc_redirect] === /invite/:token` after clicking the mismatch logout button. Skips in OSS. `bun run check` green (31/31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)