### PR TITLE
fix(runs): clearer finalize error when output tool never called

### DIFF
--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -302,6 +302,16 @@ async function finalizeRunImpl(input: FinalizeRunInput): Promise<void> {
   let outputValidationErrors: string[] | null = null;
 
   if (status === "success" && agent?.manifest.output?.schema) {
+    // Distinguish two failure shapes that both surface as a schema mismatch:
+    //   1. the agent never called `output` (`result.output` is null) — the
+    //      empty `{}` only fails because required fields are absent, so a bare
+    //      "validation failed" message misleads (it reads as a malformed
+    //      payload when the tool was simply never invoked);
+    //   2. the agent called `output` with a payload that violates the schema.
+    // A schema with no required fields still validates an empty `{}` as valid,
+    // so a side-effect-only run (output schema, nothing required) stays success
+    // in both branches — only the error string differs.
+    const outputEmitted = isPlainRecord(result.output);
     const outputRecord = isPlainRecord(result.output) ? result.output : {};
     const validation = validateOutput(
       outputRecord,
@@ -309,7 +319,11 @@ async function finalizeRunImpl(input: FinalizeRunInput): Promise<void> {
     );
     if (!validation.valid) {
       status = "failed";
-      errorMessage = `Output validation failed: ${validation.errors.join("; ")}`;
+      errorMessage = outputEmitted
+        ? `Output validation failed: ${validation.errors.join("; ")}`
+        : "Agent finished without calling the required `output` tool. This agent " +
+          "declares an output schema, so it must call `output` exactly once before " +
+          `finishing with all required fields (missing: ${validation.errors.join("; ")}).`;
       outputValidationErrors = validation.errors;
     }
   }

--- a/apps/api/test/integration/routes/runs-events-ingestion.test.ts
+++ b/apps/api/test/integration/routes/runs-events-ingestion.test.ts
@@ -1656,6 +1656,27 @@ describe("POST /api/runs/:runId/events/finalize — output-schema validation per
       .where(and(eq(runLogs.runId, runId), eq(runLogs.event, "output_validation")));
     expect(validationLogs).toHaveLength(1);
   });
+
+  it("output tool never called fails with a tool-not-called message, not a bare validation error", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/schema-agent");
+
+    // Agent reported but never emitted structured output (`result.output`
+    // stays null). The empty `{}` only fails because `answer` is required —
+    // the error must say the tool was never called, not imply a malformed
+    // payload.
+    const res = await postFinalize(runId, {
+      status: "success",
+      report: "Done, but I forgot to call output.",
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    expect(row?.error).toMatch(/without calling the required `output` tool/);
+    expect(row?.error).not.toMatch(/^Output validation failed/);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When an agent declares an `output.schema` but finishes **without ever calling the `output` tool**, finalize validates an empty `{}` against the schema and surfaces:

```
Output validation failed: Field 'summary': must have required property 'summary'
```

This misleads — it reads as a *malformed payload* when the tool was simply never invoked. Seen in production on `@tractr/client-email-dispatch` run #874 (the agent took the "0 mails to process" branch, called `report`, and ended without `output`).

## Fix

`finalizeRunImpl` (`apps/api/src/services/run-event-ingestion.ts`) now distinguishes the two failure shapes:

| Case | Error message |
| --- | --- |
| `output` emitted, payload invalid | `Output validation failed: <errs>` *(unchanged)* |
| `output` never called (`result.output` null) | `Agent finished without calling the required \`output\` tool. This agent declares an output schema, so it must call \`output\` exactly once before finishing with all required fields (missing: <errs>).` |

A schema with **no required fields** still validates an empty `{}` as valid, so a side-effect-only run (output schema declared, nothing required) stays `success` in both branches — only the error string differs.

## Scope

- No behavior change to status mapping: a missing-output run with required fields still fails (correct — declaring a schema makes `output` mandatory). Only the *message* is clearer.
- Platform prompt + tool description already instruct the agent to call `output`; this just makes the post-mortem error actionable for agent authors.

## Test

Added `output tool never called fails with a tool-not-called message` to `runs-events-ingestion.test.ts`. Targeted suite: 7 pass. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)