### PR TITLE
chore(deps): group better-auth packages into one dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      better-auth:
+        patterns:
+          - "better-auth"
+          - "@better-auth/*"
       production-dependencies:
         update-types:
           - "minor"


### PR DESCRIPTION
## Problem

Dependabot opens one PR per `@better-auth/*` package. These packages share private `oauth2` internals and must move in lockstep. Bumping one in isolation yields a half-upgraded tree:

- **#701** (better-auth → beta.6 alone): `SyntaxError: Export named 'verifyAccessToken' not found in better-auth@1.7.0-beta.6` — oauth-provider@beta.4 imports a symbol removed in beta.6.
- **#699** (oauth-provider → beta.6 alone): `SyntaxError: Export named 'enforceDpopBinding' not found in better-auth@1.7.0-beta.4` — oauth-provider@beta.6 (DPoP) imports a symbol not yet in beta.4.

Install succeeds (loose `^` peer ranges on the prereleases), lockfile resolves clean — but the ESM named-export contract breaks at load, failing `verify:openapi` + unit tests. #700 (drizzle-adapter) passes since it doesn't touch oauth2 internals.

## Why grouping didn't already catch it

The existing `production-dependencies` group filters `update-types: [minor, patch]`. A `1.7.0-beta.4 → beta.6` bump is a prerelease change (same major.minor.patch) → doesn't match the filter → falls out of grouping → split into separate PRs.

## Fix

Add a name-pattern group (no `update-type` filter, listed first so it wins) batching `better-auth` + `@better-auth/*` into one coherent PR including prereleases. Matches GitHub's documented best practice for coupled packages.

Once merged, close #699/#700/#701 — dependabot reopens them as a single grouped PR on next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)