### PR TITLE
fix(token-budget): clamp response reserve below context window

### DIFF
--- a/apps/api/src/data/pricing/cerebras.json
+++ b/apps/api/src/data/pricing/cerebras.json
@@ -3,7 +3,10 @@
     "label": "Gpt Oss 120b",
     "contextWindow": 131072,
     "maxTokens": 32768,
-    "capabilities": ["text", "reasoning"],
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.35,
       "output": 0.75
@@ -12,8 +15,10 @@
   "llama-3.3-70b": {
     "label": "Llama 3.3 70b",
     "contextWindow": 128000,
-    "maxTokens": 128000,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.85,
       "output": 1.2
@@ -22,8 +27,10 @@
   "llama3.1-70b": {
     "label": "Llama3.1 70b",
     "contextWindow": 128000,
-    "maxTokens": 128000,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.6,
       "output": 0.6
@@ -32,8 +39,10 @@
   "llama3.1-8b": {
     "label": "Llama3.1 8b",
     "contextWindow": 128000,
-    "maxTokens": 128000,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.1,
       "output": 0.1
@@ -42,8 +51,11 @@
   "qwen-3-32b": {
     "label": "Qwen 3 32b",
     "contextWindow": 128000,
-    "maxTokens": 128000,
-    "capabilities": ["text", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.4,
       "output": 0.8
@@ -52,8 +64,11 @@
   "zai-glm-4.6": {
     "label": "Zai Glm 4.6",
     "contextWindow": 128000,
-    "maxTokens": 128000,
-    "capabilities": ["text", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 2.25,
       "output": 2.75
@@ -62,8 +77,11 @@
   "zai-glm-4.7": {
     "label": "Zai Glm 4.7",
     "contextWindow": 128000,
-    "maxTokens": 128000,
-    "capabilities": ["text", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 2.25,
       "output": 2.75

--- a/apps/api/src/data/pricing/deepseek.json
+++ b/apps/api/src/data/pricing/deepseek.json
@@ -68,7 +68,7 @@
   "deepseek-v3.2": {
     "label": "Deepseek V3.2",
     "contextWindow": 163840,
-    "maxTokens": 163840,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"

--- a/apps/api/src/data/pricing/fireworks-ai.json
+++ b/apps/api/src/data/pricing/fireworks-ai.json
@@ -2,7 +2,7 @@
   "accounts/fireworks/models/chronos-hermes-13b-v2": {
     "label": "Accounts/fireworks/models/chronos Hermes 13b V2",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -14,7 +14,7 @@
   "accounts/fireworks/models/code-llama-13b": {
     "label": "Accounts/fireworks/models/code Llama 13b",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -26,7 +26,7 @@
   "accounts/fireworks/models/code-llama-13b-instruct": {
     "label": "Accounts/fireworks/models/code Llama 13b Instruct",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -38,7 +38,7 @@
   "accounts/fireworks/models/code-llama-13b-python": {
     "label": "Accounts/fireworks/models/code Llama 13b Python",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -50,7 +50,7 @@
   "accounts/fireworks/models/code-llama-34b": {
     "label": "Accounts/fireworks/models/code Llama 34b",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -62,7 +62,7 @@
   "accounts/fireworks/models/code-llama-34b-instruct": {
     "label": "Accounts/fireworks/models/code Llama 34b Instruct",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -74,7 +74,7 @@
   "accounts/fireworks/models/code-llama-34b-python": {
     "label": "Accounts/fireworks/models/code Llama 34b Python",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -86,7 +86,7 @@
   "accounts/fireworks/models/code-llama-70b": {
     "label": "Accounts/fireworks/models/code Llama 70b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -98,7 +98,7 @@
   "accounts/fireworks/models/code-llama-70b-instruct": {
     "label": "Accounts/fireworks/models/code Llama 70b Instruct",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -110,7 +110,7 @@
   "accounts/fireworks/models/code-llama-70b-python": {
     "label": "Accounts/fireworks/models/code Llama 70b Python",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -122,7 +122,7 @@
   "accounts/fireworks/models/code-llama-7b": {
     "label": "Accounts/fireworks/models/code Llama 7b",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -134,7 +134,7 @@
   "accounts/fireworks/models/code-llama-7b-instruct": {
     "label": "Accounts/fireworks/models/code Llama 7b Instruct",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -146,7 +146,7 @@
   "accounts/fireworks/models/code-llama-7b-python": {
     "label": "Accounts/fireworks/models/code Llama 7b Python",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -158,7 +158,7 @@
   "accounts/fireworks/models/code-qwen-1p5-7b": {
     "label": "Accounts/fireworks/models/code Qwen 1p5 7b",
     "contextWindow": 65536,
-    "maxTokens": 65536,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -170,7 +170,7 @@
   "accounts/fireworks/models/codegemma-2b": {
     "label": "Accounts/fireworks/models/codegemma 2b",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -182,7 +182,7 @@
   "accounts/fireworks/models/codegemma-7b": {
     "label": "Accounts/fireworks/models/codegemma 7b",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -194,7 +194,7 @@
   "accounts/fireworks/models/cogito-671b-v2-p1": {
     "label": "Accounts/fireworks/models/cogito 671b V2 P1",
     "contextWindow": 163840,
-    "maxTokens": 163840,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -206,7 +206,7 @@
   "accounts/fireworks/models/cogito-v1-preview-llama-3b": {
     "label": "Accounts/fireworks/models/cogito V1 Preview Llama 3b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -218,7 +218,7 @@
   "accounts/fireworks/models/cogito-v1-preview-llama-70b": {
     "label": "Accounts/fireworks/models/cogito V1 Preview Llama 70b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -230,7 +230,7 @@
   "accounts/fireworks/models/cogito-v1-preview-llama-8b": {
     "label": "Accounts/fireworks/models/cogito V1 Preview Llama 8b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -242,7 +242,7 @@
   "accounts/fireworks/models/cogito-v1-preview-qwen-14b": {
     "label": "Accounts/fireworks/models/cogito V1 Preview Qwen 14b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -254,7 +254,7 @@
   "accounts/fireworks/models/cogito-v1-preview-qwen-32b": {
     "label": "Accounts/fireworks/models/cogito V1 Preview Qwen 32b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -266,7 +266,7 @@
   "accounts/fireworks/models/dbrx-instruct": {
     "label": "Accounts/fireworks/models/dbrx Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -278,7 +278,7 @@
   "accounts/fireworks/models/deepseek-coder-1b-base": {
     "label": "Accounts/fireworks/models/deepseek Coder 1b Base",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -290,7 +290,7 @@
   "accounts/fireworks/models/deepseek-coder-33b-instruct": {
     "label": "Accounts/fireworks/models/deepseek Coder 33b Instruct",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -302,7 +302,7 @@
   "accounts/fireworks/models/deepseek-coder-7b-base": {
     "label": "Accounts/fireworks/models/deepseek Coder 7b Base",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -314,7 +314,7 @@
   "accounts/fireworks/models/deepseek-coder-7b-base-v1p5": {
     "label": "Accounts/fireworks/models/deepseek Coder 7b Base V1p5",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -326,7 +326,7 @@
   "accounts/fireworks/models/deepseek-coder-7b-instruct-v1p5": {
     "label": "Accounts/fireworks/models/deepseek Coder 7b Instruct V1p5",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -338,7 +338,7 @@
   "accounts/fireworks/models/deepseek-coder-v2-instruct": {
     "label": "Accounts/fireworks/models/deepseek Coder V2 Instruct",
     "contextWindow": 65536,
-    "maxTokens": 65536,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -350,7 +350,7 @@
   "accounts/fireworks/models/deepseek-coder-v2-lite-base": {
     "label": "Accounts/fireworks/models/deepseek Coder V2 Lite Base",
     "contextWindow": 163840,
-    "maxTokens": 163840,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -362,7 +362,7 @@
   "accounts/fireworks/models/deepseek-coder-v2-lite-instruct": {
     "label": "Accounts/fireworks/models/deepseek Coder V2 Lite Instruct",
     "contextWindow": 163840,
-    "maxTokens": 163840,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -374,7 +374,7 @@
   "accounts/fireworks/models/deepseek-prover-v2": {
     "label": "Accounts/fireworks/models/deepseek Prover V2",
     "contextWindow": 163840,
-    "maxTokens": 163840,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -398,7 +398,7 @@
   "accounts/fireworks/models/deepseek-r1-0528": {
     "label": "Accounts/fireworks/models/deepseek R1 0528",
     "contextWindow": 160000,
-    "maxTokens": 160000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -410,7 +410,7 @@
   "accounts/fireworks/models/deepseek-r1-0528-distill-qwen3-8b": {
     "label": "Accounts/fireworks/models/deepseek R1 0528 Distill Qwen3 8b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -434,7 +434,7 @@
   "accounts/fireworks/models/deepseek-r1-distill-llama-70b": {
     "label": "Accounts/fireworks/models/deepseek R1 Distill Llama 70b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -446,7 +446,7 @@
   "accounts/fireworks/models/deepseek-r1-distill-llama-8b": {
     "label": "Accounts/fireworks/models/deepseek R1 Distill Llama 8b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -458,7 +458,7 @@
   "accounts/fireworks/models/deepseek-r1-distill-qwen-14b": {
     "label": "Accounts/fireworks/models/deepseek R1 Distill Qwen 14b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -470,7 +470,7 @@
   "accounts/fireworks/models/deepseek-r1-distill-qwen-1p5b": {
     "label": "Accounts/fireworks/models/deepseek R1 Distill Qwen 1p5b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -482,7 +482,7 @@
   "accounts/fireworks/models/deepseek-r1-distill-qwen-32b": {
     "label": "Accounts/fireworks/models/deepseek R1 Distill Qwen 32b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -494,7 +494,7 @@
   "accounts/fireworks/models/deepseek-r1-distill-qwen-7b": {
     "label": "Accounts/fireworks/models/deepseek R1 Distill Qwen 7b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -506,7 +506,7 @@
   "accounts/fireworks/models/deepseek-v2-lite-chat": {
     "label": "Accounts/fireworks/models/deepseek V2 Lite Chat",
     "contextWindow": 163840,
-    "maxTokens": 163840,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -518,7 +518,7 @@
   "accounts/fireworks/models/deepseek-v2p5": {
     "label": "Accounts/fireworks/models/deepseek V2p5",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -542,7 +542,7 @@
   "accounts/fireworks/models/deepseek-v3-0324": {
     "label": "Accounts/fireworks/models/deepseek V3 0324",
     "contextWindow": 163840,
-    "maxTokens": 163840,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -580,7 +580,7 @@
   "accounts/fireworks/models/deepseek-v3p2": {
     "label": "Accounts/fireworks/models/deepseek V3p2",
     "contextWindow": 163840,
-    "maxTokens": 163840,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -593,7 +593,7 @@
   "accounts/fireworks/models/devstral-small-2505": {
     "label": "Accounts/fireworks/models/devstral Small 2505",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -605,7 +605,7 @@
   "accounts/fireworks/models/dobby-mini-unhinged-plus-llama-3-1-8b": {
     "label": "Accounts/fireworks/models/dobby Mini Unhinged Plus Llama 3 1 8b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -617,7 +617,7 @@
   "accounts/fireworks/models/dobby-unhinged-llama-3-3-70b-new": {
     "label": "Accounts/fireworks/models/dobby Unhinged Llama 3 3 70b New",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -629,7 +629,7 @@
   "accounts/fireworks/models/dolphin-2-9-2-qwen2-72b": {
     "label": "Accounts/fireworks/models/dolphin 2 9 2 Qwen2 72b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -641,7 +641,7 @@
   "accounts/fireworks/models/dolphin-2p6-mixtral-8x7b": {
     "label": "Accounts/fireworks/models/dolphin 2p6 Mixtral 8x7b",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -653,7 +653,7 @@
   "accounts/fireworks/models/ernie-4p5-21b-a3b-pt": {
     "label": "Accounts/fireworks/models/ernie 4p5 21b A3b Pt",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -665,7 +665,7 @@
   "accounts/fireworks/models/ernie-4p5-300b-a47b-pt": {
     "label": "Accounts/fireworks/models/ernie 4p5 300b A47b Pt",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -677,7 +677,7 @@
   "accounts/fireworks/models/fare-20b": {
     "label": "Accounts/fireworks/models/fare 20b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -689,7 +689,7 @@
   "accounts/fireworks/models/firefunction-v1": {
     "label": "Accounts/fireworks/models/firefunction V1",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -701,7 +701,7 @@
   "accounts/fireworks/models/firefunction-v2": {
     "label": "Accounts/fireworks/models/firefunction V2",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -713,7 +713,7 @@
   "accounts/fireworks/models/firellava-13b": {
     "label": "Accounts/fireworks/models/firellava 13b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -725,7 +725,7 @@
   "accounts/fireworks/models/firesearch-ocr-v6": {
     "label": "Accounts/fireworks/models/firesearch Ocr V6",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -737,7 +737,7 @@
   "accounts/fireworks/models/flux-1-dev": {
     "label": "Accounts/fireworks/models/flux 1 Dev",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -749,7 +749,7 @@
   "accounts/fireworks/models/flux-1-dev-controlnet-union": {
     "label": "Accounts/fireworks/models/flux 1 Dev Controlnet Union",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -761,7 +761,7 @@
   "accounts/fireworks/models/flux-1-schnell": {
     "label": "Accounts/fireworks/models/flux 1 Schnell",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -773,7 +773,7 @@
   "accounts/fireworks/models/gemma-2b-it": {
     "label": "Accounts/fireworks/models/gemma 2b It",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -785,7 +785,7 @@
   "accounts/fireworks/models/gemma-3-27b-it": {
     "label": "Accounts/fireworks/models/gemma 3 27b It",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -797,7 +797,7 @@
   "accounts/fireworks/models/gemma-7b": {
     "label": "Accounts/fireworks/models/gemma 7b",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -809,7 +809,7 @@
   "accounts/fireworks/models/gemma-7b-it": {
     "label": "Accounts/fireworks/models/gemma 7b It",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -821,7 +821,7 @@
   "accounts/fireworks/models/gemma2-9b-it": {
     "label": "Accounts/fireworks/models/gemma2 9b It",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -859,7 +859,7 @@
   "accounts/fireworks/models/glm-4p5v": {
     "label": "Accounts/fireworks/models/glm 4p5v",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -872,7 +872,7 @@
   "accounts/fireworks/models/glm-4p6": {
     "label": "Accounts/fireworks/models/glm 4p6",
     "contextWindow": 202800,
-    "maxTokens": 202800,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -885,7 +885,7 @@
   "accounts/fireworks/models/glm-4p7": {
     "label": "Accounts/fireworks/models/glm 4p7",
     "contextWindow": 202800,
-    "maxTokens": 202800,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -899,7 +899,7 @@
   "accounts/fireworks/models/glm-5p1": {
     "label": "Accounts/fireworks/models/glm 5p1",
     "contextWindow": 202800,
-    "maxTokens": 202800,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -913,7 +913,7 @@
   "accounts/fireworks/models/gpt-oss-120b": {
     "label": "Accounts/fireworks/models/gpt Oss 120b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -926,7 +926,7 @@
   "accounts/fireworks/models/gpt-oss-20b": {
     "label": "Accounts/fireworks/models/gpt Oss 20b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -939,7 +939,7 @@
   "accounts/fireworks/models/gpt-oss-safeguard-120b": {
     "label": "Accounts/fireworks/models/gpt Oss Safeguard 120b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -951,7 +951,7 @@
   "accounts/fireworks/models/gpt-oss-safeguard-20b": {
     "label": "Accounts/fireworks/models/gpt Oss Safeguard 20b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -963,7 +963,7 @@
   "accounts/fireworks/models/hermes-2-pro-mistral-7b": {
     "label": "Accounts/fireworks/models/hermes 2 Pro Mistral 7b",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -975,7 +975,7 @@
   "accounts/fireworks/models/internvl3-38b": {
     "label": "Accounts/fireworks/models/internvl3 38b",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -987,7 +987,7 @@
   "accounts/fireworks/models/internvl3-78b": {
     "label": "Accounts/fireworks/models/internvl3 78b",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -999,7 +999,7 @@
   "accounts/fireworks/models/internvl3-8b": {
     "label": "Accounts/fireworks/models/internvl3 8b",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1011,7 +1011,7 @@
   "accounts/fireworks/models/kat-coder": {
     "label": "Accounts/fireworks/models/kat Coder",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1023,7 +1023,7 @@
   "accounts/fireworks/models/kat-dev-32b": {
     "label": "Accounts/fireworks/models/kat Dev 32b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1035,7 +1035,7 @@
   "accounts/fireworks/models/kat-dev-72b-exp": {
     "label": "Accounts/fireworks/models/kat Dev 72b Exp",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1071,7 +1071,7 @@
   "accounts/fireworks/models/kimi-k2-thinking": {
     "label": "Accounts/fireworks/models/kimi K2 Thinking",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1083,7 +1083,7 @@
   "accounts/fireworks/models/kimi-k2p5": {
     "label": "Accounts/fireworks/models/kimi K2p5",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1096,7 +1096,7 @@
   "accounts/fireworks/models/llama-guard-2-8b": {
     "label": "Accounts/fireworks/models/llama Guard 2 8b",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1108,7 +1108,7 @@
   "accounts/fireworks/models/llama-guard-3-1b": {
     "label": "Accounts/fireworks/models/llama Guard 3 1b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1120,7 +1120,7 @@
   "accounts/fireworks/models/llama-guard-3-8b": {
     "label": "Accounts/fireworks/models/llama Guard 3 8b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1132,7 +1132,7 @@
   "accounts/fireworks/models/llama-v2-13b": {
     "label": "Accounts/fireworks/models/llama V2 13b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1144,7 +1144,7 @@
   "accounts/fireworks/models/llama-v2-13b-chat": {
     "label": "Accounts/fireworks/models/llama V2 13b Chat",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1156,7 +1156,7 @@
   "accounts/fireworks/models/llama-v2-70b": {
     "label": "Accounts/fireworks/models/llama V2 70b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1168,7 +1168,7 @@
   "accounts/fireworks/models/llama-v2-70b-chat": {
     "label": "Accounts/fireworks/models/llama V2 70b Chat",
     "contextWindow": 2048,
-    "maxTokens": 2048,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1180,7 +1180,7 @@
   "accounts/fireworks/models/llama-v2-7b": {
     "label": "Accounts/fireworks/models/llama V2 7b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1192,7 +1192,7 @@
   "accounts/fireworks/models/llama-v2-7b-chat": {
     "label": "Accounts/fireworks/models/llama V2 7b Chat",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1204,7 +1204,7 @@
   "accounts/fireworks/models/llama-v3-70b-instruct": {
     "label": "Accounts/fireworks/models/llama V3 70b Instruct",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1216,7 +1216,7 @@
   "accounts/fireworks/models/llama-v3-70b-instruct-hf": {
     "label": "Accounts/fireworks/models/llama V3 70b Instruct Hf",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1228,7 +1228,7 @@
   "accounts/fireworks/models/llama-v3-8b": {
     "label": "Accounts/fireworks/models/llama V3 8b",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1240,7 +1240,7 @@
   "accounts/fireworks/models/llama-v3-8b-instruct-hf": {
     "label": "Accounts/fireworks/models/llama V3 8b Instruct Hf",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1264,7 +1264,7 @@
   "accounts/fireworks/models/llama-v3p1-405b-instruct-long": {
     "label": "Accounts/fireworks/models/llama V3p1 405b Instruct Long",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1276,7 +1276,7 @@
   "accounts/fireworks/models/llama-v3p1-70b-instruct": {
     "label": "Accounts/fireworks/models/llama V3p1 70b Instruct",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1288,7 +1288,7 @@
   "accounts/fireworks/models/llama-v3p1-70b-instruct-1b": {
     "label": "Accounts/fireworks/models/llama V3p1 70b Instruct 1b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1300,7 +1300,7 @@
   "accounts/fireworks/models/llama-v3p1-8b-instruct": {
     "label": "Accounts/fireworks/models/llama V3p1 8b Instruct",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1312,7 +1312,7 @@
   "accounts/fireworks/models/llama-v3p1-nemotron-70b-instruct": {
     "label": "Accounts/fireworks/models/llama V3p1 Nemotron 70b Instruct",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1324,7 +1324,7 @@
   "accounts/fireworks/models/llama-v3p2-11b-vision-instruct": {
     "label": "Accounts/fireworks/models/llama V3p2 11b Vision Instruct",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -1337,7 +1337,7 @@
   "accounts/fireworks/models/llama-v3p2-1b": {
     "label": "Accounts/fireworks/models/llama V3p2 1b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1349,7 +1349,7 @@
   "accounts/fireworks/models/llama-v3p2-1b-instruct": {
     "label": "Accounts/fireworks/models/llama V3p2 1b Instruct",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1361,7 +1361,7 @@
   "accounts/fireworks/models/llama-v3p2-3b": {
     "label": "Accounts/fireworks/models/llama V3p2 3b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1373,7 +1373,7 @@
   "accounts/fireworks/models/llama-v3p2-3b-instruct": {
     "label": "Accounts/fireworks/models/llama V3p2 3b Instruct",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1385,7 +1385,7 @@
   "accounts/fireworks/models/llama-v3p2-90b-vision-instruct": {
     "label": "Accounts/fireworks/models/llama V3p2 90b Vision Instruct",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -1398,7 +1398,7 @@
   "accounts/fireworks/models/llama-v3p3-70b-instruct": {
     "label": "Accounts/fireworks/models/llama V3p3 70b Instruct",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1410,7 +1410,7 @@
   "accounts/fireworks/models/llama4-maverick-instruct-basic": {
     "label": "Accounts/fireworks/models/llama4 Maverick Instruct Basic",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1422,7 +1422,7 @@
   "accounts/fireworks/models/llama4-scout-instruct-basic": {
     "label": "Accounts/fireworks/models/llama4 Scout Instruct Basic",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1434,7 +1434,7 @@
   "accounts/fireworks/models/llamaguard-7b": {
     "label": "Accounts/fireworks/models/llamaguard 7b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1446,7 +1446,7 @@
   "accounts/fireworks/models/llava-yi-34b": {
     "label": "Accounts/fireworks/models/llava Yi 34b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1458,7 +1458,7 @@
   "accounts/fireworks/models/minimax-m1-80k": {
     "label": "Accounts/fireworks/models/minimax M1 80k",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1470,7 +1470,7 @@
   "accounts/fireworks/models/minimax-m2": {
     "label": "Accounts/fireworks/models/minimax M2",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1482,7 +1482,7 @@
   "accounts/fireworks/models/minimax-m2p1": {
     "label": "Accounts/fireworks/models/minimax M2p1",
     "contextWindow": 204800,
-    "maxTokens": 204800,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1495,7 +1495,7 @@
   "accounts/fireworks/models/ministral-3-14b-instruct-2512": {
     "label": "Accounts/fireworks/models/ministral 3 14b Instruct 2512",
     "contextWindow": 256000,
-    "maxTokens": 256000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1507,7 +1507,7 @@
   "accounts/fireworks/models/ministral-3-3b-instruct-2512": {
     "label": "Accounts/fireworks/models/ministral 3 3b Instruct 2512",
     "contextWindow": 256000,
-    "maxTokens": 256000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1519,7 +1519,7 @@
   "accounts/fireworks/models/ministral-3-8b-instruct-2512": {
     "label": "Accounts/fireworks/models/ministral 3 8b Instruct 2512",
     "contextWindow": 256000,
-    "maxTokens": 256000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1531,7 +1531,7 @@
   "accounts/fireworks/models/mistral-7b": {
     "label": "Accounts/fireworks/models/mistral 7b",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1543,7 +1543,7 @@
   "accounts/fireworks/models/mistral-7b-instruct-4k": {
     "label": "Accounts/fireworks/models/mistral 7b Instruct 4k",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1555,7 +1555,7 @@
   "accounts/fireworks/models/mistral-7b-instruct-v0p2": {
     "label": "Accounts/fireworks/models/mistral 7b Instruct V0p2",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1567,7 +1567,7 @@
   "accounts/fireworks/models/mistral-7b-instruct-v3": {
     "label": "Accounts/fireworks/models/mistral 7b Instruct V3",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1579,7 +1579,7 @@
   "accounts/fireworks/models/mistral-7b-v0p2": {
     "label": "Accounts/fireworks/models/mistral 7b V0p2",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1591,7 +1591,7 @@
   "accounts/fireworks/models/mistral-large-3-fp8": {
     "label": "Accounts/fireworks/models/mistral Large 3 Fp8",
     "contextWindow": 256000,
-    "maxTokens": 256000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1603,7 +1603,7 @@
   "accounts/fireworks/models/mistral-nemo-base-2407": {
     "label": "Accounts/fireworks/models/mistral Nemo Base 2407",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1615,7 +1615,7 @@
   "accounts/fireworks/models/mistral-nemo-instruct-2407": {
     "label": "Accounts/fireworks/models/mistral Nemo Instruct 2407",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1627,7 +1627,7 @@
   "accounts/fireworks/models/mistral-small-24b-instruct-2501": {
     "label": "Accounts/fireworks/models/mistral Small 24b Instruct 2501",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1639,7 +1639,7 @@
   "accounts/fireworks/models/mixtral-8x22b": {
     "label": "Accounts/fireworks/models/mixtral 8x22b",
     "contextWindow": 65536,
-    "maxTokens": 65536,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1651,7 +1651,7 @@
   "accounts/fireworks/models/mixtral-8x22b-instruct": {
     "label": "Accounts/fireworks/models/mixtral 8x22b Instruct",
     "contextWindow": 65536,
-    "maxTokens": 65536,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1663,7 +1663,7 @@
   "accounts/fireworks/models/mixtral-8x22b-instruct-hf": {
     "label": "Accounts/fireworks/models/mixtral 8x22b Instruct Hf",
     "contextWindow": 65536,
-    "maxTokens": 65536,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1675,7 +1675,7 @@
   "accounts/fireworks/models/mixtral-8x7b": {
     "label": "Accounts/fireworks/models/mixtral 8x7b",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1687,7 +1687,7 @@
   "accounts/fireworks/models/mixtral-8x7b-instruct": {
     "label": "Accounts/fireworks/models/mixtral 8x7b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1699,7 +1699,7 @@
   "accounts/fireworks/models/mixtral-8x7b-instruct-hf": {
     "label": "Accounts/fireworks/models/mixtral 8x7b Instruct Hf",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1711,7 +1711,7 @@
   "accounts/fireworks/models/mythomax-l2-13b": {
     "label": "Accounts/fireworks/models/mythomax L2 13b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1723,7 +1723,7 @@
   "accounts/fireworks/models/nemotron-nano-v2-12b-vl": {
     "label": "Accounts/fireworks/models/nemotron Nano V2 12b Vl",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1735,7 +1735,7 @@
   "accounts/fireworks/models/nous-capybara-7b-v1p9": {
     "label": "Accounts/fireworks/models/nous Capybara 7b V1p9",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1747,7 +1747,7 @@
   "accounts/fireworks/models/nous-hermes-2-mixtral-8x7b-dpo": {
     "label": "Accounts/fireworks/models/nous Hermes 2 Mixtral 8x7b Dpo",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1759,7 +1759,7 @@
   "accounts/fireworks/models/nous-hermes-2-yi-34b": {
     "label": "Accounts/fireworks/models/nous Hermes 2 Yi 34b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1771,7 +1771,7 @@
   "accounts/fireworks/models/nous-hermes-llama2-13b": {
     "label": "Accounts/fireworks/models/nous Hermes Llama2 13b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1783,7 +1783,7 @@
   "accounts/fireworks/models/nous-hermes-llama2-70b": {
     "label": "Accounts/fireworks/models/nous Hermes Llama2 70b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1795,7 +1795,7 @@
   "accounts/fireworks/models/nous-hermes-llama2-7b": {
     "label": "Accounts/fireworks/models/nous Hermes Llama2 7b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1807,7 +1807,7 @@
   "accounts/fireworks/models/nvidia-nemotron-nano-12b-v2": {
     "label": "Accounts/fireworks/models/nvidia Nemotron Nano 12b V2",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1819,7 +1819,7 @@
   "accounts/fireworks/models/nvidia-nemotron-nano-9b-v2": {
     "label": "Accounts/fireworks/models/nvidia Nemotron Nano 9b V2",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1831,7 +1831,7 @@
   "accounts/fireworks/models/openchat-3p5-0106-7b": {
     "label": "Accounts/fireworks/models/openchat 3p5 0106 7b",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1843,7 +1843,7 @@
   "accounts/fireworks/models/openhermes-2-mistral-7b": {
     "label": "Accounts/fireworks/models/openhermes 2 Mistral 7b",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1855,7 +1855,7 @@
   "accounts/fireworks/models/openhermes-2p5-mistral-7b": {
     "label": "Accounts/fireworks/models/openhermes 2p5 Mistral 7b",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1867,7 +1867,7 @@
   "accounts/fireworks/models/openorca-7b": {
     "label": "Accounts/fireworks/models/openorca 7b",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1879,7 +1879,7 @@
   "accounts/fireworks/models/phi-2-3b": {
     "label": "Accounts/fireworks/models/phi 2 3b",
     "contextWindow": 2048,
-    "maxTokens": 2048,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1891,7 +1891,7 @@
   "accounts/fireworks/models/phi-3-mini-128k-instruct": {
     "label": "Accounts/fireworks/models/phi 3 Mini 128k Instruct",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1903,7 +1903,7 @@
   "accounts/fireworks/models/phi-3-vision-128k-instruct": {
     "label": "Accounts/fireworks/models/phi 3 Vision 128k Instruct",
     "contextWindow": 32064,
-    "maxTokens": 32064,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1915,7 +1915,7 @@
   "accounts/fireworks/models/phind-code-llama-34b-python-v1": {
     "label": "Accounts/fireworks/models/phind Code Llama 34b Python V1",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1927,7 +1927,7 @@
   "accounts/fireworks/models/phind-code-llama-34b-v1": {
     "label": "Accounts/fireworks/models/phind Code Llama 34b V1",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1939,7 +1939,7 @@
   "accounts/fireworks/models/phind-code-llama-34b-v2": {
     "label": "Accounts/fireworks/models/phind Code Llama 34b V2",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1951,7 +1951,7 @@
   "accounts/fireworks/models/pythia-12b": {
     "label": "Accounts/fireworks/models/pythia 12b",
     "contextWindow": 2048,
-    "maxTokens": 2048,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1963,7 +1963,7 @@
   "accounts/fireworks/models/qwen-qwq-32b-preview": {
     "label": "Accounts/fireworks/models/qwen Qwq 32b Preview",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1975,7 +1975,7 @@
   "accounts/fireworks/models/qwen-v2p5-14b-instruct": {
     "label": "Accounts/fireworks/models/qwen V2p5 14b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1987,7 +1987,7 @@
   "accounts/fireworks/models/qwen-v2p5-7b": {
     "label": "Accounts/fireworks/models/qwen V2p5 7b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -1999,7 +1999,7 @@
   "accounts/fireworks/models/qwen1p5-72b-chat": {
     "label": "Accounts/fireworks/models/qwen1p5 72b Chat",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2011,7 +2011,7 @@
   "accounts/fireworks/models/qwen2-72b-instruct": {
     "label": "Accounts/fireworks/models/qwen2 72b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2023,7 +2023,7 @@
   "accounts/fireworks/models/qwen2-7b-instruct": {
     "label": "Accounts/fireworks/models/qwen2 7b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2035,7 +2035,7 @@
   "accounts/fireworks/models/qwen2-vl-2b-instruct": {
     "label": "Accounts/fireworks/models/qwen2 Vl 2b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2047,7 +2047,7 @@
   "accounts/fireworks/models/qwen2-vl-72b-instruct": {
     "label": "Accounts/fireworks/models/qwen2 Vl 72b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2059,7 +2059,7 @@
   "accounts/fireworks/models/qwen2-vl-7b-instruct": {
     "label": "Accounts/fireworks/models/qwen2 Vl 7b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2071,7 +2071,7 @@
   "accounts/fireworks/models/qwen2p5-0p5b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 0p5b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2083,7 +2083,7 @@
   "accounts/fireworks/models/qwen2p5-14b": {
     "label": "Accounts/fireworks/models/qwen2p5 14b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2095,7 +2095,7 @@
   "accounts/fireworks/models/qwen2p5-1p5b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 1p5b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2107,7 +2107,7 @@
   "accounts/fireworks/models/qwen2p5-32b": {
     "label": "Accounts/fireworks/models/qwen2p5 32b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2119,7 +2119,7 @@
   "accounts/fireworks/models/qwen2p5-32b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 32b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2131,7 +2131,7 @@
   "accounts/fireworks/models/qwen2p5-72b": {
     "label": "Accounts/fireworks/models/qwen2p5 72b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2143,7 +2143,7 @@
   "accounts/fireworks/models/qwen2p5-72b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 72b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2155,7 +2155,7 @@
   "accounts/fireworks/models/qwen2p5-7b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 7b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2167,7 +2167,7 @@
   "accounts/fireworks/models/qwen2p5-coder-0p5b": {
     "label": "Accounts/fireworks/models/qwen2p5 Coder 0p5b",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2179,7 +2179,7 @@
   "accounts/fireworks/models/qwen2p5-coder-0p5b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 Coder 0p5b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2191,7 +2191,7 @@
   "accounts/fireworks/models/qwen2p5-coder-14b": {
     "label": "Accounts/fireworks/models/qwen2p5 Coder 14b",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2203,7 +2203,7 @@
   "accounts/fireworks/models/qwen2p5-coder-14b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 Coder 14b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2215,7 +2215,7 @@
   "accounts/fireworks/models/qwen2p5-coder-1p5b": {
     "label": "Accounts/fireworks/models/qwen2p5 Coder 1p5b",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2227,7 +2227,7 @@
   "accounts/fireworks/models/qwen2p5-coder-1p5b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 Coder 1p5b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2239,7 +2239,7 @@
   "accounts/fireworks/models/qwen2p5-coder-32b": {
     "label": "Accounts/fireworks/models/qwen2p5 Coder 32b",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2251,7 +2251,7 @@
   "accounts/fireworks/models/qwen2p5-coder-32b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 Coder 32b Instruct",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2263,7 +2263,7 @@
   "accounts/fireworks/models/qwen2p5-coder-32b-instruct-128k": {
     "label": "Accounts/fireworks/models/qwen2p5 Coder 32b Instruct 128k",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2275,7 +2275,7 @@
   "accounts/fireworks/models/qwen2p5-coder-32b-instruct-32k-rope": {
     "label": "Accounts/fireworks/models/qwen2p5 Coder 32b Instruct 32k Rope",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2287,7 +2287,7 @@
   "accounts/fireworks/models/qwen2p5-coder-32b-instruct-64k": {
     "label": "Accounts/fireworks/models/qwen2p5 Coder 32b Instruct 64k",
     "contextWindow": 65536,
-    "maxTokens": 65536,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2299,7 +2299,7 @@
   "accounts/fireworks/models/qwen2p5-coder-3b": {
     "label": "Accounts/fireworks/models/qwen2p5 Coder 3b",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2311,7 +2311,7 @@
   "accounts/fireworks/models/qwen2p5-coder-3b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 Coder 3b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2323,7 +2323,7 @@
   "accounts/fireworks/models/qwen2p5-coder-7b": {
     "label": "Accounts/fireworks/models/qwen2p5 Coder 7b",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2335,7 +2335,7 @@
   "accounts/fireworks/models/qwen2p5-coder-7b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 Coder 7b Instruct",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2347,7 +2347,7 @@
   "accounts/fireworks/models/qwen2p5-math-72b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 Math 72b Instruct",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2359,7 +2359,7 @@
   "accounts/fireworks/models/qwen2p5-vl-32b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 Vl 32b Instruct",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2371,7 +2371,7 @@
   "accounts/fireworks/models/qwen2p5-vl-3b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 Vl 3b Instruct",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2383,7 +2383,7 @@
   "accounts/fireworks/models/qwen2p5-vl-72b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 Vl 72b Instruct",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2395,7 +2395,7 @@
   "accounts/fireworks/models/qwen2p5-vl-7b-instruct": {
     "label": "Accounts/fireworks/models/qwen2p5 Vl 7b Instruct",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2407,7 +2407,7 @@
   "accounts/fireworks/models/qwen3-0p6b": {
     "label": "Accounts/fireworks/models/qwen3 0p6b",
     "contextWindow": 40960,
-    "maxTokens": 40960,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2419,7 +2419,7 @@
   "accounts/fireworks/models/qwen3-14b": {
     "label": "Accounts/fireworks/models/qwen3 14b",
     "contextWindow": 40960,
-    "maxTokens": 40960,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2431,7 +2431,7 @@
   "accounts/fireworks/models/qwen3-1p7b": {
     "label": "Accounts/fireworks/models/qwen3 1p7b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2443,7 +2443,7 @@
   "accounts/fireworks/models/qwen3-1p7b-fp8-draft": {
     "label": "Accounts/fireworks/models/qwen3 1p7b Fp8 Draft",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2455,7 +2455,7 @@
   "accounts/fireworks/models/qwen3-1p7b-fp8-draft-131072": {
     "label": "Accounts/fireworks/models/qwen3 1p7b Fp8 Draft 131072",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2467,7 +2467,7 @@
   "accounts/fireworks/models/qwen3-1p7b-fp8-draft-40960": {
     "label": "Accounts/fireworks/models/qwen3 1p7b Fp8 Draft 40960",
     "contextWindow": 40960,
-    "maxTokens": 40960,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2479,7 +2479,7 @@
   "accounts/fireworks/models/qwen3-235b-a22b": {
     "label": "Accounts/fireworks/models/qwen3 235b A22b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2491,7 +2491,7 @@
   "accounts/fireworks/models/qwen3-235b-a22b-instruct-2507": {
     "label": "Accounts/fireworks/models/qwen3 235b A22b Instruct 2507",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2503,7 +2503,7 @@
   "accounts/fireworks/models/qwen3-235b-a22b-thinking-2507": {
     "label": "Accounts/fireworks/models/qwen3 235b A22b Thinking 2507",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2515,7 +2515,7 @@
   "accounts/fireworks/models/qwen3-30b-a3b": {
     "label": "Accounts/fireworks/models/qwen3 30b A3b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2527,7 +2527,7 @@
   "accounts/fireworks/models/qwen3-30b-a3b-instruct-2507": {
     "label": "Accounts/fireworks/models/qwen3 30b A3b Instruct 2507",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2539,7 +2539,7 @@
   "accounts/fireworks/models/qwen3-30b-a3b-thinking-2507": {
     "label": "Accounts/fireworks/models/qwen3 30b A3b Thinking 2507",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2551,7 +2551,7 @@
   "accounts/fireworks/models/qwen3-32b": {
     "label": "Accounts/fireworks/models/qwen3 32b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -2564,7 +2564,7 @@
   "accounts/fireworks/models/qwen3-4b": {
     "label": "Accounts/fireworks/models/qwen3 4b",
     "contextWindow": 40960,
-    "maxTokens": 40960,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2576,7 +2576,7 @@
   "accounts/fireworks/models/qwen3-4b-instruct-2507": {
     "label": "Accounts/fireworks/models/qwen3 4b Instruct 2507",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2588,7 +2588,7 @@
   "accounts/fireworks/models/qwen3-8b": {
     "label": "Accounts/fireworks/models/qwen3 8b",
     "contextWindow": 40960,
-    "maxTokens": 40960,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -2601,7 +2601,7 @@
   "accounts/fireworks/models/qwen3-coder-30b-a3b-instruct": {
     "label": "Accounts/fireworks/models/qwen3 Coder 30b A3b Instruct",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2613,7 +2613,7 @@
   "accounts/fireworks/models/qwen3-coder-480b-a35b-instruct": {
     "label": "Accounts/fireworks/models/qwen3 Coder 480b A35b Instruct",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -2626,7 +2626,7 @@
   "accounts/fireworks/models/qwen3-coder-480b-instruct-bf16": {
     "label": "Accounts/fireworks/models/qwen3 Coder 480b Instruct Bf16",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2638,7 +2638,7 @@
   "accounts/fireworks/models/qwen3-next-80b-a3b-instruct": {
     "label": "Accounts/fireworks/models/qwen3 Next 80b A3b Instruct",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2650,7 +2650,7 @@
   "accounts/fireworks/models/qwen3-next-80b-a3b-thinking": {
     "label": "Accounts/fireworks/models/qwen3 Next 80b A3b Thinking",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2662,7 +2662,7 @@
   "accounts/fireworks/models/qwen3-vl-235b-a22b-instruct": {
     "label": "Accounts/fireworks/models/qwen3 Vl 235b A22b Instruct",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2674,7 +2674,7 @@
   "accounts/fireworks/models/qwen3-vl-235b-a22b-thinking": {
     "label": "Accounts/fireworks/models/qwen3 Vl 235b A22b Thinking",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2686,7 +2686,7 @@
   "accounts/fireworks/models/qwen3-vl-30b-a3b-instruct": {
     "label": "Accounts/fireworks/models/qwen3 Vl 30b A3b Instruct",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2698,7 +2698,7 @@
   "accounts/fireworks/models/qwen3-vl-30b-a3b-thinking": {
     "label": "Accounts/fireworks/models/qwen3 Vl 30b A3b Thinking",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2710,7 +2710,7 @@
   "accounts/fireworks/models/qwen3-vl-32b-instruct": {
     "label": "Accounts/fireworks/models/qwen3 Vl 32b Instruct",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2722,7 +2722,7 @@
   "accounts/fireworks/models/qwen3-vl-8b-instruct": {
     "label": "Accounts/fireworks/models/qwen3 Vl 8b Instruct",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2734,7 +2734,7 @@
   "accounts/fireworks/models/qwq-32b": {
     "label": "Accounts/fireworks/models/qwq 32b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2746,7 +2746,7 @@
   "accounts/fireworks/models/rolm-ocr": {
     "label": "Accounts/fireworks/models/rolm Ocr",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2758,7 +2758,7 @@
   "accounts/fireworks/models/snorkel-mistral-7b-pairrm-dpo": {
     "label": "Accounts/fireworks/models/snorkel Mistral 7b Pairrm Dpo",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2770,7 +2770,7 @@
   "accounts/fireworks/models/stablecode-3b": {
     "label": "Accounts/fireworks/models/stablecode 3b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2782,7 +2782,7 @@
   "accounts/fireworks/models/starcoder-16b": {
     "label": "Accounts/fireworks/models/starcoder 16b",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2794,7 +2794,7 @@
   "accounts/fireworks/models/starcoder-7b": {
     "label": "Accounts/fireworks/models/starcoder 7b",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2806,7 +2806,7 @@
   "accounts/fireworks/models/starcoder2-15b": {
     "label": "Accounts/fireworks/models/starcoder2 15b",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2818,7 +2818,7 @@
   "accounts/fireworks/models/starcoder2-3b": {
     "label": "Accounts/fireworks/models/starcoder2 3b",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2830,7 +2830,7 @@
   "accounts/fireworks/models/starcoder2-7b": {
     "label": "Accounts/fireworks/models/starcoder2 7b",
     "contextWindow": 16384,
-    "maxTokens": 16384,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2842,7 +2842,7 @@
   "accounts/fireworks/models/toppy-m-7b": {
     "label": "Accounts/fireworks/models/toppy M 7b",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2854,7 +2854,7 @@
   "accounts/fireworks/models/yi-34b": {
     "label": "Accounts/fireworks/models/yi 34b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2866,7 +2866,7 @@
   "accounts/fireworks/models/yi-34b-200k-capybara": {
     "label": "Accounts/fireworks/models/yi 34b 200k Capybara",
     "contextWindow": 200000,
-    "maxTokens": 200000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2878,7 +2878,7 @@
   "accounts/fireworks/models/yi-34b-chat": {
     "label": "Accounts/fireworks/models/yi 34b Chat",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2890,7 +2890,7 @@
   "accounts/fireworks/models/yi-6b": {
     "label": "Accounts/fireworks/models/yi 6b",
     "contextWindow": 4096,
-    "maxTokens": 4096,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2902,7 +2902,7 @@
   "accounts/fireworks/models/yi-large": {
     "label": "Accounts/fireworks/models/yi Large",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2914,7 +2914,7 @@
   "accounts/fireworks/models/zephyr-7b-beta": {
     "label": "Accounts/fireworks/models/zephyr 7b Beta",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2926,7 +2926,7 @@
   "glm-4p7": {
     "label": "Glm 4p7",
     "contextWindow": 202800,
-    "maxTokens": 202800,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -2940,7 +2940,7 @@
   "glm-5p1": {
     "label": "Glm 5p1",
     "contextWindow": 202800,
-    "maxTokens": 202800,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -2954,7 +2954,7 @@
   "kimi-k2p5": {
     "label": "Kimi K2p5",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -2967,7 +2967,7 @@
   "minimax-m2p1": {
     "label": "Minimax M2p1",
     "contextWindow": 204800,
-    "maxTokens": 204800,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],

--- a/apps/api/src/data/pricing/groq.json
+++ b/apps/api/src/data/pricing/groq.json
@@ -2,7 +2,7 @@
   "gemma-7b-it": {
     "label": "Gemma 7b It",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -64,7 +64,7 @@
   "meta-llama/llama-guard-4-12b": {
     "label": "Meta Llama/llama Guard 4 12b",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -131,7 +131,7 @@
   "qwen/qwen3-32b": {
     "label": "Qwen/qwen3 32b",
     "contextWindow": 131000,
-    "maxTokens": 131000,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"

--- a/apps/api/src/data/pricing/mistral.json
+++ b/apps/api/src/data/pricing/mistral.json
@@ -14,7 +14,7 @@
   "codestral-2508": {
     "label": "Codestral 2508",
     "contextWindow": 256000,
-    "maxTokens": 256000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -38,7 +38,7 @@
   "codestral-mamba-latest": {
     "label": "Codestral Mamba Latest",
     "contextWindow": 256000,
-    "maxTokens": 256000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -50,7 +50,7 @@
   "devstral-2512": {
     "label": "Devstral 2512",
     "contextWindow": 256000,
-    "maxTokens": 256000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -62,7 +62,7 @@
   "devstral-latest": {
     "label": "Devstral Latest",
     "contextWindow": 256000,
-    "maxTokens": 256000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -74,7 +74,7 @@
   "devstral-medium-2507": {
     "label": "Devstral Medium 2507",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -86,7 +86,7 @@
   "devstral-medium-latest": {
     "label": "Devstral Medium Latest",
     "contextWindow": 256000,
-    "maxTokens": 256000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -98,7 +98,7 @@
   "devstral-small-2505": {
     "label": "Devstral Small 2505",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -110,7 +110,7 @@
   "devstral-small-2507": {
     "label": "Devstral Small 2507",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -122,7 +122,7 @@
   "devstral-small-latest": {
     "label": "Devstral Small Latest",
     "contextWindow": 256000,
-    "maxTokens": 256000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -134,7 +134,7 @@
   "labs-devstral-small-2512": {
     "label": "Labs Devstral Small 2512",
     "contextWindow": 256000,
-    "maxTokens": 256000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -146,7 +146,7 @@
   "magistral-medium-1-2-2509": {
     "label": "Magistral Medium 1 2 2509",
     "contextWindow": 40000,
-    "maxTokens": 40000,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -159,7 +159,7 @@
   "magistral-medium-2506": {
     "label": "Magistral Medium 2506",
     "contextWindow": 40000,
-    "maxTokens": 40000,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -172,7 +172,7 @@
   "magistral-medium-2509": {
     "label": "Magistral Medium 2509",
     "contextWindow": 40000,
-    "maxTokens": 40000,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -185,7 +185,7 @@
   "magistral-medium-latest": {
     "label": "Magistral Medium Latest",
     "contextWindow": 40000,
-    "maxTokens": 40000,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -198,7 +198,7 @@
   "magistral-small-1-2-2509": {
     "label": "Magistral Small 1 2 2509",
     "contextWindow": 40000,
-    "maxTokens": 40000,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -211,7 +211,7 @@
   "magistral-small-2506": {
     "label": "Magistral Small 2506",
     "contextWindow": 40000,
-    "maxTokens": 40000,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -224,7 +224,7 @@
   "magistral-small-latest": {
     "label": "Magistral Small Latest",
     "contextWindow": 40000,
-    "maxTokens": 40000,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -237,7 +237,7 @@
   "ministral-3-14b-2512": {
     "label": "Ministral 3 14b 2512",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -250,7 +250,7 @@
   "ministral-3-3b-2512": {
     "label": "Ministral 3 3b 2512",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -263,7 +263,7 @@
   "ministral-3-8b-2512": {
     "label": "Ministral 3 8b 2512",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -276,7 +276,7 @@
   "ministral-8b-2512": {
     "label": "Ministral 8b 2512",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -289,7 +289,7 @@
   "ministral-8b-latest": {
     "label": "Ministral 8b Latest",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -314,7 +314,7 @@
   "mistral-large-2407": {
     "label": "Mistral Large 2407",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -326,7 +326,7 @@
   "mistral-large-2411": {
     "label": "Mistral Large 2411",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -338,7 +338,7 @@
   "mistral-large-2512": {
     "label": "Mistral Large 2512",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -351,7 +351,7 @@
   "mistral-large-3": {
     "label": "Mistral Large 3",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -364,7 +364,7 @@
   "mistral-large-latest": {
     "label": "Mistral Large Latest",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -413,7 +413,7 @@
   "mistral-medium-3-1-2508": {
     "label": "Mistral Medium 3 1 2508",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -426,7 +426,7 @@
   "mistral-medium-latest": {
     "label": "Mistral Medium Latest",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -451,7 +451,7 @@
   "mistral-small-3-2-2506": {
     "label": "Mistral Small 3 2 2506",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -464,7 +464,7 @@
   "mistral-small-latest": {
     "label": "Mistral Small Latest",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -489,7 +489,7 @@
   "open-codestral-mamba": {
     "label": "Open Codestral Mamba",
     "contextWindow": 256000,
-    "maxTokens": 256000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -513,7 +513,7 @@
   "open-mistral-nemo": {
     "label": "Open Mistral Nemo",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -525,7 +525,7 @@
   "open-mistral-nemo-2407": {
     "label": "Open Mistral Nemo 2407",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -561,7 +561,7 @@
   "pixtral-12b-2409": {
     "label": "Pixtral 12b 2409",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -574,7 +574,7 @@
   "pixtral-large-2411": {
     "label": "Pixtral Large 2411",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -587,7 +587,7 @@
   "pixtral-large-latest": {
     "label": "Pixtral Large Latest",
     "contextWindow": 128000,
-    "maxTokens": 128000,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"

--- a/apps/api/src/data/pricing/moonshot.json
+++ b/apps/api/src/data/pricing/moonshot.json
@@ -2,7 +2,7 @@
   "kimi-k2-0711-preview": {
     "label": "Kimi K2 0711 Preview",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -15,7 +15,7 @@
   "kimi-k2-0905-preview": {
     "label": "Kimi K2 0905 Preview",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -28,7 +28,7 @@
   "kimi-k2-thinking": {
     "label": "Kimi K2 Thinking",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -42,7 +42,7 @@
   "kimi-k2-thinking-turbo": {
     "label": "Kimi K2 Thinking Turbo",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -56,7 +56,7 @@
   "kimi-k2-turbo-preview": {
     "label": "Kimi K2 Turbo Preview",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -69,7 +69,7 @@
   "kimi-k2.5": {
     "label": "Kimi K2.5",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image",
@@ -84,7 +84,7 @@
   "kimi-k2.6": {
     "label": "Kimi K2.6",
     "contextWindow": 262144,
-    "maxTokens": 262144,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image",
@@ -99,7 +99,7 @@
   "kimi-latest": {
     "label": "Kimi Latest",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -113,7 +113,7 @@
   "kimi-latest-128k": {
     "label": "Kimi Latest 128k",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -127,7 +127,7 @@
   "kimi-latest-32k": {
     "label": "Kimi Latest 32k",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -141,7 +141,7 @@
   "kimi-latest-8k": {
     "label": "Kimi Latest 8k",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -155,7 +155,7 @@
   "kimi-thinking-preview": {
     "label": "Kimi Thinking Preview",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -169,7 +169,7 @@
   "moonshot-v1-128k": {
     "label": "Moonshot V1 128k",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -181,7 +181,7 @@
   "moonshot-v1-128k-0430": {
     "label": "Moonshot V1 128k 0430",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -193,7 +193,7 @@
   "moonshot-v1-128k-vision-preview": {
     "label": "Moonshot V1 128k Vision Preview",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -206,7 +206,7 @@
   "moonshot-v1-32k": {
     "label": "Moonshot V1 32k",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -218,7 +218,7 @@
   "moonshot-v1-32k-0430": {
     "label": "Moonshot V1 32k 0430",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -230,7 +230,7 @@
   "moonshot-v1-32k-vision-preview": {
     "label": "Moonshot V1 32k Vision Preview",
     "contextWindow": 32768,
-    "maxTokens": 32768,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -243,7 +243,7 @@
   "moonshot-v1-8k": {
     "label": "Moonshot V1 8k",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -255,7 +255,7 @@
   "moonshot-v1-8k-0430": {
     "label": "Moonshot V1 8k 0430",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],
@@ -267,7 +267,7 @@
   "moonshot-v1-8k-vision-preview": {
     "label": "Moonshot V1 8k Vision Preview",
     "contextWindow": 8192,
-    "maxTokens": 8192,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image"
@@ -280,7 +280,7 @@
   "moonshot-v1-auto": {
     "label": "Moonshot V1 Auto",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text"
     ],

--- a/apps/api/src/data/pricing/openai.json
+++ b/apps/api/src/data/pricing/openai.json
@@ -3,7 +3,10 @@
     "label": "Chatgpt 4o Latest",
     "contextWindow": 128000,
     "maxTokens": 4096,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 5,
       "output": 15
@@ -13,7 +16,9 @@
     "label": "Ft:gpt 3.5 Turbo",
     "contextWindow": 16385,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 3,
       "output": 6
@@ -23,7 +28,9 @@
     "label": "Ft:gpt 3.5 Turbo 0125",
     "contextWindow": 16385,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 3,
       "output": 6
@@ -32,8 +39,10 @@
   "ft:gpt-3.5-turbo-0613": {
     "label": "Ft:gpt 3.5 Turbo 0613",
     "contextWindow": 4096,
-    "maxTokens": 4096,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 3,
       "output": 6
@@ -43,7 +52,9 @@
     "label": "Ft:gpt 3.5 Turbo 1106",
     "contextWindow": 16385,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 3,
       "output": 6
@@ -53,7 +64,9 @@
     "label": "Ft:gpt 4 0613",
     "contextWindow": 8192,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 30,
       "output": 60
@@ -63,7 +76,9 @@
     "label": "Ft:gpt 4.1 2025 04 14",
     "contextWindow": 1047576,
     "maxTokens": 32768,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 3,
       "output": 12,
@@ -74,7 +89,9 @@
     "label": "Ft:gpt 4.1 Mini 2025 04 14",
     "contextWindow": 1047576,
     "maxTokens": 32768,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.8,
       "output": 3.2,
@@ -85,7 +102,9 @@
     "label": "Ft:gpt 4.1 Nano 2025 04 14",
     "contextWindow": 1047576,
     "maxTokens": 32768,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.2,
       "output": 0.8,
@@ -96,7 +115,10 @@
     "label": "Ft:gpt 4o 2024 08 06",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 3.75,
       "output": 15,
@@ -107,7 +129,9 @@
     "label": "Ft:gpt 4o 2024 11 20",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 3.75,
       "output": 15,
@@ -118,7 +142,9 @@
     "label": "Ft:gpt 4o Mini 2024 07 18",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.3,
       "output": 1.2,
@@ -129,7 +155,10 @@
     "label": "Ft:o4 Mini 2025 04 16",
     "contextWindow": 200000,
     "maxTokens": 100000,
-    "capabilities": ["text", "reasoning"],
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 4,
       "output": 16,
@@ -140,7 +169,9 @@
     "label": "Gpt 3.5 Turbo",
     "contextWindow": 16385,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.5,
       "output": 1.5
@@ -150,7 +181,9 @@
     "label": "Gpt 3.5 Turbo 0125",
     "contextWindow": 16385,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.5,
       "output": 1.5
@@ -160,7 +193,9 @@
     "label": "Gpt 3.5 Turbo 1106",
     "contextWindow": 16385,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 1,
       "output": 2
@@ -170,7 +205,9 @@
     "label": "Gpt 3.5 Turbo 16k",
     "contextWindow": 16385,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 3,
       "output": 4
@@ -180,7 +217,9 @@
     "label": "Gpt 4",
     "contextWindow": 8192,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 30,
       "output": 60
@@ -190,7 +229,9 @@
     "label": "Gpt 4 0125 Preview",
     "contextWindow": 128000,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 10,
       "output": 30
@@ -200,7 +241,9 @@
     "label": "Gpt 4 0314",
     "contextWindow": 8192,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 30,
       "output": 60
@@ -210,7 +253,9 @@
     "label": "Gpt 4 0613",
     "contextWindow": 8192,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 30,
       "output": 60
@@ -220,7 +265,9 @@
     "label": "Gpt 4 1106 Preview",
     "contextWindow": 128000,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 10,
       "output": 30
@@ -230,7 +277,10 @@
     "label": "Gpt 4 Turbo",
     "contextWindow": 128000,
     "maxTokens": 4096,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 10,
       "output": 30
@@ -240,7 +290,10 @@
     "label": "Gpt 4 Turbo 2024 04 09",
     "contextWindow": 128000,
     "maxTokens": 4096,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 10,
       "output": 30
@@ -250,7 +303,9 @@
     "label": "Gpt 4 Turbo Preview",
     "contextWindow": 128000,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 10,
       "output": 30
@@ -260,7 +315,10 @@
     "label": "Gpt 4.1",
     "contextWindow": 1047576,
     "maxTokens": 32768,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 2,
       "output": 8,
@@ -271,7 +329,10 @@
     "label": "Gpt 4.1 2025 04 14",
     "contextWindow": 1047576,
     "maxTokens": 32768,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 2,
       "output": 8,
@@ -282,7 +343,10 @@
     "label": "Gpt 4.1 Mini",
     "contextWindow": 1047576,
     "maxTokens": 32768,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 0.4,
       "output": 1.6,
@@ -293,7 +357,10 @@
     "label": "Gpt 4.1 Mini 2025 04 14",
     "contextWindow": 1047576,
     "maxTokens": 32768,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 0.4,
       "output": 1.6,
@@ -304,7 +371,10 @@
     "label": "Gpt 4.1 Nano",
     "contextWindow": 1047576,
     "maxTokens": 32768,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 0.1,
       "output": 0.4,
@@ -315,7 +385,10 @@
     "label": "Gpt 4.1 Nano 2025 04 14",
     "contextWindow": 1047576,
     "maxTokens": 32768,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 0.1,
       "output": 0.4,
@@ -326,7 +399,10 @@
     "label": "Gpt 4o",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 2.5,
       "output": 10,
@@ -337,7 +413,10 @@
     "label": "Gpt 4o 2024 05 13",
     "contextWindow": 128000,
     "maxTokens": 4096,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 5,
       "output": 15
@@ -347,7 +426,10 @@
     "label": "Gpt 4o 2024 08 06",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 2.5,
       "output": 10,
@@ -358,7 +440,10 @@
     "label": "Gpt 4o 2024 11 20",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 2.5,
       "output": 10,
@@ -369,7 +454,9 @@
     "label": "Gpt 4o Audio Preview",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 2.5,
       "output": 10
@@ -379,7 +466,9 @@
     "label": "Gpt 4o Audio Preview 2024 12 17",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 2.5,
       "output": 10
@@ -389,7 +478,9 @@
     "label": "Gpt 4o Audio Preview 2025 06 03",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 2.5,
       "output": 10
@@ -399,7 +490,10 @@
     "label": "Gpt 4o Mini",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 0.15,
       "output": 0.6,
@@ -410,7 +504,10 @@
     "label": "Gpt 4o Mini 2024 07 18",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 0.15,
       "output": 0.6,
@@ -421,7 +518,9 @@
     "label": "Gpt 4o Mini Audio Preview",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.15,
       "output": 0.6
@@ -431,7 +530,9 @@
     "label": "Gpt 4o Mini Audio Preview 2024 12 17",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.15,
       "output": 0.6
@@ -441,7 +542,9 @@
     "label": "Gpt 4o Mini Realtime Preview",
     "contextWindow": 128000,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.6,
       "output": 2.4,
@@ -452,7 +555,9 @@
     "label": "Gpt 4o Mini Realtime Preview 2024 12 17",
     "contextWindow": 128000,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.6,
       "output": 2.4,
@@ -463,7 +568,10 @@
     "label": "Gpt 4o Mini Search Preview",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 0.15,
       "output": 0.6,
@@ -474,7 +582,10 @@
     "label": "Gpt 4o Mini Search Preview 2025 03 11",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 0.15,
       "output": 0.6,
@@ -485,7 +596,9 @@
     "label": "Gpt 4o Realtime Preview",
     "contextWindow": 128000,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 5,
       "output": 20,
@@ -496,7 +609,9 @@
     "label": "Gpt 4o Realtime Preview 2024 12 17",
     "contextWindow": 128000,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 5,
       "output": 20,
@@ -507,7 +622,9 @@
     "label": "Gpt 4o Realtime Preview 2025 06 03",
     "contextWindow": 128000,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 5,
       "output": 20,
@@ -518,7 +635,10 @@
     "label": "Gpt 4o Search Preview",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 2.5,
       "output": 10,
@@ -529,7 +649,10 @@
     "label": "Gpt 4o Search Preview 2025 03 11",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 2.5,
       "output": 10,
@@ -540,7 +663,11 @@
     "label": "Gpt 5",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.25,
       "output": 10,
@@ -551,7 +678,11 @@
     "label": "Gpt 5 2025 08 07",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.25,
       "output": 10,
@@ -562,7 +693,11 @@
     "label": "Gpt 5 Chat",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.25,
       "output": 10,
@@ -573,7 +708,11 @@
     "label": "Gpt 5 Chat Latest",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.25,
       "output": 10,
@@ -584,7 +723,11 @@
     "label": "Gpt 5 Mini",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.25,
       "output": 2,
@@ -595,7 +738,11 @@
     "label": "Gpt 5 Mini 2025 08 07",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.25,
       "output": 2,
@@ -606,7 +753,11 @@
     "label": "Gpt 5 Nano",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.05,
       "output": 0.4,
@@ -617,7 +768,11 @@
     "label": "Gpt 5 Nano 2025 08 07",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.05,
       "output": 0.4,
@@ -628,7 +783,10 @@
     "label": "Gpt 5 Search Api",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 1.25,
       "output": 10,
@@ -639,7 +797,10 @@
     "label": "Gpt 5 Search Api 2025 10 14",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image"],
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 1.25,
       "output": 10,
@@ -650,7 +811,11 @@
     "label": "Gpt 5.1",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.25,
       "output": 10,
@@ -661,7 +826,11 @@
     "label": "Gpt 5.1 2025 11 13",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.25,
       "output": 10,
@@ -672,7 +841,11 @@
     "label": "Gpt 5.1 Chat Latest",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.25,
       "output": 10,
@@ -683,7 +856,11 @@
     "label": "Gpt 5.2",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.75,
       "output": 14,
@@ -694,7 +871,11 @@
     "label": "Gpt 5.2 2025 12 11",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.75,
       "output": 14,
@@ -705,7 +886,11 @@
     "label": "Gpt 5.2 Chat Latest",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.75,
       "output": 14,
@@ -716,7 +901,11 @@
     "label": "Gpt 5.3 Chat Latest",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.75,
       "output": 14,
@@ -727,7 +916,11 @@
     "label": "Gpt 5.4",
     "contextWindow": 1050000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 2.5,
       "output": 15,
@@ -738,7 +931,11 @@
     "label": "Gpt 5.4 2026 03 05",
     "contextWindow": 1050000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 2.5,
       "output": 15,
@@ -749,7 +946,11 @@
     "label": "Gpt 5.4 Mini",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.75,
       "output": 4.5,
@@ -760,7 +961,11 @@
     "label": "Gpt 5.4 Mini 2026 03 17",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.75,
       "output": 4.5,
@@ -771,7 +976,11 @@
     "label": "Gpt 5.4 Nano",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.2,
       "output": 1.25,
@@ -782,7 +991,11 @@
     "label": "Gpt 5.4 Nano 2026 03 17",
     "contextWindow": 272000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.2,
       "output": 1.25,
@@ -793,7 +1006,11 @@
     "label": "Gpt 5.5",
     "contextWindow": 1050000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 5,
       "output": 30,
@@ -804,7 +1021,11 @@
     "label": "Gpt 5.5 2026 04 23",
     "contextWindow": 1050000,
     "maxTokens": 128000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 5,
       "output": 30,
@@ -815,7 +1036,9 @@
     "label": "Gpt Audio",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 2.5,
       "output": 10
@@ -825,7 +1048,9 @@
     "label": "Gpt Audio 1.5",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 2.5,
       "output": 10
@@ -835,7 +1060,9 @@
     "label": "Gpt Audio 2025 08 28",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 2.5,
       "output": 10
@@ -845,7 +1072,9 @@
     "label": "Gpt Audio Mini",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.6,
       "output": 2.4
@@ -855,7 +1084,9 @@
     "label": "Gpt Audio Mini 2025 10 06",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.6,
       "output": 2.4
@@ -865,7 +1096,9 @@
     "label": "Gpt Audio Mini 2025 12 15",
     "contextWindow": 128000,
     "maxTokens": 16384,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.6,
       "output": 2.4
@@ -875,7 +1108,9 @@
     "label": "Gpt Realtime",
     "contextWindow": 32000,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 4,
       "output": 16,
@@ -886,7 +1121,9 @@
     "label": "Gpt Realtime 1.5",
     "contextWindow": 32000,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 4,
       "output": 16,
@@ -897,7 +1134,9 @@
     "label": "Gpt Realtime 2",
     "contextWindow": 32000,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 4,
       "output": 16,
@@ -908,7 +1147,9 @@
     "label": "Gpt Realtime 2025 08 28",
     "contextWindow": 32000,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 4,
       "output": 16,
@@ -919,7 +1160,9 @@
     "label": "Gpt Realtime Mini",
     "contextWindow": 128000,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.6,
       "output": 2.4
@@ -929,7 +1172,9 @@
     "label": "Gpt Realtime Mini 2025 10 06",
     "contextWindow": 128000,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.6,
       "output": 2.4,
@@ -940,7 +1185,9 @@
     "label": "Gpt Realtime Mini 2025 12 15",
     "contextWindow": 128000,
     "maxTokens": 4096,
-    "capabilities": ["text"],
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.6,
       "output": 2.4,
@@ -951,7 +1198,11 @@
     "label": "O1",
     "contextWindow": 200000,
     "maxTokens": 100000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 15,
       "output": 60,
@@ -962,7 +1213,11 @@
     "label": "O1 2024 12 17",
     "contextWindow": 200000,
     "maxTokens": 100000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 15,
       "output": 60,
@@ -973,7 +1228,11 @@
     "label": "O3",
     "contextWindow": 200000,
     "maxTokens": 100000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 2,
       "output": 8,
@@ -984,7 +1243,11 @@
     "label": "O3 2025 04 16",
     "contextWindow": 200000,
     "maxTokens": 100000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 2,
       "output": 8,
@@ -995,7 +1258,10 @@
     "label": "O3 Mini",
     "contextWindow": 200000,
     "maxTokens": 100000,
-    "capabilities": ["text", "reasoning"],
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.1,
       "output": 4.4,
@@ -1006,7 +1272,10 @@
     "label": "O3 Mini 2025 01 31",
     "contextWindow": 200000,
     "maxTokens": 100000,
-    "capabilities": ["text", "reasoning"],
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.1,
       "output": 4.4,
@@ -1017,7 +1286,11 @@
     "label": "O4 Mini",
     "contextWindow": 200000,
     "maxTokens": 100000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.1,
       "output": 4.4,
@@ -1028,7 +1301,11 @@
     "label": "O4 Mini 2025 04 16",
     "contextWindow": 200000,
     "maxTokens": 100000,
-    "capabilities": ["text", "image", "reasoning"],
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.1,
       "output": 4.4,

--- a/apps/api/src/data/pricing/together-ai.json
+++ b/apps/api/src/data/pricing/together-ai.json
@@ -147,7 +147,7 @@
   "moonshotai/Kimi-K2.5": {
     "label": "Moonshotai/Kimi K2.5",
     "contextWindow": 256000,
-    "maxTokens": 256000,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "image",
@@ -161,7 +161,7 @@
   "openai/gpt-oss-120b": {
     "label": "Openai/gpt Oss 120b",
     "contextWindow": 131072,
-    "maxTokens": 131072,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -198,7 +198,7 @@
   "zai-org/GLM-4.6": {
     "label": "Zai Org/GLM 4.6",
     "contextWindow": 200000,
-    "maxTokens": 200000,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"
@@ -211,7 +211,7 @@
   "zai-org/GLM-4.7": {
     "label": "Zai Org/GLM 4.7",
     "contextWindow": 200000,
-    "maxTokens": 200000,
+    "maxTokens": null,
     "capabilities": [
       "text",
       "reasoning"

--- a/apps/api/src/data/pricing/xai.json
+++ b/apps/api/src/data/pricing/xai.json
@@ -2,8 +2,10 @@
   "grok-2": {
     "label": "Grok 2",
     "contextWindow": 131072,
-    "maxTokens": 131072,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 2,
       "output": 10
@@ -12,8 +14,10 @@
   "grok-2-1212": {
     "label": "Grok 2 1212",
     "contextWindow": 131072,
-    "maxTokens": 131072,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 2,
       "output": 10
@@ -22,8 +26,10 @@
   "grok-2-latest": {
     "label": "Grok 2 Latest",
     "contextWindow": 131072,
-    "maxTokens": 131072,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 2,
       "output": 10
@@ -32,8 +38,11 @@
   "grok-2-vision": {
     "label": "Grok 2 Vision",
     "contextWindow": 32768,
-    "maxTokens": 32768,
-    "capabilities": ["text", "image"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 2,
       "output": 10
@@ -42,8 +51,11 @@
   "grok-2-vision-1212": {
     "label": "Grok 2 Vision 1212",
     "contextWindow": 32768,
-    "maxTokens": 32768,
-    "capabilities": ["text", "image"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 2,
       "output": 10
@@ -52,8 +64,11 @@
   "grok-2-vision-latest": {
     "label": "Grok 2 Vision Latest",
     "contextWindow": 32768,
-    "maxTokens": 32768,
-    "capabilities": ["text", "image"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 2,
       "output": 10
@@ -62,8 +77,10 @@
   "grok-3": {
     "label": "Grok 3",
     "contextWindow": 131072,
-    "maxTokens": 131072,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 3,
       "output": 15,
@@ -73,8 +90,10 @@
   "grok-3-beta": {
     "label": "Grok 3 Beta",
     "contextWindow": 131072,
-    "maxTokens": 131072,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 3,
       "output": 15,
@@ -84,8 +103,10 @@
   "grok-3-fast-beta": {
     "label": "Grok 3 Fast Beta",
     "contextWindow": 131072,
-    "maxTokens": 131072,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 5,
       "output": 25,
@@ -95,8 +116,10 @@
   "grok-3-fast-latest": {
     "label": "Grok 3 Fast Latest",
     "contextWindow": 131072,
-    "maxTokens": 131072,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 5,
       "output": 25,
@@ -106,8 +129,10 @@
   "grok-3-latest": {
     "label": "Grok 3 Latest",
     "contextWindow": 131072,
-    "maxTokens": 131072,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 3,
       "output": 15,
@@ -117,8 +142,11 @@
   "grok-3-mini": {
     "label": "Grok 3 Mini",
     "contextWindow": 131072,
-    "maxTokens": 131072,
-    "capabilities": ["text", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.3,
       "output": 0.5,
@@ -128,8 +156,11 @@
   "grok-3-mini-beta": {
     "label": "Grok 3 Mini Beta",
     "contextWindow": 131072,
-    "maxTokens": 131072,
-    "capabilities": ["text", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.3,
       "output": 0.5,
@@ -139,8 +170,11 @@
   "grok-3-mini-fast": {
     "label": "Grok 3 Mini Fast",
     "contextWindow": 131072,
-    "maxTokens": 131072,
-    "capabilities": ["text", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.6,
       "output": 4,
@@ -150,8 +184,11 @@
   "grok-3-mini-fast-beta": {
     "label": "Grok 3 Mini Fast Beta",
     "contextWindow": 131072,
-    "maxTokens": 131072,
-    "capabilities": ["text", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.6,
       "output": 4,
@@ -161,8 +198,11 @@
   "grok-3-mini-fast-latest": {
     "label": "Grok 3 Mini Fast Latest",
     "contextWindow": 131072,
-    "maxTokens": 131072,
-    "capabilities": ["text", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.6,
       "output": 4,
@@ -172,8 +212,11 @@
   "grok-3-mini-latest": {
     "label": "Grok 3 Mini Latest",
     "contextWindow": 131072,
-    "maxTokens": 131072,
-    "capabilities": ["text", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.3,
       "output": 0.5,
@@ -183,8 +226,10 @@
   "grok-4": {
     "label": "Grok 4",
     "contextWindow": 256000,
-    "maxTokens": 256000,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 3,
       "output": 15
@@ -193,8 +238,10 @@
   "grok-4-0709": {
     "label": "Grok 4 0709",
     "contextWindow": 256000,
-    "maxTokens": 256000,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 3,
       "output": 15
@@ -203,8 +250,12 @@
   "grok-4-1-fast": {
     "label": "Grok 4 1 Fast",
     "contextWindow": 2000000,
-    "maxTokens": 2000000,
-    "capabilities": ["text", "image", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.2,
       "output": 0.5,
@@ -214,8 +265,11 @@
   "grok-4-1-fast-non-reasoning": {
     "label": "Grok 4 1 Fast Non Reasoning",
     "contextWindow": 2000000,
-    "maxTokens": 2000000,
-    "capabilities": ["text", "image"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 0.2,
       "output": 0.5,
@@ -225,8 +279,11 @@
   "grok-4-1-fast-non-reasoning-latest": {
     "label": "Grok 4 1 Fast Non Reasoning Latest",
     "contextWindow": 2000000,
-    "maxTokens": 2000000,
-    "capabilities": ["text", "image"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 0.2,
       "output": 0.5,
@@ -236,8 +293,12 @@
   "grok-4-1-fast-reasoning": {
     "label": "Grok 4 1 Fast Reasoning",
     "contextWindow": 2000000,
-    "maxTokens": 2000000,
-    "capabilities": ["text", "image", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.2,
       "output": 0.5,
@@ -247,8 +308,12 @@
   "grok-4-1-fast-reasoning-latest": {
     "label": "Grok 4 1 Fast Reasoning Latest",
     "contextWindow": 2000000,
-    "maxTokens": 2000000,
-    "capabilities": ["text", "image", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.2,
       "output": 0.5,
@@ -258,8 +323,10 @@
   "grok-4-fast-non-reasoning": {
     "label": "Grok 4 Fast Non Reasoning",
     "contextWindow": 2000000,
-    "maxTokens": 2000000,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.2,
       "output": 0.5,
@@ -269,8 +336,10 @@
   "grok-4-fast-reasoning": {
     "label": "Grok 4 Fast Reasoning",
     "contextWindow": 2000000,
-    "maxTokens": 2000000,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 0.2,
       "output": 0.5,
@@ -280,8 +349,10 @@
   "grok-4-latest": {
     "label": "Grok 4 Latest",
     "contextWindow": 256000,
-    "maxTokens": 256000,
-    "capabilities": ["text"],
+    "maxTokens": null,
+    "capabilities": [
+      "text"
+    ],
     "cost": {
       "input": 3,
       "output": 15
@@ -290,8 +361,12 @@
   "grok-4.20-0309-reasoning": {
     "label": "Grok 4.20 0309 Reasoning",
     "contextWindow": 2000000,
-    "maxTokens": 2000000,
-    "capabilities": ["text", "image", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 2,
       "output": 6,
@@ -301,8 +376,11 @@
   "grok-4.20-beta-0309-non-reasoning": {
     "label": "Grok 4.20 Beta 0309 Non Reasoning",
     "contextWindow": 2000000,
-    "maxTokens": 2000000,
-    "capabilities": ["text", "image"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 2,
       "output": 6,
@@ -312,8 +390,12 @@
   "grok-4.20-beta-0309-reasoning": {
     "label": "Grok 4.20 Beta 0309 Reasoning",
     "contextWindow": 2000000,
-    "maxTokens": 2000000,
-    "capabilities": ["text", "image", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 2,
       "output": 6,
@@ -323,8 +405,12 @@
   "grok-4.20-multi-agent-beta-0309": {
     "label": "Grok 4.20 Multi Agent Beta 0309",
     "contextWindow": 2000000,
-    "maxTokens": 2000000,
-    "capabilities": ["text", "image", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 2,
       "output": 6,
@@ -334,8 +420,12 @@
   "grok-4.3": {
     "label": "Grok 4.3",
     "contextWindow": 1000000,
-    "maxTokens": 1000000,
-    "capabilities": ["text", "image", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.25,
       "output": 2.5,
@@ -345,8 +435,12 @@
   "grok-4.3-latest": {
     "label": "Grok 4.3 Latest",
     "contextWindow": 1000000,
-    "maxTokens": 1000000,
-    "capabilities": ["text", "image", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image",
+      "reasoning"
+    ],
     "cost": {
       "input": 1.25,
       "output": 2.5,
@@ -356,8 +450,11 @@
   "grok-beta": {
     "label": "Grok Beta",
     "contextWindow": 131072,
-    "maxTokens": 131072,
-    "capabilities": ["text", "image"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 5,
       "output": 15
@@ -366,8 +463,11 @@
   "grok-code-fast": {
     "label": "Grok Code Fast",
     "contextWindow": 256000,
-    "maxTokens": 256000,
-    "capabilities": ["text", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.2,
       "output": 1.5,
@@ -377,8 +477,11 @@
   "grok-code-fast-1": {
     "label": "Grok Code Fast 1",
     "contextWindow": 256000,
-    "maxTokens": 256000,
-    "capabilities": ["text", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.2,
       "output": 1.5,
@@ -388,8 +491,11 @@
   "grok-code-fast-1-0825": {
     "label": "Grok Code Fast 1 0825",
     "contextWindow": 256000,
-    "maxTokens": 256000,
-    "capabilities": ["text", "reasoning"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "reasoning"
+    ],
     "cost": {
       "input": 0.2,
       "output": 1.5,
@@ -399,8 +505,11 @@
   "grok-vision-beta": {
     "label": "Grok Vision Beta",
     "contextWindow": 8192,
-    "maxTokens": 8192,
-    "capabilities": ["text", "image"],
+    "maxTokens": null,
+    "capabilities": [
+      "text",
+      "image"
+    ],
     "cost": {
       "input": 5,
       "output": 15

--- a/apps/api/src/routes/models.ts
+++ b/apps/api/src/routes/models.ts
@@ -40,46 +40,60 @@ import {
 } from "../lib/errors.ts";
 import { recordAuditFromContext } from "../services/audit.ts";
 
-export const createModelSchema = z.object({
-  /**
-   * Optional. When omitted, the server derives the label from the catalog
-   * (`<catalog>.label`) and dedupes against existing org rows. See
-   * {@link deriveModelLabel}.
-   */
-  label: z.string().min(1).optional(),
-  modelId: z.string().min(1, "modelId is required"),
-  // `org_models.credential_id` is a strict UUID FK to
-  // `model_provider_credentials.id` — built-in (system) credentials live
-  // in `SYSTEM_PROVIDER_KEYS` env, NOT in that table, and identify as
-  // slugs (e.g. "anthropic"). Validating as UUID here turns the
-  // legacy 500 ("invalid input syntax for type uuid") into a clean 400
-  // and lets the route handler emit a hint that points operators at the
-  // right knob (either update SYSTEM_PROVIDER_KEYS or create a custom
-  // credential).
-  credentialId: z.uuid({ message: "credentialId must be a valid UUID" }),
-  /**
-   * Catalog-derivable overrides. Omit (or send null on update) to let the
-   * read path fall back to the live catalog — keeps existing rows in sync
-   * with the weekly `refresh-pricing-catalog.ts` bump.
-   */
-  input: z.array(z.string()).optional(),
-  contextWindow: z.number().int().positive().optional(),
-  maxTokens: z.number().int().positive().optional(),
-  reasoning: z.boolean().optional(),
-  cost: modelCostSchema.optional(),
-});
+export const createModelSchema = z
+  .object({
+    /**
+     * Optional. When omitted, the server derives the label from the catalog
+     * (`<catalog>.label`) and dedupes against existing org rows. See
+     * {@link deriveModelLabel}.
+     */
+    label: z.string().min(1).optional(),
+    modelId: z.string().min(1, "modelId is required"),
+    // `org_models.credential_id` is a strict UUID FK to
+    // `model_provider_credentials.id` — built-in (system) credentials live
+    // in `SYSTEM_PROVIDER_KEYS` env, NOT in that table, and identify as
+    // slugs (e.g. "anthropic"). Validating as UUID here turns the
+    // legacy 500 ("invalid input syntax for type uuid") into a clean 400
+    // and lets the route handler emit a hint that points operators at the
+    // right knob (either update SYSTEM_PROVIDER_KEYS or create a custom
+    // credential).
+    credentialId: z.uuid({ message: "credentialId must be a valid UUID" }),
+    /**
+     * Catalog-derivable overrides. Omit (or send null on update) to let the
+     * read path fall back to the live catalog — keeps existing rows in sync
+     * with the weekly `refresh-pricing-catalog.ts` bump.
+     */
+    input: z.array(z.string()).optional(),
+    contextWindow: z.number().int().positive().optional(),
+    maxTokens: z.number().int().positive().optional(),
+    reasoning: z.boolean().optional(),
+    cost: modelCostSchema.optional(),
+  })
+  .refine(
+    // Canonical model invariant: `input + output <= context`, so a response
+    // cap can never reach the full window. Reject impossible overrides at the
+    // edge so the runtime never derives a reserve that swallows the window.
+    (d) => d.maxTokens == null || d.contextWindow == null || d.maxTokens < d.contextWindow,
+    { message: "maxTokens must be strictly less than contextWindow", path: ["maxTokens"] },
+  );
 
-export const updateModelSchema = z.object({
-  label: z.string().min(1).optional(),
-  modelId: z.string().min(1).optional(),
-  credentialId: z.uuid({ message: "credentialId must be a valid UUID" }).optional(),
-  enabled: z.boolean().optional(),
-  input: z.array(z.string()).nullable().optional(),
-  contextWindow: z.number().int().positive().nullable().optional(),
-  maxTokens: z.number().int().positive().nullable().optional(),
-  reasoning: z.boolean().nullable().optional(),
-  cost: modelCostSchema.nullable().optional(),
-});
+export const updateModelSchema = z
+  .object({
+    label: z.string().min(1).optional(),
+    modelId: z.string().min(1).optional(),
+    credentialId: z.uuid({ message: "credentialId must be a valid UUID" }).optional(),
+    enabled: z.boolean().optional(),
+    input: z.array(z.string()).nullable().optional(),
+    contextWindow: z.number().int().positive().nullable().optional(),
+    maxTokens: z.number().int().positive().nullable().optional(),
+    reasoning: z.boolean().nullable().optional(),
+    cost: modelCostSchema.nullable().optional(),
+  })
+  .refine(
+    // See createModelSchema: `max_output_tokens < context_window` always holds.
+    (d) => d.maxTokens == null || d.contextWindow == null || d.maxTokens < d.contextWindow,
+    { message: "maxTokens must be strictly less than contextWindow", path: ["maxTokens"] },
+  );
 
 export const setDefaultSchema = z.object({
   modelId: z.string().nullable(),

--- a/apps/api/test/integration/routes/models.test.ts
+++ b/apps/api/test/integration/routes/models.test.ts
@@ -105,6 +105,26 @@ describe("Models API", () => {
       expect(body.detail).toContain("UUID");
     });
 
+    it("rejects maxTokens >= contextWindow with 400 (canonical model invariant)", async () => {
+      // `input + output <= context`, so a response cap can never reach the
+      // full window. The edge guard rejects the impossible override before it
+      // reaches the runtime (where it would crash the sidecar / pin the
+      // compaction threshold at zero).
+      const credentialId = await createProviderKey();
+      const res = await app.request("/api/models", {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          label: "Bogus",
+          modelId: "bogus-model",
+          credentialId,
+          contextWindow: 256_000,
+          maxTokens: 256_000,
+        }),
+      });
+      expect(res.status).toBe(400);
+    });
+
     it("rejects a needs-reconnection credential with 400 before inserting (explicit label path)", async () => {
       // Regression for the hoisted reachability gate: with an explicit label,
       // the old code skipped `loadInferenceCredentials` entirely, inserted the

--- a/apps/api/test/unit/pricing-catalog.test.ts
+++ b/apps/api/test/unit/pricing-catalog.test.ts
@@ -12,6 +12,8 @@
  *      provider (drives the picker's "All models" group).
  */
 
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { describe, it, expect } from "bun:test";
 import {
   _catalogSize,
@@ -100,4 +102,37 @@ describe("_catalogSize", () => {
   it("indexes at least 400 chat models across the 12 vendored providers", () => {
     expect(_catalogSize()).toBeGreaterThan(400);
   });
+});
+
+describe("vendored catalog invariant — maxTokens < contextWindow", () => {
+  // Canonical model invariant: a request spends `input + output` from the
+  // same window, so `max_output_tokens < context_window` always holds. The
+  // ingest path (`refresh-pricing-catalog.ts`) nulls impossible values from
+  // LiteLLM (devstral, kimi-k2.5, … — known upstream bug). This test pins
+  // the on-disk data so a future bad refresh can't reintroduce a cap that
+  // crashes the sidecar / pins the compaction threshold at zero.
+  const dataDir = join(dirname(dirname(import.meta.dir)), "src/data/pricing");
+  const files = readdirSync(dataDir).filter((f) => f.endsWith(".json"));
+
+  it("vendors at least the 12 known provider files", () => {
+    expect(files.length).toBeGreaterThanOrEqual(12);
+  });
+
+  for (const file of files) {
+    it(`${file}: every maxTokens is null or strictly below contextWindow`, () => {
+      const entries = JSON.parse(readFileSync(join(dataDir, file), "utf8")) as Record<
+        string,
+        { contextWindow?: number; maxTokens?: number | null }
+      >;
+      const violations = Object.entries(entries)
+        .filter(
+          ([, e]) =>
+            typeof e.maxTokens === "number" &&
+            typeof e.contextWindow === "number" &&
+            e.maxTokens >= e.contextWindow,
+        )
+        .map(([id]) => id);
+      expect(violations).toEqual([]);
+    });
+  }
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,6 +73,7 @@
     "./permissions": "./src/permissions.ts",
     "./platform-types": "./src/platform-types.ts",
     "./token-usage": "./src/token-usage.ts",
+    "./token-budget": "./src/token-budget.ts",
     "./sidecar-types": "./src/sidecar-types.ts",
     "./pairing-token": "./src/pairing-token.ts",
     "./jwt": "./src/jwt.ts",

--- a/packages/core/src/token-budget.ts
+++ b/packages/core/src/token-budget.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Shared token-budget arithmetic — the single source of truth for the
+ * "response reserve" a model keeps free inside its context window.
+ *
+ * The reserve is used by two runtime surfaces that MUST agree for a given
+ * `(contextWindow, maxTokens)` pair, or the spill guard and the compaction
+ * threshold drift apart:
+ *
+ *   - `runtime-pi/sidecar/token-budget.ts` — spills `api_call` output once
+ *     `consumed + estimated > contextWindow - reserve`.
+ *   - `packages/runner-pi/src/pi-runner.ts` — feeds Pi SDK's
+ *     `shouldCompact(tokens, contextWindow, { reserveTokens })`, which
+ *     compacts once `tokens > contextWindow - reserveTokens`.
+ *
+ * **Canonical model invariant.** A request consumes `input + output`
+ * tokens, both drawn from the same context window, so
+ * `max_output_tokens < context_window` always holds — output can never
+ * occupy the entire window because the prompt needs room too. Our catalog
+ * is sourced from LiteLLM / models.dev, which report
+ * `max_output_tokens == context_window` for a class of models (devstral,
+ * kimi-k2.5, several grok / mistral entries) — a known upstream data bug
+ * (see LiteLLM issue #22478). The ingest path drops those to null, but the
+ * runtime can still receive an impossible cap (manual `org_models` row, a
+ * future bad source), so {@link deriveResponseReserveTokens} treats any
+ * `maxTokens >= contextWindow` as unusable and falls back to a derived
+ * default rather than producing a reserve that swallows the whole window
+ * (which previously threw and crashed the sidecar at boot, or pinned the
+ * compaction threshold at zero so the agent compacted every turn).
+ */
+
+/**
+ * Floor on the derived response reserve when no usable `maxTokens` is
+ * available. 16384 covers the common "no thinking" Claude / GPT response
+ * shape; larger budgets (Sonnet thinking @ 64 k) flow through an explicit
+ * `maxTokens`.
+ */
+export const RESERVE_FLOOR_TOKENS = 16_384;
+
+/**
+ * Fraction of the context window reserved for the response when no usable
+ * `maxTokens` is supplied. 20 % covers Sonnet thinking @ 64 k on a 200 k
+ * window without overshooting; smaller windows scale down naturally.
+ */
+export const RESERVE_FRACTION = 0.2;
+
+/**
+ * Hard ceiling on the reserve as a fraction of the window — always leave
+ * at least `1 - RESERVE_CEILING_FRACTION` (20 %) for the prompt, even when
+ * an explicit `maxTokens` is large relative to the window. Guarantees the
+ * returned reserve is strictly below `contextWindow`.
+ */
+export const RESERVE_CEILING_FRACTION = 0.8;
+
+/**
+ * True when `maxTokens` is a usable response cap for `contextWindow`: a
+ * positive integer strictly below the window. Encodes the canonical
+ * `input + output <= context` invariant — a cap `>= contextWindow` is
+ * mathematically impossible and signals corrupt catalog/override data.
+ */
+export function isUsableMaxOutputTokens(
+  maxTokens: number | null | undefined,
+  contextWindow: number,
+): maxTokens is number {
+  return (
+    typeof maxTokens === "number" &&
+    Number.isFinite(maxTokens) &&
+    maxTokens > 0 &&
+    maxTokens < contextWindow
+  );
+}
+
+/**
+ * Derive the response reserve (tokens kept free for the model's reply) for
+ * a context window. Guaranteed to return a positive integer strictly below
+ * `contextWindow`.
+ *
+ *   - A usable explicit `maxTokens` (positive, `< contextWindow`) is
+ *     honoured verbatim — capped only by {@link RESERVE_CEILING_FRACTION}
+ *     so a near-window cap still leaves prompt headroom. This preserves
+ *     existing behaviour for every valid model (e.g. Sonnet thinking
+ *     @ 64 k on a 200 k window stays 64 k).
+ *   - A missing or impossible `maxTokens` (`>= contextWindow`) falls back
+ *     to `max(RESERVE_FLOOR_TOKENS, contextWindow × RESERVE_FRACTION)`,
+ *     itself clamped under the ceiling.
+ *
+ * @param contextWindow Positive integer window size (caller guarantees > 0).
+ */
+export function deriveResponseReserveTokens(
+  contextWindow: number,
+  maxTokens?: number | null,
+): number {
+  // Never reserve the whole window: leave ≥20 % for the prompt. Floor at 1
+  // so degenerate tiny windows still yield a positive reserve.
+  const ceiling = Math.max(1, Math.floor(contextWindow * RESERVE_CEILING_FRACTION));
+  if (isUsableMaxOutputTokens(maxTokens, contextWindow)) {
+    return Math.min(maxTokens, ceiling);
+  }
+  const derived = Math.max(RESERVE_FLOOR_TOKENS, Math.floor(contextWindow * RESERVE_FRACTION));
+  return Math.min(derived, ceiling);
+}

--- a/packages/core/test/token-budget.test.ts
+++ b/packages/core/test/token-budget.test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "bun:test";
+import {
+  deriveResponseReserveTokens,
+  isUsableMaxOutputTokens,
+  RESERVE_FLOOR_TOKENS,
+} from "@appstrate/core/token-budget";
+
+describe("isUsableMaxOutputTokens", () => {
+  it("accepts a positive cap strictly below the window", () => {
+    expect(isUsableMaxOutputTokens(64_000, 200_000)).toBe(true);
+    expect(isUsableMaxOutputTokens(1, 2)).toBe(true);
+  });
+
+  it("rejects a cap that equals or exceeds the window (canonical invariant)", () => {
+    expect(isUsableMaxOutputTokens(256_000, 256_000)).toBe(false);
+    expect(isUsableMaxOutputTokens(300_000, 256_000)).toBe(false);
+  });
+
+  it("rejects null, undefined, non-finite, and non-positive caps", () => {
+    expect(isUsableMaxOutputTokens(null, 200_000)).toBe(false);
+    expect(isUsableMaxOutputTokens(undefined, 200_000)).toBe(false);
+    expect(isUsableMaxOutputTokens(0, 200_000)).toBe(false);
+    expect(isUsableMaxOutputTokens(-1, 200_000)).toBe(false);
+    expect(isUsableMaxOutputTokens(NaN, 200_000)).toBe(false);
+    expect(isUsableMaxOutputTokens(Infinity, 200_000)).toBe(false);
+  });
+});
+
+describe("deriveResponseReserveTokens", () => {
+  it("honours a usable explicit maxTokens verbatim (no behaviour change)", () => {
+    // Claude Sonnet thinking @ 64k on a 200k window must stay 64k.
+    expect(deriveResponseReserveTokens(200_000, 64_000)).toBe(64_000);
+  });
+
+  it("derives max(floor, 20% × window) when maxTokens is missing", () => {
+    expect(deriveResponseReserveTokens(200_000, null)).toBe(40_000);
+    expect(deriveResponseReserveTokens(200_000, undefined)).toBe(40_000);
+    // Floor wins on small windows: 50_000 × 0.2 = 10_000 < 16_384.
+    expect(deriveResponseReserveTokens(50_000, null)).toBe(RESERVE_FLOOR_TOKENS);
+  });
+
+  it("clamps an impossible maxTokens == contextWindow to the derived default", () => {
+    // Devstral 2512 regression: 256k window, bogus 256k max output.
+    expect(deriveResponseReserveTokens(256_000, 256_000)).toBe(51_200);
+  });
+
+  it("clamps maxTokens > contextWindow to the derived default", () => {
+    expect(deriveResponseReserveTokens(128_000, 200_000)).toBe(
+      Math.max(RESERVE_FLOOR_TOKENS, Math.floor(128_000 * 0.2)),
+    );
+  });
+
+  it("never returns a reserve >= contextWindow, even for tiny windows", () => {
+    for (const ctx of [500, 1_000, 8_000, 32_000, 128_000, 256_000, 1_000_000]) {
+      for (const max of [null, ctx, ctx + 1, ctx * 2, Math.floor(ctx / 2)]) {
+        const reserve = deriveResponseReserveTokens(ctx, max);
+        expect(reserve).toBeGreaterThan(0);
+        expect(reserve).toBeLessThan(ctx);
+      }
+    }
+  });
+
+  it("caps an explicit near-window maxTokens under the 80% ceiling", () => {
+    // 95k on a 100k window would leave only 5% for the prompt — clamp it.
+    expect(deriveResponseReserveTokens(100_000, 95_000)).toBe(80_000);
+  });
+});

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -39,6 +39,7 @@ import {
   type Model,
 } from "./pi-sdk.ts";
 import type { ModelApiShape } from "@appstrate/core/sidecar-types";
+import { deriveResponseReserveTokens } from "@appstrate/core/token-budget";
 import type { RunEvent, ExecutionContext } from "@appstrate/afps-runtime/types";
 import {
   emptyRunResult,
@@ -106,14 +107,6 @@ export interface PiRunnerOptions {
 }
 
 /**
- * Default response budget when the model carries no `maxTokens`.
- * 16384 covers the common "no thinking" Claude / GPT response shape;
- * larger budgets (Sonnet thinking @ 64 k) override via `model.maxTokens`.
- * Keep in sync with `runtime-pi/sidecar/token-budget.ts` — both surfaces
- * must agree so the spill guard and the compaction threshold do not drift.
- */
-const DEFAULT_RESERVE_TOKENS = 16_384;
-/**
  * Fallback context window when the model omits it. Matches the Claude
  * family's standard 200 k window — the most common runtime target.
  */
@@ -136,7 +129,7 @@ const KEEP_RECENT_FRACTION = 0.1;
  *
  * | Knob               | Mapping                                | Why                                                                                                                                                                              |
  * |--------------------|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
- * | `reserveTokens`    | `model.maxTokens ?? 16384`             | Response budget. MUST be ≥ `max_tokens` or the first call post-compaction underflows and the upstream 400 ("prompt is too long") reappears. Critical for Claude Sonnet thinking mode (`maxTokens: 64000`). |
+ * | `reserveTokens`    | `deriveResponseReserveTokens(ctx, max)`| Response budget. Honours `max_tokens` so the first call post-compaction does not underflow into the upstream 400 ("prompt is too long") — critical for Claude Sonnet thinking mode (`maxTokens: 64000`). An impossible `max_tokens >= contextWindow` (corrupt catalog data) is clamped to a derived default instead of pinning the threshold at ≤0. |
  * | `keepRecentTokens` | `max(20000, 10% × contextWindow)`      | Preserves the ratio across model sizes: 20k on Claude 200k, ~100k on GPT-4.1 1M, ~200k on Gemini 2M. The floor stops small windows from over-compacting away recent context.    |
  *
  * Operators can disable compaction entirely with
@@ -150,7 +143,12 @@ export function derivePiCompactionSettings(
 ): { enabled: false } | { enabled: true; reserveTokens: number; keepRecentTokens: number } {
   if (env["MODEL_COMPACTION_ENABLED"] === "false") return { enabled: false };
   const contextWindow = model.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
-  const reserveTokens = model.maxTokens ?? DEFAULT_RESERVE_TOKENS;
+  // Shared clamp (see `@appstrate/core/token-budget`): honours a usable
+  // `maxTokens`, but treats an impossible `maxTokens >= contextWindow`
+  // (corrupt catalog/override data) as unset and derives a sane reserve —
+  // otherwise the compaction threshold `contextWindow - reserveTokens`
+  // collapses to ≤0 and the agent compacts on every turn.
+  const reserveTokens = deriveResponseReserveTokens(contextWindow, model.maxTokens);
   const keepRecentTokens = Math.max(
     MIN_KEEP_RECENT_TOKENS,
     Math.floor(contextWindow * KEEP_RECENT_FRACTION),

--- a/packages/runner-pi/test/pi-runner-compaction.test.ts
+++ b/packages/runner-pi/test/pi-runner-compaction.test.ts
@@ -25,16 +25,28 @@ describe("derivePiCompactionSettings — reserveTokens", () => {
     expect(result.reserveTokens).toBe(64_000);
   });
 
-  it("falls back to 16384 when model.maxTokens is null", () => {
+  it("derives max(16384, 20% × window) when model.maxTokens is null", () => {
+    // Now routed through the shared `deriveResponseReserveTokens`, which
+    // matches the sidecar's spill guard: 200k × 0.2 = 40 000.
     const result = derivePiCompactionSettings({ contextWindow: 200_000, maxTokens: null }, {});
     if (result.enabled === false) throw new Error("compaction should be enabled");
-    expect(result.reserveTokens).toBe(16_384);
+    expect(result.reserveTokens).toBe(40_000);
   });
 
-  it("falls back to 16384 when model.maxTokens is undefined", () => {
+  it("derives max(16384, 20% × window) when model.maxTokens is undefined", () => {
     const result = derivePiCompactionSettings({ contextWindow: 200_000 }, {});
     if (result.enabled === false) throw new Error("compaction should be enabled");
-    expect(result.reserveTokens).toBe(16_384);
+    expect(result.reserveTokens).toBe(40_000);
+  });
+
+  it("clamps an impossible maxTokens == contextWindow (Devstral 2512 regression)", () => {
+    // Bogus catalog data (max_output_tokens == context_window) must not
+    // pin the threshold at contextWindow - reserveTokens <= 0, which made
+    // the agent compact on every turn. Falls back to the derived default.
+    const result = derivePiCompactionSettings({ contextWindow: 256_000, maxTokens: 256_000 }, {});
+    if (result.enabled === false) throw new Error("compaction should be enabled");
+    expect(result.reserveTokens).toBe(51_200);
+    expect(result.reserveTokens).toBeLessThan(256_000);
   });
 });
 

--- a/runtime-pi/sidecar/test/token-budget-integration.test.ts
+++ b/runtime-pi/sidecar/test/token-budget-integration.test.ts
@@ -593,6 +593,45 @@ describe("token-aware spill — env-var configuration via createApp", () => {
       else process.env.SIDECAR_INLINE_TOOL_OUTPUT_TOKENS = original;
     }
   });
+
+  it("boots (does not throw) when modelMaxTokens == modelContextWindow — the run_b6e99890 regression", () => {
+    // Exercises the EXACT crash site (`buildSidecarRuntimeDeps`), not just
+    // the TokenBudget constructor: the launcher forwards a resolved model's
+    // `(contextWindow, maxTokens)` verbatim, and Devstral 2512 carries the
+    // impossible `256000 / 256000` from the LiteLLM catalog. Pre-fix this
+    // threw → sidecar exited code 1 → no heartbeat → run failed after 60s.
+    const appDeps = makeDeps({
+      config: {
+        platformApiUrl: "http://mock:3000",
+        runToken: "tok",
+        proxyUrl: "",
+        modelContextWindow: 256_000,
+        modelMaxTokens: 256_000,
+      },
+    });
+    let runtimeDeps!: ReturnType<typeof buildSidecarRuntimeDeps>;
+    expect(() => {
+      runtimeDeps = buildSidecarRuntimeDeps(appDeps);
+    }).not.toThrow();
+    expect(runtimeDeps.tokenBudget.contextWindowTokens).toBe(256_000);
+    // Impossible cap dropped → derived default max(16384, 256000 × 0.2).
+    expect(runtimeDeps.tokenBudget.reserveTokens).toBe(51_200);
+    expect(runtimeDeps.tokenBudget.reserveTokens).toBeLessThan(256_000);
+  });
+
+  it("keeps a valid modelMaxTokens (< window) as the reserve at the wiring layer", () => {
+    const appDeps = makeDeps({
+      config: {
+        platformApiUrl: "http://mock:3000",
+        runToken: "tok",
+        proxyUrl: "",
+        modelContextWindow: 200_000,
+        modelMaxTokens: 64_000, // Claude Sonnet thinking — must be preserved
+      },
+    });
+    const runtimeDeps = buildSidecarRuntimeDeps(appDeps);
+    expect(runtimeDeps.tokenBudget.reserveTokens).toBe(64_000);
+  });
 });
 
 describe("token-aware spill — fallback when blob store is full", () => {

--- a/runtime-pi/sidecar/test/token-budget.test.ts
+++ b/runtime-pi/sidecar/test/token-budget.test.ts
@@ -458,15 +458,31 @@ describe("TokenBudget — context-window guard (#464)", () => {
     ).toThrow(/positive integer/);
   });
 
-  it("rejects reserveTokens ≥ contextWindowTokens (would leave zero room for tools)", () => {
-    expect(
-      () =>
-        new TokenBudget({
-          inlineCapTokens: 100,
-          runBudgetTokens: 1_000,
-          contextWindowTokens: 1_000,
-          reserveTokens: 1_000,
-        }),
-    ).toThrow(/strictly less than/);
+  it("clamps an impossible reserveTokens ≥ contextWindowTokens instead of throwing", () => {
+    // A corrupt catalog/override (max_output_tokens == context_window — a
+    // known LiteLLM data bug for devstral, kimi-k2.5, …) must degrade
+    // gracefully, never crash the sidecar at boot. The shared clamp drops
+    // the impossible cap and derives a reserve strictly below the window.
+    const b = new TokenBudget({
+      inlineCapTokens: 100,
+      runBudgetTokens: 1_000,
+      contextWindowTokens: 1_000,
+      reserveTokens: 1_000,
+    });
+    expect(b.contextWindowTokens).toBe(1_000);
+    expect(b.reserveTokens).toBeLessThan(1_000);
+    expect(b.reserveTokens).toBeGreaterThan(0);
+  });
+
+  it("clamps the real-world Devstral 2512 case (256k window, 256k bogus maxTokens)", () => {
+    const b = new TokenBudget({
+      inlineCapTokens: 10_000,
+      runBudgetTokens: 500_000,
+      contextWindowTokens: 256_000,
+      reserveTokens: 256_000, // bogus max_output_tokens == context_window
+    });
+    expect(b.contextWindowTokens).toBe(256_000);
+    // Falls back to the derived default: max(16384, 256000 × 0.2) = 51 200.
+    expect(b.reserveTokens).toBe(51_200);
   });
 });

--- a/runtime-pi/sidecar/token-budget.ts
+++ b/runtime-pi/sidecar/token-budget.ts
@@ -64,17 +64,7 @@
  */
 
 import { readPositiveIntEnv } from "./helpers.ts";
-
-/**
- * Floor on the derived response reserve when only `contextWindowTokens`
- * is supplied (no explicit `maxTokens` from the resolved model). 16384
- * covers the common "no thinking" Claude / GPT response shape; larger
- * budgets (Sonnet thinking @ 64 k) come through `reserveTokens` directly.
- * Keep in sync with `packages/runner-pi/src/pi-runner.ts` —
- * `derivePiCompactionSettings` uses the same default so the spill guard
- * and Pi SDK's compaction threshold agree for the same model.
- */
-const DEFAULT_RESERVE_FLOOR_TOKENS = 16_384;
+import { deriveResponseReserveTokens } from "@appstrate/core/token-budget";
 
 /**
  * Anthropic-recommended chars-per-token ratio for offline estimation.
@@ -232,23 +222,6 @@ export interface TokenBudgetOptions {
 }
 
 /**
- * Fraction of the context window to reserve for the model's response
- * when no explicit `reserveTokens` (or `maxTokens` on the upstream
- * model) is supplied. 20 % covers Sonnet thinking @ 64 k on a 200 k
- * window without overshooting; smaller windows scale down naturally.
- * Floored by {@link DEFAULT_RESERVE_FLOOR_TOKENS}.
- */
-const DEFAULT_RESERVE_FRACTION = 0.2;
-
-function deriveReserveTokens(contextWindowTokens: number, explicit: number | undefined): number {
-  if (explicit !== undefined) return explicit;
-  return Math.max(
-    DEFAULT_RESERVE_FLOOR_TOKENS,
-    Math.floor(contextWindowTokens * DEFAULT_RESERVE_FRACTION),
-  );
-}
-
-/**
  * Read a positive-integer token cap from an env var, falling back to
  * `defaultValue` when unset/empty. Delegates to {@link readPositiveIntEnv}
  * from `helpers.ts` with `unit: "tokens"` so misconfiguration fails loud
@@ -313,12 +286,11 @@ export class TokenBudget {
           `TokenBudget: contextWindowTokens must be a positive integer when set, got ${ctx}`,
         );
       }
-      const reserve = deriveReserveTokens(ctx, options.reserveTokens);
-      if (reserve >= ctx) {
-        throw new Error(
-          `TokenBudget: reserveTokens (${reserve}) must be strictly less than contextWindowTokens (${ctx}).`,
-        );
-      }
+      // `deriveResponseReserveTokens` guarantees `reserve < ctx`: it treats
+      // an impossible `maxTokens >= ctx` (corrupt catalog/override data) as
+      // unusable and falls back to a derived default rather than throwing —
+      // a bad datum must degrade gracefully, never crash the sidecar at boot.
+      const reserve = deriveResponseReserveTokens(ctx, options.reserveTokens);
       this.contextWindowTokens = ctx;
       this.reserveTokens = reserve;
     } else {

--- a/scripts/refresh-pricing-catalog.ts
+++ b/scripts/refresh-pricing-catalog.ts
@@ -236,10 +236,24 @@ function projectEntry(id: string, entry: LiteLLMEntry): CompactEntry | null {
     cost.cacheWrite = round(entry.cache_creation_input_token_cost * PER_MILLION);
   }
 
+  // Canonical model invariant: a request spends `input + output` from the
+  // same window, so `max_output_tokens < context_window` always holds.
+  // LiteLLM reports `max_output_tokens == max_input_tokens` for a class of
+  // models (devstral, kimi-k2.5, several grok/mistral entries) — a known
+  // upstream data bug (LiteLLM #22478). Drop the impossible value to null
+  // so the runtime derives a sane response reserve instead of inheriting a
+  // cap that swallows the whole window (which crashes the sidecar at boot
+  // and pins the compaction threshold at zero). See `@appstrate/core/token-budget`.
+  const contextWindow = entry.max_input_tokens;
+  const maxTokens =
+    typeof entry.max_output_tokens === "number" && entry.max_output_tokens < contextWindow
+      ? entry.max_output_tokens
+      : null;
+
   return {
     label: deriveLabel(id),
-    contextWindow: entry.max_input_tokens,
-    maxTokens: typeof entry.max_output_tokens === "number" ? entry.max_output_tokens : null,
+    contextWindow,
+    maxTokens,
     capabilities: caps,
     cost,
   };


### PR DESCRIPTION
## Root cause

Run [`run_b6e99890`](https://app.appstrate.com/agents/@tractr/client-email-dispatch/runs/run_b6e99890-f548-4266-bfe7-f36dbcb9dc42) failed with *"Runner stopped reporting — no heartbeat for 60s"*. The sidecar crashed **at boot**, before any heartbeat:

```
error: TokenBudget: reserveTokens (256000) must be strictly less than contextWindowTokens (256000).
"msg":"Sidecar exited before run completed"
```

Model = **Devstral 2512** (`context_window=256000`, `max_tokens=256000`). The sidecar's `TokenBudget` enforces `reserveTokens < contextWindowTokens`, with `reserve` sourced from the model's `maxTokens`. When `maxTokens == contextWindow` the constructor threw → no heartbeat → run failed after 60s.

The **same** `maxTokens` feeds `derivePiCompactionSettings` in `runner-pi`, pinning the compaction threshold at `contextWindow - reserveTokens <= 0` → the agent compacts every turn. Independent of the crash, hits the no-sidecar/agent path too.

## Not corrupt data — a known upstream convention

The canonical model invariant is `input + output <= context`, so `max_output_tokens` is always strictly below the window; `output == context` is impossible. **LiteLLM and models.dev both** report `output == context` for a class of models (devstral, kimi-k2.5, several grok/mistral entries) — a known upstream bug ([LiteLLM #22478](https://github.com/BerriAI/litellm/issues/22478)). Our catalog faithfully mirrors it. 348 vendored entries across 9 providers carry the impossible value. Because the data sources can't be trusted, robustness lives at consumption, with ingest sanitization as defense.

## Fix — defense in depth

| Layer | Change |
|---|---|
| **Runtime (shared)** | New `@appstrate/core/token-budget.deriveResponseReserveTokens` — single source of truth, guarantees `reserve < contextWindow`. Consumed by both `TokenBudget` (sidecar) and `derivePiCompactionSettings` (runner-pi), which previously duplicated the `maxTokens → reserve` mapping under a *"keep in sync"* comment. |
| **Runtime** | `TokenBudget` no longer throws on `reserve >= ctx` — it clamps to a derived default. A bad datum degrades; it never crashes the sidecar at boot. |
| **Ingest** | `refresh-pricing-catalog.ts` nulls `max_output_tokens >= context_window`; the 348 affected vendored entries are sanitized in this PR. |
| **Edge** | `routes/models.ts` rejects `maxTokens >= contextWindow` (create + update). |

### Behaviour notes
- Valid models are untouched: a usable `maxTokens` (`< contextWindow`) is honoured verbatim (e.g. Sonnet thinking 64k on a 200k window stays 64k), capped only by an 80% ceiling.
- `runner-pi`'s null-`maxTokens` fallback changes from a flat `16384` to `max(16384, 20% × window)` — now identical to the sidecar's derivation (the *"keep in sync"* intent made real).
- The `updateModelSchema` refine only catches violations present in the same payload; the runtime clamp is the authoritative guarantee.

## Tests
- Core helper: usable/clamp/never-exceeds-window, tiny-window sweep.
- Sidecar `TokenBudget`: clamp instead of throw, Devstral 256k regression.
- `runner-pi` compaction: clamp, Devstral 256k regression.
- On-disk catalog invariant, asserted per provider file (guards future bad refreshes).
- Route `400` for `maxTokens >= contextWindow`.

Local: `tsc`, `eslint`, `prettier`, `verify-openapi`, and the runtime-pi / runner-pi / api-unit suites all pass (1795 + 698 tests green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)