### PR TITLE
fix(pricing): format featured-models.json with prettier

### DIFF
--- a/apps/api/src/data/featured-models.json
+++ b/apps/api/src/data/featured-models.json
@@ -1,60 +1,18 @@
 {
-  "anthropic": [
-    "claude-fable-5",
-    "claude-opus-4-8",
-    "claude-opus-4-7"
-  ],
-  "cerebras": [
-    "zai-glm-4.7",
-    "gpt-oss-120b"
-  ],
-  "deepseek": [
-    "deepseek-v4-flash",
-    "deepseek-v4-pro",
-    "deepseek-chat"
-  ],
+  "anthropic": ["claude-fable-5", "claude-opus-4-8", "claude-opus-4-7"],
+  "cerebras": ["zai-glm-4.7", "gpt-oss-120b"],
+  "deepseek": ["deepseek-v4-flash", "deepseek-v4-pro", "deepseek-chat"],
   "fireworks-ai": [
     "accounts/fireworks/models/glm-5p2",
     "accounts/fireworks/models/kimi-k2p7-code",
     "accounts/fireworks/models/minimax-m3"
   ],
-  "google-ai": [
-    "gemini-3.5-flash",
-    "gemini-3.1-flash-lite",
-    "gemini-3.1-flash-lite-preview"
-  ],
-  "groq": [
-    "openai/gpt-oss-safeguard-20b",
-    "openai/gpt-oss-120b",
-    "openai/gpt-oss-20b"
-  ],
-  "mistral": [
-    "mistral-small-latest",
-    "devstral-2512",
-    "devstral-latest"
-  ],
-  "moonshot": [
-    "kimi-k2.6",
-    "kimi-k2.5",
-    "kimi-k2-thinking"
-  ],
-  "openai": [
-    "gpt-5.5",
-    "gpt-5.4-mini",
-    "gpt-5.4-nano"
-  ],
-  "together-ai": [
-    "Qwen/Qwen3.5-397B-A17B",
-    "moonshotai/Kimi-K2.5",
-    "openai/gpt-oss-120b"
-  ],
-  "xai": [
-    "grok-4.3",
-    "grok-4.20-0309-reasoning"
-  ],
-  "zai": [
-    "glm-5",
-    "glm-4.7",
-    "glm-4.6"
-  ]
+  "google-ai": ["gemini-3.5-flash", "gemini-3.1-flash-lite", "gemini-3.1-flash-lite-preview"],
+  "groq": ["openai/gpt-oss-safeguard-20b", "openai/gpt-oss-120b", "openai/gpt-oss-20b"],
+  "mistral": ["mistral-small-latest", "devstral-2512", "devstral-latest"],
+  "moonshot": ["kimi-k2.6", "kimi-k2.5", "kimi-k2-thinking"],
+  "openai": ["gpt-5.5", "gpt-5.4-mini", "gpt-5.4-nano"],
+  "together-ai": ["Qwen/Qwen3.5-397B-A17B", "moonshotai/Kimi-K2.5", "openai/gpt-oss-120b"],
+  "xai": ["grok-4.3", "grok-4.20-0309-reasoning"],
+  "zai": ["glm-5", "glm-4.7", "glm-4.6"]
 }


### PR DESCRIPTION
## Problem

The `Check` workflow is failing on `main`. `format:check` (prettier) exits 1 because `apps/api/src/data/featured-models.json` is not prettier-formatted.

The file was committed by the weekly **Refresh pricing catalog** workflow (#732), which generates the JSON but does not run prettier before committing.

## Fix

`bunx prettier --write apps/api/src/data/featured-models.json`

## Follow-up (not in this PR)

Add a prettier-write step to the refresh workflow before it commits, otherwise this breaks again on the next weekly run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)