### PR TITLE
ci(pricing): run prettier on generated files in refresh workflow

### DIFF
--- a/.github/workflows/refresh-pricing-catalog.yml
+++ b/.github/workflows/refresh-pricing-catalog.yml
@@ -28,6 +28,14 @@ jobs:
       - name: Refresh catalog (apply)
         run: bun scripts/refresh-pricing-catalog.ts --apply
 
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Format generated files
+        # The generator writes JSON that does not match Prettier style;
+        # without this the drift PR breaks the Check workflow's format:check.
+        run: bunx prettier --write "apps/api/src/data/**"
+
       - name: Check for drift
         id: drift
         run: |


### PR DESCRIPTION
## Problem

The weekly **Refresh pricing catalog** workflow generates JSON under `apps/api/src/data/` that does not match Prettier style. `create-pull-request` commits all changes, so unformatted files land on `main` and break the `Check` workflow's `format:check` step (see #732 → fixed in #733).

## Fix

Add two steps after the catalog refresh and before the drift check:
- `bun install --frozen-lockfile`
- `bunx prettier --write "apps/api/src/data/**"`

This guarantees committed files (pricing + `featured-models.json`) are always Prettier-clean, preventing the next weekly run from re-breaking CI.

Companion to #733 (which fixes the file currently on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)