### PR TITLE
fix(runner-pi): emit MODEL_BASE_URL on the no-sidecar run path (#741)

### DIFF
--- a/apps/api/src/services/run-launcher/pi.ts
+++ b/apps/api/src/services/run-launcher/pi.ts
@@ -264,11 +264,12 @@ async function runPlatformContainerImpl(
       agentPrompt: prompt,
       runId,
       noSidecar: skipSidecar,
-      // Without a sidecar, MODEL_BASE_URL is omitted — the Pi SDK falls
-      // back to the api-shape's native default (e.g. api.openai.com).
-      // The model definition's baseUrl is already wired on the Model
-      // object via PiRunner; runtime-pi doesn't need MODEL_BASE_URL when
-      // talking directly to the upstream.
+      // Sidecar-backed runs route LLM traffic through the sidecar proxy
+      // (sidecarProxyLlmUrl below). No-sidecar runs talk to the upstream
+      // directly, so buildRuntimePiEnv derives MODEL_BASE_URL from the
+      // model's own baseUrl (passed in `model` above) — otherwise the Pi
+      // SDK falls back to the api-shape's native default (api.openai.com)
+      // and misroutes custom-baseUrl providers like DeepSeek. See #741.
       sidecarProxyLlmUrl: skipSidecar
         ? undefined
         : llmApiKey

--- a/packages/runner-pi/src/container-env.ts
+++ b/packages/runner-pi/src/container-env.ts
@@ -116,11 +116,21 @@ export function buildRuntimePiEnv(opts: RuntimePiEnvOptions): Record<string, str
   if (opts.runId) env.AGENT_RUN_ID = opts.runId;
   if (opts.agentInput !== undefined) env.AGENT_INPUT = JSON.stringify(opts.agentInput);
 
-  // MODEL_BASE_URL is only emitted when going through a proxy — Pi SDK
-  // falls back to upstream defaults when unset, so emitting an empty
-  // string would silently override the SDK's per-API defaults.
+  // MODEL_BASE_URL tells the Pi SDK where to send inference. Two cases set it:
+  //   1. Sidecar-backed run — point at the sidecar LLM proxy, which injects the
+  //      real credential and forwards to the upstream provider.
+  //   2. No-sidecar run (static API key, no integrations/proxy) — the agent talks
+  //      to the provider directly, so it needs the model's native endpoint.
+  // Without (2), MODEL_BASE_URL stays empty and the entrypoint falls back to the
+  // Pi SDK's per-`api` default (api.openai.com for `openai-*`), which silently
+  // misroutes every OpenAI-compatible provider with a custom base URL (DeepSeek,
+  // Mistral, z.ai, OpenRouter, …) to OpenAI. See issue #741.
+  // We never emit an empty string: an absent key keeps the SDK default for the
+  // few providers whose native default is already correct.
   if (opts.sidecarProxyLlmUrl) {
     env.MODEL_BASE_URL = opts.sidecarProxyLlmUrl;
+  } else if (opts.noSidecar && model.baseUrl) {
+    env.MODEL_BASE_URL = model.baseUrl;
   }
   if (model.apiKey) {
     const placeholder = model.apiKeyPlaceholder ?? model.apiKey;

--- a/packages/runner-pi/test/container-env.test.ts
+++ b/packages/runner-pi/test/container-env.test.ts
@@ -48,6 +48,46 @@ describe("buildRuntimePiEnv", () => {
     expect(env.MODEL_API_KEY).toBe("sk-test");
   });
 
+  // Regression: #741 — a no-sidecar run (static API key, no integrations/proxy)
+  // talks to the provider directly, so MODEL_BASE_URL must carry the model's
+  // native endpoint. Without it the Pi SDK falls back to api.openai.com and
+  // sends an OpenAI-compatible key (DeepSeek/Mistral/z.ai/…) to the wrong host.
+  it("emits the model's native baseUrl when the sidecar is skipped (#741)", () => {
+    const env = buildRuntimePiEnv({
+      model: {
+        api: "openai-completions",
+        modelId: "deepseek-chat",
+        baseUrl: "https://api.deepseek.com/v1",
+        apiKey: "sk-deepseek-secret",
+      },
+      agentPrompt: "p",
+      noSidecar: true,
+    });
+    expect(env.MODEL_BASE_URL).toBe("https://api.deepseek.com/v1");
+    // No-sidecar path hands the real key directly to the agent.
+    expect(env.MODEL_API_KEY).toBe("sk-deepseek-secret");
+  });
+
+  it("does not emit MODEL_BASE_URL when the sidecar is skipped but baseUrl is empty", () => {
+    const env = buildRuntimePiEnv({
+      model: { api: "openai-completions", modelId: "gpt-4o", baseUrl: "", apiKey: "sk-x" },
+      agentPrompt: "p",
+      noSidecar: true,
+    });
+    // Empty baseUrl → keep the SDK's native default rather than emit "".
+    expect(env.MODEL_BASE_URL).toBeUndefined();
+  });
+
+  it("prefers the sidecar proxy URL over the model baseUrl when both could apply", () => {
+    const env = buildRuntimePiEnv({
+      model: { ...model, baseUrl: "https://api.deepseek.com/v1", apiKey: "sk-x" },
+      agentPrompt: "p",
+      sidecarProxyLlmUrl: "http://sidecar:8080/llm",
+      noSidecar: true,
+    });
+    expect(env.MODEL_BASE_URL).toBe("http://sidecar:8080/llm");
+  });
+
   it("emits MODEL_INPUT / MODEL_COST / MODEL_CONTEXT_WINDOW / MODEL_MAX_TOKENS conditionally", () => {
     const env = buildRuntimePiEnv({
       model: {


### PR DESCRIPTION
## Problem

Closes #741.

A run that **skips the sidecar** (static API key + no integrations + no proxy + not OAuth + not aliased — `skipSidecar=true` in `run-launcher/pi.ts`) talks to the LLM provider directly. In that path `buildRuntimePiEnv` only emitted `MODEL_BASE_URL` when `sidecarProxyLlmUrl` was set, so the model's own `baseUrl` was **dropped**. The runtime entrypoint then read an empty `MODEL_BASE_URL` (`entrypoint.ts:593 baseUrl: env.modelBaseUrl ?? ""`) and the Pi SDK fell back to its api-shape default — `https://api.openai.com/v1` for `openai-*`.

Result: every **OpenAI-compatible provider with a custom base URL** (DeepSeek, Mistral, z.ai, OpenRouter, Lightning, …) was misrouted to OpenAI. A valid third-party key was sent to `api.openai.com` →

```
401 Incorrect API key provided: sk-d6950***...09b6. You can find your API key at https://platform.openai.com/account/api-keys.
```

The key was correct; the **endpoint** was wrong. Native `openai`/`anthropic` were unaffected (their api-shape default IS the right host), and any sidecar-backed run was fine (the sidecar `/llm` proxy forwards to `model.baseUrl`). Diagnostic trap: `POST /model-provider-credentials/{id}/test` resolves platform-side and returns `200`, masking the runtime misroute.

## Fix

Derive `MODEL_BASE_URL` from `model.baseUrl` on the no-sidecar path:

```ts
if (opts.sidecarProxyLlmUrl) {
  env.MODEL_BASE_URL = opts.sidecarProxyLlmUrl;
} else if (opts.noSidecar && model.baseUrl) {
  env.MODEL_BASE_URL = model.baseUrl;
}
```

- Scoped to `noSidecar` so the sidecar/OAuth paths are untouched.
- Empty `baseUrl` is still left unset — providers whose native default is already correct keep the SDK default; we never emit `""`.
- Corrects the stale launcher comment that wrongly claimed the baseUrl was already wired on the Model object via PiRunner.

## Tests

`packages/runner-pi/test/container-env.test.ts`:
- emits the model's native `baseUrl` when the sidecar is skipped (DeepSeek repro) + hands the real key to the agent
- does **not** emit `MODEL_BASE_URL` when skipped but `baseUrl` is empty
- sidecar proxy URL still takes precedence

Full `runner-pi` suite: **153 pass / 0 fail**. `bun run check` green (typecheck, lint, format, openapi, breaking-change, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)