### PR TITLE
test(run-launcher): fix stale MODEL_BASE_URL assertion (red CI on main)

### DIFF
--- a/apps/api/test/integration/services/run-launcher-no-sidecar.test.ts
+++ b/apps/api/test/integration/services/run-launcher-no-sidecar.test.ts
@@ -158,13 +158,15 @@ describe("run-launcher — sidecar skip decision", () => {
     expect(counts.createWorkloadCalls).toBe(1);
 
     // The agent env must not advertise a sidecar URL nor a forward proxy
-    // — both would point at a non-existent service. MODEL_BASE_URL should
-    // also be absent (Pi SDK falls back to the API's native default).
+    // — both would point at a non-existent service. MODEL_BASE_URL, however,
+    // MUST carry the model's own baseUrl on the no-sidecar path so the Pi
+    // SDK talks to the correct upstream instead of falling back to the
+    // api-shape's native default (api.openai.com). See #741.
     const env = counts.capturedAgentEnv ?? {};
     expect(env.SIDECAR_URL).toBeUndefined();
     expect(env.HTTP_PROXY).toBeUndefined();
     expect(env.HTTPS_PROXY).toBeUndefined();
-    expect(env.MODEL_BASE_URL).toBeUndefined();
+    expect(env.MODEL_BASE_URL).toBe("https://api.anthropic.com");
     // The real API key must reach the container — there's no sidecar to
     // substitute the placeholder back to the real value.
     expect(env.MODEL_API_KEY).toBe("sk-test-secret");


### PR DESCRIPTION
## Problem

Test CI has been red on `main` since #741. That PR changed the no-sidecar run path to emit `MODEL_BASE_URL` from the model's own `baseUrl` (so custom-baseUrl providers like DeepSeek route to the right upstream instead of falling back to `api.openai.com`). The no-sidecar integration test still asserted `MODEL_BASE_URL` was **undefined**, so it now fails:

```
(fail) run-launcher — sidecar skip decision > skips createSidecar when no integrations AND llm uses a static API key
error: expect(received).toBeUndefined()
```

## Fix

Update the assertion to expect the model's `baseUrl` (`https://api.anthropic.com`, set in the test's plan) and refresh the comment. Code under test is correct — only the stale test assertion changed.

Blocks the v1.0.0-beta.32 release (CI must be green before tagging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)