### PR TITLE
feat(anonymizer): reversible PII anonymization (module + LLM-proxy/sidecar seam)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
     "@appstrate/emails": "workspace:*",
     "@appstrate/env": "workspace:*",
     "@appstrate/mcp-transport": "workspace:*",
+    "@appstrate/module-anonymizer": "workspace:*",
     "@appstrate/module-claude-code": "workspace:*",
     "@appstrate/module-codex": "workspace:*",
     "@appstrate/runner-pi": "workspace:*",

--- a/apps/api/src/lib/modules/module-loader.ts
+++ b/apps/api/src/lib/modules/module-loader.ts
@@ -10,6 +10,7 @@ import type {
   ModuleEvents,
   AuthStrategy,
   ModulePermissionContribution,
+  LlmBodyTransformerFactory,
 } from "@appstrate/core/module";
 import { getErrorMessage } from "@appstrate/core/errors";
 import {
@@ -376,6 +377,22 @@ export function getModuleModelProviders(): readonly ModelProviderDefinition[] {
     }
   }
   return collected;
+}
+
+/**
+ * Resolve the LLM-proxy body transformer factory (the anonymization seam).
+ *
+ * Single-owner seam: returns the first loaded module's `llmBodyTransformer()`
+ * factory, or null when no module contributes. The factory is stable for the
+ * process lifetime (it may own a loaded model), so the proxy can call it on
+ * every request. OSS invariant: null when `MODULES` carries no anonymizer.
+ */
+export function getModuleLlmBodyTransformer(): LlmBodyTransformerFactory | null {
+  for (const mod of _modules.values()) {
+    const factory = mod.llmBodyTransformer?.();
+    if (factory) return factory;
+  }
+  return null;
 }
 
 /** Collect OpenAPI tags contributed by all loaded modules. */

--- a/apps/api/src/openapi/paths/internal.ts
+++ b/apps/api/src/openapi/paths/internal.ts
@@ -347,4 +347,62 @@ export const internalPaths = {
       },
     },
   },
+  "/internal/anonymize": {
+    post: {
+      operationId: "anonymizeForRun",
+      tags: ["Internal"],
+      summary: "Mask PII in an LLM request body (or arbitrary value) for a run",
+      description:
+        "Sidecar-only (palier b2). Auth via Bearer run token. Masks PII for the run's outbound LLM traffic — the platform lends its shared detector while the sidecar holds the run's token↔value mapping (Option S). Provide exactly one of `body` (base64-encoded LLM request body, field-targeted masking) or `value` (arbitrary JSON, deep masking for the tool path), plus the run's current `mapping`. Returns the masked payload + the updated mapping. Restore is NOT here — it needs no detection and the sidecar does it locally.",
+      security: [{ bearerExecToken: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                body: {
+                  type: "string",
+                  description: "Base64-encoded LLM request body (field-targeted masking).",
+                },
+                value: { description: "Arbitrary JSON value (deep masking, tool path)." },
+                mapping: {
+                  type: "object",
+                  additionalProperties: { type: "string" },
+                  description:
+                    "The run's current token→value table (empty on the run's first call).",
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "200": {
+          description: "Masked payload + updated mapping.",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["mapping"],
+                properties: {
+                  body: {
+                    type: "string",
+                    description: "Masked body (base64), when `body` was sent.",
+                  },
+                  value: { description: "Masked value, when `value` was sent." },
+                  mapping: { type: "object", additionalProperties: { type: "string" } },
+                },
+              },
+            },
+          },
+        },
+        "400": { $ref: "#/components/responses/ValidationError" },
+        "401": { $ref: "#/components/responses/Unauthorized" },
+        "403": { $ref: "#/components/responses/Forbidden" },
+        "404": { $ref: "#/components/responses/NotFound" },
+      },
+    },
+  },
 } as const;

--- a/apps/api/src/routes/internal.ts
+++ b/apps/api/src/routes/internal.ts
@@ -37,7 +37,9 @@ import {
   notFound,
   invalidRequest,
   internalError,
+  parseBody,
 } from "../lib/errors.ts";
+import { getModuleLlmBodyTransformer } from "../lib/modules/module-loader.ts";
 import { actorFromIds, type Actor } from "../lib/actor.ts";
 import {
   forceRefreshOAuthModelProviderToken,
@@ -50,6 +52,13 @@ import {
 import { readIntegrationManifestForRun } from "../services/integration-service.ts";
 import { getLocalServerRef } from "../services/integration-manifest-helpers.ts";
 import { isIntegrationActive } from "../services/integration-connections.ts";
+
+/** Body of POST /internal/anonymize: a base64-encoded LLM request body + the
+ * run's current token↔value mapping (empty on the first call of a run). */
+const anonymizeRequestSchema = z.object({
+  body: z.string(),
+  mapping: z.record(z.string(), z.string()).default({}),
+});
 
 /**
  * Verify the run token from the Authorization header.
@@ -524,6 +533,27 @@ export function createInternalRouter() {
     });
     throw notFound(`mcp-server '${mcpServerId}' is not referenced by the running agent`);
   }
+
+  // POST /internal/anonymize — mask ONE LLM request body for a run (b2).
+  //
+  // Stateless seam: the per-run sidecar owns the mapping (Option S — the table
+  // lives with the run, not on the platform) and threads it in/out. The
+  // platform only lends its shared detector; it keeps no per-run state. Restore
+  // is NOT here — it needs no detection, the sidecar does it locally.
+  //
+  // 404 when no anonymizer module is loaded: the sidecar only calls this when
+  // anonymization is enabled for the run, which requires the module.
+  router.post("/anonymize", async (c) => {
+    await verifyRunToken(c); // any valid run token may mask its own traffic
+    const factory = getModuleLlmBodyTransformer();
+    if (!factory) throw notFound("anonymizer module not loaded");
+    const { body, mapping } = parseBody(anonymizeRequestSchema, await c.req.json());
+    const masked = await factory.maskLlmBody(Buffer.from(body, "base64"), mapping);
+    return c.json({
+      body: Buffer.from(masked.body).toString("base64"),
+      mapping: masked.mapping,
+    });
+  });
 
   return router;
 }

--- a/apps/api/src/services/llm-proxy/core.ts
+++ b/apps/api/src/services/llm-proxy/core.ts
@@ -29,6 +29,7 @@ import { parseProxyRequest } from "./helpers.ts";
 import type { LlmProxyAdapter, LlmProxyPrincipal, UpstreamUsage } from "./types.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
 import type { ModelCost } from "@appstrate/core/module";
+import { getModuleLlmBodyTransformer } from "../../lib/modules/module-loader.ts";
 import type { ModelSwap } from "@appstrate/core/sidecar-types";
 import {
   swapResponseModelJson,
@@ -129,6 +130,19 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
     cacheKeyForWrite = probe.cacheKey;
   }
 
+  // PII anonymization seam (module-anonymizer). Absent module → null → bodies
+  // forwarded untouched (zero footprint). ONE transformer per call so the mask
+  // table built for the request is the one that restores its own response.
+  // Built after the cache lookup: a cache hit already returned a restored body.
+  const anonymizer =
+    getModuleLlmBodyTransformer()?.create({
+      runId: inputs.runId,
+      orgId: inputs.principal.orgId,
+    }) ?? null;
+  const restorePii = (text: string): Promise<string> =>
+    anonymizer ? anonymizer.restoreResponse(text) : Promise.resolve(text);
+  const outboundBody = anonymizer ? await anonymizer.maskRequest(rewrittenBody) : rewrittenBody;
+
   const upstreamUrl = joinUpstreamUrl(resolved.baseUrl, inputs.upstreamPath);
   const upstreamHeaders = inputs.adapter.buildUpstreamHeaders(
     inputs.incomingHeaders,
@@ -141,7 +155,7 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
     upstream = await fetchImpl(upstreamUrl, {
       method: "POST",
       headers: upstreamHeaders,
-      body: rewrittenBody,
+      body: outboundBody,
     });
   } catch (err) {
     logger.error("llm-proxy: upstream fetch failed", {
@@ -164,8 +178,9 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
     const errorBody = await upstream.text();
     const headers = cloneResponseHeaders(upstream.headers);
     // Error bodies are free-form prose that may name the real id ("model
-    // deepseek-chat does not exist") — blind-scrub it back to the alias.
-    const clientBody = swap ? scrubModelText(errorBody, swap) : errorBody;
+    // deepseek-chat does not exist") — blind-scrub it back to the alias, then
+    // restore any PII tokens the upstream echoed into its message.
+    const clientBody = await restorePii(swap ? scrubModelText(errorBody, swap) : errorBody);
     return new Response(clientBody, { status: upstream.status, headers });
   }
 
@@ -182,12 +197,14 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
       }),
     );
     const headers = cloneResponseHeaders(upstream.headers);
-    // Rewrite the echoed real id back to the alias in every SSE frame. The tap
-    // above reads the untouched `tapStream`, so accounting still sees the real
-    // id; only the client-facing copy is swapped.
-    const clientStream2 = swap
+    // Rewrite the echoed real id back to the alias in every SSE frame, then
+    // restore PII tokens per frame. The tap above reads the untouched
+    // `tapStream`, so accounting still sees the real id and the masked tokens;
+    // only the client-facing copy is swapped + restored.
+    let clientStream2 = swap
       ? clientStream.pipeThrough(createSseModelSwapStream(swap))
       : clientStream;
+    if (anonymizer) clientStream2 = clientStream2.pipeThrough(anonymizer.restoreResponseStream());
     return new Response(clientStream2, {
       status: upstream.status,
       headers,
@@ -204,9 +221,9 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
   } catch {
     // Upstream advertised a non-JSON content-type but still returned a
     // non-SSE body — forward without metering. Scrub any real id from the
-    // free-form body for aliases.
+    // free-form body for aliases, then restore PII tokens.
     const headers = cloneResponseHeaders(upstream.headers);
-    const clientBody = swap ? scrubModelText(bodyText, swap) : bodyText;
+    const clientBody = await restorePii(swap ? scrubModelText(bodyText, swap) : bodyText);
     return new Response(clientBody, { status: upstream.status, headers });
   }
 
@@ -229,9 +246,10 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
   }
 
   const headers = cloneResponseHeaders(upstream.headers);
-  // Rewrite the echoed real id back to the alias before the body leaves the
-  // server — and BEFORE caching, so a replay returns the alias too.
-  const clientBody = swap ? swapResponseModelJson(bodyText, swap) : bodyText;
+  // Rewrite the echoed real id back to the alias AND restore PII tokens before
+  // the body leaves the server — and BEFORE caching, so a replay returns the
+  // alias + the restored (real) values too.
+  const clientBody = await restorePii(swap ? swapResponseModelJson(bodyText, swap) : bodyText);
   // Persist 2xx replies for future lookups. Tag the MISS so the caller
   // sees a consistent `x-llm-proxy-cache-status` contract whether the
   // cache is enabled or off.

--- a/apps/api/src/services/orchestrator/sidecar-env.ts
+++ b/apps/api/src/services/orchestrator/sidecar-env.ts
@@ -30,6 +30,11 @@ export function applySpecToSidecarEnv(
   if (spec.modelMaxTokens != null) {
     target.MODEL_MAX_TOKENS = String(spec.modelMaxTokens);
   }
+  if (spec.anonymize) {
+    // PII anonymization on for this run — the sidecar masks LLM traffic through
+    // the platform's /internal/anonymize endpoint (palier b2).
+    target.ANONYMIZE = "1";
+  }
   if (spec.llm) {
     if (spec.llm.authMode === "oauth") {
       // OAuth wire format: ship the LlmProxyOauthConfig as JSON so

--- a/apps/api/src/services/run-launcher/pi.ts
+++ b/apps/api/src/services/run-launcher/pi.ts
@@ -49,6 +49,7 @@ import type {
   LlmProxyOauthConfig,
   SidecarLaunchSpec,
 } from "@appstrate/core/sidecar-types";
+import { getModuleLlmBodyTransformer } from "../../lib/modules/module-loader.ts";
 
 /** Terminal state reported back to the caller once the container has exited. */
 export interface PlatformContainerResult {
@@ -162,6 +163,12 @@ async function runPlatformContainerImpl(
     // is the ONLY path that routes agent egress through it — skipping the
     // sidecar would silently drop the proxy and leak the host IP.
     const hasIntegrations = (plan.integrations?.length ?? 0) > 0;
+    // PII anonymization (palier b2) is a FIFTH reason the sidecar is mandatory:
+    // the masking of the agent's outbound LLM body lives in the sidecar's
+    // `/llm` proxy. Skipping it (api_key + no integrations) would hand the agent
+    // the real endpoint and leak the PII unmasked — so anonymization forces the
+    // sidecar on. Same gate as the spec's `anonymize` flag below.
+    const anonymizeEnabled = !!getModuleLlmBodyTransformer();
     // A model alias MUST route through the sidecar — that's the only place the
     // `model` alias→real swap happens. Skipping it would hand the agent the
     // real backing id (in its own request) and the provider's real endpoint.
@@ -170,7 +177,8 @@ async function runPlatformContainerImpl(
       !!llmConfig.apiKey &&
       !isOauthCredential &&
       !plan.proxyUrl &&
-      !llmConfig.aliased;
+      !llmConfig.aliased &&
+      !anonymizeEnabled;
 
     // Model-alias swap descriptor (LLM-gateway alias pattern). The container is
     // handed the public alias as MODEL_ID (below); the sidecar swaps it for the
@@ -218,6 +226,10 @@ async function runPlatformContainerImpl(
       // sidecar applies a conservative fallback when either is unset.
       ...(llmConfig.contextWindow != null ? { modelContextWindow: llmConfig.contextWindow } : {}),
       ...(llmConfig.maxTokens != null ? { modelMaxTokens: llmConfig.maxTokens } : {}),
+      // PII anonymization (palier b2): on iff an anonymizer module is loaded, so
+      // the sidecar's /internal/anonymize calls are guaranteed to resolve. The
+      // same gate forces `skipSidecar` off above (masking needs the sidecar).
+      ...(anonymizeEnabled ? { anonymize: true } : {}),
       // Phase 1.4 — integrations the sidecar will spawn + multiplex onto
       // the agent-facing `/mcp` surface. Resolved upstream by
       // `resolveIntegrationSpawns` (run-context-builder).

--- a/apps/api/test/unit/services/sidecar-env.test.ts
+++ b/apps/api/test/unit/services/sidecar-env.test.ts
@@ -82,5 +82,16 @@ describe("applySpecToSidecarEnv", () => {
     expect(env.INTEGRATIONS_TO_SPAWN_JSON).toBeUndefined();
     expect(env.OUTPUT_SCHEMA).toBeUndefined();
     expect(env.CONNECT_LOGIN_JSON).toBeUndefined();
+    expect(env.ANONYMIZE).toBeUndefined(); // off by default → zero footprint
+  });
+
+  it("sets ANONYMIZE=1 only when the spec enables anonymization", () => {
+    const on: Record<string, string> = {};
+    applySpecToSidecarEnv({ runToken: "rt", anonymize: true }, on);
+    expect(on.ANONYMIZE).toBe("1");
+
+    const off: Record<string, string> = {};
+    applySpecToSidecarEnv({ runToken: "rt", anonymize: false }, off);
+    expect(off.ANONYMIZE).toBeUndefined();
   });
 });

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -4022,6 +4022,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/internal/anonymize": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Mask PII in an LLM request body (or arbitrary value) for a run
+         * @description Sidecar-only (palier b2). Auth via Bearer run token. Masks PII for the run's outbound LLM traffic — the platform lends its shared detector while the sidecar holds the run's token↔value mapping (Option S). Provide exactly one of `body` (base64-encoded LLM request body, field-targeted masking) or `value` (arbitrary JSON, deep masking for the tool path), plus the run's current `mapping`. Returns the masked payload + the updated mapping. Restore is NOT here — it needs no detection and the sidecar does it locally.
+         */
+        post: operations["anonymizeForRun"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/internal/integration-credentials/{scope}/{name}": {
         parameters: {
             query?: never;
@@ -18312,6 +18332,51 @@ export interface operations {
                     };
                 };
             };
+        };
+    };
+    anonymizeForRun: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Base64-encoded LLM request body (field-targeted masking). */
+                    body?: string;
+                    /** @description Arbitrary JSON value (deep masking, tool path). */
+                    value?: unknown;
+                    /** @description The run's current token→value table (empty on the run's first call). */
+                    mapping?: {
+                        [key: string]: string;
+                    };
+                };
+            };
+        };
+        responses: {
+            /** @description Masked payload + updated mapping. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description Masked body (base64), when `body` was sent. */
+                        body?: string;
+                        /** @description Masked value, when `value` was sent. */
+                        value?: unknown;
+                        mapping: {
+                            [key: string]: string;
+                        };
+                    };
+                };
+            };
+            400: components["responses"]["ValidationError"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
         };
     };
     getIntegrationCredentials: {

--- a/bun.lock
+++ b/bun.lock
@@ -52,6 +52,7 @@
         "@appstrate/emails": "workspace:*",
         "@appstrate/env": "workspace:*",
         "@appstrate/mcp-transport": "workspace:*",
+        "@appstrate/module-anonymizer": "workspace:*",
         "@appstrate/module-claude-code": "workspace:*",
         "@appstrate/module-codex": "workspace:*",
         "@appstrate/runner-pi": "workspace:*",
@@ -327,6 +328,14 @@
         "@modelcontextprotocol/sdk": "^1.29.0",
       },
     },
+    "packages/module-anonymizer": {
+      "name": "@appstrate/module-anonymizer",
+      "version": "0.1.0",
+      "dependencies": {
+        "@appstrate/core": "workspace:*",
+        "@lmoe/gliner-onnx": "^0.1.0",
+      },
+    },
     "packages/module-claude-code": {
       "name": "@appstrate/module-claude-code",
       "version": "0.0.0",
@@ -471,6 +480,8 @@
     "@appstrate/env": ["@appstrate/env@workspace:packages/env"],
 
     "@appstrate/mcp-transport": ["@appstrate/mcp-transport@workspace:packages/mcp-transport"],
+
+    "@appstrate/module-anonymizer": ["@appstrate/module-anonymizer@workspace:packages/module-anonymizer"],
 
     "@appstrate/module-claude-code": ["@appstrate/module-claude-code@workspace:packages/module-claude-code"],
 
@@ -796,6 +807,14 @@
 
     "@hono/swagger-ui": ["@hono/swagger-ui@0.6.1", "", { "peerDependencies": { "hono": ">=4.0.0" } }, "sha512-sJTvldu1GPeEPfyeLG7gRj+W4vEuD+JDi+JjJ3TJs/DvMUtBLs0KJO5yokGegWWdy5qrbdnQGekbhgNRmPmYKQ=="],
 
+    "@huggingface/hub": ["@huggingface/hub@1.1.2", "", { "dependencies": { "@huggingface/tasks": "^0.18.2" } }, "sha512-Jf4GhvVj9ABDw4Itb3BV1T7f22iewuZva476qTicQ4kOTbosuUuFDhsVH7ZH6rVNgg20Ll9kaNBF5CXjySIT+w=="],
+
+    "@huggingface/jinja": ["@huggingface/jinja@0.5.9", "", {}, "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw=="],
+
+    "@huggingface/tasks": ["@huggingface/tasks@0.18.12", "", {}, "sha512-hUEYhXJzJCUhLSBNglW+Sji5fuzMnpBimp3kbdcGor+MaN9xb+qrcLnMC7X8aOcZaZdCErwYYIqz2oSP2EM4Bg=="],
+
+    "@huggingface/transformers": ["@huggingface/transformers@3.8.1", "", { "dependencies": { "@huggingface/jinja": "^0.5.3", "onnxruntime-node": "1.21.0", "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4", "sharp": "^0.34.1" } }, "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.7", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ=="],
@@ -810,7 +829,59 @@
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
     "@ioredis/commands": ["@ioredis/commands@1.10.0", "", {}, "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q=="],
+
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -821,6 +892,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@lmoe/gliner-onnx": ["@lmoe/gliner-onnx@0.1.0", "", { "dependencies": { "@huggingface/hub": "^1.0.0", "@huggingface/transformers": "^3.0.0" } }, "sha512-Wyz+k/eUQ3AREUkwFoEmgA/CCLUrOT0rdBCgKYN+YKMWxU2yKgrpowUYCthMyKT0Ex7tHgzvl/Eq+8vJiZJt0w=="],
 
     "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.9", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.9", "@mariozechner/clipboard-darwin-universal": "0.3.9", "@mariozechner/clipboard-darwin-x64": "0.3.9", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9", "@mariozechner/clipboard-linux-arm64-musl": "0.3.9", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-musl": "0.3.9", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9", "@mariozechner/clipboard-win32-x64-msvc": "0.3.9" } }, "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA=="],
 
@@ -1414,6 +1487,8 @@
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
+    "boolean": ["boolean@3.2.0", "", {}, "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw=="],
+
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
@@ -1463,6 +1538,8 @@
     "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
+
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
@@ -1562,6 +1639,8 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
+    "detect-node": ["detect-node@2.1.0", "", {}, "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g=="],
+
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
@@ -1621,6 +1700,8 @@
     "es-to-primitive": ["es-to-primitive@1.3.1", "", { "dependencies": { "es-abstract-get": "^1.0.0", "es-errors": "^1.3.0", "is-callable": "^1.2.7", "is-date-object": "^1.1.0", "is-symbol": "^1.1.1" } }, "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g=="],
 
     "es-toolkit": ["es-toolkit@1.47.1", "", {}, "sha512-5RAqEwf4P4E17p+W75KLOWw/nOvKZzSQpxM32IpI2KZLaVonjTrZ0Ai5ghMaVI9eKC2p8eoQgcBdkEDgzFk6+Q=="],
+
+    "es6-error": ["es6-error@4.1.1", "", {}, "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -1728,6 +1809,8 @@
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
+    "flatbuffers": ["flatbuffers@25.9.23", "", {}, "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ=="],
+
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
@@ -1780,6 +1863,8 @@
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
+    "global-agent": ["global-agent@3.0.0", "", { "dependencies": { "boolean": "^3.0.1", "es6-error": "^4.1.1", "matcher": "^3.0.0", "roarr": "^2.15.3", "semver": "^7.3.2", "serialize-error": "^7.0.1" } }, "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q=="],
+
     "global-directory": ["global-directory@5.0.0", "", { "dependencies": { "ini": "6.0.0" } }, "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w=="],
 
     "globals": ["globals@17.6.0", "", {}, "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA=="],
@@ -1793,6 +1878,8 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "guid-typescript": ["guid-typescript@1.0.9", "", {}, "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -1980,6 +2067,8 @@
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
+    "json-stringify-safe": ["json-stringify-safe@5.0.1", "", {}, "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="],
+
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "jsonpointer": ["jsonpointer@5.0.1", "", {}, "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ=="],
@@ -2061,6 +2150,8 @@
     "markdown-to-jsx": ["markdown-to-jsx@9.8.2", "", { "peerDependencies": { "react": ">= 16.0.0", "solid-js": ">=1.0.0", "vue": ">=3.0.0" }, "optionalPeers": ["react", "solid-js", "vue"] }, "sha512-rWUuxKB5NsuJmSfUOuXkQ0O5qk0J/Lr3Lk6dzxKoKQI/jeHYlsVfz3zJdMLAhI46hHoXDYERWhtBOiqtWDZ4LA=="],
 
     "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
+
+    "matcher": ["matcher@3.0.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0" } }, "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
@@ -2176,6 +2267,8 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
     "monaco-editor": ["monaco-editor@0.55.1", "", { "dependencies": { "dompurify": "3.2.7", "marked": "14.0.0" } }, "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -2235,6 +2328,12 @@
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "onnxruntime-common": ["onnxruntime-common@1.21.0", "", {}, "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ=="],
+
+    "onnxruntime-node": ["onnxruntime-node@1.21.0", "", { "dependencies": { "global-agent": "^3.0.0", "onnxruntime-common": "1.21.0", "tar": "^7.0.1" }, "os": [ "linux", "win32", "darwin", ] }, "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw=="],
+
+    "onnxruntime-web": ["onnxruntime-web@1.22.0-dev.20250409-89f8206ba4", "", { "dependencies": { "flatbuffers": "^25.1.24", "guid-typescript": "^1.0.9", "long": "^5.2.3", "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4", "platform": "^1.3.6", "protobufjs": "^7.2.4" } }, "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ=="],
 
     "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
@@ -2307,6 +2406,8 @@
     "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "platform": ["platform@1.3.6", "", {}, "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="],
 
     "playwright": ["playwright@1.61.0", "", { "dependencies": { "playwright-core": "1.61.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ=="],
 
@@ -2432,6 +2533,8 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
+    "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
+
     "rolldown": ["rolldown@1.0.3", "", { "dependencies": { "@oxc-project/types": "=0.133.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.3", "@rolldown/binding-darwin-arm64": "1.0.3", "@rolldown/binding-darwin-x64": "1.0.3", "@rolldown/binding-freebsd-x64": "1.0.3", "@rolldown/binding-linux-arm-gnueabihf": "1.0.3", "@rolldown/binding-linux-arm64-gnu": "1.0.3", "@rolldown/binding-linux-arm64-musl": "1.0.3", "@rolldown/binding-linux-ppc64-gnu": "1.0.3", "@rolldown/binding-linux-s390x-gnu": "1.0.3", "@rolldown/binding-linux-x64-gnu": "1.0.3", "@rolldown/binding-linux-x64-musl": "1.0.3", "@rolldown/binding-openharmony-arm64": "1.0.3", "@rolldown/binding-wasm32-wasi": "1.0.3", "@rolldown/binding-win32-arm64-msvc": "1.0.3", "@rolldown/binding-win32-x64-msvc": "1.0.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g=="],
 
     "rou3": ["rou3@0.7.12", "", {}, "sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg=="],
@@ -2460,7 +2563,11 @@
 
     "semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
+    "semver-compare": ["semver-compare@1.0.0", "", {}, "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="],
+
     "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
@@ -2473,6 +2580,8 @@
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -2515,6 +2624,8 @@
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "sprintf-js": ["sprintf-js@1.1.3", "", {}, "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="],
 
     "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
@@ -2567,6 +2678,8 @@
     "tailwindcss": ["tailwindcss@4.3.1", "", {}, "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "tar": ["tar@7.5.16", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w=="],
 
     "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
@@ -3066,6 +3179,8 @@
 
     "node-fetch/data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
+    "onnxruntime-web/onnxruntime-common": ["onnxruntime-common@1.22.0-dev.20250409-89f8206ba4", "", {}, "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ=="],
+
     "openapi-typescript/@redocly/openapi-core": ["@redocly/openapi-core@1.34.15", "", { "dependencies": { "@redocly/ajv": "8.11.2", "@redocly/config": "0.22.0", "colorette": "1.4.0", "https-proxy-agent": "7.0.6", "js-levenshtein": "1.1.6", "js-yaml": "4.1.1", "minimatch": "5.1.9", "pluralize": "8.0.0", "yaml-ast-parser": "0.0.43" } }, "sha512-HAwCnNyKcs5XGQqms+9t7OdAPM/5TDstmhF+0i7tdCFato2QKuYIlyWETwkXd8c5zbltr1oB+6y9NTeQLr2d6Q=="],
 
     "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
@@ -3092,6 +3207,8 @@
 
     "reflect.getprototypeof/es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
+    "serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
+
     "set-proto/es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
@@ -3101,6 +3218,8 @@
     "string.prototype.trim/es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "string.prototype.trimend/es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "tar/yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "tsutils/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -266,6 +266,23 @@ export interface AppstrateModule {
    */
   modelProviders?(): readonly ModelProviderDefinition[];
 
+  /**
+   * SEAM (single-owner legal): contribute a factory that builds a per-call
+   * transformer for LLM request/response bodies at the `/api/llm-proxy/*`
+   * gateway. The proxy builds one transformer per call, masks the outbound
+   * request body with it, and restores every response branch (JSON, SSE,
+   * error) through it.
+   *
+   * Single-owner by design: without this seam the LLM proxy
+   * (`apps/api/src/services/llm-proxy/core.ts`) would have to import the
+   * anonymizer module directly to mask bodies — exactly the lower-layer →
+   * module coupling the module system forbids. The platform resolves the
+   * first loaded module's factory (`getModuleLlmBodyTransformer()`); absent
+   * module → no transformer → the proxy forwards bytes untouched, preserving
+   * the zero-footprint invariant.
+   */
+  llmBodyTransformer?(): LlmBodyTransformerFactory;
+
   /** Called during graceful shutdown (reverse init order). */
   shutdown?(): Promise<void>;
 }
@@ -706,6 +723,60 @@ export interface ModelProviderDefinition {
    * returned (or nothing if the hook is absent).
    */
   requiredIdentityClaims?: readonly (keyof ModelProviderIdentity)[];
+}
+
+// ---------------------------------------------------------------------------
+// LLM body transformer contribution types (the llm-proxy anonymization seam)
+//
+// A module contributes a STABLE factory (holds shared state, e.g. a loaded NER
+// model). The proxy calls `create(ctx)` once per request to get a per-call
+// transformer whose mask table is consistent across that request and its
+// response. Bodies cross the seam as raw bytes (request) / text (buffered
+// response) / a byte stream (SSE) — the proxy is wire-format agnostic and never
+// looks inside.
+// ---------------------------------------------------------------------------
+
+/** Per-call context for building an {@link LlmBodyTransformer}. */
+export interface LlmBodyTransformContext {
+  /** Run id when the call is attributed to a run (`X-Run-Id`), else null. */
+  runId: string | null;
+  /** Caller org — scopes any per-run state the transformer keeps. */
+  orgId: string;
+}
+
+/**
+ * Per-call, stateful transformer for one LLM proxy request and its response.
+ * Built once per call so the outbound mask table is the same one used to
+ * restore the inbound response.
+ */
+export interface LlmBodyTransformer {
+  /** Transform the outbound request body (e.g. mask PII). Bytes in, bytes out. */
+  maskRequest(body: Uint8Array): Promise<Uint8Array>;
+  /** Transform a fully-buffered response/error body (JSON or free-form prose). */
+  restoreResponse(text: string): Promise<string>;
+  /** Transform SSE response frames as they stream back (best-effort per chunk). */
+  restoreResponseStream(): TransformStream<Uint8Array, Uint8Array>;
+}
+
+/**
+ * Stable factory contributed by {@link AppstrateModule.llmBodyTransformer}.
+ * Lives for the process lifetime (so it can own shared state like a loaded
+ * model); `create` is called once per proxy request.
+ */
+export interface LlmBodyTransformerFactory {
+  /** In-process per-call transformer — used by the platform LLM proxy (b1). */
+  create(ctx: LlmBodyTransformContext): LlmBodyTransformer;
+  /**
+   * Stateless masking of one LLM request body, used by the `/internal/anonymize`
+   * endpoint that the per-run sidecar calls (b2). The CALLER (the sidecar) holds
+   * the run's mapping and threads it in/out — the platform keeps no per-run
+   * state. Restore is NOT here: it needs no detection (pure token→value lookup),
+   * so the caller does it locally.
+   */
+  maskLlmBody(
+    body: Uint8Array,
+    mapping: Record<string, string>,
+  ): Promise<{ body: Uint8Array; mapping: Record<string, string> }>;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/sidecar-types.ts
+++ b/packages/core/src/sidecar-types.ts
@@ -48,6 +48,15 @@ export interface SidecarConfig {
    * passes to Pi SDK's compaction settings.
    */
   modelMaxTokens?: number;
+  /**
+   * Enable PII anonymization for this run (palier b2). When true, the sidecar
+   * masks the outbound LLM request body through the platform's
+   * `/internal/anonymize` endpoint and restores the response locally (the mask
+   * table lives in the sidecar — Option S). The platform sets this ONLY when an
+   * anonymizer module is loaded (so the endpoint is guaranteed to answer);
+   * unset (the default) keeps the zero-footprint passthrough.
+   */
+  anonymize?: boolean;
 }
 
 /**
@@ -68,6 +77,8 @@ export interface SidecarLaunchSpec {
   modelContextWindow?: number;
   /** See {@link SidecarConfig.modelMaxTokens}. */
   modelMaxTokens?: number;
+  /** See {@link SidecarConfig.anonymize}. Serialised as the `ANONYMIZE` env var. */
+  anonymize?: boolean;
   /**
    * Integrations to bootstrap inside the sidecar (Phase 1.4). Each entry
    * declares an `type: integration` AFPS package the agent depends on —

--- a/packages/module-anonymizer/bunfig.toml
+++ b/packages/module-anonymizer/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+preload = ["../../test/setup/preload.ts"]
+timeout = 15000

--- a/packages/module-anonymizer/package.json
+++ b/packages/module-anonymizer/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@appstrate/module-anonymizer",
+  "version": "0.1.0",
+  "description": "Appstrate module — reversible PII anonymization (in-process GLiNER2 + regex, no Python/torch) for chat and agent runs. Masks PII before the LLM, restores real values before tools, re-masks tool results. Opt-in: append `@appstrate/module-anonymizer` to MODULES to enable.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": null,
+  "module": null,
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test test/"
+  },
+  "dependencies": {
+    "@appstrate/core": "workspace:*",
+    "@lmoe/gliner-onnx": "^0.1.0"
+  }
+}

--- a/packages/module-anonymizer/src/detector.ts
+++ b/packages/module-anonymizer/src/detector.ts
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Détecteur in-process : GLiNER2 (ONNX, in-Bun, sans Python/torch) + regex
+// + deny-list + stop-list mots-rôle, avec masquage/restore RÉVERSIBLE.
+// Port TS de l'ancien server.py. Même runtime ONNX que module-search.
+//
+// Implémente l'interface AnonBackend (anonymize/restore) → AnonSession
+// l'utilise exactement comme l'ancien client HTTP.
+//
+// NB port : GLiNER2ONNXRuntime est chargé en `import()` DYNAMIQUE dans init()
+// (le type seul est importé statiquement, donc effacé à la compilation). Ça
+// garde le binding natif onnxruntime hors du chemin de boot du module : tant
+// que personne n'appelle anonymize(), aucun .node n'est chargé. Le seam
+// (palier b) est le premier vrai appelant.
+import type { GLiNER2ONNXRuntime } from "@lmoe/gliner-onnx";
+import type { Mapping } from "./run-session.ts";
+
+// ---- Config (équivalent de config.yaml) — c'est ce que la boucle d'auto-amélioration fait évoluer ----
+const GLINER_LABELS: Record<string, string> = {
+  person: "PERSON",
+  organization: "ORGANIZATION",
+  address: "ADDRESS",
+  "money amount": "MONEY",
+  date: "DATE",
+};
+const GLINER_THRESHOLD = 0.5;
+
+const REGEX: Record<string, RegExp> = {
+  EMAIL: /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
+  IBAN: /\b[A-Z]{2}\d{2}[A-Z0-9]{10,30}\b/g,
+  PHONE: /(?:\+?\d{1,2}[ .-]?)?(?:\(?\d{3}\)?[ .-]?)\d{3}[ .-]?\d{4}/g,
+  CA_POSTAL: /\b[A-Z]\d[A-Z] ?\d[A-Z]\d\b/g,
+  RBQ: /\b\d{4}-\d{4}-\d{2}\b/g,
+};
+
+const DENY: Record<string, string[]> = {
+  INTERNAL_PROJECT: ["Appstrate", "Hindsight", "module-search", "module-storage"],
+};
+
+const STOPWORDS = new Set([
+  "client",
+  "le client",
+  "la client",
+  "prestataire",
+  "prestataire de services",
+  "directeur general",
+  "directrice generale",
+  "president",
+  "employe",
+  "employee",
+  "partie",
+  "parties",
+  "une partie",
+  "societe",
+  "la societe",
+  "personnes ressources",
+  "personne-ressource",
+  "membres de son personnel",
+]);
+
+const MODEL_ID = process.env.GLINER_MODEL ?? "lmo3/gliner2-multi-v1-onnx";
+
+function norm(s: string): string {
+  return s.normalize("NFKD").replace(/[̀-ͯ]/g, "").toLowerCase().replace(/\s+/g, " ").trim();
+}
+function chunks(text: string, words = 250): string[] {
+  const w = text.split(/\s+/);
+  const out: string[] = [];
+  for (let i = 0; i < w.length; i += words) out.push(w.slice(i, i + words).join(" "));
+  return out;
+}
+
+interface Span {
+  start: number;
+  end: number;
+  type: string;
+  text: string;
+  score: number;
+}
+
+export class InProcessDetector {
+  private model: GLiNER2ONNXRuntime | null = null;
+  private ready: Promise<void> | null = null;
+
+  /** Charge le modèle une seule fois (lazy). */
+  async init(): Promise<void> {
+    if (!this.ready) {
+      this.ready = (async () => {
+        const { GLiNER2ONNXRuntime } = await import("@lmoe/gliner-onnx");
+        this.model = await GLiNER2ONNXRuntime.fromPretrained(MODEL_ID);
+      })();
+    }
+    return this.ready;
+  }
+
+  private async detect(text: string): Promise<Span[]> {
+    await this.init();
+    const spans: Span[] = [];
+    // 1) Regex (haute précision)
+    for (const [type, rx] of Object.entries(REGEX)) {
+      for (const m of text.matchAll(rx))
+        spans.push({ start: m.index!, end: m.index! + m[0]!.length, type, text: m[0]!, score: 1 });
+    }
+    // 2) Deny-list métier
+    for (const [type, words] of Object.entries(DENY)) {
+      for (const w of words) {
+        const rx = new RegExp(w.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g");
+        for (const m of text.matchAll(rx))
+          spans.push({
+            start: m.index!,
+            end: m.index! + m[0]!.length,
+            type,
+            text: m[0]!,
+            score: 0.99,
+          });
+      }
+    }
+    // 3) GLiNER2 (NER contextuel) — par chunks, offsets recalés
+    let offset = 0;
+    for (const c of chunks(text)) {
+      const idx = text.indexOf(c, offset);
+      const base = idx === -1 ? offset : idx;
+      const ents = await this.model!.extractEntities(c, Object.keys(GLINER_LABELS), {
+        threshold: GLINER_THRESHOLD,
+      });
+      for (const e of ents) {
+        if (STOPWORDS.has(norm(e.text))) continue; // filtre mots-rôle
+        spans.push({
+          start: base + e.start,
+          end: base + e.end,
+          type: GLINER_LABELS[e.label] ?? e.label.toUpperCase(),
+          text: e.text,
+          score: e.score,
+        });
+      }
+      offset = base + c.length;
+    }
+    // 4) Résolution des chevauchements : meilleur score, puis plus long
+    spans.sort((a, b) => b.score - a.score || b.end - b.start - (a.end - a.start));
+    const kept: Span[] = [];
+    for (const s of spans) {
+      if (!kept.some((k) => s.start < k.end && k.start < s.end)) kept.push(s);
+    }
+    kept.sort((a, b) => a.start - b.start);
+    return kept;
+  }
+
+  async anonymize(text: string, mapping?: Mapping): Promise<{ text: string; mapping: Mapping }> {
+    const map: Mapping = { ...(mapping ?? {}) };
+    const value2token: Record<string, string> = {};
+    const counters: Record<string, number> = {};
+    for (const [tok, v] of Object.entries(map)) {
+      const parts = tok.replace(/^\[|\]$/g, "").split("_");
+      const n = parts.pop()!;
+      const type = parts.join("_");
+      if (/^\d+$/.test(n)) {
+        counters[type] = Math.max(counters[type] ?? 0, +n);
+        value2token[`${type}::${norm(v)}`] = tok;
+      }
+    }
+    const spans = await this.detect(text);
+    let out = text;
+    for (const s of [...spans].sort((a, b) => b.start - a.start)) {
+      // fin -> début
+      const key = `${s.type}::${norm(s.text)}`;
+      let token = value2token[key];
+      if (!token) {
+        counters[s.type] = (counters[s.type] ?? 0) + 1;
+        token = `[${s.type}_${counters[s.type]}]`;
+        value2token[key] = token;
+        map[token] = s.text;
+      }
+      out = out.slice(0, s.start) + token + out.slice(s.end);
+    }
+    return { text: out, mapping: map };
+  }
+
+  async restore(text: string, mapping: Mapping): Promise<string> {
+    for (const token of Object.keys(mapping).sort((a, b) => b.length - a.length)) {
+      text = text.split(token).join(mapping[token]!);
+    }
+    return text;
+  }
+}

--- a/packages/module-anonymizer/src/index.ts
+++ b/packages/module-anonymizer/src/index.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Point d'entrée du package @appstrate/module-anonymizer.
+//   - `default`        = l'AppstrateModule chargé par le module loader (MODULES).
+//   - exports nommés   = les briques que le seam LLM-proxy consomme :
+//                        détecteur in-process + session réversible.
+//
+// Aucun de ces re-exports ne charge le binding natif onnxruntime à l'import :
+// detector.ts n'importe GLiNER qu'en `import type` (effacé) + `import()`
+// dynamique dans init(). Charger ce module = zéro empreinte runtime.
+export { default } from "./module.ts";
+
+export { InProcessDetector } from "./detector.ts";
+export { AnonSession, type AnonBackend, type Mapping } from "./run-session.ts";

--- a/packages/module-anonymizer/src/module.ts
+++ b/packages/module-anonymizer/src/module.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Anonymizer module — reversible PII anonymization layer for Appstrate
+ * (chat conversations + agent runs).
+ *
+ * The module is a pure, ISOLATED package. It ports two building blocks:
+ *   - `InProcessDetector` — GLiNER2 (ONNX, in-Bun, no Python/torch) + regex +
+ *     business deny-list + role-word stop-list, with reversible mask/restore.
+ *   - `AnonSession` — the run-scoped correspondence table: the same real value
+ *     keeps the same token end-to-end across one run, so restore stays
+ *     consistent for both the LLM answer and tool args.
+ *
+ * It wires the LLM-proxy masking seam. The proxy is a fetch gateway (not a
+ * `wrapLanguageModel`), so the module implements `LlmBodyTransformer` — masking
+ * the outgoing request body (system + messages) and restoring each response
+ * branch (JSON, SSE, error). The agent-run path reuses the SAME detector via
+ * the `/internal/anonymize` endpoint, while the sidecar keeps the per-run mask
+ * table locally (Option S) so restore stays a free, network-less lookup.
+ *
+ * Zero footprint when off: without the module in MODULES it never loads; even
+ * loaded, the onnxruntime native binding is never pulled at boot — the detector
+ * lazy-imports GLiNER on the first masked request.
+ *
+ * Opt-in: append `@appstrate/module-anonymizer` to MODULES to enable.
+ */
+
+import type { AppstrateModule, ModuleInitContext } from "@appstrate/core/module";
+import { llmBodyTransformerFactory } from "./seam-llm.ts";
+
+const anonymizerModule: AppstrateModule = {
+  manifest: { id: "anonymizer", name: "Anonymizer (reversible PII)", version: "0.1.0" },
+
+  async init(ctx: ModuleInitContext) {
+    // The GLiNER detector loads lazily on the first masked request — boot
+    // itself never pulls the onnxruntime native binding.
+    ctx.services.logger.info("anonymizer module loaded — LLM-proxy masking seam active");
+  },
+
+  // The llm-proxy anonymization seam (palier b1): a stable factory whose
+  // shared detector is reused across requests; each request gets a fresh
+  // session. The buildTools / agent-run paths land in palier b2.
+  llmBodyTransformer() {
+    return llmBodyTransformerFactory;
+  },
+};
+
+export default anonymizerModule;

--- a/packages/module-anonymizer/src/run-session.ts
+++ b/packages/module-anonymizer/src/run-session.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Session d'anonymisation = la "table de correspondance" qui vit le temps d'UN run
+// (une conversation chat OU une boucle d'agent). C'est la piece centrale :
+// les memes vraies valeurs gardent les memes jetons d'un bout a l'autre du run,
+// pour que le restore-avant-outil et le restore-final soient coherents.
+/** Table de correspondance jeton → vraie valeur, accumulée le temps d'un run. */
+export type Mapping = Record<string, string>;
+
+/** Backend de détection/masquage : implémenté par le détecteur in-process. */
+export interface AnonBackend {
+  anonymize(text: string, mapping?: Mapping): Promise<{ text: string; mapping: Mapping }>;
+  restore(text: string, mapping: Mapping): Promise<string>;
+}
+
+export class AnonSession {
+  private mapping: Mapping;
+  /** `seed` = table de départ (continuité d'un run quand l'état vit ailleurs). */
+  constructor(
+    private backend: AnonBackend,
+    seed?: Mapping,
+  ) {
+    this.mapping = seed ? { ...seed } : {};
+  }
+
+  /** Masque un texte et accumule la table du run. */
+  async mask(text: string): Promise<string> {
+    const res = await this.backend.anonymize(text, this.mapping);
+    this.mapping = res.mapping; // backend renvoie la table fusionnee
+    return res.text;
+  }
+
+  /** Restaure les vraies valeurs depuis la table du run. */
+  async unmask(text: string): Promise<string> {
+    return this.backend.restore(text, this.mapping);
+  }
+
+  /** Masque recursivement les strings d'un objet (args/result d'outil). */
+  async maskDeep<T>(value: T): Promise<T> {
+    return this.deepTransform(value, (s) => this.mask(s));
+  }
+
+  /** Restaure recursivement les strings d'un objet. */
+  async unmaskDeep<T>(value: T): Promise<T> {
+    return this.deepTransform(value, (s) => this.unmask(s));
+  }
+
+  /** Applique `fn` a chaque string en profondeur (string / array / objet). */
+  private async deepTransform<T>(value: T, fn: (s: string) => Promise<string>): Promise<T> {
+    if (typeof value === "string") return (await fn(value)) as unknown as T;
+    if (Array.isArray(value))
+      return Promise.all(value.map((v) => this.deepTransform(v, fn))) as unknown as T;
+    if (value && typeof value === "object") {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(value)) out[k] = await this.deepTransform(v, fn);
+      return out as T;
+    }
+    return value;
+  }
+
+  /** La table brute (a persister/auditer si besoin). */
+  table(): Mapping {
+    return { ...this.mapping };
+  }
+}

--- a/packages/module-anonymizer/src/seam-llm.ts
+++ b/packages/module-anonymizer/src/seam-llm.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Implémentation du seam LLM-proxy (palier b1).
+//
+// Le proxy (`apps/api/.../llm-proxy/core.ts`) construit UN transformer par
+// appel via la factory, masque le corps sortant, et restaure chaque branche
+// de réponse (JSON, SSE, erreur) à travers lui.
+//
+// - Masquage ALLER : ciblé sur les champs porteurs de texte utilisateur —
+//   `system` + `messages[].content` (couvre OpenAI chat/completions et
+//   Anthropic messages, content = string OU tableau de parts {type:"text"}).
+//   On ne masque JAMAIS la structure JSON (model, role, noms d'outils) : GLiNER
+//   voit du texte propre et le LLM garde un payload intact hors PII.
+// - Restore RETOUR : remplacement de jetons EN AVEUGLE sur tout le corps. Les
+//   jetons `[TYPE_N]` sont non ambigus → un simple split/join est sûr et
+//   suffit, sans reparser le JSON.
+//
+// Détecteur GLiNER PARTAGÉ (le modèle se charge une fois, paresseusement) ;
+// session FRAÎCHE par appel (table de correspondance propre à la requête).
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type {
+  LlmBodyTransformer,
+  LlmBodyTransformerFactory,
+  LlmBodyTransformContext,
+} from "@appstrate/core/module";
+import { InProcessDetector } from "./detector.ts";
+import { AnonSession, type AnonBackend, type Mapping } from "./run-session.ts";
+
+const decoder = new TextDecoder();
+const encoder = new TextEncoder();
+
+/**
+ * Masque les parts porteuses de texte d'un tableau de content :
+ *   - `{type:"text", text}` (texte normal)
+ *   - `{type:"tool_result", content}` (Anthropic) — RÉSULTAT d'outil renvoyé au
+ *     LLM au tour suivant : il peut porter de la PII fraîche, on le masque pour
+ *     que le modèle ne la revoie jamais. `content` = string OU tableau de parts.
+ * (Mistral/OpenAI mettent les résultats d'outils dans un `content` string de
+ * message → couverts par la branche string de `maskField`.)
+ */
+async function maskContentParts(session: AnonSession, parts: any[]): Promise<void> {
+  for (const part of parts) {
+    if (part?.type === "text" && typeof part.text === "string") {
+      part.text = await session.mask(part.text);
+    } else if (part?.type === "tool_result") {
+      if (typeof part.content === "string") {
+        part.content = await session.mask(part.content);
+      } else if (Array.isArray(part.content)) {
+        await maskContentParts(session, part.content);
+      }
+    }
+  }
+}
+
+/** Masque `obj[key]` si c'est une string OU un tableau de parts de content. */
+async function maskField(session: AnonSession, obj: any, key: string): Promise<void> {
+  const value = obj?.[key];
+  if (typeof value === "string") {
+    obj[key] = await session.mask(value);
+  } else if (Array.isArray(value)) {
+    await maskContentParts(session, value);
+  }
+}
+
+/** Parse → masque system + messages[].content → re-sérialise. Non-JSON = intact. */
+async function maskRequestBody(session: AnonSession, body: Uint8Array): Promise<Uint8Array> {
+  let payload: any;
+  try {
+    payload = JSON.parse(decoder.decode(body));
+  } catch {
+    return body; // pas du JSON (ex. multipart) → on ne touche pas
+  }
+  if (!payload || typeof payload !== "object") return body;
+  await maskField(session, payload, "system");
+  if (Array.isArray(payload.messages)) {
+    for (const message of payload.messages) await maskField(session, message, "content");
+  }
+  return encoder.encode(JSON.stringify(payload));
+}
+
+class AnonLlmBodyTransformer implements LlmBodyTransformer {
+  constructor(private session: AnonSession) {}
+
+  maskRequest(body: Uint8Array): Promise<Uint8Array> {
+    return maskRequestBody(this.session, body);
+  }
+
+  restoreResponse(text: string): Promise<string> {
+    return this.session.unmask(text);
+  }
+
+  restoreResponseStream(): TransformStream<Uint8Array, Uint8Array> {
+    const session = this.session;
+    // Décodeur à état pour ne pas couper un caractère multi-octets entre chunks.
+    // NB best-effort : un jeton coupé entre deux chunks ne sera pas restauré.
+    const streamDecoder = new TextDecoder();
+    return new TransformStream({
+      async transform(chunk, controller) {
+        const restored = await session.unmask(streamDecoder.decode(chunk, { stream: true }));
+        controller.enqueue(encoder.encode(restored));
+      },
+    });
+  }
+}
+
+/** Lie un transformer à une session donnée (= unité testable du seam). */
+export function createLlmBodyTransformer(session: AnonSession): LlmBodyTransformer {
+  return new AnonLlmBodyTransformer(session);
+}
+
+/**
+ * Masque UN corps de requête LLM de façon stateless : on sème une session
+ * jetable avec `mapping`, on masque (system + messages content), on rend le
+ * mapping mis à jour. `backend` injectable → testable sans GLiNER.
+ */
+export async function maskLlmRequestBody(
+  backend: AnonBackend,
+  body: Uint8Array,
+  mapping: Mapping,
+): Promise<{ body: Uint8Array; mapping: Mapping }> {
+  const session = new AnonSession(backend, mapping);
+  const masked = await maskRequestBody(session, body);
+  return { body: masked, mapping: session.table() };
+}
+
+// Détecteur partagé sur tout le process : le modèle GLiNER ne se charge qu'une
+// fois (paresseux), à la première vraie requête anonymisée.
+const sharedDetector = new InProcessDetector();
+
+export const llmBodyTransformerFactory: LlmBodyTransformerFactory = {
+  create(_ctx: LlmBodyTransformContext): LlmBodyTransformer {
+    return createLlmBodyTransformer(new AnonSession(sharedDetector));
+  },
+
+  // Stateless mask pour l'endpoint /internal/anonymize (sidecar, b2) : délègue
+  // à maskLlmRequestBody avec le détecteur partagé. Aucune session conservée.
+  maskLlmBody(body: Uint8Array, mapping: Mapping): Promise<{ body: Uint8Array; mapping: Mapping }> {
+    return maskLlmRequestBody(sharedDetector, body, mapping);
+  },
+};

--- a/packages/module-anonymizer/test/seam-llm.test.ts
+++ b/packages/module-anonymizer/test/seam-llm.test.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Seam LLM-proxy (palier b1) — preuve comportementale SANS GLiNER : un backend
+// déterministe est injecté dans la session, ce qui isole la logique du seam
+// (ciblage des champs masqués + restore + continuité des jetons) de la qualité
+// du détecteur. Aucun onnxruntime, aucune table : test pur-logique.
+import { describe, it, expect } from "bun:test";
+import { AnonSession, type AnonBackend, type Mapping } from "../src/run-session.ts";
+import { createLlmBodyTransformer, maskLlmRequestBody } from "../src/seam-llm.ts";
+
+/** Backend déterministe : masque une liste fixe de littéraux, restore par table. */
+function fakeBackend(terms: Record<string, string>): AnonBackend {
+  return {
+    async anonymize(text: string, mapping: Mapping = {}) {
+      const map: Mapping = { ...mapping };
+      const value2token: Record<string, string> = {};
+      let counter = 0;
+      for (const [tok, val] of Object.entries(map)) {
+        value2token[val] = tok;
+        const n = +tok.replace(/\D/g, "");
+        if (n > counter) counter = n;
+      }
+      let out = text;
+      for (const [literal, type] of Object.entries(terms)) {
+        if (!out.includes(literal)) continue;
+        let tok = value2token[literal];
+        if (!tok) {
+          tok = `[${type}_${++counter}]`;
+          map[tok] = literal;
+          value2token[literal] = tok;
+        }
+        out = out.split(literal).join(tok);
+      }
+      return { text: out, mapping: map };
+    },
+    async restore(text: string, mapping: Mapping) {
+      for (const [tok, val] of Object.entries(mapping)) text = text.split(tok).join(val);
+      return text;
+    },
+  };
+}
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+const toBytes = (o: unknown) => enc.encode(JSON.stringify(o));
+const fromBytes = (u: Uint8Array) => JSON.parse(dec.decode(u));
+
+describe("llm-proxy anonymization seam", () => {
+  it("masks OpenAI message content but leaves model/role intact", async () => {
+    const t = createLlmBodyTransformer(
+      new AnonSession(fakeBackend({ "Benjamin Macé": "PERSON", Appstrate: "ORG" })),
+    );
+    const masked = fromBytes(
+      await t.maskRequest(
+        toBytes({
+          model: "gpt-5.5",
+          messages: [
+            { role: "system", content: "Tu es utile." },
+            { role: "user", content: "Écris à Benjamin Macé au sujet de Appstrate." },
+          ],
+        }),
+      ),
+    );
+    expect(masked.model).toBe("gpt-5.5");
+    expect(masked.messages[1].role).toBe("user");
+    expect(JSON.stringify(masked)).not.toContain("Benjamin Macé");
+    expect(masked.messages[1].content).toMatch(/\[PERSON_\d+\]/);
+  });
+
+  it("restores PII tokens the model echoes back in a JSON response", async () => {
+    const t = createLlmBodyTransformer(
+      new AnonSession(fakeBackend({ "Benjamin Macé": "PERSON", Appstrate: "ORG" })),
+    );
+    // build the mask table from a request first (same session)
+    await t.maskRequest(
+      toBytes({ messages: [{ role: "user", content: "Benjamin Macé / Appstrate" }] }),
+    );
+    const restored = await t.restoreResponse(
+      JSON.stringify({ choices: [{ message: { content: "Fait pour [PERSON_1] chez [ORG_2]." } }] }),
+    );
+    expect(restored).toContain("Benjamin Macé");
+    expect(restored).toContain("Appstrate");
+  });
+
+  it("masks Anthropic system + text parts, keeps the same token for the same value", async () => {
+    const t = createLlmBodyTransformer(new AnonSession(fakeBackend({ "Benjamin Macé": "PERSON" })));
+    const masked = fromBytes(
+      await t.maskRequest(
+        toBytes({
+          model: "claude-opus-4-8",
+          system: "Contexte sur Benjamin Macé.",
+          messages: [
+            {
+              role: "user",
+              content: [
+                { type: "text", text: "Relance Benjamin Macé." },
+                { type: "image", source: { url: "x" } },
+              ],
+            },
+          ],
+        }),
+      ),
+    );
+    expect(masked.system).not.toContain("Benjamin Macé");
+    expect(masked.messages[0].content[0].text).not.toContain("Benjamin Macé");
+    expect(masked.messages[0].content[1].source.url).toBe("x"); // non-text part untouched
+    const tokenInSystem = masked.system.match(/\[PERSON_\d+\]/)?.[0];
+    const tokenInPart = masked.messages[0].content[0].text.match(/\[PERSON_\d+\]/)?.[0];
+    expect(tokenInSystem).toBeTruthy();
+    expect(tokenInSystem).toBe(tokenInPart); // run-scoped continuity
+  });
+
+  it("forwards a non-JSON body untouched", async () => {
+    const t = createLlmBodyTransformer(new AnonSession(fakeBackend({ Benjamin: "PERSON" })));
+    const out = await t.maskRequest(enc.encode("pas du json Benjamin"));
+    expect(dec.decode(out)).toBe("pas du json Benjamin");
+  });
+
+  it("masks Anthropic tool_result content fed back into the request (string and nested)", async () => {
+    const t = createLlmBodyTransformer(new AnonSession(fakeBackend({ "Benjamin Macé": "PERSON" })));
+    const masked = fromBytes(
+      await t.maskRequest(
+        toBytes({
+          messages: [
+            {
+              role: "user",
+              content: [
+                { type: "tool_result", content: "Le client est Benjamin Macé" },
+                { type: "tool_result", content: [{ type: "text", text: "aussi Benjamin Macé" }] },
+              ],
+            },
+          ],
+        }),
+      ),
+    );
+    const parts = masked.messages[0].content;
+    expect(parts[0].content).not.toContain("Benjamin Macé"); // string tool_result masked
+    expect(parts[0].content).toMatch(/\[PERSON_\d+\]/);
+    expect(parts[1].content[0].text).not.toContain("Benjamin Macé"); // nested tool_result masked
+    expect(JSON.stringify(masked)).not.toContain("Benjamin Macé");
+  });
+});
+
+describe("stateless maskLlmRequestBody (the /internal/anonymize endpoint seam)", () => {
+  it("masks a body and returns the updated mapping (no session kept)", async () => {
+    const { body, mapping } = await maskLlmRequestBody(
+      fakeBackend({ "Benjamin Macé": "PERSON" }),
+      toBytes({ messages: [{ role: "user", content: "Bonjour Benjamin Macé" }] }),
+      {},
+    );
+    expect(fromBytes(body).messages[0].content).toMatch(/\[PERSON_\d+\]/);
+    expect(Object.values(mapping)).toContain("Benjamin Macé");
+  });
+
+  it("reuses a seeded token across calls (run continuity — table lives in the caller)", async () => {
+    const backend = fakeBackend({ "Benjamin Macé": "PERSON" });
+    const first = await maskLlmRequestBody(
+      backend,
+      toBytes({ messages: [{ role: "user", content: "Benjamin Macé" }] }),
+      {},
+    );
+    const seededToken = Object.keys(first.mapping)[0]!;
+    // 2ᵉ appel SÉMÉ avec le mapping du 1er → même valeur ⇒ même jeton
+    const second = await maskLlmRequestBody(
+      backend,
+      toBytes({ messages: [{ role: "user", content: "Encore Benjamin Macé" }] }),
+      first.mapping,
+    );
+    expect(fromBytes(second.body).messages[0].content).toContain(seededToken);
+    expect(Object.keys(second.mapping)).toHaveLength(1); // pas de doublon
+  });
+});

--- a/packages/module-anonymizer/test/tables.ts
+++ b/packages/module-anonymizer/test/tables.ts
@@ -1,0 +1,5 @@
+/**
+ * anonymizer contributes no tables — the reversible mapping (AnonSession) lives
+ * in memory for the lifetime of a single run and is never persisted.
+ */
+export default [] as const;

--- a/packages/module-anonymizer/tsconfig.json
+++ b/packages/module-anonymizer/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ESNext"]
+  },
+  "include": ["src"]
+}

--- a/runtime-pi/sidecar/anonymizer.ts
+++ b/runtime-pi/sidecar/anonymizer.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Anonymiseur côté sidecar (palier b2 — Option S).
+//
+// La TABLE de correspondance du run vit ICI : le sidecar est le seul process qui
+// couvre tout le run (forward LLM + exécution d'outils), donc la table est
+// locale à ses deux consommateurs. La plateforme ne garde aucun état per-run.
+//
+//   - MASQUAGE  → exige la détection (GLiNER, centralisée) → appel HTTP à
+//     l'endpoint `POST /internal/anonymize` (run-token), qui rend le corps
+//     masqué + la table mise à jour.
+//   - RESTORE   → n'exige AUCUNE détection (pure recherche jeton→valeur) → 100 %
+//     LOCAL, gratuit. C'est tout l'intérêt de garder la table dans le sidecar.
+//
+// Le sidecar n'importe RIEN du module d'anonymisation : il parle uniquement par
+// le seam (l'endpoint). Frontière propre, et zéro modèle dans l'image runner.
+
+type Mapping = Record<string, string>;
+
+export interface RunAnonymizer {
+  /** Masque un corps de requête LLM via la plateforme ; accumule la table du run. */
+  maskBody(bodyText: string): Promise<string>;
+  /** Restaure les jetons d'un texte (réponse/erreur) — LOCAL, sans réseau. */
+  restore(text: string): string;
+  /** Restaure les jetons d'un flux SSE — LOCAL, par chunk (best-effort). */
+  restoreStream(): TransformStream<Uint8Array, Uint8Array>;
+}
+
+export interface RunAnonymizerOptions {
+  /** URL complète de l'endpoint, ex. `${platformApiUrl}/internal/anonymize`. */
+  endpointUrl: string;
+  /** Run-token HMAC (le même que pour `/internal/credentials`). */
+  runToken: string;
+  /** Injecté pour les tests ; défaut `globalThis.fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+const encoder = new TextEncoder();
+
+/** Restore = recherche pure jeton→valeur, jetons les plus longs d'abord. */
+function restoreLocal(text: string, mapping: Mapping): string {
+  for (const token of Object.keys(mapping).sort((a, b) => b.length - a.length)) {
+    text = text.split(token).join(mapping[token]!);
+  }
+  return text;
+}
+
+class HttpRunAnonymizer implements RunAnonymizer {
+  private mapping: Mapping = {};
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(private readonly opts: RunAnonymizerOptions) {
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  async maskBody(bodyText: string): Promise<string> {
+    const res = await this.fetchImpl(this.opts.endpointUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${this.opts.runToken}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        body: Buffer.from(bodyText, "utf8").toString("base64"),
+        mapping: this.mapping,
+      }),
+    });
+    if (!res.ok) {
+      // Fail-CLOSED : mieux vaut faire échouer la requête LLM que laisser fuiter
+      // de la PII en clair vers l'upstream. (b2.2b pourra raffiner la politique.)
+      const detail = await res.text().catch(() => "");
+      throw new Error(`anonymize endpoint ${res.status}: ${detail}`);
+    }
+    const out = (await res.json()) as { body: string; mapping: Mapping };
+    this.mapping = out.mapping; // la plateforme rend la table fusionnée
+    return Buffer.from(out.body, "base64").toString("utf8");
+  }
+
+  restore(text: string): string {
+    return restoreLocal(text, this.mapping);
+  }
+
+  restoreStream(): TransformStream<Uint8Array, Uint8Array> {
+    const mappingRef = () => this.mapping;
+    // Décodeur à état : ne coupe pas un caractère multi-octets entre chunks.
+    // Best-effort : un jeton scindé entre deux chunks ne sera pas restauré.
+    const streamDecoder = new TextDecoder();
+    return new TransformStream({
+      transform(chunk, controller) {
+        const restored = restoreLocal(streamDecoder.decode(chunk, { stream: true }), mappingRef());
+        controller.enqueue(encoder.encode(restored));
+      },
+    });
+  }
+}
+
+export function createRunAnonymizer(opts: RunAnonymizerOptions): RunAnonymizer {
+  return new HttpRunAnonymizer(opts);
+}

--- a/runtime-pi/sidecar/app.ts
+++ b/runtime-pi/sidecar/app.ts
@@ -37,6 +37,7 @@ import {
   adaptHeaderForRetry,
   TransformBodyTooLargeError,
 } from "./oauth-identity.ts";
+import type { RunAnonymizer } from "./anonymizer.ts";
 import { logger } from "./logger.ts";
 import { filterSensitiveHeaders } from "./redact.ts";
 
@@ -59,6 +60,14 @@ export interface AppDeps {
   refreshCredentials?: NonNullable<ApiCallDeps["refreshCredentials"]>;
   cookieJar: Map<string, string[]>;
   fetchFn?: typeof fetch; // default: global fetch — injectable for tests
+  /**
+   * Per-run PII anonymizer (palier b2). Present iff anonymization is enabled
+   * for this run — then the `/llm/*` reverse proxy masks the outbound request
+   * body through it and restores the response. Absent (the default) → bytes
+   * pass through untouched (zero footprint). The mask table lives in this
+   * object, for the lifetime of the run (Option S).
+   */
+  anonymizer?: RunAnonymizer;
   isReady?: () => boolean; // default: () => true — controls /health
   /**
    * OAuth token cache. Required when the sidecar serves OAuth-mode LLM
@@ -170,6 +179,7 @@ async function passUpstream(
   upstream: Response,
   observe?: LlmStreamObservation,
   swap?: ModelSwap,
+  anonymizer?: RunAnonymizer,
 ): Promise<Response> {
   const responseHeaders: Record<string, string> = {};
   for (const name of PASSTHROUGH_RESPONSE_HEADERS) {
@@ -198,9 +208,10 @@ async function passUpstream(
   // blind substring replace is safe here (it isn't for 2xx). Applies to ANY
   // content type on a non-2xx, mirroring the platform gateway (`llm-proxy/
   // core.ts`); errors are tiny, so buffering them costs nothing.
-  if (swap && !upstream.ok) {
+  if ((swap || anonymizer) && !upstream.ok) {
     const text = await upstream.text();
-    return new Response(scrubModelText(text, swap), {
+    const scrubbed = swap ? scrubModelText(text, swap) : text;
+    return new Response(anonymizer ? anonymizer.restore(scrubbed) : scrubbed, {
       status: upstream.status,
       headers: responseHeaders,
     });
@@ -210,12 +221,18 @@ async function passUpstream(
   // rewritten chunk-by-chunk — buffer the whole thing, swap, re-serialize. SSE
   // is rewritten in-stream below (frame-buffered). Other content types and the
   // no-swap path keep the zero-copy telemetry passthrough.
-  if (swap && contentType.includes("application/json") && !contentType.includes("event-stream")) {
+  if (
+    (swap || anonymizer) &&
+    contentType.includes("application/json") &&
+    !contentType.includes("event-stream")
+  ) {
     const text = await upstream.text();
-    const rewritten = swapResponseModelJson(text, swap);
+    const rewritten = swap ? swapResponseModelJson(text, swap) : text;
+    // Restore PII tokens the model echoed back (buffered → no token-split issue).
+    const restored = anonymizer ? anonymizer.restore(rewritten) : rewritten;
     // Length changed by the rewrite — let Response recompute Content-Length
     // rather than forward a now-wrong upstream value.
-    return new Response(rewritten, { status: upstream.status, headers: responseHeaders });
+    return new Response(restored, { status: upstream.status, headers: responseHeaders });
   }
 
   const reader = upstream.body.getReader();
@@ -279,10 +296,13 @@ async function passUpstream(
   // each frame as it flows. Frame-buffered, so a chunk boundary mid-frame is
   // handled. The telemetry passthrough (`observed`) stays in front so stream
   // metrics still reflect the upstream timing.
-  const body =
+  const swapped =
     swap && contentType.includes("event-stream")
       ? observed.pipeThrough(createSseModelSwapStream(swap))
       : observed;
+  // Restore PII tokens in-stream (per chunk, best-effort across chunk
+  // boundaries). Covers SSE and any other streamed content type.
+  const body = anonymizer ? swapped.pipeThrough(anonymizer.restoreStream()) : swapped;
 
   return new Response(body, { status: upstream.status, headers: responseHeaders });
 }
@@ -440,6 +460,10 @@ export function createApp(deps: AppDeps): Hono {
   const { config } = deps;
   const fetchFn = deps.fetchFn ?? fetch;
   const isReady = deps.isReady ?? (() => true);
+  // Per-run PII anonymizer (palier b2). Present iff anonymization is on for this
+  // run; the `/llm/*` reverse proxy masks the request through it and restores
+  // the response. Absent → no-op (bytes untouched).
+  const anonymizer = deps.anonymizer;
 
   const app = new Hono();
 
@@ -526,11 +550,15 @@ export function createApp(deps: AppDeps): Hono {
     // a zero-copy ReadableStream; for an alias we must buffer it to rewrite the
     // `model` field. Only aliases pay that cost — every other model stays
     // zero-copy.
+    // Buffer the body when we must transform it (model-alias swap and/or PII
+    // masking); otherwise keep the zero-copy stream passthrough.
     let body: string | ReadableStream<Uint8Array> | undefined;
     if (method !== "GET" && method !== "HEAD") {
-      if (apiKeyConfig.modelSwap) {
-        const text = await c.req.raw.text();
-        body = text ? swapRequestModel(text, apiKeyConfig.modelSwap) : undefined;
+      if (apiKeyConfig.modelSwap || anonymizer) {
+        let text = await c.req.raw.text();
+        if (text && apiKeyConfig.modelSwap) text = swapRequestModel(text, apiKeyConfig.modelSwap);
+        if (text && anonymizer) text = await anonymizer.maskBody(text);
+        body = text || undefined;
       } else {
         body = c.req.raw.body ?? undefined;
       }
@@ -560,7 +588,12 @@ export function createApp(deps: AppDeps): Hono {
       return llmFetchErrorResponse(c, targetUrl, err);
     }
 
-    return passUpstream(upstream, { targetUrl, authMode: "api_key" }, apiKeyConfig.modelSwap);
+    return passUpstream(
+      upstream,
+      { targetUrl, authMode: "api_key" },
+      apiKeyConfig.modelSwap,
+      anonymizer,
+    );
   });
 
   async function handleOauthLlmRequest(
@@ -643,6 +676,10 @@ export function createApp(deps: AppDeps): Hono {
         if (llmConfig.modelSwap) {
           bodyText = swapRequestModel(bodyText, llmConfig.modelSwap);
         }
+        // PII anonymization (palier b2.2c): mask the OAuth (claude-code) request
+        // body too, so subscription agent runs mask like api_key/Mistral runs.
+        // After the swap, before content-length — masking changes the length.
+        if (anonymizer) bodyText = await anonymizer.maskBody(bodyText);
         // Refresh content-length to match the transformed body so the
         // upstream doesn't read a stale value forwarded from the agent.
         forwardedHeaders["content-length"] = String(new TextEncoder().encode(bodyText).byteLength);
@@ -697,6 +734,7 @@ export function createApp(deps: AppDeps): Hono {
             authMode: "oauth",
           },
           llmConfig.modelSwap,
+          anonymizer,
         );
       }
       forwardedHeaders = {
@@ -738,6 +776,7 @@ export function createApp(deps: AppDeps): Hono {
         authMode: "oauth",
       },
       llmConfig.modelSwap,
+      anonymizer,
     );
   }
 

--- a/runtime-pi/sidecar/server.ts
+++ b/runtime-pi/sidecar/server.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { createApp, buildSidecarRuntimeDeps, SIDECAR_IDLE_TIMEOUT_SECONDS } from "./app.ts";
+import { createRunAnonymizer } from "./anonymizer.ts";
 import { createForwardProxy } from "./forward-proxy.ts";
 import type { CredentialsResponse, LlmProxyConfig, ModelSwap } from "./helpers.ts";
 import { logger } from "./logger.ts";
@@ -87,6 +88,7 @@ const config = {
   llm: readLlmConfigFromEnv(),
   modelContextWindow: readPositiveIntFromEnv("MODEL_CONTEXT_WINDOW"),
   modelMaxTokens: readPositiveIntFromEnv("MODEL_MAX_TOKENS"),
+  anonymize: process.env.ANONYMIZE === "1",
 };
 
 // ─── P4 — connect mode (`runAt: "link"` ephemeral connect-run) ───
@@ -260,6 +262,17 @@ const integrationBootPromise =
         })
     : Promise.resolve();
 
+// Per-run anonymizer (palier b2). Built only when the platform enabled
+// anonymization for this run (which it does ONLY when an anonymizer module is
+// loaded, so `/internal/anonymize` is guaranteed to answer). Off → undefined →
+// the `/llm/*` proxy passes bytes through untouched.
+const anonymizer = config.anonymize
+  ? createRunAnonymizer({
+      endpointUrl: `${config.platformApiUrl}/internal/anonymize`,
+      runToken: config.runToken,
+    })
+  : undefined;
+
 const app = createApp({
   config,
   fetchCredentials,
@@ -268,6 +281,7 @@ const app = createApp({
   runtimeDeps,
   isReady: () => proxy.readySync,
   oauthTokenCache,
+  anonymizer,
   additionalMcpToolsProvider: () => [...runtimeToolDefs, ...integrationTools],
   integrationBootPromise,
   integrationBootReportProvider: () => integrationBootReport,

--- a/runtime-pi/sidecar/test/anonymizer-llm.test.ts
+++ b/runtime-pi/sidecar/test/anonymizer-llm.test.ts
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration test of the b2.2b wiring: the REAL `/llm/*` reverse-proxy handler
+ * (`createApp` → api_key flow → `passUpstream`) with a per-run anonymizer
+ * injected. Boundaries are mocked (the platform `/internal/anonymize` endpoint
+ * and the upstream LLM), so this exercises the exact critical-path code without
+ * Docker / a real model.
+ *
+ * Asserts the round-trip: the upstream LLM receives a MASKED body (never the
+ * real PII) and the agent receives a RESTORED response.
+ */
+import { describe, it, expect, mock } from "bun:test";
+import { createApp, type AppDeps } from "../app.ts";
+import { createRunAnonymizer } from "../anonymizer.ts";
+import type { CredentialsResponse } from "../helpers.ts";
+
+const b64 = (s: string) => Buffer.from(s, "utf8").toString("base64");
+const unb64 = (s: string) => Buffer.from(s, "base64").toString("utf8");
+
+/** Stand-in for POST /internal/anonymize: masks a fixed literal, threads the mapping. */
+function fakeAnonEndpoint(terms: Record<string, string>): typeof fetch {
+  return (async (_url: string, init: RequestInit) => {
+    const parsed = JSON.parse(init.body as string) as {
+      body: string;
+      mapping: Record<string, string>;
+    };
+    const map = { ...parsed.mapping };
+    let counter = Object.keys(map).length;
+    let out = unb64(parsed.body);
+    for (const [literal, type] of Object.entries(terms)) {
+      if (!out.includes(literal)) continue;
+      const existing = Object.entries(map).find(([, v]) => v === literal)?.[0];
+      const tok = existing ?? `[${type}_${++counter}]`;
+      if (!existing) map[tok] = literal;
+      out = out.split(literal).join(tok);
+    }
+    return new Response(JSON.stringify({ body: b64(out), mapping: map }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+}
+
+function baseDeps(fetchFn: typeof fetch, overrides?: Partial<AppDeps>): AppDeps {
+  return {
+    config: {
+      platformApiUrl: "http://platform.test",
+      runToken: "run-tok",
+      proxyUrl: "",
+      llm: {
+        authMode: "api_key",
+        baseUrl: "https://api.example.com",
+        apiKey: "k",
+        placeholder: "ph",
+      },
+    },
+    fetchCredentials: mock(
+      async (): Promise<CredentialsResponse> => ({
+        credentials: { access_token: "x" },
+        authorizedUris: [],
+        allowAllUris: false,
+        credentialHeaderName: "Authorization",
+        credentialHeaderPrefix: "Bearer",
+        credentialFieldName: "access_token",
+      }),
+    ),
+    cookieJar: new Map(),
+    fetchFn,
+    isReady: () => true,
+    ...overrides,
+  };
+}
+
+describe("/llm/* PII anonymization (b2.2b)", () => {
+  it("masks the body the upstream LLM sees and restores the agent's response", async () => {
+    let upstreamBody = "";
+    const fetchFn = mock(async (_url: string, init: RequestInit) => {
+      upstreamBody = init.body as string; // what the real LLM would receive
+      // The model reasons in tokens, so it echoes the token it was given.
+      return new Response(
+        JSON.stringify({ choices: [{ message: { content: "C'est noté pour [PERSON_1]." } }] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const anonymizer = createRunAnonymizer({
+      endpointUrl: "http://platform.test/internal/anonymize",
+      runToken: "run-tok",
+      fetchImpl: fakeAnonEndpoint({ "Benjamin Macé": "PERSON" }),
+    });
+
+    const app = createApp(baseDeps(fetchFn, { anonymizer }));
+    const res = await app.request("/llm/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        model: "mistral-large",
+        messages: [{ role: "user", content: "Écris à Benjamin Macé." }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    // 1) The upstream LLM NEVER saw the real PII — only a token.
+    expect(upstreamBody).not.toContain("Benjamin Macé");
+    expect(upstreamBody).toContain("[PERSON_1]");
+    // 2) The agent gets the RESTORED response (real value back, no token).
+    const agentSees = await res.text();
+    expect(agentSees).toContain("Benjamin Macé");
+    expect(agentSees).not.toContain("[PERSON_1]");
+  });
+
+  it("is a no-op on the response when no anonymizer is configured", async () => {
+    const fetchFn = mock(
+      async () =>
+        new Response('{"choices":[{"message":{"content":"hi"}}]}', {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    ) as unknown as typeof fetch;
+    const app = createApp(baseDeps(fetchFn)); // no anonymizer
+    const res = await app.request("/llm/v1/chat/completions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "Benjamin Macé" }] }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('{"choices":[{"message":{"content":"hi"}}]}');
+  });
+});

--- a/runtime-pi/sidecar/test/anonymizer.test.ts
+++ b/runtime-pi/sidecar/test/anonymizer.test.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Sidecar RunAnonymizer (palier b2 — Option S).
+ *
+ * Le masquage passe par un faux endpoint `/internal/anonymize` injecté ; le
+ * restore est LOCAL (assertion centrale : il n'appelle JAMAIS le réseau). On
+ * vérifie aussi la continuité de la table entre deux appels et le fail-closed.
+ */
+import { describe, it, expect } from "bun:test";
+import { createRunAnonymizer } from "../anonymizer.ts";
+
+const b64 = (s: string) => Buffer.from(s, "utf8").toString("base64");
+const unb64 = (s: string) => Buffer.from(s, "base64").toString("utf8");
+
+/** Faux endpoint qui masque une liste fixe de littéraux + fusionne la table,
+ *  comme le vrai `/internal/anonymize`. Compte ses appels. */
+function fakeEndpoint(terms: Record<string, string>) {
+  const calls: Array<{ auth: string | null; body: string; mapping: Record<string, string> }> = [];
+  const impl = (async (_url: string, init: RequestInit) => {
+    const parsed = JSON.parse(init.body as string) as {
+      body: string;
+      mapping: Record<string, string>;
+    };
+    calls.push({
+      auth: new Headers(init.headers).get("authorization"),
+      body: unb64(parsed.body),
+      mapping: parsed.mapping,
+    });
+    const map = { ...parsed.mapping };
+    const value2token: Record<string, string> = {};
+    let counter = 0;
+    for (const [tok, val] of Object.entries(map)) {
+      value2token[val] = tok;
+      const n = +tok.replace(/\D/g, "");
+      if (n > counter) counter = n;
+    }
+    let out = unb64(parsed.body);
+    for (const [literal, type] of Object.entries(terms)) {
+      if (!out.includes(literal)) continue;
+      let tok = value2token[literal];
+      if (!tok) {
+        tok = `[${type}_${++counter}]`;
+        map[tok] = literal;
+        value2token[literal] = tok;
+      }
+      out = out.split(literal).join(tok);
+    }
+    return new Response(JSON.stringify({ body: b64(out), mapping: map }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { impl, calls };
+}
+
+describe("sidecar RunAnonymizer", () => {
+  it("masks a body via the endpoint (auth + base64) and returns the decoded result", async () => {
+    const ep = fakeEndpoint({ "Benjamin Macé": "PERSON" });
+    const anon = createRunAnonymizer({
+      endpointUrl: "http://platform/internal/anonymize",
+      runToken: "tok-123",
+      fetchImpl: ep.impl,
+    });
+    const body = JSON.stringify({ messages: [{ role: "user", content: "Salut Benjamin Macé" }] });
+    const masked = await anon.maskBody(body);
+    expect(masked).toMatch(/\[PERSON_\d+\]/);
+    expect(masked).not.toContain("Benjamin Macé");
+    expect(ep.calls).toHaveLength(1);
+    expect(ep.calls[0]!.auth).toBe("Bearer tok-123");
+    expect(ep.calls[0]!.body).toContain("Benjamin Macé"); // envoyé en base64, décodé ici
+  });
+
+  it("restores LOCALLY — no network call", async () => {
+    const ep = fakeEndpoint({ "Benjamin Macé": "PERSON" });
+    const anon = createRunAnonymizer({
+      endpointUrl: "http://platform/internal/anonymize",
+      runToken: "tok",
+      fetchImpl: ep.impl,
+    });
+    await anon.maskBody(JSON.stringify({ messages: [{ role: "user", content: "Benjamin Macé" }] }));
+    const callsAfterMask = ep.calls.length;
+    const restored = anon.restore("Le modèle a écrit [PERSON_1] dans sa réponse.");
+    expect(restored).toContain("Benjamin Macé");
+    expect(ep.calls.length).toBe(callsAfterMask); // RESTORE = zéro réseau
+  });
+
+  it("keeps run continuity: same value → same token across calls", async () => {
+    const ep = fakeEndpoint({ "Benjamin Macé": "PERSON" });
+    const anon = createRunAnonymizer({
+      endpointUrl: "http://platform/internal/anonymize",
+      runToken: "tok",
+      fetchImpl: ep.impl,
+    });
+    const first = await anon.maskBody(
+      JSON.stringify({ messages: [{ role: "user", content: "Benjamin Macé" }] }),
+    );
+    const token = first.match(/\[PERSON_\d+\]/)![0];
+    // 2ᵉ appel : la table accumulée est renvoyée à l'endpoint → même jeton
+    const second = await anon.maskBody(
+      JSON.stringify({ messages: [{ role: "user", content: "Re Benjamin Macé" }] }),
+    );
+    expect(second).toContain(token);
+    expect(ep.calls[1]!.mapping[token]).toBe("Benjamin Macé"); // table threadée
+  });
+
+  it("fails CLOSED when the endpoint errors (no PII leak)", async () => {
+    const failing = (async () => new Response("boom", { status: 503 })) as unknown as typeof fetch;
+    const anon = createRunAnonymizer({
+      endpointUrl: "http://platform/internal/anonymize",
+      runToken: "tok",
+      fetchImpl: failing,
+    });
+    await expect(anon.maskBody(JSON.stringify({ messages: [] }))).rejects.toThrow(/503/);
+  });
+
+  it("restores an SSE stream locally, chunk by chunk", async () => {
+    const ep = fakeEndpoint({ "Benjamin Macé": "PERSON" });
+    const anon = createRunAnonymizer({
+      endpointUrl: "http://platform/internal/anonymize",
+      runToken: "tok",
+      fetchImpl: ep.impl,
+    });
+    await anon.maskBody(JSON.stringify({ messages: [{ role: "user", content: "Benjamin Macé" }] }));
+    const enc = new TextEncoder();
+    const dec = new TextDecoder();
+    const source = new ReadableStream<Uint8Array>({
+      start(c) {
+        c.enqueue(enc.encode('data: {"delta":"[PERSON_1]"}\n\n'));
+        c.close();
+      },
+    });
+    const out = source.pipeThrough(anon.restoreStream());
+    const reader = out.getReader();
+    let text = "";
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      text += dec.decode(value);
+    }
+    expect(text).toContain("Benjamin Macé");
+  });
+});

--- a/scripts/verify-module-contract.ts
+++ b/scripts/verify-module-contract.ts
@@ -80,6 +80,7 @@ const MODULE_TENANT: Record<string, Tenant> = {
   "core-providers": "oss",
   "module-codex": "oss",
   "module-claude-code": "oss",
+  "module-anonymizer": "oss",
   cloud: "cloud",
 };
 
@@ -96,6 +97,7 @@ const DECLARER_ROOTS: Record<string, string> = {
   "core-providers": "appstrate/apps/api/src/modules/core-providers",
   "module-codex": "appstrate/packages/module-codex/src",
   "module-claude-code": "appstrate/packages/module-claude-code/src",
+  "module-anonymizer": "appstrate/packages/module-anonymizer/src",
   cloud: "cloud/src",
 };
 
@@ -150,6 +152,13 @@ const LEDGER: Record<ContractMember, LedgerEntry> = {
     owners: ["cloud"],
     justification:
       "Email-template override into @appstrate/emails registry — cloud branding, single-owner by design.",
+  },
+  llmBodyTransformer: {
+    kind: "seam",
+    owners: ["module-anonymizer"],
+    justification:
+      "LLM-proxy body masking/restore — the proxy (apps/api/.../llm-proxy/core.ts) sits below the " +
+      "module layer; a direct import would name module-anonymizer. Single-owner by design.",
   },
 } satisfies Record<ContractMember, LedgerEntry>;
 

--- a/scripts/verify-openapi.ts
+++ b/scripts/verify-openapi.ts
@@ -283,6 +283,7 @@ const expectedEndpoints = [
   "GET /internal/mcp-server-bundle/{scope}/{name}",
   "GET /internal/integration-credentials/{scope}/{name}",
   "POST /internal/integration-credentials/{scope}/{name}/refresh",
+  "POST /internal/anonymize",
 
   // Meta
   "GET /api/openapi.json",


### PR DESCRIPTION
## Ce que fait cette PR

Nouveau module **`@appstrate/module-anonymizer`** (opt-in via `MODULES`) : masque la PII **avant** le LLM et la restaure dans la réponse — **réversible**, pour le **chat** comme pour les **agent runs**.

## Les briques

- **Détecteur à 4 étages** (pas que du ML) : regex haute-précision (EMAIL/IBAN/PHONE…) → deny-list métier → **GLiNER2** (NER *zero-shot* : on donne les labels à l'appel, sans réentraîner ; **ONNX in-Bun**, sans Python/torch) → arbitrage des chevauchements ; + stop-list de mots-rôle. Modèle chargé **paresseusement** → zéro binding natif au boot.
- **Réversible** : jetons `[TYPE_N]` non ambigus → restore = simple lookup. Même valeur ⇒ même jeton (table cohérente sur tout un run).

```
toi : « Appelle Jean Dupont (jean@acme.fr) »
   │ MASQUER (détecteur)
   ▼
« Appelle [PERSON_1] ([EMAIL_1]) » ─────────►  LLM (ne voit QUE des alias)
« Je contacte Jean Dupont »  ◄── RESTORE (table) ──  « Je contacte [PERSON_1] »
   table : [PERSON_1]=Jean Dupont · [EMAIL_1]=jean@acme.fr  (ne sort JAMAIS)
```

## Choix d'archi : un seam *single-owner*

Le proxy LLM est une **passerelle `fetch`** (pas un `wrapLanguageModel`) → on a **conçu un point d'extension du core** : `LlmBodyTransformer` / `LlmBodyTransformerFactory`. Le core demande « y a-t-il un transformer de corps ? » (`getModuleLlmBodyTransformer()`) — **par capacité, pas par nom de module**. Un seul module le branche.

Deux seams, **un** détecteur :
- **b1 — chat** : le proxy masque/restaure (JSON · SSE · erreur), table dans le process plateforme.
- **b2 — agent runs (Option S)** : la table vit dans le **sidecar** (seul process couvrant *forward LLM + exécution d'outils*). Masquer exige le détecteur (HTTP `POST /internal/anonymize`, run-token, **fail-closed**) ; **restaurer est 100 % local** (pur lookup) → *on loge la table là où on restaure*. **Zéro modèle dans l'image runner.**

## Respect de l'approche module

- **Zéro empreinte éteint** : absent de `MODULES` = no-op total ; même chargé sans trafic, onnxruntime n'est jamais tiré.
- **Aucune table** ; le sidecar **n'importe rien** du module (il parle uniquement par l'endpoint = frontière propre).

## Vérification

`bun run check` vert (32/32) + **28 tests** (module 7 · sidecar anonymizer-llm+app 21).

---
*Fiche concept interne : GLiNER / ONNX / pile détecteur / briques core → flux mask-restore + Option S.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
