### PR TITLE
perf(chat): réduire le TTFT (parallélisation préambule + hops + index MCP)

### DIFF
--- a/apps/api/src/lib/modules/registry.ts
+++ b/apps/api/src/lib/modules/registry.ts
@@ -20,6 +20,8 @@ import { getEnv } from "@appstrate/env";
 import { logger } from "../logger.ts";
 import { rateLimit } from "../../middleware/rate-limit.ts";
 import { listLlmUsageForRun } from "../../services/state/runs.ts";
+import { listUsableIntegrationsForActor } from "../../services/integration-connections.ts";
+import { getPlatformApp } from "../platform-app.ts";
 
 // ---------------------------------------------------------------------------
 // Registry — env-driven module specifiers
@@ -96,6 +98,21 @@ function buildPlatformServices(): PlatformServices {
       rateLimit: (maxPerMinute) => rateLimit(maxPerMinute) as MiddlewareHandler,
     },
     runs: { listLlmUsage: listLlmUsageForRun },
+    integrations: {
+      // The chat module's in-process replacement for its old GET
+      // /api/me/context loopback hop — identity + role come off the request
+      // context, only the integration list needs this single DB read.
+      listUsableForActor: ({ orgId, applicationId, actor }) =>
+        listUsableIntegrationsForActor({ orgId, applicationId }, actor),
+    },
+    inProcess: {
+      // Re-enter the fully-wired platform app in-process (no socket hop). The
+      // app is registered by `registerModuleRoutes`; this throws if called
+      // before that runs (a programming error, not a runtime condition).
+      // `app.fetch` is `Response | Promise<Response>`; the async wrapper
+      // normalizes it to the `Promise<Response>` the service contract declares.
+      dispatch: async (request) => getPlatformApp().fetch(request),
+    },
   };
 }
 

--- a/apps/api/src/modules/mcp/catalog.ts
+++ b/apps/api/src/modules/mcp/catalog.ts
@@ -209,16 +209,20 @@ export function buildOperationIndex(permissions?: ReadonlySet<string>): string {
   const byTag = new Map<string, string[]>();
   for (const op of operations.values()) {
     const tag = op.tags[0] ?? "Other";
-    const line = `- ${op.operationId}${op.summary ? ` — ${op.summary}` : ""}`;
-    (byTag.get(tag) ?? byTag.set(tag, []).get(tag)!).push(line);
+    // operationId ONLY — the per-op summary is dropped from the index to keep it
+    // compact (it's several KB across ~230 ops, re-sent every uncached turn).
+    // describe_operation remains the source of truth for what each op does + its
+    // schema, so the model gets the full detail when it picks an id from here.
+    (byTag.get(tag) ?? byTag.set(tag, []).get(tag)!).push(op.operationId);
   }
 
   const sections = [...byTag.keys()]
     .sort()
     .filter((tag) => !permissions || tagVisible(tag, permissions))
     .map((tag) => {
-      const lines = byTag.get(tag)!.sort();
-      return `## ${tag}\n${lines.join("\n")}`;
+      // One compact, comma-separated line of operationIds per tag.
+      const ids = byTag.get(tag)!.sort();
+      return `## ${tag}\n${ids.join(", ")}`;
     });
 
   const result = sections.join("\n\n");

--- a/apps/api/src/modules/mcp/test/integration/mcp.test.ts
+++ b/apps/api/src/modules/mcp/test/integration/mcp.test.ts
@@ -383,8 +383,9 @@ describe("mcp tool round-trip", () => {
     // chat splits on the same literal to strip it for uncached/no-tool
     // providers (see applyOperationIndexPolicy in module-chat). Keep in sync.
     expect(instructions).toContain("## Operation index");
-    // ...and the index actually lists operations under it.
-    expect(instructions!.split("## Operation index")[1]).toContain("- listAgents");
+    // ...and the index actually lists operations under it (compact form:
+    // comma-separated operationIds per tag, no per-op summary).
+    expect(instructions!.split("## Operation index")[1]).toContain("listAgents");
   });
 });
 

--- a/apps/api/src/modules/mcp/test/integration/mcp.test.ts
+++ b/apps/api/src/modules/mcp/test/integration/mcp.test.ts
@@ -385,7 +385,14 @@ describe("mcp tool round-trip", () => {
     expect(instructions).toContain("## Operation index");
     // ...and the index actually lists operations under it (compact form:
     // comma-separated operationIds per tag, no per-op summary).
-    expect(instructions!.split("## Operation index")[1]).toContain("listAgents");
+    const indexSection = instructions!.split("## Operation index")[1]!;
+    expect(indexSection).toContain("listAgents");
+    // Regression guard for the compact index (TTFT): operationIds only, never the
+    // old `- operationId — summary` form. The bullet+em-dash would re-bloat the
+    // index (~3.4k tokens) that every uncached turn re-sends. If summaries return,
+    // this fails — re-evaluate the token cost first.
+    expect(indexSection).not.toContain(" — ");
+    expect(indexSection).not.toMatch(/^- \w/m);
   });
 });
 

--- a/apps/api/src/openapi/paths/models.ts
+++ b/apps/api/src/openapi/paths/models.ts
@@ -7,7 +7,17 @@ export const modelsPaths = {
       tags: ["Models"],
       summary: "List organization models",
       description: "Returns all models (built-in + custom) for the current organization.",
-      parameters: [{ $ref: "#/components/parameters/XOrgId" }],
+      parameters: [
+        { $ref: "#/components/parameters/XOrgId" },
+        {
+          name: "metadata_only",
+          in: "query",
+          required: false,
+          description:
+            "When true, resolve each model's protocol family and base URL from the provider registry WITHOUT decrypting its credential. Faster for callers that only need to pick a model (e.g. the chat model picker); a model whose secret is unusable is not filtered and surfaces an error only at inference time.",
+          schema: { type: "boolean" },
+        },
+      ],
       responses: {
         "200": {
           description: "Model list",

--- a/apps/api/src/routes/models.ts
+++ b/apps/api/src/routes/models.ts
@@ -130,7 +130,13 @@ export function createModelsRouter() {
   // GET /api/models — list all models (system + DB)
   router.get("/", requirePermission("models", "read"), async (c) => {
     const orgId = c.get("orgId");
-    const models = await listOrgModels(orgId);
+    // `metadata_only`: resolve protocol family/baseUrl from the registry without
+    // decrypting each model's credential. For callers that only need to pick a
+    // model row (e.g. the chat picker), not to call inference. Rows with a gone
+    // credential/provider are still dropped, but a model whose secret is unusable
+    // (dead OAuth) is NOT filtered here — it surfaces and errors at inference.
+    const metadataOnly = c.req.query("metadata_only") === "true";
+    const models = await listOrgModels(orgId, { metadataOnly });
     // Strip the backing of any model alias before it reaches the dashboard user
     // (Threat A) — see projectAliasedModel. Non-aliased models pass through.
     //

--- a/apps/api/src/services/model-providers/credentials.ts
+++ b/apps/api/src/services/model-providers/credentials.ts
@@ -184,6 +184,40 @@ export async function loadCredentialRow(
   };
 }
 
+/**
+ * Registry-derived credential metadata WITHOUT decrypting the secret blob.
+ * `providerId` is a plaintext column; `apiShape`/`baseUrl` come from the
+ * provider registry. Used by metadata-only listings (e.g. the chat model
+ * picker) that need to resolve the protocol family + base URL but never the
+ * key itself — the real secret is decrypted later, at inference time.
+ */
+export interface CredentialMetadata {
+  providerId: string;
+  apiShape: ModelApiShape;
+  baseUrl: string;
+}
+
+export async function loadCredentialMetadata(
+  id: string,
+  orgId: string,
+): Promise<CredentialMetadata | null> {
+  const [row] = await db
+    .select({
+      orgId: modelProviderCredentials.orgId,
+      providerId: modelProviderCredentials.providerId,
+      baseUrlOverride: modelProviderCredentials.baseUrlOverride,
+    })
+    .from(modelProviderCredentials)
+    .where(eq(modelProviderCredentials.id, id))
+    .limit(1);
+  if (!row || row.orgId !== orgId) return null;
+  const cfg = getModelProvider(row.providerId);
+  if (!cfg) return null;
+  const baseUrl =
+    row.baseUrlOverride && cfg.baseUrlOverridable ? row.baseUrlOverride : cfg.defaultBaseUrl;
+  return { providerId: row.providerId, apiShape: cfg.apiShape, baseUrl };
+}
+
 // ─── Create ────────────────────────────────────────────────────────────────
 
 export interface CreateApiKeyCredentialInput {

--- a/apps/api/src/services/model-providers/credentials.ts
+++ b/apps/api/src/services/model-providers/credentials.ts
@@ -31,6 +31,7 @@ import { dedupeLabel } from "@appstrate/core/dedupe-label";
 import { getSystemModelProviderCredentials, getSystemModels } from "../model-registry.ts";
 import { logger } from "../../lib/logger.ts";
 import type { ModelProviderCredentialInfo } from "@appstrate/shared-types";
+import { clearResolvedModelCache } from "../resolved-model-cache.ts";
 
 // ─── Blob shapes (encrypted at rest) ───────────────────────────────────────
 
@@ -361,6 +362,9 @@ export async function updateModelProviderCredential(
         extra: [eq(modelProviderCredentials.id, id)],
       }),
     );
+  // Models backed by this credential may have a cached resolution carrying the
+  // old key/baseUrl — drop it so the rotation takes effect immediately.
+  clearResolvedModelCache();
 }
 
 // ─── Label derivation ──────────────────────────────────────────────────────
@@ -449,6 +453,10 @@ async function updateOAuthBlob(
         extra: [eq(modelProviderCredentials.id, id)],
       }),
     );
+  // Chokepoint for every OAuth blob write (token refresh + needsReconnection):
+  // bust the resolved-model cache so a rotated token or a freshly-dead credential
+  // stops being served immediately, not after the TTL.
+  clearResolvedModelCache();
 }
 
 export async function updateOAuthCredentialTokens(
@@ -552,6 +560,9 @@ export async function deleteModelProviderCredential(orgId: string, id: string): 
       extra: [eq(modelProviderCredentials.id, id)],
     }),
   );
+  // Any model backed by the deleted credential is now unresolvable — drop cached
+  // resolutions so they don't serve a stale (now-deleted) secret.
+  clearResolvedModelCache();
 }
 
 // ─── Aggregated UI surface (system env-driven + DB) ────────────────────────

--- a/apps/api/src/services/org-models.ts
+++ b/apps/api/src/services/org-models.ts
@@ -18,6 +18,11 @@ import {
   loadCredentialMetadata,
 } from "./model-providers/credentials.ts";
 import type { ModelApiShape } from "@appstrate/core/sidecar-types";
+import {
+  getResolvedModel,
+  setResolvedModel,
+  invalidateResolvedModel,
+} from "./resolved-model-cache.ts";
 import { toISORequired } from "../lib/date-helpers.ts";
 import {
   mergeSystemAndDb,
@@ -323,6 +328,8 @@ export async function updateOrgModel(
     .update(orgModels)
     .set(updates)
     .where(scopedWhere(orgModels, { orgId, extra: [eq(orgModels.id, modelDbId)] }));
+  // Drop the cached resolution (modelId/enabled/credential/cost may have changed).
+  invalidateResolvedModel(orgId, modelDbId);
 }
 
 export async function deleteOrgModel(orgId: string, modelDbId: string): Promise<void> {
@@ -332,6 +339,7 @@ export async function deleteOrgModel(orgId: string, modelDbId: string): Promise<
   await db
     .delete(orgModels)
     .where(scopedWhere(orgModels, { orgId, extra: [eq(orgModels.id, modelDbId)] }));
+  invalidateResolvedModel(orgId, modelDbId);
   // If the deleted model was the org default, clear the now-dangling pointer so
   // the resolver falls cleanly to the system cascade (no stale-id badge).
   await defaultModel.clearDanglingPointer(orgId, modelDbId);
@@ -629,26 +637,6 @@ export async function resolveModel(
   return null;
 }
 
-// Short-TTL cache of resolved DB models. A single chat turn / agent run fans
-// out into many `loadModel(orgId, presetId)` calls (the llm-proxy resolves the
-// preset on EVERY inference request, up to MAX_STEPS per turn) — each otherwise
-// re-queries `org_models` + re-decrypts the credential. Caching the resolved
-// model for a few seconds collapses that to one resolve per window. Only the
-// successful (non-null) DB result is cached; system models are already in-memory
-// and not cached here. Trade-off: a credential rotation/disable is visible after
-// at most `RESOLVED_MODEL_TTL_MS`.
-const resolvedModelCache = new Map<string, { value: ResolvedModel; exp: number }>();
-const RESOLVED_MODEL_TTL_MS = 30_000;
-const RESOLVED_MODEL_CACHE_MAX = 500;
-
-function cacheResolvedModel(key: string, value: ResolvedModel): void {
-  if (resolvedModelCache.size >= RESOLVED_MODEL_CACHE_MAX && !resolvedModelCache.has(key)) {
-    const oldest = resolvedModelCache.keys().next().value;
-    if (oldest !== undefined) resolvedModelCache.delete(oldest);
-  }
-  resolvedModelCache.set(key, { value, exp: Date.now() + RESOLVED_MODEL_TTL_MS });
-}
-
 export async function loadModel(orgId: string, modelDbId: string): Promise<ResolvedModel | null> {
   // Check system models first
   const system = getSystemModels();
@@ -657,9 +645,11 @@ export async function loadModel(orgId: string, modelDbId: string): Promise<Resol
     return buildSystemResolvedModel(systemDef);
   }
 
-  const cacheKey = `${orgId}:${modelDbId}`;
-  const cached = resolvedModelCache.get(cacheKey);
-  if (cached && cached.exp > Date.now()) return cached.value;
+  // Short-TTL cache (see resolved-model-cache.ts). Only the successful (non-null)
+  // DB result is cached; system models are already in-memory. Invalidated
+  // eagerly by model + credential mutators, so the TTL is a backstop.
+  const cached = getResolvedModel(orgId, modelDbId);
+  if (cached) return cached;
 
   // Check DB. `orgModels.id` is a `uuid` column — a `modelDbId` that isn't a
   // valid UUID (e.g. a human-readable model name like `gpt-5.5`) makes Postgres
@@ -699,7 +689,7 @@ export async function loadModel(orgId: string, modelDbId: string): Promise<Resol
   if (!creds) return null;
 
   const resolved = buildDbResolvedModel(row, creds);
-  cacheResolvedModel(cacheKey, resolved);
+  setResolvedModel(orgId, modelDbId, resolved);
   return resolved;
 }
 

--- a/apps/api/src/services/org-models.ts
+++ b/apps/api/src/services/org-models.ts
@@ -15,8 +15,9 @@ import type { ModelMetadata, OrgModelInfo, TestResult } from "@appstrate/shared-
 import {
   loadInferenceCredentials,
   loadCredentialRow,
-  type DecryptedModelProviderCredentials,
+  loadCredentialMetadata,
 } from "./model-providers/credentials.ts";
+import type { ModelApiShape } from "@appstrate/core/sidecar-types";
 import { toISORequired } from "../lib/date-helpers.ts";
 import {
   mergeSystemAndDb,
@@ -130,7 +131,10 @@ export function projectAliasedModel(model: OrgModelInfo): OrgModelInfo {
 
 // --- List (system + DB) ---
 
-export async function listOrgModels(orgId: string): Promise<OrgModelInfo[]> {
+export async function listOrgModels(
+  orgId: string,
+  opts?: { metadataOnly?: boolean },
+): Promise<OrgModelInfo[]> {
   const system = getSystemModels();
   const rows = await db.select().from(orgModels).where(scopedWhere(orgModels, { orgId }));
   // The default is an org-level pointer: when set, exactly that id is the
@@ -138,15 +142,26 @@ export async function listOrgModels(orgId: string): Promise<OrgModelInfo[]> {
   const pointer = await defaultModel.getDefaultId(orgId);
   const now = toISORequired(new Date());
 
-  // Resolve apiShape/baseUrl from the registry via the credential's providerId.
-  // The DB row no longer stores these — they're derivatives of `providerId`.
-  // Rows whose credential is unreachable (deleted upstream, decryption failed,
-  // dead OAuth) are skipped silently — they can't be loaded for inference
-  // anyway, so surfacing them in the list would only confuse the UI.
-  const credByRow = new Map<string, DecryptedModelProviderCredentials>();
+  // Resolve apiShape/providerId/baseUrl per row (the DB row no longer stores
+  // them — they derive from the credential's `providerId`). Two modes:
+  //   - default: decrypt each credential (`loadInferenceCredentials`); a row
+  //     with an unreachable credential (deleted upstream, dead OAuth, decrypt
+  //     failure) is dropped — surfacing it would confuse the UI.
+  //   - metadataOnly: resolve from the registry WITHOUT touching the secret
+  //     (`loadCredentialMetadata`). Skips the decrypt for callers that only need
+  //     the protocol family (e.g. the chat model picker); the real secret is
+  //     resolved later at inference time. A row whose credential/provider is
+  //     gone is still dropped. mapRow below reads only providerId/apiShape/
+  //     baseUrl, so both resolvers feed it the same shape.
+  const credByRow = new Map<
+    string,
+    { providerId: string; apiShape: ModelApiShape; baseUrl: string }
+  >();
   await Promise.all(
     rows.map(async (r) => {
-      const creds = await loadInferenceCredentials(orgId, r.credentialId);
+      const creds = opts?.metadataOnly
+        ? await loadCredentialMetadata(r.credentialId, orgId)
+        : await loadInferenceCredentials(orgId, r.credentialId);
       if (creds) credByRow.set(r.id, creds);
     }),
   );
@@ -614,6 +629,26 @@ export async function resolveModel(
   return null;
 }
 
+// Short-TTL cache of resolved DB models. A single chat turn / agent run fans
+// out into many `loadModel(orgId, presetId)` calls (the llm-proxy resolves the
+// preset on EVERY inference request, up to MAX_STEPS per turn) — each otherwise
+// re-queries `org_models` + re-decrypts the credential. Caching the resolved
+// model for a few seconds collapses that to one resolve per window. Only the
+// successful (non-null) DB result is cached; system models are already in-memory
+// and not cached here. Trade-off: a credential rotation/disable is visible after
+// at most `RESOLVED_MODEL_TTL_MS`.
+const resolvedModelCache = new Map<string, { value: ResolvedModel; exp: number }>();
+const RESOLVED_MODEL_TTL_MS = 30_000;
+const RESOLVED_MODEL_CACHE_MAX = 500;
+
+function cacheResolvedModel(key: string, value: ResolvedModel): void {
+  if (resolvedModelCache.size >= RESOLVED_MODEL_CACHE_MAX && !resolvedModelCache.has(key)) {
+    const oldest = resolvedModelCache.keys().next().value;
+    if (oldest !== undefined) resolvedModelCache.delete(oldest);
+  }
+  resolvedModelCache.set(key, { value, exp: Date.now() + RESOLVED_MODEL_TTL_MS });
+}
+
 export async function loadModel(orgId: string, modelDbId: string): Promise<ResolvedModel | null> {
   // Check system models first
   const system = getSystemModels();
@@ -621,6 +656,10 @@ export async function loadModel(orgId: string, modelDbId: string): Promise<Resol
   if (systemDef) {
     return buildSystemResolvedModel(systemDef);
   }
+
+  const cacheKey = `${orgId}:${modelDbId}`;
+  const cached = resolvedModelCache.get(cacheKey);
+  if (cached && cached.exp > Date.now()) return cached.value;
 
   // Check DB. `orgModels.id` is a `uuid` column — a `modelDbId` that isn't a
   // valid UUID (e.g. a human-readable model name like `gpt-5.5`) makes Postgres
@@ -659,7 +698,9 @@ export async function loadModel(orgId: string, modelDbId: string): Promise<Resol
   const creds = await loadInferenceCredentials(orgId, row.credentialId);
   if (!creds) return null;
 
-  return buildDbResolvedModel(row, creds);
+  const resolved = buildDbResolvedModel(row, creds);
+  cacheResolvedModel(cacheKey, resolved);
+  return resolved;
 }
 
 /**

--- a/apps/api/src/services/resolved-model-cache.ts
+++ b/apps/api/src/services/resolved-model-cache.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Short-TTL cache of resolved DB models, shared by `loadModel` (writer/reader)
+ * and the credential mutators (invalidation). A single chat turn / agent run
+ * fans out into many `loadModel(orgId, presetId)` calls — the llm-proxy resolves
+ * the preset on EVERY inference request (up to MAX_STEPS per turn) — each
+ * otherwise re-queries `org_models` + the credential row and re-decrypts. The
+ * cache collapses that to one resolve per window.
+ *
+ * Lives in its own module (not `org-models.ts`) so `credentials.ts` can bust it
+ * on a credential mutation WITHOUT an import cycle (`org-models` already imports
+ * `credentials`). The `ResolvedModel` value type is a TYPE-ONLY import — erased
+ * at runtime, so it introduces no runtime dependency edge.
+ *
+ * Security: the cached value carries the decrypted credential, so a disable /
+ * rotation / reconnection-flag change MUST invalidate it immediately (not wait
+ * out the TTL). Every credential mutator calls `clearResolvedModelCache()`; the
+ * TTL is only a backstop for anything not explicitly wired.
+ */
+
+import type { ResolvedModel } from "./org-models.ts";
+
+const TTL_MS = 30_000;
+const MAX = 500;
+
+const cache = new Map<string, { value: ResolvedModel; exp: number }>();
+
+const keyOf = (orgId: string, modelDbId: string): string => `${orgId}:${modelDbId}`;
+
+export function getResolvedModel(orgId: string, modelDbId: string): ResolvedModel | null {
+  const hit = cache.get(keyOf(orgId, modelDbId));
+  if (hit && hit.exp > Date.now()) return hit.value;
+  return null;
+}
+
+export function setResolvedModel(orgId: string, modelDbId: string, value: ResolvedModel): void {
+  const key = keyOf(orgId, modelDbId);
+  if (cache.size >= MAX && !cache.has(key)) {
+    const oldest = cache.keys().next().value;
+    if (oldest !== undefined) cache.delete(oldest);
+  }
+  cache.set(key, { value, exp: Date.now() + TTL_MS });
+}
+
+/** Drop one model's entry — call when that specific model row changes. */
+export function invalidateResolvedModel(orgId: string, modelDbId: string): void {
+  cache.delete(keyOf(orgId, modelDbId));
+}
+
+/**
+ * Drop the whole cache — call on a credential mutation. A credential backs N
+ * models (1:N); the cache is keyed by model id, so there's no cheap by-credential
+ * eviction. Credential mutations are rare/admin/refresh-worker ops, so clearing
+ * all is the simplest correct choice (the cache just rebuilds on next use).
+ */
+export function clearResolvedModelCache(): void {
+  cache.clear();
+}

--- a/apps/api/test/unit/modules/platform-services.test.ts
+++ b/apps/api/test/unit/modules/platform-services.test.ts
@@ -31,4 +31,12 @@ describe("ModuleInitContext.services — platform service wiring", () => {
   it("wires the run-ledger read (runs.listLlmUsage — sole cross-tenant consumer: cloud)", () => {
     expect(typeof services.runs.listLlmUsage).toBe("function");
   });
+
+  it("wires the integration read (integrations.listUsableForActor — chat caller context)", () => {
+    expect(typeof services.integrations.listUsableForActor).toBe("function");
+  });
+
+  it("wires in-process dispatch (inProcess.dispatch — chat loopback-free reads)", () => {
+    expect(typeof services.inProcess.dispatch).toBe("function");
+  });
 });

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -12162,7 +12162,10 @@ export interface operations {
     };
     listModels: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description When true, resolve each model's protocol family and base URL from the provider registry WITHOUT decrypting its credential. Faster for callers that only need to pick a model (e.g. the chat model picker); a model whose secret is unusable is not filtered and surfaces an error only at inference time. */
+                metadata_only?: boolean;
+            };
             header?: {
                 /** @description Organization ID. Required for cookie auth. Not needed for API key auth (org resolved from key). */
                 "X-Org-Id"?: components["parameters"]["XOrgId"];

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -992,4 +992,31 @@ export interface PlatformServices {
       sources: readonly string[];
     }): Promise<Array<{ id: number; costUsd: number; source: string }>>;
   };
+  /**
+   * Integration read surface. `listUsableForActor` returns the integrations an
+   * actor could attach when building an agent in the given application (the
+   * actor's own connections plus org-shared ones) — the same data the
+   * `get_me` / `GET /api/me/context` payload exposes, read in-process WITHOUT a
+   * loopback HTTP hop. The `chat` module assembles its system-prompt context
+   * block from this (identity + role come straight off the request context).
+   */
+  integrations: {
+    listUsableForActor(args: {
+      orgId: string;
+      applicationId: string;
+      actor: { type: "user" | "end_user"; id: string };
+    }): Promise<Array<{ integration_id: string; name: string; source: string }>>;
+  };
+  /**
+   * In-process dispatch into the fully-wired platform Hono app — the same
+   * request the loopback `fetch("http://127.0.0.1:<port>/api/…")` would make,
+   * but without the socket round-trip and HTTP (de)serialization. The auth
+   * pipeline + RBAC still run on every dispatched request (it goes through the
+   * whole middleware chain), so a caller can never exceed what the forwarded
+   * credential could do over REST. Callers MUST set the caller's auth/scoping
+   * headers on the `Request` exactly as they would for the loopback fetch.
+   */
+  inProcess: {
+    dispatch(request: Request): Promise<Response>;
+  };
 }

--- a/packages/module-chat/src/chat-stream.ts
+++ b/packages/module-chat/src/chat-stream.ts
@@ -25,6 +25,7 @@ import { selfOrigin, forwardedHeaders } from "./self.ts";
 import { mintLoopbackToken } from "./loopback-auth.ts";
 import { subscriptionEngineDef } from "@appstrate/core/subscription-engines";
 import { buildTranscriptPrompt } from "./transcript.ts";
+import { getIntegrationsService } from "./platform-services.ts";
 
 const MAX_STEPS = 16;
 
@@ -138,6 +139,56 @@ function clientErrorMessage(error: unknown): string {
   return `Le modèle a échoué : ${trimmed.length > 400 ? `${trimmed.slice(0, 400)}…` : trimmed}`;
 }
 
+/**
+ * Build the caller-context system-prompt block WITHOUT a loopback HTTP hop when
+ * possible. Identity (name/email) and role come straight off the request
+ * context (already authenticated by the platform pipeline); only the connected
+ * integrations need a read, served in-process via the injected platform
+ * service. Falls back to the `GET /api/me/context` loopback when the service
+ * isn't wired (OSS/tests). Best-effort: any failure degrades to no block ("").
+ */
+async function buildCallerContextBlock(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  c: Context<any>,
+  args: {
+    origin: string;
+    headers: Record<string, string>;
+    orgId: string;
+    applicationId?: string;
+    user: { id: string; name?: string | null; email?: string | null };
+  },
+): Promise<string> {
+  const { origin, headers, orgId, applicationId, user } = args;
+  const role = (c.get("orgRole") as string | undefined) ?? undefined;
+  try {
+    const svc = getIntegrationsService();
+    if (svc && applicationId) {
+      // In-process: identity/role from context, only connections hit the DB.
+      const connections = await svc.listUsableForActor({
+        orgId,
+        applicationId,
+        actor: { type: "user", id: user.id },
+      });
+      return formatCallerContext({
+        user: { name: user.name ?? null, email: user.email ?? null },
+        org: { role: role ?? null },
+        connections,
+      });
+    }
+    // Fallback: the original loopback hop (kept for OSS/test wiring).
+    const ctxHeaders: Record<string, string> = { ...headers };
+    if (applicationId) ctxHeaders["x-application-id"] = applicationId;
+    const res = await fetch(new URL("/api/me/context", origin), { headers: ctxHeaders });
+    if (res.ok) return formatCallerContext(await res.json());
+    return "";
+  } catch (err) {
+    logger.warn("me/context unavailable — chat degrades without caller context", {
+      err: String(err),
+    });
+    return "";
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function handleChatStream(c: Context<any>): Promise<Response> {
   const orgId = c.get("orgId") as string;
@@ -149,6 +200,14 @@ export async function handleChatStream(c: Context<any>): Promise<Response> {
 
   const origin = selfOrigin();
   const headers = forwardedHeaders(c);
+
+  // Per-turn observability: structured per-step logs to stdout. Full payloads
+  // only under CHAT_DEBUG — they may carry PII/customer content.
+  const debug = Boolean(process.env.CHAT_DEBUG);
+  const turnStart = Date.now();
+  let step = 0;
+  let stepStart = turnStart;
+  let firstChunkAt = 0;
 
   // The proxy surfaces are bearer-only (cookies refused — CSRF model):
   // inference loopback calls carry a short-lived token only this process
@@ -167,82 +226,28 @@ export async function handleChatStream(c: Context<any>): Promise<Response> {
     "X-Org-Id": orgId,
   };
 
-  // Model chosen in the picker (X-Model-Id), else the request body, else the
-  // org default. We pick the org model row first (so we can read its
-  // providerId) and only then decide the engine — `claude-code` (Claude
-  // subscription) goes through the Agent SDK; everything else through ai-sdk.
+  // ── Preamble phase A (parallel) ──────────────────────────────────────────
+  // The model list and the default application id are independent reads, so
+  // fire them together rather than back-to-back. `listModels` decides the
+  // engine (we read the chosen row's providerId); the app id scopes the MCP
+  // + integration reads that follow. Pin from the header when the caller
+  // already supplied one (no lookup needed).
   const modelId = c.req.header("X-Model-Id") ?? body.modelId;
-  const models = await listModels(origin, inferenceHeaders);
+  const pinnedAppId = c.req.header("x-application-id");
+  const phaseAStart = Date.now();
+  const [models, applicationId] = await Promise.all([
+    listModels(origin, inferenceHeaders),
+    pinnedAppId
+      ? Promise.resolve(pinnedAppId)
+      : resolveDefaultApplicationId(origin, headers, orgId),
+  ]);
   const chosen = pickModel(models, modelId);
+  const phaseAMs = Date.now() - phaseAStart;
   logger.info("model resolved", {
     model: chosen.id,
     modelId: chosen.modelId,
     providerId: chosen.providerId,
   });
-  // App-scoped ops (agents, runs) need an application context; resolve the
-  // org's default app unless the caller already pinned one.
-  const applicationId =
-    c.req.header("x-application-id") ?? (await resolveDefaultApplicationId(origin, headers, orgId));
-  // Graceful degradation: the chat's tools come from the platform MCP module
-  // (`/api/mcp/o/:org`). If it's unreachable (e.g. `mcp` not in MODULES), keep
-  // the turn usable for plain conversation instead of 500-ing. The UI surfaces
-  // a "no tools" banner via the `mcp` app-config feature flag.
-  let mcp: Awaited<ReturnType<typeof openPlatformMcp>> | null = null;
-  // Single MCP-teardown path. The session must be closed on EVERY exit (the
-  // claude engine's early return, the ai-sdk stream's `onError` AND `onFinish`,
-  // and a mid-stream client disconnect) or it leaks per turn — close failures are
-  // swallowed (warn only) so they never mask the turn result. `await` it on the
-  // synchronous paths, `void` it inside the stream callbacks.
-  const closeMcp = async (): Promise<void> => {
-    try {
-      await mcp?.close();
-    } catch (err) {
-      logger.warn("mcp close failed", { err: String(err) });
-    }
-  };
-  try {
-    mcp = await openPlatformMcp({ origin, headers, orgId, applicationId });
-  } catch (err) {
-    logger.warn("platform MCP unavailable — chat degrades to no-tools", { err: String(err) });
-  }
-
-  // Per-turn observability: structured per-step logs to stdout. Full payloads
-  // only under CHAT_DEBUG — they may carry PII/customer content.
-  const debug = Boolean(process.env.CHAT_DEBUG);
-  const turnStart = Date.now();
-  let step = 0;
-  let stepStart = turnStart;
-
-  let system = !mcp
-    ? NO_TOOLS_SYSTEM_PROMPT
-    : mcp.instructions
-      ? `${SYSTEM_PROMPT}\n\n${mcp.instructions}`
-      : SYSTEM_PROMPT;
-  if (body.context) {
-    system += `\n\nThe user is currently looking at: ${body.context.type} "${body.context.label ?? body.context.id}" (id: ${body.context.id}). Prefer this context when the question is ambiguous.`;
-  }
-
-  // Caller context (identity, role, connected integrations) — one source of
-  // truth shared with the MCP `get_me` tool: GET /api/me/context. Best-effort,
-  // a failure degrades to no context block rather than breaking the turn.
-  try {
-    const ctxHeaders: Record<string, string> = { ...headers };
-    if (applicationId) ctxHeaders["x-application-id"] = applicationId;
-    const res = await fetch(new URL("/api/me/context", origin), { headers: ctxHeaders });
-    if (res.ok) {
-      const block = formatCallerContext(await res.json());
-      if (block) system += `\n\n${block}`;
-    }
-  } catch (err) {
-    logger.warn("me/context unavailable — chat degrades without caller context", {
-      err: String(err),
-    });
-  }
-
-  // Platform MCP wiring shared by both engines: the meta-tools live at
-  // /api/mcp/o/:org and run with the caller's own credentials (RBAC fidelity).
-  const mcpHeaders: Record<string, string> = { ...headers };
-  if (applicationId) mcpHeaders["x-application-id"] = applicationId;
 
   // Subscription engine with a chat surface — the binding AND its chat driver
   // are contributed by the provider module via the shared core registry (the
@@ -253,20 +258,96 @@ export async function handleChatStream(c: Context<any>): Promise<Response> {
   // (filtered from the chat model list by CHAT_USABLE_FAMILIES) and contributes
   // no chatHandler — so today only the Claude Agent SDK reaches this branch.
   const subscriptionEngine = subscriptionEngineDef(chosen.providerId ?? "");
+  const isSubscription = Boolean(subscriptionEngine?.chatHandler);
 
+  // Platform MCP wiring shared by both engines: the meta-tools live at
+  // /api/mcp/o/:org and run with the caller's own credentials (RBAC fidelity).
+  const mcpHeaders: Record<string, string> = { ...headers };
+  if (applicationId) mcpHeaders["x-application-id"] = applicationId;
+
+  // ── Preamble phase B (parallel) ──────────────────────────────────────────
+  // The caller-context block (both paths) and the platform MCP probe (ai-sdk
+  // path only) are independent — run them together.
+  //
+  // The subscription (claude-code) path SKIPS the probe entirely: the official
+  // binary opens its OWN MCP connection from `platformMcp.url`, and the MCP
+  // server's instructions reach the model through that handshake. A probe here
+  // would be a second handshake we'd immediately close (2 round-trips wasted on
+  // the TTFT path). We pass `platformMcp` optimistically; if the `mcp` module is
+  // absent the SDK just gets no tools.
+  let mcp: Awaited<ReturnType<typeof openPlatformMcp>> | null = null;
+  // Single MCP-teardown path. The session must be closed on EVERY ai-sdk exit
+  // (stream `onError` AND `onFinish`, and a mid-stream client disconnect) or it
+  // leaks per turn — close failures are swallowed (warn only) so they never mask
+  // the turn result. `await` it on the synchronous paths, `void` in callbacks.
+  const closeMcp = async (): Promise<void> => {
+    try {
+      await mcp?.close();
+    } catch (err) {
+      logger.warn("mcp close failed", { err: String(err) });
+    }
+  };
+
+  const phaseBStart = Date.now();
+  const contextPromise = buildCallerContextBlock(c, {
+    origin,
+    headers,
+    orgId,
+    applicationId,
+    user,
+  });
+  let contextBlock: string;
+  if (isSubscription) {
+    contextBlock = await contextPromise;
+  } else {
+    // Graceful degradation: the chat's tools come from the platform MCP module
+    // (`/api/mcp/o/:org`). If it's unreachable (e.g. `mcp` not in MODULES), keep
+    // the turn usable for plain conversation instead of 500-ing. The UI surfaces
+    // a "no tools" banner via the `mcp` app-config feature flag.
+    const [openedMcp, block] = await Promise.all([
+      openPlatformMcp({ origin, headers, orgId, applicationId }).catch((err) => {
+        logger.warn("platform MCP unavailable — chat degrades to no-tools", {
+          err: String(err),
+        });
+        return null;
+      }),
+      contextPromise,
+    ]);
+    mcp = openedMcp;
+    contextBlock = block;
+  }
+  const phaseBMs = Date.now() - phaseBStart;
+
+  // Assemble the system prompt. Subscription path: tool-grounding prompt, no
+  // inline instructions (the SDK's own MCP handshake delivers them). ai-sdk
+  // path: prompt + probe instructions, or the no-tools prompt when MCP is down.
+  let system = isSubscription
+    ? SYSTEM_PROMPT
+    : !mcp
+      ? NO_TOOLS_SYSTEM_PROMPT
+      : mcp.instructions
+        ? `${SYSTEM_PROMPT}\n\n${mcp.instructions}`
+        : SYSTEM_PROMPT;
+  if (body.context) {
+    system += `\n\nThe user is currently looking at: ${body.context.type} "${body.context.label ?? body.context.id}" (id: ${body.context.id}). Prefer this context when the question is ambiguous.`;
+  }
+  if (contextBlock) system += `\n\n${contextBlock}`;
   system = applyOperationIndexPolicy(system, chosen.apiShape);
 
-  // The official binary opens its OWN MCP connection — so close the probe client
-  // (used only for reachability + instructions), point the engine at the
-  // platform MCP endpoint + forwarded headers, and mint one turn-scoped loopback
-  // bearer for the credential-injection gateway (which swaps it server-side; the
-  // real subscription token never enters this process or the spawned binary's
-  // env). The gateway slug derives from the provider id — no vendor literal.
+  logger.info("chat preamble", {
+    engine: isSubscription ? "subscription" : "ai-sdk",
+    providerId: chosen.providerId,
+    phaseAMs,
+    phaseBMs,
+    preambleMs: Date.now() - turnStart,
+    hasTools: isSubscription || Boolean(mcp),
+  });
+
+  // The credential-injection gateway swaps the placeholder bearer server-side;
+  // the real subscription token never enters this process or the spawned
+  // binary's env. The gateway slug derives from the provider id — no vendor
+  // literal. `platformMcp` is passed unconditionally (see phase B note).
   if (subscriptionEngine?.chatHandler) {
-    const platformMcp = mcp
-      ? { url: `${origin}/api/mcp/o/${encodeURIComponent(orgId)}`, headers: mcpHeaders }
-      : undefined;
-    await closeMcp();
     const loopbackToken = mintLoopbackToken(
       { userId: user.id, email: user.email, name: user.name, orgId, orgRole },
       { ttlMs: ENGINE_LOOPBACK_TTL_MS },
@@ -277,7 +358,7 @@ export async function handleChatStream(c: Context<any>): Promise<Response> {
       modelId: chosen.modelId,
       gatewayBaseUrl: `${origin}/api/llm-proxy/${subscriptionEngine.providerId}-sdk/${encodeURIComponent(chosen.id)}`,
       placeholderToken: loopbackToken,
-      platformMcp,
+      platformMcp: { url: `${origin}/api/mcp/o/${encodeURIComponent(orgId)}`, headers: mcpHeaders },
       abortSignal: c.req.raw.signal,
       onError: clientErrorMessage,
     });
@@ -311,6 +392,14 @@ export async function handleChatStream(c: Context<any>): Promise<Response> {
       tools: mcp ? mcp.tools : undefined,
       stopWhen: stepCountIs(MAX_STEPS),
       abortSignal: c.req.raw.signal,
+      onChunk: ({ chunk }) => {
+        // TTFT marker: log once on the first model output (text or tool call),
+        // measured from turn start. The dominant lever this work optimizes.
+        if (firstChunkAt === 0 && (chunk.type === "text-delta" || chunk.type === "tool-call")) {
+          firstChunkAt = Date.now();
+          logger.info("chat first token", { firstTokenMs: firstChunkAt - turnStart });
+        }
+      },
       onStepFinish: ({ toolCalls, toolResults, finishReason, usage }) => {
         const now = Date.now();
         logger.info("chat step", {

--- a/packages/module-chat/src/chat-stream.ts
+++ b/packages/module-chat/src/chat-stream.ts
@@ -74,6 +74,14 @@ Respect the user's role: actions beyond it will be refused by the platform — d
 // tells the model to be upfront about the limitation.
 const NO_TOOLS_SYSTEM_PROMPT = `You are Appstrate's assistant. Right now your instance tools are unavailable because the platform MCP module is not active, so you cannot search operations, run agents, inspect runs, or schedule. Answer the user's questions directly and conversationally. If the user asks for an action that needs those tools, say plainly that tools are disabled until the \`mcp\` module is enabled, rather than pretending to act.`;
 
+// The subscription (claude-code) path doesn't probe the platform MCP for
+// reachability (the SDK opens its own connection) — so unlike the ai-sdk path it
+// can't pre-select NO_TOOLS_SYSTEM_PROMPT when the `mcp` module is absent. This
+// note makes the tool-grounding prompt degrade gracefully in that rare config
+// (claude-code enabled, mcp disabled): the model reports tools are off instead
+// of looping on failing tool calls. Harmless when tools ARE present.
+const SUBSCRIPTION_TOOLS_NOTE = `If your tool calls fail because the platform tools are unavailable (the \`mcp\` module is disabled on this instance), do not retry — tell the user plainly that instance tools are off and answer conversationally instead.`;
+
 /** Shape of GET /api/me/context (the `get_me` payload). Validated loosely. */
 interface CallerContext {
   user?: { name?: string | null; email?: string | null } | null;
@@ -332,7 +340,7 @@ export async function handleChatStream(c: Context<any>): Promise<Response> {
   // inline instructions (the SDK's own MCP handshake delivers them). ai-sdk
   // path: prompt + probe instructions, or the no-tools prompt when MCP is down.
   let system = isSubscription
-    ? SYSTEM_PROMPT
+    ? `${SYSTEM_PROMPT}\n\n${SUBSCRIPTION_TOOLS_NOTE}`
     : !mcp
       ? NO_TOOLS_SYSTEM_PROMPT
       : mcp.instructions

--- a/packages/module-chat/src/chat-stream.ts
+++ b/packages/module-chat/src/chat-stream.ts
@@ -162,13 +162,19 @@ async function buildCallerContextBlock(
   const role = (c.get("orgRole") as string | undefined) ?? undefined;
   try {
     const svc = getIntegrationsService();
-    if (svc && applicationId) {
-      // In-process: identity/role from context, only connections hit the DB.
-      const connections = await svc.listUsableForActor({
-        orgId,
-        applicationId,
-        actor: { type: "user", id: user.id },
-      });
+    if (svc) {
+      // In-process: identity/role come from the request context. The connection
+      // list is app-scoped — fetch it only when an application id is known;
+      // without one we still emit the identity/role block (empty connections)
+      // rather than fall back to a loopback that would itself 400 without app
+      // context.
+      const connections = applicationId
+        ? await svc.listUsableForActor({
+            orgId,
+            applicationId,
+            actor: { type: "user", id: user.id },
+          })
+        : [];
       return formatCallerContext({
         user: { name: user.name ?? null, email: user.email ?? null },
         org: { role: role ?? null },
@@ -236,7 +242,11 @@ export async function handleChatStream(c: Context<any>): Promise<Response> {
   const pinnedAppId = c.req.header("x-application-id");
   const phaseAStart = Date.now();
   const [models, applicationId] = await Promise.all([
-    listModels(origin, inferenceHeaders),
+    // metadata_only (skip credential decrypt) is safe only when an explicit
+    // model is pinned — that id came from the filtered picker, so it's reachable.
+    // Without a pin we resolve the org default from the full filtered list, so a
+    // dead-credential default is dropped rather than picked → inference error.
+    listModels(origin, inferenceHeaders, { metadataOnly: Boolean(modelId) }),
     pinnedAppId
       ? Promise.resolve(pinnedAppId)
       : resolveDefaultApplicationId(origin, headers, orgId),

--- a/packages/module-chat/src/index.ts
+++ b/packages/module-chat/src/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./routes.ts";
 import { chatPaths, chatComponentSchemas } from "./openapi.ts";
 import { chatLoopbackStrategy } from "./loopback-auth.ts";
+import { setIntegrationsService, setInProcessService } from "./platform-services.ts";
 import { z } from "zod";
 
 declare module "@appstrate/core/permissions" {
@@ -47,6 +48,11 @@ const chatModule: AppstrateModule = {
     // No workers: chat is request-driven. Wire the platform rate limiter
     // into the router (POST /api/chat fans out into metered LLM traffic).
     setRateLimitFactory((maxPerMinute) => ctx.services.http.rateLimit(maxPerMinute));
+    // In-process platform reads — drop the chat's me/context loopback hop and
+    // the models/applications socket round-trips. Optional: absent under the
+    // OSS/test wiring, where the chat falls back to loopback fetch.
+    setIntegrationsService(ctx.services.integrations ?? null);
+    setInProcessService(ctx.services.inProcess ?? null);
   },
 
   createRouter() {

--- a/packages/module-chat/src/llm.ts
+++ b/packages/module-chat/src/llm.ts
@@ -17,8 +17,20 @@ import type { LanguageModel } from "ai";
 import { badGateway, invalidRequest } from "@appstrate/core/api-errors";
 import { CHAT_USABLE_FAMILIES } from "./chat-families.ts";
 import { logger } from "./logger.ts";
+import { getInProcessService } from "./platform-services.ts";
 
 const LLM_PROXY_PATH = "/api/llm-proxy";
+
+/**
+ * Reach the platform IN-PROCESS when the host wired `inProcess.dispatch`
+ * (re-enters the Hono app, no socket hop), else the loopback `fetch` the chat
+ * has always used. The auth pipeline runs either way — same headers, same RBAC.
+ */
+function platformFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+  const svc = getInProcessService();
+  if (svc) return svc.dispatch(new Request(input, init));
+  return fetch(input, init);
+}
 
 export interface OrgModel {
   id: string;
@@ -51,7 +63,11 @@ export async function listModels(
   origin: string,
   headers: Record<string, string>,
 ): Promise<OrgModel[]> {
-  const res = await fetch(`${origin}/api/models`, { headers });
+  // `metadata_only`: the picker needs only id/modelId/apiShape/providerId/
+  // enabled/is_default, never a credential — skip the per-model credential
+  // decrypt + reachability filter the full listing does. (The real key is
+  // resolved later, server-side, by the llm-proxy on the actual inference call.)
+  const res = await platformFetch(`${origin}/api/models?metadata_only=true`, { headers });
   if (!res.ok) throw badGateway(`/api/models returned ${res.status}`);
   const body = (await res.json()) as { models?: OrgModel[]; data?: OrgModel[] };
   const models = body.models ?? body.data;
@@ -130,7 +146,7 @@ export function modelFromFamily(
   const fetchImpl = (async (input, init) => {
     const h = new Headers(init?.headers);
     h.set("authorization", `Bearer ${mintAuth()}`);
-    return fetch(input, { ...init, headers: h });
+    return platformFetch(input, { ...init, headers: h });
   }) as typeof fetch;
 
   // The proxy resolves `body.model` as the Appstrate **preset id** (the org
@@ -196,7 +212,7 @@ export async function resolveDefaultApplicationId(
   origin: string,
   headers: Record<string, string>,
   orgId: string,
-  fetchImpl: typeof fetch = fetch,
+  fetchImpl: typeof fetch = platformFetch as typeof fetch,
 ): Promise<string | undefined> {
   const cached = appCache.get(orgId);
   if (cached !== undefined) return cached;

--- a/packages/module-chat/src/llm.ts
+++ b/packages/module-chat/src/llm.ts
@@ -62,12 +62,19 @@ interface ResolveArgs {
 export async function listModels(
   origin: string,
   headers: Record<string, string>,
+  opts?: { metadataOnly?: boolean },
 ): Promise<OrgModel[]> {
-  // `metadata_only`: the picker needs only id/modelId/apiShape/providerId/
-  // enabled/is_default, never a credential — skip the per-model credential
-  // decrypt + reachability filter the full listing does. (The real key is
-  // resolved later, server-side, by the llm-proxy on the actual inference call.)
-  const res = await platformFetch(`${origin}/api/models?metadata_only=true`, { headers });
+  // `metadata_only` skips the per-model credential decrypt + reachability filter
+  // — faster, but it also stops dropping models whose credential is dead
+  // (needs-reconnection). Safe ONLY when the caller will match an explicit,
+  // user-picked id (that id came from the browser's filtered picker, so it is
+  // already reachable). For DEFAULT resolution (no explicit id) we must use the
+  // full filtered list, or a dead org-default would be picked and fail at
+  // inference. The caller passes `metadataOnly` accordingly.
+  const url = opts?.metadataOnly
+    ? `${origin}/api/models?metadata_only=true`
+    : `${origin}/api/models`;
+  const res = await platformFetch(url, { headers });
   if (!res.ok) throw badGateway(`/api/models returned ${res.status}`);
   const body = (await res.json()) as { models?: OrgModel[]; data?: OrgModel[] };
   const models = body.models ?? body.data;

--- a/packages/module-chat/src/platform-services.ts
+++ b/packages/module-chat/src/platform-services.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Injected platform capabilities (set by index.ts at module init from
+ * `ctx.services`). They let the chat read the platform IN-PROCESS instead of
+ * over a loopback HTTP hop:
+ *
+ *   - `integrations.listUsableForActor` replaces the `GET /api/me/context`
+ *     round-trip used only to list the caller's connected integrations
+ *     (identity + role come straight off the request context).
+ *   - `inProcess.dispatch` re-enters the fully-wired platform Hono app without
+ *     the socket hop (auth + RBAC still run on the dispatched Request).
+ *
+ * Both are OPTIONAL: before init, in tests, or on a platform that doesn't wire
+ * them, the chat falls back to the loopback `fetch` it has always used. Mirrors
+ * the `setRateLimitFactory` injection in routes.ts.
+ */
+
+export interface ChatIntegrationsService {
+  listUsableForActor(args: {
+    orgId: string;
+    applicationId: string;
+    actor: { type: "user" | "end_user"; id: string };
+  }): Promise<Array<{ integration_id: string; name: string; source: string }>>;
+}
+
+export interface ChatInProcessService {
+  dispatch(request: Request): Promise<Response>;
+}
+
+let integrationsService: ChatIntegrationsService | null = null;
+let inProcessService: ChatInProcessService | null = null;
+
+export function setIntegrationsService(svc: ChatIntegrationsService | null): void {
+  integrationsService = svc;
+}
+
+export function getIntegrationsService(): ChatIntegrationsService | null {
+  return integrationsService;
+}
+
+export function setInProcessService(svc: ChatInProcessService | null): void {
+  inProcessService = svc;
+}
+
+export function getInProcessService(): ChatInProcessService | null {
+  return inProcessService;
+}


### PR DESCRIPTION
## Objectif

Réduire le **TTFT** (time-to-first-token) du chat — le délai entre l'envoi du message et le premier token du LLM. Diagnostic complet (moi + revue indépendante Codex) : le goulot était l'**orchestration**, pas le LLM. `POST /api/chat` enchaînait **4 allers-retours HTTP loopback séquentiels** avant le premier appel d'inférence, chacun ré-entrant tout le pipeline auth + org-context.

## Changements (7 phases)

| # | Phase | Effet TTFT |
|---|-------|-----------|
| 0 | **Instrumentation** | logs `phaseAMs`/`phaseBMs`/`preambleMs` + `firstTokenMs` pour mesurer |
| 1 | **Parallélisation du préambule** | `listModels ∥ applications`, puis `MCP probe ∥ caller-context` (était 4 hops en série) |
| 3 | **Skip probe MCP (claude-code)** | le SDK officiel ouvre sa propre connexion MCP et reçoit les instructions ; le probe (open+tools+close) était un handshake gaspillé par tour |
| 2 | **Drop hop `me/context`** | identité+rôle viennent du contexte de requête ; seules les intégrations font un read, désormais in-process via `PlatformServices.integrations.listUsableForActor` (fallback loopback conservé) |
| 4 | **`/api/models?metadata_only`** | résout famille/baseURL via le registry sans décrypter les credentials de tous les modèles (le picker n'a jamais besoin du secret) |
| 6 | **Dispatch in-process** | `PlatformServices.inProcess.dispatch = app.fetch` pour models/applications/llm-proxy — pas de socket, auth toujours exécutée |
| 5 | **Cache `loadModel`** | mémo `(orgId, presetId)` TTL 30s ; un tour fait jusqu'à 16 résolutions de preset, chacune re-query + re-decrypt |
| 7 | **Index MCP compact** | operationIds par tag, sans résumés (~3,4k tokens) ; `describe_operation` reste la source de vérité. **Portée globale** (Claude Code/Cursor/agents) |

## Tradeoffs assumés (validés)

- **Cache `loadModel`** : rotation/révocation de credential visible après ≤30s.
- **`metadata_only`** : un modèle au secret mort peut apparaître au picker → erreur claire seulement à l'inférence (pas filtré).
- **Index MCP global** : tous les clients MCP voient l'index sans résumés ; un peu plus de `search_operations`/`describe_operation` possible. `cache_control` Anthropic amortissait déjà l'index dès le tour 2.
- **`@appstrate/core`** : `PlatformServices` étendu → republish npm en lockstep après merge (consommateurs externes).

## Vérification

- `bun run check` ✅ 34/34
- `bun test packages/module-chat` ✅ 33
- platform-services + mcp ✅ 22 · llm-proxy + models + org-models ✅ 47

## Suite recommandée

Checkpoint : déployer, lire `firstTokenMs` médian (chemins ai-sdk Anthropic + claude-code) avant/après pour chiffrer le gain réel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
