### PR TITLE
feat(mcp,chat): drop redundant get_me tool for context-injected callers

### DIFF
--- a/apps/api/src/modules/mcp/router.ts
+++ b/apps/api/src/modules/mcp/router.ts
@@ -121,8 +121,18 @@ const MCP_RATE_LIMIT_PER_MIN = 120;
  * surface grows without editing this text. describe_operation (or
  * search_operations' best_match) remains the source of truth for input schemas.
  */
-function buildServerInstructions(permissions?: ReadonlySet<string>): string {
-  return `Appstrate runs autonomous AI agents in sandboxed Docker containers. The tools here let you discover and call any operation of the Appstrate REST API — their own descriptions tell you how. Start by calling get_me to learn who you are acting for, your role in this organization, and which integrations are already connected (prefer those when building or configuring an agent). The operation index at the end of these instructions lists the operations available to your role by tag; it is your primary way to find an operation. Default to picking an operationId straight from that index, then call describe_operation for its input schema and invoke_operation to run it. Reach for search_operations only when the index is genuinely ambiguous or a capability you expect isn't listed — not as a routine first step. Never guess an operationId or body shape: describe_operation (or search_operations' best_match) is the source of truth for the input schema.
+function buildServerInstructions(
+  permissions?: ReadonlySet<string>,
+  contextInjected = false,
+): string {
+  // A `contextInjected` caller (the chat module) already injects the get_me
+  // payload into its own system prompt and we drop the get_me tool for it, so
+  // pushing "call get_me first" would point the model at a tool that isn't
+  // there. Tell it the context is already provided instead.
+  const grounding = contextInjected
+    ? "Your caller context — who you are acting for, your role in this organization, and which integrations are already connected (prefer those when building or configuring an agent) — is already provided to you; there is no get_me tool, do not look for one."
+    : "Start by calling get_me to learn who you are acting for, your role in this organization, and which integrations are already connected (prefer those when building or configuring an agent).";
+  return `Appstrate runs autonomous AI agents in sandboxed Docker containers. The tools here let you discover and call any operation of the Appstrate REST API — their own descriptions tell you how. ${grounding} The operation index at the end of these instructions lists the operations available to your role by tag; it is your primary way to find an operation. Default to picking an operationId straight from that index, then call describe_operation for its input schema and invoke_operation to run it. Reach for search_operations only when the index is genuinely ambiguous or a capability you expect isn't listed — not as a routine first step. Never guess an operationId or body shape: describe_operation (or search_operations' best_match) is the source of truth for the input schema.
 
 ## Core model
 Organization → Applications (id \`app_…\`, one default) → Agents → Runs. End-users (\`eu_…\`) are external identities for embedded use. Packages (agents, integrations, skills…) are identified as \`@scope/name\` (e.g. \`@appstrate/my-agent\`). Depending on the operation this is passed either as a single \`packageId\` param or split into separate \`scope\` and \`name\` params — describe_operation shows which; always keep the \`@\`, and the \`/\` when it's a single param.
@@ -267,7 +277,13 @@ export function createMcpRouter(): Hono<AppEnv> {
       throw forbidden("This MCP endpoint serves a different organization than your credentials.");
     }
 
-    const origin = new URL(c.req.url).origin;
+    const reqUrl = new URL(c.req.url);
+    const origin = reqUrl.origin;
+    // A consumer that injects the get_me payload (`/api/me/context`) into its
+    // own system prompt tags the session `?context=injected` so the redundant
+    // get_me tool — and its "call get_me first" instruction — are dropped. Only
+    // the in-process chat sets it; external MCP clients omit it and keep get_me.
+    const contextInjected = reqUrl.searchParams.get("context") === "injected";
     const permissions = c.get("permissions") ?? new Set<string>();
     const authHeaders = forwardAuthHeaders(c.req.raw.headers);
     const dispatch: Dispatch = async (req) => getPlatformApp().fetch(req);
@@ -321,11 +337,18 @@ export function createMcpRouter(): Hono<AppEnv> {
     // need no actor context. get_me likewise carries no actor context: it
     // dispatches in-process to /api/me/context, which resolves the caller from
     // the forwarded auth headers. The index is scoped to the caller's role.
-    const tools = buildMcpTools({ origin, permissions, authHeaders, dispatch, observe });
+    const tools = buildMcpTools({
+      origin,
+      permissions,
+      authHeaders,
+      dispatch,
+      observe,
+      contextInjected,
+    });
     const server = createMcpServer(
       tools,
       { name: "appstrate", version: MCP_SERVER_VERSION },
-      { instructions: buildServerInstructions(permissions) },
+      { instructions: buildServerInstructions(permissions, contextInjected) },
     );
     const transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: undefined,

--- a/apps/api/src/modules/mcp/test/unit/tools.test.ts
+++ b/apps/api/src/modules/mcp/test/unit/tools.test.ts
@@ -427,3 +427,28 @@ describe("buildOperationIndex", () => {
     expect(b).toBe(a);
   });
 });
+
+describe("buildMcpTools contextInjected", () => {
+  beforeEach(() => resetCatalog());
+
+  it("exposes get_me by default (external MCP clients have no injected context)", () => {
+    const { byName } = makeTools(["mcp:read"]);
+    expect(byName.has("get_me")).toBe(true);
+  });
+
+  it("drops get_me when the caller already injected its context, keeping the rest", () => {
+    const dispatch: Dispatch = async () =>
+      new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+    const tools = buildMcpTools({
+      origin: "https://test.local",
+      authHeaders: new Headers({ authorization: "Bearer tok", "x-org-id": "org_1" }),
+      permissions: new Set(["mcp:read"]),
+      dispatch,
+      contextInjected: true,
+    });
+    const names = tools.map((t) => t.descriptor.name).sort();
+    // get_me is redundant for a context-injected caller; search_operations stays
+    // (its best_match schema is not covered by the injected operation index).
+    expect(names).toEqual(["describe_operation", "invoke_operation", "search_operations"]);
+  });
+});

--- a/apps/api/src/modules/mcp/tools.ts
+++ b/apps/api/src/modules/mcp/tools.ts
@@ -88,6 +88,13 @@ export interface McpToolContext {
    * tests and any non-HTTP caller need not provide one.
    */
   observe?: McpObserver;
+  /**
+   * The caller already injects the get_me payload (`GET /api/me/context`) into
+   * its own system prompt, so the redundant get_me tool is dropped. Only the
+   * in-process chat consumer sets this (it injects that block + carries the
+   * server instructions); external MCP clients leave it false and keep get_me.
+   */
+  contextInjected?: boolean;
 }
 
 /** Never let an observer error affect the tool result. */
@@ -675,5 +682,12 @@ function buildGetMeTool(ctx: McpToolContext): AppstrateToolDefinition {
 
 /** Build the per-request tool set. Handlers close over the caller's auth context. */
 export function buildMcpTools(ctx: McpToolContext): AppstrateToolDefinition[] {
-  return [buildSearchTool(ctx), buildDescribeTool(ctx), buildInvokeTool(ctx), buildGetMeTool(ctx)];
+  const tools = [buildSearchTool(ctx), buildDescribeTool(ctx), buildInvokeTool(ctx)];
+  // get_me dispatches to GET /api/me/context. A consumer that already injects
+  // that payload into its own system prompt (the chat module) drops the tool —
+  // it would only re-fetch what the model already has. search_operations is
+  // kept either way: the operation index is injected too, but its `best_match`
+  // schema still saves a describe_operation round-trip, so it is not redundant.
+  if (!ctx.contextInjected) tools.push(buildGetMeTool(ctx));
+  return tools;
 }

--- a/packages/module-chat/src/chat-stream.ts
+++ b/packages/module-chat/src/chat-stream.ts
@@ -20,7 +20,7 @@ import { z } from "zod";
 import { parseBody, invalidRequest } from "@appstrate/core/api-errors";
 import { logger } from "./logger.ts";
 import { listModels, pickModel, modelFromFamily, resolveDefaultApplicationId } from "./llm.ts";
-import { openPlatformMcp } from "./platform-mcp.ts";
+import { openPlatformMcp, platformMcpUrl } from "./platform-mcp.ts";
 import { selfOrigin, forwardedHeaders } from "./self.ts";
 import { mintLoopbackToken } from "./loopback-auth.ts";
 import { subscriptionEngineDef } from "@appstrate/core/subscription-engines";
@@ -376,7 +376,7 @@ export async function handleChatStream(c: Context<any>): Promise<Response> {
       modelId: chosen.modelId,
       gatewayBaseUrl: `${origin}/api/llm-proxy/${subscriptionEngine.providerId}-sdk/${encodeURIComponent(chosen.id)}`,
       placeholderToken: loopbackToken,
-      platformMcp: { url: `${origin}/api/mcp/o/${encodeURIComponent(orgId)}`, headers: mcpHeaders },
+      platformMcp: { url: platformMcpUrl(origin, orgId), headers: mcpHeaders },
       abortSignal: c.req.raw.signal,
       onError: clientErrorMessage,
     });

--- a/packages/module-chat/src/platform-mcp.ts
+++ b/packages/module-chat/src/platform-mcp.ts
@@ -25,6 +25,20 @@ export interface McpHandle {
   close: () => Promise<void>;
 }
 
+/**
+ * URL of the platform's org-scoped MCP endpoint, tagged `?context=injected`.
+ *
+ * The chat injects the get_me payload (`/api/me/context`) straight into its own
+ * system prompt, so the server's get_me tool would only re-fetch what the model
+ * already has. The tag tells the server to drop that redundant tool (and its
+ * "call get_me first" instruction). Both chat engines build their MCP URL
+ * through this helper — the ai-sdk client here and the subscription binary's
+ * own connection (chat-stream.ts) — so the two never drift.
+ */
+export function platformMcpUrl(origin: string, orgId: string): string {
+  return `${origin}/api/mcp/o/${encodeURIComponent(orgId)}?context=injected`;
+}
+
 export async function openPlatformMcp(args: {
   origin: string;
   headers: Record<string, string>;
@@ -39,7 +53,7 @@ export async function openPlatformMcp(args: {
   const client = await createMCPClient({
     transport: {
       type: "http",
-      url: `${args.origin}/api/mcp/o/${encodeURIComponent(args.orgId)}`,
+      url: platformMcpUrl(args.origin, args.orgId),
       headers,
     },
     onUncaughtError: (err) => logger.error("MCP uncaught error", { err: String(err) }),


### PR DESCRIPTION
## Problème

Dans le chat, l'agent appelle systématiquement le tool MCP `get_me` au début de chaque conversation. Ce tool dispatche vers `GET /api/me/context` — exactement le payload (identité, rôle, intégrations connectées) que le chat **injecte déjà** dans son system prompt (`formatCallerContext`). Pire : les instructions du serveur MCP poussent activement l'appel ("Start by calling get_me to learn who you are acting for…"), garantissant l'aller-retour redondant à chaque tour.

## Solution

Le serveur MCP (`/api/mcp/o/:org`) est **partagé** : le chat l'utilise, mais aussi des clients MCP externes (Claude Desktop via auto-DCR) qui n'ont, eux, aucune injection system-prompt. Supprimer `get_me` globalement les casserait.

→ Mécanisme per-consumer. Un consommateur qui injecte le contexte tague sa session `?context=injected`. Le serveur alors :
- omet `get_me` de la tool set (`buildMcpTools`)
- retire la phrase "call get_me first" des instructions (et indique au modèle que le contexte est déjà fourni)

Les clients externes omettent le flag → `get_me` inchangé.

## Pourquoi `search_operations` est conservé

`search_operations` (« lister les opérations ») est aussi partiellement redondant avec l'index d'opérations injecté — mais il apporte un `best_match` (schéma d'input du top résultat) qui économise un aller-retour `describe_operation`. Contrairement à `get_me`, il n'est pas un duplicate pur. On garde. L'alignement porte sur le **mécanisme** (un seul switch serveur context-aware), pas sur une suppression symétrique.

## Alignement

Les deux moteurs de chat construisent leur URL MCP via un seul helper `platformMcpUrl()` (client ai-sdk + connexion propre du binaire subscription) pour éviter toute dérive.

## Changements

- `apps/api/src/modules/mcp/tools.ts` — `contextInjected` sur `McpToolContext` ; `buildMcpTools` omet `get_me` si présent
- `apps/api/src/modules/mcp/router.ts` — lit `?context=injected`, thread vers `buildMcpTools` + `buildServerInstructions` (phrase get_me conditionnelle)
- `packages/module-chat/src/platform-mcp.ts` — helper `platformMcpUrl()` partagé
- `packages/module-chat/src/chat-stream.ts` — les 2 moteurs utilisent le helper

## Tests

- 2 tests unitaires : `get_me` présent par défaut / absent avec `contextInjected`, les 3 autres tools conservés
- typecheck + eslint + prettier OK sur `@appstrate/api` et `@appstrate/module-chat`
- 2 échecs pré-existants dans `buildOperationIndex` (échouent aussi sans ce diff — hors scope)
