### PR TITLE
fix(oidc): patch @better-auth/cimd to filter unsupported grant_types (unblocks claude.ai MCP)

### DIFF
--- a/apps/api/src/modules/oidc/test/unit/cimd-grant-types-patch.test.ts
+++ b/apps/api/src/modules/oidc/test/unit/cimd-grant-types-patch.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression guard for the local patch of `@better-auth/cimd`
+ * (`patches/@better-auth%2Fcimd@1.7.0-beta.4.patch`).
+ *
+ * Upstream's CIMD metadata validator rejected a Client ID Metadata Document
+ * whenever its `grant_types` was NOT a subset of
+ * `{authorization_code, refresh_token}` — a strict `.every()` check. claude.ai
+ * publishes a CIMD document (the canonical MCP connector client) that declares
+ *
+ *   "grant_types": ["authorization_code","refresh_token",
+ *                   "urn:ietf:params:oauth:grant-type:jwt-bearer"]
+ *
+ * The extra `jwt-bearer` grant (declared, never used by the browser auth-code
+ * flow) tripped the subset check, so every claude.ai connection to our OAuth
+ * authorization server failed at `/oauth2/authorize` with:
+ *
+ *   {"error":"invalid_client",
+ *    "error_description":"grant_types must be a subset of [...]"}
+ *
+ * Per RFC 7591 §2, `grant_types` enumerates what a client *may* use; an AS that
+ * does not support a declared grant should ignore it, not reject the client.
+ * Our patch replaces the reject-on-superset behavior with a filter: unsupported
+ * grants are dropped, and the client is rejected only if NOTHING supported
+ * remains. This file pins that behavior so a Better Auth bump that silently
+ * drops the patch fails loudly here.
+ *
+ * `validateCimdMetadata` mutates the passed `raw` object in place (the resolver
+ * relies on this: it persists the same object as the client record), so we
+ * assert both the validation verdict and the post-filter `grant_types`.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { validateCimdMetadata } from "@better-auth/cimd";
+
+const CLIENT_ID = "https://claude.ai/oauth/mcp-oauth-client-metadata";
+const ORIGIN_BOUND = ["redirect_uris"];
+
+/** A valid claude.ai-shaped CIMD document, parameterized on grant_types. */
+function cimdDoc(grantTypes: unknown): Record<string, unknown> {
+  return {
+    client_id: CLIENT_ID,
+    redirect_uris: ["https://claude.ai/api/mcp/auth_callback"],
+    response_types: ["code"],
+    token_endpoint_auth_method: "none",
+    ...(grantTypes === undefined ? {} : { grant_types: grantTypes }),
+  };
+}
+
+describe("@better-auth/cimd patch — grant_types filtering", () => {
+  it("accepts claude.ai's document (extra jwt-bearer grant) and filters it out", () => {
+    const doc = cimdDoc([
+      "authorization_code",
+      "refresh_token",
+      "urn:ietf:params:oauth:grant-type:jwt-bearer",
+    ]);
+
+    const result = validateCimdMetadata(CLIENT_ID, doc, ORIGIN_BOUND);
+
+    expect(result.valid).toBe(true);
+    // jwt-bearer dropped; supported grants preserved (order-independent).
+    expect(new Set(doc.grant_types as string[])).toEqual(
+      new Set(["authorization_code", "refresh_token"]),
+    );
+  });
+
+  it("rejects a document whose grant_types are ALL unsupported", () => {
+    const doc = cimdDoc(["client_credentials", "urn:ietf:params:oauth:grant-type:jwt-bearer"]);
+
+    const result = validateCimdMetadata(CLIENT_ID, doc, ORIGIN_BOUND);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("grant_types must include at least one");
+  });
+
+  it("rejects a non-array grant_types", () => {
+    const doc = cimdDoc("authorization_code");
+
+    const result = validateCimdMetadata(CLIENT_ID, doc, ORIGIN_BOUND);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("grant_types must be an array");
+  });
+
+  it("accepts a document that omits grant_types (field is optional)", () => {
+    const doc = cimdDoc(undefined);
+
+    const result = validateCimdMetadata(CLIENT_ID, doc, ORIGIN_BOUND);
+
+    expect(result.valid).toBe(true);
+    expect("grant_types" in doc).toBe(false);
+  });
+
+  it("leaves a standard authorization_code + refresh_token document unchanged", () => {
+    const doc = cimdDoc(["authorization_code", "refresh_token"]);
+
+    const result = validateCimdMetadata(CLIENT_ID, doc, ORIGIN_BOUND);
+
+    expect(result.valid).toBe(true);
+    expect(doc.grant_types).toEqual(["authorization_code", "refresh_token"]);
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -433,6 +433,7 @@
   },
   "patchedDependencies": {
     "@better-auth/oauth-provider@1.7.0-beta.4": "patches/@better-auth%2Foauth-provider@1.7.0-beta.4.patch",
+    "@better-auth/cimd@1.7.0-beta.4": "patches/@better-auth%2Fcimd@1.7.0-beta.4.patch",
   },
   "overrides": {
     "zod": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
   },
   "patchedDependencies": {
     "@redocly/openapi-core@2.25.2": "patches/@redocly%2Fopenapi-core@2.25.2.patch",
-    "@better-auth/oauth-provider@1.7.0-beta.4": "patches/@better-auth%2Foauth-provider@1.7.0-beta.4.patch"
+    "@better-auth/oauth-provider@1.7.0-beta.4": "patches/@better-auth%2Foauth-provider@1.7.0-beta.4.patch",
+    "@better-auth/cimd@1.7.0-beta.4": "patches/@better-auth%2Fcimd@1.7.0-beta.4.patch"
   }
 }

--- a/patches/@better-auth%2Fcimd@1.7.0-beta.4.patch
+++ b/patches/@better-auth%2Fcimd@1.7.0-beta.4.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index b9657a059117934c1a2245197e3ce044c6b0cf73..6ef29b4ca7da3d05c5818dcd474bb0e77645ba16 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -161,10 +161,17 @@ function validateCimdMetadata(fetchUrl, raw, originBoundFields) {
+ 		valid: false,
+ 		error: "redirect_uris must be a non-empty array of absolute HTTP(S) URIs"
+ 	};
+-	if (doc.grant_types !== void 0 && !(Array.isArray(doc.grant_types) && doc.grant_types.every((g) => typeof g === "string" && ALLOWED_GRANT_TYPES.has(g)))) return {
+-		valid: false,
+-		error: `grant_types must be a subset of [${[...ALLOWED_GRANT_TYPES].map((g) => `"${g}"`).join(", ")}]`
+-	};
++	if (doc.grant_types !== void 0) {
++		if (!Array.isArray(doc.grant_types)) return {
++			valid: false,
++			error: "grant_types must be an array of strings"
++		};
++		doc.grant_types = doc.grant_types.filter((g) => typeof g === "string" && ALLOWED_GRANT_TYPES.has(g));
++		if (doc.grant_types.length === 0) return {
++			valid: false,
++			error: `grant_types must include at least one of [${[...ALLOWED_GRANT_TYPES].map((g) => `"${g}"`).join(", ")}]`
++		};
++	}
+ 	if (doc.response_types !== void 0 && !(Array.isArray(doc.response_types) && doc.response_types.every((r) => typeof r === "string" && ALLOWED_RESPONSE_TYPES.has(r)))) return {
+ 		valid: false,
+ 		error: "response_types must be a subset of [\"code\"]"


### PR DESCRIPTION
## Problème

Connecter un serveur MCP HTTP Appstrate depuis claude.ai (ex. Cloud Cowork) échoue au moment de la redirection OAuth `/api/auth/oauth2/authorize` :

```json
{"error":"invalid_client",
 "error_description":"grant_types must be a subset of [\"authorization_code\", \"refresh_token\"]"}
```

## Cause racine

claude.ai s'enregistre via **CIMD** (Client ID Metadata Document — `client_id` = une URL). Better Auth fetch ce document et le valide via `@better-auth/cimd@1.7.0-beta.4`.

Le document publié par claude.ai (vérifié en live) déclare :

```json
"grant_types": ["authorization_code","refresh_token","urn:ietf:params:oauth:grant-type:jwt-bearer"]
```

Le validateur CIMD exige que `grant_types` soit un **sous-ensemble strict** de `{authorization_code, refresh_token}` (`.every()`), donc le `jwt-bearer` supplémentaire — déclaré mais jamais utilisé par le flow auth-code navigateur — fait rejeter **tout** le client.

Per [RFC 7591 §2](https://www.rfc-editor.org/rfc/rfc7591), `grant_types` énumère ce que le client *peut* utiliser ; un AS qui ne supporte pas un grant déclaré doit l'**ignorer**, pas rejeter le client. Bug upstream confirmé (analogue côté [FastMCP #2460](https://github.com/jlowin/fastmcp/issues/2460)). `@better-auth/cimd@1.7.0-beta.9` (dernière) a toujours le check strict → un bump BA ne corrige pas.

## Correctif

`bun patch` sur `@better-auth/cimd@1.7.0-beta.4` (`patches/@better-auth%2Fcimd@1.7.0-beta.4.patch`) : remplace reject-on-superset par un **filtre**. Les grants non supportés sont retirés (le resolver persiste l'ensemble filtré), et le client n'est rejeté que si **rien** de supporté ne reste.

```diff
-	if (doc.grant_types !== void 0 && !(Array.isArray(doc.grant_types) && doc.grant_types.every(...))) return {...};
+	if (doc.grant_types !== void 0) {
+		if (!Array.isArray(doc.grant_types)) return { valid: false, error: "grant_types must be an array of strings" };
+		doc.grant_types = doc.grant_types.filter((g) => typeof g === "string" && ALLOWED_GRANT_TYPES.has(g));
+		if (doc.grant_types.length === 0) return { valid: false, error: `grant_types must include at least one of [...]` };
+	}
```

Suit le pattern de patch BA déjà en place dans ce repo (`@better-auth/oauth-provider`).

## Tests

Nouveau test de régression `apps/api/src/modules/oidc/test/unit/cimd-grant-types-patch.test.ts` (5 cas, importe `validateCimdMetadata` réel donc échoue si le patch saute lors d'un bump BA) :

- ✅ document claude.ai (jwt-bearer extra) → `valid:true` + `grant_types` filtré à `[authorization_code, refresh_token]`
- ✅ grants tous non supportés → rejet
- ✅ `grant_types` non-array → rejet
- ✅ `grant_types` absent (optionnel) → accepté
- ✅ document standard 2-grants → inchangé

`bun test` : 5 pass. `tsc --noEmit` : clean. prettier : clean.

## Suivi

Issue/PR upstream Better Auth à ouvrir pour relâcher la validation (filtre au lieu de rejet) → retirer le patch ensuite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)