### PR TITLE
fix(integrations): unify activation rule so env-backed system integrations show as active everywhere

### DIFF
--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -28,9 +28,6 @@
 
 import { Hono } from "hono";
 import { z } from "zod";
-import { eq, and } from "drizzle-orm";
-import { db } from "@appstrate/db/client";
-import { applicationPackages, packages } from "@appstrate/db/schema";
 import {
   handleIntegrationOAuthCallback,
   OAuthCallbackError,
@@ -54,7 +51,6 @@ import { getAppScope } from "../lib/scope.ts";
 import { recordAuditFromContext } from "./../services/audit.ts";
 import { updateInstalledPackage } from "../services/application-packages.ts";
 import { listIntegrations } from "../services/integration-service.ts";
-import { isSystemIntegration } from "../services/integration-client-registry.ts";
 import {
   assertIsIntegration,
   createIntegrationOAuthClient,
@@ -63,6 +59,7 @@ import {
   listIntegrationClients,
   listIntegrationConnections,
   readIntegrationAuth,
+  resolveIntegrationActivations,
   serializeIntegrationConnection,
   setDefaultIntegrationClient,
   toPublicClient,
@@ -212,34 +209,20 @@ export function createIntegrationsRouter() {
     const fields = parseFieldSelection(c, INTEGRATION_FIELDS);
     const pagination = parseListPagination(c, { defaultLimit: 100 });
     const summaries = await listIntegrations(scope.orgId);
-    // Decorate with `active` + `blockUserConnections` flags for the
-    // current application. Same precedence as `isIntegrationActive` (the one
-    // source of truth): an explicit `application_packages` row wins via its
-    // `enabled` flag; with no row, a system integration (offered via
-    // `SYSTEM_INTEGRATIONS`, with or without a shared OAuth client) is
-    // auto-active. `blockUserConnections` defaults to false when no per-app row
-    // exists.
-    const installedRows = await db
-      .select({
-        packageId: applicationPackages.packageId,
-        enabled: applicationPackages.enabled,
-        blockUserConnections: applicationPackages.blockUserConnections,
-      })
-      .from(applicationPackages)
-      .innerJoin(packages, eq(applicationPackages.packageId, packages.id))
-      .where(
-        and(
-          eq(applicationPackages.applicationId, scope.applicationId),
-          eq(packages.type, "integration"),
-        ),
-      );
-    const installedMap = new Map(installedRows.map((r) => [r.packageId, r]));
+    // Decorate with `active` + `block_user_connections` flags for the current
+    // application via the shared resolver — the single source of truth, also
+    // used by the agent-editor detail endpoint, so the two surfaces can never
+    // diverge (env-backed SYSTEM integrations stay active on both).
+    const activations = await resolveIntegrationActivations(
+      summaries.map((s) => s.id),
+      scope.applicationId,
+    );
     const enriched = summaries.map((s) => {
-      const row = installedMap.get(s.id);
+      const a = activations.get(s.id)!;
       return {
         ...s,
-        active: row !== undefined ? row.enabled : isSystemIntegration(s.id),
-        block_user_connections: row?.blockUserConnections ?? false,
+        active: a.active,
+        block_user_connections: a.blockUserConnections,
       };
     });
     const { page, total, hasMore } = paginate(enriched, pagination);

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -14,6 +14,7 @@ import { postInstallPackage } from "../services/post-install-package.ts";
 import { handleImportBundle } from "../services/bundle-import.ts";
 import { parsePackageIdentity } from "@appstrate/afps-runtime/bundle";
 import { installPackage, hasPackageAccess } from "../services/application-packages.ts";
+import { resolveIntegrationActivations } from "../services/integration-connections.ts";
 import { parseManifestBytesSafe } from "../lib/manifest-parser.ts";
 import { getAllPackageIds } from "../services/package-catalog.ts";
 import { isSystemPackage } from "../services/system-packages.ts";
@@ -415,12 +416,28 @@ function makeListHandler(rcfg: PackageRouteConfig) {
   return async (c: Context<AppEnv>) => {
     const orgId = c.get("orgId");
     const applicationId = c.get("applicationId");
-    // `?active=true` narrows to packages active (installed + enabled) in this
-    // app — the agent editor's integration picker uses it so it doesn't pull
-    // the whole catalogue.
-    const activeOnly = c.req.query("active") === "true";
-    const items = await listOrgItems(orgId, rcfg.cfg, applicationId, { activeOnly });
-    const enriched = await enrichWithCreatorNames(items);
+    // `?active=true` narrows to packages active in this app (agent-editor
+    // integration picker). For most types "active" means an installed +
+    // enabled `application_packages` row (generic SQL narrowing in
+    // `listOrgItems`). INTEGRATIONS additionally auto-activate env-backed
+    // SYSTEM integrations that have no row — so they resolve through the
+    // canonical activation rule (`resolveIntegrationActivations`), the single
+    // source of truth shared with the settings list + detail endpoints, rather
+    // than the generic SQL filter (which would hide them).
+    const wantActive = c.req.query("active") === "true";
+    const isIntegration = rcfg.cfg.type === "integration";
+    const items = await listOrgItems(orgId, rcfg.cfg, applicationId, {
+      activeOnly: wantActive && !isIntegration,
+    });
+    let visible = items;
+    if (wantActive && isIntegration) {
+      const activations = await resolveIntegrationActivations(
+        items.map((i) => i.id),
+        applicationId,
+      );
+      visible = items.filter((i) => activations.get(i.id)?.active);
+    }
+    const enriched = await enrichWithCreatorNames(visible);
     return c.json(listResponse(enriched));
   };
 }

--- a/apps/api/src/services/integration-connections.ts
+++ b/apps/api/src/services/integration-connections.ts
@@ -345,9 +345,22 @@ export async function selectAccessibleConnection(
 }
 
 /**
- * `true` when the integration is active in the app. Single precedence rule —
- * the one source of truth every call site (spawn resolver, agent readiness,
- * sidecar guards, UI list) consults:
+ * Per-app activation state for an integration: the `active` flag plus the admin
+ * `block_user_connections` gate. `blockUserConnections` defaults to `false` when
+ * no per-app row exists.
+ */
+export interface IntegrationActivation {
+  active: boolean;
+  blockUserConnections: boolean;
+}
+
+/**
+ * THE activation resolver — the single source of truth every call site (spawn
+ * resolver, agent readiness, sidecar guards, settings list, agent-editor detail)
+ * consults, directly or via the {@link isIntegrationActive} /
+ * {@link listActiveIntegrationIds} wrappers below. One SELECT over
+ * `application_packages` for the whole set; the precedence rule lives here and
+ * nowhere else:
  *
  *   1. An `application_packages` row EXISTS → its `enabled` flag wins. This is
  *      the explicit, sticky operator decision: an installed-and-enabled row is
@@ -361,43 +374,22 @@ export async function selectAccessibleConnection(
  *
  * Disabling a never-installed system integration materializes a row with
  * `enabled = false` (see the enable/disable upsert), which then wins via rule 1
- * — that is what makes the opt-out sticky. Use {@link assertIntegrationActive}
- * when the caller needs a structured 404 instead of a boolean.
+ * — that is what makes the opt-out sticky.
+ *
+ * Returns a map keyed by package id; every requested id is present (rows absent
+ * from the table resolve via the system-integration fallback).
  */
-export async function isIntegrationActive(
-  packageId: string,
-  applicationId: string,
-): Promise<boolean> {
-  const [row] = await db
-    .select({ enabled: applicationPackages.enabled })
-    .from(applicationPackages)
-    .where(
-      and(
-        eq(applicationPackages.applicationId, applicationId),
-        eq(applicationPackages.packageId, packageId),
-      ),
-    )
-    .limit(1);
-  // Rule 1: explicit row wins. Rule 2: no row → auto-active iff system.
-  return row !== undefined ? row.enabled : isSystemIntegration(packageId);
-}
-
-/**
- * Batched variant of {@link isIntegrationActive} — one SELECT over
- * `application_packages` for the whole set instead of N serial queries. Applies
- * the exact same precedence (explicit row wins, else auto-active iff system).
- * Used on the run-kickoff hot path (agent readiness) where an agent may declare
- * several integrations.
- */
-export async function listActiveIntegrationIds(
+export async function resolveIntegrationActivations(
   packageIds: readonly string[],
   applicationId: string,
-): Promise<Set<string>> {
-  if (packageIds.length === 0) return new Set();
+): Promise<Map<string, IntegrationActivation>> {
+  const result = new Map<string, IntegrationActivation>();
+  if (packageIds.length === 0) return result;
   const rows = await db
     .select({
       packageId: applicationPackages.packageId,
       enabled: applicationPackages.enabled,
+      blockUserConnections: applicationPackages.blockUserConnections,
     })
     .from(applicationPackages)
     .where(
@@ -406,13 +398,44 @@ export async function listActiveIntegrationIds(
         inArray(applicationPackages.packageId, packageIds as string[]),
       ),
     );
-  const enabledById = new Map(rows.map((r) => [r.packageId, r.enabled]));
-  const active = new Set<string>();
+  const byId = new Map(rows.map((r) => [r.packageId, r]));
   for (const id of packageIds) {
-    const explicit = enabledById.get(id);
-    if (explicit !== undefined ? explicit : isSystemIntegration(id)) {
-      active.add(id);
-    }
+    const row = byId.get(id);
+    result.set(id, {
+      // Rule 1: explicit row wins. Rule 2: no row → auto-active iff system.
+      active: row !== undefined ? row.enabled : isSystemIntegration(id),
+      blockUserConnections: row?.blockUserConnections ?? false,
+    });
+  }
+  return result;
+}
+
+/**
+ * `true` when the integration is active in the app — thin wrapper over
+ * {@link resolveIntegrationActivations}. Use {@link assertIntegrationActive}
+ * when the caller needs a structured 404 instead of a boolean.
+ */
+export async function isIntegrationActive(
+  packageId: string,
+  applicationId: string,
+): Promise<boolean> {
+  const map = await resolveIntegrationActivations([packageId], applicationId);
+  return map.get(packageId)!.active;
+}
+
+/**
+ * Active subset of `packageIds` — thin wrapper over
+ * {@link resolveIntegrationActivations}. Used on the run-kickoff hot path
+ * (agent readiness) where an agent may declare several integrations.
+ */
+export async function listActiveIntegrationIds(
+  packageIds: readonly string[],
+  applicationId: string,
+): Promise<Set<string>> {
+  const map = await resolveIntegrationActivations(packageIds, applicationId);
+  const active = new Set<string>();
+  for (const [id, activation] of map) {
+    if (activation.active) active.add(id);
   }
   return active;
 }
@@ -2049,19 +2072,11 @@ export async function getIntegrationAuthStatuses(
   });
 
   const allConnections = await listIntegrationConnections(scope, packageId, actor);
-  const [installedRow] = await db
-    .select({
-      enabled: applicationPackages.enabled,
-      blockUserConnections: applicationPackages.blockUserConnections,
-    })
-    .from(applicationPackages)
-    .where(
-      and(
-        eq(applicationPackages.applicationId, scope.applicationId),
-        eq(applicationPackages.packageId, packageId),
-      ),
-    )
-    .limit(1);
+  // Same precedence rule as the settings list endpoint, via the shared
+  // resolver — env-backed SYSTEM integrations stay `active` here too.
+  const activation = (await resolveIntegrationActivations([packageId], scope.applicationId)).get(
+    packageId,
+  )!;
   const oauthClients = await db
     .select({ authKey: integrationOauthClients.authKey })
     .from(integrationOauthClients)
@@ -2108,8 +2123,8 @@ export async function getIntegrationAuthStatuses(
     tool_catalog: toolCatalog,
     allow_undeclared_tools:
       (manifest as { allow_undeclared_tools?: boolean }).allow_undeclared_tools === true,
-    active: installedRow !== undefined && installedRow.enabled,
-    block_user_connections: installedRow?.blockUserConnections ?? false,
+    active: activation.active,
+    block_user_connections: activation.blockUserConnections,
   };
 }
 

--- a/apps/api/test/integration/routes/packages.test.ts
+++ b/apps/api/test/integration/routes/packages.test.ts
@@ -1,11 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, beforeEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { zipSync } from "fflate";
 import { getTestApp } from "../../helpers/app.ts";
 import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
-import { seedAgent, seedPackage, seedPackageVersion, seedApplication } from "../../helpers/seed.ts";
+import {
+  seedAgent,
+  seedPackage,
+  seedPackageVersion,
+  seedApplication,
+  seedInstalledPackage,
+} from "../../helpers/seed.ts";
+import {
+  initSystemIntegrations,
+  __resetSystemIntegrationsForTest,
+} from "../../../src/services/integration-client-registry.ts";
 import { installPackage } from "../../../src/services/application-packages.ts";
 import { assertDbMissing, assertDbHas } from "../../helpers/assertions.ts";
 import { auditEvents, packages, packageDistTags } from "@appstrate/db/schema";
@@ -464,6 +474,74 @@ describe("Packages API", () => {
       expect(res.status).toBe(201);
       const body = (await res.json()) as { id: string };
       expect(body.id).toBe("@otherscope/foreign-agent");
+    });
+  });
+
+  // ═══════════════════════════════════════════════
+  // GET /api/packages/integrations?active=true — agent-editor picker
+  // ═══════════════════════════════════════════════
+
+  describe("GET /api/packages/integrations?active=true (agent-editor picker)", () => {
+    const ENV_SYSTEM = "@pkgorg/gmail"; // env SYSTEM integration, no install row
+    const PLAIN = "@pkgorg/clickup"; // org integration, not installed
+    const INSTALLED = "@pkgorg/notion"; // org integration, installed + enabled
+
+    beforeEach(async () => {
+      // A deployment offering a shared OAuth client for gmail via
+      // SYSTEM_INTEGRATIONS — auto-active without an install row.
+      initSystemIntegrations([
+        {
+          id: ENV_SYSTEM,
+          clients: [
+            {
+              id: "gmail-system",
+              auth_key: "google",
+              client_id: "sys.apps.googleusercontent.com",
+              client_secret: "sys-secret",
+            },
+          ],
+        },
+      ]);
+      // gmail ships as a system-source package (visible in the catalogue with
+      // no install row, like the real one).
+      await seedPackage({ id: ENV_SYSTEM, orgId: null, type: "integration", source: "system" });
+      await seedPackage({ id: PLAIN, orgId: ctx.orgId, type: "integration" });
+      await seedPackage({ id: INSTALLED, orgId: ctx.orgId, type: "integration" });
+      await seedInstalledPackage(ctx.defaultAppId, INSTALLED, { enabled: true });
+    });
+
+    afterEach(() => {
+      __resetSystemIntegrationsForTest();
+    });
+
+    async function activeIds(): Promise<Set<string>> {
+      const res = await app.request("/api/packages/integrations?active=true", {
+        headers: authHeaders(ctx),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { data: { id: string }[] };
+      return new Set(body.data.map((i) => i.id));
+    }
+
+    it("includes an env-backed SYSTEM integration with no install row (regression)", async () => {
+      const ids = await activeIds();
+      expect(ids.has(ENV_SYSTEM)).toBe(true);
+    });
+
+    it("includes an installed + enabled org integration", async () => {
+      const ids = await activeIds();
+      expect(ids.has(INSTALLED)).toBe(true);
+    });
+
+    it("excludes a non-system org integration with no install row", async () => {
+      const ids = await activeIds();
+      expect(ids.has(PLAIN)).toBe(false);
+    });
+
+    it("excludes a SYSTEM integration with a sticky explicit disable", async () => {
+      await seedInstalledPackage(ctx.defaultAppId, ENV_SYSTEM, { enabled: false });
+      const ids = await activeIds();
+      expect(ids.has(ENV_SYSTEM)).toBe(false);
     });
   });
 

--- a/apps/api/test/integration/services/integration-active.test.ts
+++ b/apps/api/test/integration/services/integration-active.test.ts
@@ -24,6 +24,7 @@ import { applicationPackages } from "@appstrate/db/schema";
 import {
   isIntegrationActive,
   listActiveIntegrationIds,
+  resolveIntegrationActivations,
 } from "../../../src/services/integration-connections.ts";
 import {
   initSystemIntegrations,
@@ -136,5 +137,30 @@ describe("integration activation precedence", () => {
     );
     expect(flipped.has(SYSTEM_INTEGRATION)).toBe(false);
     expect(flipped.has(PLAIN_INTEGRATION)).toBe(true);
+  });
+
+  it("resolveIntegrationActivations applies the same precedence + carries block flag", async () => {
+    // This is the shared resolver feeding BOTH the settings list endpoint and
+    // the agent-editor detail endpoint. Regression guard: the detail path used
+    // to drop the system fallback, hiding env-backed system integrations in the
+    // agent editor. system (no row) → active; plain (no row) → inactive.
+    const map = await resolveIntegrationActivations(
+      [SYSTEM_INTEGRATION, DCR_INTEGRATION, PLAIN_INTEGRATION],
+      ctx.defaultAppId,
+    );
+    expect(map.get(SYSTEM_INTEGRATION)).toEqual({ active: true, blockUserConnections: false });
+    expect(map.get(DCR_INTEGRATION)).toEqual({ active: true, blockUserConnections: false });
+    expect(map.get(PLAIN_INTEGRATION)).toEqual({ active: false, blockUserConnections: false });
+
+    // Every requested id is present even with no row.
+    expect(map.size).toBe(3);
+
+    // Explicit disable on the system one is sticky and wins over auto-active.
+    await installRow(SYSTEM_INTEGRATION, false);
+    const after = await resolveIntegrationActivations([SYSTEM_INTEGRATION], ctx.defaultAppId);
+    expect(after.get(SYSTEM_INTEGRATION)?.active).toBe(false);
+
+    // Empty input → empty map (no query).
+    expect((await resolveIntegrationActivations([], ctx.defaultAppId)).size).toBe(0);
   });
 });


### PR DESCRIPTION
## Problème

Les intégrations système définies via `SYSTEM_INTEGRATIONS` (clients OAuth par défaut au niveau déploiement) sont **auto-actives** sans ligne `application_packages`. La liste des intégrations le respectait, mais deux autres surfaces ré-encodaient la règle de précédence et **oubliaient le fallback système** → les mêmes intégrations apparaissaient désactivées dans l'éditeur d'agent.

## Cause racine

La règle `row ? enabled : isSystemIntegration(id)` était dupliquée dans **4 endroits**, dont 2 divergents :

- `getIntegrationAuthStatuses` (endpoint détail → onglet intégrations de l'éditeur) : `active = installedRow !== undefined && installedRow.enabled` — **pas de fallback système**.
- `listOrgItems?active=true` (picker d'intégrations de l'éditeur) : filtre SQL pur `enabled = true`, excluant entièrement les intégrations env-système sans ligne.

## Correctif — une seule règle

Collapse vers une primitive unique `resolveIntegrationActivations(packageIds, applicationId) → Map<id, { active, blockUserConnections }>`, seule source de vérité :

- `isIntegrationActive` et `listActiveIntegrationIds` deviennent de fins wrappers.
- Liste + détail décorent via la primitive.
- Le picker résout l'« active » des intégrations via la primitive au niveau route (le narrowing SQL générique installed+enabled reste pour skill/mcp).

Nettoie les imports désormais morts dans `routes/integrations.ts`. Ajoute la couverture de régression pour `resolveIntegrationActivations` et le picker (env-système visible, sticky-disable exclu).

## Tests

- tsc / eslint / prettier ✅
- 136 tests pass sur la base `main` (services + routes intégrations + packages).
- +5 nouveaux : 1 service (`resolveIntegrationActivations`), 4 route picker (régression env-système + sticky-disable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)