### PR TITLE
feat(connect): label API-key connections with a masked secret fingerprint

### DIFF
--- a/apps/api/src/services/connect/fields-strategy.ts
+++ b/apps/api/src/services/connect/fields-strategy.ts
@@ -18,6 +18,7 @@ import {
   type IntegrationConnectionSummary,
 } from "../integration-connections.ts";
 import { validateConnectionCredentials } from "../schema.ts";
+import { maskCredentialLabel } from "./mask-label.ts";
 import { invalidRequest } from "../../lib/errors.ts";
 import type {
   ConnectContext,
@@ -54,6 +55,11 @@ export class FieldsStrategy implements IntegrationConnectStrategy {
     }
 
     const { accountId, identityClaims } = extractIdentity(manifest, ctx.authKey, credentials);
+    // No upstream identity → derive a recognisable label from the secret itself
+    // (masked fingerprint, e.g. `fc****f10b`) rather than fall back to
+    // "Connexion N". Only honoured on INSERT — the persist layer never touches
+    // `label` on reconnect, so this stays stable.
+    const labelHint = maskCredentialLabel(auth.credentials?.schema, credentials);
     return saveIntegrationConnection(ctx.scope, {
       packageId: ctx.integrationId,
       authKey: ctx.authKey,
@@ -61,6 +67,7 @@ export class FieldsStrategy implements IntegrationConnectStrategy {
       credentials,
       identityClaims,
       actor: ctx.actor,
+      ...(labelHint ? { labelHint } : {}),
       ...(ctx.connectionId ? { connectionId: ctx.connectionId } : {}),
     });
   }

--- a/apps/api/src/services/connect/mask-label.ts
+++ b/apps/api/src/services/connect/mask-label.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Derive a human-recognisable connection label from a pasted credential bag —
+ * a partially-masked fingerprint of the secret (e.g. `fc****f10b` for a
+ * Firecrawl key `fc-xxxxxxxxf10b`). Used only when no upstream identity
+ * (email / login) was extracted, so the user can still tell two API-key
+ * connections of the same integration apart without us inventing
+ * "Connexion 2" / "Connexion 3".
+ *
+ * Selection is structural, NOT name-based (no `api_key`/`token` allow-list —
+ * that would be fragile + per-provider). We mask the credential iff the auth
+ * declares exactly one fingerprintable secret field:
+ *
+ *   1. Consider only `string`-typed properties of `credentials.schema`.
+ *   2. Drop `format:"password"` / `writeOnly:true` fields — those are the
+ *      never-show class (a human account password; revealing even the last 4
+ *      is a real leak). They must NEVER reach a plaintext label column.
+ *   3. If the schema lists `required`, restrict to required fields (an
+ *      optional `base_url` shouldn't disqualify a single-key integration).
+ *   4. Mask iff exactly ONE field survives; ambiguous multi-secret auths
+ *      (Twilio sid+token, Shopify domain+token) fall back to "Connexion N".
+ *
+ * The label is stored as plaintext (the `label` column is not encrypted), so
+ * the mask only ever exposes a 2-char prefix + last 4 — the industry-standard
+ * fingerprint (Stripe/AWS/GitHub). Values shorter than 8 chars are skipped to
+ * avoid leaking too large a fraction of a short secret.
+ */
+
+const MIN_FINGERPRINT_LENGTH = 8;
+
+interface SchemaProperty {
+  type?: unknown;
+  format?: unknown;
+  writeOnly?: unknown;
+}
+
+function isStringTyped(prop: SchemaProperty): boolean {
+  const t = prop.type;
+  if (t === "string") return true;
+  if (Array.isArray(t)) return t.includes("string");
+  return false;
+}
+
+function isNeverShow(prop: SchemaProperty): boolean {
+  return prop.format === "password" || prop.writeOnly === true;
+}
+
+/**
+ * `fc-xxxxxxxxf10b` → `fc****f10b`. Returns undefined for non-strings or
+ * values too short to mask without leaking most of the secret.
+ */
+export function fingerprintSecret(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  if (value.length < MIN_FINGERPRINT_LENGTH) return undefined;
+  return `${value.slice(0, 2)}****${value.slice(-4)}`;
+}
+
+export function maskCredentialLabel(
+  schema: Record<string, unknown> | undefined,
+  credentials: Record<string, unknown>,
+): string | undefined {
+  const properties = schema?.properties as Record<string, SchemaProperty> | undefined;
+  if (!properties || typeof properties !== "object") return undefined;
+
+  let candidates = Object.entries(properties)
+    .filter(([, prop]) => prop && isStringTyped(prop) && !isNeverShow(prop))
+    .map(([key]) => key);
+
+  const required = schema?.required;
+  if (Array.isArray(required) && required.length > 0) {
+    const requiredSet = new Set(required.filter((r): r is string => typeof r === "string"));
+    candidates = candidates.filter((key) => requiredSet.has(key));
+  }
+
+  const only = candidates[0];
+  if (candidates.length !== 1 || only === undefined) return undefined;
+  return fingerprintSecret(credentials[only]);
+}

--- a/apps/api/src/services/integration-connections.ts
+++ b/apps/api/src/services/integration-connections.ts
@@ -1522,6 +1522,12 @@ export interface StoreConnectionInput {
    */
   connectionId?: string;
   /**
+   * Optional display-name seed used ONLY on INSERT when no upstream identity
+   * was extracted (e.g. a masked API-key fingerprint from FieldsStrategy).
+   * Identity still wins; ignored on reconnect (label is never re-derived).
+   */
+  labelHint?: string;
+  /**
    * Which registered client minted this connection — a flat client id (system
    * env id or custom `integration_oauth_clients.id`). Pinned on the row so token
    * refresh resolves the same credentials. Set by OAuth2Strategy on every oauth2
@@ -1589,6 +1595,11 @@ export interface PersistCredentialInput {
   accountId?: string;
   identityClaims?: Record<string, unknown>;
   scopesGranted?: string[];
+  /**
+   * INSERT-only label seed (masked secret fingerprint). Used after identity
+   * but before the "Connexion N" counter. Never applied on UPDATE paths.
+   */
+  labelHint?: string;
   /** INSERT only — the `(packageId, authKey)` the new row belongs to. */
   packageId?: string;
   authKey?: string;
@@ -1660,6 +1671,7 @@ export async function persistCredentialBundle(
     const ownerFilter = userId ? sql`user_id = ${userId}` : sql`end_user_id = ${endUserId}`;
     const labelValue: string | SQL =
       identityLabel ??
+      input.labelHint ??
       sql<string>`'Connexion ' || ((SELECT COUNT(*) FROM integration_connections WHERE application_id = ${target.scope.applicationId} AND integration_package_id = ${input.packageId} AND ${ownerFilter}) + 1)`;
     const inserted = await db
       .insert(integrationConnections)
@@ -1860,6 +1872,7 @@ export async function saveIntegrationConnection(
     scopesGranted: input.scopesGranted ?? [],
     needsReconnection: false,
     expiresAt: input.expiresAt ?? null,
+    ...(input.labelHint ? { labelHint: input.labelHint } : {}),
     ...(input.clientRef !== undefined ? { clientRef: input.clientRef } : {}),
   };
   const summary = input.connectionId

--- a/apps/api/test/unit/mask-label.test.ts
+++ b/apps/api/test/unit/mask-label.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `maskCredentialLabel` — the structural picker that turns a
+ * single-secret credential bag into a masked fingerprint label, and refuses
+ * to label ambiguous multi-secret or never-show (password) fields.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { fingerprintSecret, maskCredentialLabel } from "../../src/services/connect/mask-label.ts";
+
+describe("fingerprintSecret", () => {
+  it("masks the middle, keeping 2-char prefix + last 4", () => {
+    expect(fingerprintSecret("fc-abcdef01f10b")).toBe("fc****f10b");
+  });
+
+  it("returns undefined for values shorter than 8 chars", () => {
+    expect(fingerprintSecret("short")).toBeUndefined();
+    expect(fingerprintSecret("1234567")).toBeUndefined();
+    expect(fingerprintSecret("12345678")).toBe("12****5678");
+  });
+
+  it("returns undefined for non-strings", () => {
+    expect(fingerprintSecret(undefined)).toBeUndefined();
+    expect(fingerprintSecret(42)).toBeUndefined();
+    expect(fingerprintSecret(null)).toBeUndefined();
+  });
+});
+
+describe("maskCredentialLabel", () => {
+  it("masks the sole string secret of a single-field schema", () => {
+    const schema = {
+      type: "object",
+      properties: { api_key: { type: "string" } },
+      required: ["api_key"],
+    };
+    expect(maskCredentialLabel(schema, { api_key: "sk_live_abcdef12a1b2" })).toBe("sk****a1b2");
+  });
+
+  it("ignores an optional non-required field when a single required secret exists", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        api_key: { type: "string" },
+        base_url: { type: "string" },
+      },
+      required: ["api_key"],
+    };
+    expect(
+      maskCredentialLabel(schema, { api_key: "key_abcdef12cdef", base_url: "https://x" }),
+    ).toBe("ke****cdef");
+  });
+
+  it("returns undefined for ambiguous multi-secret schemas (Twilio)", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        account_sid: { type: "string" },
+        auth_token: { type: "string" },
+      },
+      required: ["account_sid", "auth_token"],
+    };
+    expect(
+      maskCredentialLabel(schema, { account_sid: "ACxxxxxxxxxxxx", auth_token: "toktoktoktok" }),
+    ).toBeUndefined();
+  });
+
+  it("excludes format:password fields (never-show class)", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        email: { type: "string" },
+        password: { type: "string", format: "password" },
+      },
+      required: ["email", "password"],
+    };
+    // password dropped → only `email` remains → single candidate masked.
+    expect(
+      maskCredentialLabel(schema, { email: "user@example.com", password: "hunter2hunter" }),
+    ).toBe("us****.com");
+  });
+
+  it("returns undefined when the sole field is writeOnly", () => {
+    const schema = {
+      type: "object",
+      properties: { password: { type: "string", writeOnly: true } },
+      required: ["password"],
+    };
+    expect(maskCredentialLabel(schema, { password: "supersecretvalue" })).toBeUndefined();
+  });
+
+  it('handles union string types ["string","null"]', () => {
+    const schema = {
+      type: "object",
+      properties: { token: { type: ["string", "null"] } },
+      required: ["token"],
+    };
+    expect(maskCredentialLabel(schema, { token: "tok_abcdef12wxyz" })).toBe("to****wxyz");
+  });
+
+  it("returns undefined when the secret value is too short to fingerprint", () => {
+    const schema = {
+      type: "object",
+      properties: { api_key: { type: "string" } },
+      required: ["api_key"],
+    };
+    expect(maskCredentialLabel(schema, { api_key: "abc" })).toBeUndefined();
+  });
+
+  it("returns undefined for a missing/empty schema", () => {
+    expect(maskCredentialLabel(undefined, { api_key: "whatever_long_value" })).toBeUndefined();
+    expect(
+      maskCredentialLabel({ type: "object" }, { api_key: "whatever_long_value" }),
+    ).toBeUndefined();
+  });
+
+  it("falls back to all string fields when no required array is present", () => {
+    const schema = {
+      type: "object",
+      properties: { api_key: { type: "string" } },
+    };
+    expect(maskCredentialLabel(schema, { api_key: "key_abcdef12ghij" })).toBe("ke****ghij");
+  });
+});


### PR DESCRIPTION
## Problème

À la création d'une connexion : si une identité upstream est détectée (OAuth, basic auth avec email), on enregistre l'email comme nom. Sinon → `Connexion N` (compteur incrémental). Résultat : 3 clés API du même provider = `Connexion 1/2/3`, impossible à distinguer.

## Changement

Pour les connexions **fields (clé API) sans identité**, on dérive le nom d'une **empreinte masquée du secret** (ex. `fc****f10b`) au lieu de `Connexion N`. L'utilisateur peut alors faire le lien avec la clé affichée dans son dashboard provider (même convention que Stripe/AWS/GitHub).

Précédence à l'INSERT : `identité > empreinte masquée > Connexion N`.

## Sélection du champ — structurelle, pas par nom

Pas d'allow-list `api_key`/`token` (fragile, par-provider). On masque **ssi** l'auth déclare exactement **un** champ secret fingerprintable :

1. Propriétés `string` du `credentials.schema` uniquement.
2. **Exclusion** des champs `format:"password"` / `writeOnly:true` — classe *never-show* (un password humain ; révéler même les 4 derniers caractères = fuite réelle). Ne doivent jamais atteindre la colonne `label` (plaintext).
3. Si `required` présent → restreint aux champs requis (un `base_url` optionnel ne disqualifie pas une intégration mono-clé).
4. Masque ssi **un seul** champ survit. Multi-secret ambigu (Twilio `sid`+`token`, Shopify `domain`+`token`) → `Connexion N`. Valeurs < 8 chars → skip.

Empreinte = préfixe 2 chars + 4 derniers (`fc-xxxxxxxxf10b` → `fc****f10b`).

## Portée

- Touche **uniquement** le chemin INSERT. Reconnect/refresh ne re-dérivent jamais le `label` (comportement inchangé). Label éditable par l'utilisateur après coup.
- OAuth non affecté (pas de secret collable).
- Couverture : Stripe/Firecrawl/Brevo (mono-champ) → masqué ✅ ; Twilio/Shopify (multi) → `Connexion N` jusqu'à ce que le manifest marque le champ sensible.

## Fichiers

| Fichier | Rôle |
|---|---|
| `apps/api/src/services/connect/mask-label.ts` | nouveau helper `maskCredentialLabel` + `fingerprintSecret` |
| `apps/api/test/unit/mask-label.test.ts` | 12 tests unitaires (tier 0) |
| `apps/api/src/services/connect/fields-strategy.ts` | calcule `labelHint`, passe à `saveIntegrationConnection` |
| `apps/api/src/services/integration-connections.ts` | `labelHint` sur `StoreConnectionInput`/`PersistCredentialInput` + précédence INSERT |

## Tests

`bun test apps/api/test/unit/mask-label.test.ts` → 12 pass. `tsc --noEmit` + eslint + prettier OK.

## Suite possible (hors scope)

Adopter `format:"password"` comme marqueur AFPS sur les manifests multi-champs → masque déterministe + bonus `<input type=password>` en UI (absent aujourd'hui dans `packages/ui`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)