### PR TITLE
fix(sidecar): stop silently dropping JSON-object api_call bodies (#765)

### DIFF
--- a/runtime-pi/sidecar/credential-proxy.ts
+++ b/runtime-pi/sidecar/credential-proxy.ts
@@ -56,8 +56,9 @@ import { filterSensitiveHeaders } from "./redact.ts";
 /**
  * Body modes the proxy core accepts. The HTTP handler can produce
  * "none" / "buffered" / "streaming"; the MCP handler produces
- * "buffered" for text + binary uploads, and "formData" for the
- * `{ multipart: [...] }` body shape.
+ * "buffered" for text + binary uploads, "formData" for the
+ * `{ multipart: [...] }` body shape, and "json" for a plain JSON
+ * object/array (serialized here, after leaf substitution).
  *
  * The `formData` variant carries a builder closure rather than a
  * pre-baked `FormData` so the per-attempt body can be regenerated with
@@ -65,7 +66,7 @@ import { filterSensitiveHeaders } from "./redact.ts";
  * part must see the refreshed token after a 401-retry, identical to
  * the buffered text path.
  */
-type ApiCallRequestBody =
+export type ApiCallRequestBody =
   | { kind: "none" }
   | { kind: "buffered"; bytes: ArrayBuffer; text?: string }
   | { kind: "streaming"; stream: ReadableStream }
@@ -79,6 +80,18 @@ type ApiCallRequestBody =
        * text path. Empty/omitted means no substitution will happen.
        */
       fieldTemplates?: string[];
+    }
+  | {
+      /**
+       * A plain JSON object/array body. Serialization is DEFERRED to the
+       * proxy (like `formData`) so that `{{var}}` substitution happens on
+       * the structured leaf values BEFORE `JSON.stringify` — the serializer
+       * then escapes every value, so an injected credential containing `"`
+       * or `\` can never produce malformed JSON on the wire. Re-serialized
+       * per attempt so a 401-retry sees refreshed credentials.
+       */
+      kind: "json";
+      value: unknown;
     };
 
 export interface ApiCallArgs {
@@ -154,6 +167,47 @@ export interface ApiCallDeps {
    * Production callers omit it (system resolver via `node:dns`).
    */
   resolveHost?: HostResolver;
+}
+
+/**
+ * Recursively apply `{{var}}` substitution to the string leaves of a
+ * JSON value, returning a NEW value (input untouched). When `creds` is
+ * undefined the value is returned structurally unchanged (no
+ * substitution requested). Substituting on the structured leaves — then
+ * letting `JSON.stringify` escape — is what makes the `json` body shape
+ * injection-safe: a credential containing `"`/`\`/newline is escaped by
+ * the serializer instead of corrupting the surrounding JSON.
+ */
+function deepSubstituteJson(value: unknown, creds: Record<string, string> | undefined): unknown {
+  if (typeof value === "string") return creds ? substituteVars(value, creds) : value;
+  if (Array.isArray(value)) return value.map((v) => deepSubstituteJson(v, creds));
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) out[k] = deepSubstituteJson(v, creds);
+    return out;
+  }
+  return value;
+}
+
+/** Collect unresolved `{{placeholders}}` left in a JSON value's string leaves. */
+function findUnresolvedJsonPlaceholders(
+  value: unknown,
+  creds: Record<string, string>,
+  acc: Set<string> = new Set(),
+): Set<string> {
+  if (typeof value === "string") {
+    for (const p of findUnresolvedPlaceholders(substituteVars(value, creds))) acc.add(p);
+  } else if (Array.isArray(value)) {
+    for (const v of value) findUnresolvedJsonPlaceholders(v, creds, acc);
+  } else if (value && typeof value === "object") {
+    for (const v of Object.values(value)) findUnresolvedJsonPlaceholders(v, creds, acc);
+  }
+  return acc;
+}
+
+/** Exhaustiveness guard: a new body kind without a buildBody case fails to compile here. */
+function assertNever(value: never): never {
+  throw new Error(`Unhandled request-body kind: ${JSON.stringify(value)}`);
 }
 
 /**
@@ -274,18 +328,41 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
       };
     }
   }
+  if (substituteBody && body.kind === "json") {
+    const unresolved = findUnresolvedJsonPlaceholders(body.value, creds.credentials);
+    if (unresolved.size) {
+      return {
+        ok: false,
+        status: 400,
+        error: `Unresolved placeholders in body: {{${[...unresolved].join()}}}`,
+      };
+    }
+  }
 
   /** Build the request body with credential substitution applied. */
   const buildBody = (
     activeCreds: Record<string, string>,
   ): ArrayBuffer | string | ReadableStream | FormData | undefined => {
-    if (body.kind === "none") return undefined;
-    if (body.kind === "streaming") return body.stream;
-    if (body.kind === "formData") return body.build(activeCreds);
-    if (substituteBody && body.text !== undefined) {
-      return substituteVars(body.text, activeCreds);
+    switch (body.kind) {
+      case "none":
+        return undefined;
+      case "streaming":
+        return body.stream;
+      case "formData":
+        return body.build(activeCreds);
+      case "json":
+        // Substitute on the structured leaves first, THEN serialize so
+        // every value is escaped by `JSON.stringify` (injection-safe).
+        return JSON.stringify(
+          deepSubstituteJson(body.value, substituteBody ? activeCreds : undefined),
+        );
+      case "buffered":
+        return substituteBody && body.text !== undefined
+          ? substituteVars(body.text, activeCreds)
+          : body.bytes;
+      default:
+        return assertNever(body);
     }
-    return body.bytes;
   };
 
   /**

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -211,6 +211,18 @@ function sanitiseApiCallHeaders(raw: Record<string, string> | undefined): {
 }
 
 /**
+ * Case-insensitive presence check over a sanitised header map. HTTP
+ * header names are case-insensitive, but a plain `Record` lookup is
+ * not — so a caller's `content-type` would not be seen by a literal
+ * `headers["Content-Type"]` read. Used to decide whether the sidecar
+ * may inject a default Content-Type without clobbering an explicit one.
+ */
+function hasHeader(headers: Record<string, string>, name: string): boolean {
+  const lower = name.toLowerCase();
+  return Object.keys(headers).some((k) => k.toLowerCase() === lower);
+}
+
+/**
  * Legacy byte-based inline threshold. Kept as a defence-in-depth
  * fallback when no {@link TokenBudget} is configured (today: never in
  * production, but the option keeps tests and embedders simple).
@@ -504,7 +516,11 @@ function buildSidecarTools(options: MountMcpOptions): {
       body: {
         description:
           "Request body. Shapes:\n" +
-          "  - string: text/JSON endpoints.\n" +
+          '  - JSON object (e.g. { "url": "https://…" }): serialized to a JSON ' +
+          "string and sent with Content-Type: application/json by default (unless you set " +
+          "the header yourself). Use this for ordinary JSON request bodies.\n" +
+          "  - string: pre-serialized text/JSON/XML/form bodies. No Content-Type is added " +
+          "automatically — set it yourself when the endpoint needs one.\n" +
           "  - { fromFile: <workspace-relative path> }: send a workspace file's bytes as the " +
           "body without base64-encoding it into this argument. Resolved agent-side (read + " +
           "base64) before the call, so the file never enters the model context. Capped at " +
@@ -593,6 +609,20 @@ function buildSidecarTools(options: MountMcpOptions): {
                   ],
                 },
               },
+            },
+          },
+          {
+            // Plain JSON object: serialized to a JSON string and sent with
+            // a default `Content-Type: application/json` (unless the caller
+            // set one). `not` excludes the reserved wrapper shapes above so
+            // this variant stays disjoint from them under strict oneOf.
+            type: "object",
+            not: {
+              anyOf: [
+                { required: ["fromFile"] },
+                { required: ["fromBytes"] },
+                { required: ["multipart"] },
+              ],
             },
           },
         ],
@@ -827,7 +857,9 @@ function buildSidecarTools(options: MountMcpOptions): {
         body?:
           | string
           | { fromBytes: string; encoding: "base64" }
-          | { multipart: MultipartPartArg[] };
+          | { multipart: MultipartPartArg[] }
+          | { fromFile: string }
+          | Record<string, unknown>;
         substituteBody?: boolean;
       };
 
@@ -899,6 +931,10 @@ function buildSidecarTools(options: MountMcpOptions): {
       //    Content-Type so the boundary token matches the body bytes.
       let buffered: ArrayBuffer | undefined;
       let bodyText: string | undefined;
+      // Set when the body was a plain JSON object we serialized ourselves
+      // — the only case where the sidecar may safely default the
+      // Content-Type (we know the wire bytes are JSON).
+      let jsonSerialized = false;
       let multipartBody:
         | {
             build: (activeCreds: Record<string, string>) => FormData;
@@ -953,7 +989,7 @@ function buildSidecarTools(options: MountMcpOptions): {
             _meta: API_CALL_PREFLIGHT_META,
           };
         }
-        const decoded = decodeStrictBase64(args.body.fromBytes);
+        const decoded = decodeStrictBase64((args.body as { fromBytes: string }).fromBytes);
         if (decoded === "invalid") {
           return {
             content: [
@@ -999,6 +1035,69 @@ function buildSidecarTools(options: MountMcpOptions): {
           decoded.byteOffset,
           decoded.byteOffset + decoded.byteLength,
         ) as ArrayBuffer;
+      } else if (args.body && typeof args.body === "object" && "fromFile" in args.body) {
+        // `{ fromFile }` is resolved agent-side into `{ fromBytes }`
+        // BEFORE the call reaches the sidecar (see the body schema): the
+        // runtime reads the workspace file and base64-encodes it so the
+        // bytes never enter the model context. If a raw `{ fromFile }`
+        // arrives here, that resolver did not run — error rather than
+        // JSON-stringify the wrapper object and POST a bogus `{"fromFile":…}`.
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `${ctx.label}: body.fromFile was not resolved before the call — this is a ` +
+                "runtime bug. The file should be materialised into " +
+                "{ fromBytes, encoding: 'base64' } agent-side before invoking api_call.",
+            },
+          ],
+          isError: true,
+          _meta: API_CALL_PREFLIGHT_META,
+        };
+      } else if (args.body !== null && typeof args.body === "object") {
+        // Plain JSON object — the LLM's natural reflex for a JSON body.
+        // Earlier branches already consumed the `multipart` / `fromBytes`
+        // / `fromFile` object shapes, so anything still an object here is
+        // a JSON payload. Serialize it ONCE and remember we did, so we
+        // can default the Content-Type below. This mirrors the HTTP-client
+        // convention (fetch/axios/`PostAsJsonAsync`): the caller passes the
+        // object, the client serializes and sets the header together.
+        // String bodies above pass through untouched → no double-encoding.
+        bodyText = JSON.stringify(args.body);
+        buffered = new TextEncoder().encode(bodyText).buffer;
+        jsonSerialized = true;
+      }
+
+      // A body that was PRESENT but no branch could turn into bytes must
+      // error — never silently fall through to `{ kind: "none" }` and ship
+      // an empty-bodied request (the silent-drop footgun: the upstream
+      // returns "field X missing" while the agent believes it sent X).
+      // Gate on `!= null` so an explicit `null` / absent body still means
+      // "no body" and is allowed through as `{ kind: "none" }`.
+      if (args.body != null && buffered === undefined && multipartBody === undefined) {
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                `${ctx.label}: 'body' has an unsupported shape and cannot be sent. Pass a JSON ` +
+                "object, a string, { fromBytes, encoding: 'base64' }, or { multipart: [...] }.",
+            },
+          ],
+          isError: true,
+          _meta: API_CALL_PREFLIGHT_META,
+        };
+      }
+
+      // Default Content-Type for a body we serialized from a JSON object:
+      // we KNOW the wire bytes are JSON, and most JSON APIs require the
+      // header to parse the body. Only when the caller did not set one —
+      // never override an explicit choice. Raw string bodies are left
+      // alone on purpose (they may be XML / form-encoded / NDJSON, and
+      // guessing the media type there would be wrong).
+      if (jsonSerialized && !hasHeader(callerHeaders, "content-type")) {
+        callerHeaders["Content-Type"] = "application/json";
       }
 
       const result = await executeApiCall(

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -93,7 +93,7 @@ function decodeStrictBase64(s: string): Uint8Array | "invalid" {
   }
 }
 import type { BlobStore } from "./blob-store.ts";
-import { executeApiCall, type ApiCallDeps } from "./credential-proxy.ts";
+import { executeApiCall, type ApiCallDeps, type ApiCallRequestBody } from "./credential-proxy.ts";
 import {
   UPSTREAM_META_KEY,
   buildPreflightUpstreamMeta,
@@ -347,6 +347,182 @@ function multipartError(
       _meta: API_CALL_PREFLIGHT_META,
     },
   };
+}
+
+/**
+ * Resolved `api_call` request body: either the internal discriminated
+ * {@link ApiCallRequestBody} ready for the proxy (optionally with a
+ * Content-Type the sidecar may default), or a preflight error result.
+ */
+type ResolvedRequestBody =
+  | { ok: true; body: ApiCallRequestBody; defaultContentType?: string }
+  | { ok: false; result: CallToolResult };
+
+/** Build a labelled preflight error result for a body that cannot be sent. */
+function bodyPreflightError(
+  label: string,
+  text: string,
+  structuredContent?: CallToolResult["structuredContent"],
+): ResolvedRequestBody {
+  return {
+    ok: false,
+    result: {
+      content: [{ type: "text", text: `${label}: ${text}` }],
+      ...(structuredContent ? { structuredContent } : {}),
+      isError: true,
+      _meta: API_CALL_PREFLIGHT_META,
+    },
+  };
+}
+
+/**
+ * Resolve the loosely-typed `api_call` body argument (untyped LLM input,
+ * no discriminant tag) into the internal discriminated
+ * {@link ApiCallRequestBody}. All shape narrowing lives here via `in`
+ * checks — the right tool for external, tag-less data — so the handler
+ * stays linear and this logic is unit-testable in isolation.
+ *
+ * Invariant (#765): a body that is PRESENT but cannot be turned into a
+ * sendable shape returns an error result — it is NEVER silently dropped
+ * to `{ kind: "none" }` and shipped as an empty request.
+ *
+ * Serialization of a plain JSON object is deferred to the proxy
+ * (`kind: "json"`) so `{{var}}` substitution runs on the structured leaf
+ * values BEFORE `JSON.stringify` escapes them — an injected credential
+ * can never produce malformed JSON.
+ */
+function resolveRequestBody(
+  rawBody: unknown,
+  opts: { label: string; substituteBody: boolean },
+): ResolvedRequestBody {
+  const { label, substituteBody } = opts;
+
+  // Absent / explicit null → genuinely no body.
+  if (rawBody == null) return { ok: true, body: { kind: "none" } };
+
+  // multipart/form-data: structured parts, serialization deferred to a
+  // FormData build closure so fetch() sets the boundary token itself.
+  if (typeof rawBody === "object" && "multipart" in rawBody) {
+    const validation = validateMultipartParts((rawBody as { multipart: unknown }).multipart);
+    if (!validation.ok) return { ok: false, result: validation.result };
+    const { files, fields } = validation;
+    const wants = substituteBody;
+    return {
+      ok: true,
+      body: {
+        kind: "formData",
+        fieldTemplates: wants ? fields.map((f) => f.value) : [],
+        build: (activeCreds: Record<string, string>): FormData => {
+          const fd = new FormData();
+          // Field parts honour {{var}} substitution when opted in; binary
+          // parts pass through (substituting into bytes would corrupt them).
+          for (const f of fields) {
+            fd.append(f.name, wants ? substituteVars(f.value, activeCreds) : f.value);
+          }
+          for (const file of files) {
+            // Slice into a fresh ArrayBuffer so the Blob owns a copy
+            // independent of the Uint8Array's backing buffer.
+            const ab = file.bytes.buffer.slice(
+              file.bytes.byteOffset,
+              file.bytes.byteOffset + file.bytes.byteLength,
+            ) as ArrayBuffer;
+            fd.append(file.name, new Blob([ab], { type: file.contentType }), file.filename);
+          }
+          return fd;
+        },
+      },
+    };
+  }
+
+  // Pre-serialized string (text/JSON/XML/form/NDJSON). Sent verbatim; no
+  // Content-Type is guessed — the media type is the caller's to declare.
+  if (typeof rawBody === "string") {
+    return {
+      ok: true,
+      body: {
+        kind: "buffered",
+        bytes: new TextEncoder().encode(rawBody).buffer,
+        ...(substituteBody ? { text: rawBody } : {}),
+      },
+    };
+  }
+
+  // Binary upload, base64-encoded agent-side.
+  if (typeof rawBody === "object" && "fromBytes" in rawBody) {
+    if (substituteBody) {
+      return bodyPreflightError(
+        label,
+        "substituteBody requires a text body — pass body as a string, not { fromBytes }.",
+      );
+    }
+    const decoded = decodeStrictBase64((rawBody as { fromBytes: string }).fromBytes);
+    if (decoded === "invalid") {
+      return bodyPreflightError(
+        label,
+        "body.fromBytes is not standard base64 (RFC 4648 §4, alphabet `+/`, no whitespace).",
+      );
+    }
+    if (decoded.byteLength > MAX_REQUEST_BODY_SIZE) {
+      return bodyPreflightError(
+        label,
+        `body.fromBytes is ${decoded.byteLength} bytes, which exceeds the per-request limit of ` +
+          `${MAX_REQUEST_BODY_SIZE} bytes. Operators can raise the cap with ` +
+          `SIDECAR_MAX_REQUEST_BODY_BYTES (and SIDECAR_MAX_MCP_ENVELOPE_BYTES, since base64 ` +
+          `inflation must still fit the JSON-RPC envelope). Files larger than the cap must be ` +
+          `split across multiple api_call invocations.`,
+        {
+          error: {
+            code: "PAYLOAD_TOO_LARGE",
+            scope: "request_body",
+            limit: MAX_REQUEST_BODY_SIZE,
+            actual: decoded.byteLength,
+            envVar: "SIDECAR_MAX_REQUEST_BODY_BYTES",
+          },
+        },
+      );
+    }
+    return {
+      ok: true,
+      body: {
+        kind: "buffered",
+        bytes: decoded.buffer.slice(
+          decoded.byteOffset,
+          decoded.byteOffset + decoded.byteLength,
+        ) as ArrayBuffer,
+      },
+    };
+  }
+
+  // `{ fromFile }` must be resolved into `{ fromBytes }` agent-side before
+  // the call reaches the sidecar (the file bytes never enter model
+  // context). A raw wrapper here means that resolver did not run — error
+  // rather than POST a bogus `{"fromFile":…}` JSON body.
+  if (typeof rawBody === "object" && "fromFile" in rawBody) {
+    return bodyPreflightError(
+      label,
+      "body.fromFile was not resolved before the call — this is a runtime bug. The file should " +
+        "be materialised into { fromBytes, encoding: 'base64' } agent-side before invoking api_call.",
+    );
+  }
+
+  // Plain JSON object/array — the LLM's natural reflex. Serialization is
+  // deferred to the proxy (kind:"json"); default Content-Type to
+  // application/json since we know the wire bytes will be JSON.
+  if (typeof rawBody === "object") {
+    return {
+      ok: true,
+      body: { kind: "json", value: rawBody },
+      defaultContentType: "application/json",
+    };
+  }
+
+  // Present but not a usable shape (number, boolean, …). Per #765 this must
+  // error — never silently fall through to an empty-bodied request.
+  return bodyPreflightError(
+    label,
+    "'body' has an unsupported shape and cannot be sent. Pass a JSON object, a string, " +
+      "{ fromBytes, encoding: 'base64' }, or { multipart: [...] }.",
+  );
 }
 
 /**
@@ -854,12 +1030,10 @@ function buildSidecarTools(options: MountMcpOptions): {
         target: string;
         method?: string;
         headers?: Record<string, string>;
-        body?:
-          | string
-          | { fromBytes: string; encoding: "base64" }
-          | { multipart: MultipartPartArg[] }
-          | { fromFile: string }
-          | Record<string, unknown>;
+        // Untyped LLM input — a tag-less union of body shapes. Narrowed
+        // by `resolveRequestBody` (via `in` checks, the right tool for
+        // external data) into the internal discriminated body type.
+        body?: unknown;
         substituteBody?: boolean;
       };
 
@@ -919,185 +1093,22 @@ function buildSidecarTools(options: MountMcpOptions): {
         };
       }
 
-      // Resolve the request body to raw bytes. Three shapes supported:
-      //  - string: TextEncoder → bytes (text/JSON endpoints)
-      //  - { fromBytes, encoding: "base64" }: base64 → bytes (binary
-      //    uploads — runtime resolvers materialise workspace files into
-      //    this shape before MCP because JSON-RPC has no native byte
-      //    type and forwarding bytes as a string corrupts non-UTF-8
-      //    payloads).
-      //  - { multipart: [...] }: structured multipart/form-data. The
-      //    sidecar builds a `FormData` and lets `fetch()` set the
-      //    Content-Type so the boundary token matches the body bytes.
-      let buffered: ArrayBuffer | undefined;
-      let bodyText: string | undefined;
-      // Set when the body was a plain JSON object we serialized ourselves
-      // — the only case where the sidecar may safely default the
-      // Content-Type (we know the wire bytes are JSON).
-      let jsonSerialized = false;
-      let multipartBody:
-        | {
-            build: (activeCreds: Record<string, string>) => FormData;
-            fieldTemplates: string[];
-          }
-        | undefined;
-      if (args.body && typeof args.body === "object" && "multipart" in args.body) {
-        const validation = validateMultipartParts(args.body.multipart);
-        if (!validation.ok) {
-          return validation.result;
-        }
-        const { files, fields } = validation;
-        const wantsSubstitution = !!args.substituteBody;
-        multipartBody = {
-          fieldTemplates: wantsSubstitution ? fields.map((f) => f.value) : [],
-          build: (activeCreds: Record<string, string>): FormData => {
-            const fd = new FormData();
-            // Field parts honour {{var}} substitution when opted in;
-            // binary parts intentionally pass through (substituting into
-            // bytes would corrupt the payload).
-            for (const f of fields) {
-              const value = wantsSubstitution ? substituteVars(f.value, activeCreds) : f.value;
-              fd.append(f.name, value);
-            }
-            for (const file of files) {
-              // Slice into a fresh ArrayBuffer so the Blob owns a copy
-              // independent of the Uint8Array's backing buffer.
-              const ab = file.bytes.buffer.slice(
-                file.bytes.byteOffset,
-                file.bytes.byteOffset + file.bytes.byteLength,
-              ) as ArrayBuffer;
-              fd.append(file.name, new Blob([ab], { type: file.contentType }), file.filename);
-            }
-            return fd;
-          },
-        };
-      } else if (typeof args.body === "string") {
-        buffered = new TextEncoder().encode(args.body).buffer;
-        bodyText = args.body;
-      } else if (args.body && typeof args.body === "object" && "fromBytes" in args.body) {
-        if (args.substituteBody) {
-          return {
-            content: [
-              {
-                type: "text",
-                text:
-                  `${ctx.label}: substituteBody requires a text body — pass body as a string, ` +
-                  "not { fromBytes }.",
-              },
-            ],
-            isError: true,
-            _meta: API_CALL_PREFLIGHT_META,
-          };
-        }
-        const decoded = decodeStrictBase64((args.body as { fromBytes: string }).fromBytes);
-        if (decoded === "invalid") {
-          return {
-            content: [
-              {
-                type: "text",
-                text:
-                  `${ctx.label}: body.fromBytes is not standard base64 (RFC 4648 §4, ` +
-                  "alphabet `+/`, no whitespace).",
-              },
-            ],
-            isError: true,
-            _meta: API_CALL_PREFLIGHT_META,
-          };
-        }
-        if (decoded.byteLength > MAX_REQUEST_BODY_SIZE) {
-          return {
-            content: [
-              {
-                type: "text",
-                text:
-                  `${ctx.label}: body.fromBytes is ${decoded.byteLength} bytes, ` +
-                  `which exceeds the per-request limit of ${MAX_REQUEST_BODY_SIZE} bytes. ` +
-                  `Operators can raise the cap with SIDECAR_MAX_REQUEST_BODY_BYTES (and ` +
-                  `SIDECAR_MAX_MCP_ENVELOPE_BYTES, since base64 inflation must still fit ` +
-                  `the JSON-RPC envelope). Files larger than the cap must be split across ` +
-                  `multiple api_call invocations.`,
-              },
-            ],
-            structuredContent: {
-              error: {
-                code: "PAYLOAD_TOO_LARGE",
-                scope: "request_body",
-                limit: MAX_REQUEST_BODY_SIZE,
-                actual: decoded.byteLength,
-                envVar: "SIDECAR_MAX_REQUEST_BODY_BYTES",
-              },
-            },
-            isError: true,
-            _meta: API_CALL_PREFLIGHT_META,
-          };
-        }
-        buffered = decoded.buffer.slice(
-          decoded.byteOffset,
-          decoded.byteOffset + decoded.byteLength,
-        ) as ArrayBuffer;
-      } else if (args.body && typeof args.body === "object" && "fromFile" in args.body) {
-        // `{ fromFile }` is resolved agent-side into `{ fromBytes }`
-        // BEFORE the call reaches the sidecar (see the body schema): the
-        // runtime reads the workspace file and base64-encodes it so the
-        // bytes never enter the model context. If a raw `{ fromFile }`
-        // arrives here, that resolver did not run — error rather than
-        // JSON-stringify the wrapper object and POST a bogus `{"fromFile":…}`.
-        return {
-          content: [
-            {
-              type: "text",
-              text:
-                `${ctx.label}: body.fromFile was not resolved before the call — this is a ` +
-                "runtime bug. The file should be materialised into " +
-                "{ fromBytes, encoding: 'base64' } agent-side before invoking api_call.",
-            },
-          ],
-          isError: true,
-          _meta: API_CALL_PREFLIGHT_META,
-        };
-      } else if (args.body !== null && typeof args.body === "object") {
-        // Plain JSON object — the LLM's natural reflex for a JSON body.
-        // Earlier branches already consumed the `multipart` / `fromBytes`
-        // / `fromFile` object shapes, so anything still an object here is
-        // a JSON payload. Serialize it ONCE and remember we did, so we
-        // can default the Content-Type below. This mirrors the HTTP-client
-        // convention (fetch/axios/`PostAsJsonAsync`): the caller passes the
-        // object, the client serializes and sets the header together.
-        // String bodies above pass through untouched → no double-encoding.
-        bodyText = JSON.stringify(args.body);
-        buffered = new TextEncoder().encode(bodyText).buffer;
-        jsonSerialized = true;
+      // Resolve the loosely-typed body argument into the internal
+      // discriminated `ApiCallRequestBody`. All shape narrowing + the
+      // silent-drop guard (#765) live in `resolveRequestBody`, keeping
+      // this handler linear and the logic unit-testable in isolation.
+      const resolved = resolveRequestBody(args.body, {
+        label: ctx.label,
+        substituteBody: !!args.substituteBody,
+      });
+      if (!resolved.ok) {
+        return resolved.result;
       }
-
-      // A body that was PRESENT but no branch could turn into bytes must
-      // error — never silently fall through to `{ kind: "none" }` and ship
-      // an empty-bodied request (the silent-drop footgun: the upstream
-      // returns "field X missing" while the agent believes it sent X).
-      // Gate on `!= null` so an explicit `null` / absent body still means
-      // "no body" and is allowed through as `{ kind: "none" }`.
-      if (args.body != null && buffered === undefined && multipartBody === undefined) {
-        return {
-          content: [
-            {
-              type: "text",
-              text:
-                `${ctx.label}: 'body' has an unsupported shape and cannot be sent. Pass a JSON ` +
-                "object, a string, { fromBytes, encoding: 'base64' }, or { multipart: [...] }.",
-            },
-          ],
-          isError: true,
-          _meta: API_CALL_PREFLIGHT_META,
-        };
-      }
-
-      // Default Content-Type for a body we serialized from a JSON object:
-      // we KNOW the wire bytes are JSON, and most JSON APIs require the
-      // header to parse the body. Only when the caller did not set one —
-      // never override an explicit choice. Raw string bodies are left
-      // alone on purpose (they may be XML / form-encoded / NDJSON, and
-      // guessing the media type there would be wrong).
-      if (jsonSerialized && !hasHeader(callerHeaders, "content-type")) {
-        callerHeaders["Content-Type"] = "application/json";
+      // Default Content-Type only when the resolver knows the wire bytes
+      // are JSON (object body) AND the caller did not set one — never
+      // override an explicit choice, never guess for a raw string body.
+      if (resolved.defaultContentType && !hasHeader(callerHeaders, "content-type")) {
+        callerHeaders["Content-Type"] = resolved.defaultContentType;
       }
 
       const result = await executeApiCall(
@@ -1106,19 +1117,7 @@ function buildSidecarTools(options: MountMcpOptions): {
           targetUrl: args.target,
           method,
           callerHeaders,
-          body: multipartBody
-            ? {
-                kind: "formData" as const,
-                build: multipartBody.build,
-                fieldTemplates: multipartBody.fieldTemplates,
-              }
-            : buffered
-              ? {
-                  kind: "buffered" as const,
-                  bytes: buffered,
-                  ...(bodyText !== undefined && args.substituteBody ? { text: bodyText } : {}),
-                }
-              : { kind: "none" as const },
+          body: resolved.body,
           substituteBody: !!args.substituteBody,
           proxyUrl: config.proxyUrl,
         },

--- a/runtime-pi/sidecar/test/api-call-body.test.ts
+++ b/runtime-pi/sidecar/test/api-call-body.test.ts
@@ -1,0 +1,343 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for the buffered (non-multipart) body shapes of `{ns}__api_call`,
+ * with a focus on the regression in issue #765: a `body` passed as a plain
+ * JSON object was silently dropped — the upstream POST went out with an
+ * empty body (`kind: "none"`) and no signal to the agent.
+ *
+ * These pin the corrected contract:
+ *
+ *   - JSON object body → serialized once to a JSON string AND sent with a
+ *     default `Content-Type: application/json`.
+ *   - A caller-supplied Content-Type is never overridden by the default.
+ *   - A raw string body is forwarded verbatim with NO Content-Type guess.
+ *   - `{{var}}` substitution still applies to an object body under
+ *     `substituteBody: true` (the object is serialized first).
+ *   - A present-but-unrecognized body (number/boolean) ERRORS at preflight
+ *     instead of silently shipping an empty request.
+ *   - A raw `{ fromFile }` that reached the sidecar unresolved ERRORS.
+ *   - GET + body is still rejected at preflight (pre-existing guard).
+ *   - The descriptor advertises the JSON-object shape.
+ */
+
+import { describe, it, expect, mock } from "bun:test";
+import { createApp, buildSidecarRuntimeDeps, type AppDeps } from "../app.ts";
+import { buildApiCallHost } from "./helpers/api-call-host.ts";
+import type { CredentialsResponse } from "../helpers.ts";
+
+const integrationCreds = (): CredentialsResponse => ({
+  credentials: { access_token: "tok-abc" },
+  authorizedUris: ["https://api.example.com/**"],
+  allowAllUris: false,
+  credentialHeaderName: "Authorization",
+  credentialHeaderPrefix: "Bearer",
+  credentialFieldName: "access_token",
+});
+
+function makeDeps(overrides?: Partial<AppDeps>): AppDeps {
+  return {
+    config: { platformApiUrl: "http://mock:3000", runToken: "tok", proxyUrl: "" },
+    fetchCredentials: mock(async (): Promise<CredentialsResponse> => integrationCreds()),
+    cookieJar: new Map(),
+    fetchFn: mock(
+      async () =>
+        new Response('{"ok":true}', {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    ) as unknown as typeof fetch,
+    isReady: () => true,
+    ...overrides,
+  };
+}
+
+async function makeApp(overrides?: Partial<AppDeps>) {
+  const appDeps = makeDeps(overrides);
+  const runtimeDeps = buildSidecarRuntimeDeps(appDeps);
+  const host = await buildApiCallHost(
+    [
+      {
+        namespace: "test",
+        integrationId: "@appstrate/test",
+        fetchCredentials: async () => integrationCreds(),
+        refreshCredentials: async () => integrationCreds(),
+      },
+    ],
+    runtimeDeps,
+  );
+  return createApp({
+    ...appDeps,
+    runtimeDeps,
+    additionalMcpToolsProvider: () => host.buildTools(),
+  });
+}
+
+async function rpc(
+  app: ReturnType<typeof createApp>,
+  body: { method: string; params?: unknown },
+): Promise<{ status: number; json: Record<string, unknown> }> {
+  const res = await app.request("/mcp", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      Host: "localhost",
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, ...body }),
+  });
+  return { status: res.status, json: JSON.parse(await res.text()) };
+}
+
+/**
+ * Build an app whose upstream fetch captures the request body bytes and
+ * the Content-Type actually sent on the wire (read off `init`).
+ */
+function captureApp() {
+  const captured: { body: string | null; contentType: string | null } = {
+    body: null,
+    contentType: null,
+  };
+  const fetchFn = mock(async (_url: string, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    captured.contentType = headers.get("content-type");
+    const b = init?.body;
+    if (typeof b === "string") {
+      captured.body = b;
+    } else if (b instanceof ArrayBuffer) {
+      captured.body = new TextDecoder().decode(b);
+    } else if (b instanceof Uint8Array) {
+      captured.body = new TextDecoder().decode(b);
+    } else if (b == null) {
+      captured.body = null;
+    } else {
+      captured.body = "<non-buffered>";
+    }
+    return new Response('{"ok":true}', {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  return { captured, fetchFn: fetchFn as unknown as typeof fetch };
+}
+
+describe("POST /mcp — api_call JSON-object body (issue #765)", () => {
+  it("serializes a plain JSON object and defaults Content-Type: application/json", async () => {
+    const { captured, fetchFn } = captureApp();
+    const app = await makeApp({ fetchFn });
+
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "test__api_call",
+        arguments: {
+          target: "https://api.example.com/scrape",
+          method: "POST",
+          body: { url: "https://example.com", formats: ["markdown"] },
+        },
+      },
+    });
+
+    const result = res.json.result as { isError?: boolean };
+    expect(result.isError).toBeFalsy();
+    // The body actually reached the upstream — NOT dropped to kind:"none".
+    expect(captured.body).not.toBeNull();
+    expect(JSON.parse(captured.body!)).toEqual({
+      url: "https://example.com",
+      formats: ["markdown"],
+    });
+    expect(captured.contentType).toBe("application/json");
+  });
+
+  it("does not override a caller-supplied Content-Type", async () => {
+    const { captured, fetchFn } = captureApp();
+    const app = await makeApp({ fetchFn });
+
+    await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "test__api_call",
+        arguments: {
+          target: "https://api.example.com/scrape",
+          method: "POST",
+          headers: { "Content-Type": "application/vnd.api+json" },
+          body: { url: "https://example.com" },
+        },
+      },
+    });
+
+    // Caller's explicit choice wins; the JSON default must not clobber it.
+    expect(captured.contentType).toBe("application/vnd.api+json");
+    expect(JSON.parse(captured.body!)).toEqual({ url: "https://example.com" });
+  });
+
+  it("serializes a JSON array body", async () => {
+    const { captured, fetchFn } = captureApp();
+    const app = await makeApp({ fetchFn });
+
+    await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "test__api_call",
+        arguments: {
+          target: "https://api.example.com/batch",
+          method: "POST",
+          body: [{ id: 1 }, { id: 2 }],
+        },
+      },
+    });
+
+    expect(JSON.parse(captured.body!)).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(captured.contentType).toBe("application/json");
+  });
+
+  it("substitutes {{vars}} inside an object body when substituteBody: true", async () => {
+    const { captured, fetchFn } = captureApp();
+    const app = await makeApp({ fetchFn });
+
+    await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "test__api_call",
+        arguments: {
+          target: "https://api.example.com/auth",
+          method: "POST",
+          substituteBody: true,
+          body: { authorization: "Bearer {{access_token}}" },
+        },
+      },
+    });
+
+    expect(JSON.parse(captured.body!)).toEqual({ authorization: "Bearer tok-abc" });
+  });
+});
+
+describe("POST /mcp — api_call string body Content-Type", () => {
+  it("forwards a raw string body verbatim and adds NO Content-Type", async () => {
+    const { captured, fetchFn } = captureApp();
+    const app = await makeApp({ fetchFn });
+
+    await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "test__api_call",
+        arguments: {
+          target: "https://api.example.com/ingest",
+          method: "POST",
+          body: "<xml>raw</xml>",
+        },
+      },
+    });
+
+    expect(captured.body).toBe("<xml>raw</xml>");
+    // Deliberately not guessed — a string may be XML/form/NDJSON.
+    expect(captured.contentType).toBeNull();
+  });
+});
+
+describe("POST /mcp — api_call body silent-drop guard", () => {
+  it("errors on a present-but-unrecognized body (number) instead of sending empty", async () => {
+    const fetchFn = mock(async () => new Response("{}", { status: 200 }));
+    const app = await makeApp({ fetchFn: fetchFn as unknown as typeof fetch });
+
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "test__api_call",
+        arguments: {
+          target: "https://api.example.com/x",
+          method: "POST",
+          body: 42 as unknown as object,
+        },
+      },
+    });
+
+    const result = res.json.result as { content: Array<{ text: string }>; isError?: boolean };
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("unsupported shape");
+    // Never contacted the upstream with an empty body.
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("errors on a boolean body", async () => {
+    const fetchFn = mock(async () => new Response("{}", { status: 200 }));
+    const app = await makeApp({ fetchFn: fetchFn as unknown as typeof fetch });
+
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "test__api_call",
+        arguments: {
+          target: "https://api.example.com/x",
+          method: "POST",
+          body: true as unknown as object,
+        },
+      },
+    });
+
+    const result = res.json.result as { content: Array<{ text: string }>; isError?: boolean };
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("unsupported shape");
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("errors when a raw { fromFile } reaches the sidecar unresolved", async () => {
+    const fetchFn = mock(async () => new Response("{}", { status: 200 }));
+    const app = await makeApp({ fetchFn: fetchFn as unknown as typeof fetch });
+
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "test__api_call",
+        arguments: {
+          target: "https://api.example.com/x",
+          method: "POST",
+          body: { fromFile: "data.json" },
+        },
+      },
+    });
+
+    const result = res.json.result as { content: Array<{ text: string }>; isError?: boolean };
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("fromFile was not resolved");
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("still rejects a body on GET (pre-existing preflight)", async () => {
+    const fetchFn = mock(async () => new Response("{}", { status: 200 }));
+    const app = await makeApp({ fetchFn: fetchFn as unknown as typeof fetch });
+
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "test__api_call",
+        arguments: {
+          target: "https://api.example.com/x",
+          method: "GET",
+          body: { url: "https://example.com" },
+        },
+      },
+    });
+
+    const result = res.json.result as { content: Array<{ text: string }>; isError?: boolean };
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toContain("not allowed with method 'GET'");
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /mcp — api_call descriptor advertises JSON-object body", () => {
+  it("lists a JSON-object variant and documents Content-Type defaulting", async () => {
+    const app = await makeApp();
+    const res = await rpc(app, { method: "tools/list" });
+    const result = res.json.result as {
+      tools: Array<{
+        name: string;
+        inputSchema: { properties: { body?: { oneOf?: unknown[]; description?: string } } };
+      }>;
+    };
+    const proxy = result.tools.find((t) => t.name === "test__api_call")!;
+    expect(proxy.inputSchema.properties.body?.oneOf?.length).toBe(5);
+    expect(proxy.inputSchema.properties.body?.description).toContain("application/json");
+  });
+});

--- a/runtime-pi/sidecar/test/api-call-body.test.ts
+++ b/runtime-pi/sidecar/test/api-call-body.test.ts
@@ -26,8 +26,8 @@ import { createApp, buildSidecarRuntimeDeps, type AppDeps } from "../app.ts";
 import { buildApiCallHost } from "./helpers/api-call-host.ts";
 import type { CredentialsResponse } from "../helpers.ts";
 
-const integrationCreds = (): CredentialsResponse => ({
-  credentials: { access_token: "tok-abc" },
+const integrationCreds = (token = "tok-abc"): CredentialsResponse => ({
+  credentials: { access_token: token },
   authorizedUris: ["https://api.example.com/**"],
   allowAllUris: false,
   credentialHeaderName: "Authorization",
@@ -52,7 +52,7 @@ function makeDeps(overrides?: Partial<AppDeps>): AppDeps {
   };
 }
 
-async function makeApp(overrides?: Partial<AppDeps>) {
+async function makeApp(overrides?: Partial<AppDeps>, token = "tok-abc") {
   const appDeps = makeDeps(overrides);
   const runtimeDeps = buildSidecarRuntimeDeps(appDeps);
   const host = await buildApiCallHost(
@@ -60,8 +60,8 @@ async function makeApp(overrides?: Partial<AppDeps>) {
       {
         namespace: "test",
         integrationId: "@appstrate/test",
-        fetchCredentials: async () => integrationCreds(),
-        refreshCredentials: async () => integrationCreds(),
+        fetchCredentials: async () => integrationCreds(token),
+        refreshCredentials: async () => integrationCreds(token),
       },
     ],
     runtimeDeps,
@@ -209,6 +209,34 @@ describe("POST /mcp — api_call JSON-object body (issue #765)", () => {
     });
 
     expect(JSON.parse(captured.body!)).toEqual({ authorization: "Bearer tok-abc" });
+  });
+
+  it("produces VALID JSON when a substituted credential contains quotes/backslashes", async () => {
+    // The escaping-safety guarantee: substitution happens on the structured
+    // leaf BEFORE JSON.stringify, so a credential with `"` / `\` / newline is
+    // escaped by the serializer instead of corrupting the surrounding JSON.
+    // Quote + backslash are the JSON-structural chars; a newline is omitted
+    // only because it is independently invalid in the injected auth header.
+    const nasty = 'a"b\\c';
+    const { captured, fetchFn } = captureApp();
+    const app = await makeApp({ fetchFn }, nasty);
+
+    await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "test__api_call",
+        arguments: {
+          target: "https://api.example.com/auth",
+          method: "POST",
+          substituteBody: true,
+          body: { secret: "{{access_token}}" },
+        },
+      },
+    });
+
+    // Must parse without throwing, and round-trip the raw credential value.
+    expect(() => JSON.parse(captured.body!)).not.toThrow();
+    expect(JSON.parse(captured.body!)).toEqual({ secret: nasty });
   });
 });
 

--- a/runtime-pi/sidecar/test/multipart.test.ts
+++ b/runtime-pi/sidecar/test/multipart.test.ts
@@ -522,8 +522,8 @@ describe("POST /mcp — api_call multipart/form-data", () => {
       }>;
     };
     const proxy = result.tools.find((t) => t.name === "test__api_call")!;
-    // string | { fromFile } | { fromBytes } | { multipart }
-    expect(proxy.inputSchema.properties.body?.oneOf?.length).toBe(4);
+    // string | { fromFile } | { fromBytes } | { multipart } | JSON object
+    expect(proxy.inputSchema.properties.body?.oneOf?.length).toBe(5);
     expect(proxy.inputSchema.properties.body?.description).toContain("multipart");
     expect(proxy.inputSchema.properties.body?.description).toContain("fromFile");
   });


### PR DESCRIPTION
Fixes #765.

## Problem

`{ns}__api_call` recognized only three body shapes (`string`, `{ fromBytes }`, `{ multipart }`). A `body` passed as a **plain JSON object** — the LLM's natural reflex — matched no branch, so `buffered`/`bodyText` stayed `undefined` and the request fell through to `{ kind: "none" }`: the upstream POST went out with an **empty body**. The API returned a generic "field missing" error and the agent had no signal its body was discarded, leading it to misdiagnose the failure as a URL/SSRF/proxy problem and flail (observed live with `@appstrate/firecrawl`).

Secondary: even with a correct string body, no default `Content-Type` was set.

## Approach (validated against SOTA)

HTTP-client convention (fetch/axios/`PostAsJsonAsync`) and MCP tool-design guidance (FastMCP coercion + "never silently drop, surface actionable tool-result errors") both point the same way: **coerce the benign LLM quirk, never drop silently.**

- **Serialize a plain JSON object** once via `JSON.stringify` and default `Content-Type: application/json` — only when the caller didn't set one (never override an explicit choice).
- **String bodies pass through untouched** — no double-encoding, and **no Content-Type is guessed** for them (a string may be XML / form-encoded / NDJSON; guessing would be wrong). This is a deliberate divergence from the issue's "default CT for string too" option.
- **Kill the silent fall-through**: a body that was present but no branch could turn into bytes now **errors at preflight** instead of shipping an empty request.
- **Reject a raw `{ fromFile }`** that reached the sidecar unresolved (it must be materialized into `{ fromBytes }` agent-side) rather than stringifying the wrapper object.
- **Declare the JSON-object shape in the input schema** (5th `oneOf` variant, `not`-excluding the reserved wrapper keys to stay disjoint under strict `oneOf`) and document the Content-Type defaulting.

## Tests

New `runtime-pi/sidecar/test/api-call-body.test.ts` (10 cases): object body → serialize + default CT; caller CT not overridden; array body; `{{var}}` substitution into an object body; raw string body (no CT added); `number`/`boolean` body → preflight error + upstream **not contacted**; unresolved `{ fromFile }` → error; GET+body preflight (regression); descriptor advertises the JSON-object variant.

Existing `multipart.test.ts` `oneOf` length assertion updated 4 → 5.

## Verification

- `runtime-pi/sidecar` typecheck: pass
- Sidecar suite (api-call-body, multipart, mcp, credential-proxy, api-call-credentials, mcp-host): 139 pass, 0 fail
- prettier + eslint: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)