### PR TITLE
fix(runs): fail fast when a declared integration has an unhealthy manifest (#737)

### DIFF
--- a/apps/api/src/services/agent-readiness.ts
+++ b/apps/api/src/services/agent-readiness.ts
@@ -11,7 +11,11 @@ import {
   translateResolutionError,
 } from "./integration-connection-resolver.ts";
 import { listActiveIntegrationIds } from "./integration-connections.ts";
-import type { IntegrationManifestCache } from "./integration-service.ts";
+import {
+  fetchIntegrationManifest,
+  type IntegrationManifestCache,
+  type IntegrationManifestLoadFailure,
+} from "./integration-service.ts";
 import { validateConfig } from "./schema.ts";
 import { extractManifestSchemas } from "../lib/manifest-utils.ts";
 import { isPromptEmpty, findMissingDependencies } from "@appstrate/core/validation";
@@ -63,6 +67,43 @@ export interface AgentReadinessParams {
  * `validateAgentReadiness` delegates to this. Fail-fast sequence:
  * prompt → skills → integration install/enable → integration connections → config.
  */
+/**
+ * Map an {@link IntegrationManifestLoadFailure} to a structured readiness
+ * error. The `integrations.` field prefix routes it into the 412 envelope
+ * in `validateAgentReadiness` (request runs) and into `failSchedule`
+ * (scheduled runs), so a declared-but-unspawnable integration produces a
+ * visible failed run instead of a silent success (#737).
+ */
+function manifestFailureError(
+  integrationId: string,
+  failure: IntegrationManifestLoadFailure,
+): ValidationFieldError {
+  const field = `integrations.${integrationId}`;
+  switch (failure.kind) {
+    case "not_found":
+      return {
+        field,
+        code: "integration_not_found",
+        title: "Integration Not Found",
+        message: `Integration '${integrationId}' is declared by the agent but no such package exists.`,
+      };
+    case "not_integration":
+      return {
+        field,
+        code: "integration_wrong_type",
+        title: "Invalid Integration",
+        message: `Package '${integrationId}' is declared as an integration but is a '${failure.actualType}'.`,
+      };
+    case "invalid_manifest":
+      return {
+        field,
+        code: "integration_invalid_manifest",
+        title: "Invalid Integration Manifest",
+        message: `Integration '${integrationId}' has an invalid manifest and cannot be loaded.`,
+      };
+  }
+}
+
 export async function collectAgentReadinessErrors(
   params: AgentReadinessParams,
 ): Promise<ValidationFieldError[]> {
@@ -106,11 +147,47 @@ export async function collectAgentReadinessErrors(
   // integration instead of N serial single-row queries (run-kickoff hot path).
   const declaredIntegrations = parseManifestIntegrations(manifest as Record<string, unknown>);
   if (declaredIntegrations.length > 0) {
+    // Integration manifest-health gate (#737) — mirrors the manifest drop
+    // conditions in `resolveOne` (integration-spawn-resolver.ts): a declared
+    // integration whose package is missing (`not_found`), is the wrong type
+    // (`not_integration`), or fails manifest validation (`invalid_manifest`)
+    // is silently skipped at spawn, so the agent launches without its tools
+    // yet the run finishes `success`. The connection resolver below
+    // deliberately ignores these (`buildRequirement` returns null and defers
+    // to this check), so readiness is the single place that surfaces them.
+    // Runs regardless of actor — manifest validity is a package-level fact.
+    // Fetched through the shared `manifestCache` so the connection-resolution
+    // and spawn passes reuse the same SELECT + Zod parse within this run.
+    const manifestResults = await Promise.all(
+      declaredIntegrations.map(async (entry) => ({
+        id: entry.id,
+        result: await fetchIntegrationManifest(entry.id, params.manifestCache),
+      })),
+    );
+    const manifestUnhealthy = new Set<string>();
+    for (const { id, result } of manifestResults) {
+      if (result.ok) continue;
+      manifestUnhealthy.add(id);
+      errors.push(manifestFailureError(id, result.failure));
+    }
+
+    // Install/enable gate — every declared integration MUST be installed AND
+    // enabled on the application. Without this the run silently degrades: the
+    // runtime spawn resolver skips an inactive integration (`isIntegrationActive`
+    // false) and the agent launches without its tools. The connection resolver
+    // below does NOT catch this — it gates on whether an accessible connection
+    // exists, and a disabled/uninstalled integration can still have lingering
+    // connections that resolve cleanly. Checked before connections so an
+    // inactive integration fails fast with a clear cause rather than a
+    // downstream `not_connected`. Integrations already flagged for a manifest
+    // failure are skipped here — a missing package is necessarily inactive too,
+    // and the manifest error is the more precise cause (no double-report).
     const activeIds = await listActiveIntegrationIds(
       declaredIntegrations.map((entry) => entry.id),
       applicationId,
     );
     for (const entry of declaredIntegrations) {
+      if (manifestUnhealthy.has(entry.id)) continue;
       if (!activeIds.has(entry.id)) {
         errors.push({
           field: `integrations.${entry.id}`,

--- a/apps/api/test/integration/routes/runs-412-missing-connection.test.ts
+++ b/apps/api/test/integration/routes/runs-412-missing-connection.test.ts
@@ -466,6 +466,106 @@ describe("POST /api/agents/:scope/:name/run — 412 missing_integration_connecti
     expect(err!.code).toBe("integration_not_active");
   });
 
+  it("returns 412 integration_not_found when a declared integration package does not exist (#737)", async () => {
+    // The agent declares `@runorg/svc` but no such package was ever seeded.
+    // resolveOne would `fetchIntegrationManifest` → `not_found` → skip silently
+    // at spawn, leaving the agent without the tools it depends on yet finishing
+    // `success`. Readiness must fail fast instead.
+    await seedAgent({
+      id: AGENT,
+      orgId: ctx.orgId,
+      createdBy: ctx.user.id,
+      draftManifest: buildAgentManifest([INTEGRATION]),
+    });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, AGENT);
+    // Deliberately no integration package seeded.
+
+    const res = await app.request(`/api/agents/${AGENT}/run?version=draft`, {
+      method: "POST",
+      headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(412);
+    const body = (await res.json()) as ProblemDetails;
+    expect(body.code).toBe("missing_integration_connection");
+    // Exactly one error — the manifest failure, NOT a piled-on
+    // integration_not_active (a missing package is necessarily inactive too;
+    // the manifest cause is the precise one).
+    expect(body.errors).toHaveLength(1);
+    const err = body.errors![0]!;
+    expect(err.field).toBe(`integrations.${INTEGRATION}`);
+    expect(err.code).toBe("integration_not_found");
+    expect(err.title).toBeTruthy();
+    expect(err.message).toBeTruthy();
+  });
+
+  it("returns 412 integration_wrong_type when the declared package is not an integration (#737)", async () => {
+    await seedAgent({
+      id: AGENT,
+      orgId: ctx.orgId,
+      createdBy: ctx.user.id,
+      draftManifest: buildAgentManifest([INTEGRATION]),
+    });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, AGENT);
+    // A package with that id exists but is a SKILL, not an integration.
+    await seedPackage({
+      id: INTEGRATION,
+      orgId: ctx.orgId,
+      type: "skill",
+      source: "local",
+      draftManifest: { name: INTEGRATION, version: "1.0.0", type: "skill" },
+    });
+
+    const res = await app.request(`/api/agents/${AGENT}/run?version=draft`, {
+      method: "POST",
+      headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(412);
+    const body = (await res.json()) as ProblemDetails;
+    expect(body.code).toBe("missing_integration_connection");
+    expect(body.errors).toHaveLength(1);
+    const err = body.errors![0]!;
+    expect(err.field).toBe(`integrations.${INTEGRATION}`);
+    expect(err.code).toBe("integration_wrong_type");
+  });
+
+  it("returns 412 integration_invalid_manifest when the integration manifest fails validation (#737)", async () => {
+    await seedAgent({
+      id: AGENT,
+      orgId: ctx.orgId,
+      createdBy: ctx.user.id,
+      draftManifest: buildAgentManifest([INTEGRATION]),
+    });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, AGENT);
+    // Integration package of the right TYPE but with a manifest that fails
+    // `integrationManifestSchema` (missing every required field).
+    await seedPackage({
+      id: INTEGRATION,
+      orgId: ctx.orgId,
+      type: "integration",
+      source: "local",
+      draftManifest: { not: "a valid integration manifest" },
+    });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, INTEGRATION);
+
+    const res = await app.request(`/api/agents/${AGENT}/run?version=draft`, {
+      method: "POST",
+      headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+
+    expect(res.status).toBe(412);
+    const body = (await res.json()) as ProblemDetails;
+    expect(body.code).toBe("missing_integration_connection");
+    expect(body.errors).toHaveLength(1);
+    const err = body.errors![0]!;
+    expect(err.field).toBe(`integrations.${INTEGRATION}`);
+    expect(err.code).toBe("integration_invalid_manifest");
+  });
+
   it("happy path: returns NON-412 status when the actor has exactly one accessible connection", async () => {
     // Sanity foil — proves the 412 only fires when there's a real gap.
     // Note: the run may still hit a downstream error (e.g. no model

--- a/apps/api/test/integration/services/scheduler.test.ts
+++ b/apps/api/test/integration/services/scheduler.test.ts
@@ -747,6 +747,56 @@ describeRequiresRedis("scheduler service", () => {
     });
   });
 
+  // ── triggerScheduledRun — declared-but-unspawnable integration (#737) ──
+  //
+  // Sibling of #735: here the schedule HAS an actor, but the agent declares an
+  // integration whose package does not exist. resolveOne would skip it silently
+  // at spawn (`fetchIntegrationManifest` → not_found → null), so the run would
+  // otherwise finish `success` without the integration's tools. The readiness
+  // manifest-health gate must turn this into a VISIBLE failed run on the
+  // scheduled path too (parity with the 412 on the request path).
+
+  describe("triggerScheduledRun integration manifest health (#737)", () => {
+    it("fails fast with a visible failed run when a declared integration package is missing", async () => {
+      const agent = await seedPackage({
+        orgId,
+        id: `@${orgSlug}/missing-integration-agent`,
+        draftManifest: {
+          name: `@${orgSlug}/missing-integration-agent`,
+          version: "0.1.0",
+          type: "agent",
+          description: "Agent declaring a non-existent integration",
+          dependencies: { integrations: { "@vendor/does-not-exist": "1.0.0" } },
+        },
+      });
+
+      const schedule = await createSchedule(
+        { orgId, applicationId: defaultAppId },
+        agent.id,
+        actor,
+        { cronExpression: "0 * * * *", versionOverride: "draft" },
+      );
+
+      await triggerScheduledRun(
+        schedule.id,
+        agent.id,
+        actor, // actor PRESENT — #735 guard does not apply
+        orgId,
+        defaultAppId,
+        undefined,
+        { versionOverride: "draft" },
+      );
+
+      const failed = await db.select().from(runs).where(eq(runs.scheduleId, schedule.id));
+      expect(failed).toHaveLength(1);
+      expect(failed[0]!.status).toBe("failed");
+      const err = (failed[0]!.error ?? "").toLowerCase();
+      // The manifest-not-found cause, NOT the #735 execution-identity message.
+      expect(err).not.toContain("execution identity");
+      expect(err).toContain("no such package");
+    });
+  });
+
   // Pure-predicate unit coverage — no DB, no fire path.
   describe("scheduleCannotResolveIntegrations (#735)", () => {
     const withIntegrations = {


### PR DESCRIPTION
Closes #737.

## Problem

Sibling of #735 (fixed by #736). #735 closed the **actor-less** zero-integration case. This closes a remaining **actor-present** sliver: a run whose agent declares an integration that gets **silently dropped at spawn for a manifest reason** can still finish `status = success` with that integration's tools missing.

`resolveOne` (`integration-spawn-resolver.ts`) warn-and-skips (returns `null`) when an integration's manifest is unhealthy — `not_found`, `not_integration` (wrong package type), `invalid_manifest` — and the connection resolver deliberately ignores the same cases (`buildRequirement` returns null), deferring to readiness.

## What was already covered upstream (and why this is narrow)

This PR is intentionally scoped to the **residual** gap. Two upstream guards already exist:

- **Install/enable gate (#574)** — `collectAgentReadinessErrors` already errors `integration_not_active` when a declared integration is not installed/enabled. Because `application_packages.packageId → packages.id ON DELETE CASCADE`, deleting an integration package cascades its install row, so a *normally-installed* package that goes missing is already caught as inactive. The issue's headline scenario ("uninstalled after the agent was configured" / "app-scoped install gap") is **already handled** by this gate.
- **Version freeze** (`resolveRunIntegrationVersions`) — hard-fails `unsatisfiable_pin` / `no_published_version` (422). An agent pinning a non-existent integration version is already loud.

What neither covers (all genuine silent-success paths today):

1. **System integration** (auto-active via `SYSTEM_INTEGRATIONS`, no install row, so the install gate's active check passes) whose `packages` row is missing or invalid.
2. **Active package of the wrong type** declared as an integration — the install gate's active check (`row.enabled`) does **not** inspect `packages.type`.
3. **Active integration whose draft manifest fails validation** — the install gate does not validate the manifest.

## Fix

Add a manifest-health gate to `collectAgentReadinessErrors` that mirrors the exact manifest drop conditions in `resolveOne`:

| failure | code |
| --- | --- |
| `not_found` | `integration_not_found` |
| `not_integration` | `integration_wrong_type` |
| `invalid_manifest` | `integration_invalid_manifest` |

Readiness is the **single source of truth** consumed by both run paths, so the gate covers them uniformly:
- **Request runs** → `412 missing_integration_connection` (the envelope `MissingConnectionsModal` already parses).
- **Scheduled runs** → `failSchedule` → a visible failed run.

It uses the same `fetchIntegrationManifest(id, manifestCache)` call the connection-readiness pass already uses at the same point, so it introduces no new draft-vs-published divergence. The install/enable gate is deduped: an integration already flagged for a manifest failure is skipped there (a missing/typoed package would otherwise report both `integration_not_found` and `integration_not_active`; the manifest cause is the precise one).

## Acceptance (from #737)

- [x] An actor-present run whose agent declares an integration that has a missing/wrong-type/invalid manifest fails fast (412 / visible failed run), not `success`.
- [x] Coverage for both the request run path and the scheduled run path.

## Tests

- `runs-412-missing-connection.test.ts` — 412 for `not_found`, `wrong_type`, `invalid_manifest`, each asserting **exactly one** error (proves the dedup; no piled-on `integration_not_active`). Green locally under `TEST_TIER=0`.
- `scheduler.test.ts` — actor-present scheduled run with a missing declared integration records a visible failed run (parity with the request path). Runs in CI (BullMQ/Redis, Docker required).

Refs #574, #735, #736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)