### PR TITLE
fix(runner-claude): idle-stall watchdog → failed not timeout (#771)

### DIFF
--- a/packages/runner-claude/src/claude-agent-runner.ts
+++ b/packages/runner-claude/src/claude-agent-runner.ts
@@ -87,10 +87,30 @@ export interface ClaudeAgentRunnerOptions {
   query?: ClaudeQueryFn;
   /** Injectable clock for deterministic tests. */
   now?: () => number;
+  /**
+   * Idle-stall watchdog: max ms with no SDK stream message before the run is
+   * aborted as a failure. Defaults to {@link DEFAULT_IDLE_TIMEOUT_MS}; `0` or a
+   * negative value disables it. Catches the silent hang when the claude-code
+   * binary retries an upstream 429 (plan / rate limit) up to 10× in the
+   * background without ever emitting a message — without this the only backstop
+   * is the platform's 300s container watchdog, which can only ever produce a
+   * `timeout` status (never an actionable `failed` + rate-limit message).
+   */
+  idleTimeoutMs?: number;
 }
 
 /** Upper bound on agent turns per run (autonomous loop). */
 const DEFAULT_MAX_TURNS = 100;
+
+/**
+ * Default idle-stall watchdog window. Picked to sit comfortably below the
+ * platform's 300s container watchdog (so a stall surfaces as a `failed` run
+ * with an explicit message instead of a SIGKILL-induced `timeout`) while
+ * staying well above any legitimate gap between SDK stream messages — note a
+ * long native tool call (e.g. a heavy Bash build) produces no intermediate
+ * message, so this must not be set too tight.
+ */
+const DEFAULT_IDLE_TIMEOUT_MS = 120_000;
 
 function resolveStartMessage(context: ExecutionContext): string {
   // Shared string|null|JSON.stringify normalisation; the fallback sentence
@@ -174,6 +194,30 @@ export class ClaudeAgentRunner implements Runner {
       else signal.addEventListener("abort", () => controller.abort(signal.reason), { once: true });
     }
 
+    // Idle-stall watchdog. Aborts the SDK's OWN controller (never the AFPS
+    // `signal`) on prolonged silence: that keeps `signal.aborted === false`, so
+    // `finalizeThrownFailure` runs its full epilogue (status="failed" + explicit
+    // error) instead of its abort-rethrow arm reserved for real cancellation.
+    // Re-armed on every stream message; cleared once a message arrives and in
+    // every exit path so the timer can't outlive the run.
+    const idleMs = this.opts.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    let idleAborted = false;
+    const clearIdle = (): void => {
+      if (idleTimer !== undefined) {
+        clearTimeout(idleTimer);
+        idleTimer = undefined;
+      }
+    };
+    const armIdle = (): void => {
+      if (idleMs <= 0) return;
+      clearIdle();
+      idleTimer = setTimeout(() => {
+        idleAborted = true;
+        controller.abort(new Error("claude-agent-runner: idle-stall watchdog"));
+      }, idleMs);
+    };
+
     const queryOptions: Record<string, unknown> = {
       pathToClaudeCodeExecutable: this.opts.binaryPath,
       env: buildClaudeSdkEnv({
@@ -200,14 +244,30 @@ export class ClaudeAgentRunner implements Runner {
         prompt: resolveStartMessage(context),
         options: queryOptions,
       });
+      armIdle();
       for await (const msg of stream) {
+        clearIdle(); // the model is responsive — stand the watchdog down
         for (const event of mapper.map(msg)) await emit(event);
         // Drain journaled runtime events at this message boundary (single sink →
         // sequence intact). The SDK awaits each tool's completion before the
         // next message, so by the time we drain the tool's events are journaled.
         await drainAndEmit();
+        armIdle(); // re-arm for the gap before the next message
       }
+      clearIdle();
     } catch (err) {
+      clearIdle();
+      // A watchdog-fired abort throws an opaque SDK AbortError; translate it
+      // into an explicit, actionable failure. Gated on `!signal.aborted` so a
+      // real cancellation that raced the watchdog still flows through the
+      // epilogue's abort-rethrow arm untouched.
+      const failure =
+        idleAborted && !signal?.aborted
+          ? new Error(
+              `claude-agent-runner: no agent activity for ${Math.round(idleMs / 1000)}s — ` +
+                "the model was unreachable (likely a Claude plan / rate limit)",
+            )
+          : err;
       // Shared thrown-failure epilogue (abort-rethrow → emit appstrate.error →
       // best-effort final drain → reduce → status="failed" → stamp usage →
       // finalize). No redaction needed — the Claude path holds no in-run
@@ -215,7 +275,7 @@ export class ClaudeAgentRunner implements Runner {
       // flight), so the transform stays identity.
       await finalizeThrownFailure({
         events,
-        err,
+        err: failure,
         signal,
         runId,
         now,

--- a/packages/runner-claude/test/claude-agent-runner.test.ts
+++ b/packages/runner-claude/test/claude-agent-runner.test.ts
@@ -285,5 +285,95 @@ describe("ClaudeAgentRunner — runtime-event drain", () => {
     expect(m.result?.status).toBe("success");
   });
 });
+describe("ClaudeAgentRunner — idle-stall watchdog", () => {
+  // A `query` that yields an optional prelude, then hangs until the SDK's own
+  // AbortController (passed in `options.abortController`) fires — at which point
+  // it throws, mirroring how the real SDK surfaces an aborted run. This models
+  // the claude-code binary silently retrying an upstream 429 with no messages.
+  function hangingQuery(prelude: SdkRunMessage[] = []) {
+    const fn = (input: ClaudeQueryInput): AsyncIterable<SdkRunMessage> => {
+      const controller = (input.options as { abortController?: AbortController }).abortController;
+      return (async function* () {
+        for (const m of prelude) yield m;
+        await new Promise<void>((resolve) => {
+          const sig = controller?.signal;
+          if (!sig || sig.aborted) return resolve();
+          sig.addEventListener("abort", () => resolve(), { once: true });
+        });
+        throw new Error("aborted by SDK controller");
+      })();
+    };
+    return { fn };
+  }
+
+  it("aborts a silent hang → failed with an explicit rate-limit message", async () => {
+    const { fn } = hangingQuery();
+    const m = memorySink();
+    await new ClaudeAgentRunner(baseOpts({ query: fn, idleTimeoutMs: 20 })).run({
+      context: ctx,
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+    expect(m.result?.status).toBe("failed");
+    expect(m.result?.error?.message).toMatch(/rate limit/i);
+    expect(m.result?.error?.message).toMatch(/no agent activity/i);
+    expect(m.events.some((e) => e.type === "appstrate.error")).toBe(true);
+  });
+
+  it("re-arms after each message → still fails when the stream stalls mid-run", async () => {
+    const { fn } = hangingQuery([
+      { type: "assistant", message: { content: [{ type: "text", text: "thinking" }] } },
+    ]);
+    const m = memorySink();
+    await new ClaudeAgentRunner(baseOpts({ query: fn, idleTimeoutMs: 20 })).run({
+      context: ctx,
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+    expect(m.result?.status).toBe("failed");
+    expect(m.result?.error?.message).toMatch(/no agent activity/i);
+  });
+
+  it("does not fire on a fast run even with a tiny window (no false positive)", async () => {
+    const { fn } = fakeQuery([
+      { type: "assistant", message: { content: [{ type: "text", text: "quick" }] } },
+      {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        total_cost_usd: 0.01,
+        duration_ms: 10,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    ]);
+    const m = memorySink();
+    await new ClaudeAgentRunner(baseOpts({ query: fn, idleTimeoutMs: 20 })).run({
+      context: ctx,
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+    expect(m.result?.status).toBe("success");
+  });
+
+  it("a real signal abort racing the watchdog still rethrows (not masked as a stall)", async () => {
+    const controller = new AbortController();
+    const fn = () =>
+      (async function* (): AsyncIterable<SdkRunMessage> {
+        yield { type: "assistant", message: { content: [{ type: "text", text: "step" }] } };
+        controller.abort();
+        throw new Error("aborted by signal");
+      })();
+    const m = memorySink();
+    await expect(
+      new ClaudeAgentRunner(baseOpts({ query: fn, idleTimeoutMs: 20 })).run({
+        context: ctx,
+        eventSink: m.sink,
+        bundle: undefined as never,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+    expect(m.result).toBeNull();
+  });
+});
 // `buildClaudeSdkEnv` is shared infra — its tests live in
 // `@appstrate/core` (test/claude-binary.test.ts).


### PR DESCRIPTION
## Problème (#771)

Un run engine `claude` (abonnement claude-code) qui atteint la limite de plan Anthropic finit en **`timeout`** ("Run timed out after 300s") au lieu d'une erreur de rate-limit explicite. `token_usage`/`cost` null, 0 tour d'agent, 300s de silence puis SIGKILL plateforme.

**Cause** : 429 → le binaire claude-code (piloté par l'Agent SDK) retry les transitoires 10× en exp backoff **silencieusement** (aucun message de stream en mode SDK). La boucle `for await` du runner n'échoue que si `query()` **throw** → le retry silencieux se présente comme un hang. Seul backstop = watchdog plateforme 300s → SIGKILL container → ne peut produire QUE `timeout`, jamais un `failed` actionnable.

## Fix — idle-stall watchdog (Phase 1)

Ajoute un watchdog d'inactivité dans `ClaudeAgentRunner` :

- Ré-armé à **chaque** message de stream ; sur N secondes de silence il abort le **`AbortController` propre au SDK** — **jamais** le `signal` AFPS.
- Aborter le controller SDK garde `signal.aborted === false` → `finalizeThrownFailure` exécute son épilogue complet (`status:"failed"` + erreur explicite) au lieu de l'arm abort-rethrow réservé à la vraie annulation.
- L'`AbortError` opaque du SDK est traduit en message actionnable : *"no agent activity for Ns — the model was unreachable (likely a Claude plan / rate limit)"*.
- Fenêtre par défaut **120s** (< 300s plateforme, > tout gap inter-message légitime, y compris un long tool natif Bash) ; `idleTimeoutMs: 0` désactive.

Indépendant du watchdog 300s, et attrape **tout** stall silencieux (pas seulement les 429).

## Tests

`packages/runner-claude/test/claude-agent-runner.test.ts` (+4) :
- hang silencieux → `failed` + message rate-limit
- ré-arm déclenche en milieu de run
- pas de faux positif sur un run rapide même avec fenêtre minuscule
- une vraie annulation `signal` qui court avec le watchdog rethrow toujours (non masquée en stall)

13/13 pass · `tsc`/`eslint`/`prettier` verts sur le package.

## Hors scope (Phase 2, suivi)

Classification sidecar 429→fatal (libellé exact + échec plus rapide en sautant le backoff). Gated sur validation de la politique de retry du binaire claude-code — PR séparée. Détail : `claudedocs/issue-771-plan.md`.

Closes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)