### PR TITLE
fix(run-options): honor selected version in run-with-options modal (#770)

### DIFF
--- a/apps/api/src/openapi/paths/agents.ts
+++ b/apps/api/src/openapi/paths/agents.ts
@@ -235,6 +235,14 @@ export const agentsPaths = {
         { $ref: "#/components/parameters/XAppId" },
         { $ref: "#/components/parameters/PackageScope" },
         { $ref: "#/components/parameters/PackageName" },
+        {
+          name: "version",
+          in: "query",
+          required: false,
+          schema: { type: "string" },
+          description:
+            "Which agent definition to assess: `draft` (the live editor working copy), `published` (the latest published version), or a version spec (exact version, dist-tag, or semver range). **Omitting the parameter resolves the `draft`** — preserving the launch-badge default. Pass a concrete version to get the same run-blocking verdict the run would produce for that pinned version (issue #770), so the modal and badge never disagree with the actual run. Ignored for system agents.",
+        },
       ],
       responses: {
         "200": {

--- a/apps/api/src/openapi/paths/packages.ts
+++ b/apps/api/src/openapi/paths/packages.ts
@@ -960,6 +960,14 @@ export const packagesPaths = {
         { $ref: "#/components/parameters/XAppId" },
         { $ref: "#/components/parameters/PackageScope" },
         { $ref: "#/components/parameters/PackageName" },
+        {
+          name: "version",
+          in: "query",
+          required: false,
+          schema: { type: "string" },
+          description:
+            "Which agent definition to project: `draft` (the live editor working copy), `published` (latest published), or a version spec (exact version, dist-tag, or semver range). **Omitting resolves the `draft`** (the editor default). A concrete version returns config / input / integrations / skills from that published manifest — the same definition the run executes (issue #770) — so the run-with-options modal stays consistent with the selected version. Ignored for system agents.",
+        },
       ],
       responses: {
         "200": {

--- a/apps/api/src/routes/agent-detail-handler.ts
+++ b/apps/api/src/routes/agent-detail-handler.ts
@@ -3,7 +3,10 @@
 import type { Context } from "hono";
 import type { AppEnv } from "../types/index.ts";
 import { getPackage, getPackageWithAccess } from "../services/package-catalog.ts";
-import { resolveAgentRunVersion } from "../services/agent-version-resolver.ts";
+import {
+  resolveAgentRunVersion,
+  VERSION_SELECTOR_DRAFT,
+} from "../services/agent-version-resolver.ts";
 import { getOrgItem } from "../services/package-items/crud.ts";
 import { CONFIG_BY_TYPE } from "../services/package-items/config.ts";
 import {
@@ -62,7 +65,7 @@ export async function buildAgentDetailDto(
   // version manifest's `dependencies.skills` map (the resolved `agent.skills`
   // closure is the draft's — id + range is what the dependency-override UI needs).
   const versionSel = opts.version?.trim();
-  const versioned = !!versionSel && versionSel !== "draft";
+  const versioned = !!versionSel && versionSel !== VERSION_SELECTOR_DRAFT;
   const effective = versioned ? await resolveAgentRunVersion(agent, versionSel) : null;
   const m = effective?.agent.manifest ?? agent.manifest;
   const effectivePrompt = effective?.agent.prompt ?? agent.prompt;

--- a/apps/api/src/routes/agent-detail-handler.ts
+++ b/apps/api/src/routes/agent-detail-handler.ts
@@ -3,6 +3,7 @@
 import type { Context } from "hono";
 import type { AppEnv } from "../types/index.ts";
 import { getPackage, getPackageWithAccess } from "../services/package-catalog.ts";
+import { resolveAgentRunVersion } from "../services/agent-version-resolver.ts";
 import { getOrgItem } from "../services/package-items/crud.ts";
 import { CONFIG_BY_TYPE } from "../services/package-items/config.ts";
 import {
@@ -36,7 +37,7 @@ import { getAppScope } from "../lib/scope.ts";
  */
 export async function buildAgentDetailDto(
   c: Context<AppEnv>,
-  opts: { itemId?: string; requireAccess?: boolean } = {},
+  opts: { itemId?: string; requireAccess?: boolean; version?: string } = {},
 ): Promise<Record<string, unknown> | null> {
   const scope = getAppScope(c);
   const { orgId, applicationId } = scope;
@@ -54,7 +55,28 @@ export async function buildAgentDetailDto(
     return null;
   }
 
-  const m = agent.manifest;
+  // Version-aware projection (issue #770). `draft`/omitted reads the live
+  // manifest; a concrete version substitutes the published manifest + prompt
+  // via the same resolver the run uses, so the detail (config/input/integrations)
+  // matches what the run will execute. Skills are pinned per-version from the
+  // version manifest's `dependencies.skills` map (the resolved `agent.skills`
+  // closure is the draft's — id + range is what the dependency-override UI needs).
+  const versionSel = opts.version?.trim();
+  const versioned = !!versionSel && versionSel !== "draft";
+  const effective = versioned ? await resolveAgentRunVersion(agent, versionSel) : null;
+  const m = effective?.agent.manifest ?? agent.manifest;
+  const effectivePrompt = effective?.agent.prompt ?? agent.prompt;
+
+  const skillDeps = versioned
+    ? Object.entries(
+        (m as { dependencies?: { skills?: Record<string, string> } }).dependencies?.skills ?? {},
+      ).map(([id, version]) => ({ id, ...(version ? { version } : {}) }))
+    : agent.skills.map((s) => ({
+        id: s.id,
+        ...(s.version ? { version: s.version } : {}),
+        ...(s.name ? { name: s.name } : {}),
+        ...(s.description ? { description: s.description } : {}),
+      }));
 
   const packageConfig = await getPackageConfig(applicationId, agent.id);
 
@@ -86,12 +108,7 @@ export async function buildAgentDetailDto(
     scope: parsed ? `@${parsed.scope}` : null,
     version: m.version ?? null,
     dependencies: {
-      skills: agent.skills.map((s) => ({
-        id: s.id,
-        ...(s.version ? { version: s.version } : {}),
-        ...(s.name ? { name: s.name } : {}),
-        ...(s.description ? { description: s.description } : {}),
-      })),
+      skills: skillDeps,
       // AFPS §4.1 mcp_servers dependency group ({ id: version-range }). Agents
       // can declare these via an imported manifest even though the dashboard
       // editor doesn't surface them — return them so the detail response is a
@@ -131,17 +148,17 @@ export async function buildAgentDetailDto(
     forked_from: rawItem?.forked_from ?? null,
     ...(agent.source !== "system" && rawItem
       ? {
-          manifest: agent.manifest,
+          manifest: m,
           updatedAt: rawItem.updatedAt,
           lock_version: rawItem.lock_version,
-          prompt: agent.prompt,
+          prompt: effectivePrompt,
         }
       : {}),
   };
 }
 
 export async function agentDetailHandler(c: Context<AppEnv>) {
-  const dto = await buildAgentDetailDto(c, {});
+  const dto = await buildAgentDetailDto(c, { version: c.req.query("version") });
   if (!dto) {
     throw notFound(`Agent '${getItemId(c)}' not found`);
   }

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -171,6 +171,7 @@ export function createAgentsRouter() {
           agentPackageId: agent.id,
           actor: getActor(c),
           isAdmin: role === "owner" || role === "admin",
+          version: c.req.query("version"),
         }),
       );
     },

--- a/apps/api/src/services/integration-pins-service.ts
+++ b/apps/api/src/services/integration-pins-service.ts
@@ -53,6 +53,7 @@ import type { AppScope } from "../lib/scope.ts";
 import type { Actor } from "../lib/actor.ts";
 import type { ValidationFieldError } from "../lib/errors.ts";
 import { getPackage } from "./package-catalog.ts";
+import { resolveAgentRunVersion } from "./agent-version-resolver.ts";
 import { fetchIntegrationManifest } from "./integration-service.ts";
 import { getOrgDefault } from "./integration-org-defaults-service.ts";
 import {
@@ -818,10 +819,21 @@ export async function resolveAgentConnectionReadiness(args: {
   agentPackageId: string;
   actor: Actor;
   isAdmin: boolean;
+  /**
+   * Version selector (`draft` | `published` | concrete semver | dist-tag).
+   * Omitted ⇒ `draft` — preserves the launch-badge default. Any other value
+   * resolves the same manifest the run would execute (issue #770), so the
+   * readiness verdict matches the run for a pinned version, not the draft.
+   */
+  version?: string;
 }): Promise<AgentConnectionReadiness> {
-  const { scope, agentPackageId, actor, isAdmin } = args;
-  const agent = await getPackage(agentPackageId, scope.orgId);
-  if (!agent) throw notFound(`Agent '${agentPackageId}' not found in this organization`);
+  const { scope, agentPackageId, actor, isAdmin, version } = args;
+  const loaded = await getPackage(agentPackageId, scope.orgId);
+  if (!loaded) throw notFound(`Agent '${agentPackageId}' not found in this organization`);
+  // Resolve the effective definition for the selected version. `draft`/omitted
+  // short-circuits to the draft `LoadedPackage` untouched; a concrete version
+  // substitutes the published manifest via the same resolver the run uses.
+  const { agent } = await resolveAgentRunVersion(loaded, version ?? "draft");
   const agentManifest = agent.manifest as unknown as Record<string, unknown>;
   const declared = parseManifestIntegrations(agentManifest);
 

--- a/apps/api/test/integration/routes/agent-connection-readiness.test.ts
+++ b/apps/api/test/integration/routes/agent-connection-readiness.test.ts
@@ -19,7 +19,9 @@ import { db, truncateAll } from "../../helpers/db.ts";
 import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
 import { seedAgent, seedPackage } from "../../helpers/seed.ts";
 import { installPackage } from "../../../src/services/application-packages.ts";
-import { integrationConnections } from "@appstrate/db/schema";
+import { createVersionFromDraft } from "../../../src/services/package-versions.ts";
+import { eq } from "drizzle-orm";
+import { integrationConnections, packages } from "@appstrate/db/schema";
 import { encryptCredentials } from "@appstrate/connect";
 import {
   localIntegrationManifest,
@@ -204,5 +206,52 @@ describe("GET /api/agents/:scope/:name/connection-readiness", () => {
     const integ = body.integrations.find((i) => i.integration_id === INTEGRATION);
     expect(integ!.run_blocking).toBe(false);
     expect(integ!.resolution.resolved_connection_id).not.toBeNull();
+  });
+
+  // #770 — readiness must assess the SELECTED version's manifest, not always the
+  // draft. Published 1.0.0 declares no integrations; the draft adds an active,
+  // unconnected one. `?version=1.0.0` must see the frozen (clean) set, while the
+  // default (draft) still blocks — otherwise the modal/badge disagree with the run.
+  it("?version pins readiness to that published manifest's integration set", async () => {
+    // Publish 1.0.0 from a draft with NO integrations → frozen clean.
+    await seedAgentWith(buildAgentManifest([], false));
+    const published = await createVersionFromDraft({
+      packageId: AGENT,
+      orgId: ctx.orgId,
+      userId: ctx.user.id,
+    });
+    expect("version" in published && published.version).toBe("1.0.0");
+
+    // Dirty the draft: add an ACTIVE integration with no connection → draft blocks.
+    await db
+      .update(packages)
+      .set({
+        draftManifest: buildAgentManifest([INTEGRATION], true),
+        updatedAt: new Date(Date.now() + 5_000),
+      })
+      .where(eq(packages.id, AGENT));
+    await seedIntegration(false);
+
+    // Default (draft) verdict: the integration is declared, unconnected → blocks.
+    const draftBody = (await (await getReadiness()).json()) as ReadinessBody;
+    expect(draftBody.blocks_run).toBe(true);
+    expect(draftBody.integrations.map((i) => i.integration_id)).toContain(INTEGRATION);
+
+    // Pinned 1.0.0 verdict: the frozen manifest has no integrations → clean.
+    const verRes = await app.request(`/api/agents/${AGENT}/connection-readiness?version=1.0.0`, {
+      method: "GET",
+      headers: authHeaders(ctx),
+    });
+    expect(verRes.status).toBe(200);
+    const verBody = (await verRes.json()) as ReadinessBody;
+    expect(verBody.blocks_run).toBe(false);
+    expect(verBody.integrations).toHaveLength(0);
+
+    // `?version=draft` explicitly is identical to the default (draft) verdict.
+    const draftExplicit = await app.request(
+      `/api/agents/${AGENT}/connection-readiness?version=draft`,
+      { method: "GET", headers: authHeaders(ctx) },
+    );
+    expect(((await draftExplicit.json()) as ReadinessBody).blocks_run).toBe(true);
   });
 });

--- a/apps/api/test/integration/routes/agents.test.ts
+++ b/apps/api/test/integration/routes/agents.test.ts
@@ -3,12 +3,13 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 import { and, eq } from "drizzle-orm";
 import { getTestApp } from "../../helpers/app.ts";
-import { truncateAll } from "../../helpers/db.ts";
+import { db, truncateAll } from "../../helpers/db.ts";
 import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
 import { seedAgent, seedRun, seedApplication } from "../../helpers/seed.ts";
 import { installPackage } from "../../../src/services/application-packages.ts";
+import { createVersionFromDraft } from "../../../src/services/package-versions.ts";
 import { assertDbCount } from "../../helpers/assertions.ts";
-import { runs } from "@appstrate/db/schema";
+import { packages, runs } from "@appstrate/db/schema";
 import { addMemories, upsertPinned } from "../../../src/services/state/package-persistence.ts";
 
 const app = getTestApp();
@@ -209,6 +210,85 @@ describe("Agents API", () => {
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
       expect(body.id).toBe("@myorg/custom-installed");
+    });
+
+    // #770 — the detail projection must follow `?version=`, not always the
+    // draft. Publish 1.0.0 from one manifest, then dirty the draft with a
+    // different input / skills / integrations set. `?version=1.0.0` must return
+    // the FROZEN definition (what the run executes); default + `?version=draft`
+    // return the live draft — otherwise the run-options modal renders the wrong
+    // config/input/skills for the selected version.
+    it("?version projects input/skills/integrations from that published manifest", async () => {
+      const VER = "@myorg/versioned-detail";
+      const publishedManifest = {
+        name: VER,
+        version: "1.0.0",
+        type: "agent",
+        schema_version: "0.2",
+        display_name: "Versioned Detail",
+        input: { schema: { type: "object", properties: { alpha: { type: "string" } } } },
+        dependencies: {
+          skills: { "@myorg/skill-pub": "^1.0.0" },
+          integrations: { "@myorg/int-pub": "^1.0.0" },
+        },
+      };
+
+      // Seed draft = the to-be-published manifest, then freeze it as 1.0.0.
+      await seedInstalledAgent({
+        id: VER,
+        orgId: ctx.orgId,
+        createdBy: ctx.user.id,
+        applicationId: ctx.defaultAppId,
+        draftManifest: publishedManifest,
+      });
+      const published = await createVersionFromDraft({
+        packageId: VER,
+        orgId: ctx.orgId,
+        userId: ctx.user.id,
+      });
+      expect("version" in published && published.version).toBe("1.0.0");
+
+      // Dirty the draft: different input field, skills, and integrations.
+      await db
+        .update(packages)
+        .set({
+          draftManifest: {
+            ...publishedManifest,
+            input: { schema: { type: "object", properties: { beta: { type: "string" } } } },
+            dependencies: {
+              skills: { "@myorg/skill-draft": "^2.0.0" },
+              integrations: { "@myorg/int-draft": "^1.0.0" },
+            },
+          },
+          updatedAt: new Date(Date.now() + 5_000),
+        })
+        .where(eq(packages.id, VER));
+
+      const get = (suffix: string) =>
+        app.request(`/api/packages/agents/${VER}${suffix}`, { headers: authHeaders(ctx) });
+
+      // Default → draft projection. Input + integrations are manifest-derived
+      // on the draft path; skills there come from the resolved closure
+      // (`agent.skills`, empty for these unseeded skill packages), so the
+      // version-vs-draft contrast is asserted on input + integrations.
+      const draftBody = (await (await get("")).json()) as any;
+      expect(draftBody.input.schema.properties).toHaveProperty("beta");
+      expect(draftBody.dependencies.integrations.map((i: any) => i.id)).toEqual([
+        "@myorg/int-draft",
+      ]);
+
+      // ?version=1.0.0 → frozen published projection. Skills here are read
+      // straight from the version manifest's `dependencies.skills`.
+      const verRes = await get("?version=1.0.0");
+      expect(verRes.status).toBe(200);
+      const verBody = (await verRes.json()) as any;
+      expect(verBody.input.schema.properties).toHaveProperty("alpha");
+      expect(verBody.dependencies.skills.map((s: any) => s.id)).toEqual(["@myorg/skill-pub"]);
+      expect(verBody.dependencies.integrations.map((i: any) => i.id)).toEqual(["@myorg/int-pub"]);
+
+      // ?version=draft ≡ default.
+      const draftExplicit = (await (await get("?version=draft")).json()) as any;
+      expect(draftExplicit.input.schema.properties).toHaveProperty("beta");
     });
   });
 

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -6083,7 +6083,10 @@ export interface operations {
     };
     getAgentConnectionReadiness: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Which agent definition to assess: `draft` (the live editor working copy), `published` (the latest published version), or a version spec (exact version, dist-tag, or semver range). **Omitting the parameter resolves the `draft`** — preserving the launch-badge default. Pass a concrete version to get the same run-blocking verdict the run would produce for that pinned version (issue #770), so the modal and badge never disagree with the actual run. Ignored for system agents. */
+                version?: string;
+            };
             header?: {
                 /** @description Organization ID. Required for cookie auth. Not needed for API key auth (org resolved from key). */
                 "X-Org-Id"?: components["parameters"]["XOrgId"];
@@ -14073,7 +14076,10 @@ export interface operations {
     };
     getAgentPackage: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Which agent definition to project: `draft` (the live editor working copy), `published` (latest published), or a version spec (exact version, dist-tag, or semver range). **Omitting resolves the `draft`** (the editor default). A concrete version returns config / input / integrations / skills from that published manifest — the same definition the run executes (issue #770) — so the run-with-options modal stays consistent with the selected version. Ignored for system agents. */
+                version?: string;
+            };
             header?: {
                 /** @description Organization ID. Required for cookie auth. Not needed for API key auth (org resolved from key). */
                 "X-Org-Id"?: components["parameters"]["XOrgId"];

--- a/apps/web/src/components/integration-connect/integration-connection-picker.tsx
+++ b/apps/web/src/components/integration-connect/integration-connection-picker.tsx
@@ -94,6 +94,7 @@ export function IntegrationConnectionPicker({
   agentTools,
   agentScopes,
   persistence = DEFAULT_PERSISTENCE,
+  version,
 }: {
   integrationId: string;
   agentPackageId: string;
@@ -103,15 +104,22 @@ export function IntegrationConnectionPicker({
   agentTools: string[] | "*" | undefined;
   agentScopes: string[] | undefined;
   persistence?: ConnectionPickerPersistence;
+  /**
+   * Version selector for the readiness verdict (#770). A non-`draft` value
+   * pins the per-integration resolution + run-blocking flag to that published
+   * manifest so the run-options modal matches the run. Omitted → draft.
+   */
+  version?: string;
 }) {
   const { t } = useTranslation(["agents", "settings"]);
   const { data: resolution, isPending } = useIntegrationAgentResolution(
     integrationId,
     agentPackageId,
+    version,
   );
   // Authoritative run-blocking flag for this integration (run semantics) — same
   // bulk query as the launch badge, selected per-integration.
-  const { data: runBlocking } = useIntegrationRunBlocking(integrationId, agentPackageId);
+  const { data: runBlocking } = useIntegrationRunBlocking(integrationId, agentPackageId, version);
   const upsertPin = useUpsertMemberIntegrationPin();
   const deletePin = useDeleteMemberIntegrationPin();
   const { openPopup, isPending: oauthPending } = useIntegrationOAuthPopup();
@@ -258,7 +266,10 @@ export function IntegrationConnectionPicker({
         return;
       }
       const { data: fresh } = await client.GET("/api/agents/{scope}/{name}/connection-readiness", {
-        params: { path: splitPackageRef(agentPackageId) },
+        params: {
+          path: splitPackageRef(agentPackageId),
+          ...(version && version !== "draft" ? { query: { version } } : {}),
+        },
       });
       const freshCandidates = fresh?.integrations.find((i) => i.integration_id === integrationId)
         ?.resolution.candidates;

--- a/apps/web/src/components/integration-connect/integration-connection-picker.tsx
+++ b/apps/web/src/components/integration-connect/integration-connection-picker.tsx
@@ -44,6 +44,7 @@ import { connectableAuthKeys } from "./connectable-auth-keys";
 import { requiredScopesForAgent } from "@appstrate/core/integration";
 import { client } from "../../api/client";
 import { splitPackageRef } from "../../lib/package-paths";
+import { isVersioned } from "../../lib/version-selector";
 
 /**
  * How the picker persists the actor's pick:
@@ -268,7 +269,7 @@ export function IntegrationConnectionPicker({
       const { data: fresh } = await client.GET("/api/agents/{scope}/{name}/connection-readiness", {
         params: {
           path: splitPackageRef(agentPackageId),
-          ...(version && version !== "draft" ? { query: { version } } : {}),
+          ...(isVersioned(version) ? { query: { version } } : {}),
         },
       });
       const freshCandidates = fresh?.integrations.find((i) => i.integration_id === integrationId)

--- a/apps/web/src/components/run-overrides-panel.tsx
+++ b/apps/web/src/components/run-overrides-panel.tsx
@@ -69,6 +69,12 @@ export interface RunOverridesPanelProps {
   /** Current value (controlled). */
   value: RunOverridesValue;
   onChange: (next: RunOverridesValue) => void;
+  /**
+   * Version selector (#770) forwarded to the integration connection pickers so
+   * their per-integration readiness verdict matches the run for a pinned
+   * version. Omitted → draft (the schedule editor passes nothing).
+   */
+  version?: string;
 }
 
 /**
@@ -96,6 +102,7 @@ export function RunOverridesPanel({
   agentIntegrations,
   value,
   onChange,
+  version,
 }: RunOverridesPanelProps) {
   const { t } = useTranslation(["agents", "settings"]);
   const { data: orgModels } = useModels();
@@ -240,6 +247,7 @@ export function RunOverridesPanel({
         <ScheduleConnectionOverridesSection
           agentPackageId={packageId}
           integrations={agentIntegrations}
+          version={version}
           value={value.connection_overrides ?? {}}
           onChange={(next) => {
             // Drop falsy entries — empty string === "Inherit", which is
@@ -278,11 +286,13 @@ export function RunOverridesPanel({
 function ScheduleConnectionOverridesSection({
   agentPackageId,
   integrations,
+  version,
   value,
   onChange,
 }: {
   agentPackageId: string;
   integrations: AgentIntegrationRef[];
+  version?: string;
   value: Record<string, string>;
   onChange: (next: Record<string, string>) => void;
 }) {
@@ -297,6 +307,7 @@ function ScheduleConnectionOverridesSection({
             key={integ.id}
             agentPackageId={agentPackageId}
             integration={integ}
+            version={version}
             value={value[integ.id] ?? ""}
             onChange={(connId) => {
               const next = { ...value };
@@ -314,11 +325,13 @@ function ScheduleConnectionOverridesSection({
 function IntegrationOverrideRow({
   agentPackageId,
   integration,
+  version,
   value,
   onChange,
 }: {
   agentPackageId: string;
   integration: AgentIntegrationRef;
+  version?: string;
   /** Currently-picked connection id; empty = inherit. */
   value: string;
   onChange: (next: string) => void;
@@ -345,6 +358,7 @@ function IntegrationOverrideRow({
         agentTools={integration.tools}
         agentScopes={undefined}
         persistence={{ mode: "override", value, onChange }}
+        version={version}
       />
     </div>
   );

--- a/apps/web/src/components/run-with-options-modal.tsx
+++ b/apps/web/src/components/run-with-options-modal.tsx
@@ -98,18 +98,22 @@ function RunWithOptionsForm({
   isPending?: boolean;
 }) {
   const { t } = useTranslation(["agents", "common"]);
-  const deps = useScheduleFormDeps(agent.id);
-  const labels = useSchemaFormLabels();
   const [inputData, setInputData] = useState<Record<string, unknown>>({});
   const [version, setVersion] = useState<string>(DEFAULT_VERSION);
   const [overrides, setOverrides] = useState<RunOverridesValue>({});
   const [dependencyOverrides, setDependencyOverrides] = useState<Record<string, string>>({});
   const inputFormRef = useRef<RjsfForm>(null);
+  // Deps follow the selected version (#770): the config / input / integrations /
+  // skills the modal renders match what the run will execute, not the draft.
+  const deps = useScheduleFormDeps(agent.id, version);
+  const labels = useSchemaFormLabels();
 
-  const inputWrapper: SchemaWrapper = agent.input ?? { schema: EMPTY_SCHEMA };
+  // Version-pinned input wrapper / skills (fall back to the draft props the
+  // parent passed while the version-aware detail is still loading).
+  const inputWrapper: SchemaWrapper = deps?.inputWrapper ?? agent.input ?? { schema: EMPTY_SCHEMA };
   const hasInputFields =
     !!inputWrapper.schema?.properties && Object.keys(inputWrapper.schema.properties).length > 0;
-  const skills = agent.dependencies?.skills ?? [];
+  const skills = deps?.skills ?? agent.dependencies?.skills ?? [];
 
   const fire = (input: Record<string, unknown>) =>
     onSubmit({ input, version, overrides, dependencyOverrides });
@@ -162,6 +166,7 @@ function RunWithOptionsForm({
           agentIntegrations={deps.agentIntegrations}
           value={overrides}
           onChange={setOverrides}
+          version={version}
         />
       )}
 

--- a/apps/web/src/hooks/use-integrations.ts
+++ b/apps/web/src/hooks/use-integrations.ts
@@ -162,16 +162,23 @@ export function agentConnectionReadinessQueryOptions(
   orgId: string | null | undefined,
   applicationId: string | null | undefined,
   agentPackageId: string | undefined,
+  version?: string,
 ) {
   const { scope, name } = agentPackageId
     ? splitPackageRef(agentPackageId)
     : { scope: "", name: "" };
+  // A non-`draft` version pins the verdict to that published manifest, so the
+  // run-options modal's per-integration badge matches the run (#770). Omitted/
+  // `draft` → no query param → the draft verdict the launch badge has always
+  // shown. `version` rides the query so the cache key splits per version.
+  const versioned = version && version !== "draft";
   return $api.queryOptions(
     "get",
     "/api/agents/{scope}/{name}/connection-readiness",
     {
       params: {
         path: { scope, name },
+        ...(versioned ? { query: { version } } : {}),
         header: {
           "X-Org-Id": orgId ?? undefined,
           "X-Application-Id": applicationId ?? undefined,
@@ -204,11 +211,12 @@ export function useAgentConnectionReadiness(agentPackageId: string | undefined) 
 export function useIntegrationAgentResolution(
   integrationId: string | undefined,
   agentPackageId: string | undefined,
+  version?: string,
 ) {
   const orgId = useCurrentOrgId();
   const applicationId = useCurrentApplicationId();
   return useQuery({
-    ...agentConnectionReadinessQueryOptions(orgId, applicationId, agentPackageId),
+    ...agentConnectionReadinessQueryOptions(orgId, applicationId, agentPackageId, version),
     enabled: Boolean(orgId && applicationId && integrationId && agentPackageId),
     select: (data) =>
       data.integrations.find((i) => i.integration_id === integrationId)?.resolution ?? null,
@@ -223,11 +231,12 @@ export function useIntegrationAgentResolution(
 export function useIntegrationRunBlocking(
   integrationId: string | undefined,
   agentPackageId: string | undefined,
+  version?: string,
 ) {
   const orgId = useCurrentOrgId();
   const applicationId = useCurrentApplicationId();
   return useQuery({
-    ...agentConnectionReadinessQueryOptions(orgId, applicationId, agentPackageId),
+    ...agentConnectionReadinessQueryOptions(orgId, applicationId, agentPackageId, version),
     enabled: Boolean(orgId && applicationId && integrationId && agentPackageId),
     select: (data) =>
       data.integrations.find((i) => i.integration_id === integrationId)?.run_blocking ?? false,

--- a/apps/web/src/hooks/use-integrations.ts
+++ b/apps/web/src/hooks/use-integrations.ts
@@ -22,6 +22,7 @@ import type {
 } from "@appstrate/shared-types";
 import { $api, client, type paths } from "../api/client";
 import { splitPackageRef } from "../lib/package-paths";
+import { isVersioned } from "../lib/version-selector";
 
 // Spec-pinned narrowings for the two integration read endpoints. They take the
 // generated OpenAPI response shape verbatim (so a rename/removal of any
@@ -171,14 +172,13 @@ export function agentConnectionReadinessQueryOptions(
   // run-options modal's per-integration badge matches the run (#770). Omitted/
   // `draft` → no query param → the draft verdict the launch badge has always
   // shown. `version` rides the query so the cache key splits per version.
-  const versioned = version && version !== "draft";
   return $api.queryOptions(
     "get",
     "/api/agents/{scope}/{name}/connection-readiness",
     {
       params: {
         path: { scope, name },
-        ...(versioned ? { query: { version } } : {}),
+        ...(isVersioned(version) ? { query: { version } } : {}),
         header: {
           "X-Org-Id": orgId ?? undefined,
           "X-Application-Id": applicationId ?? undefined,

--- a/apps/web/src/hooks/use-packages.ts
+++ b/apps/web/src/hooks/use-packages.ts
@@ -9,6 +9,7 @@ import { stripScope } from "@appstrate/core/naming";
 import { asJSONSchemaObject } from "@appstrate/core/form";
 import { client, type components } from "../api/client";
 import { splitPackageRef } from "../lib/package-paths";
+import { VERSION_DRAFT, isVersioned } from "../lib/version-selector";
 import { useCurrentOrgId } from "./use-org";
 import { useCurrentApplicationId } from "./use-current-application";
 import { packageKeys, agentsKeys } from "../lib/query-keys";
@@ -118,9 +119,8 @@ async function fetchPackageDetail(
     // `version` is only meaningful for agents (issue #770): a non-`draft`
     // selector projects that published manifest's config/input/integrations/
     // skills, matching what the run will execute. Omitted/`draft` → draft.
-    const versioned = version && version !== "draft";
     const { data } = await client.GET("/api/packages/agents/{scope}/{name}", {
-      params: { path, ...(versioned ? { query: { version } } : {}) },
+      params: { path, ...(isVersioned(version) ? { query: { version } } : {}) },
     });
     return normalizeAgentDetail(data!);
   }
@@ -172,7 +172,7 @@ function usePackageDetail<T extends PackageType>(
   // `version` rides the query key so switching the run-options version dropdown
   // refetches the version-pinned detail instead of serving the cached draft
   // (issue #770). Omitted → `"draft"`, preserving every existing caller's key.
-  const version = opts?.version ?? "draft";
+  const version = opts?.version ?? VERSION_DRAFT;
 
   return useQuery({
     queryKey: packageKeys.detail(cfg.path, orgId, applicationId, id!, version),

--- a/apps/web/src/hooks/use-packages.ts
+++ b/apps/web/src/hooks/use-packages.ts
@@ -106,15 +106,21 @@ function normalizePackageItemDetail(
 function fetchPackageDetail<T extends PackageType>(
   type: T,
   packageId: string,
+  version?: string,
 ): Promise<PackageDetailMap[T]>;
 async function fetchPackageDetail(
   type: PackageType,
   packageId: string,
+  version?: string,
 ): Promise<AgentDetail | OrgPackageItemDetail> {
   const path = splitPackageRef(packageId);
   if (type === "agent") {
+    // `version` is only meaningful for agents (issue #770): a non-`draft`
+    // selector projects that published manifest's config/input/integrations/
+    // skills, matching what the run will execute. Omitted/`draft` → draft.
+    const versioned = version && version !== "draft";
     const { data } = await client.GET("/api/packages/agents/{scope}/{name}", {
-      params: { path },
+      params: { path, ...(versioned ? { query: { version } } : {}) },
     });
     return normalizeAgentDetail(data!);
   }
@@ -158,15 +164,19 @@ function usePackageList(type: PackageType, opts?: { activeOnly?: boolean }) {
 function usePackageDetail<T extends PackageType>(
   type: T,
   id: string | undefined,
-  opts?: { enabled?: boolean },
+  opts?: { enabled?: boolean; version?: string },
 ) {
   const orgId = useCurrentOrgId();
   const applicationId = useCurrentApplicationId();
   const cfg = PACKAGE_CONFIG[type];
+  // `version` rides the query key so switching the run-options version dropdown
+  // refetches the version-pinned detail instead of serving the cached draft
+  // (issue #770). Omitted → `"draft"`, preserving every existing caller's key.
+  const version = opts?.version ?? "draft";
 
   return useQuery({
-    queryKey: packageKeys.detail(cfg.path, orgId, applicationId, id!),
-    queryFn: () => fetchPackageDetail(type, id!),
+    queryKey: packageKeys.detail(cfg.path, orgId, applicationId, id!, version),
+    queryFn: () => fetchPackageDetail(type, id!, version),
     enabled: !!orgId && !!applicationId && !!id && (opts?.enabled ?? true),
   });
 }

--- a/apps/web/src/hooks/use-schedules.ts
+++ b/apps/web/src/hooks/use-schedules.ts
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { schemaHasFileFields, type JSONSchemaObject } from "@appstrate/core/form";
+import {
+  schemaHasFileFields,
+  type JSONSchemaObject,
+  type SchemaWrapper,
+} from "@appstrate/core/form";
 import { client, type paths } from "../api/client";
 import { splitPackageRef } from "../lib/package-paths";
 import { useCurrentOrgId } from "./use-org";
@@ -164,6 +168,12 @@ export function useDeleteSchedule() {
 
 export interface ScheduleFormDeps {
   inputSchema: JSONSchemaObject | undefined;
+  /**
+   * Full input wrapper (schema + ui_hints + file_constraints + property_order)
+   * — the run-options modal feeds this to `<SchemaForm>` so version-pinned
+   * input renders with full fidelity, not just the bare schema (#770).
+   */
+  inputWrapper: SchemaWrapper | undefined;
   configSchema: JSONSchemaObject | undefined;
   persistedConfig: Record<string, unknown>;
   persistedModelId: string | null;
@@ -176,15 +186,27 @@ export interface ScheduleFormDeps {
    * integrations.
    */
   agentIntegrations: Array<{ id: string; tools?: string[] | "*" }>;
+  /**
+   * Agent's declared skill dependencies — drives the per-skill dependency
+   * override picker. Version-pinned when `version` is passed (#770).
+   */
+  skills: Array<{ id: string; version?: string; name?: string }>;
 }
 
 /**
  * Aggregates the agent-detail / model / proxy lookups that both
  * `ScheduleCreatePage` and `ScheduleEditPage` feed into `<ScheduleForm>`.
  * Returns `null` while inputs aren't ready or no agent is selected.
+ *
+ * `version` (#770) pins the agent-detail projection to a published version so
+ * the config / input / integrations / skills the form renders match the version
+ * the run will execute. Omitted → `draft` (the editor working copy).
  */
-export function useScheduleFormDeps(packageId: string | undefined): ScheduleFormDeps | null {
-  const { data: agentDetail } = usePackageDetail("agent", packageId);
+export function useScheduleFormDeps(
+  packageId: string | undefined,
+  version?: string,
+): ScheduleFormDeps | null {
+  const { data: agentDetail } = usePackageDetail("agent", packageId, { version });
   const { data: agentModel } = useAgentModel(packageId);
   const { data: agentProxy } = useAgentProxy(packageId);
 
@@ -195,8 +217,14 @@ export function useScheduleFormDeps(packageId: string | undefined): ScheduleForm
     id: d.id,
     ...(d.tools ? { tools: d.tools } : {}),
   }));
+  const skillDeps = (agentDetail?.dependencies?.skills ?? []).map((s) => ({
+    id: s.id,
+    ...(s.version ? { version: s.version } : {}),
+    ...(s.name ? { name: s.name } : {}),
+  }));
   return {
     inputSchema,
+    inputWrapper: agentDetail?.input ?? undefined,
     configSchema: agentDetail?.config?.schema ?? undefined,
     persistedConfig: agentDetail?.config?.current ?? {},
     persistedModelId: agentModel?.modelId ?? null,
@@ -204,5 +232,6 @@ export function useScheduleFormDeps(packageId: string | undefined): ScheduleForm
     persistedVersion: agentDetail?.version ?? null,
     hasFileInputs: schemaHasFileFields(inputSchema),
     agentIntegrations: integrationDeps,
+    skills: skillDeps,
   };
 }

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -69,8 +69,8 @@ export const packageKeys = {
   familyInOrg: (path: string, orgId: Id) => ["packages", path, orgId] as const,
   list: (path: string, orgId: Id, applicationId: Id, filter: string) =>
     ["packages", path, orgId, applicationId, filter] as const,
-  detail: (path: string, orgId: Id, applicationId: Id, id: string) =>
-    ["packages", path, orgId, applicationId, id] as const,
+  detail: (path: string, orgId: Id, applicationId: Id, id: string, version: string = "draft") =>
+    ["packages", path, orgId, applicationId, id, version] as const,
 };
 
 /** Agent catalog list (sidebar, agent list page). */

--- a/apps/web/src/lib/version-selector.ts
+++ b/apps/web/src/lib/version-selector.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The default version selector — the live editor working copy. Omitting a
+ * version anywhere on the dashboard resolves the draft, preserving the
+ * launch-badge / editor default (#770).
+ */
+export const VERSION_DRAFT = "draft";
+
+/**
+ * True when `version` pins a concrete published definition (a semver, dist-tag,
+ * or `"published"`) rather than the draft. Drives whether a `?version=` query
+ * param is sent and whether the cache key splits per version. Omitted or
+ * `"draft"` → false (the draft verdict the badge has always shown).
+ */
+export function isVersioned(version: string | undefined): version is string {
+  return !!version && version !== VERSION_DRAFT;
+}


### PR DESCRIPTION
Closes #770.

## Problem

The "Run options" modal lets the user pick a version (draft vs published semver), but every data-fetching hook was keyed on `agent.id` only — never the selected version. The version string went into the submit payload and nowhere else, so the config form, input schema, skills list and **integration list** were always built from the **draft** manifest, while the run executes the **published** version's manifest. Draft and published can declare different integrations/config → the UI offers to connect one set while the run needs another. The shared launch-readiness badge had the same root cause.

## Fix

Make the agent-detail and connection-readiness paths version-aware, reusing `resolveAgentRunVersion` (the same resolver the run uses) so the readiness verdict and the projected config/input/integrations/skills match what the run executes for a pinned version. `draft`/omitted preserves the existing draft default everywhere (badge default unchanged).

### Backend
- `resolveAgentConnectionReadiness` accepts `version`; resolves the effective manifest via `resolveAgentRunVersion` before deriving integrations + the run-blocking verdict.
- `GET /api/agents/:scope/:name/connection-readiness` reads `?version=`.
- `buildAgentDetailDto` accepts `version`; projects config/input/integrations/skills from the version manifest (skills pinned from the version manifest's `dependencies.skills`).
- `GET /api/packages/agents/:scope/:name` reads `?version=`.
- OpenAPI: `version` query param declared on both endpoints.

### Frontend
- `usePackageDetail` / `useScheduleFormDeps` accept `version`, thread it into the query path + cache key → switching the dropdown refetches the pinned detail.
- The modal passes the selected version into deps, renders input + skills from the version-aware deps, and forwards the version to `RunOverridesPanel` → `IntegrationConnectionPicker` so the per-integration readiness verdict matches the version.
- `ScheduleFormDeps` exposes the full input wrapper + skills.

### Notes / scope
- For a pinned version, skills come from the version manifest's `dependencies.skills` (id + range), not the draft's resolved closure — id + version is what the dependency-override UI needs.
- Transitive skill-closure pinning at run time stays a separate follow-up (#686); this only pins the agent's own definition for the modal/badge.

## Tests
- `bun run check` ✅ (tsc + eslint + prettier + OpenAPI validation).
- New route test in `agent-connection-readiness.test.ts`: `?version=1.0.0` pins the verdict to the published manifest's integration set (clean) while the draft default still blocks; `?version=draft` ≡ default.
- Existing readiness / version-resolver / pins / runs-412 suites pass (Tier 0).

## Manual verification
Reproduce #770: agent whose draft declares an extra active integration vs a published `1.0.0` that doesn't. Open "Run options" → default draft lists both integrations; switch to `1.0.0` → modal refetches and lists only the published set; config/input/skills reflect `1.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)