### PR TITLE
fix(auth): centralize Appstrate-User header policy (reject under non-API-key auth)

### DIFF
--- a/apps/api/src/lib/auth-pipeline.ts
+++ b/apps/api/src/lib/auth-pipeline.ts
@@ -56,6 +56,29 @@ export interface AuthPipelineOptions {
 }
 
 /**
+ * Headers honored only under specific auth methods. Enforced once, centrally,
+ * by the guard mounted in `applyAuthPipeline` — NOT per auth branch (the
+ * per-branch checks drifted: cookie auth rejected `Appstrate-User` while the
+ * module-strategy/OAuth branch silently ignored it).
+ *
+ * Headers NOT listed are deliberately left alone: per the HTTP robustness
+ * principle (RFC 9110 §5.1) servers ignore unrecognized headers, and
+ * blanket-rejecting unknown headers breaks proxies, tracing and middleboxes.
+ * This guard only rejects a KNOWN header used under an auth method that cannot
+ * honor it. Adding a new conditional header is one row here.
+ */
+const AUTH_CONDITIONAL_HEADERS: ReadonlyArray<{
+  header: string;
+  allowed: ReadonlySet<string>;
+  code: string;
+}> = [
+  // `Appstrate-User` end-user impersonation is resolved only in the API-key
+  // branch. Under any other auth method it has no effect, so reject it loudly
+  // instead of silently ignoring it.
+  { header: "Appstrate-User", allowed: new Set(["api_key"]), code: "header_not_allowed" },
+];
+
+/**
  * Mount the Better Auth handler and install the full auth middleware chain
  * on the given Hono app. Behavior must stay byte-identical between the
  * production and test harness callers — any change here must preserve the
@@ -207,16 +230,9 @@ export function applyAuthPipeline(app: Hono<AppEnv>, opts: AuthPipelineOptions):
       throw unauthorized("Invalid or missing session");
     }
 
-    // Appstrate-User header is NOT allowed with cookie auth
-    if (c.req.header("Appstrate-User")) {
-      throw new ApiError({
-        status: 400,
-        code: "header_not_allowed",
-        title: "Header Not Allowed",
-        detail: "Appstrate-User header is not allowed with cookie authentication",
-        param: "Appstrate-User",
-      });
-    }
+    // Appstrate-User rejection under cookie auth is enforced centrally by the
+    // auth-conditional header guard below (see AUTH_CONDITIONAL_HEADERS), so it
+    // cannot drift per-branch the way it previously did.
 
     c.set("user", {
       id: session.user.id,
@@ -248,6 +264,29 @@ export function applyAuthPipeline(app: Hono<AppEnv>, opts: AuthPipelineOptions):
       if (userRow) c.set("sessionRealm", userRow.realm);
     }
 
+    return next();
+  });
+
+  // Auth-conditional header policy (see AUTH_CONDITIONAL_HEADERS). A known
+  // header that is only meaningful under certain auth methods is rejected with
+  // 400 when presented under any other — replacing the previous per-branch
+  // checks that drifted. Runs after the auth middleware has resolved
+  // `authMethod`, only for authenticated requests. Unlisted headers untouched.
+  app.use("*", async (c, next) => {
+    if (skipAuth(c.req.path, publicPaths(), c.req.raw.headers)) return next();
+    if (!c.get("user")) return next();
+    const authMethod = c.get("authMethod");
+    for (const { header, allowed, code } of AUTH_CONDITIONAL_HEADERS) {
+      if (c.req.header(header) && (!authMethod || !allowed.has(authMethod))) {
+        throw new ApiError({
+          status: 400,
+          code,
+          title: "Header Not Allowed",
+          detail: `${header} is only supported with ${[...allowed].join(", ")} auth, not ${authMethod ?? "this"} authentication.`,
+          param: header,
+        });
+      }
+    }
     return next();
   });
 

--- a/apps/api/src/modules/oidc/test/integration/middleware/enduser-token-auth.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/middleware/enduser-token-auth.test.ts
@@ -170,6 +170,31 @@ describe("OIDC auth strategy — end-to-end via getTestApp", () => {
     expect(res.status).toBe(200);
   });
 
+  it("rejects Appstrate-User under an OAuth (end-user token) auth method with 400", async () => {
+    const token = await mintToken({
+      sub: authUserId,
+      actor_type: "end_user",
+      end_user_id: endUserId,
+      application_id: applicationId,
+      email: "stage3@example.com",
+      name: "Stage Three",
+      scope: "openid runs:read",
+    });
+    const res = await app.request(`/api/end-users/${endUserId}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "X-Application-Id": applicationId,
+        "Appstrate-User": endUserId,
+      },
+    });
+    // Impersonation via Appstrate-User is API-key-only; under any OAuth method
+    // the central auth-conditional header guard rejects it (400) instead of
+    // silently ignoring it — the drift this guard exists to prevent.
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).toBe("header_not_allowed");
+  });
+
   it("falls through when the end-user claim is unknown", async () => {
     const token = await mintToken({
       sub: authUserId,

--- a/apps/api/src/routes/end-users.ts
+++ b/apps/api/src/routes/end-users.ts
@@ -22,31 +22,38 @@ import { recordAuditFromContext } from "../services/audit.ts";
 import { requirePermission } from "../middleware/require-permission.ts";
 import { getAppScope } from "../lib/scope.ts";
 
-export const createEndUserSchema = z.object({
-  name: z.string().max(200).nullable().optional(),
-  email: z.email().nullable().optional(),
-  externalId: z.string().max(255).nullable().optional(),
-  metadata: z
-    .record(
-      z.string().min(1).max(40),
-      z.union([z.string().max(500), z.number(), z.boolean(), z.null()]),
-    )
-    .refine((obj) => Object.keys(obj).length <= 50, "Maximum 50 metadata keys")
-    .optional(),
-});
+// Strict: reject unknown top-level keys. End-user identity is a sensitive
+// write surface — silently dropping an unexpected field could mask a client
+// bug or a privilege-shaped typo. Unknown keys surface as 400 `unknown_field`.
+export const createEndUserSchema = z
+  .object({
+    name: z.string().max(200).nullable().optional(),
+    email: z.email().nullable().optional(),
+    externalId: z.string().max(255).nullable().optional(),
+    metadata: z
+      .record(
+        z.string().min(1).max(40),
+        z.union([z.string().max(500), z.number(), z.boolean(), z.null()]),
+      )
+      .refine((obj) => Object.keys(obj).length <= 50, "Maximum 50 metadata keys")
+      .optional(),
+  })
+  .strict();
 
-export const updateEndUserSchema = z.object({
-  name: z.string().max(200).nullable().optional(),
-  email: z.email().nullable().optional(),
-  externalId: z.string().max(255).nullable().optional(),
-  metadata: z
-    .record(
-      z.string().min(1).max(40),
-      z.union([z.string().max(500), z.number(), z.boolean(), z.null()]),
-    )
-    .refine((obj) => Object.keys(obj).length <= 50, "Maximum 50 metadata keys")
-    .optional(),
-});
+export const updateEndUserSchema = z
+  .object({
+    name: z.string().max(200).nullable().optional(),
+    email: z.email().nullable().optional(),
+    externalId: z.string().max(255).nullable().optional(),
+    metadata: z
+      .record(
+        z.string().min(1).max(40),
+        z.union([z.string().max(500), z.number(), z.boolean(), z.null()]),
+      )
+      .refine((obj) => Object.keys(obj).length <= 50, "Maximum 50 metadata keys")
+      .optional(),
+  })
+  .strict();
 
 export function createEndUsersRouter() {
   const router = new Hono<AppEnv>();

--- a/apps/api/test/integration/middleware/auth-conditional-headers.test.ts
+++ b/apps/api/test/integration/middleware/auth-conditional-headers.test.ts
@@ -66,6 +66,19 @@ describe("auth-conditional header guard (Appstrate-User)", () => {
     expect(body.code).not.toBe("header_not_allowed");
   });
 
+  it("does NOT reject unrecognized headers (HTTP robustness, RFC 9110 §5.1)", async () => {
+    // The guard rejects only KNOWN headers used under an auth method that cannot
+    // honor them. Unknown headers must pass through untouched — blanket-rejecting
+    // them would break proxies, tracing middleboxes, and forward-compat clients.
+    // This pins the design decision so a future "reject unknown headers" change
+    // can't land silently.
+    const res = await app.request("/api/runs", {
+      headers: { ...authHeaders(ctx), "X-Unrecognized-Header": "whatever" },
+    });
+
+    expect(res.status).toBe(200);
+  });
+
   it("honors Appstrate-User impersonation under API-key auth (valid end-user → 200)", async () => {
     const endUser = await seedEndUser({
       applicationId: ctx.defaultAppId,

--- a/apps/api/test/integration/middleware/auth-conditional-headers.test.ts
+++ b/apps/api/test/integration/middleware/auth-conditional-headers.test.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Auth-conditional header guard — `Appstrate-User`.
+ *
+ * `Appstrate-User` end-user impersonation is honored ONLY under API-key auth.
+ * Under any other auth method it has no effect, so the central guard in
+ * `auth-pipeline.ts` (AUTH_CONDITIONAL_HEADERS) rejects it with
+ * `400 header_not_allowed` instead of silently ignoring it. Previously this
+ * rule lived per-branch and had drifted: cookie auth 400'd, the OAuth/strategy
+ * branch silently ignored the header.
+ *
+ * These tests pin both sides of the guard:
+ *   - non-API-key auth (cookie/session) + header → 400 header_not_allowed
+ *   - API-key auth is NOT preempted: bad-prefix header still reaches the
+ *     API-key branch's own validation, and a valid end-user still impersonates
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { getTestApp } from "../../helpers/app.ts";
+import { truncateAll } from "../../helpers/db.ts";
+import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
+import { seedApiKey, seedEndUser } from "../../helpers/seed.ts";
+
+const app = getTestApp();
+
+describe("auth-conditional header guard (Appstrate-User)", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "guardorg" });
+  });
+
+  it("rejects Appstrate-User under cookie/session auth with 400 header_not_allowed", async () => {
+    const res = await app.request("/api/runs", {
+      headers: { ...authHeaders(ctx), "Appstrate-User": "eu_anything" },
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code?: string; param?: string };
+    expect(body.code).toBe("header_not_allowed");
+    expect(body.param).toBe("Appstrate-User");
+  });
+
+  it("does not preempt the API-key branch: a bad-prefix header is handled there, not by the guard", async () => {
+    const apiKey = await seedApiKey({
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      createdBy: ctx.user.id,
+      name: "guard-key-badprefix",
+    });
+
+    const res = await app.request("/api/runs", {
+      headers: {
+        Authorization: `Bearer ${apiKey.rawKey}`,
+        "X-Application-Id": ctx.defaultAppId,
+        "Appstrate-User": "not-an-eu-id",
+      },
+    });
+
+    // The API-key branch validates the eu_ prefix itself and rejects first —
+    // the guard must NOT shadow it with header_not_allowed.
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { code?: string };
+    expect(body.code).not.toBe("header_not_allowed");
+  });
+
+  it("honors Appstrate-User impersonation under API-key auth (valid end-user → 200)", async () => {
+    const endUser = await seedEndUser({
+      applicationId: ctx.defaultAppId,
+      orgId: ctx.orgId,
+      externalId: "ext-guard-eu",
+    });
+    const apiKey = await seedApiKey({
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      createdBy: ctx.user.id,
+      name: "guard-key-valid",
+    });
+
+    const res = await app.request("/api/runs", {
+      headers: {
+        Authorization: `Bearer ${apiKey.rawKey}`,
+        "X-Application-Id": ctx.defaultAppId,
+        "Appstrate-User": endUser.id,
+      },
+    });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/api/test/integration/routes/end-users.test.ts
+++ b/apps/api/test/integration/routes/end-users.test.ts
@@ -76,6 +76,22 @@ describe("End-Users API", () => {
 
       expect(res.status).toBe(401);
     });
+
+    it("rejects unknown top-level keys with 400 unknown_field (strict schema)", async () => {
+      const res = await app.request("/api/end-users", {
+        method: "POST",
+        headers: { ...apiKeyHeaders(), "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Strict", role: "admin" }),
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as {
+        code?: string;
+        errors?: Array<{ code?: string }>;
+      };
+      expect(body.code).toBe("validation_failed");
+      expect(body.errors?.some((e) => e.code === "unknown_field")).toBe(true);
+    });
   });
 
   describe("GET /api/end-users", () => {


### PR DESCRIPTION
Two related auth-surface hardening changes.

## 1. Centralize the `Appstrate-User` header policy

`Appstrate-User` end-user impersonation is honored **only** under API-key auth. The rule lived **per auth branch** and had drifted:

- **cookie/session** → `400 header_not_allowed` ✅
- **OAuth / module-strategy** branch (incl. the **MCP bearer**, `oauth2-*`) → **silently ignored** ❌

A caller authenticating via OAuth who set `Appstrate-User` got a run attributed to themselves, no error. Not a security hole (ignored, never honored) but a silent-failure DX trap + latent drift bug.

**Fix:** replace per-branch checks with a single declarative table enforced once after auth resolves `authMethod`:

```ts
const AUTH_CONDITIONAL_HEADERS = [
  { header: "Appstrate-User", allowed: new Set(["api_key"]), code: "header_not_allowed" },
];
```

The rule can't drift across branches again (the drift *was* the root cause). Inline cookie rejection removed (now central). API-key branch unchanged (still consumes + validates the header).

**Why not a generic "reject unknown headers" firewall?** Per the HTTP robustness principle (RFC 9110 §5.1) servers ignore unrecognized headers; blanket-rejecting breaks proxies/tracing/middleboxes. This guard only rejects a **known** header used under an auth method that can't honor it.

## 2. Strict request bodies on the end-user identity routes (scoped)

Make `create`/`update` end-user schemas `.strict()` → unknown top-level keys → `400 unknown_field` instead of being silently stripped. The error mapper already maps `unrecognized_keys → unknown_field` (infra was built for it).

**Deliberately scoped** to end-user identity (sensitive auth surface; bodies carry schema fields only, verified vs typed client + tests). **API-key create was evaluated and left lenient** — its body carries `applicationId` resolved from auth context, not the schema, so strict would break the happy path. Concrete proof this is a per-route decision, not a blanket sweep (a global `.strict()` would break the running app, since Appstrate currently strips unknown keys Stripe-style).

## Tests (all green)
- `auth-conditional-headers.test.ts` (new): cookie → 400; API-key bad-prefix not preempted; API-key + valid end-user impersonates (200).
- `oidc/.../enduser-token-auth.test.ts`: OAuth end-user token + `Appstrate-User` → 400 (exact regression).
- `end-users.test.ts`: unknown body key → 400 `unknown_field`.

`tsc --noEmit`, eslint, prettier clean. `bun test` on all touched files green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)