### PR TITLE
fix(llm-proxy): catch streamed teardown at the source + thin process backstop

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -4,7 +4,7 @@ import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { serveStatic } from "hono/bun";
 import { getEnv } from "@appstrate/env";
-import { initObservability, observability } from "./observability/index.ts";
+import { initObservability, observability, recordProcessAnomaly } from "./observability/index.ts";
 import { logger } from "./lib/logger.ts";
 import { boot } from "./lib/boot.ts";
 import { createShutdownHandler } from "./lib/shutdown.ts";
@@ -250,6 +250,48 @@ const shutdown = createShutdownHandler(() => {
 });
 process.on("SIGINT", () => void shutdown());
 process.on("SIGTERM", () => void shutdown());
+
+// ── Process-level last-resort net ──────────────────────────────────────────
+// Single-process, multi-tenant server: an async error that escapes EVERY
+// request try/catch would otherwise crash Bun and take down every tenant. This
+// is a BACKSTOP, not a fix — the known offender (an LLM stream teardown that
+// rejects after the response is already on the wire) is caught at its source in
+// `services/llm-proxy/metering.ts#guardSseTeardown`. A non-zero
+// `appstrate.process.anomaly` rate under normal load signals a NEW escape to
+// chase upstream, not a healthy steady state.
+const UNCAUGHT_DRAIN_CEILING_MS = 35_000;
+let crashing = false;
+
+function formatProcessError(err: unknown): string {
+  return err instanceof Error ? (err.stack ?? err.message) : String(err);
+}
+
+// A rejected promise leaves the event loop intact — log, meter, keep serving
+// the other tenants. (Node's default since v15 would crash here.)
+process.on("unhandledRejection", (reason) => {
+  recordProcessAnomaly({ kind: "unhandledRejection" });
+  logger.error("Unhandled promise rejection (kept alive)", {
+    kind: "unhandledRejection",
+    error: formatProcessError(reason),
+  });
+});
+
+// A thrown exception that unwound to the top leaves the process in an undefined
+// state — crash-only per Node guidance. Drain in-flight runs gracefully, then
+// let the supervisor restart a clean process; force-exit if the drain hangs.
+process.on("uncaughtException", (err, origin) => {
+  recordProcessAnomaly({ kind: "uncaughtException" });
+  logger.error("Uncaught exception (shutting down)", {
+    kind: "uncaughtException",
+    origin,
+    error: formatProcessError(err),
+  });
+  if (crashing) return;
+  crashing = true;
+  const force = setTimeout(() => process.exit(1), UNCAUGHT_DRAIN_CEILING_MS);
+  force.unref();
+  void shutdown();
+});
 
 // Routes
 const userAgentsRouter = createUserAgentsRouter();

--- a/apps/api/src/observability/index.ts
+++ b/apps/api/src/observability/index.ts
@@ -16,6 +16,7 @@ export {
   recordRunTerminal,
   recordContainerSpawn,
   recordLlmLatency,
+  recordProcessAnomaly,
 } from "./otel.ts";
 
 export { observability } from "./middleware.ts";

--- a/apps/api/src/observability/otel.ts
+++ b/apps/api/src/observability/otel.ts
@@ -70,6 +70,7 @@ let runDuration: Histogram | undefined;
 let runTerminal: Counter | undefined;
 let containerSpawn: Histogram | undefined;
 let llmLatency: Histogram | undefined;
+let processAnomaly: Counter | undefined;
 
 /**
  * Pull provider for the scheduler queue-depth observable gauge. The scheduler
@@ -238,6 +239,11 @@ function createInstruments(m: Meter): void {
     unit: "s",
     description: "Upstream LLM call latency observed at the platform proxy seam.",
     advice: { explicitBucketBoundaries: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60] },
+  });
+  processAnomaly = m.createCounter("appstrate.process.anomaly", {
+    description:
+      "Count of async errors that escaped every request try/catch and hit the " +
+      "process-level last-resort handler, tagged by kind (uncaughtException|unhandledRejection).",
   });
   m.createObservableGauge("appstrate.scheduler.queue_depth", {
     description: "Pending jobs in the run-scheduler queue (BullMQ).",
@@ -437,6 +443,16 @@ export function recordRunTerminal(attrs: { status: string; errorCode?: string })
     status: attrs.status,
     error_code: clampErrorCode(attrs.errorCode),
   });
+}
+
+/**
+ * Record one async error that escaped the request lifecycle and reached the
+ * process-level last-resort handler. A non-zero rate under normal load is a
+ * real upstream regression to chase — NOT a healthy steady state.
+ */
+export function recordProcessAnomaly(attrs: { kind: string }): void {
+  if (!enabled) return;
+  processAnomaly?.add(1, { kind: attrs.kind });
 }
 
 export function recordContainerSpawn(

--- a/apps/api/src/services/llm-proxy/metering.ts
+++ b/apps/api/src/services/llm-proxy/metering.ts
@@ -193,25 +193,41 @@ export interface MeteredForwardOptions {
   onUpstreamError?: (status: number) => void;
 }
 
+/** `controller.close()` throws if the stream is already closed/errored (e.g. the
+ * consumer cancelled mid-pull). That is not a teardown — swallow it. */
+function closeSafely(controller: ReadableStreamDefaultController<Uint8Array>): void {
+  try {
+    controller.close();
+  } catch {
+    // already closed/errored — nothing to do
+  }
+}
+
 /**
- * Wrap the client-facing SSE stream so a teardown that rejects/throws AFTER
- * the response headers are already on the wire is caught HERE — at the seam we
- * own — instead of escaping the request lifecycle as an unhandled rejection.
+ * Wrap an SSE source so a teardown that rejects/throws AFTER the response
+ * headers are already on the wire is caught HERE — at the seam we own —
+ * instead of escaping the request lifecycle as an unhandled rejection.
  *
- * Why this is the root-cause fix: the upstream body is `tee()`d into a
- * client branch and a metering branch. The metering tap is already guarded
- * (its `.catch` logs + no-ops). The client branch, returned as the `Response`
- * body and sometimes `pipeThrough`-swapped, has no such guard — when an
- * upstream gateway breaks mid-flux the `tee()` branch (and any internal
- * `pipeThrough` pipe) rejects with no request `try/catch` left to catch it. On
- * a single-process multi-tenant server that lands as a process-level
- * `unhandledRejection` — one tenant's broken stream threatening every tenant.
+ * Context: the upstream body is `tee()`d into a client branch and a metering
+ * branch. The metering tap is already guarded (its `.catch` logs + no-ops).
+ * The client branch — returned as the `Response` body, sometimes
+ * `pipeThrough`-swapped for model aliases — was not. When an upstream gateway
+ * breaks mid-flux the `tee()` branch rejects with no request `try/catch` left
+ * to catch it. On a single-process multi-tenant server that lands as a
+ * process-level `unhandledRejection` — one tenant's broken stream threatening
+ * every tenant.
  *
- * We pump the source through our own reader inside a `try/catch`: a mid-stream
- * error closes the client stream cleanly (the caller sees a truncated SSE
- * stream — the best achievable once upstream broke) and is logged. Identity
- * passthrough otherwise — `pull` is demand-driven, so backpressure is
- * preserved and nothing is buffered.
+ * IMPORTANT — wrap BEFORE the alias-swap `pipeThrough`, not after. The guarded
+ * wrapper never errors (it closes cleanly on an upstream reject), so the
+ * internal `pipeTo` that `pipeThrough` runs sees a normal close instead of a
+ * rejected abort. That removes the leak regardless of whether the runtime
+ * marks `pipeThrough`'s internal pipe promise `[[handled]]` — guarding the
+ * consumer read alone would not. The swap transform then flushes its buffered
+ * partial line on that clean close.
+ *
+ * `pull` is demand-driven, so backpressure is preserved and nothing is
+ * buffered. `onTeardownError` fires only for a genuine upstream read rejection
+ * — never for a consumer-cancel close race (those are swallowed).
  */
 export function guardSseTeardown(
   source: ReadableStream<Uint8Array>,
@@ -220,16 +236,25 @@ export function guardSseTeardown(
   const reader = source.getReader();
   return new ReadableStream<Uint8Array>({
     async pull(controller) {
+      let result: Awaited<ReturnType<typeof reader.read>>;
       try {
-        const { done, value } = await reader.read();
-        if (done) {
-          controller.close();
-          return;
-        }
-        controller.enqueue(value);
+        result = await reader.read();
       } catch (err) {
+        // The only genuine teardown signal: the upstream/tee branch rejected
+        // mid-flux. Report once, then close the client stream cleanly (the
+        // caller sees a truncated SSE stream — the best achievable here).
         onTeardownError(err);
-        controller.close();
+        closeSafely(controller);
+        return;
+      }
+      if (result.done) {
+        closeSafely(controller);
+        return;
+      }
+      try {
+        controller.enqueue(result.value);
+      } catch {
+        // Consumer cancelled between read and enqueue — not a teardown.
       }
     },
     cancel(reason) {
@@ -294,17 +319,18 @@ export async function forwardMeteredResponse(
         });
       });
     const headers = cloneResponseHeaders(upstream.headers);
-    const swapped = swap ? clientStream.pipeThrough(createSseModelSwapStream(swap)) : clientStream;
-    // Guard the client-facing branch: an upstream teardown that rejects AFTER
-    // the response is on the wire is caught at the seam we own (see
-    // {@link guardSseTeardown}) instead of escaping the request lifecycle.
-    const clientStream2 = guardSseTeardown(swapped, (err) => {
+    // Guard the raw client branch FIRST (before the alias-swap pipe) so the
+    // swapped stream is fed by a source that never errors — see
+    // {@link guardSseTeardown} for why guarding after `pipeThrough` would leave
+    // its internal pipe promise exposed.
+    const guarded = guardSseTeardown(clientStream, (err) => {
       logger.error(`${logLabel}: SSE client stream teardown failed`, {
         runId: ctx.runId,
         presetId: ctx.presetId,
         error: getErrorMessage(err),
       });
     });
+    const clientStream2 = swap ? guarded.pipeThrough(createSseModelSwapStream(swap)) : guarded;
     return new Response(clientStream2, { status: upstream.status, headers });
   }
 

--- a/apps/api/src/services/llm-proxy/metering.ts
+++ b/apps/api/src/services/llm-proxy/metering.ts
@@ -194,6 +194,53 @@ export interface MeteredForwardOptions {
 }
 
 /**
+ * Wrap the client-facing SSE stream so a teardown that rejects/throws AFTER
+ * the response headers are already on the wire is caught HERE — at the seam we
+ * own — instead of escaping the request lifecycle as an unhandled rejection.
+ *
+ * Why this is the root-cause fix: the upstream body is `tee()`d into a
+ * client branch and a metering branch. The metering tap is already guarded
+ * (its `.catch` logs + no-ops). The client branch, returned as the `Response`
+ * body and sometimes `pipeThrough`-swapped, has no such guard — when an
+ * upstream gateway breaks mid-flux the `tee()` branch (and any internal
+ * `pipeThrough` pipe) rejects with no request `try/catch` left to catch it. On
+ * a single-process multi-tenant server that lands as a process-level
+ * `unhandledRejection` — one tenant's broken stream threatening every tenant.
+ *
+ * We pump the source through our own reader inside a `try/catch`: a mid-stream
+ * error closes the client stream cleanly (the caller sees a truncated SSE
+ * stream — the best achievable once upstream broke) and is logged. Identity
+ * passthrough otherwise — `pull` is demand-driven, so backpressure is
+ * preserved and nothing is buffered.
+ */
+export function guardSseTeardown(
+  source: ReadableStream<Uint8Array>,
+  onTeardownError: (err: unknown) => void,
+): ReadableStream<Uint8Array> {
+  const reader = source.getReader();
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      try {
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(value);
+      } catch (err) {
+        onTeardownError(err);
+        controller.close();
+      }
+    },
+    cancel(reason) {
+      // Client disconnected — release the upstream/tee branch. Swallow a
+      // cancel rejection so teardown cleanup can't itself escape.
+      void reader.cancel(reason).catch(() => {});
+    },
+  });
+}
+
+/**
  * Forward an upstream LLM response to the caller and record usage — the single
  * forwarding terminus shared by the protocol-adapter core ({@link proxyLlmCall})
  * and the Claude Code subscription SDK gateway. Handles the three branches
@@ -247,9 +294,17 @@ export async function forwardMeteredResponse(
         });
       });
     const headers = cloneResponseHeaders(upstream.headers);
-    const clientStream2 = swap
-      ? clientStream.pipeThrough(createSseModelSwapStream(swap))
-      : clientStream;
+    const swapped = swap ? clientStream.pipeThrough(createSseModelSwapStream(swap)) : clientStream;
+    // Guard the client-facing branch: an upstream teardown that rejects AFTER
+    // the response is on the wire is caught at the seam we own (see
+    // {@link guardSseTeardown}) instead of escaping the request lifecycle.
+    const clientStream2 = guardSseTeardown(swapped, (err) => {
+      logger.error(`${logLabel}: SSE client stream teardown failed`, {
+        runId: ctx.runId,
+        presetId: ctx.presetId,
+        error: getErrorMessage(err),
+      });
+    });
     return new Response(clientStream2, { status: upstream.status, headers });
   }
 

--- a/apps/api/test/unit/llm-proxy-metering.test.ts
+++ b/apps/api/test/unit/llm-proxy-metering.test.ts
@@ -10,7 +10,11 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { computeCostUsd, tapSseUsage } from "../../src/services/llm-proxy/metering.ts";
+import {
+  computeCostUsd,
+  tapSseUsage,
+  guardSseTeardown,
+} from "../../src/services/llm-proxy/metering.ts";
 import { anthropicMessagesAdapter } from "../../src/services/llm-proxy/anthropic.ts";
 import type { UpstreamUsage } from "../../src/services/llm-proxy/types.ts";
 
@@ -100,5 +104,69 @@ describe("tapSseUsage (anthropic-messages)", () => {
   it("returns null when the stream carries no usage-bearing frame", async () => {
     const frames = `event: content_block_delta\ndata: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hi"}}\n\nevent: message_stop\ndata: {"type":"message_stop"}\n\n`;
     expect(await tapSseUsage(streamFrom([frames]), anthropicMessagesAdapter)).toBeNull();
+  });
+});
+
+async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
+  const dec = new TextDecoder();
+  const reader = stream.getReader();
+  let out = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += dec.decode(value, { stream: true });
+  }
+  return out;
+}
+
+describe("guardSseTeardown", () => {
+  it("passes frames through unchanged when the source closes normally", async () => {
+    const seen: unknown[] = [];
+    const guarded = guardSseTeardown(streamFrom(["a", "bc", "d"]), (e) => seen.push(e));
+    expect(await readAll(guarded)).toBe("abcd");
+    expect(seen).toEqual([]);
+  });
+
+  it("catches a mid-stream source error: yields what arrived, closes, reports once", async () => {
+    // The defining case: an upstream teardown that rejects AFTER bytes are on
+    // the wire must NOT escape as an unhandled rejection — it closes the client
+    // stream cleanly and surfaces via the callback.
+    const enc = new TextEncoder();
+    let sent = false;
+    const boom = new Error("upstream gateway broke mid-flux");
+    const source = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (!sent) {
+          controller.enqueue(enc.encode("partial"));
+          sent = true;
+          return;
+        }
+        controller.error(boom);
+      },
+    });
+
+    const seen: unknown[] = [];
+    const guarded = guardSseTeardown(source, (e) => seen.push(e));
+
+    // readAll must resolve (not reject) — the error was swallowed at the seam.
+    expect(await readAll(guarded)).toBe("partial");
+    expect(seen).toEqual([boom]);
+  });
+
+  it("propagates client cancel to the source", async () => {
+    let cancelledWith: unknown = undefined;
+    const source = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new TextEncoder().encode("x"));
+      },
+      cancel(reason) {
+        cancelledWith = reason;
+      },
+    });
+    const guarded = guardSseTeardown(source, () => {});
+    const reader = guarded.getReader();
+    await reader.read();
+    await reader.cancel("client gone");
+    expect(cancelledWith).toBe("client gone");
   });
 });

--- a/apps/api/test/unit/llm-proxy-metering.test.ts
+++ b/apps/api/test/unit/llm-proxy-metering.test.ts
@@ -14,9 +14,12 @@ import {
   computeCostUsd,
   tapSseUsage,
   guardSseTeardown,
+  forwardMeteredResponse,
+  type MeteredForwardContext,
 } from "../../src/services/llm-proxy/metering.ts";
 import { anthropicMessagesAdapter } from "../../src/services/llm-proxy/anthropic.ts";
 import type { UpstreamUsage } from "../../src/services/llm-proxy/types.ts";
+import type { ResolvedModel } from "../../src/services/org-models.ts";
 
 function streamFrom(chunks: string[]): ReadableStream<Uint8Array> {
   const enc = new TextEncoder();
@@ -153,7 +156,51 @@ describe("guardSseTeardown", () => {
     expect(seen).toEqual([boom]);
   });
 
-  it("propagates client cancel to the source", async () => {
+  it("full forward path: upstream errors mid-flux under alias-swap → body completes, no escape", async () => {
+    // End-to-end through `forwardMeteredResponse` (tee + tap + pipeThrough swap
+    // + guard). The upstream emits one frame then errors. With the guard wired
+    // BEFORE the swap pipe, the returned body must read to completion (no
+    // rejection escaping the `pipeThrough` internal pipe) and the one frame
+    // that arrived must be alias-swapped.
+    const enc = new TextEncoder();
+    let sent = 0;
+    const upstreamBody = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (sent === 0) {
+          controller.enqueue(enc.encode('data: {"type":"x","model":"real-model"}\n\n'));
+          sent++;
+          return;
+        }
+        controller.error(new Error("upstream gateway broke mid-flux"));
+      },
+    });
+    const upstream = new Response(upstreamBody, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+    const ctx: MeteredForwardContext = {
+      principal: { kind: "jwt_user", userId: "u", orgId: "o" },
+      runId: null,
+      presetId: "preset",
+      // Only read by the metering path, which no-ops on the null usage an
+      // errored stream yields — a minimal stand-in is sufficient here.
+      resolved: {
+        modelId: "real-model",
+        apiShape: "anthropic-messages",
+      } as unknown as ResolvedModel,
+      started: 0,
+    };
+
+    const res = await forwardMeteredResponse(upstream, anthropicMessagesAdapter, ctx, {
+      swap: { alias: "alias-model", real: "real-model" },
+      logLabel: "test",
+    });
+    const out = await readAll(res.body!);
+    expect(out).toContain("alias-model");
+    expect(out).not.toContain("real-model");
+  });
+
+  it("propagates client cancel to the source without a spurious teardown error", async () => {
     let cancelledWith: unknown = undefined;
     const source = new ReadableStream<Uint8Array>({
       pull(controller) {
@@ -163,10 +210,13 @@ describe("guardSseTeardown", () => {
         cancelledWith = reason;
       },
     });
-    const guarded = guardSseTeardown(source, () => {});
+    const seen: unknown[] = [];
+    const guarded = guardSseTeardown(source, (e) => seen.push(e));
     const reader = guarded.getReader();
     await reader.read();
     await reader.cancel("client gone");
     expect(cancelledWith).toBe("client gone");
+    // A normal disconnect must NOT be reported as an upstream teardown.
+    expect(seen).toEqual([]);
   });
 });


### PR DESCRIPTION
## Quoi

Durcissement à la source de l'erreur async « échappée » derrière #749 et #764, + un filet process-level minimal en defense-in-depth. Remplace les deux PR/issues.

## Cause racine

Le LLM-proxy forward une réponse SSE upstream en `tee()`-ant le corps en deux branches : une branche **client** (rendue comme corps de la `Response`, parfois `pipeThrough`-swappée pour les alias modèle) et une branche **metering**.

- La branche metering est **déjà gardée** (`tapSseUsage` catch ses erreurs de read, `recordProxyUsage` avale ses erreurs DB).
- La branche **client** ne l'était **pas**. Quand un gateway upstream casse en plein flux, cette branche (et tout pipe interne de `pipeThrough`) rejette **après** que la réponse est partie — plus aucun `try/catch` de requête pour la rattraper.

Sur un serveur **mono-process multi-tenant**, ça atterrit en `unhandledRejection` process-level : le stream cassé d'**un** locataire menace **tous** les locataires.

## Changements

- **`metering.ts` — `guardSseTeardown()`** : pompe la branche client via notre propre reader dans un `try/catch`. Wrappé **AVANT** le pipe d'alias-swap (`pipeThrough`), pas après — le wrapper gardé ne rejette jamais (close propre sur reject upstream), donc le `pipeTo` interne de `pipeThrough` voit une fermeture normale au lieu d'un abort rejeté. Ça neutralise la fuite **indépendamment** du fait que le runtime marque ou non la promesse de pipe interne `[[handled]]` (l'edge Bun runtime/streaming que #764 disait non-localisable). Pull demand-driven → backpressure préservée, rien bufferisé. `onTeardownError` ne se déclenche **que** sur un vrai reject de read upstream (pas sur un close-race de cancel client).
- **`index.ts` — filet process-level minimal** (defense-in-depth, car le fix source n'est pas prouvé comme l'unique échappée) :
  - `unhandledRejection` → log + metric + keep-alive (le défaut Node depuis v15 crasherait).
  - `uncaughtException` → log + metric + drain gracieux puis restart (force-exit si le drain hang). État process indéfini après une exception remontée = crash-only par guidance Node.
  - **Supersede** le filet autonome proposé en #749.
- **Observability** — compteur `appstrate.process.anomaly{kind=uncaughtException|unhandledRejection}` : un taux non-nul sous charge normale = nouvelle échappée à traquer en amont, pas un état sain.
- **Tests** — `guardSseTeardown` (passthrough, erreur mid-stream avalée + reportée une fois, cancel client sans erreur spurious) **+** le chemin complet `forwardMeteredResponse` (tee + tap + swap pipe + guard) sous erreur upstream en plein flux : prouve que le corps se lit jusqu'au bout, alias appliqué, rien d'échappé.

## Critical-review follow-up (2e commit)

La 1re version gardait la branche **après** `pipeThrough` → ne couvrait que la lecture consommateur, pas le pipe interne. Corrigé en guard-avant-swap. Aussi corrigé : un close-race sur cancel client loggait une fausse erreur de teardown à chaque déconnexion → `close()`/`enqueue()` sont maintenant state-safe.

## Vérification

- `apps/api/test/unit/llm-proxy-metering.test.ts` : 12 pass (4 nouveaux pour le guard + chemin complet).
- `bunx tsc --noEmit` (apps/api) : vert. eslint + prettier : vert.

## Tradeoffs assumés (filet process)

- `uncaughtException` lance le `shutdown()` async complet sur un état potentiellement corrompu — borné par un force-exit (35s). Choix acté en review #749 (drain gracieux > kill brutal pour le multi-tenant) ; le force-exit limite le risque si le drain hang.
- Pas de throttle sur le flood de logs/metric d'`unhandledRejection` (YAGNI tant qu'on n'observe pas un hot-loop en prod).

## Pourquoi pas juste le filet global (#749)

Un filet `unhandledRejection`/`uncaughtException` global est un **backstop**, pas un fix — il masque la cause. Le SOTA = neutraliser au bord du stream (ce que fait `guardSseTeardown`). Le filet reste, mais minimal et observable, pour les échappées **inconnues** restantes.

## Acceptance (#764)

- [x] Teardown fautif neutralisé à la source (`guardSseTeardown`, guard-avant-swap).
- [x] Backstop process-level garde le serveur debout + métrique de suivi.
- [ ] `appstrate.process.anomaly{kind=uncaughtException}` ~0 sous charge → à confirmer en prod (la métrique existe maintenant).

Closes #749
Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)
