### PR TITLE
chore: remove dead redundant re-exports + unused test helper

### DIFF
--- a/apps/api/src/services/bundle-import.ts
+++ b/apps/api/src/services/bundle-import.ts
@@ -421,7 +421,3 @@ export async function handleImportBundle(
   }
   return importBundle(bundle, scope, userId);
 }
-
-// Re-export the root extractor so the route doesn't have to reach into
-// `@appstrate/afps-runtime/bundle` directly for the bundle-of-one path.
-export { extractRootFromAfps };

--- a/apps/api/src/services/llm-proxy/claude-code-sdk-gateway.ts
+++ b/apps/api/src/services/llm-proxy/claude-code-sdk-gateway.ts
@@ -54,9 +54,7 @@ export const CLAUDE_CODE_PROVIDER_ID = "claude-code";
 // The shared, no-forge Anthropic OAuth-gateway policy (OAuth-beta merge, bearer
 // swap, x-api-key drop, auth-error envelope) lives in
 // `@appstrate/core/claude-oauth-gateway` so this chat gateway and the sidecar
-// run gateway cannot drift. Re-exported so existing callers/tests keep the
-// `anthropicAuthErrorResponse` symbol on this module.
-export { anthropicAuthErrorResponse };
+// run gateway cannot drift.
 
 /** URL prefix this gateway is mounted under (within the llm-proxy router). */
 const ROUTE_PREFIX = "/api/llm-proxy/claude-code-sdk";

--- a/apps/api/src/services/run-creation.ts
+++ b/apps/api/src/services/run-creation.ts
@@ -44,13 +44,6 @@ export interface SinkRequest {
   ttlSeconds?: number;
 }
 
-// SinkCredentials + mintSinkCredentials live in
-// `../lib/mint-sink-credentials.ts` (pure, no db imports) so unit tests
-// can exercise the URL / secret derivation without spinning up the DB.
-// Re-exported here for callers already importing from this service.
-export { mintSinkCredentials };
-export type { SinkCredentials };
-
 export interface CreateRunInput {
   runId: string;
   orgId: string;

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -28,7 +28,6 @@ import { runs, TERMINAL_RUN_EVENT_TYPES, type RunResultPayload } from "@appstrat
 import { type CloudEventEnvelope } from "@appstrate/afps-runtime/events";
 import type { RunEvent } from "@appstrate/afps-runtime/types";
 import { emptyRunResult, type RunResult } from "@appstrate/afps-runtime/runner";
-import { notFound } from "../lib/errors.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
 import { logger } from "../lib/logger.ts";
 import { getCache, getEventBuffer } from "../infra/index.ts";
@@ -969,7 +968,3 @@ function mapTerminalStatus(result: RunResult): "success" | "failed" | "timeout" 
   if (result.status) return result.status;
   return result.error ? "failed" : "success";
 }
-
-// notFound is imported for symmetry with gone() — callers (the middleware)
-// map null lookups to 404. Exported so the middleware has a single source.
-export { notFound };

--- a/apps/cli/src/lib/api.ts
+++ b/apps/cli/src/lib/api.ts
@@ -140,28 +140,6 @@ async function resolveProfileOrThrow(profileName: string): Promise<Profile> {
   return profile;
 }
 
-/**
- * Return a usable access token for `profileName`, silently rotating via
- * the stored refresh token when the access token is missing or about to
- * expire. Exported (prefixed `_`) for unit testing.
- *
- * Failure modes:
- *   - No tokens stored → `AuthError` ("run appstrate login").
- *   - Access expired, refresh token also expired → clears local
- *     credentials, `AuthError`.
- *   - Refresh call returns `invalid_grant` (revoked, rotated, reused)
- *     → clears local credentials, `AuthError`.
- *   - Refresh call returns a transient error (network, 5xx) → the
- *     error bubbles as-is so the caller can report it without wiping
- *     the user's credentials for a server-side hiccup.
- */
-export async function _resolveAccessTokenForTesting(
-  profileName: string,
-  profile: Profile,
-): Promise<string> {
-  return resolveAccessToken(profileName, profile);
-}
-
 export interface AuthContext {
   instance: string;
   accessToken: string;

--- a/packages/afps-runtime/src/bundle/read.ts
+++ b/packages/afps-runtime/src/bundle/read.ts
@@ -29,7 +29,6 @@ import {
   serializeRecord,
 } from "./integrity.ts";
 import {
-  BUNDLE_FORMAT_VERSION,
   parsePackageIdentity,
   type AfpsManifest,
   type Bundle,
@@ -349,5 +348,3 @@ function sha256Digest(data: Uint8Array): Buffer {
   h.update(data);
   return h.digest();
 }
-
-export { BUNDLE_FORMAT_VERSION };

--- a/packages/afps-runtime/src/conformance/default-adapter.ts
+++ b/packages/afps-runtime/src/conformance/default-adapter.ts
@@ -15,7 +15,7 @@
  */
 
 import { extractRootFromAfps } from "../bundle/build.ts";
-import { bundleIntegrity, type RecordEntry } from "../bundle/integrity.ts";
+import { bundleIntegrity } from "../bundle/integrity.ts";
 import {
   BUNDLE_FORMAT_VERSION,
   parsePackageIdentity,
@@ -97,8 +97,3 @@ function bundleOfOne(root: BundlePackage): Bundle {
     integrity: bundleIntegrity(pkgIndex),
   };
 }
-
-// Silence unused import warning — RecordEntry is re-exported below as
-// a convenience for downstream adapters that want to introspect integrity
-// entries against their own implementation.
-export type { RecordEntry };


### PR DESCRIPTION
## Summary

Follow-up cleanup of the same genre as #761, surfaced by a `knip` dead-export sweep across the monorepo and verified caller-by-caller. Two categories:

### Redundant re-exports (dead lines)
Every consumer already imports the symbol from its canonical module — the re-export line was dead weight. The symbol stays alive at its source; only the duplicate `export` (and any import that existed *solely* to feed it) is removed.

| File | Symbol | Why dead |
|---|---|---|
| `apps/api/.../run-event-ingestion.ts` | `notFound` | callers import from `lib/errors.ts` |
| `apps/api/.../llm-proxy/claude-code-sdk-gateway.ts` | `anthropicAuthErrorResponse` | no external importer (stale "callers/tests" comment); internal use keeps the import |
| `apps/api/.../run-creation.ts` | `mintSinkCredentials`, `SinkCredentials` | all callers import from `lib/mint-sink-credentials.ts` |
| `apps/api/.../bundle-import.ts` | `extractRootFromAfps` | all callers import from `@appstrate/afps-runtime/bundle` |
| `packages/afps-runtime/.../bundle/read.ts` | `BUNDLE_FORMAT_VERSION` | `bundle/index.ts` re-exports it from `types.ts` (canonical) |
| `packages/afps-runtime/.../conformance/default-adapter.ts` | `RecordEntry` | available via the public `./bundle` export |

### Truly dead code
- `apps/cli/src/lib/api.ts` → `_resolveAccessTokenForTesting`: a test-only wrapper over `resolveAccessToken` with **zero importers** (no test references it). `resolveAccessToken` itself stays (still used at 2 sites).

## Not included (out of scope)
A broader sweep also found ~50 **over-exported** symbols (used only in their own file — `export` keyword redundant but code alive) and one larger #761-genre orphan, `BundledSkillResolver` (afps-runtime, public-API entanglement). Left for separate decisions.

## Verify
- `bun run check` — 33/33 turbo tasks green ✅
- `bun test` afps-runtime (599) + cli (1061) pass ✅
- run-event-ingestion unit tests pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)