### PR TITLE
feat(web): relocate user menu, org switcher, logo and settings in app layout

### DIFF
--- a/apps/web/public/icon-dark.svg
+++ b/apps/web/public/icon-dark.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg stroke-miterlimit="10" style="fill-rule:nonzero;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;" version="1.1" viewBox="-41.44 54.52 911.5 911.5" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<linearGradient gradientTransform="matrix(-1.78402 635.69 -635.69 -1.78402 1.17019 188.234)" gradientUnits="userSpaceOnUse" id="LinearGradient" x1="0" x2="1" y1="0" y2="0">
+<stop offset="0" stop-color="#efefef"/>
+<stop offset="1" stop-color="#e6e6e6"/>
+</linearGradient>
+<linearGradient gradientTransform="matrix(1.78402 -635.69 635.69 1.78402 827.459 832.031)" gradientUnits="userSpaceOnUse" id="LinearGradient_2" x1="0" x2="1" y1="0" y2="0">
+<stop offset="0" stop-color="#e6e6e6"/>
+<stop offset="1" stop-color="#efefef"/>
+</linearGradient>
+<linearGradient gradientTransform="matrix(183.518 -700.939 668.645 183.518 322.275 861.818)" gradientUnits="userSpaceOnUse" id="LinearGradient_3" x1="0" x2="1" y1="0" y2="0">
+<stop offset="0" stop-color="#ff7e27"/>
+<stop offset="0.495194" stop-color="#e55342"/>
+<stop offset="1" stop-color="#ce2e59"/>
+</linearGradient>
+</defs>
+<path d="M20 191.25C8.95432 191.25 1.24759e-05 200.204 1.24759e-05 211.25L1.24759e-05 239.75L1.24759e-05 780.781L5.14469e-06 809.281C2.30336e-06 820.327 8.95431 829.281 20 829.281L48.5 829.281L236.5 829.281C247.546 829.281 256.5 820.327 256.5 809.281L256.5 780.781C256.5 769.736 247.546 760.781 236.5 760.781L68.5 760.781L68.5 259.75L236.5 259.75C247.546 259.75 256.5 250.796 256.5 239.75L256.5 211.25C256.5 200.204 247.546 191.25 236.5 191.25L20 191.25Z" fill="url(#LinearGradient)" fill-rule="nonzero" opacity="1" stroke="none"/>
+<path d="M808.629 829.016C819.675 829.016 828.629 820.061 828.629 809.016L828.629 780.516L828.629 239.484L828.629 210.984C828.629 199.939 819.675 190.984 808.629 190.984L780.129 190.984L592.129 190.984C581.084 190.984 572.129 199.939 572.129 210.984L572.129 239.484C572.129 250.53 581.084 259.484 592.129 259.484L760.129 259.484L760.129 760.516L592.129 760.516C581.084 760.516 572.129 769.47 572.129 780.516L572.129 809.016C572.129 820.061 581.084 829.016 592.129 829.016L808.629 829.016Z" fill="url(#LinearGradient_2)" fill-rule="nonzero" opacity="1" stroke="none"/>
+<path d="M494.661 235.491C497.945 215.235 472.235 203.762 459.351 219.734L211.082 527.525C200.529 540.607 209.841 560.082 226.649 560.082L346.214 560.082C358.537 560.082 367.929 571.118 365.957 583.282L332.684 788.509C329.4 808.765 355.11 820.238 367.993 804.266L616.263 496.475C626.815 483.393 617.504 463.918 600.696 463.918L481.13 463.918C468.807 463.918 459.416 452.882 461.388 440.718L494.661 235.491Z" fill="url(#LinearGradient_3)" fill-rule="nonzero" opacity="1" stroke="none"/>
+</svg>

--- a/apps/web/public/icon-light.svg
+++ b/apps/web/public/icon-light.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg stroke-miterlimit="10" style="fill-rule:nonzero;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;" version="1.1" viewBox="-41.44 54.52 911.5 911.5" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<defs>
+<linearGradient gradientTransform="matrix(-1.78402 635.69 -635.69 -1.78402 1.17019 188.234)" gradientUnits="userSpaceOnUse" id="LinearGradient" x1="0" x2="1" y1="0" y2="0">
+<stop offset="0" stop-color="#111111"/>
+<stop offset="1" stop-color="#333333"/>
+</linearGradient>
+<linearGradient gradientTransform="matrix(1.78402 -635.69 635.69 1.78402 827.459 832.031)" gradientUnits="userSpaceOnUse" id="LinearGradient_2" x1="0" x2="1" y1="0" y2="0">
+<stop offset="0" stop-color="#333333"/>
+<stop offset="1" stop-color="#111111"/>
+</linearGradient>
+<linearGradient gradientTransform="matrix(183.518 -700.939 668.645 183.518 322.275 861.818)" gradientUnits="userSpaceOnUse" id="LinearGradient_3" x1="0" x2="1" y1="0" y2="0">
+<stop offset="0" stop-color="#ff7e27"/>
+<stop offset="0.495194" stop-color="#e55342"/>
+<stop offset="1" stop-color="#ce2e59"/>
+</linearGradient>
+</defs>
+<path d="M20 191.25C8.95432 191.25 1.24759e-05 200.204 1.24759e-05 211.25L1.24759e-05 239.75L1.24759e-05 780.781L5.14469e-06 809.281C2.30336e-06 820.327 8.95431 829.281 20 829.281L48.5 829.281L236.5 829.281C247.546 829.281 256.5 820.327 256.5 809.281L256.5 780.781C256.5 769.736 247.546 760.781 236.5 760.781L68.5 760.781L68.5 259.75L236.5 259.75C247.546 259.75 256.5 250.796 256.5 239.75L256.5 211.25C256.5 200.204 247.546 191.25 236.5 191.25L20 191.25Z" fill="url(#LinearGradient)" fill-rule="nonzero" opacity="1" stroke="none"/>
+<path d="M808.629 829.016C819.675 829.016 828.629 820.061 828.629 809.016L828.629 780.516L828.629 239.484L828.629 210.984C828.629 199.939 819.675 190.984 808.629 190.984L780.129 190.984L592.129 190.984C581.084 190.984 572.129 199.939 572.129 210.984L572.129 239.484C572.129 250.53 581.084 259.484 592.129 259.484L760.129 259.484L760.129 760.516L592.129 760.516C581.084 760.516 572.129 769.47 572.129 780.516L572.129 809.016C572.129 820.061 581.084 829.016 592.129 829.016L808.629 829.016Z" fill="url(#LinearGradient_2)" fill-rule="nonzero" opacity="1" stroke="none"/>
+<path d="M494.661 235.491C497.945 215.235 472.235 203.762 459.351 219.734L211.082 527.525C200.529 540.607 209.841 560.082 226.649 560.082L346.214 560.082C358.537 560.082 367.929 571.118 365.957 583.282L332.684 788.509C329.4 808.765 355.11 820.238 367.993 804.266L616.263 496.475C626.815 483.393 617.504 463.918 600.696 463.918L481.13 463.918C468.807 463.918 459.416 452.882 461.388 440.718L494.661 235.491Z" fill="url(#LinearGradient_3)" fill-rule="nonzero" opacity="1" stroke="none"/>
+</svg>

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -1,15 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, lazy, Suspense } from "react";
-import {
-  Routes,
-  Route,
-  Outlet,
-  useLocation,
-  useSearchParams,
-  Navigate,
-  Link,
-} from "react-router-dom";
+import { Routes, Route, Outlet, useLocation, useSearchParams, Navigate } from "react-router-dom";
 import { PackageList } from "./pages/package-list";
 import { DashboardPage } from "./pages/dashboard";
 import { InviteAcceptPage } from "./pages/invite-accept";
@@ -24,6 +16,7 @@ import { ErrorBoundary } from "./components/error-boundary";
 import { HostedAuthGate } from "./components/hosted-auth-gate";
 import { AppSidebar } from "./components/app-sidebar";
 import { NotificationBell } from "./components/notification-bell";
+import { NavUser } from "./components/nav-user";
 import { LoadingState } from "./components/page-states";
 import { PendingPairingsWatcher } from "./components/pending-pairings-watcher";
 
@@ -32,11 +25,9 @@ import { useAppConfig } from "./hooks/use-app-config";
 import { useOrg } from "./hooks/use-org";
 import { useGlobalRunSync } from "./hooks/use-global-run-sync";
 import { useApplicationResolver } from "./hooks/use-current-application";
-import { useTheme } from "./stores/theme-store";
 import { useSidebarStore } from "./stores/sidebar-store";
 import { Spinner } from "./components/spinner";
 import { HostedConnectPage } from "./pages/hosted-connect";
-import { Separator } from "@appstrate/ui/components/separator";
 import { SidebarInset, SidebarProvider, SidebarTrigger } from "@appstrate/ui/components/sidebar";
 import { AppToaster } from "./components/app-toaster";
 
@@ -192,7 +183,6 @@ function LazyRoute({ children }: { children: React.ReactNode }) {
 }
 
 function MainLayout() {
-  const { resolvedTheme } = useTheme();
   const { open: sidebarOpen, setOpen: setSidebarOpen } = useSidebarStore();
   useApplicationResolver();
 
@@ -201,20 +191,12 @@ function MainLayout() {
       <AppSidebar />
       <SidebarInset>
         <header className="flex h-16 shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-          <div className="flex items-center gap-2 px-4">
-            <SidebarTrigger className="-ml-1" />
-            <Separator orientation="vertical" className="mr-2 data-[orientation=vertical]:h-4" />
-            <Link to="/">
-              <img
-                src={resolvedTheme === "dark" ? "/logo-dark.svg" : "/logo-light.svg"}
-                alt="Appstrate"
-                className="h-7 w-auto"
-              />
-            </Link>
-          </div>
+          {/* Mobile-only trigger — desktop collapse lives in the sidebar header */}
+          <SidebarTrigger className="ml-2 md:hidden" />
           <div className="flex-1" />
-          <div className="px-4">
+          <div className="flex items-center gap-1 px-4">
             <NotificationBell />
+            <NavUser />
           </div>
         </header>
         <div className="flex flex-1 flex-col">

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1,29 +1,63 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ComponentProps } from "react";
+import { Link } from "react-router-dom";
 import { OrgSwitcher } from "@/components/org-switcher";
 import { NavOrg } from "@/components/nav-org";
 import { SidebarBilling } from "@/components/sidebar-billing";
-import { NavUser } from "@/components/nav-user";
+import { useTheme } from "@/stores/theme-store";
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
   SidebarHeader,
+  SidebarTrigger,
 } from "@appstrate/ui/components/sidebar";
+
+/**
+ * Sidebar header branding + collapse control.
+ *
+ * - Expanded: wordmark logo + collapse toggle (toggle pinned right).
+ * - Collapsed: square app icon only.
+ * - Collapsed + hovered: the icon is swapped for the collapse toggle, which
+ *   stays clickable to re-open the sidebar.
+ */
+function SidebarLogo() {
+  const { resolvedTheme } = useTheme();
+
+  return (
+    <div className="group/logo flex w-full items-center gap-2 pl-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:pl-0">
+      <Link to="/" className="flex items-center group-data-[collapsible=icon]:hidden">
+        <img
+          src={resolvedTheme === "dark" ? "/logo-dark.svg" : "/logo-light.svg"}
+          alt="Appstrate"
+          className="h-7 w-auto"
+        />
+      </Link>
+      {/* Collapsed-only app icon — hidden as soon as the header is hovered */}
+      <img
+        src="/favicon.svg"
+        alt="Appstrate"
+        className="hidden size-7 shrink-0 group-data-[collapsible=icon]:block group-data-[collapsible=icon]:group-hover/logo:hidden"
+      />
+      {/* Toggle: always shown when expanded; collapsed only on hover */}
+      <SidebarTrigger className="ml-auto shrink-0 group-data-[collapsible=icon]:ml-0 group-data-[collapsible=icon]:hidden group-data-[collapsible=icon]:group-hover/logo:flex" />
+    </div>
+  );
+}
 
 export function AppSidebar(props: ComponentProps<typeof Sidebar>) {
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader className="border-sidebar-border h-16 justify-center border-b group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-        <OrgSwitcher />
+        <SidebarLogo />
       </SidebarHeader>
       <SidebarContent className="gap-0">
         <NavOrg />
         <SidebarBilling />
       </SidebarContent>
       <SidebarFooter>
-        <NavUser />
+        <OrgSwitcher />
       </SidebarFooter>
     </Sidebar>
   );

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -36,7 +36,7 @@ function SidebarLogo() {
       </Link>
       {/* Collapsed-only app icon — hidden as soon as the header is hovered */}
       <img
-        src="/favicon.svg"
+        src={resolvedTheme === "dark" ? "/icon-dark.svg" : "/icon-light.svg"}
         alt="Appstrate"
         className="hidden size-7 shrink-0 group-data-[collapsible=icon]:block group-data-[collapsible=icon]:group-hover/logo:hidden"
       />

--- a/apps/web/src/components/nav-org.tsx
+++ b/apps/web/src/components/nav-org.tsx
@@ -14,6 +14,7 @@ import {
   Users,
   Boxes,
   MessageSquare,
+  Settings,
   type LucideIcon,
 } from "lucide-react";
 import { useUnreadCount } from "../hooks/use-notifications";
@@ -72,6 +73,7 @@ export function NavOrg() {
       ? [{ path: "/webhooks", label: t("nav.webhooks"), icon: Webhook }]
       : []),
     ...(isAdmin ? [{ path: "/end-users", label: t("nav.endUsers"), icon: Users }] : []),
+    ...(isAdmin ? [{ path: "/org-settings", label: t("nav.settings"), icon: Settings }] : []),
   ];
 
   const renderItems = (

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -3,11 +3,12 @@
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
-import { Check, ChevronsUpDown, LogOut, Settings, FileText, Palette } from "lucide-react";
+import { Check, LogOut, Settings, FileText, Palette } from "lucide-react";
 import { useAuth } from "../hooks/use-auth";
 import { useTheme } from "../stores/theme-store";
 import { themeOptions } from "../lib/theme";
 import { Avatar, AvatarFallback } from "@appstrate/ui/components/avatar";
+import { Button } from "@appstrate/ui/components/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,12 +20,6 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
 } from "@appstrate/ui/components/dropdown-menu";
-import {
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  useSidebar,
-} from "@appstrate/ui/components/sidebar";
 
 function getInitials(name: string): string {
   return name
@@ -39,7 +34,6 @@ export function NavUser() {
   const { t } = useTranslation();
   const { user, profile, logout } = useAuth();
   const { theme, setTheme } = useTheme();
-  const { isMobile } = useSidebar();
   const queryClient = useQueryClient();
 
   if (!user) return null;
@@ -53,100 +47,80 @@ export function NavUser() {
   };
 
   return (
-    <SidebarMenu>
-      <SidebarMenuItem>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <SidebarMenuButton
-              size="lg"
-              aria-label={t("userMenu.ariaLabel")}
-              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
-            >
-              <Avatar className="h-8 w-8 rounded-lg">
-                <AvatarFallback className="bg-sidebar-primary text-sidebar-primary-foreground rounded-lg text-sm font-medium">
-                  {initials}
-                </AvatarFallback>
-              </Avatar>
-              <div className="grid flex-1 text-left text-sm leading-tight">
-                <span className="truncate font-semibold">{displayName}</span>
-                <span className="truncate text-xs">{user.email}</span>
-              </div>
-              <ChevronsUpDown className="ml-auto size-4" />
-            </SidebarMenuButton>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            className="w-(--radix-dropdown-menu-trigger-width) min-w-56 rounded-lg"
-            side={isMobile ? "bottom" : "right"}
-            align="end"
-            sideOffset={4}
-          >
-            <DropdownMenuLabel className="p-0 font-normal">
-              <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
-                <Avatar className="size-8 rounded-lg">
-                  <AvatarFallback className="bg-sidebar-primary text-sidebar-primary-foreground rounded-lg text-sm font-medium">
-                    {initials}
-                  </AvatarFallback>
-                </Avatar>
-                <div className="grid flex-1 text-left text-sm leading-tight">
-                  <span className="truncate font-semibold">{displayName}</span>
-                  <span className="truncate text-xs">{user.email}</span>
-                </div>
-              </div>
-            </DropdownMenuLabel>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem asChild>
-              <Link to="/preferences" className="flex items-center gap-2">
-                <Settings size={14} />
-                {t("userMenu.preferences")}
-              </Link>
-            </DropdownMenuItem>
-            <DropdownMenuSub>
-              <DropdownMenuSubTrigger>
-                <Palette size={14} />
-                {t("userMenu.theme")}
-              </DropdownMenuSubTrigger>
-              <DropdownMenuSubContent>
-                {themeOptions.map(({ value, labelKey, icon: Icon }) => (
-                  <DropdownMenuItem
-                    key={value}
-                    onSelect={() => setTheme(value)}
-                    className="flex items-center gap-2"
-                  >
-                    <Icon size={14} />
-                    {t(labelKey)}
-                    {theme === value && (
-                      <Check
-                        size={14}
-                        strokeWidth={2.5}
-                        className="text-primary ml-auto shrink-0"
-                      />
-                    )}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuSubContent>
-            </DropdownMenuSub>
-            <DropdownMenuItem asChild>
-              <a
-                href="/api/docs"
-                target="_blank"
-                rel="noopener noreferrer"
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={t("userMenu.ariaLabel")}
+          className="rounded-full"
+        >
+          <Avatar className="size-8 rounded-full">
+            <AvatarFallback className="bg-sidebar-primary text-sidebar-primary-foreground rounded-full text-sm font-medium">
+              {initials}
+            </AvatarFallback>
+          </Avatar>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="min-w-56 rounded-lg" side="bottom" align="end" sideOffset={4}>
+        <DropdownMenuLabel className="p-0 font-normal">
+          <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+            <Avatar className="size-8 rounded-lg">
+              <AvatarFallback className="bg-sidebar-primary text-sidebar-primary-foreground rounded-lg text-sm font-medium">
+                {initials}
+              </AvatarFallback>
+            </Avatar>
+            <div className="grid flex-1 text-left text-sm leading-tight">
+              <span className="truncate font-semibold">{displayName}</span>
+              <span className="truncate text-xs">{user.email}</span>
+            </div>
+          </div>
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link to="/preferences" className="flex items-center gap-2">
+            <Settings size={14} />
+            {t("userMenu.preferences")}
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <Palette size={14} />
+            {t("userMenu.theme")}
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            {themeOptions.map(({ value, labelKey, icon: Icon }) => (
+              <DropdownMenuItem
+                key={value}
+                onSelect={() => setTheme(value)}
                 className="flex items-center gap-2"
               >
-                <FileText size={14} />
-                {t("userMenu.apiDocs")}
-              </a>
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              onSelect={() => void handleLogout()}
-              className="flex items-center gap-2"
-            >
-              <LogOut size={14} />
-              {t("userMenu.logout")}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </SidebarMenuItem>
-    </SidebarMenu>
+                <Icon size={14} />
+                {t(labelKey)}
+                {theme === value && (
+                  <Check size={14} strokeWidth={2.5} className="text-primary ml-auto shrink-0" />
+                )}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuItem asChild>
+          <a
+            href="/api/docs"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2"
+          >
+            <FileText size={14} />
+            {t("userMenu.apiDocs")}
+          </a>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => void handleLogout()} className="flex items-center gap-2">
+          <LogOut size={14} />
+          {t("userMenu.logout")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/apps/web/src/components/org-switcher.tsx
+++ b/apps/web/src/components/org-switcher.tsx
@@ -2,7 +2,7 @@
 
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { ChevronsUpDown, Check, Plus, Star, Settings, Library } from "lucide-react";
+import { ChevronsUpDown, Check, Plus, Star, Library } from "lucide-react";
 import { useOrg } from "../hooks/use-org";
 import { useApplications } from "../hooks/use-applications";
 import { useCurrentApplicationId, useAppSwitcher } from "../hooks/use-current-application";
@@ -163,14 +163,6 @@ export function OrgSwitcher() {
                 <Link to="/library" className="text-primary flex items-center gap-2">
                   <Library size={14} />
                   {t("nav.library")}
-                </Link>
-              </DropdownMenuItem>
-            )}
-            {isAdmin && (
-              <DropdownMenuItem asChild>
-                <Link to="/org-settings" className="text-primary flex items-center gap-2">
-                  <Settings size={14} />
-                  {t("nav.settings")}
                 </Link>
               </DropdownMenuItem>
             )}

--- a/packages/module-chat/src/ui/thread-list.tsx
+++ b/packages/module-chat/src/ui/thread-list.tsx
@@ -134,7 +134,7 @@ function ConversationRow({
       <button
         type="button"
         onClick={() => select?.(session.id)}
-        className="flex min-w-0 flex-1 items-center gap-1.5 py-1 text-left"
+        className="flex min-w-0 flex-1 items-center gap-1.5 rounded-none bg-transparent px-0 py-1 text-left text-inherit hover:bg-transparent"
       >
         {unread && (
           <span
@@ -151,7 +151,7 @@ function ConversationRow({
         <span className="text-muted-foreground text-xs transition-opacity group-hover:opacity-0">
           {relativeTime(session.updatedAt)}
         </span>
-        <div className="absolute right-0 flex items-center opacity-0 transition-opacity group-hover:opacity-100">
+        <div className="bg-background absolute right-0 flex items-center gap-0.5 rounded-md p-0.5 opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
           <button
             type="button"
             aria-label="Renommer"


### PR DESCRIPTION
## Summary

Refactor the global app layout (sidebar + top nav-bar) and fix related styling.

### Layout
- **User menu** → top-right of the nav-bar as an avatar dropdown (circle with initials), next to the notification bell. Same items (preferences / theme / API docs / logout).
- **Organization switcher** → sidebar footer (former user-menu slot). Same dropdown (orgs, app submenu, create org, library).
- **Logo** → sidebar header (top-left), with left padding in expanded mode, collapse toggle pinned right.
- **Sidebar header 3-state** (pure CSS):
  - expanded → wordmark logo + collapse toggle
  - collapsed → square app icon only
  - collapsed + hover → icon swaps for the collapse toggle (clickable to reopen)
- **Org "Settings"** → moved out of the org dropdown into a dedicated sidebar nav item (admin-only). Library stays in the dropdown.
- **Mobile**: kept a mobile-only sidebar trigger in the header (`md:hidden`) so the off-canvas sidebar stays reachable.

### Fixes
- **Theme-aware collapsed icon**: the old `favicon.svg` was a dark-mode raster (light brackets) and disappeared on the light sidebar. Extracted the brand glyph into vector `icon-light.svg` / `icon-dark.svg`, swapped by resolved theme (matches the wordmark).
- **Chat conversation list "double fond"**: the global base `<button>` style leaked `px-3 / rounded-md / hover:bg-accent` into the unstyled conversation-title button, nesting a second background + padding inside each row. Neutralized on that button.
- **Chat row actions**: rename/delete buttons now sit on a solid background pill so they read clearly over the hovered/active row.

## Files
- `apps/web/src/app.tsx` — nav-bar header
- `apps/web/src/components/app-sidebar.tsx` — sidebar header (logo + theme icon) + footer (org switcher)
- `apps/web/src/components/nav-user.tsx` — user dropdown (header)
- `apps/web/src/components/nav-org.tsx` — Settings sidebar item
- `apps/web/src/components/org-switcher.tsx` — removed Settings from dropdown
- `apps/web/public/icon-light.svg`, `apps/web/public/icon-dark.svg` — new theme-aware app icons
- `packages/module-chat/src/ui/thread-list.tsx` — conversation-row styling fixes

## Test
- `tsc --noEmit`, eslint, prettier — clean.
- Not fully browser-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)