### PR TITLE
fix(db): emit run NOTIFY timestamps as true UTC

### DIFF
--- a/packages/db/src/notify.ts
+++ b/packages/db/src/notify.ts
@@ -72,8 +72,8 @@ export async function createNotifyTriggers(db: Db): Promise<void> {
         'application_id', NEW.application_id,
         'schedule_id', NEW.schedule_id,
         'error', NEW.error,
-        'started_at', to_char(NEW.started_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
-        'completed_at', to_char(NEW.completed_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'started_at', to_char(NEW.started_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
+        'completed_at', to_char(NEW.completed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'),
         'duration', NEW.duration
       )::text);
       RETURN NEW;
@@ -103,7 +103,7 @@ export async function createNotifyTriggers(db: Db): Promise<void> {
           WHEN octet_length(NEW.data::text) <= 6000 THEN NEW.data
           ELSE '"[payload too large]"'::jsonb
         END,
-        'created_at', to_char(NEW.created_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+        'created_at', to_char(NEW.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
       )::text);
       RETURN NEW;
     END;


### PR DESCRIPTION
## Problem

On the run detail page the live elapsed-seconds counter showed a negative value (~`-3600`) on first load, then corrected after a page refresh.

## Root cause

The `run_update` / `run_log_insert` PG NOTIFY triggers (`packages/db/src/notify.ts`) formatted `timestamptz` columns with:

```sql
to_char(NEW.started_at, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
```

`to_char` renders a `timestamptz` in the **DB session timezone** but the format string hard-codes a literal `"Z"` (UTC) suffix. So the SSE frame carried local wall-clock time mislabeled as UTC. The frontend (`run-row.tsx`) parsed `started_at` as ~1h in the future → `Date.now() - start` went negative.

The REST path serializes via `.toISOString()` (true UTC), so a refresh looked correct — masking the bug.

## Fix

Convert each timestamp with `AT TIME ZONE 'UTC'` before formatting, so the emitted wall-clock is genuinely UTC and matches the `"Z"` suffix. Applied to `started_at`, `completed_at`, and run-log `created_at`.

Triggers reinstall at boot via `CREATE OR REPLACE FUNCTION` — no migration required. Restart the server to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)