### PR TITLE
fix(runs): surface timeouts as `timeout` and exclude boot from the budget

### DIFF
--- a/apps/api/src/services/run-launcher/execute-background.ts
+++ b/apps/api/src/services/run-launcher/execute-background.ts
@@ -35,6 +35,13 @@ export interface ExecuteAgentInBackgroundInput {
    * exercise the lifecycle without a real container runtime.
    */
   orchestrator?: ContainerOrchestrator;
+  /**
+   * Grace (ms) added to `plan.timeout` for the platform's safety-net
+   * container watchdog. Production leaves this unset (the runner owns the
+   * primary, boot-excluded budget; the platform default folds in cold-start).
+   * Tests inject `0` to exercise the net at the budget itself.
+   */
+  timeoutBootGraceMs?: number;
 }
 
 /**
@@ -121,6 +128,9 @@ async function executeAgentInBackgroundImpl(input: ExecuteAgentInBackgroundInput
         sinkCredentials,
         signal,
         ...(input.orchestrator ? { orchestrator: input.orchestrator } : {}),
+        ...(input.timeoutBootGraceMs !== undefined
+          ? { timeoutBootGraceMs: input.timeoutBootGraceMs }
+          : {}),
       });
     } catch (err) {
       // Orchestrator-level failure (Docker unreachable, image missing, ...)

--- a/apps/api/src/services/run-launcher/pi.ts
+++ b/apps/api/src/services/run-launcher/pi.ts
@@ -53,6 +53,19 @@ import { getEnv } from "@appstrate/env";
 import { getModelProvider } from "../model-providers/registry.ts";
 import type { LlmProxyConfig, SidecarLaunchSpec } from "@appstrate/core/sidecar-types";
 
+/**
+ * Grace added to the platform's container watchdog on top of the agent's
+ * execution budget. The runner enforces `plan.timeout` ITSELF from the moment
+ * its run loop starts (boot excluded) and finalises a first-class `timeout`.
+ * This platform-side timer is the SAFETY NET for the cases the runner can't
+ * cover — a container wedged in cold-start/boot before its watchdog arms, or a
+ * runner that died without finalising. The grace folds in cold-start (image
+ * pull, workspace init, MCP handshake) so a slow boot does not trip the net
+ * before the runner has had its full budget. When it does fire,
+ * `execute-background` synthesises the `timeout` terminal.
+ */
+const PLATFORM_TIMEOUT_BOOT_GRACE_MS = 90_000;
+
 /** Terminal state reported back to the caller once the container has exited. */
 export interface PlatformContainerResult {
   /** Exit code reported by the orchestrator (0 = clean, non-zero = crash). */
@@ -81,6 +94,13 @@ export interface RunPlatformContainerInput {
    */
   uploadBundle?: typeof uploadRunBundle;
   deleteWorkspace?: typeof deleteRunWorkspace;
+  /**
+   * Grace (ms) added to `plan.timeout` for the platform's safety-net
+   * container watchdog. Defaults to {@link PLATFORM_TIMEOUT_BOOT_GRACE_MS}.
+   * Tests that exercise the net directly (no real runner to self-terminate)
+   * set it to `0` so the net fires at the budget itself.
+   */
+  timeoutBootGraceMs?: number;
 }
 
 /**
@@ -325,6 +345,10 @@ async function runPlatformContainerImpl(
       },
       agentPrompt: prompt,
       runId,
+      // Forward the execution budget so the runner enforces it itself, from the
+      // run-loop start (boot excluded), and finalises a first-class `timeout`.
+      // The platform setTimeout in `waitForWorkload` is the longer safety net.
+      timeoutSeconds: plan.timeout,
       noSidecar: skipSidecar,
       // Sidecar-backed runs route LLM traffic through the sidecar proxy
       // (sidecarProxyLlmUrl below). No-sidecar runs talk to the upstream
@@ -399,7 +423,14 @@ async function runPlatformContainerImpl(
     recordContainerSpawn(Date.now() - spawnStart, { sidecar: !skipSidecar });
     spawnRecorded = true;
 
-    return await waitForWorkload(orch, agent, sidecar, plan.timeout, signal);
+    return await waitForWorkload(
+      orch,
+      agent,
+      sidecar,
+      plan.timeout,
+      signal,
+      input.timeoutBootGraceMs ?? PLATFORM_TIMEOUT_BOOT_GRACE_MS,
+    );
   } catch (err) {
     // SOTA per OTel "Recording errors": the spawn histogram covers failures too,
     // tagged with a bounded `error.type` naming the phase that failed (no
@@ -448,9 +479,11 @@ async function runPlatformContainerImpl(
 }
 
 /**
- * Drive the agent container lifecycle: start, enforce timeout, propagate
- * cancellation, wait for exit. Sidecar is stopped alongside the agent on
- * any terminal condition so neither lingers after the run has ended.
+ * Drive the agent container lifecycle: start, enforce the SAFETY-NET timeout
+ * (`timeoutSeconds` + {@link PLATFORM_TIMEOUT_BOOT_GRACE_MS} — the runner owns
+ * the primary, boot-excluded budget), propagate cancellation, wait for exit.
+ * Sidecar is stopped alongside the agent on any terminal condition so neither
+ * lingers after the run has ended.
  */
 async function waitForWorkload(
   orch: ContainerOrchestrator,
@@ -458,6 +491,7 @@ async function waitForWorkload(
   sidecar: WorkloadHandle | undefined,
   timeoutSeconds: number,
   signal: AbortSignal | undefined,
+  bootGraceMs: number,
 ): Promise<PlatformContainerResult> {
   await orch.startWorkload(agent);
 
@@ -480,11 +514,14 @@ async function waitForWorkload(
   })();
 
   let timedOut = false;
-  const timeoutHandle = setTimeout(() => {
-    timedOut = true;
-    orch.stopWorkload(agent).catch(() => {});
-    if (sidecar) orch.stopWorkload(sidecar).catch(() => {});
-  }, timeoutSeconds * 1000);
+  const timeoutHandle = setTimeout(
+    () => {
+      timedOut = true;
+      orch.stopWorkload(agent).catch(() => {});
+      if (sidecar) orch.stopWorkload(sidecar).catch(() => {});
+    },
+    timeoutSeconds * 1000 + bootGraceMs,
+  );
 
   const onAbort = () => {
     orch.stopWorkload(agent).catch(() => {});

--- a/apps/api/test/integration/services/platform-container-sink.test.ts
+++ b/apps/api/test/integration/services/platform-container-sink.test.ts
@@ -271,8 +271,11 @@ describe("runPlatformContainer — sink env-var injection", () => {
     expect(env.APPSTRATE_SINK_SECRET).toBe(credentials.secret);
   });
 
-  it("reports timedOut=true when the run exceeds its timeout window", async () => {
-    // 100ms timeout, 500ms agent lifetime → must flip to timedOut.
+  it("reports timedOut=true when the run exceeds its timeout window (safety net)", async () => {
+    // 100ms budget, 500ms agent lifetime → the platform safety-net watchdog
+    // must flip timedOut. `timeoutBootGraceMs: 0` exercises the net at the
+    // budget itself (the fake orchestrator has no real runner to self-time-out,
+    // so the net is the only timeout in play here).
     const fake = createFakeOrchestrator({ exitCode: 0, exitDelayMs: 500 });
     const plan = buildRunPlan();
     plan.timeout = 0.1; // 100 ms
@@ -287,9 +290,33 @@ describe("runPlatformContainer — sink env-var injection", () => {
         ttlSeconds: 60,
       }),
       orchestrator: fake.orchestrator,
+      timeoutBootGraceMs: 0,
     });
 
     expect(result.timedOut).toBe(true);
+  });
+
+  it("the boot grace defers the safety net past the raw budget", async () => {
+    // 50ms budget but a large grace → the net must NOT fire within the agent's
+    // 200ms lifetime, so a clean exit-0 wins (timedOut stays false).
+    const fake = createFakeOrchestrator({ exitCode: 0, exitDelayMs: 200 });
+    const plan = buildRunPlan();
+    plan.timeout = 0.05; // 50 ms budget
+
+    const result = await runPlatformContainer({
+      runId: "run_grace",
+      context: buildContext("run_grace"),
+      plan,
+      sinkCredentials: mintSinkCredentials({
+        runId: "run_grace",
+        appUrl: "http://platform:3000",
+        ttlSeconds: 60,
+      }),
+      orchestrator: fake.orchestrator,
+      timeoutBootGraceMs: 5_000,
+    });
+
+    expect(result.timedOut).toBe(false);
   });
 
   it("reports cancelled=true when the AbortSignal fires before exit", async () => {
@@ -330,6 +357,7 @@ describe("executeAgentInBackground — server-side finalize synthesis", () => {
     exitCode: number;
     exitDelayMs?: number;
     timeoutSeconds?: number;
+    timeoutBootGraceMs?: number;
   }): Promise<{ runId: string; packageId: string }> {
     const pkg = await seedPackage({
       id: `@${ctx.orgId.slice(0, 6)}/agent-${crypto.randomUUID().slice(0, 6)}`,
@@ -370,6 +398,9 @@ describe("executeAgentInBackground — server-side finalize synthesis", () => {
       plan,
       sinkCredentials: realCredentials,
       orchestrator: fake.orchestrator,
+      ...(input.timeoutBootGraceMs !== undefined
+        ? { timeoutBootGraceMs: input.timeoutBootGraceMs }
+        : {}),
     };
 
     await executeAgentInBackground(execInput);
@@ -393,11 +424,13 @@ describe("executeAgentInBackground — server-side finalize synthesis", () => {
   });
 
   it("synthesises a timeout finalize when the run exceeds its timeout", async () => {
-    // 100ms timeout, 500ms agent lifetime → timeout path.
+    // 100ms budget, 500ms agent lifetime, zero boot grace → safety-net timeout
+    // path (no real runner here to self-time-out).
     const { runId } = await runWithFakeOrchestrator({
       exitCode: 0,
       exitDelayMs: 500,
       timeoutSeconds: 0.1,
+      timeoutBootGraceMs: 0,
     });
     const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
     expect(row!.status).toBe("timeout");

--- a/packages/afps-runtime/src/runner/finalize-thrown-failure.ts
+++ b/packages/afps-runtime/src/runner/finalize-thrown-failure.ts
@@ -84,8 +84,15 @@ export interface FinalizeThrownFailureOptions {
    * `{ message, stack }`; Codex overrides to `{ code: "adapter_error", message }`.
    */
   buildError?: (message: string, err: unknown) => RunError;
-  /** Stamp `status = "failed"` on the result. Defaults to `true`. */
+  /** Stamp the terminal status on the result. Defaults to `true`. */
   setFailedStatus?: boolean;
+  /**
+   * Terminal status stamped when {@link setFailedStatus} is not `false`.
+   * Defaults to `"failed"`. A runner-enforced timeout passes `"timeout"`
+   * so the run surfaces its specific terminal cause instead of a generic
+   * failure. Ignored when `setFailedStatus === false`.
+   */
+  terminalStatus?: NonNullable<RunResult["status"]>;
   /** Extra terminal stamping (cost / durationMs) applied after `usage`. */
   stamp?: (result: RunResult, usage: TokenUsage | undefined) => void;
   /** Transform applied to the emitted error event AND the terminal result. Defaults to identity. */
@@ -130,7 +137,7 @@ export async function finalizeThrownFailure(opts: FinalizeThrownFailureOptions):
       stack: e instanceof Error ? e.stack : undefined,
     }));
   const result = reduceEvents(events, { error: buildError(message, err) });
-  if (opts.setFailedStatus !== false) result.status = "failed";
+  if (opts.setFailedStatus !== false) result.status = opts.terminalStatus ?? "failed";
   if (usage !== undefined) result.usage = usage;
   opts.stamp?.(result, usage);
   await eventSink.finalize(transform(result));

--- a/packages/afps-runtime/src/runner/finalize-thrown-failure.ts
+++ b/packages/afps-runtime/src/runner/finalize-thrown-failure.ts
@@ -114,10 +114,22 @@ export async function finalizeThrownFailure(opts: FinalizeThrownFailureOptions):
 
   const transform = opts.transform ?? (<T>(value: T): T => value);
   const message = errorMessage(err);
+  const buildError =
+    opts.buildError ??
+    ((m: string, e: unknown): RunError => ({
+      message: m,
+      stack: e instanceof Error ? e.stack : undefined,
+    }));
+  const resultError = buildError(message, err);
 
   // 2. Surface the failure as a live event (transformed first so a
   //    redaction transform scrubs it before it reaches the sink).
-  const errorEvent: RunEvent = { type: "appstrate.error", timestamp: now(), runId, message };
+  const errorEvent: RunEvent = {
+    type: "appstrate.error",
+    timestamp: now(),
+    runId,
+    message: resultError.message,
+  };
   await emit(transform(errorEvent));
 
   // 3. Best-effort final drain: capture any runtime events journaled before
@@ -130,13 +142,7 @@ export async function finalizeThrownFailure(opts: FinalizeThrownFailureOptions):
 
   // 4. Reduce → stamp → finalize. `reduceEvents` (not emptyRunResult) so any
   //    partial canonical output the agent emitted before the throw survives.
-  const buildError =
-    opts.buildError ??
-    ((m: string, e: unknown): RunError => ({
-      message: m,
-      stack: e instanceof Error ? e.stack : undefined,
-    }));
-  const result = reduceEvents(events, { error: buildError(message, err) });
+  const result = reduceEvents(events, { error: resultError });
   if (opts.setFailedStatus !== false) result.status = opts.terminalStatus ?? "failed";
   if (usage !== undefined) result.usage = usage;
   opts.stamp?.(result, usage);

--- a/packages/afps-runtime/src/types/execution-context.ts
+++ b/packages/afps-runtime/src/types/execution-context.ts
@@ -120,7 +120,7 @@ export const executionContextSchema = z.object({
    * than letting the platform kill the container and surface a generic
    * abort. Absent ⇒ no runner-side enforcement (platform safety net only).
    */
-  timeoutSeconds: z.number().int().positive().optional(),
+  timeoutSeconds: z.number().finite().positive().optional(),
 });
 
 export type ExecutionContext = z.infer<typeof executionContextSchema>;

--- a/packages/afps-runtime/src/types/execution-context.ts
+++ b/packages/afps-runtime/src/types/execution-context.ts
@@ -109,6 +109,18 @@ export const executionContextSchema = z.object({
   // Reproducibility knobs
   dryRun: z.boolean().optional(),
   traceparent: z.string().optional(), // W3C Trace Context
+
+  /**
+   * Wall-clock execution budget for the run, in seconds. When set, the
+   * runner arms its OWN timeout watchdog measured from the moment
+   * `run()` starts — so container cold-start / boot is deliberately
+   * EXCLUDED from the budget (the platform arms a separate, longer safety
+   * net that folds in boot). On expiry the runner finalizes a `timeout`
+   * terminal with an explicit `Run timed out after Ns` message, rather
+   * than letting the platform kill the container and surface a generic
+   * abort. Absent ⇒ no runner-side enforcement (platform safety net only).
+   */
+  timeoutSeconds: z.number().int().positive().optional(),
 });
 
 export type ExecutionContext = z.infer<typeof executionContextSchema>;

--- a/packages/afps-runtime/test/runner/finalize-thrown-failure.test.ts
+++ b/packages/afps-runtime/test/runner/finalize-thrown-failure.test.ts
@@ -192,6 +192,64 @@ describe("finalizeThrownFailure", () => {
     expect(h.finalized?.usage).toEqual(USAGE);
   });
 
+  it("stamps `terminalStatus` instead of the default failed (runner-enforced timeout)", async () => {
+    const h = harness();
+    await finalizeThrownFailure({
+      events: [],
+      err: new Error("run timeout watchdog"),
+      signal: undefined,
+      runId: "run_timeout",
+      now: () => 1,
+      emit: h.emit,
+      drainAndEmit: h.drainAndEmit,
+      eventSink: h.eventSink,
+      usage: USAGE,
+      terminalStatus: "timeout",
+      buildError: () => ({ code: "timeout", message: "Run timed out after 5s" }),
+      stamp: (result) => {
+        result.durationMs = 5000;
+      },
+    });
+
+    expect(h.finalized?.status).toBe("timeout");
+    expect(h.finalized?.error).toEqual({ code: "timeout", message: "Run timed out after 5s" });
+    expect(h.finalized?.durationMs).toBe(5000);
+  });
+
+  it("ignores `terminalStatus` when setFailedStatus:false (status stays unset)", async () => {
+    const h = harness();
+    await finalizeThrownFailure({
+      events: [],
+      err: new Error("e"),
+      signal: undefined,
+      runId: "run_ts_off",
+      now: () => 1,
+      emit: h.emit,
+      drainAndEmit: h.drainAndEmit,
+      eventSink: h.eventSink,
+      usage: USAGE,
+      setFailedStatus: false,
+      terminalStatus: "timeout",
+    });
+    expect(h.finalized?.status).toBeUndefined();
+  });
+
+  it("defaults the terminal status to failed when terminalStatus is omitted", async () => {
+    const h = harness();
+    await finalizeThrownFailure({
+      events: [],
+      err: new Error("boom"),
+      signal: undefined,
+      runId: "run_default",
+      now: () => 1,
+      emit: h.emit,
+      drainAndEmit: h.drainAndEmit,
+      eventSink: h.eventSink,
+      usage: USAGE,
+    });
+    expect(h.finalized?.status).toBe("failed");
+  });
+
   it("leaves usage unset when undefined is passed (Pi bridge-null path)", async () => {
     const h = harness();
     await finalizeThrownFailure({

--- a/packages/afps-runtime/test/runner/finalize-thrown-failure.test.ts
+++ b/packages/afps-runtime/test/runner/finalize-thrown-failure.test.ts
@@ -214,6 +214,10 @@ describe("finalizeThrownFailure", () => {
     expect(h.finalized?.status).toBe("timeout");
     expect(h.finalized?.error).toEqual({ code: "timeout", message: "Run timed out after 5s" });
     expect(h.finalized?.durationMs).toBe(5000);
+    expect(h.emitted[0]).toMatchObject({
+      type: "appstrate.error",
+      message: "Run timed out after 5s",
+    });
   });
 
   it("ignores `terminalStatus` when setFailedStatus:false (status stays unset)", async () => {

--- a/packages/afps-runtime/test/types/execution-context.test.ts
+++ b/packages/afps-runtime/test/types/execution-context.test.ts
@@ -39,8 +39,18 @@ describe("executionContextSchema", () => {
       },
       dryRun: false,
       traceparent: "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+      timeoutSeconds: 1.5,
     });
     expect(result.success).toBe(true);
+  });
+
+  it("rejects non-finite timeoutSeconds", () => {
+    const result = executionContextSchema.safeParse({
+      runId: "run_abc123",
+      input: {},
+      timeoutSeconds: Infinity,
+    });
+    expect(result.success).toBe(false);
   });
 
   it("rejects missing runId", () => {

--- a/packages/runner-claude/src/claude-agent-runner.ts
+++ b/packages/runner-claude/src/claude-agent-runner.ts
@@ -154,6 +154,11 @@ export class ClaudeAgentRunner implements Runner {
 
     const runId = context.runId;
     const now = this.opts.now ?? Date.now;
+    // Captured here, NOT at module/instance scope: the timeout budget is
+    // measured from the moment the run loop starts (boot/cold-start already
+    // behind us), so the `timeout` terminal reports an execution-window
+    // duration that lines up with the budget the user configured.
+    const runStart = now();
     const events: RunEvent[] = [];
     const emit = async (event: RunEvent): Promise<void> => {
       events.push(event);
@@ -218,6 +223,30 @@ export class ClaudeAgentRunner implements Runner {
       }, idleMs);
     };
 
+    // Hard timeout watchdog: an ABSOLUTE execution budget (unlike the idle
+    // watchdog, never re-armed) measured from `runStart`. Aborts the runner's
+    // OWN controller (never the AFPS `signal`) so `signal.aborted` stays false
+    // and the catch can stamp an explicit `timeout` terminal instead of taking
+    // `finalizeThrownFailure`'s abort-rethrow arm. The platform arms a longer
+    // safety-net timeout (this budget + a boot grace) that folds in cold-start;
+    // it only fires if this watchdog never gets a chance to (e.g. a wedged
+    // boot), in which case the platform synthesises the `timeout` terminal.
+    const timeoutSeconds = context.timeoutSeconds ?? 0;
+    let timedOut = false;
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+    const clearRunTimeout = (): void => {
+      if (timeoutTimer !== undefined) {
+        clearTimeout(timeoutTimer);
+        timeoutTimer = undefined;
+      }
+    };
+    if (timeoutSeconds > 0) {
+      timeoutTimer = setTimeout(() => {
+        timedOut = true;
+        controller.abort(new Error("claude-agent-runner: run timeout watchdog"));
+      }, timeoutSeconds * 1000);
+    }
+
     const queryOptions: Record<string, unknown> = {
       pathToClaudeCodeExecutable: this.opts.binaryPath,
       env: buildClaudeSdkEnv({
@@ -255,8 +284,38 @@ export class ClaudeAgentRunner implements Runner {
         armIdle(); // re-arm for the gap before the next message
       }
       clearIdle();
+      clearRunTimeout();
     } catch (err) {
       clearIdle();
+      clearRunTimeout();
+
+      // Runner-enforced timeout: surface a first-class `timeout` terminal
+      // (explicit status + `Run timed out after Ns` message + an
+      // execution-window duration) instead of a generic failure. Gated on
+      // `!signal.aborted` so a real cancellation that raced the watchdog still
+      // flows through the epilogue's abort-rethrow arm untouched.
+      if (timedOut && !signal?.aborted) {
+        await finalizeThrownFailure({
+          events,
+          err,
+          signal,
+          runId,
+          now,
+          emit,
+          drainAndEmit: () => drainAndEmit(true),
+          eventSink,
+          usage: mapper.liveUsageSnapshot(),
+          terminalStatus: "timeout",
+          buildError: () => ({
+            code: "timeout",
+            message: `Run timed out after ${timeoutSeconds}s`,
+          }),
+          stamp: (result) => {
+            result.durationMs = now() - runStart;
+          },
+        });
+        return;
+      }
       // A watchdog-fired abort throws an opaque SDK AbortError; translate it
       // into an explicit, actionable failure. Gated on `!signal.aborted` so a
       // real cancellation that raced the watchdog still flows through the

--- a/packages/runner-claude/test/claude-agent-runner.test.ts
+++ b/packages/runner-claude/test/claude-agent-runner.test.ts
@@ -375,5 +375,99 @@ describe("ClaudeAgentRunner — idle-stall watchdog", () => {
     expect(m.result).toBeNull();
   });
 });
+describe("ClaudeAgentRunner — timeout watchdog", () => {
+  // Same shape as the idle test's hanging query: yields an optional prelude,
+  // then blocks until the SDK's own AbortController (which BOTH watchdogs and a
+  // real cancel drive) fires, at which point it throws like the real SDK.
+  function hangingQuery(prelude: SdkRunMessage[] = []) {
+    const fn = (input: ClaudeQueryInput): AsyncIterable<SdkRunMessage> => {
+      const controller = (input.options as { abortController?: AbortController }).abortController;
+      return (async function* () {
+        for (const m of prelude) yield m;
+        await new Promise<void>((resolve) => {
+          const sig = controller?.signal;
+          if (!sig || sig.aborted) return resolve();
+          sig.addEventListener("abort", () => resolve(), { once: true });
+        });
+        throw new Error("aborted by SDK controller");
+      })();
+    };
+    return { fn };
+  }
+
+  it("fires the budget → finalizes a first-class `timeout` terminal (status + message + duration)", async () => {
+    const { fn } = hangingQuery();
+    const m = memorySink();
+    // Real clock so the execution-window duration is a positive measurement.
+    // `0.05` s → a 50ms watchdog (the field is seconds; the runner × 1000).
+    await new ClaudeAgentRunner(baseOpts({ query: fn, now: Date.now, idleTimeoutMs: 0 })).run({
+      context: { ...ctx, timeoutSeconds: 0.05 },
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+
+    expect(m.result?.status).toBe("timeout");
+    expect(m.result?.error?.code).toBe("timeout");
+    expect(m.result?.error?.message).toMatch(/timed out after/i);
+    // Duration is the runner-stamped execution window (from run() start), not
+    // left for the platform to infer as `now - startedAt` (which folds in boot).
+    expect(typeof m.result?.durationMs).toBe("number");
+    expect(m.result!.durationMs!).toBeGreaterThanOrEqual(0);
+    expect(m.events.some((e) => e.type === "appstrate.error")).toBe(true);
+  });
+
+  it("does not fire on a fast run even with a tiny budget (no false positive)", async () => {
+    const { fn } = fakeQuery([
+      { type: "assistant", message: { content: [{ type: "text", text: "quick" }] } },
+      {
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        duration_ms: 5,
+        usage: { input_tokens: 1, output_tokens: 1 },
+      },
+    ]);
+    const m = memorySink();
+    await new ClaudeAgentRunner(baseOpts({ query: fn })).run({
+      context: { ...ctx, timeoutSeconds: 0.05 },
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+    expect(m.result?.status).toBe("success");
+  });
+
+  it("a real cancel is NOT masked as a timeout (abort-rethrow arm wins, no finalize)", async () => {
+    const controller = new AbortController();
+    const fn = () =>
+      (async function* (): AsyncIterable<SdkRunMessage> {
+        yield { type: "assistant", message: { content: [{ type: "text", text: "step" }] } };
+        controller.abort();
+        throw new Error("aborted by signal");
+      })();
+    const m = memorySink();
+    await expect(
+      // Budget set generously so only the cancel fires — proving cancel
+      // precedence over the timeout terminal.
+      new ClaudeAgentRunner(baseOpts({ query: fn, idleTimeoutMs: 0 })).run({
+        context: { ...ctx, timeoutSeconds: 100 },
+        eventSink: m.sink,
+        bundle: undefined as never,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow();
+    expect(m.result).toBeNull();
+  });
+
+  it("no budget set → watchdog never arms (a completed run still succeeds)", async () => {
+    const { fn } = fakeQuery([{ type: "result", subtype: "success", is_error: false, usage: {} }]);
+    const m = memorySink();
+    await new ClaudeAgentRunner(baseOpts({ query: fn })).run({
+      context: ctx, // no timeoutSeconds
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+    expect(m.result?.status).toBe("success");
+  });
+});
 // `buildClaudeSdkEnv` is shared infra — its tests live in
 // `@appstrate/core` (test/claude-binary.test.ts).

--- a/packages/runner-pi/src/container-env.ts
+++ b/packages/runner-pi/src/container-env.ts
@@ -99,6 +99,15 @@ export interface RuntimePiEnvOptions {
    * Forwarded as `TRACEPARENT` env var, consumed by HttpSink at boot.
    */
   traceparent?: string;
+  /**
+   * Wall-clock execution budget for the run, in seconds. Forwarded as
+   * `AGENT_TIMEOUT_SECONDS`; the entrypoint surfaces it on
+   * `ExecutionContext.timeoutSeconds`, where the runner arms its own
+   * timeout watchdog (measured from the run loop start, so boot is
+   * excluded). Omitted when absent or non-positive — the platform's own
+   * container watchdog stays the only backstop.
+   */
+  timeoutSeconds?: number;
 }
 
 /**
@@ -128,6 +137,13 @@ export function buildRuntimePiEnv(opts: RuntimePiEnvOptions): Record<string, str
 
   if (opts.runId) env.AGENT_RUN_ID = opts.runId;
   if (opts.agentInput !== undefined) env.AGENT_INPUT = JSON.stringify(opts.agentInput);
+  if (
+    opts.timeoutSeconds !== undefined &&
+    Number.isInteger(opts.timeoutSeconds) &&
+    opts.timeoutSeconds > 0
+  ) {
+    env.AGENT_TIMEOUT_SECONDS = String(opts.timeoutSeconds);
+  }
 
   // MODEL_BASE_URL tells the Pi SDK where to send inference. Two cases set it:
   //   1. Sidecar-backed run — point at the sidecar LLM proxy, which injects the

--- a/packages/runner-pi/src/container-env.ts
+++ b/packages/runner-pi/src/container-env.ts
@@ -139,7 +139,7 @@ export function buildRuntimePiEnv(opts: RuntimePiEnvOptions): Record<string, str
   if (opts.agentInput !== undefined) env.AGENT_INPUT = JSON.stringify(opts.agentInput);
   if (
     opts.timeoutSeconds !== undefined &&
-    Number.isInteger(opts.timeoutSeconds) &&
+    Number.isFinite(opts.timeoutSeconds) &&
     opts.timeoutSeconds > 0
   ) {
     env.AGENT_TIMEOUT_SECONDS = String(opts.timeoutSeconds);

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -248,9 +248,72 @@ export class PiRunner implements Runner {
       }
     };
 
+    // Hard timeout watchdog. An internal controller fires on EITHER the AFPS
+    // `signal` (cancellation, forwarded below) OR this run's wall-clock budget,
+    // measured from `runStart` (boot/cold-start already excluded — the platform
+    // arms a longer safety net that folds it in). `executeSession` races the
+    // prompt against THIS combined signal, but `finalizeThrownFailure` still
+    // inspects the ORIGINAL `signal`: a real cancel (signal.aborted) takes the
+    // abort-rethrow arm; a timeout (signal.aborted === false) finalizes a
+    // first-class `timeout` terminal in the catch below.
+    const runStart = Date.now();
+    const timeoutSeconds = context.timeoutSeconds ?? 0;
+    let timedOut = false;
+    const runController = new AbortController();
+    const forwardAbort = (): void => runController.abort(signal?.reason);
+    if (signal) {
+      if (signal.aborted) runController.abort(signal.reason);
+      else signal.addEventListener("abort", forwardAbort, { once: true });
+    }
+    let timeoutTimer: ReturnType<typeof setTimeout> | undefined;
+    if (timeoutSeconds > 0) {
+      timeoutTimer = setTimeout(() => {
+        timedOut = true;
+        runController.abort(new Error("pi-runner: run timeout watchdog"));
+      }, timeoutSeconds * 1000);
+    }
+    const clearRunTimeout = (): void => {
+      if (timeoutTimer !== undefined) {
+        clearTimeout(timeoutTimer);
+        timeoutTimer = undefined;
+      }
+      if (signal) signal.removeEventListener("abort", forwardAbort);
+    };
+
     try {
-      await this.executeSession(context, internalSink, signal, captureBridge);
+      await this.executeSession(context, internalSink, runController.signal, captureBridge);
     } catch (err) {
+      clearRunTimeout();
+
+      // Runner-enforced timeout: a first-class `timeout` terminal (explicit
+      // status + `Run timed out after Ns` message + an execution-window
+      // duration), distinct from the generic failure epilogue below. Gated on
+      // `!signal.aborted` so a real cancellation racing the watchdog still
+      // takes `finalizeThrownFailure`'s abort-rethrow arm.
+      if (timedOut && !signal?.aborted) {
+        const bridge = bridgeRef.current;
+        await finalizeThrownFailure({
+          events,
+          err,
+          signal,
+          runId,
+          now: Date.now,
+          emit,
+          drainAndEmit: () => bridge?.drainPending() ?? Promise.resolve(),
+          eventSink,
+          usage: bridge ? bridge.getUsage() : undefined,
+          terminalStatus: "timeout",
+          buildError: () => ({
+            code: "timeout",
+            message: `Run timed out after ${timeoutSeconds}s`,
+          }),
+          stamp: (result) => {
+            if (bridge) result.cost = bridge.getCost();
+            result.durationMs = Date.now() - runStart;
+          },
+        });
+        return;
+      }
       // Shared thrown-failure epilogue (abort-rethrow → emit appstrate.error →
       // best-effort drain → reduce → stamp usage/cost → finalize). The Pi runner
       // leaves `status` unset on this path (setFailedStatus: false, preserved
@@ -278,6 +341,8 @@ export class PiRunner implements Runner {
       });
       return;
     }
+    // Session ran to completion — stand the timeout watchdog down.
+    clearRunTimeout();
 
     // Authoritative terminal verdict, captured by the bridge while it
     // streamed `message_end` events. When the agent loop ended on an

--- a/packages/runner-pi/test/container-env.test.ts
+++ b/packages/runner-pi/test/container-env.test.ts
@@ -29,6 +29,23 @@ describe("buildRuntimePiEnv", () => {
     expect(env.MODEL_API_KEY).toBeUndefined();
   });
 
+  it("emits AGENT_TIMEOUT_SECONDS only for a positive integer budget", () => {
+    expect(buildRuntimePiEnv({ model, agentPrompt: "p" }).AGENT_TIMEOUT_SECONDS).toBeUndefined();
+    expect(
+      buildRuntimePiEnv({ model, agentPrompt: "p", timeoutSeconds: 300 }).AGENT_TIMEOUT_SECONDS,
+    ).toBe("300");
+    // Non-positive / non-integer budgets are dropped (no enforcement key).
+    expect(
+      buildRuntimePiEnv({ model, agentPrompt: "p", timeoutSeconds: 0 }).AGENT_TIMEOUT_SECONDS,
+    ).toBeUndefined();
+    expect(
+      buildRuntimePiEnv({ model, agentPrompt: "p", timeoutSeconds: -5 }).AGENT_TIMEOUT_SECONDS,
+    ).toBeUndefined();
+    expect(
+      buildRuntimePiEnv({ model, agentPrompt: "p", timeoutSeconds: 1.5 }).AGENT_TIMEOUT_SECONDS,
+    ).toBeUndefined();
+  });
+
   it("omits RUN_ENGINE for Pi (byte-identical) and emits it only for claude", () => {
     expect(buildRuntimePiEnv({ model, agentPrompt: "p" }).RUN_ENGINE).toBeUndefined();
     expect(buildRuntimePiEnv({ model, agentPrompt: "p", engine: "pi" }).RUN_ENGINE).toBeUndefined();

--- a/packages/runner-pi/test/container-env.test.ts
+++ b/packages/runner-pi/test/container-env.test.ts
@@ -29,12 +29,15 @@ describe("buildRuntimePiEnv", () => {
     expect(env.MODEL_API_KEY).toBeUndefined();
   });
 
-  it("emits AGENT_TIMEOUT_SECONDS only for a positive integer budget", () => {
+  it("emits AGENT_TIMEOUT_SECONDS only for a positive finite budget", () => {
     expect(buildRuntimePiEnv({ model, agentPrompt: "p" }).AGENT_TIMEOUT_SECONDS).toBeUndefined();
     expect(
       buildRuntimePiEnv({ model, agentPrompt: "p", timeoutSeconds: 300 }).AGENT_TIMEOUT_SECONDS,
     ).toBe("300");
-    // Non-positive / non-integer budgets are dropped (no enforcement key).
+    expect(
+      buildRuntimePiEnv({ model, agentPrompt: "p", timeoutSeconds: 1.5 }).AGENT_TIMEOUT_SECONDS,
+    ).toBe("1.5");
+    // Non-positive / non-finite budgets are dropped (no enforcement key).
     expect(
       buildRuntimePiEnv({ model, agentPrompt: "p", timeoutSeconds: 0 }).AGENT_TIMEOUT_SECONDS,
     ).toBeUndefined();
@@ -42,7 +45,8 @@ describe("buildRuntimePiEnv", () => {
       buildRuntimePiEnv({ model, agentPrompt: "p", timeoutSeconds: -5 }).AGENT_TIMEOUT_SECONDS,
     ).toBeUndefined();
     expect(
-      buildRuntimePiEnv({ model, agentPrompt: "p", timeoutSeconds: 1.5 }).AGENT_TIMEOUT_SECONDS,
+      buildRuntimePiEnv({ model, agentPrompt: "p", timeoutSeconds: Infinity })
+        .AGENT_TIMEOUT_SECONDS,
     ).toBeUndefined();
   });
 

--- a/packages/runner-pi/test/pi-runner.test.ts
+++ b/packages/runner-pi/test/pi-runner.test.ts
@@ -363,6 +363,88 @@ describe("PiRunner.run — cancellation", () => {
   });
 });
 
+describe("PiRunner.run — timeout watchdog", () => {
+  it("fires the budget → finalizes a first-class `timeout` terminal (status + message + duration)", async () => {
+    const sink = createCaptureSink();
+    // The scripted session waits on the COMBINED signal executeSession is
+    // handed (the watchdog drives it); on abort it throws like a cancelled
+    // prompt. `0.05`s → a 50ms watchdog (the field is seconds; runner × 1000).
+    const runner = new ScriptedPiRunner(async (_session, _ctx, signal) => {
+      await new Promise<void>((resolve) => {
+        if (signal?.aborted) return resolve();
+        signal?.addEventListener("abort", () => resolve(), { once: true });
+      });
+      throw signal?.reason ?? new Error("aborted");
+    });
+
+    await runner.run({
+      bundle: STUB_BUNDLE,
+      context: makeContext({ timeoutSeconds: 0.05 }),
+      eventSink: sink,
+    });
+
+    expect(sink.finalized?.status).toBe("timeout");
+    expect(sink.finalized?.error?.code).toBe("timeout");
+    expect(sink.finalized?.error?.message).toMatch(/timed out after/i);
+    expect(typeof sink.finalized?.durationMs).toBe("number");
+    expect(sink.finalized!.durationMs!).toBeGreaterThanOrEqual(0);
+  });
+
+  it("does not fire on a fast run even with a budget set (no false positive)", async () => {
+    const sink = createCaptureSink();
+    const runner = new ScriptedPiRunner(async (session) => {
+      session.emit({ type: "message_end" });
+      session.emit({ type: "agent_end" });
+    });
+
+    await runner.run({
+      bundle: STUB_BUNDLE,
+      context: makeContext({ timeoutSeconds: 100 }),
+      eventSink: sink,
+    });
+
+    expect(sink.finalized?.status).toBe("success");
+  });
+
+  it("a real cancel is NOT masked as a timeout (rethrows, no finalize)", async () => {
+    const sink = createCaptureSink();
+    const controller = new AbortController();
+    // Budget set generously so only the cancel fires.
+    const runner = new ScriptedPiRunner(async (_session, _ctx, signal) => {
+      controller.abort(new Error("user cancelled"));
+      await Promise.resolve();
+      if (signal?.aborted) throw signal.reason ?? new Error("cancelled");
+    });
+
+    await expect(
+      runner.run({
+        bundle: STUB_BUNDLE,
+        context: makeContext({ timeoutSeconds: 100 }),
+        eventSink: sink,
+        signal: controller.signal,
+      }),
+    ).rejects.toBeDefined();
+
+    expect(sink.finalizeCalls).toBe(0);
+  });
+
+  it("no budget set → watchdog never arms (a completed run still succeeds)", async () => {
+    const sink = createCaptureSink();
+    const runner = new ScriptedPiRunner(async (session) => {
+      session.emit({ type: "message_end" });
+      session.emit({ type: "agent_end" });
+    });
+
+    await runner.run({
+      bundle: STUB_BUNDLE,
+      context: makeContext(), // no timeoutSeconds
+      eventSink: sink,
+    });
+
+    expect(sink.finalized?.status).toBe("success");
+  });
+});
+
 describe("PiRunner.run — Runner contract", () => {
   it("implements Runner.name", () => {
     const runner = new ScriptedPiRunner(async () => {});

--- a/runtime-pi/entrypoint.ts
+++ b/runtime-pi/entrypoint.ts
@@ -668,6 +668,11 @@ const context: ExecutionContext = {
   input: env.agentInput,
   memories: [],
   config: {},
+  // When the platform forwarded a budget, the runner enforces it itself
+  // (watchdog from the run-loop start, boot excluded) and finalizes a
+  // first-class `timeout` terminal — instead of waiting for the platform's
+  // safety-net container kill, which can only surface a generic abort.
+  ...(env.timeoutSeconds !== undefined ? { timeoutSeconds: env.timeoutSeconds } : {}),
 };
 
 // --- 5. Resolve bundle for PiRunner (fallback to synthetic when no .afps) ---
@@ -842,6 +847,19 @@ try {
 } catch (err) {
   heartbeat.stop();
   await mcpClient?.close().catch(() => {});
+
+  // External abort (SIGTERM/SIGINT = platform timeout safety-net or a user
+  // cancel). The runner already honours this by rethrowing WITHOUT finalizing
+  // (`finalizeThrownFailure`'s abort-rethrow arm) — and only the platform knows
+  // WHICH terminal cause it was. Finalizing `failed` + the SDK's generic
+  // "operation was aborted" message here would win the finalize CAS and mask
+  // the platform's authoritative `timeout`/`cancelled` synthesis. So we must
+  // NOT finalize (nor emit a spurious adapter_error): just exit non-zero and
+  // let `execute-background` synthesise the real terminal state.
+  if (runAbort.signal.aborted) {
+    process.exit(1);
+  }
+
   const message = getErrorMessage(err);
   await emitError(message);
   try {

--- a/runtime-pi/env.ts
+++ b/runtime-pi/env.ts
@@ -203,6 +203,21 @@ function parsePositiveInt(
   return n;
 }
 
+function parsePositiveNumber(
+  name: string,
+  raw: string | undefined,
+  fallback: number,
+  issues: string[],
+): number {
+  if (!raw) return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    issues.push(`${name}: must be a positive finite number (got "${raw}")`);
+    return fallback;
+  }
+  return n;
+}
+
 /**
  * Parse + validate the runtime-pi env vars from a source object.
  *
@@ -283,10 +298,10 @@ export function parseRuntimeEnv(source: NodeJS.ProcessEnv = process.env): Runtim
     DEFAULT_MCP_CONNECT_DEADLINE_MS,
     issues,
   );
-  // Optional: a 0 fallback means "absent" (parsePositiveInt only returns it
+  // Optional: a 0 fallback means "absent" (parsePositiveNumber only returns it
   // for a missing var, or after pushing an issue for a malformed one). We map
   // 0 → undefined so an absent budget leaves runner-side enforcement off.
-  const agentTimeoutSeconds = parsePositiveInt(
+  const agentTimeoutSeconds = parsePositiveNumber(
     "AGENT_TIMEOUT_SECONDS",
     source.AGENT_TIMEOUT_SECONDS,
     0,

--- a/runtime-pi/env.ts
+++ b/runtime-pi/env.ts
@@ -51,6 +51,13 @@ export interface RuntimeEnv {
   sidecarUrl?: string;
   /** Heartbeat ping interval (ms). */
   heartbeatIntervalMs: number;
+  /**
+   * Wall-clock execution budget for the run, in seconds. Surfaced on
+   * `ExecutionContext.timeoutSeconds`; the runner arms its own timeout
+   * watchdog from it (boot excluded). Absent when the platform did not
+   * forward `AGENT_TIMEOUT_SECONDS` — no runner-side enforcement.
+   */
+  timeoutSeconds?: number;
   /** Optional output JSON schema for constrained decoding (raw string — Pi SDK consumes it directly). */
   outputSchemaRaw?: string;
   /**
@@ -276,6 +283,15 @@ export function parseRuntimeEnv(source: NodeJS.ProcessEnv = process.env): Runtim
     DEFAULT_MCP_CONNECT_DEADLINE_MS,
     issues,
   );
+  // Optional: a 0 fallback means "absent" (parsePositiveInt only returns it
+  // for a missing var, or after pushing an issue for a malformed one). We map
+  // 0 → undefined so an absent budget leaves runner-side enforcement off.
+  const agentTimeoutSeconds = parsePositiveInt(
+    "AGENT_TIMEOUT_SECONDS",
+    source.AGENT_TIMEOUT_SECONDS,
+    0,
+    issues,
+  );
 
   if (issues.length > 0) throw new RuntimeEnvError(issues);
 
@@ -296,6 +312,7 @@ export function parseRuntimeEnv(source: NodeJS.ProcessEnv = process.env): Runtim
     sink: { url: sinkUrl!, finalizeUrl: sinkFinalizeUrl!, secret: sinkSecret! },
     sidecarUrl: sidecarUrl || undefined,
     heartbeatIntervalMs,
+    timeoutSeconds: agentTimeoutSeconds > 0 ? agentTimeoutSeconds : undefined,
     mcpConnectDeadlineMs,
     outputSchemaRaw: source.OUTPUT_SCHEMA || undefined,
     traceparent: source.TRACEPARENT || undefined,

--- a/runtime-pi/test/env.test.ts
+++ b/runtime-pi/test/env.test.ts
@@ -35,6 +35,12 @@ describe("parseRuntimeEnv — happy path", () => {
     expect(env.sidecarUrl).toBeUndefined();
     expect(env.modelApiKey).toBeUndefined();
     expect(env.outputSchemaRaw).toBeUndefined();
+    expect(env.timeoutSeconds).toBeUndefined();
+  });
+
+  it("parses AGENT_TIMEOUT_SECONDS into env.timeoutSeconds", () => {
+    const env = parseRuntimeEnv({ ...VALID, AGENT_TIMEOUT_SECONDS: "300" });
+    expect(env.timeoutSeconds).toBe(300);
   });
 
   it("parses optional fields when set", () => {
@@ -173,6 +179,15 @@ describe("parseRuntimeEnv — fail-fast errors", () => {
 
   it("rejects malformed SIDECAR_URL", () => {
     expect(() => parseRuntimeEnv({ ...VALID, SIDECAR_URL: "weird://x" })).toThrow(/SIDECAR_URL/);
+  });
+
+  it("rejects a non-positive-integer AGENT_TIMEOUT_SECONDS", () => {
+    expect(() => parseRuntimeEnv({ ...VALID, AGENT_TIMEOUT_SECONDS: "0" })).toThrow(
+      /AGENT_TIMEOUT_SECONDS: must be a positive integer/,
+    );
+    expect(() => parseRuntimeEnv({ ...VALID, AGENT_TIMEOUT_SECONDS: "1.5" })).toThrow(
+      /AGENT_TIMEOUT_SECONDS: must be a positive integer/,
+    );
   });
 
   it("error message lists every issue (not just the first)", () => {

--- a/runtime-pi/test/env.test.ts
+++ b/runtime-pi/test/env.test.ts
@@ -39,8 +39,8 @@ describe("parseRuntimeEnv — happy path", () => {
   });
 
   it("parses AGENT_TIMEOUT_SECONDS into env.timeoutSeconds", () => {
-    const env = parseRuntimeEnv({ ...VALID, AGENT_TIMEOUT_SECONDS: "300" });
-    expect(env.timeoutSeconds).toBe(300);
+    const env = parseRuntimeEnv({ ...VALID, AGENT_TIMEOUT_SECONDS: "1.5" });
+    expect(env.timeoutSeconds).toBe(1.5);
   });
 
   it("parses optional fields when set", () => {
@@ -181,12 +181,12 @@ describe("parseRuntimeEnv — fail-fast errors", () => {
     expect(() => parseRuntimeEnv({ ...VALID, SIDECAR_URL: "weird://x" })).toThrow(/SIDECAR_URL/);
   });
 
-  it("rejects a non-positive-integer AGENT_TIMEOUT_SECONDS", () => {
+  it("rejects a non-positive or non-finite AGENT_TIMEOUT_SECONDS", () => {
     expect(() => parseRuntimeEnv({ ...VALID, AGENT_TIMEOUT_SECONDS: "0" })).toThrow(
-      /AGENT_TIMEOUT_SECONDS: must be a positive integer/,
+      /AGENT_TIMEOUT_SECONDS: must be a positive finite number/,
     );
-    expect(() => parseRuntimeEnv({ ...VALID, AGENT_TIMEOUT_SECONDS: "1.5" })).toThrow(
-      /AGENT_TIMEOUT_SECONDS: must be a positive integer/,
+    expect(() => parseRuntimeEnv({ ...VALID, AGENT_TIMEOUT_SECONDS: "Infinity" })).toThrow(
+      /AGENT_TIMEOUT_SECONDS: must be a positive finite number/,
     );
   });
 


### PR DESCRIPTION
## Problème

Un run qui atteint son timeout finalisait en `failed` avec le message **"The operation was aborted."** au lieu de `timeout` / "Run timed out after Ns". En plus, la durée affichée (`duration`) excluait le cold-start du container tandis que l'horloge du timeout l'incluait → un agent à 5s n'avait réellement que ~2.7s d'exécution, et `duration` (2.6s) ne correspondait pas à la fenêtre du timeout (5s).

Diagnostiqué sur un run local `@pierre-cabriere/ping` (timeout manifest = 5s) : `status=failed`, `error="The operation was aborted."`, `duration=2611ms`, wall ≈ 6.4s = `2315ms boot + 2611ms exécution ≈ 5000ms`.

## Causes racines

1. **Mauvais label.** Sur SIGTERM (timeout *ou* cancel) le runner rethrow **sans finaliser** (bras abort de `finalizeThrownFailure`). Mais le catch top-level de l'entrypoint finalisait quand même `failed` + le message générique du SDK → il gagnait le CAS `sink_closed_at IS NULL` et masquait la synthèse plateforme autoritative (`timeout`/`cancelled`).
2. **Boot dans le budget.** Le timeout plateforme était armé à `startWorkload` (avant la fin du boot), donc le budget incluait le cold-start ; `duration` était mesuré depuis le démarrage de `runner.run()`.

## Correctif — le runner possède le budget primaire (boot exclu)

- Plomberie `timeoutSeconds` : `plan.timeout` → `AGENT_TIMEOUT_SECONDS` → `ExecutionContext.timeoutSeconds`.
- **runner-claude** + **runner-pi** arment leur propre watchdog timeout depuis le début de `run()` (boot exclu). Il abort le controller *propre* du runner (le signal AFPS reste non-aborté) et finalise un terminal `timeout` de première classe : status explicite, message "Run timed out after Ns", et `durationMs` = fenêtre d'exécution.
- `finalizeThrownFailure` gagne un `terminalStatus` optionnel (défaut `"failed"`) pour stamper `timeout`.
- Le catch de l'entrypoint **skip la finalize** (et l'`adapter_error` parasite) sur abort externe → `execute-background` synthétise le vrai terminal.
- Le `setTimeout` plateforme devient un **filet de sécurité** à `plan.timeout + PLATFORM_TIMEOUT_BOOT_GRACE_MS` (90s, injectable via `timeoutBootGraceMs`) — couvre un container coincé en boot ou un runner mort sans finaliser.

## Sémantique résultante

| | Avant | Après |
|---|---|---|
| Statut au timeout | `failed` | `timeout` |
| Message | "The operation was aborted." | "Run timed out after Ns" |
| Budget timeout | wall incl. boot | exécution agent (boot exclu) |
| `duration` vs budget | incohérent | même fenêtre |

## Tests

- runner-claude + runner-pi : watchdog timeout (fire → `timeout` ; pas de faux positif sur run rapide ; cancel **non** masqué en timeout ; budget absent → pas d'armement).
- `finalizeThrownFailure` : `terminalStatus` (timeout / ignoré si `setFailedStatus:false` / défaut failed).
- container-env : émission `AGENT_TIMEOUT_SECONDS` (entier positif uniquement).
- runtime-pi env reader : parse + rejet non-entier-positif.
- platform safety-net : le grace repousse le net au-delà du budget brut / fire au budget avec grace 0.

`bun run check` ✅ (33/33). Suites runner ✅ (243). Intégration run-launcher ✅ (8/8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)