### PR TITLE
feat(mcp): serve system skills via load_skill on the platform MCP server

### DIFF
--- a/apps/api/src/modules/mcp/assistant-skills.ts
+++ b/apps/api/src/modules/mcp/assistant-skills.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * System skills exposed by the platform MCP server.
+ *
+ * These `SKILL.md` files ship in `skills/` next to this module's code, so they
+ * are present on EVERY instance with zero import, zero DB. The MCP server lists
+ * a short index of them in its `instructions` and serves the full body on demand
+ * via the `load_skill` tool (progressive disclosure). Because they live on the
+ * platform MCP surface, EVERY orchestrator-level MCP consumer inherits them: the
+ * built-in chat (both engines) AND any external MCP client (Claude Code, …)
+ * connected to `/api/mcp/o/:org`. Sandboxed run agents reach only the sidecar
+ * MCP server, never this one — so they never see these skills (that is the org
+ * `dependencies.skills` path instead).
+ *
+ * They drive the ASSISTANT/orchestrator, not the agents. The whitelist is the
+ * folder itself — `load_skill` can only ever read a SKILL.md shipped here.
+ *
+ * Format = Anthropic Agent Skills (same as Claude Code): YAML frontmatter
+ * (`name` / `description`) + markdown body, plus optional `references/*.md`
+ * loaded on demand (disclosure level 3).
+ */
+
+import { join, resolve, sep } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { extractSkillMeta } from "@appstrate/core/validation";
+import { logger } from "../../lib/logger.ts";
+
+/** Skill names / reference ids are folder/file slugs — kebab-case only. The
+ * guard is what makes path traversal impossible: a value that isn't a bare slug
+ * never reaches the filesystem. */
+const SLUG = /^[a-z0-9][a-z0-9-]*$/;
+
+/** `skills/` sits beside this file in the module. apps/api runs from source
+ * under Bun, so `import.meta.dir` is this module's directory at runtime. */
+const skillsDir = resolve(import.meta.dir, "skills");
+
+export interface AssistantSkillMeta {
+  name: string;
+  description: string;
+}
+
+let cachedIndex: AssistantSkillMeta[] | null = null;
+
+/**
+ * Scan `skills/<name>/SKILL.md` and parse each frontmatter into {name,
+ * description}. Cached after the first call (the folder is static per deploy).
+ * A folder whose name disagrees with its frontmatter `name`, or whose
+ * description is empty, is skipped with a warning rather than poisoning the
+ * index. Returns `[]` when the folder is absent (degrades, never throws).
+ */
+export function listAssistantSkills(): AssistantSkillMeta[] {
+  if (cachedIndex) return cachedIndex;
+  const out: AssistantSkillMeta[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(skillsDir);
+  } catch {
+    cachedIndex = out;
+    return out;
+  }
+  for (const name of entries.sort()) {
+    if (!SLUG.test(name)) continue;
+    const file = join(skillsDir, name, "SKILL.md");
+    if (!existsSync(file)) continue;
+    try {
+      const { name: fmName, description } = extractSkillMeta(readFileSync(file, "utf8"));
+      if (fmName !== name) {
+        logger.warn("assistant skill name mismatch — skipped", {
+          folder: name,
+          frontmatter: fmName,
+        });
+        continue;
+      }
+      if (!description) {
+        logger.warn("assistant skill missing description — skipped", { name });
+        continue;
+      }
+      out.push({ name, description });
+    } catch (err) {
+      logger.warn("assistant skill unreadable — skipped", { name, err: String(err) });
+    }
+  }
+  cachedIndex = out;
+  return out;
+}
+
+/**
+ * Render the `## Assistant skills` block for the MCP server `instructions`, or
+ * "" when none are loadable. Injected BEFORE the operation index so it survives
+ * the chat's Mistral instruction-trim (which cuts from `## Operation index`).
+ */
+export function renderAssistantSkillsIndex(): string {
+  const skills = listAssistantSkills();
+  if (!skills.length) return "";
+  const lines = [
+    "## Assistant skills",
+    "Beyond the API operations, this instance ships skills that guide YOU on how to operate it. " +
+      "When the user's intent matches one, call the `load_skill` tool with its name to read it in " +
+      "full, then follow it before acting. A skill may point to a `references/<ref>.md` — load it " +
+      "with `load_skill({ name, reference })`.",
+  ];
+  for (const s of skills) lines.push(`- \`${s.name}\` — ${s.description}`);
+  return lines.join("\n");
+}
+
+/**
+ * Read a skill body, or one of its references when `reference` is given. Returns
+ * `null` when the (validated) target doesn't exist. Both args are checked
+ * against the slug guard AND the scanned whitelist, and the resolved path is
+ * asserted to stay under `skills/` — a request can only ever read code shipped
+ * with the module.
+ */
+export function loadAssistantSkill(name: string, reference?: string): { content: string } | null {
+  if (!SLUG.test(name)) return null;
+  if (!listAssistantSkills().some((s) => s.name === name)) return null;
+
+  let target: string;
+  if (reference !== undefined) {
+    if (!SLUG.test(reference)) return null;
+    target = join(skillsDir, name, "references", `${reference}.md`);
+  } else {
+    target = join(skillsDir, name, "SKILL.md");
+  }
+
+  // Defence in depth: even with the slug guard, never read outside skills/.
+  const resolved = resolve(target);
+  if (resolved !== skillsDir && !resolved.startsWith(skillsDir + sep)) return null;
+  if (!existsSync(resolved)) return null;
+
+  try {
+    return { content: readFileSync(resolved, "utf8") };
+  } catch (err) {
+    logger.warn("assistant skill read failed", { name, reference, err: String(err) });
+    return null;
+  }
+}
+
+/** Test hook: drop the cached index so a fresh scan runs on the next call. */
+export function resetAssistantSkillsCache(): void {
+  cachedIndex = null;
+}

--- a/apps/api/src/modules/mcp/router.ts
+++ b/apps/api/src/modules/mcp/router.ts
@@ -48,6 +48,7 @@ import { dispatchInProcess } from "../../lib/platform-app.ts";
 import { getMcpOrgResourceUri, orgIdFromMcpAudience } from "./audiences.ts";
 import { buildMcpTools, FORWARDED_AUTH_HEADERS, type Dispatch, type McpObserver } from "./tools.ts";
 import { buildOperationIndex } from "./catalog.ts";
+import { renderAssistantSkillsIndex } from "./assistant-skills.ts";
 
 const MCP_SERVER_VERSION = "1.0.0";
 /** Path prefix owning the per-org sub-tree. `:org` is the organization id. */
@@ -133,6 +134,11 @@ function buildServerInstructions(
   const grounding = contextInjected
     ? "Your caller context — who you are acting for, your role in this organization, and which integrations are already connected (prefer those when building or configuring an agent) — is already provided to you; there is no get_me tool, do not look for one."
     : "Start by calling get_me to learn who you are acting for, your role in this organization, and which integrations are already connected (prefer those when building or configuring an agent).";
+  // The `## Assistant skills` index (system skills shipped with this module,
+  // served by the load_skill tool). Placed BEFORE the operation index so it
+  // survives the chat's Mistral instruction-trim, which cuts from
+  // `## Operation index` onward. Empty string when no skills folder.
+  const skillsIndex = renderAssistantSkillsIndex();
   return `Appstrate runs autonomous AI agents in sandboxed Docker containers. The tools here let you discover and call any operation of the Appstrate REST API — their own descriptions tell you how. ${grounding} The operation index at the end of these instructions lists the operations available to your role by tag; it is your primary way to find an operation. Default to picking an operationId straight from that index, then call describe_operation for its input schema and invoke_operation to run it. Reach for search_operations only when the index is genuinely ambiguous or a capability you expect isn't listed — not as a routine first step. Never guess an operationId or body shape: describe_operation (or search_operations' best_match) is the source of truth for the input schema. Exception: when you need to launch or wait on an agent run, do not call runAgent, runInline, or getRun through invoke_operation; use the run_and_wait tool directly.
 
 ## Core model
@@ -151,7 +157,7 @@ This MCP server is scoped to ONE organization — the one this endpoint serves �
 - Integration preference — when a task needs an integration, prefer in order: (1) one the caller has already connected (listed in your caller context / get_me — connecting it was an explicit choice), then (2) one that is activated for this application but not yet connected, then (3) one that is neither. \`GET /api/integrations\` lists every integration with an \`active\` flag (activated for this app) and \`block_user_connections\`; use it to tell tiers 2 and 3 apart. Do not silently activate or connect an integration the caller did not ask for — surface that it would be needed and let them decide.
 - Connecting or reconnecting an integration before a run — an integration may be unconnected, expired, needs-reconnection, under-scoped, or otherwise unusable. Do NOT pre-validate just to launch a "do it now" inline run: \`run_and_wait\` already runs the same readiness preflight and returns a 400 without consuming credits when the manifest cannot run. If \`run_and_wait\` fails with field errors whose \`field\` is \`integrations.<id>\` (or if you intentionally call \`validateInlineRun\` only to iterate/check readiness without launching), that integration is not ready — whatever the \`code\` (\`not_connected\`, \`needs_reconnection\`, \`insufficient_scopes\`, \`auth_key_mismatch\`, …). For each such error you MUST start its connect flow (do not just describe it): CALL \`invoke_operation\` with \`operation_id: "initiateIntegrationConnect"\`, \`path_params: { packageId: "<id>", authKey: "<key>" }\` (the auth key is in \`manifest.auths\` of the integration row from \`GET /api/integrations\`). This op is auth-type-agnostic — it works for every auth (oauth2, api_key, basic, mtls, custom), so you never inspect the auth type yourself. If the error carries a \`connection_id\`, also pass \`body: { connection_id: "<that id>" }\` so the existing connection is reconnected/upgraded in place instead of duplicated. This tool call is what renders the one-click connect button (from its result); without it there is NO button, so never claim a button will appear unless you just made this exact call this turn. After the call, the client renders the connect button on its own from your tool result — your text must NOT duplicate it: do NOT paste the returned \`connect_url\`, do NOT describe the button or tell the caller where to click, do NOT restate the connection request. End your turn with ONE short sentence saying you'll continue once the integration is connected — do NOT poll, loop, wait, or run in the same turn. On a later turn, call \`run_and_wait\` again (or \`validateInlineRun\` if you are only checking readiness); when readiness passes, proceed with the run. (Non-interactive clients with no button can open the returned \`connect_url\`.)
 
-${OPERATION_INDEX_HEADING}
+${skillsIndex ? `${skillsIndex}\n\n` : ""}${OPERATION_INDEX_HEADING}
 ${buildOperationIndex(permissions)}`;
 }
 

--- a/apps/api/src/modules/mcp/router.ts
+++ b/apps/api/src/modules/mcp/router.ts
@@ -48,6 +48,7 @@ import { dispatchInProcess } from "../../lib/platform-app.ts";
 import { getMcpOrgResourceUri, orgIdFromMcpAudience } from "./audiences.ts";
 import { buildMcpTools, FORWARDED_AUTH_HEADERS, type Dispatch, type McpObserver } from "./tools.ts";
 import { buildOperationIndex } from "./catalog.ts";
+import { renderAssistantSkillsIndex } from "./assistant-skills.ts";
 
 const MCP_SERVER_VERSION = "1.0.0";
 /** Path prefix owning the per-org sub-tree. `:org` is the organization id. */
@@ -133,6 +134,11 @@ function buildServerInstructions(
   const grounding = contextInjected
     ? "Your caller context — who you are acting for, your role in this organization, and which integrations are already connected (prefer those when building or configuring an agent) — is already provided to you; there is no get_me tool, do not look for one."
     : "Start by calling get_me to learn who you are acting for, your role in this organization, and which integrations are already connected (prefer those when building or configuring an agent).";
+  // The `## Assistant skills` index (system skills shipped with this module,
+  // served by the load_skill tool). Placed BEFORE the operation index so it
+  // survives the chat's Mistral instruction-trim, which cuts from
+  // `## Operation index` onward. Empty string when no skills folder.
+  const skillsIndex = renderAssistantSkillsIndex();
   return `Appstrate runs autonomous AI agents in sandboxed Docker containers. The tools here let you discover and call any operation of the Appstrate REST API — their own descriptions tell you how. ${grounding} The operation index at the end of these instructions lists the operations available to your role by tag; it is your primary way to find an operation. Default to picking an operationId straight from that index, then call describe_operation for its input schema and invoke_operation to run it. Reach for search_operations only when the index is genuinely ambiguous or a capability you expect isn't listed — not as a routine first step. Never guess an operationId or body shape: describe_operation (or search_operations' best_match) is the source of truth for the input schema.
 
 ## Core model
@@ -149,7 +155,7 @@ This MCP server is scoped to ONE organization — the one this endpoint serves �
 - Integration preference — when a task needs an integration, prefer in order: (1) one the caller has already connected (listed in your caller context / get_me — connecting it was an explicit choice), then (2) one that is activated for this application but not yet connected, then (3) one that is neither. \`GET /api/integrations\` lists every integration with an \`active\` flag (activated for this app) and \`block_user_connections\`; use it to tell tiers 2 and 3 apart. Do not silently activate or connect an integration the caller did not ask for — surface that it would be needed and let them decide.
 - Connecting or reconnecting an integration before a run — an integration may be unconnected, expired, needs-reconnection, under-scoped, or otherwise unusable. Do NOT try to interpret connection state yourself. Instead, before running an inline manifest that uses integrations, CALL \`validateInlineRun\` (\`POST /api/runs/inline/validate\`) with your \`manifest\` (+ \`prompt\`/\`config\`). It returns field errors; any error whose \`field\` is \`integrations.<id>\` means that integration is not ready to run — whatever the \`code\` (\`not_connected\`, \`needs_reconnection\`, \`insufficient_scopes\`, \`auth_key_mismatch\`, …). For each such error you MUST start its OAuth (do not just describe it): CALL \`invoke_operation\` with \`operation_id: "initiateIntegrationOAuth"\`, \`path_params: { packageId: "<id>", authKey: "<key>" }\` (the auth key is in \`manifest.auths\` of the integration row from \`GET /api/integrations\` — usually the lone oauth2 entry), and — if the error carries a \`connection_id\` — also pass \`body: { connection_id: "<that id>" }\` so the existing connection is reconnected/upgraded in place instead of duplicated. This tool call is what renders the one-click connect button (from its result); without it there is NO button, so never claim a button will appear unless you just made this exact call this turn. Do NOT paste the returned \`auth_url\` as text. Then end your turn and tell the caller you'll continue once connected — do NOT poll, loop, wait, or run in the same turn. On a later turn, re-run \`validateInlineRun\`; when it returns no \`integrations.*\` errors, proceed with the run. (Non-interactive clients with no button can read \`auth_url\` from the tool result.)
 
-${OPERATION_INDEX_HEADING}
+${skillsIndex ? `${skillsIndex}\n\n` : ""}${OPERATION_INDEX_HEADING}
 ${buildOperationIndex(permissions)}`;
 }
 

--- a/apps/api/src/modules/mcp/skills/connector-choice/SKILL.md
+++ b/apps/api/src/modules/mcp/skills/connector-choice/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: connector-choice
+description: Choisir le bon connecteur pour brancher un service à un agent. Charge ce skill quand il faut connecter un nouvel outil (Gmail, Slack, Notion, ClickUp, HubSpot…) et qu'il existe plusieurs variantes. Règle : préférer la variante MCP distante (id en -mcp, un clic) à la variante API (qui force souvent à enregistrer une app dev avec client id/secret). Donne la cascade de décision et le garde-fou « ne jamais coller un secret dans le chat ».
+---
+
+# Choix du connecteur — MCP distant d'abord
+
+Quand l'utilisateur doit brancher un service, plusieurs chemins existent. Choisis le plus léger
+**pour lui**, pas le plus puissant pour toi.
+
+## Étape 0 — cherche le sibling `-mcp` AVANT de connecter (obligatoire)
+
+Ne génère **jamais** un formulaire ou un lien de connexion sur le premier connecteur qui matche le nom
+du service. Le caller-context ne liste que les intégrations **déjà connectées** : un service pas encore
+branché n'y figure pas, et sa variante `-mcp` non plus. Tu dois donc la **chercher activement** :
+
+1. Liste les intégrations disponibles : `GET /api/integrations`.
+2. Pour le service demandé (ex. `clickup`), cherche un **sibling dont l'id se termine par `-mcp`**
+   (`clickup-mcp`, `notion-mcp`, `github-mcp`…). Le nom nu (`clickup`) est presque toujours la variante
+   API lourde ; la variante un-clic est le sibling `-mcp`.
+3. Si le sibling `-mcp` existe → connecte **celui-là**. Ne te rabats sur la variante API que si **aucun**
+   `-mcp` n'existe pour ce service. Ne prends jamais le premier match par défaut.
+
+## Cascade
+
+1. **Le service a une variante MCP distante** (son id se termine par `-mcp`, `source.kind: "remote"`) →
+   **préfère-la**. Elle connecte en **un clic** (OAuth/DCR côté fournisseur), sans que l'utilisateur ait à
+   créer quoi que ce soit. C'est le défaut.
+2. **Sinon, la variante API simple** (`source.kind: "local"`, `auths: oauth2 | api_key`) → utilise-la.
+   Quel que soit le type d'auth (OAuth, clé API, basic, custom), déclenche le flux de connexion natif :
+   il rend un **bouton one-click** dans le chat qui ouvre une page de connexion hébergée (écran OAuth du
+   fournisseur ou formulaire de credentials selon l'auth — le secret y est saisi, jamais dans le chat).
+   Ne fabrique jamais d'URL à la main. Attention : beaucoup d'API à clé forcent quand même l'utilisateur
+   à **enregistrer une app développeur** (client id / secret) chez le fournisseur — c'est friction,
+   d'où la préférence pour le MCP.
+3. **Aucune des deux** → fabrique (MCP via `mcp-builder`, ou intégration REST/OAuth). Voir le skill
+   `copilot`, Phase 3.
+
+## Garde-fou (toujours)
+
+Ne demande **jamais** à l'utilisateur de coller une clé API, un secret OAuth (client id/secret), un
+token ou un mot de passe **dans la conversation**. La connexion passe par le flux natif : un **bouton
+one-click** dans le chat qui ouvre une page de connexion **hébergée** où le secret est saisi (jamais
+dans le chat), quel que soit le type d'auth.
+
+## Vérifier ce qui existe
+
+Avant de proposer une connexion, regarde si une variante est déjà disponible / connectée :
+`GET /api/integrations` liste les intégrations de l'org (l'id en `-mcp` signale la variante MCP), et
+`GET /api/integrations/{packageId}/connections` dit si une connexion existe déjà. Si le service n'est
+pas configurable sur l'instance (par ex. un 403 à la génération du lien), dis-le franchement et
+propose une alternative plutôt que de boucler.

--- a/apps/api/src/modules/mcp/skills/copilot/SKILL.md
+++ b/apps/api/src/modules/mcp/skills/copilot/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: copilot
+description: Accompagne l'utilisateur pour concevoir et mettre en place une automatisation (agent ou run inline) à partir de son contexte. Charge ce skill dès que l'intention est de créer/automatiser/déléguer quelque chose, gagner du temps, « faire des agents », ou quand l'utilisateur ne sait pas par où commencer ou vient de connecter des outils. Prends le contrôle : ancre l'entretien sur le rôle + les outils utilisés, puis PROPOSE des automatisations concrètes (ne demande jamais « quelle tâche vous prend du temps »). Pas pour seulement lancer/inspecter un agent existant.
+---
+
+# Copilote de création d'agents Appstrate
+
+Ton rôle : transformer « je ne sais pas quoi automatiser » en un **agent Appstrate
+fonctionnel**, sans que l'utilisateur ait à connaître la plateforme. Tu mènes un
+entretien court, tu proposes des automatisations adaptées à **son** contexte, et
+tu assembles l'agent pour lui.
+
+Modèle mental à garder en tête en permanence :
+
+> **Agent = skill (le savoir-faire) × connecteur (l'accès à ses données) + orchestration (le pilotage).**
+> Et `+ mcp-server` quand il faut du calcul (analyse, parsing, anonymisation).
+
+Ne propose jamais une automatisation dans le vide : elle doit être **actionnable
+avec ce que l'utilisateur a** (ou peut connecter en un clic).
+
+**Quelle forme ? Choisis la plus légère qui répond au besoin** — tout n'est pas un agent enregistré :
+
+- **Run inline** (one-shot, rien à enregistrer) — pour une action ponctuelle : le chat lance un run
+  éphémère (manifest + prompt inline), souvent en réutilisant un skill. Ex. « cherche X », « résume
+  ce doc », « extrais les infos de cette facture ». C'est ce que fait le skill `web-search`.
+- **Agent enregistré** (importé) — quand c'est **réutilisable** (l'utilisateur le relancera) et/ou
+  **récurrent/autonome** (`schedule`, `checkpoint`). Ex. veille quotidienne ⏰, brief du matin,
+  relances d'impayés.
+- Le **skill** est le savoir-faire (consommé par l'un ou l'autre), pas une forme d'exécution.
+
+N'enregistre un agent que si ça vaut le coup de le garder ; sinon, un **run inline** suffit.
+
+## Phase 1 — Comprendre le contexte (l'entretien d'abord)
+
+**Principe central : l'utilisateur n'a pas d'imagination — il ne sait pas ce qui lui prend du
+temps.** Lui demander « qu'est-ce qui te prend du temps ? », « quelle est ta douleur ? » ou « quel
+processus veux-tu automatiser ? » le **bloque**. Ancre l'entretien sur ce qui est **facile et
+factuel** pour lui — **son rôle et ses outils** — et c'est **TOI** qui apportes l'imagination en
+proposant. Reconnaître une bonne idée est facile ; l'inventer est dur.
+
+Capte deux choses seulement, légèrement (1-2 questions, en devinant ce que tu peux) :
+
+1. **Qui il est** — sa fonction (sales, marketing, support, RH, finance, ops, dev, direction,
+   fondateur…). _Le rôle détermine les automatisations à plus forte valeur._ Devine l'entreprise
+   (secteur, taille, B2B/B2C) depuis le domaine de l'e-mail — ne le demande pas frontalement.
+2. **Ses outils — LA question d'ancrage**, facile : « Quels outils utilises-tu au quotidien ? »
+   Au besoin, balaie par catégorie : mail, agenda, docs/drive, messagerie d'équipe, gestion de
+   projet, CRM, facturation/compta, support. Mappe chaque outil à un connecteur (built-in, MCP
+   distant, ou à fabriquer — cascade Phase 3 et `references/connecteurs-et-recettes.md`). **Lis
+   d'abord les intégrations déjà connectées** (`references/piloter-appstrate.md`), mais demande
+   quand même : beaucoup d'outils utiles ne sont pas encore branchés.
+
+**Ne demande PAS sa douleur ni « ce qui lui prend du temps ».** Déduis-la de son rôle + ses outils
+et passe directement à la **proposition** (Phase 2). S'il exprime spontanément un besoin précis
+(« je veux automatiser mes relances »), creuse ce besoin-là ; sinon, **c'est à toi de proposer la
+liste** — il choisira (reconnaître est facile).
+
+Les **paramètres** (langue, volume, 💬 à la demande vs ⏰ autonome) se précisent **au moment de
+choisir une proposition**, pas dans l'ouverture. Reste conversationnel : jamais un bloc de 4+
+questions.
+
+## Phase 2 — Proposer des automatisations
+
+Croise **(rôle × secteur) → cas prioritaires**, puis **filtre par les connecteurs
+disponibles** et **calibre par les paramètres**. Présente 3 à 6 idées concrètes,
+chacune en une ligne de bénéfice, marquée 💬 (chat) ou ⏰ (run autonome).
+
+Deux sources :
+
+- **Recettes curées par connecteur** — `references/connecteurs-et-recettes.md`.
+- **Listings d'automatisation publics** (inspiration vivante) — via le skill `web-search`
+  (run inline ; le runtime est sandboxé, pas d'accès web direct), interroge les templates **n8n**
+  et remappe sur les connecteurs Appstrate. Détails et garde-fous : `references/sources-et-securite.md`.
+
+Exemples de croisement :
+
+- _Commercial · PME B2B · HubSpot + Gmail_ → brief avant call 💬, relances pipeline ⏰, qualif des leads ⏰.
+- _DAF · PME · QuickBooks + Drive_ → relances d'impayés ⏰, rapport cash hebdo ⏰, extraction de factures ⏰.
+- _Fondateur · startup · Gmail + Slack + ClickUp_ → brief du matin ⏰, digest d'équipe ⏰, extraire les tâches des mails ⏰.
+
+## Phase 3 — Résoudre les dépendances
+
+Une fois une idée choisie, réunis ses briques.
+
+**Le savoir-faire (skill)** :
+
+- Déjà dans l'org → déclare-le en dépendance.
+- Dans un repo whitelisté (`anthropics/skills` → `skill-creator`, `mcp-builder` ; `letta-ai/skills`)
+  → importe-le depuis GitHub.
+- Aucun → rédige-le à la méthode du skill `skill-creator`.
+
+**L'accès (connecteur)** — applique la **cascade** (on n'est PAS limité aux connecteurs
+built-in) :
+
+1. **Built-in** (parmi les ~64) → propose le **lien de connexion** (OAuth / clé API) dans le chat.
+2. **Sinon, MCP distant existant** → cherche dans les registres MCP publics, branche-le en `remote`.
+3. **Sinon, fabrique** → scaffolde un MCP (`mcp-builder`) ou une intégration REST/OAuth.
+
+Quand un service offre à la fois une variante MCP distante (id en `-mcp`) et une API simple, préfère
+le MCP : un clic, là où l'API force souvent à enregistrer une app dev. Détails par service et règle
+de choix : charge le skill `connector-choice`.
+
+Modèle d'intégration : `source.kind` ∈ `none | local | remote` ; `auths` ∈ `oauth2 | api_key |
+basic | mtls | custom`. Opérations concrètes (lire les connexions, générer les liens, importer) :
+`references/piloter-appstrate.md`. Pièges & `prompt.md` (le format du manifest vient du schéma
+AFPS via `describe_operation`) : `references/format-agent-appstrate.md`.
+
+## Phase 4 — Assembler, valider, activer
+
+> Pour un **one-shot**, saute l'enregistrement : lance directement un **run inline** et montre le
+> résultat. Les étapes ci-dessous valent pour un **agent enregistré** (réutilisable / récurrent).
+
+1. **Génère** le `manifest.json` + `prompt.md` de l'agent : déclare le(s) skill(s) et
+   intégration(s), câble `integrations_configuration.<id>.tools` (sinon zéro tool exposé),
+   choisis les `runtime_tools`, définis `input`/`output`. Voir `references/format-agent-appstrate.md`.
+2. **Valide** en dry-run — aucun crédit consommé.
+3. **Connecte** ce qui manque via le flux de connexion natif : quel que soit le type d'auth (OAuth,
+   clé API, basic, custom), il rend un **bouton de connexion one-click** dans le chat qui ouvre une
+   page de connexion hébergée (écran OAuth du fournisseur ou formulaire de credentials selon l'auth).
+   Le secret est saisi sur cette page hébergée, jamais dans la conversation — ne demande donc JAMAIS
+   de coller un secret dans le chat.
+4. **Importe** l'agent, puis **propose un `schedule`** si c'est un agent ⏰.
+5. **Itère** : lance un premier run, montre le résultat, ajuste.
+
+Toutes ces opérations (lire les connexions, valider, importer, connecter, planifier) :
+`references/piloter-appstrate.md`.
+
+## Format d'une proposition
+
+Présente chaque idée ainsi, sans jargon :
+
+- **Nom** court et parlant.
+- **Ce qu'il fait** : une phrase, le bénéfice concret.
+- **Type** : 💬 chat ou ⏰ run (+ fréquence si run).
+- **Ce qu'il faut** : le(s) connecteur(s), en marquant ✅ déjà connecté / 🔌 à connecter.
+
+## Exemple de bout en bout
+
+> _Contexte capté : DAF d'une PME, utilise QuickBooks et Google Drive, douleur = les relances d'impayés prennent du temps._
+
+1. **Proposition** — « **Relances d'impayés** ⏰ — chaque lundi matin, je repère les factures en
+   retard et je prépare les relances. Besoin : QuickBooks 🔌 (à connecter). »
+2. **Choix + dépendances** — savoir-faire : orchestration simple (pas de skill dédié) ; connecteur :
+   `quickbooks-online` non connecté → je génère le lien OAuth dans le chat (« Connecte QuickBooks → »).
+3. **Génération** — agent : dépend de `@appstrate/quickbooks-online` (`tools: ["api_call"]`),
+   `runtime_tools: ["output","report"]`, prompt « lis les factures en retard → prépare les relances ».
+   Dry-run OK.
+4. **Connexion + activation** — le user clique le lien, autorise. J'importe l'agent et propose un
+   `schedule` lundi 8h.
+5. **Preuve** — premier run : je montre la liste des relances préparées, puis j'ajuste le ton si besoin.
+
+## Principes
+
+- **Lean** : ne pose que les questions qui changent la proposition. Devine le reste.
+- **Concret** : chaque idée nomme la tâche réelle et le bénéfice, pas un concept abstrait.
+- **Honnête** : si une idée demande un connecteur ou un calcul qu'on n'a pas encore,
+  dis-le et propose le chemin (connecter / scaffolder).
+- **Sûr** : ne récupère jamais un skill ou un MCP arbitraire sans validation. Whitelist
+  de confiance + dry-run avant import. Voir `references/sources-et-securite.md`.

--- a/apps/api/src/modules/mcp/skills/copilot/references/connecteurs-et-recettes.md
+++ b/apps/api/src/modules/mcp/skills/copilot/references/connecteurs-et-recettes.md
@@ -1,0 +1,90 @@
+# Connecteurs Appstrate & recettes d'automatisation
+
+> Chargé à la demande par le copilote en Phase 2 (proposer) et Phase 3 (résoudre l'accès).
+> Légende : 💬 chat (à la demande) · ⏰ run (autonome/cron) · `skill` = savoir-faire mobilisé.
+
+## Connecteurs built-in (~64), par famille
+
+| Famille             | Connecteurs `@appstrate/*`                                                                                 |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| E-mail              | `gmail`, `gmail-mcp`, `microsoft-outlook`, `brevo`, `mailchimp`, `convertkit`                              |
+| Agenda & réunions   | `google-calendar`, `calendly`, `zoom`, `fathom` (transcripts), `loom`                                      |
+| Messagerie interne  | `slack`, `microsoft-teams`, `discord`, `telegram`                                                          |
+| Docs & knowledge    | `google-drive`, `onedrive`, `dropbox`, `notion`, `notion-mcp`, `google-sheets`, `airtable`                 |
+| Tâches & projet     | `clickup`, `clickup-mcp`, `jira`, `linear`, `asana`, `monday`, `basecamp`, `teamwork`, `wrike`, `shortcut` |
+| CRM                 | `hubspot`, `salesforce`, `pipedrive`, `zoho-crm`, `dynamics365`, `freshsales`, `activecampaign`            |
+| Support / ticketing | `zendesk`, `intercom`, `freshdesk`                                                                         |
+| Web & veille        | `firecrawl` (crawl/scrape/search), `reddit`, `youtube`, `x`, `linkedin`                                    |
+| Dev                 | `github`, `github-git`, `github-mcp`                                                                       |
+| Finance             | `stripe`, `paypal`, `quickbooks-online`, `xero`                                                            |
+| E-commerce / CMS    | `shopify`, `woocommerce`, `wordpress`, `canva`, `pinterest`                                                |
+| Forms / infra       | `typeform`, `google-forms`, `twilio` (SMS), `webhooks`                                                     |
+
+> Préfère la saveur **MCP** quand elle existe (`gmail-mcp`, `clickup-mcp`, `notion-mcp`, `github-mcp`) : tools nommés plus riches, self-describing via `tools/list`.
+> **Pas dans la liste ?** Ce n'est pas bloquant — voir la cascade (MCP distant / scaffolder) dans `SKILL.md` Phase 3 et `format-agent-appstrate.md`.
+
+## Recettes par connecteur
+
+### 📧 Mail — `gmail` / `microsoft-outlook`
+
+- ⏰ Brief inbox du matin (tri + résumé + priorités) · `triage-sentiment`
+- ⏰ Auto-brouillons de réponses récurrentes · `email-reply`
+- ⏰ Extraire les engagements/tâches des mails → projet · `minutes-actions`
+- ⏰ Alerte VIP / mots-clés (devis, résiliation, plainte) · `triage-sentiment`
+- 💬 Réponds à ce fil dans mon ton · `email-reply`
+
+### 📁 Drive — `google-drive` / `onedrive` / `dropbox` / `notion`
+
+- 💬 Q&A sourcé sur tes documents · `sourced-rag`
+- ⏰ Résumé des nouveaux fichiers (hebdo) · `incremental-digest`
+- 💬 Extraire les infos clés d'un doc (contrat, facture, CV) · `doc-extraction`
+- ⏰ Veille sur un dossier partagé → notifier · `incremental-digest`
+
+### 📋 Gestion de projet — `clickup` / `jira` / `linear` / `asana` / `notion`
+
+- ⏰ Digest des tâches dues / en retard (matin) · `incremental-digest`
+- 💬 Crée une tâche depuis ce message/mail · (orchestration)
+- ⏰ Rapport d'avancement hebdo (sprint/projet) · `sprint-report`
+- ⏰ Relancer les tâches sans update depuis N jours · (orchestration)
+
+### 🧾 Facturation — `quickbooks-online` / `xero` / `stripe`
+
+- ⏰ Relances d'impayés automatiques · (orchestration)
+- ⏰ Rapport cash / encaissements hebdo · `data-analysis`
+- ⏰ Catégoriser les transactions · `data-analysis`
+- 💬 Statut de la facture X ? · (orchestration)
+
+### 📅 Calendrier & réunions — `google-calendar` / `zoom` / `fathom`
+
+- ⏰ Prépa des réunions du jour (participants + docs liés) · `meeting-prep`
+- ⏰ CR + actions après chaque réunion (Fathom) · `minutes-actions`
+- 💬 Trouve un créneau avec X · (orchestration)
+
+### 💬 Messagerie interne — `slack` / `microsoft-teams`
+
+- ⏰ Digest des canaux clés + décisions + actions · `incremental-digest`
+- 💬 Résume #canal depuis hier · `minutes-actions`
+- ⏰ FAQ interne dans un canal · `sourced-rag`
+
+### 🤝 CRM — `hubspot` / `salesforce` / `pipedrive`
+
+- 💬 Brief avant call · `customer-research`
+- ⏰ Relances pipeline du jour · (orchestration)
+- ⏰ Qualifier les leads entrants vs ICP · `customer-research`
+
+### 🎧 Support — `zendesk` / `intercom` / `freshdesk`
+
+- ⏰ Tri + priorisation + sentiment des tickets · `triage-sentiment`
+- ⏰ Brouillons depuis la KB · `sourced-rag`
+- ⏰ Voice of customer → produit · `triage-sentiment`
+
+### 👩‍💻 Dev — `github-mcp` / `jira` / `linear`
+
+- ⏰ Résumé des PR ouvertes (matin) · `code-review`
+- 💬 Explique cette PR / ce diff · `code-review`
+- ⏰ Triage des issues entrantes · `triage-sentiment`
+
+### 🌐 Veille (transverse) — `firecrawl` + livraison `slack`/`gmail`
+
+- ⏰ Veille concurrents / sujets → digest du nouveau (checkpoint) · `incremental-digest`
+- 💬 Cherche & synthétise un sujet maintenant · `sourced-research`

--- a/apps/api/src/modules/mcp/skills/copilot/references/format-agent-appstrate.md
+++ b/apps/api/src/modules/mcp/skills/copilot/references/format-agent-appstrate.md
@@ -1,0 +1,33 @@
+# Générer un agent — ce que le schéma ne dit pas
+
+> **Le format du manifest est le schéma AFPS canonique** (`https://schemas.afps.dev/v0/agent.schema.json`),
+> exposé par les opérations `runs/inline`, `…/validate` et `packages/import` (composant `AgentManifest`).
+> Découvre-le via `describe_operation` — **ne recopie pas le squelette ici**. Ce mémo ne porte que ce
+> que le schéma n'explicite pas : les pièges runtime et le contrat du `prompt.md`.
+
+## Pièges qui ne sautent pas aux yeux dans le schéma
+
+- **`integrations_configuration.<id>.tools` est obligatoire pour exposer un tool.** Absent ou `[]`
+  → **zéro tool** (l'agent ne voit pas le connecteur). Intégration `none` → `["api_call"]` ;
+  intégration MCP (`*-mcp`) → les vrais noms de tools (ou `"*"`).
+- **`output` doit figurer dans `runtime_tools` dès qu'un `output.schema` est déclaré** (sinon rejet).
+- **Lecture du résultat : `result.output.<champ>`** (pas `result.<champ>`).
+- Pas de type `"file"` : champ string `format:"uri"` + `contentMediaType` + sibling `file_constraints`.
+- `required` = tableau top-level (pas un booléen par propriété).
+
+## Le prompt.md (n'est pas dans le manifest)
+
+Markdown simple. La plateforme injecte automatiquement : identité, environnement, **contrat de
+communication**, `## User Input`, `## Configuration`, `## Checkpoint`, doc des intégrations,
+`## Output Format`. Donc :
+
+- **Ne liste jamais les tools** (l'agent les découvre via `tools/list`).
+- **Tout passe par un tool** : le texte libre hors tool call est ignoré. Écris « appelle `output`
+  avec… », « appelle `report` pour… » — jamais « réponds avec… ».
+- Décris l'**objectif**, les **étapes**, les **règles** (anti-hallucination, erreurs). Pour un agent
+  ⏰ : lire l'état depuis `## Checkpoint`, écrire `pin({key:"checkpoint"})` à la fin (incrémental).
+
+## Cascade connecteur (rappel)
+
+`source.kind` ∈ `none | local | remote` ; `auths` ∈ `oauth2 | api_key | basic | mtls | custom`.
+Connexion = via l'opération OAuth/champs (le lien présenté dans le chat) — voir `piloter-appstrate.md`.

--- a/apps/api/src/modules/mcp/skills/copilot/references/piloter-appstrate.md
+++ b/apps/api/src/modules/mcp/skills/copilot/references/piloter-appstrate.md
@@ -1,0 +1,34 @@
+# Agir sur Appstrate (sans dupliquer le platform MCP)
+
+> Dans le chat, tu pilotes Appstrate via le **platform MCP** : `search_operations` →
+> `describe_operation` → `invoke_operation`. **C'est lui la source de vérité** des opérations
+> et de leurs paramètres (avec ses propres `instructions`). Ne réapprends pas l'API ici —
+> découvre-la avec ces tools. Ce mémo ne liste que les **intentions** propres au copilote et
+> l'**ordre** à respecter.
+
+## Intentions à chercher (via `search_operations`)
+
+- voir les intégrations disponibles et **ce qui est déjà connecté** ;
+- **démarrer une connexion** (OAuth → récupérer le lien à présenter au user ; ou champs / clé API) ;
+- lister les **skills** disponibles ; **importer un skill depuis un repo GitHub** (whitelisté) ;
+- **valider un agent en dry-run** (sans coût) ;
+- importer un package ; lancer un agent ; le **planifier** (cron).
+
+Les noms et paramètres exacts : `describe_operation`. Ne hardcode pas d'URL.
+
+## Règles d'ordre propres au copilote
+
+1. **Avant de proposer une connexion**, vérifie ce qui est déjà connecté — ne propose que le manquant.
+2. **Liens de connexion** : pour un connecteur manquant, démarre la connexion OAuth et **présente
+   l'URL comme un lien cliquable** dans le chat (« Connecte Gmail → ») ; pour une clé API, demande-la.
+3. **Dry-run avant import** : valide toujours l'agent généré avant de l'importer (0 crédit).
+4. **Récupérer un skill** : d'abord l'org, sinon import depuis un repo **whitelisté** — validation
+   obligatoire (voir `sources-et-securite.md`).
+5. Tout passe par les **permissions du user** (le platform MCP réapplique l'auth/RBAC à chaque appel).
+6. **Connexion qui échoue** : si générer un lien OAuth renvoie une erreur (ex. **403** = pas de client
+   OAuth configuré pour ce service sur l'instance), **ne réessaie pas en boucle**. Explique-le
+   simplement (« l'intégration X n'est pas encore configurée ici — un admin doit ajouter les
+   credentials d'app ») et propose une **alternative** (un autre connecteur, un export CSV/collé, ou
+   faire sans pour démarrer).
+7. **Ne régénère pas un lien déjà donné** : si tu as déjà fourni le lien de connexion d'un service
+   dans la conversation, réutilise-le — ne rappelle pas l'opération OAuth à chaque tour.

--- a/apps/api/src/modules/mcp/skills/copilot/references/sources-et-securite.md
+++ b/apps/api/src/modules/mcp/skills/copilot/references/sources-et-securite.md
@@ -1,0 +1,48 @@
+# Sources dynamiques & sécurité
+
+> Chargé quand le copilote va chercher des idées (Phase 2) ou un skill/MCP (Phase 3).
+> **Capacité d'accès** : le runtime est **sandboxé** — pas d'HTTP direct. Toute recherche / lecture
+> web passe par le skill **`@default/web-search`** (recette de **run inline**) : il détecte les
+> fournisseurs connectés (**Brave** déjà connecté sur i31, Firecrawl, Tavily…) et retombe sur
+> `@default/web-fetch` pour lire une URL publique (n8n templates, `raw.githubusercontent.com`,
+> registres MCP). Réutilise ce skill, n'invente pas d'accès réseau.
+
+## Listings d'automatisation (inspiration « ce que les gens automatisent »)
+
+| Plateforme       | Accès                                                       | Verdict              |
+| ---------------- | ----------------------------------------------------------- | -------------------- |
+| **n8n**          | API publique de templates, **zéro auth** (~1000+ workflows) | ✅ source par défaut |
+| **Activepieces** | API templates + open source                                 | ✅ bon               |
+| **Make**         | API `templates/public`, **token requis**                    | ⚠️ si clé dispo      |
+| **Zapier**       | Partner API restreinte                                      | ❌ éviter            |
+
+Usage : chercher les templates qui matchent le **profil** (rôle/secteur/tâche), puis
+**remapper sur les connecteurs Appstrate** (un template n8n « Gmail → Sheets » devient un
+agent `gmail` + `google-sheets`). C'est de l'**inspiration**, pas un import direct (formats
+incompatibles). Confirme l'endpoint exact au moment du fetch (l'API n8n est servie sous
+`api.n8n.io`).
+
+## Repos de skills (récupérer un savoir-faire manquant)
+
+Format standard `SKILL.md` + frontmatter (`name`, `description`). Fetch direct :
+`https://raw.githubusercontent.com/<owner>/<repo>/main/<path>/SKILL.md`.
+
+**Whitelist de confiance** (n'élargir qu'avec revue) :
+
+- `anthropics/skills` — dont `skill-creator` (écrire un skill) et `mcp-builder` (scaffolder un MCP).
+- `letta-ai/skills`.
+
+## Registres MCP (brancher un service non built-in)
+
+Pour un service sans connecteur Appstrate, chercher un serveur MCP distant publié
+(registre MCP officiel, annuaires communautaires), puis le brancher en intégration
+`source.kind: remote`. Si rien n'existe : scaffolder via `mcp-builder`, ou créer une
+intégration REST `none` + auth.
+
+## Garde-fous (leçon « ClawHavoc » — marketplace ouverte = skills malveillants)
+
+- **Whitelist** de repos / MCP de confiance. Ne jamais fetcher un skill/MCP arbitraire sur simple nom.
+- **Valider** tout package récupéré : lire le `SKILL.md` / le manifeste avant usage ; se méfier du typosquatting (nom proche d'un repo connu).
+- **Aucune exécution de code non revue.** Un skill = du texte ; un MCP = du code → revue obligatoire avant de le brancher.
+- **Dry-run** (`/api/runs/inline/validate`) avant tout import.
+- La **curation** est un avantage Appstrate vs les marketplaces ouvertes — l'assumer.

--- a/apps/api/src/modules/mcp/skills/web-search/SKILL.md
+++ b/apps/api/src/modules/mcp/skills/web-search/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: web-search
+description: Chercher ou lire le web en lançant un run inline (le chat n'a pas d'accès web direct — le runtime est sandboxé). Charge ce skill dès qu'il faut une recherche web (requête en langage naturel) ou lire une/des URLs. Détecte au runtime les fournisseurs de recherche connectés (Brave, Firecrawl, Tavily, Exa, SerpAPI) et les utilise ; sinon retombe sur @default/web-fetch (GET d'URLs publiques, sans credential), ou propose d'en connecter un. Donne le manifest inline, l'input et l'output structuré de chaque branche.
+---
+
+# Web Search — recette de run inline
+
+L'assistant du chat (et les agents) n'a pas d'outil web natif : le runtime est sandboxé, l'egress
+réseau est limité aux `authorized_uris` des intégrations. Pour chercher / lire le web, on **lance un
+run inline** (`POST /api/runs/inline`) qui embarque une intégration web, puis on **attend** le run
+(`wait_for_run` / `GET /api/runs/{id}`) et on lit son `result.output`.
+
+Depuis le chat, tu fais ça via `invoke_operation` sur les opérations de l'API (`runInline`, puis
+`wait_for_run`). Ne poll pas `getRun` en boucle toi-même.
+
+## Arbre de décision
+
+1. **Regarde ce qui est connecté.** Appelle `GET /api/integrations` et, pour chaque fournisseur de
+   recherche connu, `GET /api/integrations/{packageId}/connections`. Fournisseurs reconnus (par ordre
+   de préférence) : `@default/brave-search`, `@appstrate/firecrawl`, `@default/tavily`,
+   `@default/exa`, `@default/serpapi`. Un fournisseur est utilisable s'il a **≥1 connexion**
+   accessible (ou une connexion défaut org).
+2. **Si un fournisseur de recherche est connecté** et que la demande est une _recherche_ (requête en
+   langage naturel) → **Recette A** avec ce fournisseur.
+3. **Sinon, ou si on te donne des URLs précises à lire** → **Recette B** (`@default/web-fetch`),
+   qui fait un simple GET et renvoie le contenu. Pas de moteur de recherche : il faut connaître l'URL.
+4. Si tu voulais chercher mais qu'aucun fournisseur n'est connecté, **dis-le** à l'utilisateur
+   (« aucun moteur de recherche connecté — connecte Firecrawl/Brave/… ou donne-moi une URL ») et
+   propose de le connecter (via le flux de connexion natif) au lieu d'inventer des résultats.
+
+Toujours : citer ce que l'outil renvoie, ne jamais fabriquer un résultat.
+
+## Recette A — recherche via un fournisseur (exemple Firecrawl)
+
+Body de `POST /api/runs/inline` :
+
+```json
+{
+  "manifest": {
+    "name": "@default/inline-web-search",
+    "version": "1.0.0",
+    "type": "agent",
+    "schema_version": "0.1",
+    "display_name": "inline web search",
+    "description": "Recherche web via le fournisseur connecté, renvoie des résultats structurés.",
+    "dependencies": {
+      "skills": {},
+      "mcp_servers": {},
+      "integrations": { "@appstrate/firecrawl": "^1.0.0" }
+    },
+    "integrations_configuration": {
+      "@appstrate/firecrawl": { "auth_key": "primary", "tools": ["api_call"] }
+    },
+    "runtime_tools": ["output"],
+    "input": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "query": { "type": "string" },
+          "limit": { "type": "integer", "default": 5 }
+        },
+        "required": ["query"]
+      }
+    },
+    "output": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": { "type": "string" },
+                "url": { "type": "string" },
+                "snippet": { "type": "string" }
+              },
+              "required": ["title", "url"]
+            }
+          }
+        },
+        "required": ["results"]
+      }
+    }
+  },
+  "prompt": "Avec l'integration @appstrate/firecrawl (api_call), fais un POST sur https://api.firecrawl.dev/v1/search avec le corps {\"query\": <query>, \"limit\": <limit>}. Mappe la reponse vers output.results = [{title, url, snippet}] (snippet = description/extrait). Ne renvoie que des resultats reels issus de l'API.",
+  "input": { "query": "VOTRE REQUETE", "limit": 5 }
+}
+```
+
+Pour un **autre fournisseur** : garde la même structure, change `dependencies.integrations` +
+`integrations_configuration` pour l'id du fournisseur, et adapte l'URL/le corps dans le `prompt` :
+
+- Brave : `GET https://api.search.brave.com/res/v1/web/search?q=<query>&count=<count>` (en-tête `Accept: application/json`), mappe `web.results[]`.
+- Tavily : `POST https://api.tavily.com/search`.
+- Exa : `POST https://api.exa.ai/search`.
+- SerpAPI : `GET https://serpapi.com/search`.
+
+L'output structuré `results[]` reste identique. La plupart des moteurs ne renvoient que titre/url/
+description. Pour le **contenu** d'une page trouvée, enchaîne avec la Recette B (`@default/web-fetch`)
+sur l'URL choisie.
+
+## Recette B — fetch d'URL publique (fallback sans credential)
+
+Intégration `@default/web-fetch` (source none, `allow_all_uris`, **sans clé**). Body de
+`POST /api/runs/inline` :
+
+```json
+{
+  "manifest": {
+    "name": "@default/inline-web-fetch",
+    "version": "1.0.0",
+    "type": "agent",
+    "schema_version": "0.1",
+    "display_name": "inline web fetch",
+    "description": "GET d'une ou plusieurs URLs publiques, renvoie leur contenu.",
+    "dependencies": {
+      "skills": {},
+      "mcp_servers": {},
+      "integrations": { "@default/web-fetch": "^1.0.0" }
+    },
+    "integrations_configuration": {
+      "@default/web-fetch": { "auth_key": "primary", "tools": ["api_call"] }
+    },
+    "runtime_tools": ["output"],
+    "input": {
+      "schema": {
+        "type": "object",
+        "properties": { "urls": { "type": "array", "items": { "type": "string" } } },
+        "required": ["urls"]
+      }
+    },
+    "output": {
+      "schema": {
+        "type": "object",
+        "properties": {
+          "pages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "url": { "type": "string" },
+                "status": { "type": "integer" },
+                "content": {
+                  "type": "string",
+                  "description": "Contenu textuel/HTML nettoyé de la page"
+                }
+              },
+              "required": ["url", "content"]
+            }
+          }
+        },
+        "required": ["pages"]
+      }
+    }
+  },
+  "prompt": "Pour chaque URL de input.urls, utilise @default/web-fetch (api_call) pour faire un GET. Renvoie output.pages = [{url, status, content}] ou content = le corps de la reponse (si HTML, extrais le texte lisible principal). N'invente rien : si une URL echoue, mets son status et un content vide.",
+  "input": { "urls": ["https://example.com"] }
+}
+```
+
+## Après le lancement
+
+`runInline` renvoie `202 { runId }`. Appelle `wait_for_run` avec ce `runId` (il bloque jusqu'à la fin),
+puis lis `result.output` (`output.results` pour A, `output.pages` pour B). Status terminaux :
+`success | failed | timeout | cancelled`. En cas d'échec, lis `GET /api/runs/{id}/logs` pour la cause.
+
+## Notes
+
+- `@default/web-fetch` a besoin d'une **connexion** (même sans credential : champ `note` bidon) et d'un
+  **défaut org** pour que le run inline la résolve. Si elle manque, propose de la créer.
+- Le fetch générique ne contourne pas les portails authentifiés / anti-bot ni le JS côté client ;
+  pour ça, préférer un fournisseur de scraping (Firecrawl `/v1/scrape`).
+- Limite le nombre d'URLs / la taille par run (réponses > ~32 KB spillent en `resource_link`).

--- a/apps/api/src/modules/mcp/test/unit/skills.test.ts
+++ b/apps/api/src/modules/mcp/test/unit/skills.test.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * System skills served by the platform MCP server. The scan is the whitelist:
+ * `loadAssistantSkill` only ever reads a SKILL.md (or a `references/*.md`) that
+ * belongs to a scanned skill, so a path-traversal value can never escape the
+ * `skills/` folder. The `load_skill` tool wraps it for MCP consumers.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { AppstrateRequestExtra } from "@appstrate/mcp-transport";
+import {
+  listAssistantSkills,
+  loadAssistantSkill,
+  renderAssistantSkillsIndex,
+  resetAssistantSkillsCache,
+} from "../../assistant-skills.ts";
+import { buildMcpTools } from "../../tools.ts";
+
+const noExtra = {} as unknown as AppstrateRequestExtra;
+
+function parseResult(result: CallToolResult): Record<string, unknown> {
+  const first = result.content[0];
+  if (!first || first.type !== "text") throw new Error("expected text content");
+  return JSON.parse(first.text) as Record<string, unknown>;
+}
+
+function loadSkillTool() {
+  const tools = buildMcpTools({
+    origin: "https://test.local",
+    authHeaders: new Headers(),
+    permissions: new Set(["mcp:read"]),
+    dispatch: async () => new Response("{}", { status: 200 }),
+  });
+  const t = tools.find((x) => x.descriptor.name === "load_skill");
+  if (!t) throw new Error("load_skill tool not built");
+  return t;
+}
+
+beforeEach(() => resetAssistantSkillsCache());
+
+describe("listAssistantSkills", () => {
+  it("indexes the skills shipped with the mcp module", () => {
+    const names = listAssistantSkills().map((s) => s.name);
+    expect(names).toContain("copilot");
+    expect(names).toContain("web-search");
+    expect(names).toContain("connector-choice");
+  });
+
+  it("gives every skill a non-empty single-line description", () => {
+    for (const s of listAssistantSkills()) {
+      expect(s.description.trim().length).toBeGreaterThan(0);
+      expect(s.description).not.toContain("\n");
+    }
+  });
+});
+
+describe("renderAssistantSkillsIndex", () => {
+  it("renders a '## Assistant skills' block naming each skill and the load_skill tool", () => {
+    const block = renderAssistantSkillsIndex();
+    expect(block).toContain("## Assistant skills");
+    expect(block).toContain("`copilot`");
+    expect(block).toContain("load_skill");
+  });
+});
+
+describe("loadAssistantSkill", () => {
+  it("returns the SKILL.md body for a known skill", () => {
+    const loaded = loadAssistantSkill("copilot");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.content).toContain("Copilote de création d'agents");
+  });
+
+  it("returns a reference doc when asked", () => {
+    const loaded = loadAssistantSkill("copilot", "piloter-appstrate");
+    expect(loaded).not.toBeNull();
+    expect(loaded!.content.length).toBeGreaterThan(0);
+  });
+
+  it("returns null for unknown skill / reference", () => {
+    expect(loadAssistantSkill("does-not-exist")).toBeNull();
+    expect(loadAssistantSkill("copilot", "nope")).toBeNull();
+  });
+
+  it("rejects path-traversal in name and reference", () => {
+    expect(loadAssistantSkill("../../../../etc/passwd")).toBeNull();
+    expect(loadAssistantSkill("copilot", "../../../../../../etc/passwd")).toBeNull();
+    expect(loadAssistantSkill("copilot/../web-search")).toBeNull();
+  });
+});
+
+describe("load_skill MCP tool", () => {
+  it("is read-only and built without mcp:invoke", () => {
+    const t = loadSkillTool();
+    expect(t.descriptor.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it("returns the skill content for a valid name", async () => {
+    const res = await loadSkillTool().handler({ name: "copilot" }, noExtra);
+    expect(res.isError).toBeFalsy();
+    const body = parseResult(res);
+    expect(String(body.content)).toContain("Copilote de création d'agents");
+  });
+
+  it("returns an isError result for an unknown skill", async () => {
+    const res = await loadSkillTool().handler({ name: "nope" }, noExtra);
+    expect(res.isError).toBe(true);
+    expect(String(parseResult(res).error)).toContain("No skill named");
+  });
+});

--- a/apps/api/src/modules/mcp/test/unit/tools.test.ts
+++ b/apps/api/src/modules/mcp/test/unit/tools.test.ts
@@ -454,6 +454,12 @@ describe("buildMcpTools contextInjected", () => {
     const names = tools.map((t) => t.descriptor.name).sort();
     // get_me is redundant for a context-injected caller; search_operations stays
     // (its best_match schema is not covered by the injected operation index).
-    expect(names).toEqual(["describe_operation", "invoke_operation", "search_operations"]);
+    // load_skill is always exposed (it serves system-skill docs, no injected equivalent).
+    expect(names).toEqual([
+      "describe_operation",
+      "invoke_operation",
+      "load_skill",
+      "search_operations",
+    ]);
   });
 });

--- a/apps/api/src/modules/mcp/test/unit/tools.test.ts
+++ b/apps/api/src/modules/mcp/test/unit/tools.test.ts
@@ -454,9 +454,11 @@ describe("buildMcpTools contextInjected", () => {
     const names = tools.map((t) => t.descriptor.name).sort();
     // get_me is redundant for a context-injected caller; search_operations stays
     // (its best_match schema is not covered by the injected operation index).
+    // load_skill is always exposed (it serves system-skill docs, no injected equivalent).
     expect(names).toEqual([
       "describe_operation",
       "invoke_operation",
+      "load_skill",
       "run_and_wait",
       "search_operations",
     ]);

--- a/apps/api/src/modules/mcp/tools.ts
+++ b/apps/api/src/modules/mcp/tools.ts
@@ -35,6 +35,7 @@ import {
   type RunAndWaitLaunch,
 } from "@appstrate/core/run-and-wait-client";
 import { getCatalog, collectReferencedSchemas, type CatalogOperation } from "./catalog.ts";
+import { loadAssistantSkill } from "./assistant-skills.ts";
 import { internalDispatchHeader } from "../../lib/internal-dispatch.ts";
 
 /** Issue an in-process request back through the platform app. */
@@ -46,6 +47,7 @@ export type McpToolName =
   | "describe_operation"
   | "invoke_operation"
   | "run_and_wait"
+  | "load_skill"
   | "get_me";
 
 /** Outcome of an `invoke_operation` call, for audit + telemetry. */
@@ -963,6 +965,71 @@ function buildGetMeTool(ctx: McpToolContext): AppstrateToolDefinition {
   return { descriptor, handler };
 }
 
+/**
+ * Serve the full body of a system skill shipped with the platform (the `## Assistant
+ * skills` index in the server instructions lists which ones). Pure read: it returns
+ * the skill's markdown — no dispatch, no credential, no side effect — so it carries
+ * no `mcp:invoke` gate (the endpoint's `mcp:read` already governs access). Every
+ * orchestrator-level MCP consumer (the chat on both engines, external clients) gets
+ * it; sandboxed agents reach only the sidecar MCP and never see it. The whitelist is
+ * the skills folder itself — see ./assistant-skills.ts for the path-traversal guard.
+ */
+function buildLoadSkillTool(ctx: McpToolContext): AppstrateToolDefinition {
+  const descriptor: Tool = {
+    name: "load_skill",
+    description:
+      "Read the full body of a system skill listed under '## Assistant skills' in these server " +
+      "instructions (progressive disclosure). Call it when the user's intent matches a skill, then " +
+      "follow it before acting. Pass `reference` to read one of that skill's referenced docs " +
+      "instead of its main body.",
+    annotations: {
+      title: "Load a skill",
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          description: "The skill name, exactly as listed (e.g. 'copilot').",
+        },
+        reference: {
+          type: "string",
+          description: "Optional reference doc name to load instead of the main SKILL.md body.",
+        },
+      },
+      required: ["name"],
+    },
+  };
+
+  const handler = async (args: Record<string, unknown>): Promise<CallToolResult> => {
+    const start = performance.now();
+    const name = asString(args.name);
+    if (!name) {
+      throw new McpError(ErrorCode.InvalidParams, "name is required.");
+    }
+    const reference = asString(args.reference);
+    emit(ctx, { tool: "load_skill", durationMs: performance.now() - start });
+
+    const loaded = loadAssistantSkill(name, reference);
+    if (!loaded) {
+      return textResult(
+        {
+          error: reference
+            ? `No reference "${reference}" for skill "${name}". Load the skill's main body first to see which references it offers.`
+            : `No skill named "${name}". See the '## Assistant skills' list in the server instructions for valid names.`,
+        },
+        true,
+      );
+    }
+    return textResult({ content: loaded.content });
+  };
+
+  return { descriptor, handler };
+}
+
 /** Build the per-request tool set. Handlers close over the caller's auth context. */
 export function buildMcpTools(ctx: McpToolContext): AppstrateToolDefinition[] {
   const tools = [
@@ -970,6 +1037,7 @@ export function buildMcpTools(ctx: McpToolContext): AppstrateToolDefinition[] {
     buildDescribeTool(ctx),
     buildInvokeTool(ctx),
     buildRunAndWaitTool(ctx),
+    buildLoadSkillTool(ctx),
   ];
   // get_me dispatches to GET /api/me/context. A consumer that already injects
   // that payload into its own system prompt (the chat module) drops the tool —

--- a/apps/api/src/modules/mcp/tools.ts
+++ b/apps/api/src/modules/mcp/tools.ts
@@ -31,6 +31,7 @@ import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import type { CallToolResult, Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { AppstrateToolDefinition } from "@appstrate/mcp-transport";
 import { getCatalog, collectReferencedSchemas, type CatalogOperation } from "./catalog.ts";
+import { loadAssistantSkill } from "./assistant-skills.ts";
 import { internalDispatchHeader } from "../../lib/internal-dispatch.ts";
 
 /** Issue an in-process request back through the platform app. */
@@ -41,6 +42,7 @@ export type McpToolName =
   | "search_operations"
   | "describe_operation"
   | "invoke_operation"
+  | "load_skill"
   | "get_me";
 
 /** Outcome of an `invoke_operation` call, for audit + telemetry. */
@@ -680,9 +682,79 @@ function buildGetMeTool(ctx: McpToolContext): AppstrateToolDefinition {
   return { descriptor, handler };
 }
 
+/**
+ * Serve the full body of a system skill shipped with the platform (the `## Assistant
+ * skills` index in the server instructions lists which ones). Pure read: it returns
+ * the skill's markdown — no dispatch, no credential, no side effect — so it carries
+ * no `mcp:invoke` gate (the endpoint's `mcp:read` already governs access). Every
+ * orchestrator-level MCP consumer (the chat on both engines, external clients) gets
+ * it; sandboxed agents reach only the sidecar MCP and never see it. The whitelist is
+ * the skills folder itself — see ./assistant-skills.ts for the path-traversal guard.
+ */
+function buildLoadSkillTool(ctx: McpToolContext): AppstrateToolDefinition {
+  const descriptor: Tool = {
+    name: "load_skill",
+    description:
+      "Read the full body of a system skill listed under '## Assistant skills' in these server " +
+      "instructions (progressive disclosure). Call it when the user's intent matches a skill, then " +
+      "follow it before acting. Pass `reference` to read one of that skill's referenced docs " +
+      "instead of its main body.",
+    annotations: {
+      title: "Load a skill",
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+          description: "The skill name, exactly as listed (e.g. 'copilot').",
+        },
+        reference: {
+          type: "string",
+          description: "Optional reference doc name to load instead of the main SKILL.md body.",
+        },
+      },
+      required: ["name"],
+    },
+  };
+
+  const handler = async (args: Record<string, unknown>): Promise<CallToolResult> => {
+    const start = performance.now();
+    const name = asString(args.name);
+    if (!name) {
+      throw new McpError(ErrorCode.InvalidParams, "name is required.");
+    }
+    const reference = asString(args.reference);
+    emit(ctx, { tool: "load_skill", durationMs: performance.now() - start });
+
+    const loaded = loadAssistantSkill(name, reference);
+    if (!loaded) {
+      return textResult(
+        {
+          error: reference
+            ? `No reference "${reference}" for skill "${name}". Load the skill's main body first to see which references it offers.`
+            : `No skill named "${name}". See the '## Assistant skills' list in the server instructions for valid names.`,
+        },
+        true,
+      );
+    }
+    return textResult({ content: loaded.content });
+  };
+
+  return { descriptor, handler };
+}
+
 /** Build the per-request tool set. Handlers close over the caller's auth context. */
 export function buildMcpTools(ctx: McpToolContext): AppstrateToolDefinition[] {
-  const tools = [buildSearchTool(ctx), buildDescribeTool(ctx), buildInvokeTool(ctx)];
+  const tools = [
+    buildSearchTool(ctx),
+    buildDescribeTool(ctx),
+    buildInvokeTool(ctx),
+    buildLoadSkillTool(ctx),
+  ];
   // get_me dispatches to GET /api/me/context. A consumer that already injects
   // that payload into its own system prompt (the chat module) drops the tool —
   // it would only re-fetch what the model already has. search_operations is

--- a/packages/module-chat/src/chat-stream.ts
+++ b/packages/module-chat/src/chat-stream.ts
@@ -134,6 +134,12 @@ You already have the exact shapes for these three operations: \`runAgent\` takes
 
 When a tool call fails with a recoverable error (e.g. a validation error naming a missing or malformed field, or a wrong-endpoint 404), do not stop and report it. Read the error detail, correct the input — re-read the operation schema if needed — and retry, up to a few attempts. Only surface the failure to the user once you have genuinely exhausted reasonable fixes; then show the exact error.
 
+Some know-how lives in **assistant skills** you load on demand (listed under "## Assistant skills" in your instructions, when present) — read the matching one with the \`load_skill\` tool BEFORE acting, then follow it:
+- When the user wants to automate something, build an agent, save time, or doesn't know what Appstrate can do for them, adopt the copilot stance: \`load_skill({ name: "copilot" })\`. (Short version: never ask "what takes you time?" — anchor on their role and tools and PROPOSE concrete automations yourself.)
+- To search or read the web (you have no direct web access — the runtime is sandboxed): \`load_skill({ name: "web-search" })\`, which runs an inline agent through a connected search/fetch provider.
+- When choosing how to connect a new service: \`load_skill({ name: "connector-choice" })\`.
+Stay conversational and propose early.
+
 Respect the user's role: actions beyond it will be refused by the platform — don't attempt them. When building or configuring an agent, prefer integrations the user already has connected (listed in their context below) over asking them to connect new ones.`;
 
 /** Shape of GET /api/me/context (the `get_me` payload). Validated loosely. */

--- a/packages/module-chat/src/prompt.ts
+++ b/packages/module-chat/src/prompt.ts
@@ -91,14 +91,11 @@ Never quote run metrics — duration, cost, token usage — in your replies, eve
 
 When a tool call fails with a recoverable error (e.g. a validation error naming a missing or malformed field, or a wrong-endpoint 404), do not stop and report it. Read the error detail, correct the input — re-read the operation schema if needed — and retry, up to a few attempts. Only surface the failure to the user once you have genuinely exhausted reasonable fixes; then show the exact error.
 
-Some know-how lives in **assistant skills** you load on demand (listed under "## Assistant skills" in your instructions, when present) — read the matching one with the \`load_skill\` tool BEFORE acting, then follow it:
-- When the user wants to automate something, build an agent, save time, or doesn't know what Appstrate can do for them, adopt the copilot stance: \`load_skill({ name: "copilot" })\`. (Short version: never ask "what takes you time?" — anchor on their role and tools and PROPOSE concrete automations yourself.)
-- To search or read the web (you have no direct web access — the runtime is sandboxed): \`load_skill({ name: "web-search" })\`, which runs an inline agent through a connected search/fetch provider.
-- When choosing how to connect a new service: \`load_skill({ name: "connector-choice" })\`.
-
 When a service offers both a plain integration and a remote-MCP variant (its id ends in \`-mcp\`), prefer the \`-mcp\` variant: it connects in one click (OAuth/DCR on the provider side), whereas the plain API variant usually forces the user to register a developer app. The caller context only lists ALREADY-connected integrations, so a not-yet-connected service and its \`-mcp\` sibling won't appear there — look it up with \`GET /api/integrations\` before connecting, and prefer the sibling whose id ends in \`-mcp\`.
 
-Stay conversational and propose early.
+Stay conversational and proactive: propose concrete next steps yourself rather than interrogating the user with open-ended questions.
+
+Some know-how lives in **assistant skills** you load on demand — they are listed with their descriptions under "## Assistant skills" in your instructions. When the user's intent matches one, read it in full with the \`load_skill\` tool BEFORE acting, then follow it.
 
 Respect the user's role: actions beyond it will be refused by the platform — don't attempt them.`;
 

--- a/packages/module-chat/src/prompt.ts
+++ b/packages/module-chat/src/prompt.ts
@@ -91,6 +91,15 @@ Never quote run metrics — duration, cost, token usage — in your replies, eve
 
 When a tool call fails with a recoverable error (e.g. a validation error naming a missing or malformed field, or a wrong-endpoint 404), do not stop and report it. Read the error detail, correct the input — re-read the operation schema if needed — and retry, up to a few attempts. Only surface the failure to the user once you have genuinely exhausted reasonable fixes; then show the exact error.
 
+Some know-how lives in **assistant skills** you load on demand (listed under "## Assistant skills" in your instructions, when present) — read the matching one with the \`load_skill\` tool BEFORE acting, then follow it:
+- When the user wants to automate something, build an agent, save time, or doesn't know what Appstrate can do for them, adopt the copilot stance: \`load_skill({ name: "copilot" })\`. (Short version: never ask "what takes you time?" — anchor on their role and tools and PROPOSE concrete automations yourself.)
+- To search or read the web (you have no direct web access — the runtime is sandboxed): \`load_skill({ name: "web-search" })\`, which runs an inline agent through a connected search/fetch provider.
+- When choosing how to connect a new service: \`load_skill({ name: "connector-choice" })\`.
+
+When a service offers both a plain integration and a remote-MCP variant (its id ends in \`-mcp\`), prefer the \`-mcp\` variant: it connects in one click (OAuth/DCR on the provider side), whereas the plain API variant usually forces the user to register a developer app. The caller context only lists ALREADY-connected integrations, so a not-yet-connected service and its \`-mcp\` sibling won't appear there — look it up with \`GET /api/integrations\` before connecting, and prefer the sibling whose id ends in \`-mcp\`.
+
+Stay conversational and propose early.
+
 Respect the user's role: actions beyond it will be refused by the platform — don't attempt them.`;
 
 /** Shape of GET /api/me/context (the `get_me` payload). Validated loosely. */


### PR DESCRIPTION
feat(mcp): serve system skills via load_skill on the platform MCP server

## Summary

Give the chat assistant (and any MCP client) a way to load **system skills**
on demand. The skills ship as Anthropic-format `SKILL.md` files inside the
`mcp` module and are served by the **platform MCP server** through a read-only
`load_skill` tool plus a `## Assistant skills` index in the server
instructions. The detailed know-how (how to run the agent-creation copilot,
how to search the web, how to pick a connector) moves OUT of the chat system
prompt and INTO these skills, loaded only when relevant (progressive
disclosure).

## Why on the MCP server (and not local to the chat)

A chat-local `load_skill` tool would only reach the **API-key** engine, where
the chat composes the toolset itself. The **claude-code subscription** engine
spawns the official binary, which opens its **own** MCP connection — the chat
never composes its tools, so a local tool would be invisible there.

Putting the tool on `/api/mcp/o/:org` fixes that in one move: both chat engines
pick it up through their respective MCP connections, **and** any external MCP
client (Claude Code, Claude Desktop, Cursor…) connected to the same endpoint
inherits the same skills. The instance becomes self-describing over MCP — the
hands (API operations) and the know-how (skills) at one counter.

Two MCP servers, two audiences: the **platform** server is the orchestrator's;
the **sidecar** server (inside the run container) is the agent's. So sandboxed
run agents never see `load_skill` — giving a skill to an *agent* stays the
separate `dependencies.skills` (in-container) path.

## Progressive disclosure

1. **Index** (always in context) — `## Assistant skills` in the server
   instructions: one line per skill (`name — description`).
2. **Body** (on demand) — `load_skill({ name })` returns the full `SKILL.md`.
3. **References** (level 3) — `load_skill({ name, reference })` returns
   `references/<reference>.md`.

## Changes

- `skills/{copilot,web-search,connector-choice}/` — initial system skills
  (copilot + 4 references). Frontmatter parsed via core's `extractSkillMeta`;
  `name` must equal the folder slug, `description` single-line. Connection
  guidance points at the **native flow** already in main (one-click OAuth
  button via `initiateIntegrationOAuth`; integrations page for API keys) and
  never asks the user to paste a secret.
- `assistant-skills.ts` — scan + render index + load, with a slug + whitelist
  + `startsWith` guard (no path traversal; reads only under `skills/`).
- `tools.ts` — `buildLoadSkillTool`, registered unconditionally; **no
  `mcp:invoke` gate** (pure read of shipped docs; `mcp:read` already governs
  the endpoint).
- `router.ts` — index injected **before** `## Operation index` so it survives
  the chat's Mistral instruction-trim.
- `chat-stream.ts` — `SYSTEM_PROMPT` keeps only a short copilot posture that
  points at `load_skill`; the detailed instructions now live in the SKILL.md.

## Testing

- `apps/api/src/modules/mcp/test/unit/skills.test.ts` — scan, index render,
  load body/reference, path-traversal rejection, and the `load_skill` tool
  (10 tests).
- `tools.test.ts` toolset assertion updated to include `load_skill`
  (full file green, 31/31).
- `bun run typecheck` green (api + module-chat).
- **Validated live on the subscription (claude-code) engine**: "aide-moi à
  faire des agents" → the assistant calls `load_skill({name:"copilot"})` and
  runs the tools-first interview (anchors on role + connected tools, proposes
  concrete automations) — proving the subscription-path gap is closed.

## Scope / coordination

- Built on current `main` (post-#688). Independent of the in-flight
  credential-form work (`request_connection`) — this PR references only the
  OAuth-button connection flow already present in main, so it merges on its
  own with no cross-dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
