### PR TITLE
[codex] fix e2e end-user strict body contract

### DIFF
--- a/e2e/tests/isolation/app-isolation.api.spec.ts
+++ b/e2e/tests/isolation/app-isolation.api.spec.ts
@@ -372,34 +372,25 @@ test.describe("Cross-app resource isolation", () => {
   // ─── End-user creation scoping ────────────
 
   test.describe("End-user creation scoping", () => {
-    test("POST /end-users ignores applicationId in body — always uses X-Application-Id", async ({
-      request,
+    test("POST /end-users rejects applicationId in body", async ({
       apiClient: clientA,
-      orgContext,
       orgOnlyClient,
     }) => {
       const appB = await createApplication(orgOnlyClient, `AppB-eu-body-${Date.now()}`);
-      const clientB = createApiClient(request, {
-        cookie: orgContext.auth.cookie,
-        orgId: orgContext.org.orgId,
-        applicationId: appB.id,
-      });
 
-      // Create end-user from AppA context, but sneak appB's ID in the body
+      // App scoping is taken from X-Application-Id; body-level applicationId is
+      // rejected so clients cannot rely on a silently ignored override.
       const res = await clientA.post("/end-users", {
         name: "Body Override Test",
         applicationId: appB.id,
       });
-      expect(res.status()).toBe(201);
-      const eu = await res.json();
-
-      // The end-user should belong to AppA (the X-Application-Id), not AppB
-      const resA = await clientA.get(`/end-users/${eu.id}`);
-      expect(resA.status()).toBe(200);
-
-      // AppB should NOT see this end-user
-      const resB = await clientB.get(`/end-users/${eu.id}`);
-      expect(resB.status()).toBe(404);
+      expect(res.status()).toBe(400);
+      const body = (await res.json()) as {
+        code?: string;
+        errors?: Array<{ code?: string; message?: string }>;
+      };
+      expect(body.code).toBe("validation_failed");
+      expect(body.errors?.some((e) => e.code === "unknown_field")).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Align the cross-app end-user E2E with the strict request-body contract introduced by #778. `POST /end-users` now rejects a body-level `applicationId` as an unknown field instead of silently ignoring it, so the stale E2E assertion expected the old 201 behavior and kept `main` red.

## Validation

- `cd apps/web && bun run build`
- `bun test apps/api/test/integration/routes/end-users.test.ts`
- `bunx prettier --check e2e/tests/isolation/app-isolation.api.spec.ts`

Attempted the targeted Playwright API spec locally, but the local webServer did not become ready before the test ran: first because `.env` pointed `DATABASE_URL` at `localhost:5423`, then because local PGlite boot/storage infra failed before reaching the test. CI should exercise the updated E2E in its clean environment.

## Root Cause

PR #778 made the end-user create/update schemas strict and added an integration test for `400 unknown_field`, but the cross-app E2E still asserted the previous lenient behavior for `applicationId` in the body.
