### PR TITLE
fix(runs): avoid deprecated zod finite check

### DIFF
--- a/packages/afps-runtime/src/types/execution-context.ts
+++ b/packages/afps-runtime/src/types/execution-context.ts
@@ -120,7 +120,7 @@ export const executionContextSchema = z.object({
    * than letting the platform kill the container and surface a generic
    * abort. Absent ⇒ no runner-side enforcement (platform safety net only).
    */
-  timeoutSeconds: z.number().finite().positive().optional(),
+  timeoutSeconds: z.number().positive().optional(),
 });
 
 export type ExecutionContext = z.infer<typeof executionContextSchema>;


### PR DESCRIPTION
## Summary

- Replace the deprecated Zod `.finite()` call on `ExecutionContext.timeoutSeconds` with `z.number().positive()`.
- Keeps the existing non-finite timeout coverage; Zod 4 rejects `Infinity` through `z.number()` already.

## Validation

- `bun test packages/afps-runtime/test/types/execution-context.test.ts`
- `bun run --filter @appstrate/afps-runtime typecheck`
- pre-push `bun run check` (33/33 successful)