### PR TITLE
fix(chat): harden run orchestration

### DIFF
--- a/packages/module-chat/src/chat-stream.ts
+++ b/packages/module-chat/src/chat-stream.ts
@@ -144,6 +144,8 @@ Do NOT pre-validate a manifest with the \`validateInlineRun\` operation (\`POST 
 
 Runs are asynchronous, but \`run_and_wait\` handles both launch and waiting for you. Use \`run_and_wait\` for agent/inline runs, then read its returned \`result\` field — that is the sub-agent's deliverable. Do NOT call run-get/\`getRun\` after \`run_and_wait\` just to wait for completion. Answer the user from \`result\`; never fabricate it. If the run fails, read its error and report it plainly.
 
+When calling \`run_and_wait\`, pass a real tool input object. Never serialize the whole \`run_and_wait\` input as a JSON string, never wrap it in backticks, and keep long prompts as the \`prompt\` string field inside the object. If a \`run_and_wait\` tool call fails because the input was malformed, immediately retry once with the same data as a proper object.
+
 Example — summarising the user's latest emails (adapt the integration id, version, tools, and schema to the actual request):
 \`\`\`json
 {
@@ -175,6 +177,10 @@ Example — summarising the user's latest emails (adapt the integration id, vers
 Then read \`result.summary\` from the \`run_and_wait\` result and reply to the user from it.
 
 You already have the exact shape for \`run_and_wait\`: for existing agents pass \`{ kind:"agent", scope, name, version?, input? }\`; for inline runs pass \`{ kind:"inline", manifest, prompt, config? }\`. Do NOT call \`describe_operation\` for run launching, and do NOT call run-get/\`getRun\` after \`run_and_wait\` just to wait. (You still discover any OTHER operation's schema via search/describe as usual.)
+
+Integration connection UX: if you call \`initiateIntegrationConnect\`, the tool result renders the native connect card. Do NOT paste the returned \`connect_url\` or turn it into a markdown link. End the turn and tell the user to connect with the card; a later resume message will say the integration is connected and you can continue.
+
+Schedules: if you create a schedule and then manually run the agent to verify it, say exactly that. Do NOT claim the schedule itself was tested or executed successfully unless the run you inspected has that schedule id.
 
 When a tool call fails with a recoverable error (e.g. a validation error naming a missing or malformed field, or a wrong-endpoint 404), do not stop and report it. Read the error detail, correct the input — re-read the operation schema if needed — and retry, up to a few attempts. Only surface the failure to the user once you have genuinely exhausted reasonable fixes; then show the exact error.
 

--- a/packages/module-chat/src/llm.ts
+++ b/packages/module-chat/src/llm.ts
@@ -31,7 +31,18 @@ export interface OrgModel {
   enabled?: boolean;
   /** snake_case to match the `/api/models` wire field — camelCase silently never matches. */
   is_default?: boolean;
+  /** "built-in" for system models, "custom" for org rows. */
+  source?: string;
 }
+
+const CHAT_DEPRIORITIZED_SYSTEM_DEFAULT_PROVIDERS = new Set(["deepseek"]);
+const CHAT_PROVIDER_PREFERENCE = new Map<string, number>([
+  ["anthropic", 50],
+  ["claude-code", 45],
+  ["openai", 40],
+  ["mistral", 25],
+  ["deepseek", -50],
+]);
 
 export async function listModels(
   origin: string,
@@ -68,9 +79,15 @@ export function pickModel(models: OrgModel[], modelId?: string): OrgModel {
       "Aucun modèle utilisable par le chat n'est configuré. Connectez un modèle par clé API (Anthropic, OpenAI, Mistral) ou un abonnement Claude Code dans Settings → Models.",
     );
   }
-  const chosen = modelId
-    ? pool.find((m) => m.id === modelId || m.modelId === modelId)
-    : (pool.find((m) => m.is_default) ?? pool[0]);
+  const explicit = modelId ? pool.find((m) => m.id === modelId || m.modelId === modelId) : null;
+  const defaultModel = pool.find((m) => m.is_default);
+  const chosen =
+    explicit ??
+    (defaultModel &&
+    (defaultModel.source !== "built-in" ||
+      !CHAT_DEPRIORITIZED_SYSTEM_DEFAULT_PROVIDERS.has(defaultModel.providerId ?? ""))
+      ? defaultModel
+      : [...pool].sort((a, b) => chatModelPreference(b) - chatModelPreference(a))[0]);
   if (!chosen) {
     throw invalidRequest(
       modelId
@@ -79,6 +96,15 @@ export function pickModel(models: OrgModel[], modelId?: string): OrgModel {
     );
   }
   return chosen;
+}
+
+function chatModelPreference(model: OrgModel): number {
+  let score = CHAT_PROVIDER_PREFERENCE.get(model.providerId ?? "") ?? 0;
+  if (model.source !== "built-in") score += 10;
+  if (model.is_default) score += 5;
+  if (model.apiShape === "anthropic-messages") score += 4;
+  if (model.apiShape === "openai-completions") score += 2;
+  return score;
 }
 
 type ProxyKind = "anthropic" | "openai-compatible";

--- a/packages/module-chat/src/platform-mcp.ts
+++ b/packages/module-chat/src/platform-mcp.ts
@@ -71,6 +71,7 @@ export async function openPlatformMcp(args: {
   let tools: ToolSet;
   try {
     tools = await client.tools();
+    tools = wrapInvokeOperationTool(tools);
     tools = wrapRunAndWaitTool(tools, {
       origin: args.origin,
       headers,
@@ -102,32 +103,177 @@ function callToolResult(payload: unknown, isError = false): unknown {
   };
 }
 
-function parseNestedJsonObject(text: string): Record<string, unknown> | null {
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function parseLooseJsonObject(text: string): Record<string, unknown> | null {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith("{")) return null;
+
+  try {
+    return asRecord(JSON.parse(trimmed));
+  } catch {
+    // Some tool-call providers hand us an object encoded as a string but leave
+    // literal newlines/tabs inside string values. JSON.parse rejects that, while
+    // the intended object is still unambiguous enough to recover.
+  }
+
+  let repaired = "";
+  let inString = false;
+  let escaped = false;
+  for (const ch of trimmed) {
+    if (escaped) {
+      repaired += ch;
+      escaped = false;
+      continue;
+    }
+    if (ch === "\\") {
+      repaired += ch;
+      escaped = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      repaired += ch;
+      continue;
+    }
+    if (inString && ch === "\n") {
+      repaired += "\\n";
+      continue;
+    }
+    if (inString && ch === "\r") {
+      repaired += "\\r";
+      continue;
+    }
+    if (inString && ch === "\t") {
+      repaired += "\\t";
+      continue;
+    }
+    repaired += ch;
+  }
+
+  try {
+    return asRecord(JSON.parse(repaired));
+  } catch {
+    return null;
+  }
+}
+
+function parseStringifiedJsonObject(text: string): Record<string, unknown> | null {
   try {
     const outer = JSON.parse(text) as unknown;
     if (typeof outer !== "string") return null;
-    const inner = JSON.parse(outer) as unknown;
-    return typeof inner === "object" && inner !== null && !Array.isArray(inner)
-      ? (inner as Record<string, unknown>)
-      : null;
+    return parseLooseJsonObject(outer);
   } catch {
     return null;
   }
 }
 
 /**
- * Some models occasionally double-encode MCP tool inputs, producing a JSON
- * string whose value is the real object. Repair only that narrow case; malformed
- * JSON and schema-invalid objects still fail normally so the model can correct
- * them.
+ * Some models occasionally string-encode MCP tool inputs, producing a JSON
+ * string whose value is the real object. Repair only that narrow case; schema-
+ * invalid objects still fail normally so the model can correct them.
  */
 export const repairStringifiedToolCall: ToolCallRepairFunction<AiToolSet> = async ({
   toolCall,
 }) => {
-  const input = parseNestedJsonObject(toolCall.input);
+  const input =
+    parseStringifiedJsonObject(toolCall.input) ??
+    (toolCall.toolName === "run_and_wait" ? parseLooseJsonObject(toolCall.input) : null);
   if (!input) return null;
   return { ...toolCall, input: JSON.stringify(input) };
 };
+
+function normalizeRunAndWaitArgs(rawArgs: unknown): unknown {
+  if (asRecord(rawArgs)) return rawArgs;
+  if (typeof rawArgs !== "string") return rawArgs;
+  return parseLooseJsonObject(rawArgs) ?? rawArgs;
+}
+
+function parseMcpTextResult(output: unknown): Record<string, unknown> | null {
+  const content = asRecord(output)?.content;
+  if (!Array.isArray(content)) return null;
+  const first = asRecord(content[0]);
+  const text = first?.type === "text" && typeof first.text === "string" ? first.text : null;
+  if (!text) return null;
+  try {
+    return asRecord(JSON.parse(text));
+  } catch {
+    return null;
+  }
+}
+
+function compactIntegrationSummary(value: unknown): Record<string, unknown> | null {
+  const row = asRecord(value);
+  if (!row) return null;
+  const manifest = asRecord(row.manifest);
+  return {
+    id: row.id,
+    active: row.active,
+    block_user_connections: row.block_user_connections,
+    display_name: manifest?.display_name,
+    description: manifest?.description,
+    default_tools: manifest?.default_tools,
+  };
+}
+
+function compactListIntegrationsResult(output: unknown): unknown {
+  const envelope = parseMcpTextResult(output);
+  if (!envelope) return output;
+
+  const body = envelope.body;
+  const bodyRecord = asRecord(body);
+  const data = Array.isArray(bodyRecord?.data) ? bodyRecord.data : null;
+  if (data) {
+    const compacted = data.map(compactIntegrationSummary).filter(Boolean);
+    return callToolResult({
+      status: envelope.status,
+      compacted: true,
+      object: bodyRecord?.object,
+      total: compacted.length,
+      data: compacted,
+      hasMore: bodyRecord?.hasMore,
+      note: "Compacted for chat context. For a specific integration, call getIntegration with path_params.packageId to inspect auths, default_tools, and tool_catalog.",
+    });
+  }
+
+  if (envelope.truncated || typeof body === "string") {
+    return callToolResult({
+      status: envelope.status,
+      compacted: true,
+      truncated: envelope.truncated === true,
+      note: "listIntegrations returned a large response omitted from chat context. For a task-specific integration, call getIntegration with the expected @scope/name id, then listIntegrationConnections or initiateIntegrationConnect as needed.",
+    });
+  }
+
+  return output;
+}
+
+export function wrapInvokeOperationTool(tools: ToolSet): ToolSet {
+  const invoke = tools.invoke_operation as
+    | (Record<string, unknown> & {
+        execute?: (args: unknown, options: { abortSignal?: AbortSignal }) => unknown;
+      })
+    | undefined;
+  if (!invoke?.execute) return tools;
+
+  const wrapped = {
+    ...invoke,
+    async execute(rawArgs: unknown, options: { abortSignal?: AbortSignal }) {
+      const output = await invoke.execute!(rawArgs, options);
+      const args = asRecord(rawArgs);
+      if (args?.operation_id !== "listIntegrations") return output;
+      return compactListIntegrationsResult(output);
+    },
+  };
+
+  const next = { ...tools } as Record<string, unknown>;
+  next.invoke_operation = wrapped;
+  return next as unknown as ToolSet;
+}
 
 export function wrapRunAndWaitTool(
   tools: ToolSet,
@@ -143,7 +289,7 @@ export function wrapRunAndWaitTool(
   const wrapped = {
     ...runAndWait,
     async *execute(rawArgs: unknown, options: { abortSignal?: AbortSignal }) {
-      for await (const step of runAndWaitSteps(rawArgs, {
+      for await (const step of runAndWaitSteps(normalizeRunAndWaitArgs(rawArgs), {
         origin: opts.origin,
         headers: opts.headers,
         fetch: opts.fetch,

--- a/packages/module-chat/src/ui/markdown-text.tsx
+++ b/packages/module-chat/src/ui/markdown-text.tsx
@@ -12,13 +12,14 @@ export function MarkdownText() {
       className="prose prose-sm dark:prose-invert max-w-none break-words [&_code]:text-[0.85em] [&_pre]:rounded-md [&_pre]:p-3 [&_pre]:text-xs"
       components={{
         a: ({ node: _node, href, children, ...props }) => {
-          // Suppress integration OAuth authorize links the model pastes despite
-          // guidance: the native connect card already handles the flow, and a
-          // raw auth link is a dead-end (full-tab callback, no resume). Detected
-          // by our callback path in its redirect_uri — generic across providers,
-          // independent of model compliance. Render the label as inert muted
-          // text pointing at the card instead of a clickable link.
-          if (href && /integrations(%2f|\/)callback/i.test(href)) {
+          // Suppress integration OAuth/connect links the model pastes despite
+          // guidance: the native connect card owns the resumable flow. Render
+          // the label as inert muted text pointing at the card instead.
+          if (
+            href &&
+            (/integrations(%2f|\/)callback/i.test(href) ||
+              /\/api\/integrations\/connect\/start\?/i.test(href))
+          ) {
             return (
               <span className="text-muted-foreground italic">
                 {children}{" "}

--- a/packages/module-chat/test/llm.test.ts
+++ b/packages/module-chat/test/llm.test.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from "bun:test";
+import { pickModel, type OrgModel } from "../src/llm.ts";
+
+function model(overrides: Partial<OrgModel>): OrgModel {
+  return {
+    id: overrides.id ?? "m",
+    modelId: overrides.modelId ?? overrides.id ?? "m",
+    apiShape: overrides.apiShape ?? "openai-completions",
+    providerId: overrides.providerId,
+    enabled: overrides.enabled,
+    is_default: overrides.is_default,
+    source: overrides.source,
+  };
+}
+
+describe("pickModel", () => {
+  test("keeps explicit model selection even for a deprioritized provider", () => {
+    const deepseek = model({
+      id: "deepseek",
+      providerId: "deepseek",
+      source: "built-in",
+      is_default: true,
+    });
+    const openai = model({ id: "openai", providerId: "openai", source: "built-in" });
+
+    expect(pickModel([deepseek, openai], "deepseek")).toBe(deepseek);
+  });
+
+  test("deprioritizes the built-in DeepSeek fallback for chat tool orchestration", () => {
+    const deepseek = model({
+      id: "deepseek",
+      providerId: "deepseek",
+      source: "built-in",
+      is_default: true,
+    });
+    const openai = model({ id: "openai", providerId: "openai", source: "built-in" });
+
+    expect(pickModel([deepseek, openai])).toBe(openai);
+  });
+
+  test("respects a custom default model", () => {
+    const custom = model({
+      id: "custom",
+      providerId: "deepseek",
+      source: "custom",
+      is_default: true,
+    });
+    const openai = model({ id: "openai", providerId: "openai", source: "built-in" });
+
+    expect(pickModel([custom, openai])).toBe(custom);
+  });
+});

--- a/packages/module-chat/test/platform-mcp.test.ts
+++ b/packages/module-chat/test/platform-mcp.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, test } from "bun:test";
-import { wrapRunAndWaitTool } from "../src/platform-mcp.ts";
+import { wrapInvokeOperationTool, wrapRunAndWaitTool } from "../src/platform-mcp.ts";
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -21,7 +21,7 @@ function parseToolResult(output: unknown): Record<string, unknown> {
 
 async function collectRunAndWait(
   fetchImpl: typeof fetch,
-  args: Record<string, unknown>,
+  args: unknown,
 ): Promise<{
   outputs: Record<string, unknown>[];
   originalCalled: boolean;
@@ -106,6 +106,37 @@ describe("platform MCP run_and_wait wrapper", () => {
     ]);
   });
 
+  test("normalizes a run_and_wait input object encoded as a JSON string", async () => {
+    const calls: Array<{ url: string; method: string; body: unknown }> = [];
+    const responses = [
+      jsonResponse({ id: "run_1", packageId: "@inline/r-1", status: "pending" }),
+      jsonResponse({ id: "run_1", packageId: "@inline/r-1", status: "success" }),
+    ];
+    const fetchImpl: typeof fetch = async (input, init) => {
+      calls.push({
+        url: String(input),
+        method: init?.method ?? "GET",
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+      });
+      const res = responses.shift();
+      if (!res) throw new Error("unexpected fetch");
+      return res;
+    };
+
+    const { outputs } = await collectRunAndWait(
+      fetchImpl,
+      `{"kind":"inline","manifest":{"name":"@inline/t1"},"prompt":"Step 1
+Step 2"}`,
+    );
+
+    expect(outputs.at(-1)).toMatchObject({ id: "run_1", status: "success", done: true });
+    expect(calls[0]).toMatchObject({
+      url: "https://test.local/api/runs/inline",
+      method: "POST",
+      body: { manifest: { name: "@inline/t1" }, prompt: "Step 1\nStep 2" },
+    });
+  });
+
   test("surfaces launch failures without polling", async () => {
     const calls: string[] = [];
     const fetchImpl: typeof fetch = async (input) => {
@@ -131,5 +162,62 @@ describe("platform MCP run_and_wait wrapper", () => {
     const { outputs } = await collectRunAndWait(fetchImpl, { kind: "inline" });
 
     expect(outputs).toEqual([{ error: "`manifest` is required for kind:'inline'." }]);
+  });
+});
+
+describe("platform MCP invoke_operation wrapper", () => {
+  test("compacts listIntegrations results before they re-enter chat context", async () => {
+    const tools = wrapInvokeOperationTool({
+      invoke_operation: {
+        execute: () => ({
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                status: 200,
+                body: {
+                  object: "list",
+                  hasMore: false,
+                  data: [
+                    {
+                      id: "@appstrate/gmail",
+                      active: true,
+                      block_user_connections: false,
+                      manifest: {
+                        display_name: "Gmail",
+                        description: "Read Gmail messages",
+                        default_tools: ["api_call"],
+                        noisy: "x".repeat(10_000),
+                      },
+                    },
+                  ],
+                },
+              }),
+            },
+          ],
+        }),
+      },
+    } as never) as {
+      invoke_operation: {
+        execute: (rawArgs: unknown, options: { abortSignal?: AbortSignal }) => Promise<unknown>;
+      };
+    };
+
+    const output = await tools.invoke_operation.execute({ operation_id: "listIntegrations" }, {});
+    const parsed = parseToolResult(output);
+
+    expect(parsed).toMatchObject({
+      status: 200,
+      compacted: true,
+      data: [
+        {
+          id: "@appstrate/gmail",
+          active: true,
+          display_name: "Gmail",
+          default_tools: ["api_call"],
+        },
+      ],
+    });
+    expect(JSON.stringify(parsed)).not.toContain("noisy");
   });
 });

--- a/packages/module-chat/test/tool-call-repair.test.ts
+++ b/packages/module-chat/test/tool-call-repair.test.ts
@@ -3,12 +3,12 @@
 import { describe, expect, test } from "bun:test";
 import { repairStringifiedToolCall } from "../src/platform-mcp.ts";
 
-function repair(input: string) {
+function repair(input: string, toolName = "invoke_operation") {
   return repairStringifiedToolCall({
     toolCall: {
       type: "tool-call",
       toolCallId: "call_1",
-      toolName: "invoke_operation",
+      toolName,
       input,
     },
     tools: {},
@@ -36,8 +36,27 @@ describe("repairStringifiedToolCall", () => {
     });
   });
 
-  test("does not rewrite ordinary object JSON or malformed JSON", async () => {
+  test("unwraps a direct JSON object string with literal newlines in string fields", async () => {
+    const input = `{"kind":"inline","manifest":{"name":"@inline/gmail-summary"},"prompt":"Step 1
+Step 2"}`;
+
+    const repaired = await repair(input, "run_and_wait");
+
+    expect(repaired).toMatchObject({
+      type: "tool-call",
+      toolCallId: "call_1",
+      toolName: "run_and_wait",
+      input: JSON.stringify({
+        kind: "inline",
+        manifest: { name: "@inline/gmail-summary" },
+        prompt: "Step 1\nStep 2",
+      }),
+    });
+  });
+
+  test("does not rewrite malformed non-object JSON", async () => {
     await expect(repair(JSON.stringify({ operation_id: "runInline" }))).resolves.toBeNull();
     await expect(repair('{"operation_id":')).resolves.toBeNull();
+    await expect(repair("[1,2,3]")).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- repair stringified `run_and_wait` inputs, including direct JSON object strings with literal newlines
- compact `listIntegrations` MCP results and suppress raw integration connect links in chat markdown
- prefer stronger chat orchestration defaults over built-in DeepSeek while keeping explicit and custom selections respected

## Tests
- `bun test packages/module-chat/test/tool-call-repair.test.ts packages/module-chat/test/platform-mcp.test.ts packages/module-chat/test/llm.test.ts apps/api/src/modules/mcp/test/unit/run-and-wait.test.ts packages/module-chat/test/run-events.test.ts packages/core/test/format.test.ts`
- `bun run --filter @appstrate/module-chat typecheck`
- `bunx prettier --check packages/module-chat/src/platform-mcp.ts packages/module-chat/src/chat-stream.ts packages/module-chat/src/llm.ts packages/module-chat/src/ui/markdown-text.tsx packages/module-chat/test/tool-call-repair.test.ts packages/module-chat/test/platform-mcp.test.ts packages/module-chat/test/llm.test.ts`
- pre-push turbo gate: `typecheck lint format:check verify:openapi verify:api-types verify:type-coverage verify:compose-defaults detect:breaking build:system-packages:check lint:manifest-casing conformance:check verify:module-isolation typecheck:scripts verify:module-contract`
