### PR TITLE
fix(chat): show only model name in model-select trigger

### DIFF
--- a/packages/module-chat/src/ui/model-select.tsx
+++ b/packages/module-chat/src/ui/model-select.tsx
@@ -114,10 +114,7 @@ export function ModelSelect({ models, selectedId, onSelect }: Props) {
         title="Modèle"
       >
         {active ? (
-          <>
-            <span className="text-muted-foreground shrink-0">{providerLabel(active)}</span>
-            <span className="truncate font-medium">{active.label ?? active.modelId}</span>
-          </>
+          <span className="truncate font-medium">{active.label ?? active.modelId}</span>
         ) : (
           <span className="font-medium">Modèle</span>
         )}


### PR DESCRIPTION
## Résumé

Dans le sélecteur de modèle du chat, la valeur sélectionnée (le trigger/input) affichait à la fois le nom du provider **et** le nom du modèle. On n'affiche plus que le nom du modèle dans le trigger. Le nom du provider reste présent dans le dropdown lui-même (en-tête de groupe).

## Changement

`packages/module-chat/src/ui/model-select.tsx` — trigger : suppression du `<span>{providerLabel(active)}</span>`, on garde uniquement `{active.label ?? active.modelId}`. La liste déroulante (groupage par provider) est inchangée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)