### PR TITLE
fix(chat): apply model selection to the next send instead of the mount-time model

### DIFF
--- a/packages/module-chat/src/ui/index.tsx
+++ b/packages/module-chat/src/ui/index.tsx
@@ -33,8 +33,7 @@ import { fetchModels, type OrgModelOption } from "./models-data.ts";
 import { loadHistory, mintSessionId, SESSIONS_QUERY_KEY, type SessionSummary } from "./sessions.ts";
 import { useSessions } from "./use-sessions.ts";
 import { subscribeSeen, getSeen, markSeen, isUnread } from "./unread-store.ts";
-
-const MODEL_STORAGE_KEY = "appstrate.chat.model";
+import { subscribeModel, getSelectedModel, setSelectedModel } from "./model-store.ts";
 
 export interface ChatPageProps {
   getHeaders?: GetHeaders;
@@ -85,24 +84,21 @@ export function ChatPage({
   const [mobileOpen, setMobileOpen] = useState(false);
 
   const [models, setModels] = useState<OrgModelOption[]>([]);
-  const [selectedModel, setSelectedModel] = useState<string | null>(() =>
-    typeof localStorage === "undefined" ? null : localStorage.getItem(MODEL_STORAGE_KEY),
-  );
+  // Model selection lives in an external store (localStorage-backed), not React
+  // state: the transport's header builder reads it per request through a stable
+  // function (see ConversationInner), so a switch applies to the very next send
+  // without remounting the conversation. This hook only mirrors it for the picker.
+  const selectedModel = useSyncExternalStore(subscribeModel, getSelectedModel, getSelectedModel);
 
   useEffect(() => {
     void fetchModels(getHeaders).then((list) => {
       setModels(list);
-      setSelectedModel((cur) => {
-        if (cur && list.some((m) => m.id === cur)) return cur;
-        return (list.find((m) => m.is_default) ?? list[0])?.id ?? null;
-      });
+      // Reconcile a stale/absent stored selection to the org default.
+      const cur = getSelectedModel();
+      if (cur && list.some((m) => m.id === cur)) return;
+      setSelectedModel((list.find((m) => m.is_default) ?? list[0])?.id ?? null);
     });
   }, [getHeaders]);
-
-  const selectModel = (id: string) => {
-    setSelectedModel(id);
-    localStorage.setItem(MODEL_STORAGE_KEY, id);
-  };
 
   // Unread replies for conversations the user left mid-generation. The list
   // query polls (fast while generating); the seen watermark is an external store
@@ -170,11 +166,14 @@ export function ChatPage({
                 key={activeId}
                 id={activeId}
                 getHeaders={getHeaders}
-                selectedModel={selectedModel}
                 isPersisted={isPersisted}
                 onConversationChange={onConversationChange}
                 composerSlot={
-                  <ModelSelect models={models} selectedId={selectedModel} onSelect={selectModel} />
+                  <ModelSelect
+                    models={models}
+                    selectedId={selectedModel}
+                    onSelect={setSelectedModel}
+                  />
                 }
               />
             </main>
@@ -188,7 +187,6 @@ export function ChatPage({
 interface ConversationProps {
   id: string;
   getHeaders?: GetHeaders;
-  selectedModel: string | null;
   isPersisted: boolean;
   onConversationChange?: SelectConversation;
   composerSlot?: React.ReactNode;
@@ -240,23 +238,25 @@ function ConversationInner({
   id,
   getHeaders,
   initialMessages,
-  selectedModel,
   isPersisted,
   onConversationChange,
   composerSlot,
 }: ConversationProps & { initialMessages: UIMessage[] }) {
   const queryClient = useQueryClient();
 
-  // Header builder invoked by the transport at request/reconnect time. Depends on
-  // the model state (no ref), so the transport rebuilds when the model changes —
-  // useChat picks it up for the next send. `getHeaders` is a stable host fn.
-  const buildHeaders = useCallback(
-    (): Record<string, string> => ({
+  // Header builder invoked by the transport at request/reconnect time. It reads
+  // the model from the external store, NOT from React state: `useChat` recreates
+  // its `Chat` instance only when `id` changes, so a transport rebuilt over
+  // fresh state would be silently ignored and every send would keep the model
+  // captured at mount. The store read resolves per request, so a model switch
+  // applies to the next send. `getHeaders` is a stable host fn.
+  const buildHeaders = useCallback((): Record<string, string> => {
+    const model = getSelectedModel();
+    return {
       ...getHeaders?.(),
-      ...(selectedModel ? { "X-Model-Id": selectedModel } : {}),
-    }),
-    [getHeaders, selectedModel],
-  );
+      ...(model ? { "X-Model-Id": model } : {}),
+    };
+  }, [getHeaders]);
 
   const transport = useMemo(
     () =>

--- a/packages/module-chat/src/ui/model-store.ts
+++ b/packages/module-chat/src/ui/model-store.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Currently selected chat model (org preset id), persisted in localStorage.
+ *
+ * Exposed as an external store (`useSyncExternalStore`) rather than React
+ * state so the transport's per-request header builder can read the CURRENT
+ * selection through a stable function: `useChat` recreates its `Chat` instance
+ * only when the conversation id changes, so a transport rebuilt over fresh
+ * state is silently ignored and every send would keep the model captured at
+ * mount. Same pattern as `unread-store.ts`.
+ */
+
+const KEY = "appstrate.chat.model";
+
+let cache: string | null = typeof localStorage === "undefined" ? null : localStorage.getItem(KEY);
+const listeners = new Set<() => void>();
+
+export function subscribeModel(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function getSelectedModel(): string | null {
+  return cache;
+}
+
+export function setSelectedModel(id: string | null): void {
+  if (cache === id) return;
+  cache = id;
+  try {
+    if (id === null) localStorage.removeItem(KEY);
+    else localStorage.setItem(KEY, id);
+  } catch {
+    // ignore quota / unavailable storage — the selection just won't persist.
+  }
+  for (const l of listeners) l();
+}


### PR DESCRIPTION
## Problème

Changer de modèle dans le picker puis envoyer un message (nouveau chat déjà monté, ou conversation en cours) utilisait toujours l'**ancien** modèle — impression de « cache ».

## Cause

`useChat` (`@ai-sdk/react`) ne recrée son instance `Chat` que lorsque `id` change :

```js
const shouldRecreateChat = ("chat" in options && options.chat !== chatRef.current)
  || ("id" in options && chatRef.current.id !== options.id);
```

Le transport reconstruit après un changement de modèle (nouvelle closure sur le state frais) était donc silencieusement ignoré : chaque envoi gardait le `X-Model-Id` capturé au mount de la conversation. Le serveur, lui, résout bien le modèle par tour depuis le header (`chat-stream.ts`) — pas de cache serveur.

## Fix

- La sélection de modèle passe dans un **store externe** adossé à `localStorage` (`model-store.ts`, même pattern que `unread-store.ts`), consommé via `useSyncExternalStore` pour le picker.
- Le header builder du transport lit le store **à chaque requête** (`DefaultChatTransport` résout `headers` par requête) : un seul transport stable dont les headers reflètent toujours la sélection courante.
- La clé `localStorage` (`appstrate.chat.model`) est inchangée — la sélection persistée existante est reprise telle quelle.

Note : la lecture par ref (variante initiale) est rejetée par la règle React Compiler `react-hooks/refs` ; le store externe est la forme conforme.

## Test

- `bun run check` complet vert (typecheck + eslint recommended-latest + prettier + turbo).
- Manuel : ouvrir `/chat`, changer le modèle, envoyer → le log serveur `model resolved` montre le modèle choisi ; idem en cours de conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)