### PR TITLE
fix(chat): settle run card timer on server-authoritative runs.duration

### DIFF
--- a/packages/module-chat/src/ui/chat-run-progress-card.tsx
+++ b/packages/module-chat/src/ui/chat-run-progress-card.tsx
@@ -87,7 +87,7 @@ export function ChatRunProgressCard({
   modalTitle: React.ReactNode;
   details: React.ReactNode;
 }) {
-  const { logs, status, packageId, startedAt, completedAt } = useRunLogStream(
+  const { logs, status, packageId, startedAt, completedAt, duration } = useRunLogStream(
     runId,
     initialStatus,
     initialPackageId,
@@ -96,8 +96,12 @@ export function ChatRunProgressCard({
     status ?? (isTerminalStatus(initialStatus) ? (initialStatus as RunStatus) : undefined);
   const [open, setOpen] = React.useState(false);
 
-  // Live execution time — ticks each second while running, freezes on completion.
-  const elapsedMs = useLiveElapsedMs(startedAt, completedAt);
+  // Live execution time — ticks while running, then settles on the
+  // server-authoritative `runs.duration` (same value the run page shows).
+  // The local `completedAt - startedAt` fallback covers frames that predate
+  // the duration column being populated.
+  const liveElapsedMs = useLiveElapsedMs(startedAt, completedAt);
+  const elapsedMs = duration ?? liveElapsedMs;
 
   // Pace the log line: a burst of lines plays back one at a time (≥500ms each)
   // rather than flashing straight to the last one. `current` carries a stable

--- a/packages/module-chat/src/ui/run-events.ts
+++ b/packages/module-chat/src/ui/run-events.ts
@@ -119,6 +119,7 @@ export const runUpdateLiteSchema = z.object({
   error: z.string().nullable().optional(),
   startedAt: z.string().nullable().optional(),
   completedAt: z.string().nullable().optional(),
+  duration: z.number().nullable().optional(),
 });
 export type RunUpdateLite = z.infer<typeof runUpdateLiteSchema>;
 

--- a/packages/module-chat/src/ui/use-run-log-stream.ts
+++ b/packages/module-chat/src/ui/use-run-log-stream.ts
@@ -38,6 +38,13 @@ export interface RunLogStream {
   startedAt: string | undefined;
   /** ISO timestamp the run reached a terminal status, once reported. */
   completedAt: string | undefined;
+  /**
+   * Server-authoritative duration in ms (`runs.duration`), once reported.
+   * This is the same value the run page shows — prefer it over a local
+   * `completedAt - startedAt` computation, which diverges whenever the
+   * runner supplied its own execution-window `durationMs` at finalize.
+   */
+  duration: number | undefined;
   /** True while the live SSE tail is connected (run not yet terminal). */
   live: boolean;
 }
@@ -61,6 +68,7 @@ export function useRunLogStream(
   const [packageId, setPackageId] = useState<string | undefined>(undefined);
   const [startedAt, setStartedAt] = useState<string | undefined>(undefined);
   const [completedAt, setCompletedAt] = useState<string | undefined>(undefined);
+  const [duration, setDuration] = useState<number | undefined>(undefined);
   const [live, setLive] = useState(false);
 
   useEffect(() => {
@@ -123,6 +131,7 @@ export function useRunLogStream(
       if (update.packageId) setPackageId(update.packageId);
       if (update.startedAt) setStartedAt(update.startedAt);
       if (update.completedAt) setCompletedAt(update.completedAt);
+      if (typeof update.duration === "number") setDuration(update.duration);
       if (isTerminalStatus(update.status)) {
         // One final full history sweep to catch log lines the trigger may have
         // emitted in the same tick as the terminal status (mergeLogs dedups the
@@ -157,5 +166,13 @@ export function useRunLogStream(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runId]);
 
-  return { logs, status, packageId: packageId ?? initialPackageId, startedAt, completedAt, live };
+  return {
+    logs,
+    status,
+    packageId: packageId ?? initialPackageId,
+    startedAt,
+    completedAt,
+    duration,
+    live,
+  };
 }


### PR DESCRIPTION
## Problem

The time shown in the chat `run_and_wait` card differs from the time shown on the run page.

- **Card** (`chat-run-progress-card.tsx`): computed its own duration as `completedAt − startedAt` from SSE `run_update` frames.
- **Run page** (`run-info-tab.tsx`, `run-row.tsx`): shows the `runs.duration` DB column.

These diverge whenever the runner supplies its own execution-window `durationMs` at finalize (`run-event-ingestion.ts`: `result.durationMs ?? now − startedAt`) — pi-runner timeout, entrypoint failure, and every `execute-background` synthesized terminal. That window is measured from container/process start, while `startedAt` is stamped at `createRun` (pending), so the gap is the container boot time.

## Source of truth

`runs.duration` — written once at finalize (CAS), consumed by the run page, run lists, the `recordRunDuration` SLI histogram, the `afterRun` hook, and the API. The chat card was the only consumer recomputing its own value, and the SSE `run_update` payload (PG trigger + connect snapshot) already carries `duration` — the card's zod schema just dropped it.

## Fix (frontend only, module-chat)

- `run-events.ts` — parse `duration` in `runUpdateLiteSchema`.
- `use-run-log-stream.ts` — track and expose `duration` (non-null only on terminal frames).
- `chat-run-progress-card.tsx` — `elapsedMs = duration ?? liveElapsedMs`: live tick unchanged while running, settles on the server value once terminal (same pattern as `run-row.tsx`).

## Validation

- `bunx tsc --noEmit` (module-chat) clean
- `bun test packages/module-chat/test/` — all pass
- prettier + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)