### PR TITLE
fix(module-chat): run card stuck on "Lancement" after mid-run reload

### DIFF
--- a/packages/module-chat/src/ui/run-events.ts
+++ b/packages/module-chat/src/ui/run-events.ts
@@ -183,6 +183,19 @@ export function parseRunUpdateFrame(raw: string): RunUpdateLite | undefined {
 }
 
 /**
+ * Parse a `GET /api/runs/:id` run resource down to the same lifecycle subset as
+ * a `run_update` frame (the resource is a superset — extra fields are dropped).
+ * Used to seed the run badge immediately on a mid-run reload, instead of waiting
+ * for the SSE snapshot: the persisted `run_and_wait` result only carries the
+ * transient launch status (`pending`), so without this the card would read
+ * "Lancement" for an already-running run until the first live frame arrives.
+ */
+export function parseRunResource(body: unknown): RunUpdateLite | undefined {
+  const parsed = runUpdateLiteSchema.safeParse(body);
+  return parsed.success ? parsed.data : undefined;
+}
+
+/**
  * Parse the `GET /runs/:id/logs` list envelope (`{ object:"list", data, … }`)
  * into log lines, dropping any malformed row rather than failing the batch.
  */

--- a/packages/module-chat/src/ui/use-run-log-stream.ts
+++ b/packages/module-chat/src/ui/use-run-log-stream.ts
@@ -25,6 +25,7 @@ import {
   orgAppFromHeaders,
   parseLogListResponse,
   parseRunLogFrame,
+  parseRunResource,
   parseRunUpdateFrame,
   type RunLogLine,
   type RunStatus,
@@ -92,6 +93,32 @@ export function useRunLogStream(
         });
         if (!res.ok || cancelled) return;
         apply(parseLogListResponse(await res.json()));
+      } catch {
+        // ignore — SSE remains the source of truth
+      }
+    })();
+
+    // 1b. One-shot current-status fetch (best-effort). On a mid-run reload the
+    //     persisted launch result only holds the transient `pending`, so the
+    //     badge would read "Lancement" until the SSE snapshot lands. Seed the
+    //     live lifecycle fields from the run resource so the card is correct
+    //     immediately. Every setter is a `prev ?? …` merge, so a live
+    //     `run_update` frame that arrives first always wins.
+    void (async () => {
+      try {
+        const res = await fetch(`/api/runs/${encodeURIComponent(runId)}`, {
+          headers,
+          credentials: "include",
+        });
+        if (!res.ok || cancelled) return;
+        const run = parseRunResource(await res.json());
+        if (!run || cancelled) return;
+        setStatus((prev) => prev ?? (run.status as RunStatus));
+        if (run.packageId) setPackageId((prev) => prev ?? run.packageId ?? undefined);
+        if (run.startedAt) setStartedAt((prev) => prev ?? run.startedAt ?? undefined);
+        if (run.completedAt) setCompletedAt((prev) => prev ?? run.completedAt ?? undefined);
+        if (typeof run.duration === "number")
+          setDuration((prev) => prev ?? run.duration ?? undefined);
       } catch {
         // ignore — SSE remains the source of truth
       }

--- a/packages/module-chat/test/run-events.test.ts
+++ b/packages/module-chat/test/run-events.test.ts
@@ -14,6 +14,7 @@ import {
   orgAppFromHeaders,
   parseLogListResponse,
   parseRunLogFrame,
+  parseRunResource,
   parseRunUpdateFrame,
   safeJsonParse,
   shouldRenderRunLaunchPanel,
@@ -93,6 +94,28 @@ describe("run-events helpers", () => {
     expect(update?.status).toBe("running");
     expect(update?.packageId).toBe("@inline/run");
     expect(parseRunUpdateFrame(JSON.stringify({ id: "run_1" }))).toBeUndefined();
+  });
+
+  it("parses a GET /runs/:id run resource down to the lifecycle subset", () => {
+    // A running run's resource carries extra fields (agent_scope, cost, …) that
+    // the lifecycle subset drops. This is what seeds the badge on a mid-run
+    // reload so it reads the live status, not the persisted "pending".
+    const run = parseRunResource({
+      id: "run_1",
+      status: "running",
+      packageId: "@inline/run",
+      startedAt: "2026-06-30T00:00:00Z",
+      completedAt: null,
+      duration: null,
+      agentScope: "@inline",
+      cost: 0,
+    });
+    expect(run?.status).toBe("running");
+    expect(run?.packageId).toBe("@inline/run");
+    expect(run?.startedAt).toBe("2026-06-30T00:00:00Z");
+    // Malformed body (no status) → undefined, so the seed is skipped.
+    expect(parseRunResource({ id: "run_1" })).toBeUndefined();
+    expect(parseRunResource(null)).toBeUndefined();
   });
 
   it("parses, merges, and filters log rows", () => {


### PR DESCRIPTION
## Problème

Refresh de la page pendant qu'un run inline (`run_and_wait`) est en cours → la carte de run dans le chat affiche « Lancement » alors que le run est en exécution.

## Cause

- Le résultat préliminaire persisté de `run_and_wait` porte le status transitoire `pending` (`run-and-wait-client.ts`).
- `useRunLogStream` ne seed le status initial **que s'il est terminal** — un status non-terminal est jeté → `effectiveStatus` = `undefined` → placeholder « Lancement » (`chat-run-progress-card.tsx`).
- Le fetch d'historique ne charge que les logs, jamais le status. Seul le snapshot SSE `run_update` peut corriger — flash visible au mieux, blocage permanent si le SSE ne s'ouvre pas (headers org/app non hydratés quand l'effect `[runId]` tourne).

## Fix

Fetch one-shot `GET /api/runs/:id` au mount (en parallèle du fetch de logs) pour seeder `status`/`packageId`/`startedAt`/`completedAt`/`duration`. Chaque setter merge en `prev ?? …` : une frame SSE live arrivée avant garde la priorité.

- `run-events.ts` — nouveau `parseRunResource` (réutilise `runUpdateLiteSchema`, subset lifecycle)
- `use-run-log-stream.ts` — étape « 1b » : seed du status courant
- `run-events.test.ts` — couverture du parser

## Vérifications

- `tsc --noEmit` clean, eslint clean
- `bun test packages/module-chat/test/run-events.test.ts` — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)