### PR TITLE
fix(chat): correlate connect-card completion by packageId, dedupe resume appends

### DIFF
--- a/packages/module-chat/src/ui/auth-offer.ts
+++ b/packages/module-chat/src/ui/auth-offer.ts
@@ -17,6 +17,65 @@ export interface AuthOffer {
   state?: string;
 }
 
+/** Payload the OAuth callback page broadcasts (see `apps/api/src/lib/oauth-popup-html.ts`). */
+export interface CompletionDetail {
+  type?: string;
+  ok?: boolean;
+  state?: string;
+  packageId?: string;
+  error?: string;
+}
+
+/**
+ * Whether a completion broadcast is addressed to the card identified by
+ * `{ state, packageId }`. BroadcastChannel/postMessage signals fan out to every
+ * mounted card, so correlation lives here:
+ *
+ *  - `state` — exact when both sides carry one. The hosted-connect offer
+ *    (`connect_url`) carries NO state (its OAuth state is minted later, at
+ *    /connect/start click time), so cards from that flow can't rely on it.
+ *  - `packageId` — the package-level filter, mirroring the SSE
+ *    `connection_update` backstop so all three completion signals share the
+ *    same semantics. Without it, one Gmail connect flipped an unrelated card
+ *    "connected" and double-resumed the conversation (forked thread).
+ *
+ * Completions without a packageId (context-less error pages such as "Missing
+ * connect token") stay accepted: they only surface an error, never an append.
+ */
+export function completionMatches(
+  detail: CompletionDetail | undefined,
+  card: { messageType: string; state?: string; packageId?: string },
+): boolean {
+  if (!detail || detail.type !== card.messageType) return false;
+  if (card.state && detail.state && detail.state !== card.state) return false;
+  if (card.packageId && detail.packageId && detail.packageId !== card.packageId) return false;
+  return true;
+}
+
+/**
+ * One resume append per (package, completion) across every card in this tab.
+ *
+ * A single completion signal reaches ALL mounted cards, so two cards awaiting
+ * the same package — e.g. a retry card issued after an abandoned first
+ * attempt — would BOTH append a resume message, forking the conversation into
+ * two concurrent turns (each user turn chains onto the last message, but each
+ * assistant turn chains onto its own trigger). The first card to complete
+ * claims the append; siblings settle for the connected visual. The short TTL
+ * only needs to outlive the fan-out burst (all cards fire within ms of one
+ * broadcast) while staying well under any legitimate later reconnect in the
+ * same conversation.
+ */
+const RESUME_CLAIM_TTL_MS = 30_000;
+const resumeClaims = new Map<string, number>();
+
+export function claimResume(packageId: string | undefined, now = Date.now()): boolean {
+  if (!packageId) return true;
+  const prev = resumeClaims.get(packageId);
+  if (prev !== undefined && now - prev < RESUME_CLAIM_TTL_MS) return false;
+  resumeClaims.set(packageId, now);
+  return true;
+}
+
 /**
  * Prefix the chat auto-resume message carries so the UI can render it as a
  * discreet "connected" notice instead of a raw user bubble. It is an invisible

--- a/packages/module-chat/src/ui/oauth-connect-card.tsx
+++ b/packages/module-chat/src/ui/oauth-connect-card.tsx
@@ -29,19 +29,17 @@ import { AlertTriangleIcon, CheckIcon, Loader2Icon } from "lucide-react";
 import { encodePackageIdPath } from "@appstrate/core/naming";
 import { Button } from "./button.tsx";
 import { useChatHeaders } from "./runtime-context.ts";
-import { encodeResume, type ResumeMeta } from "./auth-offer.ts";
+import {
+  claimResume,
+  completionMatches,
+  encodeResume,
+  type CompletionDetail,
+  type ResumeMeta,
+} from "./auth-offer.ts";
 import { IntegrationIcon } from "./integration-icon.tsx";
 
 const BROADCAST_CHANNEL = "appstrate_integration";
 const MESSAGE_TYPE = "appstrate:integration_connection";
-
-interface CompletionDetail {
-  type?: string;
-  ok?: boolean;
-  state?: string;
-  packageId?: string;
-  error?: string;
-}
 
 type Phase = "idle" | "pending" | "done" | "connected" | "error";
 
@@ -153,6 +151,13 @@ export function OAuthConnectCard({
         return;
       }
       resumed.current = true;
+      // Another card already appended the resume for this package (same
+      // completion burst) — show the connected state without a second append,
+      // which would fork the conversation into two concurrent turns.
+      if (!claimResume(packageId)) {
+        setPhase("connected");
+        return;
+      }
       setPhase("done");
       thread.append({
         content: [
@@ -179,8 +184,11 @@ export function OAuthConnectCard({
   useEffect(() => {
     if (phase === "done" || phase === "connected") return;
 
+    // Correlation (state AND packageId) lives in `completionMatches` — see its
+    // doc for why packageId is required: the hosted-connect offer carries no
+    // state, so without the package filter every card accepted every completion.
     const matches = (d: CompletionDetail | undefined) =>
-      !!d && d.type === MESSAGE_TYPE && (!state || !d.state || d.state === state);
+      completionMatches(d, { messageType: MESSAGE_TYPE, state, packageId });
 
     const onMessage = (ev: MessageEvent) => {
       const d = ev.data as CompletionDetail | undefined;

--- a/packages/module-chat/test/connect-card-correlation.test.ts
+++ b/packages/module-chat/test/connect-card-correlation.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "bun:test";
+import { completionMatches, claimResume, type CompletionDetail } from "../src/ui/auth-offer.ts";
+
+const TYPE = "appstrate:integration_connection";
+
+function detail(overrides: Partial<CompletionDetail> = {}): CompletionDetail {
+  return { type: TYPE, ok: true, ...overrides };
+}
+
+describe("completionMatches", () => {
+  it("rejects a foreign message type", () => {
+    expect(completionMatches(detail({ type: "other" }), { messageType: TYPE })).toBe(false);
+    expect(completionMatches(undefined, { messageType: TYPE })).toBe(false);
+  });
+
+  it("matches on exact state when both sides carry one", () => {
+    const card = { messageType: TYPE, state: "s1" };
+    expect(completionMatches(detail({ state: "s1" }), card)).toBe(true);
+    expect(completionMatches(detail({ state: "s2" }), card)).toBe(false);
+  });
+
+  it("rejects a completion for another package (the cross-card resume bug)", () => {
+    // Regression: the hosted-connect offer (`connect_url`) has no state, so a
+    // stateless card must still ignore a completion addressed to a different
+    // package — connecting @appstrate/gmail must not resume the
+    // @appstrate/gmail-mcp card.
+    const card = { messageType: TYPE, packageId: "@appstrate/gmail-mcp" };
+    expect(completionMatches(detail({ packageId: "@appstrate/gmail" }), card)).toBe(false);
+    expect(completionMatches(detail({ packageId: "@appstrate/gmail-mcp" }), card)).toBe(true);
+  });
+
+  it("accepts a context-less completion (error pages emit no state/packageId)", () => {
+    const card = { messageType: TYPE, packageId: "@appstrate/gmail" };
+    expect(completionMatches(detail({ ok: false, error: "Missing connect token" }), card)).toBe(
+      true,
+    );
+  });
+
+  it("accepts a package-addressed completion on a card that lacks a packageId", () => {
+    expect(
+      completionMatches(detail({ packageId: "@appstrate/gmail" }), { messageType: TYPE }),
+    ).toBe(true);
+  });
+});
+
+describe("claimResume", () => {
+  it("lets the first card claim and blocks siblings within the TTL", () => {
+    const t0 = 1_000_000;
+    expect(claimResume("@test/claim-a", t0)).toBe(true);
+    expect(claimResume("@test/claim-a", t0 + 5)).toBe(false);
+    expect(claimResume("@test/claim-a", t0 + 29_999)).toBe(false);
+  });
+
+  it("allows a fresh claim after the TTL (legitimate later reconnect)", () => {
+    const t0 = 2_000_000;
+    expect(claimResume("@test/claim-b", t0)).toBe(true);
+    expect(claimResume("@test/claim-b", t0 + 30_000)).toBe(true);
+  });
+
+  it("scopes claims per package", () => {
+    const t0 = 3_000_000;
+    expect(claimResume("@test/claim-c", t0)).toBe(true);
+    expect(claimResume("@test/claim-d", t0)).toBe(true);
+  });
+
+  it("never blocks a card without a packageId", () => {
+    expect(claimResume(undefined, 4_000_000)).toBe(true);
+    expect(claimResume(undefined, 4_000_000)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problème

Session repro : `chs_a4f54322159a41bc9fc24dde858b8259` (analysée en DB locale).

Deux cartes de connexion en attente dans le fil (`@appstrate/gmail-mcp` et `@appstrate/gmail`). L'utilisateur connecte **une seule** intégration (`@appstrate/gmail`) → **les deux** cartes passent "connectée" et chacune append son message de resume (2 messages user `integration-connected` à 12 ms d'écart en DB). Les deux resumes déclenchent deux turns `/api/chat` concurrents → la conversation **fork** (chaque turn assistant se chaîne sur son propre user turn) : 2 runs inline exécutés, une branche invisible après reload.

## Cause

`oauth-connect-card.tsx` — le matcher de complétion :

```ts
const matches = (d) => !!d && d.type === MESSAGE_TYPE && (!state || !d.state || d.state === state);
```

L'offre hosted-connect (`connect_url`, issue #769) ne porte **pas de `state`** — le state OAuth est minté plus tard, au clic sur `/connect/start`. Toutes les cartes de ce flux montent donc avec `state === undefined` → `!state` court-circuite → chaque carte accepte **toute** complétion. Le callback (`oauth-popup-html.ts`) envoie pourtant `packageId`, ignoré par le matcher. Le backstop SSE (`connection_update`) filtre déjà par `packageId`, lui.

## Fix

1. **Corrélation par `packageId`** dans le matcher, alignant postMessage/BroadcastChannel sur la sémantique package-level que le backstop SSE définit déjà — mêmes règles sur les trois signaux. Les complétions sans `packageId` (pages d'erreur sans contexte, ex. "Missing connect token") restent acceptées : elles n'affichent qu'une erreur, jamais d'append.
2. **Claim d'append par package (TTL 30 s)** : un seul resume append par (package, burst de complétion), même si deux cartes attendent le *même* package (carte de retry). Les cartes non gagnantes passent en visuel "connectée" sans append — plus de fork possible depuis ce chemin.

Logique extraite dans `auth-offer.ts` (React-free, pattern existant du fichier) + tests unitaires.

## Non couvert (volontairement)

- Garde serveur contre les turns concurrents par session (`active_stream_id` vivant → 409) — hardening séparé, touche la sémantique de `/api/chat`.
- Affichage "connectée" de la carte après reload : vérifié côté serveur (`GET /api/integrations/@appstrate/gmail` → `ready: true` avec la vraie session) — si le symptôme persiste au reload, c'est un bug de rendu client distinct.

## Tests

- `bun test packages/module-chat` — 140 pass (dont 9 nouveaux dans `connect-card-correlation.test.ts`)
- `tsc --noEmit`, eslint, prettier — clean
- Non vérifié en navigateur réel (extension Chrome indisponible pendant la session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)