### PR TITLE
fix(runs): actionable errors when inline run prompt is missing or nested in manifest

### DIFF
--- a/apps/api/src/modules/mcp/test/unit/run-and-wait.test.ts
+++ b/apps/api/src/modules/mcp/test/unit/run-and-wait.test.ts
@@ -130,6 +130,29 @@ describe("run_and_wait", () => {
     expect(calls.some((c) => c.method === "GET")).toBe(false);
   });
 
+  it("rejects an inline run without a top-level prompt before dispatching", async () => {
+    const { tool, calls } = makeRunAndWait({});
+
+    const res = await tool.handler({ kind: "inline", manifest: { name: "tmp" } }, noExtra);
+
+    expect(res.isError).toBe(true);
+    expect(parseResult(res).error).toContain("top-level argument");
+    expect(calls.length).toBe(0);
+  });
+
+  it("tells the model to move a prompt nested inside the manifest", async () => {
+    const { tool, calls } = makeRunAndWait({});
+
+    const res = await tool.handler(
+      { kind: "inline", manifest: { name: "tmp", prompt: "do it" } },
+      noExtra,
+    );
+
+    expect(res.isError).toBe(true);
+    expect(parseResult(res).error).toContain("found inside `manifest`");
+    expect(calls.length).toBe(0);
+  });
+
   it("validates required arguments and permissions", async () => {
     const { tool } = makeRunAndWait({});
     expect((await tool.handler({ kind: "agent", name: "b" }, noExtra)).isError).toBe(true);

--- a/apps/api/src/modules/mcp/tools.ts
+++ b/apps/api/src/modules/mcp/tools.ts
@@ -744,14 +744,16 @@ function buildRunAndWaitTool(ctx: McpToolContext): AppstrateToolDefinition {
           description:
             'Inline agent manifest to run (kind:inline). Include `"runtime_tools": ["log"]` so the ' +
             "run can emit progress lines the chat shows live (the panel surfaces only `log`-tool " +
-            "output).",
+            "output). Do NOT put the prompt inside the manifest — it goes in the separate " +
+            "top-level `prompt` argument.",
           additionalProperties: true,
         },
         prompt: {
           type: "string",
           description:
-            "Prompt for the inline run (kind:inline). Tell the run to call the `log` tool to report " +
-            "each meaningful step — those lines are what the chat shows live.",
+            "REQUIRED for kind:inline. The inline run's system prompt, as a top-level argument " +
+            "alongside `manifest` (never nested inside it). Tell the run to call the `log` tool " +
+            "to report each meaningful step — those lines are what the chat shows live.",
         },
         config: {
           type: "object",
@@ -820,9 +822,31 @@ function buildRunAndWaitTool(ctx: McpToolContext): AppstrateToolDefinition {
         });
         return textResult({ error: "`manifest` is required for kind:'inline'." }, true);
       }
-      const body: Record<string, unknown> = { manifest };
+      // Reject a missing top-level prompt here instead of forwarding a
+      // promptless body to the route: the route's field error alone doesn't
+      // tell the model WHERE the prompt goes, and the observed failure mode
+      // is nesting it inside the manifest (AFPS agents ship a prompt.md, so
+      // models naturally put it there) then retrying blind.
       const prompt = asString(args.prompt);
-      if (prompt) body.prompt = prompt;
+      if (!prompt) {
+        emit(ctx, {
+          tool: "run_and_wait",
+          durationMs: performance.now() - start,
+          outcome: "rejected",
+        });
+        const nested = typeof manifest.prompt === "string";
+        return textResult(
+          {
+            error: nested
+              ? "`prompt` was found inside `manifest`. It must be a TOP-LEVEL argument of " +
+                "run_and_wait, alongside `manifest` — move it out of the manifest and retry."
+              : "`prompt` is required for kind:'inline'. Pass it as a top-level argument " +
+                "alongside `manifest` (not inside it).",
+          },
+          true,
+        );
+      }
+      const body: Record<string, unknown> = { manifest, prompt };
       if (asRecord(args.config)) body.config = args.config;
       launchResponse = await dispatchCatalogOperation(ctx, "runInline", { body, signal });
     }

--- a/apps/api/src/services/inline-manifest-validation.ts
+++ b/apps/api/src/services/inline-manifest-validation.ts
@@ -41,8 +41,25 @@ export function validateInlineManifest(
   const errors: string[] = [];
 
   // --- 1. Prompt type + size (UTF-8 bytes, matches manifest_bytes) ---
+  // Distinguish "missing" from "wrong type", and detect the common LLM
+  // mistake of nesting the prompt inside the manifest (AFPS agents ship a
+  // prompt.md, so models naturally put it there) — a bare "must be a string"
+  // sends callers chasing phantom causes instead of moving the field.
   if (typeof input.prompt !== "string") {
-    errors.push("prompt: must be a string");
+    const nested =
+      input.manifest &&
+      typeof input.manifest === "object" &&
+      !Array.isArray(input.manifest) &&
+      typeof (input.manifest as Record<string, unknown>).prompt === "string";
+    if (nested) {
+      errors.push(
+        "prompt: found inside `manifest` — move it to the top-level `prompt` field, alongside `manifest`",
+      );
+    } else if (input.prompt === undefined) {
+      errors.push("prompt: missing (required top-level field, alongside `manifest`)");
+    } else {
+      errors.push("prompt: must be a string");
+    }
   } else {
     const promptByteLength = Buffer.byteLength(input.prompt, "utf8");
     if (promptByteLength > limits.prompt_bytes) {

--- a/apps/api/test/unit/inline-manifest-validation.test.ts
+++ b/apps/api/test/unit/inline-manifest-validation.test.ts
@@ -95,6 +95,26 @@ describe("validateInlineManifest — size caps", () => {
     expect(result.errors.join(" ")).toContain("prompt: must be a string");
   });
 
+  it("reports a missing prompt as missing, not as a type error", () => {
+    const result = validateInlineManifest({
+      manifest: baseManifest(),
+      prompt: undefined,
+      limits: defaults,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(" ")).toContain("prompt: missing");
+  });
+
+  it("points at a prompt nested inside the manifest", () => {
+    const result = validateInlineManifest({
+      manifest: { ...baseManifest(), prompt: "do it" },
+      prompt: undefined,
+      limits: defaults,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(" ")).toContain("prompt: found inside `manifest`");
+  });
+
   it("rejects manifests larger than manifest_bytes", () => {
     const tight = { ...defaults, manifest_bytes: 100 };
     // Valid structure but padded description blows the byte cap

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`@appstrate/core/run-and-wait-client`** — `kind:"inline"` now rejects a
+  missing top-level `prompt` before dispatching, with an actionable message.
+  When the prompt is found nested inside `manifest` (the common LLM mistake —
+  AFPS agents ship a `prompt.md`, so models naturally put it there), the error
+  says to move it to the top level instead of forwarding a promptless body to
+  `POST /api/runs/inline` and surfacing the route's bare
+  `prompt: must be a string`.
+
 ### Added
 
 - **`@appstrate/core/subscription-engines`** — the provider→execution-engine

--- a/packages/core/src/run-and-wait-client.ts
+++ b/packages/core/src/run-and-wait-client.ts
@@ -206,10 +206,29 @@ export async function launchRunAndWait(
         step: { payload: { error: "`manifest` is required for kind:'inline'." }, isError: true },
       };
     }
-    launchPath = "/api/runs/inline";
-    launchBody = { manifest };
+    // Reject a missing top-level prompt before hitting the route: the route's
+    // field error alone doesn't tell the model WHERE the prompt goes, and the
+    // observed failure mode is nesting it inside the manifest (AFPS agents
+    // ship a prompt.md, so models naturally put it there) then retrying blind.
     const prompt = asString(args.prompt);
-    if (prompt) launchBody.prompt = prompt;
+    if (!prompt) {
+      const nested = typeof manifest.prompt === "string";
+      return {
+        ok: false,
+        step: {
+          payload: {
+            error: nested
+              ? "`prompt` was found inside `manifest`. It must be a TOP-LEVEL argument of " +
+                "run_and_wait, alongside `manifest` — move it out of the manifest and retry."
+              : "`prompt` is required for kind:'inline'. Pass it as a top-level argument " +
+                "alongside `manifest` (not inside it).",
+          },
+          isError: true,
+        },
+      };
+    }
+    launchPath = "/api/runs/inline";
+    launchBody = { manifest, prompt };
     if (asRecord(args.config)) launchBody.config = args.config;
   } else {
     return {

--- a/packages/core/test/run-and-wait-client.test.ts
+++ b/packages/core/test/run-and-wait-client.test.ts
@@ -120,6 +120,29 @@ describe("run_and_wait client", () => {
     ]);
   });
 
+  test("rejects an inline run without a top-level prompt before dispatching", async () => {
+    const fetchImpl = fakeFetch(async () => {
+      throw new Error("should not fetch");
+    });
+
+    const steps = await collectSteps(fetchImpl, { kind: "inline", manifest: { name: "tmp" } });
+    expect(steps).toHaveLength(1);
+    expect(steps[0]?.error).toContain("top-level argument");
+  });
+
+  test("tells the caller to move a prompt nested inside the manifest", async () => {
+    const fetchImpl = fakeFetch(async () => {
+      throw new Error("should not fetch");
+    });
+
+    const steps = await collectSteps(fetchImpl, {
+      kind: "inline",
+      manifest: { name: "tmp", prompt: "do it" },
+    });
+    expect(steps).toHaveLength(1);
+    expect(steps[0]?.error).toContain("found inside `manifest`");
+  });
+
   test("returns a bounded timeout payload", async () => {
     const fetchImpl = fakeFetch(async () =>
       jsonResponse({ id: "run_1", packageId: "@acme/writer", status: "pending" }),


### PR DESCRIPTION
## Problem

Analysis of a real chat session (`chs_c56f768c…`): the chat model nested `prompt` inside the `manifest` argument of `run_and_wait` — a natural mistake, since AFPS agents ship a `prompt.md` as part of the package. The tool forwarded a promptless body to `POST /api/runs/inline`, which answered with the bare field error `prompt: must be a string`.

That message names neither the real problem (the field is *missing* at the top level) nor the fix (move it out of the manifest). The model hallucinated a prompt-length limit, shortened the prompt twice, re-read the operation schema, retried once more with the same nesting — three identical 400s — and only succeeded by bypassing `run_and_wait` via `invoke_operation runInline`.

## Fix

Catch the mistake at every layer with a message that says where the prompt goes:

- **`@appstrate/core/run-and-wait-client`** (the path the chat engines actually use): `kind:"inline"` without a top-level `prompt` is rejected before dispatch. When a string `prompt` sits inside `manifest`, the error explicitly says to move it to the top level.
- **`mcp/tools.ts` `run_and_wait` handler** (platform MCP surface): same guard, same messages.
- **`validateInlineManifest`** (route-level, covers direct `POST /api/runs/inline` callers): distinguishes `prompt: missing (required top-level field, alongside \`manifest\`)` from `prompt: must be a string`, and points at a manifest-nested prompt.
- **`run_and_wait` inputSchema**: `prompt` description now states it is REQUIRED for `kind:inline` and never nested inside `manifest`; `manifest` description says the same from the other side.

## Tests

- `packages/core/test/run-and-wait-client.test.ts` — missing prompt rejected pre-dispatch; nested prompt gets the move-it message (2 new tests).
- `apps/api/src/modules/mcp/test/unit/run-and-wait.test.ts` — same two cases through the MCP tool handler, asserting zero dispatch calls.
- `apps/api/test/unit/inline-manifest-validation.test.ts` — missing vs wrong-type vs nested messages (2 new tests).
- Existing integration tests (`inline-run.test.ts`, `inline-run-validate.test.ts`) assert on error `code`/`field` only and pass unchanged.

`bun run check` green (33/33 tasks); targeted suites pass (core client, mcp module, inline-run integration, module-chat full suite, claude-code bridge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)