### PR TITLE
perf: cut wasted LLM round-trips and run-boot latency on inline runs

### DIFF
--- a/apps/api/src/services/integration-spawn-resolver.ts
+++ b/apps/api/src/services/integration-spawn-resolver.ts
@@ -117,35 +117,41 @@ export async function resolveIntegrationSpawns(
 
   const entries = parseManifestIntegrations(agentManifest);
   if (entries.length === 0) return [];
-  const out: IntegrationSpawnSpec[] = [];
-  for (const entry of entries) {
-    try {
-      const spec = await resolveOne(
-        entry.id,
-        applicationId,
-        actor,
-        entry.tools,
-        resolvedConnections?.[entry.id] ?? null,
-        entry.auth_key,
-        input.manifestCache,
-      );
-      if (spec) out.push(spec);
-    } catch (err) {
-      // An unsatisfiable referenced-mcp-server pin is a hard failure: the run
-      // must NOT silently spawn without the integration's tools. resolveOne
-      // raises a DEPENDENCY_UNRESOLVED BundleError for it; let it propagate so
-      // the pipeline maps it to a structured 422 (#686), matching the skill
-      // closure (#666). Every other failure (not installed / not connected /
-      // missing referenced package) stays a per-integration warn-and-skip.
-      if (err instanceof BundleError && err.code === "DEPENDENCY_UNRESOLVED") throw err;
-      logger.warn("integration resolve failed; skipping", {
-        integrationId: entry.id,
-        applicationId,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
-  }
-  return out;
+  // Resolve every declared integration concurrently — each resolution is an
+  // independent chain of DB reads + storage fetch + credential decrypt, and
+  // the sequential version paid their latencies back-to-back on the run
+  // kickoff critical path. Declaration order is preserved by mapping then
+  // compacting.
+  const specs = await Promise.all(
+    entries.map(async (entry) => {
+      try {
+        return await resolveOne(
+          entry.id,
+          applicationId,
+          actor,
+          entry.tools,
+          resolvedConnections?.[entry.id] ?? null,
+          entry.auth_key,
+          input.manifestCache,
+        );
+      } catch (err) {
+        // An unsatisfiable referenced-mcp-server pin is a hard failure: the run
+        // must NOT silently spawn without the integration's tools. resolveOne
+        // raises a DEPENDENCY_UNRESOLVED BundleError for it; let it propagate so
+        // the pipeline maps it to a structured 422 (#686), matching the skill
+        // closure (#666). Every other failure (not installed / not connected /
+        // missing referenced package) stays a per-integration warn-and-skip.
+        if (err instanceof BundleError && err.code === "DEPENDENCY_UNRESOLVED") throw err;
+        logger.warn("integration resolve failed; skipping", {
+          integrationId: entry.id,
+          applicationId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return null;
+      }
+    }),
+  );
+  return specs.filter((s): s is IntegrationSpawnSpec => s !== null);
 }
 
 async function resolveOne(

--- a/apps/api/src/services/orchestrator/docker-orchestrator.ts
+++ b/apps/api/src/services/orchestrator/docker-orchestrator.ts
@@ -61,6 +61,16 @@ export class DockerOrchestrator implements ContainerOrchestrator {
    * defensively cleared in {@link removeWorkload} / {@link shutdown}.
    */
   private expectedSidecarExits = new Set<string>();
+  /**
+   * Images verified present in this process's lifetime (pre-pulled at
+   * {@link initialize} or ensured by a prior run). {@link ensureImages}
+   * skips these — the per-run `imageExists` inspect round-trip was pure
+   * overhead on the run-boot critical path for images that are pulled
+   * once at boot and effectively never disappear mid-lifetime. If a host
+   * prune removes one anyway, the container create fails with a clear
+   * `No such image` and the next boot's `initialize()` re-pulls.
+   */
+  private verifiedImages = new Set<string>();
 
   async initialize(): Promise<void> {
     // Ensure runtime images are present (may have been pruned by host cleanup).
@@ -76,6 +86,8 @@ export class DockerOrchestrator implements ContainerOrchestrator {
       docker.detectPlatformNetwork(),
       docker.createNetwork("appstrate-egress"),
     ]);
+    this.verifiedImages.add(env.PI_IMAGE);
+    this.verifiedImages.add(env.SIDECAR_IMAGE);
     this.egressNetworkId = egressId;
   }
 
@@ -91,7 +103,10 @@ export class DockerOrchestrator implements ContainerOrchestrator {
   }
 
   async ensureImages(images: string[]): Promise<void> {
-    await Promise.all(images.map((image) => docker.ensureImage(image)));
+    const missing = images.filter((image) => !this.verifiedImages.has(image));
+    if (missing.length === 0) return;
+    await Promise.all(missing.map((image) => docker.ensureImage(image)));
+    for (const image of missing) this.verifiedImages.add(image);
   }
 
   async cleanupOrphans(): Promise<CleanupReport> {
@@ -103,6 +118,7 @@ export class DockerOrchestrator implements ContainerOrchestrator {
     const env = getEnv();
     const name = `${docker.EXEC_NETWORK_PREFIX}${runId}`;
     const volumeName = `${docker.WORKSPACE_VOLUME_PREFIX}${runId}`;
+    const useTmpfs = env.WORKSPACE_TMPFS_SIZE_MB > 0;
 
     // Create the per-run network + workspace volume in parallel — both
     // are independent Docker resources and either may hit pool/quota
@@ -134,12 +150,18 @@ export class DockerOrchestrator implements ContainerOrchestrator {
         await docker.removeVolume(volumeName).catch(() => {});
         return docker.createVolume(volumeName, {
           labels: { "appstrate.run": runId },
-          ...(env.WORKSPACE_TMPFS_SIZE_MB > 0
+          ...(useTmpfs
             ? {
+                // `uid`/`gid` are kernel tmpfs mount options: ownership is
+                // set at mount time for the agent's `pi` user (UID 1001 —
+                // see runtime-pi/Dockerfile `adduser ... -u 1001 pi`), so
+                // the disk path's chown init container (below) is skipped
+                // entirely on this branch — a full ephemeral-container
+                // lifecycle (~150 ms) off the run-boot critical path.
                 driverOpts: {
                   type: "tmpfs",
                   device: "tmpfs",
-                  o: `size=${env.WORKSPACE_TMPFS_SIZE_MB}m`,
+                  o: `size=${env.WORKSPACE_TMPFS_SIZE_MB}m,uid=1001,gid=1001`,
                 },
               }
             : {}),
@@ -162,20 +184,23 @@ export class DockerOrchestrator implements ContainerOrchestrator {
 
     const networkId = networkResult.value;
 
-    // Chown the freshly created volume to the agent's `pi` user (UID
-    // 1001 — see runtime-pi/Dockerfile L144 `adduser ... -u 1001 pi`,
-    // contract-locked by the workspace volume tests in
-    // apps/api/test/integration/services/docker-api.test.ts). Docker
-    // named volumes default to root-owned on first mount, which
-    // would block the agent from writing to /workspace. A one-shot
-    // busybox container with the volume mounted is the canonical
-    // pattern: cheap (cached image, ~150ms warm), portable across
-    // drivers, and avoids baking workspace setup into the agent
-    // image's startup path.
+    // Disk-backed volumes (WORKSPACE_TMPFS_SIZE_MB=0) still need the chown
+    // init: Docker local named volumes default to root-owned on first
+    // mount, which would block the agent (`pi`, UID 1001 — see
+    // runtime-pi/Dockerfile `adduser ... -u 1001 pi`, contract-locked by
+    // the workspace volume tests in
+    // apps/api/test/integration/services/docker-api.test.ts) from writing
+    // to /workspace. A one-shot busybox container with the volume mounted
+    // is the canonical pattern: portable across drivers, avoids baking
+    // workspace setup into the agent image's startup path. The tmpfs
+    // branch (the default) skips this — ownership is set via the volume's
+    // `uid`/`gid` mount options at create time above, saving the
+    // ephemeral container's full create+start+wait+remove round-trip
+    // (~150 ms) on the run-boot critical path.
     //
-    // Subtle Docker quirk: `chown` against the mount-point root only
-    // sticks across remounts when the volume has at least one file
-    // inside (otherwise Docker resets the mount-point uid:gid from
+    // Subtle Docker quirk (disk path): `chown` against the mount-point
+    // root only sticks across remounts when the volume has at least one
+    // file inside (otherwise Docker resets the mount-point uid:gid from
     // the image's directory metadata on each subsequent mount). The
     // `touch /workspace/.appstrate-init` is the marker file that
     // pins the chown — small, predictable, hidden from agent
@@ -187,20 +212,25 @@ export class DockerOrchestrator implements ContainerOrchestrator {
     // BEFORE rethrowing so the orchestrator doesn't leak a half-
     // initialised boundary. The caller never sees the partial
     // resources and the orphan reaper has nothing to do.
-    try {
-      await docker.runEphemeralCommand({
-        image: env.WORKSPACE_INIT_IMAGE,
-        cmd: [
-          "sh",
-          "-c",
-          "touch /workspace/.appstrate-init && chown 1001:1001 /workspace /workspace/.appstrate-init",
-        ],
-        binds: [`${volumeName}:/workspace`],
-        runId,
-      });
-    } catch (err) {
-      await Promise.allSettled([docker.removeNetwork(networkId), docker.removeVolume(volumeName)]);
-      throw err;
+    if (!useTmpfs) {
+      try {
+        await docker.runEphemeralCommand({
+          image: env.WORKSPACE_INIT_IMAGE,
+          cmd: [
+            "sh",
+            "-c",
+            "touch /workspace/.appstrate-init && chown 1001:1001 /workspace /workspace/.appstrate-init",
+          ],
+          binds: [`${volumeName}:/workspace`],
+          runId,
+        });
+      } catch (err) {
+        await Promise.allSettled([
+          docker.removeNetwork(networkId),
+          docker.removeVolume(volumeName),
+        ]);
+        throw err;
+      }
     }
 
     return {

--- a/apps/api/src/services/run-context-builder.ts
+++ b/apps/api/src/services/run-context-builder.ts
@@ -120,6 +120,28 @@ export async function buildRunContext(params: {
   const skipConfigFetch =
     params.config !== undefined && params.modelId !== undefined && params.proxyId !== undefined;
 
+  // Phase 1.4 — resolve any declared `dependencies.integrations` into
+  // ready-to-spawn specs (manifest + bundle bytes + delivery env with
+  // live credentials). Kicked off FIRST: its inputs are all available at
+  // entry and it is the slowest independent chain (storage fetch +
+  // credential decrypt + possible OAuth refresh), so it runs concurrently
+  // with the config/checkpoint/bundle and model/proxy resolution below
+  // instead of serializing after them. Failures here are per-integration
+  // warnings; the run proceeds with the surviving subset. The resolver
+  // reads the version from `dependencies.integrations[id]` (§4.1) and the
+  // tool/scope selection from `integrations_configuration[id]` (§4.4).
+  const integrationSpawnsPromise = resolveIntegrationSpawns({
+    applicationId,
+    actor,
+    agentManifest: agent.manifest as Record<string, unknown>,
+    resolvedConnections: params.resolvedConnections ?? null,
+    ...(params.manifestCache ? { manifestCache: params.manifestCache } : {}),
+  });
+  // Guard against an unhandled rejection when a step below throws before
+  // the spawn resolution is awaited; the await further down still surfaces
+  // the original error.
+  integrationSpawnsPromise.catch(() => {});
+
   // Step 1: load all independent data in parallel
   const persistenceScope = scopeFromActor(actor);
   const [configFull, previousCheckpoint, agentPackageResult, latestVersion, pinnedSlotRows] =
@@ -206,19 +228,8 @@ export async function buildRunContext(params: {
     ...(params.traceparent ? { traceparent: params.traceparent } : {}),
   };
 
-  // Phase 1.4 — resolve any declared `dependencies.integrations` into
-  // ready-to-spawn specs (manifest + bundle bytes + delivery env with
-  // live credentials). Failures here are per-integration warnings; the
-  // run proceeds with the surviving subset. The resolver reads the version
-  // from `dependencies.integrations[id]` (§4.1) and the tool/scope selection
-  // from `integrations_configuration[id]` (§4.4).
-  const integrationSpawns = await resolveIntegrationSpawns({
-    applicationId,
-    actor,
-    agentManifest: agent.manifest as Record<string, unknown>,
-    resolvedConnections: params.resolvedConnections ?? null,
-    ...(params.manifestCache ? { manifestCache: params.manifestCache } : {}),
-  });
+  // Converge the integration spawn resolution kicked off at entry.
+  const integrationSpawns = await integrationSpawnsPromise;
 
   // AFPS: snake_case. The editor writes `runtime_tools`; reading the wrong key
   // here would silently drop every author's runtime-tool selection.

--- a/packages/afps-runtime/src/bundle/platform-prompt.ts
+++ b/packages/afps-runtime/src/bundle/platform-prompt.ts
@@ -375,11 +375,13 @@ export function renderPlatformPrompt(opts: PlatformPromptOptions): string {
   if (opts.outputSchema && Object.keys(opts.outputSchema).length > 0) {
     sections.push("## Output Format\n");
     sections.push(
-      "You MUST call the `output` tool **exactly once** before finishing, " +
+      "You MUST call the `output` tool **exactly once**, as your FINAL action, " +
         "with a `data` parameter that satisfies the JSON Schema below. " +
         "Provide ALL required fields in that single call — do not probe " +
         "with `output({})` first, and do not split the payload across " +
-        "multiple calls (each call REPLACES the previous one).\n",
+        "multiple calls. A successful `output` call ends the run immediately: " +
+        "finish all other work before calling it, and do not plan any message " +
+        "or step after it.\n",
     );
 
     const required = Array.isArray(opts.outputSchema.required)

--- a/packages/core/src/runtime-tool-defs.ts
+++ b/packages/core/src/runtime-tool-defs.ts
@@ -153,12 +153,12 @@ function buildOutputDef(outputSchema: Record<string, unknown> | null): RuntimeTo
   // output schema the agent MUST call it (once, valid); otherwise it may
   // finish without it (a side-effect-only run is a valid success).
   const description = outputSchema
-    ? "Call exactly once before finishing with the complete output object that satisfies " +
-      "the declared schema (all required fields must be provided). Calling again replaces " +
-      "the previous output."
-    : "Optional — call at most once to return a JSON object as the run result. " +
-      "If your task produces no result to return, finish without calling it. " +
-      "Calling again replaces the previous output.";
+    ? "Call exactly once, as your final action, with the complete output object that " +
+      "satisfies the declared schema (all required fields must be provided). A successful " +
+      "call ends the run immediately — do all other work first."
+    : "Optional — call at most once, as your final action, to return a JSON object as the " +
+      "run result. If your task produces no result to return, finish without calling it. " +
+      "A successful call ends the run immediately — do all other work first.";
   return {
     descriptor: {
       name: "output",

--- a/packages/module-chat/src/prompt.ts
+++ b/packages/module-chat/src/prompt.ts
@@ -85,6 +85,8 @@ Then read \`result.summary\` from the \`run_and_wait\` result and reply to the u
 
 You already have the exact shape for \`run_and_wait\`: for existing agents pass \`{ kind:"agent", scope, name, version?, input? }\`; for inline runs pass \`{ kind:"inline", manifest, prompt, config? }\`. (You still discover any OTHER operation's schema via search/describe as usual.) Read \`run_and_wait\`'s returned \`result\` field — that is the sub-agent's deliverable; answer the user from it and never fabricate it. If the run fails, read its \`error\` and report it plainly.
 
+After a successful \`run_and_wait\`, deliver the result directly and briefly: present the \`result\` content (formatted for readability) and stop. Do not narrate what the run did, restate its progress logs, or add closing commentary — the user watched the run live on its card. One short lead-in sentence at most.
+
 Never quote run metrics — duration, cost, token usage — in your replies, even when a run resource you read carries them: the chat UI already displays them on the run card. Report only what the run produced (its result) or why it failed (its error).
 
 When a tool call fails with a recoverable error (e.g. a validation error naming a missing or malformed field, or a wrong-endpoint 404), do not stop and report it. Read the error detail, correct the input — re-read the operation schema if needed — and retry, up to a few attempts. Only surface the failure to the user once you have genuinely exhausted reasonable fixes; then show the exact error.

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -113,6 +113,17 @@ export interface PiRunnerOptions {
   authStoragePath?: string;
   /** Pi SDK thinking level. Defaults to `"medium"`. */
   thinkingLevel?: "low" | "medium" | "high";
+  /**
+   * Tool names whose first successful execution ends the run. When one of
+   * these tools completes without error the runner aborts the Pi session
+   * instead of paying one more LLM round-trip for a trailing text-only turn
+   * whose content is never delivered (the platform's communication contract
+   * routes everything through tools). Appstrate passes `["output"]` when the
+   * agent declares the `output` runtime tool. The abort raced here is
+   * recognised by the bridge and does NOT count as a terminal failure.
+   * Default: none (external consumers keep the SDK's natural stop).
+   */
+  terminalTools?: string[];
 }
 
 /**
@@ -457,7 +468,16 @@ export class PiRunner implements Runner {
       }),
     });
 
-    const bridge = installSessionBridge(session, internalSink, context.runId);
+    const terminalTools = this.opts.terminalTools ?? [];
+    const bridge = installSessionBridge(session, internalSink, context.runId, {
+      terminalTools,
+      // Early-stop: abort the SDK loop as soon as a terminal tool has
+      // executed successfully. `session.abort()` resolves once the agent
+      // is idle; detached because the bridge callback is synchronous.
+      onTerminalTool: () => {
+        void session.abort().catch(() => {});
+      },
+    });
     // Hand the bridge to `run()` immediately so a throw from
     // `session.prompt()` further down does not lose the accumulator.
     onBridgeReady?.(bridge);
@@ -688,11 +708,31 @@ function terminalErrorMessage(errorMessage: string | undefined): string {
     : "The agent's final model turn ended in an error";
 }
 
+export interface SessionBridgeOptions {
+  /**
+   * Tool names whose first successful `tool_execution_end` marks the run
+   * as complete. See {@link PiRunnerOptions.terminalTools}.
+   */
+  terminalTools?: string[];
+  /**
+   * Invoked once, synchronously, when a terminal tool completes without
+   * error. The runner uses this to abort the SDK loop early.
+   */
+  onTerminalTool?: () => void;
+}
+
 export function installSessionBridge(
   session: BridgeableSession,
   sink: InternalSink,
   runId: string,
+  options: SessionBridgeOptions = {},
 ): SessionBridgeHandle {
+  const terminalTools = options.terminalTools ?? [];
+  // Set once a terminal tool (e.g. `output`) has executed successfully.
+  // From that point the run is semantically complete: the early-stop abort
+  // the runner fires may surface as a trailing `stopReason: "aborted"`
+  // assistant turn, which must NOT be read as a terminal failure.
+  let terminalToolCompleted = false;
   // Token usage accumulator across all assistant turns (shared zero-shape).
   const totalUsage: TokenUsage = zeroTokenUsage();
   let totalCost = 0;
@@ -778,7 +818,14 @@ export function installSessionBridge(
         // bare `runs.error`. A transient error turn the agent later
         // recovers from also logs here (harmless — the trail no longer
         // drives status).
-        if (isTerminalErrorStop(last.stopReason)) {
+        // Suppress the verdict for the abort we raced ourselves after a
+        // terminal tool completed — the run is already semantically done
+        // (mirrored in `getTerminalError()` so log trail and stamped
+        // status stay consistent).
+        if (
+          isTerminalErrorStop(last.stopReason) &&
+          !(terminalToolCompleted && last.stopReason === "aborted")
+        ) {
           fire(
             buildError({ runId, timestamp: Date.now() }, terminalErrorMessage(last.errorMessage)),
           );
@@ -838,6 +885,13 @@ export function installSessionBridge(
             },
           ),
         );
+        // Early-stop on the first SUCCESSFUL terminal tool. A failed call
+        // (e.g. output-schema validation error) does not qualify — the
+        // model gets its retry turn as before.
+        if (!terminalToolCompleted && e.isError !== true && terminalTools.includes(tool)) {
+          terminalToolCompleted = true;
+          options.onTerminalTool?.();
+        }
         break;
       }
 
@@ -863,6 +917,11 @@ export function installSessionBridge(
       // `terminalErrorMessage` are shared with the live `appstrate.error`
       // emit above, so the stamped status and the `run_logs` trail can
       // never disagree on what counts as a terminal failure.
+      // A trailing "aborted" turn AFTER a successful terminal tool is the
+      // runner's own early-stop, not a failure.
+      if (terminalToolCompleted && lastAssistantStopReason === "aborted") {
+        return undefined;
+      }
       if (!isTerminalErrorStop(lastAssistantStopReason)) {
         return undefined;
       }

--- a/packages/runner-pi/test/session-bridge.test.ts
+++ b/packages/runner-pi/test/session-bridge.test.ts
@@ -852,3 +852,135 @@ describe("installSessionBridge — fire-and-forget rejection handling", () => {
     expect(bridge.getCost()).toBe(0);
   });
 });
+
+describe("installSessionBridge — terminal tools (early stop on output)", () => {
+  it("invokes onTerminalTool once on the first successful terminal tool execution", () => {
+    const sink = createInternalCapture();
+    const session = createFakeSession();
+    let calls = 0;
+    installSessionBridge(session, sink, RUN_ID, {
+      terminalTools: ["output"],
+      onTerminalTool: () => {
+        calls += 1;
+      },
+    });
+
+    session.emit({ type: "tool_execution_end", toolName: "output", result: "ok" });
+    session.emit({ type: "tool_execution_end", toolName: "output", result: "ok" });
+
+    expect(calls).toBe(1);
+  });
+
+  it("does NOT invoke onTerminalTool on a failed terminal tool call (validation retry)", () => {
+    const sink = createInternalCapture();
+    const session = createFakeSession();
+    let calls = 0;
+    installSessionBridge(session, sink, RUN_ID, {
+      terminalTools: ["output"],
+      onTerminalTool: () => {
+        calls += 1;
+      },
+    });
+
+    session.emit({
+      type: "tool_execution_end",
+      toolName: "output",
+      result: "Output validation failed",
+      isError: true,
+    });
+    expect(calls).toBe(0);
+
+    // The retry that succeeds still triggers the early stop.
+    session.emit({ type: "tool_execution_end", toolName: "output", result: "ok" });
+    expect(calls).toBe(1);
+  });
+
+  it("does NOT invoke onTerminalTool for non-terminal tools", () => {
+    const sink = createInternalCapture();
+    const session = createFakeSession();
+    let calls = 0;
+    installSessionBridge(session, sink, RUN_ID, {
+      terminalTools: ["output"],
+      onTerminalTool: () => {
+        calls += 1;
+      },
+    });
+
+    session.emit({ type: "tool_execution_end", toolName: "log", result: "ok" });
+    session.emit({ type: "tool_execution_end", toolName: "gmail__api_call", result: "ok" });
+
+    expect(calls).toBe(0);
+  });
+
+  it("treats a trailing aborted turn after a successful terminal tool as clean (no error event, no terminal error)", () => {
+    const sink = createInternalCapture();
+    const session = createFakeSession();
+    const bridge = installSessionBridge(session, sink, RUN_ID, {
+      terminalTools: ["output"],
+      onTerminalTool: () => {},
+    });
+
+    session.emit({ type: "tool_execution_end", toolName: "output", result: "ok" });
+
+    // The runner's own early-stop abort can surface as a partial assistant
+    // turn with stopReason "aborted" — semantically a clean finish.
+    session.pushMessage({
+      role: "assistant",
+      stopReason: "aborted",
+      errorMessage: "Request was aborted",
+      content: [],
+    });
+    session.emit({ type: "message_end" });
+
+    expect(sink.events.find((e) => e.type === "appstrate.error")).toBeUndefined();
+    expect(bridge.getTerminalError()).toBeUndefined();
+  });
+
+  it("still reports a genuine error turn after a successful terminal tool", () => {
+    const sink = createInternalCapture();
+    const session = createFakeSession();
+    const bridge = installSessionBridge(session, sink, RUN_ID, {
+      terminalTools: ["output"],
+      onTerminalTool: () => {},
+    });
+
+    session.emit({ type: "tool_execution_end", toolName: "output", result: "ok" });
+
+    session.pushMessage({
+      role: "assistant",
+      stopReason: "error",
+      errorMessage: "provider exploded",
+      content: [],
+    });
+    session.emit({ type: "message_end" });
+
+    expect(sink.events.find((e) => e.type === "appstrate.error")).toBeDefined();
+    expect(bridge.getTerminalError()).toEqual({
+      code: "adapter_error",
+      message: "provider exploded",
+    });
+  });
+
+  it("keeps aborted-as-failure semantics when no terminal tool completed", () => {
+    const sink = createInternalCapture();
+    const session = createFakeSession();
+    const bridge = installSessionBridge(session, sink, RUN_ID, {
+      terminalTools: ["output"],
+      onTerminalTool: () => {},
+    });
+
+    session.pushMessage({
+      role: "assistant",
+      stopReason: "aborted",
+      errorMessage: "Request was aborted",
+      content: [],
+    });
+    session.emit({ type: "message_end" });
+
+    expect(sink.events.find((e) => e.type === "appstrate.error")).toBeDefined();
+    expect(bridge.getTerminalError()).toEqual({
+      code: "adapter_error",
+      message: "Request was aborted",
+    });
+  });
+});

--- a/runtime-pi/entrypoint.ts
+++ b/runtime-pi/entrypoint.ts
@@ -733,6 +733,16 @@ const heartbeat = startSinkHeartbeat({
 
 /** Construct the default Pi runner (every non-`claude-code` run). */
 function buildPiRunner(): PiRunner {
+  // When the agent selected the `output` runtime tool, a successful call is
+  // the run's semantic end — stop the SDK loop there instead of paying one
+  // more LLM round-trip for a trailing text-only turn whose content the
+  // communication contract discards anyway. Gated on the manifest selection
+  // so a bundle-defined tool that happens to be named `output` (no
+  // `runtime_tools` opt-in) keeps the SDK's natural stop.
+  const declaredRuntimeTools = bundle
+    ? ((bundle.packages.get(bundle.root)?.manifest as { runtime_tools?: string[] } | undefined)
+        ?.runtime_tools ?? [])
+    : [];
   return new PiRunner({
     model,
     apiKey: env.modelApiKey,
@@ -741,6 +751,7 @@ function buildPiRunner(): PiRunner {
     agentDir: "/tmp/pi-agent",
     extensionFactories,
     authStoragePath: "/tmp/pi-auth/auth.json",
+    ...(declaredRuntimeTools.includes("output") ? { terminalTools: ["output"] } : {}),
   });
 }
 

--- a/runtime-pi/sidecar/integrations-boot.ts
+++ b/runtime-pi/sidecar/integrations-boot.ts
@@ -1015,6 +1015,21 @@ export async function bootIntegrations(
     });
     throw err;
   }
+  // ─── Phase 1.5 (kickoff) — MITM run-CA mint, raced with adapter.prepare ───
+  // The CA mint (openssl keygen + self-sign, ~100 ms) only needs the runId;
+  // it has no dependency on the adapter context, so it runs concurrently
+  // with `adapter.prepare` instead of serializing after it — the agent's
+  // boot-report gate waits on the slower of the two, not their sum. The
+  // result is awaited (with its breadcrumb) right after the adapter phase.
+  const mitmIntegrationCount = specs.filter(
+    (s) => s.httpDeliveryAuths && Object.keys(s.httpDeliveryAuths).length > 0,
+  ).length;
+  const caStart = performance.now();
+  const runCaPromise = mitmIntegrationCount > 0 ? prepareRunCa(runId, "afps-ca-") : null;
+  // Rejection is handled at the await below; this guard only prevents an
+  // unhandled-rejection crash if adapter.prepare throws first.
+  runCaPromise?.catch(() => {});
+
   const adapterPrepareStart = performance.now();
   const adapterCtx = await adapter.prepare(runId);
   const adapterPrepareMs = performance.now() - adapterPrepareStart;
@@ -1044,19 +1059,16 @@ export async function bootIntegrations(
     data: { adapter: adapter.id, prepareMs: Math.round(adapterPrepareMs) },
   });
 
-  // ─── Phase 1.5 — MITM bring-up (run-CA + cert minter), only when needed ───
-  // Mint the CA once per run, regardless of how many integrations need it.
+  // ─── Phase 1.5 (converge) — MITM bring-up (run-CA + cert minter) ───
+  // The CA was minted once per run (kicked off above, concurrent with the
+  // adapter phase), regardless of how many integrations need it.
   // Per-integration listeners share the same minter (lazily creates leaf
   // certs per upstream SNI host). The CA cert PEM lands on local fs so
   // the adapter can ferry it into each runner's trust store.
-  const mitmIntegrationCount = specs.filter(
-    (s) => s.httpDeliveryAuths && Object.keys(s.httpDeliveryAuths).length > 0,
-  ).length;
   let runCa: RunCaMaterials | null = null;
-  if (mitmIntegrationCount > 0) {
-    const caStart = performance.now();
+  if (runCaPromise) {
     try {
-      runCa = await prepareRunCa(runId, "afps-ca-");
+      runCa = await runCaPromise;
       const caMs = Math.round(performance.now() - caStart);
       logger.info("integration MITM CA minted", {
         runId,


### PR DESCRIPTION
## Contexte

Analyse de perf sur un run inline chat réel (`run_364f7795`, tâche Gmail à 2 appels API) : ~19 s perçus, dont 11.2 s de run. Décomposition mesurée : ~8 s = 4 tours LLM séquentiels (~2.5–3 s chacun), ~1.1 s d'infra Docker, ~0.8 s d'appels Gmail. Le goulot est le nombre de round-trips LLM × la latence par tour, pas l'infra. Sur la flotte, la durée des runs est quasi linéaire au nombre de tool calls.

## Changements

### Réduction des round-trips LLM

- **`output` devient un tool terminal dans le runner Pi** (`packages/runner-pi`) — nouvelle option `terminalTools`. Après un appel `output` **réussi**, le runner aborte la session au lieu de payer un tour LLM complet pour un wrap-up texte (« Terminé ! ») que le contrat de communication jette de toute façon. Le bridge reconnaît cet abort volontaire : un `stopReason:"aborted"` trailing après un tool terminal réussi ne compte pas comme échec ; un vrai `error` post-output reste un échec ; un appel `output` invalide (validation de schéma) garde son tour de retry. Câblé depuis l'entrypoint uniquement quand le manifest déclare `runtime_tools: ["output"]` — miroir du chemin natif `structured_output` du runner Claude. **Gain : −1 tour LLM par run (~2.5–3 s).**
- **Prompts alignés** : la description du tool `output` et la section `## Output Format` du prompt plateforme annoncent que le run se termine à l'appel, pour que le modèle ne planifie rien après.
- **Wrap-up chat allégé** (`module-chat/prompt.ts`) : après un `run_and_wait` réussi, restituer le résultat directement (une phrase d'intro max), sans re-narrer le déroulé — la run card affiche déjà le live.

### Latence de boot du run

- **`resolveIntegrationSpawns` démarré à l'entrée de `buildRunContext`** (ses entrées y sont toutes disponibles) au lieu d'être sérialisé après les résolutions config/bundle puis model/proxy ; résolution des intégrations déclarées en `Promise.all` (ordre de déclaration préservé, sémantique warn-and-skip et propagation `DEPENDENCY_UNRESOLVED` inchangées). Le seed du `manifestCache` par `freezeRunSpawnDependencies` précède toujours `buildRunContext`, donc les pins de version restent honorés.
- **Ownership du workspace via options de mount tmpfs** (`uid=1001,gid=1001`) sur le chemin par défaut — supprime le container busybox éphémère de chown (~150 ms de round-trips Docker série par run). État final identique (1001:1001, mode 1777, vérifié contre le daemon). Le fallback disque (`WORKSPACE_TMPFS_SIZE_MB=0`) conserve le chown init.
- **`ensureImages` memoizé** dans l'orchestrateur Docker (images pré-pull au boot ; l'inspect par run était redondant ; un prune hôte se manifeste en erreur `No such image` claire).
- **Mint du MITM CA parallèle à `adapter.prepare`** dans le boot sidecar (~100 ms recouverts) — le gate boot-report de l'agent attend le plus lent des deux, plus leur somme.

### Non retenu (délibéré)

- Trim de l'index d'opérations chat : déjà optimal (ids-only, memoized, prompt-caché) ; le retirer ajouterait des round-trips `search_operations`.
- Batch de l'ingestion d'événements : touche le contrat CAS de séquence + la signature Standard-Webhooks par message pour un gain de charge DB sans latence perçue.
- Parallélisation de `freezeRunSpawnDependencies`/`resolveRunConnectionsOrError` : le seed du `manifestCache` impose l'ordre.

## Tests

- 6 nouveaux tests bridge (`session-bridge.test.ts`) : déclenchement unique sur premier succès, pas de déclenchement sur erreur/tools non terminaux, abort-après-output propre (pas d'`appstrate.error`, `getTerminalError()` undefined), erreur réelle post-output toujours signalée, sémantique aborted=failure préservée sans tool terminal.
- `bun run check` : 33/33 ✅ (tsc, eslint, prettier, verify-openapi).
- Suites : module-chat + runner-pi + runtime-pi (414), spawn-resolver + orchestrator (36), runs route + parallel-boot + sidecar (669), DinD docker-api avec `TEST_DOCKER=1` (33) — 0 fail.
- Validation directe daemon : volume tmpfs `uid/gid` monté `1001:1001 1777`, écriture UID 1001 OK.

## Notes de déploiement

- Rebuild de l'image PI requis (changements `runner-pi` + `entrypoint`) ; changements C1/C2 côté plateforme uniquement.
- Gain attendu sur l'échange de référence : ~19 s → ~13–14 s. Le plancher restant est le TTFT du modèle système (`deepseek-chat` aliasé « Appstrate Flash ») × 3 tours incompressibles — changement de modèle hors périmètre de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)