### PR TITLE
fix(models): stop aliased models leaking the real provider in errors, headers and DTOs

### DIFF
--- a/apps/api/src/routes/llm-proxy.ts
+++ b/apps/api/src/routes/llm-proxy.ts
@@ -234,6 +234,12 @@ async function handleProxy(
       throw invalidRequest(err.message);
     }
     if (err instanceof LlmProxyUnsupportedSubscriptionError) {
+      // The backing provider id is server-log-only — the caller-facing
+      // message deliberately doesn't name it (model-alias masking).
+      logger.warn("llm-proxy: rejected OAuth-subscription model", {
+        providerId: err.providerId,
+        orgId,
+      });
       throw invalidRequest(err.message, "model");
     }
     if (err instanceof LlmProxyModelApiMismatchError) {

--- a/apps/api/src/routes/llm-proxy.ts
+++ b/apps/api/src/routes/llm-proxy.ts
@@ -243,6 +243,14 @@ async function handleProxy(
       throw invalidRequest(err.message, "model");
     }
     if (err instanceof LlmProxyModelApiMismatchError) {
+      // For an aliased model the message is generic — the backing apiShape is
+      // server-log-only (model-alias masking, same posture as the branch above).
+      logger.warn("llm-proxy: model/endpoint apiShape mismatch", {
+        presetId: err.presetId,
+        expected: err.expected,
+        actual: err.actual,
+        orgId,
+      });
       throw invalidRequest(err.message, "model");
     }
     // No `status`: the upstream attempt produced no response, which the

--- a/apps/api/src/services/llm-proxy/claude-code-sdk-gateway.ts
+++ b/apps/api/src/services/llm-proxy/claude-code-sdk-gateway.ts
@@ -137,9 +137,13 @@ async function resolveClaudeSubscriptionToken(
     throw invalidRequest(`Model preset "${presetId}" is not enabled for this org`);
   }
   if (resolved.providerId !== CLAUDE_CODE_PROVIDER_ID) {
-    throw invalidRequest(
-      `Model preset "${presetId}" is not a Claude Code subscription model (provider: ${resolved.providerId})`,
-    );
+    // Backing provider id is server-log-only — never in the caller-facing body
+    // (model-alias masking).
+    logger.warn(`${logLabel}: preset is not a Claude Code subscription model`, {
+      presetId,
+      providerId: resolved.providerId,
+    });
+    throw invalidRequest(`Model preset "${presetId}" is not a Claude Code subscription model`);
   }
   if (!resolved.credentialId) {
     throw invalidRequest(`Model preset "${presetId}" has no OAuth credential to resolve`);
@@ -194,7 +198,13 @@ export async function handleClaudeCodeSdkGateway(
   // gateway becoming an SSRF hole if that flag is ever flipped, instead of the
   // protection silently depending on a provider def in another repo.
   if (isBlockedUrl(resolved.baseUrl)) {
-    throw invalidRequest(`Model base URL targets a blocked network: ${resolved.baseUrl}`);
+    logger.error("claude-code-sdk gateway: refused blocked upstream (SSRF)", {
+      presetId,
+      baseUrl: resolved.baseUrl,
+    });
+    throw invalidRequest(
+      `Model preset "${presetId}" resolves to a blocked address — refusing to proxy.`,
+    );
   }
 
   const buf = await c.req.arrayBuffer();

--- a/apps/api/src/services/llm-proxy/core.ts
+++ b/apps/api/src/services/llm-proxy/core.ts
@@ -58,13 +58,21 @@ export class LlmProxyUnsupportedModelError extends Error {
 }
 
 export class LlmProxyModelApiMismatchError extends Error {
+  // For an ALIASED model the backing `actual` apiShape is hidden (the public
+  // DTO nulls it — `projectAliasedModel`), so naming it here would leak the
+  // backing protocol family. The caller-facing message then stays generic;
+  // `actual` remains a property for server-side logging only. Non-aliased
+  // models keep the detailed message (debugging value, nothing to hide).
   constructor(
     public readonly presetId: string,
     public readonly expected: string,
     public readonly actual: string,
+    aliased = false,
   ) {
     super(
-      `Model "${presetId}" uses "${actual}"; this endpoint serves "${expected}". Use the corresponding /api/llm-proxy/<api>/… route.`,
+      aliased
+        ? `Model "${presetId}" is not served by this endpoint.`
+        : `Model "${presetId}" uses "${actual}"; this endpoint serves "${expected}". Use the corresponding /api/llm-proxy/<api>/… route.`,
     );
     this.name = "LlmProxyModelApiMismatchError";
   }
@@ -128,9 +136,8 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
   // `realHost` extends the scrub to the backing hostname in error prose
   // (provider error bodies, gateway messages) — the host identifies the
   // backing as surely as the model id.
-  const realHost = resolved.aliased ? hostnameOf(resolved.baseUrl) : undefined;
   const swap: ModelSwap | null = resolved.aliased
-    ? { alias: presetId, real: resolved.modelId, ...(realHost ? { realHost } : {}) }
+    ? { alias: presetId, real: resolved.modelId, realHost: hostnameOf(resolved.baseUrl) }
     : null;
 
   // Response-cache lookup. The cache is keyed on `(orgId, presetId,
@@ -232,7 +239,7 @@ async function resolvePresetForOrg(
     throw new LlmProxyUnsupportedModelError(presetId);
   }
   if (loaded.apiShape !== expectedApi) {
-    throw new LlmProxyModelApiMismatchError(presetId, expectedApi, loaded.apiShape);
+    throw new LlmProxyModelApiMismatchError(presetId, expectedApi, loaded.apiShape, loaded.aliased);
   }
   return loaded;
 }

--- a/apps/api/src/services/llm-proxy/core.ts
+++ b/apps/api/src/services/llm-proxy/core.ts
@@ -30,6 +30,7 @@ import { getErrorMessage } from "@appstrate/core/errors";
 import { isBlockedUrl } from "@appstrate/core/ssrf";
 import { getModelProvider } from "../model-providers/registry.ts";
 import type { ModelSwap } from "@appstrate/core/sidecar-types";
+import { hostnameOf } from "@appstrate/core/model-swap";
 
 /** Maximum request body the proxy will accept before refusing up-front. */
 const DEFAULT_MAX_REQUEST_BYTES = 10 * 1024 * 1024;
@@ -79,9 +80,12 @@ export class LlmProxyModelApiMismatchError extends Error {
  * here — this gateway never forges).
  */
 export class LlmProxyUnsupportedSubscriptionError extends Error {
+  // `providerId` stays a property for server-side logging only — the message
+  // is caller-facing and must not name the backing provider (an aliased
+  // model's whole point is that the caller never learns it).
   constructor(public readonly providerId: string) {
     super(
-      `Provider "${providerId}" is an OAuth subscription and cannot be served through ` +
+      `This model is backed by an OAuth subscription and cannot be served through ` +
         `this gateway (no fingerprint forging). Subscription chat is only available when ` +
         `the provider's subscription engine has a dedicated official-binary SDK gateway; ` +
         `this credential's engine has none. Use an API-key model instead.`,
@@ -121,8 +125,12 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
   // dashboard `jwt_user`) never sees the backing. The request `model` was
   // already rewritten alias→real by `request.rewriteModel` above. This mirrors
   // the in-container sidecar path; both share `@appstrate/core/model-swap`.
+  // `realHost` extends the scrub to the backing hostname in error prose
+  // (provider error bodies, gateway messages) — the host identifies the
+  // backing as surely as the model id.
+  const realHost = resolved.aliased ? hostnameOf(resolved.baseUrl) : undefined;
   const swap: ModelSwap | null = resolved.aliased
-    ? { alias: presetId, real: resolved.modelId }
+    ? { alias: presetId, real: resolved.modelId, ...(realHost ? { realHost } : {}) }
     : null;
 
   // Response-cache lookup. The cache is keyed on `(orgId, presetId,
@@ -160,7 +168,10 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
   // documented fail-closed consumer of `@appstrate/core/ssrf`.
   if (isBlockedUrl(upstreamUrl)) {
     logger.error("llm-proxy: refused blocked upstream (SSRF)", { presetId, upstreamUrl });
-    throw invalidRequest(`Refusing to proxy to a blocked address: ${resolved.baseUrl}`);
+    // Generic message: the resolved base URL is the real backing (hidden for
+    // aliased models) — it belongs in the server log above, never in the
+    // caller-facing error body.
+    throw invalidRequest(`Model "${presetId}" resolves to a blocked address — refusing to proxy.`);
   }
 
   const upstreamHeaders = inputs.adapter.buildUpstreamHeaders(

--- a/apps/api/src/services/llm-proxy/metering.ts
+++ b/apps/api/src/services/llm-proxy/metering.ts
@@ -41,6 +41,46 @@ import type { LlmProxyAdapter, LlmProxyPrincipal, UpstreamUsage } from "./types.
 export const cloneResponseHeaders = stripUpstreamResponseHeaders;
 
 /**
+ * Response headers forwarded for an ALIASED model. The permissive
+ * `stripUpstreamResponseHeaders` clone forwards everything the upstream sends —
+ * `server: cloudflare`, `cf-ray`, `anthropic-*`, `openai-organization`, … —
+ * which fingerprints the backing provider even when every body field is
+ * swapped. An alias therefore gets a strict allowlist instead (the same
+ * posture as the sidecar's `PASSTHROUGH_RESPONSE_HEADERS` and the response
+ * cache's `CACHE_REPLAY_HEADERS`): content-type to parse the body, the
+ * rate-limit family + retry-after for backoff, x-request-id for provider-side
+ * error correlation.
+ */
+const ALIAS_PASSTHROUGH_RESPONSE_HEADERS = [
+  "content-type",
+  "retry-after",
+  "ratelimit-limit",
+  "ratelimit-remaining",
+  "ratelimit-reset",
+  "x-ratelimit-limit-requests",
+  "x-ratelimit-remaining-requests",
+  "x-ratelimit-reset-requests",
+  "x-ratelimit-limit-tokens",
+  "x-ratelimit-remaining-tokens",
+  "x-ratelimit-reset-tokens",
+  "x-request-id",
+];
+
+/**
+ * Build the client-facing headers for one upstream response: permissive clone
+ * for a regular model, strict allowlist when a model-alias swap is active.
+ */
+function buildClientHeaders(upstream: Headers, swap: ModelSwap | null | undefined): Headers {
+  if (!swap) return cloneResponseHeaders(upstream);
+  const out = new Headers();
+  for (const name of ALIAS_PASSTHROUGH_RESPONSE_HEADERS) {
+    const value = upstream.get(name);
+    if (value !== null) out.set(name, value);
+  }
+  return out;
+}
+
+/**
  * Upper bound on usage-bearing frames retained by {@link tapSseUsage}.
  * Real providers emit at most two (Anthropic: `message_start` + terminal
  * `message_delta`; OpenAI-compatible: the terminal frame when
@@ -298,7 +338,7 @@ export async function forwardMeteredResponse(
   if (!upstream.ok) {
     options.onUpstreamError?.(upstream.status);
     const errorBody = await upstream.text();
-    const headers = cloneResponseHeaders(upstream.headers);
+    const headers = buildClientHeaders(upstream.headers, swap);
     const clientBody = swap ? scrubModelText(errorBody, swap) : errorBody;
     return new Response(clientBody, { status: upstream.status, headers });
   }
@@ -318,7 +358,7 @@ export async function forwardMeteredResponse(
           error: getErrorMessage(err),
         });
       });
-    const headers = cloneResponseHeaders(upstream.headers);
+    const headers = buildClientHeaders(upstream.headers, swap);
     // Guard the raw client branch FIRST (before the alias-swap pipe) so the
     // swapped stream is fed by a source that never errors — see
     // {@link guardSseTeardown} for why guarding after `pipeThrough` would leave
@@ -341,7 +381,7 @@ export async function forwardMeteredResponse(
     parsed = JSON.parse(bodyText);
   } catch {
     // Non-JSON 2xx (unexpected) — forward without metering, scrubbing aliases.
-    const headers = cloneResponseHeaders(upstream.headers);
+    const headers = buildClientHeaders(upstream.headers, swap);
     const clientBody = swap ? scrubModelText(bodyText, swap) : bodyText;
     return new Response(clientBody, { status: upstream.status, headers });
   }
@@ -351,7 +391,7 @@ export async function forwardMeteredResponse(
   // no-ops on null usage). Streaming uses `void` deliberately — already on wire.
   await meter(adapter.parseJsonUsage(parsed));
 
-  const headers = cloneResponseHeaders(upstream.headers);
+  const headers = buildClientHeaders(upstream.headers, swap);
   // Rewrite the echoed real id back to the alias BEFORE the body leaves the
   // server — and before caching, so a replay returns the alias too.
   const clientBody = swap ? swapResponseModelJson(bodyText, swap) : bodyText;

--- a/apps/api/src/services/llm-proxy/metering.ts
+++ b/apps/api/src/services/llm-proxy/metering.ts
@@ -31,6 +31,7 @@ import {
   swapResponseModelJson,
   createSseModelSwapStream,
   scrubModelText,
+  LLM_PASSTHROUGH_RESPONSE_HEADERS,
 } from "@appstrate/core/model-swap";
 import { stripUpstreamResponseHeaders } from "@appstrate/connect/proxy-primitives";
 import type { ResolvedModel } from "../org-models.ts";
@@ -41,39 +42,19 @@ import type { LlmProxyAdapter, LlmProxyPrincipal, UpstreamUsage } from "./types.
 export const cloneResponseHeaders = stripUpstreamResponseHeaders;
 
 /**
- * Response headers forwarded for an ALIASED model. The permissive
- * `stripUpstreamResponseHeaders` clone forwards everything the upstream sends —
- * `server: cloudflare`, `cf-ray`, `anthropic-*`, `openai-organization`, … —
- * which fingerprints the backing provider even when every body field is
- * swapped. An alias therefore gets a strict allowlist instead (the same
- * posture as the sidecar's `PASSTHROUGH_RESPONSE_HEADERS` and the response
- * cache's `CACHE_REPLAY_HEADERS`): content-type to parse the body, the
- * rate-limit family + retry-after for backoff, x-request-id for provider-side
- * error correlation.
- */
-const ALIAS_PASSTHROUGH_RESPONSE_HEADERS = [
-  "content-type",
-  "retry-after",
-  "ratelimit-limit",
-  "ratelimit-remaining",
-  "ratelimit-reset",
-  "x-ratelimit-limit-requests",
-  "x-ratelimit-remaining-requests",
-  "x-ratelimit-reset-requests",
-  "x-ratelimit-limit-tokens",
-  "x-ratelimit-remaining-tokens",
-  "x-ratelimit-reset-tokens",
-  "x-request-id",
-];
-
-/**
  * Build the client-facing headers for one upstream response: permissive clone
- * for a regular model, strict allowlist when a model-alias swap is active.
+ * for a regular model, strict allowlist when a model-alias swap is active. The
+ * permissive `stripUpstreamResponseHeaders` clone forwards everything the
+ * upstream sends — `server: cloudflare`, `cf-ray`, `anthropic-*`,
+ * `openai-organization`, … — which fingerprints the backing provider even when
+ * every body field is swapped. An alias therefore gets
+ * {@link LLM_PASSTHROUGH_RESPONSE_HEADERS}, the same allowlist the sidecar
+ * applies on its own responses.
  */
 function buildClientHeaders(upstream: Headers, swap: ModelSwap | null | undefined): Headers {
   if (!swap) return cloneResponseHeaders(upstream);
   const out = new Headers();
-  for (const name of ALIAS_PASSTHROUGH_RESPONSE_HEADERS) {
+  for (const name of LLM_PASSTHROUGH_RESPONSE_HEADERS) {
     const value = upstream.get(name);
     if (value !== null) out.set(name, value);
   }

--- a/apps/api/src/services/model-providers/credentials.ts
+++ b/apps/api/src/services/model-providers/credentials.ts
@@ -622,9 +622,15 @@ export async function listOrgModelProviderCredentials(
     mapSystem: (id, def): ModelProviderCredentialInfo => {
       const provider = getModelProvider(def.providerId);
       const aliasOnly = aliasOnlySystemCredentials.has(id);
+      // Alias-only: the displayName/providerId label fallbacks NAME the hidden
+      // backing ("DeepSeek") — as revealing as the nulled apiShape/baseUrl.
+      // Without an explicit env label, fall back to a neutral one.
+      const label = aliasOnly
+        ? (def.label ?? "System models")
+        : (def.label ?? provider?.displayName ?? def.providerId);
       return {
         id,
-        label: def.label ?? provider?.displayName ?? def.providerId,
+        label,
         apiShape: aliasOnly ? null : def.apiShape,
         baseUrl: aliasOnly ? null : def.baseUrl,
         source: "built-in",

--- a/apps/api/src/services/org-models.ts
+++ b/apps/api/src/services/org-models.ts
@@ -17,7 +17,8 @@ import {
   loadCredentialRow,
   loadCredentialMetadata,
 } from "./model-providers/credentials.ts";
-import type { ModelApiShape } from "@appstrate/core/sidecar-types";
+import type { ModelApiShape, ModelSwap } from "@appstrate/core/sidecar-types";
+import { hostnameOf } from "@appstrate/core/model-swap";
 import {
   getResolvedModel,
   setResolvedModel,
@@ -229,6 +230,31 @@ export async function listOrgModels(
       };
     },
   }).sort((a, b) => a.label.localeCompare(b.label));
+}
+
+/**
+ * Every model-alias swap visible to an org, for scrubbing free-form text
+ * (run terminal errors) that may name a real backing id or hostname. Uses the
+ * metadata-only credential resolution — no secret is decrypted. Failures
+ * degrade to an empty list (scrubbing is defense-in-depth, never a reason to
+ * fail a finalize).
+ */
+export async function listAliasSwapsForOrg(orgId: string): Promise<ModelSwap[]> {
+  try {
+    const models = await listOrgModels(orgId, { metadataOnly: true });
+    return models
+      .filter((m) => m.aliased && m.modelId)
+      .map((m) => {
+        const realHost = m.baseUrl ? hostnameOf(m.baseUrl) : undefined;
+        return { alias: m.id, real: m.modelId as string, ...(realHost ? { realHost } : {}) };
+      });
+  } catch (err) {
+    logger.warn("org-models: alias-swap listing failed — skipping scrub", {
+      orgId,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
 }
 
 /**

--- a/apps/api/src/services/org-models.ts
+++ b/apps/api/src/services/org-models.ts
@@ -234,20 +234,44 @@ export async function listOrgModels(
 
 /**
  * Every model-alias swap visible to an org, for scrubbing free-form text
- * (run terminal errors) that may name a real backing id or hostname. Uses the
- * metadata-only credential resolution — no secret is decrypted. Failures
- * degrade to an empty list (scrubbing is defense-in-depth, never a reason to
- * fail a finalize).
+ * (run terminal errors) that may name a real backing id or hostname. Runs on
+ * every errored finalize, so it deliberately does NOT go through
+ * {@link listOrgModels} (which resolves credential metadata for every model
+ * row): system aliases come straight from the in-memory registry, and DB
+ * aliases from one select filtered on `aliased` — credential metadata (for the
+ * backing hostname) is resolved only for those rare rows, never decrypting a
+ * secret. Failures degrade to an empty list (scrubbing is defense-in-depth,
+ * never a reason to fail a finalize).
  */
 export async function listAliasSwapsForOrg(orgId: string): Promise<ModelSwap[]> {
   try {
-    const models = await listOrgModels(orgId, { metadataOnly: true });
-    return models
-      .filter((m) => m.aliased && m.modelId)
-      .map((m) => {
-        const realHost = m.baseUrl ? hostnameOf(m.baseUrl) : undefined;
-        return { alias: m.id, real: m.modelId as string, ...(realHost ? { realHost } : {}) };
-      });
+    const swaps: ModelSwap[] = [];
+    for (const [id, def] of getSystemModels()) {
+      if (def.aliased === true) {
+        swaps.push({ alias: id, real: def.modelId, realHost: hostnameOf(def.baseUrl) });
+      }
+    }
+    const rows = await db
+      .select({
+        id: orgModels.id,
+        modelId: orgModels.modelId,
+        credentialId: orgModels.credentialId,
+      })
+      .from(orgModels)
+      .where(scopedWhere(orgModels, { orgId, extra: [eq(orgModels.aliased, true)] }));
+    await Promise.all(
+      rows.map(async (row) => {
+        // A row whose credential is unreachable still contributes its swap —
+        // the model id must be masked even when the hostname can't be resolved.
+        const creds = await loadCredentialMetadata(row.credentialId, orgId);
+        swaps.push({
+          alias: row.id,
+          real: row.modelId,
+          realHost: creds?.baseUrl ? hostnameOf(creds.baseUrl) : undefined,
+        });
+      }),
+    );
+    return swaps;
   } catch (err) {
     logger.warn("org-models: alias-swap listing failed — skipping scrub", {
       orgId,

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -48,6 +48,8 @@ import { validateOutput } from "./schema.ts";
 import { asJSONSchemaObject } from "@appstrate/core/form";
 import { callHook, emitEvent } from "../lib/modules/module-loader.ts";
 import { isInlineShadowPackageId } from "./inline-run.ts";
+import { listAliasSwapsForOrg } from "./org-models.ts";
+import { scrubModelText } from "@appstrate/core/model-swap";
 import type { RunStatusChangeParams } from "@appstrate/core/module";
 import { assertSinkOpen, verifyRunSignatureHeaders } from "../lib/run-signature.ts";
 import { clearRunMetricBroadcastState } from "./run-metric-broadcaster.ts";
@@ -353,6 +355,18 @@ async function finalizeRunImpl(input: FinalizeRunInput): Promise<void> {
     if (runHadZeroTokens(validatedUsage)) {
       status = "failed";
       errorMessage = llmUnreachableMessage(run);
+    }
+  }
+
+  // 3b. Model-alias scrub on the terminal error — defense-in-depth at the last
+  //     platform boundary before the message fans out (runs.error → run DTO,
+  //     `run_update` SSE, terminal run_log, webhook payload). The sidecar
+  //     already scrubs its own responses, but the runner-supplied message can
+  //     carry upstream prose the sidecar never saw. The run's own swap isn't
+  //     persisted, so scrub against every alias visible to the org.
+  if (errorMessage) {
+    for (const aliasSwap of await listAliasSwapsForOrg(run.orgId)) {
+      errorMessage = scrubModelText(errorMessage, aliasSwap);
     }
   }
 

--- a/apps/api/src/services/run-launcher/pi.ts
+++ b/apps/api/src/services/run-launcher/pi.ts
@@ -224,12 +224,11 @@ async function runPlatformContainerImpl(
     // `realHost` lets the sidecar scrub the backing hostname out of error
     // prose (fetch failures, provider error bodies) — it identifies the
     // backing as surely as the model id.
-    const realHost = llmConfig.aliased ? hostnameOf(llmConfig.baseUrl) : undefined;
     const modelSwap = llmConfig.aliased
       ? {
           alias: llmConfig.aliasId,
           real: llmConfig.modelId,
-          ...(realHost ? { realHost } : {}),
+          realHost: hostnameOf(llmConfig.baseUrl),
         }
       : undefined;
 

--- a/apps/api/src/services/run-launcher/pi.ts
+++ b/apps/api/src/services/run-launcher/pi.ts
@@ -52,6 +52,7 @@ import {
 import { getEnv } from "@appstrate/env";
 import { getModelProvider } from "../model-providers/registry.ts";
 import type { LlmProxyConfig, SidecarLaunchSpec } from "@appstrate/core/sidecar-types";
+import { hostnameOf } from "@appstrate/core/model-swap";
 
 /**
  * Grace added to the platform's container watchdog on top of the agent's
@@ -220,8 +221,16 @@ async function runPlatformContainerImpl(
     // Model-alias swap descriptor (LLM-gateway alias pattern). The container is
     // handed the public alias as MODEL_ID (below); the sidecar swaps it for the
     // real upstream id on every call. The real id never enters the container.
+    // `realHost` lets the sidecar scrub the backing hostname out of error
+    // prose (fetch failures, provider error bodies) — it identifies the
+    // backing as surely as the model id.
+    const realHost = llmConfig.aliased ? hostnameOf(llmConfig.baseUrl) : undefined;
     const modelSwap = llmConfig.aliased
-      ? { alias: llmConfig.aliasId, real: llmConfig.modelId }
+      ? {
+          alias: llmConfig.aliasId,
+          real: llmConfig.modelId,
+          ...(realHost ? { realHost } : {}),
+        }
       : undefined;
 
     // Engine selection (Pi vs the official Claude Agent SDK). Resolved from the

--- a/apps/api/test/integration/routes/llm-proxy.test.ts
+++ b/apps/api/test/integration/routes/llm-proxy.test.ts
@@ -225,6 +225,27 @@ describe("POST /api/llm-proxy/openai-completions/v1/chat/completions", () => {
       }),
     });
     expect(res.status).toBe(400);
+    // Non-aliased: the detailed message names both shapes (debugging value).
+    expect(await res.text()).toContain("anthropic-messages");
+  });
+
+  it("hides the backing apiShape in the protocol-mismatch error for an ALIASED preset", async () => {
+    // The public DTO nulls an alias's apiShape (`projectAliasedModel`) — the
+    // mismatch error must not hand it back in prose.
+    const h = await buildHarness({ apiShape: "anthropic-messages", aliased: true });
+    mockUpstream(async () => new Response("should not be called", { status: 599 }));
+    const res = await app.request("/api/llm-proxy/openai-completions/v1/chat/completions", {
+      method: "POST",
+      headers: authHeaders(h),
+      body: JSON.stringify({
+        model: h.presetId,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.text();
+    expect(body).not.toContain("anthropic");
+    expect(body).toContain("is not served by this endpoint");
   });
 
   it("forwards upstream errors verbatim without recording usage", async () => {

--- a/apps/api/test/integration/services/org-models-alias.test.ts
+++ b/apps/api/test/integration/services/org-models-alias.test.ts
@@ -13,7 +13,11 @@
  */
 
 import { describe, it, expect, beforeEach } from "bun:test";
-import { listOrgModels, loadModel } from "../../../src/services/org-models.ts";
+import {
+  listOrgModels,
+  loadModel,
+  listAliasSwapsForOrg,
+} from "../../../src/services/org-models.ts";
 import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
 import { seedOrgModel, seedOrgModelProviderKey } from "../../helpers/seed.ts";
@@ -79,5 +83,35 @@ describe("org-models — aliased flag (DB path)", () => {
     // The user-selected alias is the row id; the real backing is hidden behind it.
     expect(resolved!.aliasId).toBe(model.id);
     expect(resolved!.modelId).toBe("gpt-4o");
+  });
+
+  it("listAliasSwapsForOrg returns only aliased rows, with realHost from the credential", async () => {
+    const cred = await seedCred();
+    await seedOrgModel({
+      orgId: ctx.orgId,
+      credentialId: cred.id,
+      label: "Plain GPT-4o",
+      modelId: "gpt-4o",
+      enabled: true,
+    });
+    const alias = await seedOrgModel({
+      orgId: ctx.orgId,
+      credentialId: cred.id,
+      label: "Appstrate Medium",
+      modelId: "gpt-4o-mini",
+      enabled: true,
+      aliased: true,
+    });
+
+    const swaps = await listAliasSwapsForOrg(ctx.orgId);
+    const dbSwaps = swaps.filter((s) => s.alias === alias.id);
+    expect(dbSwaps).toHaveLength(1);
+    expect(dbSwaps[0]).toEqual({
+      alias: alias.id,
+      real: "gpt-4o-mini",
+      realHost: "api.openai.com",
+    });
+    // The non-aliased row contributes no swap.
+    expect(swaps.some((s) => s.real === "gpt-4o")).toBe(false);
   });
 });

--- a/apps/api/test/unit/llm-proxy-metering.test.ts
+++ b/apps/api/test/unit/llm-proxy-metering.test.ts
@@ -200,6 +200,89 @@ describe("guardSseTeardown", () => {
     expect(out).not.toContain("real-model");
   });
 
+  it("alias: strips provider-fingerprinting response headers, keeps the operational set", async () => {
+    const upstream = new Response('{"error":{"message":"overloaded"}}', {
+      status: 529,
+      headers: {
+        "content-type": "application/json",
+        server: "cloudflare",
+        "cf-ray": "8d2-CDG",
+        "anthropic-organization-id": "org_123",
+        "openai-organization": "org-abc",
+        "retry-after": "7",
+        "x-request-id": "req_1",
+      },
+    });
+    const ctx: MeteredForwardContext = {
+      principal: { kind: "jwt_user", userId: "u", orgId: "o" },
+      runId: null,
+      presetId: "preset",
+      resolved: {
+        modelId: "real-model",
+        apiShape: "anthropic-messages",
+      } as unknown as ResolvedModel,
+      started: 0,
+    };
+    const res = await forwardMeteredResponse(upstream, anthropicMessagesAdapter, ctx, {
+      swap: { alias: "alias-model", real: "real-model" },
+      logLabel: "test",
+    });
+    expect(res.headers.get("server")).toBeNull();
+    expect(res.headers.get("cf-ray")).toBeNull();
+    expect(res.headers.get("anthropic-organization-id")).toBeNull();
+    expect(res.headers.get("openai-organization")).toBeNull();
+    expect(res.headers.get("retry-after")).toBe("7");
+    expect(res.headers.get("x-request-id")).toBe("req_1");
+    expect(res.headers.get("content-type")).toBe("application/json");
+  });
+
+  it("no alias: response headers pass through as before", async () => {
+    const upstream = new Response('{"error":{"message":"overloaded"}}', {
+      status: 529,
+      headers: { "content-type": "application/json", server: "cloudflare" },
+    });
+    const ctx: MeteredForwardContext = {
+      principal: { kind: "jwt_user", userId: "u", orgId: "o" },
+      runId: null,
+      presetId: "preset",
+      resolved: {
+        modelId: "real-model",
+        apiShape: "anthropic-messages",
+      } as unknown as ResolvedModel,
+      started: 0,
+    };
+    const res = await forwardMeteredResponse(upstream, anthropicMessagesAdapter, ctx, {
+      swap: null,
+      logLabel: "test",
+    });
+    expect(res.headers.get("server")).toBe("cloudflare");
+  });
+
+  it("alias: scrubs the real hostname from an upstream error body via realHost", async () => {
+    const upstream = new Response(
+      '{"error":{"message":"api.deepseek.com refused the connection for real-model"}}',
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+    const ctx: MeteredForwardContext = {
+      principal: { kind: "jwt_user", userId: "u", orgId: "o" },
+      runId: null,
+      presetId: "preset",
+      resolved: {
+        modelId: "real-model",
+        apiShape: "anthropic-messages",
+      } as unknown as ResolvedModel,
+      started: 0,
+    };
+    const res = await forwardMeteredResponse(upstream, anthropicMessagesAdapter, ctx, {
+      swap: { alias: "alias-model", real: "real-model", realHost: "api.deepseek.com" },
+      logLabel: "test",
+    });
+    const out = await res.text();
+    expect(out).not.toContain("api.deepseek.com");
+    expect(out).not.toContain("real-model");
+    expect(out).toContain("alias-model");
+  });
+
   it("propagates client cancel to the source without a spurious teardown error", async () => {
     let cancelledWith: unknown = undefined;
     const source = new ReadableStream<Uint8Array>({

--- a/packages/core/src/model-swap.ts
+++ b/packages/core/src/model-swap.ts
@@ -163,25 +163,61 @@ export function hostnameOf(url: string): string | undefined {
 
 export function scrubModelText(text: string, swap: ModelSwap): string {
   let out = text;
-  if (out.includes(swap.real)) out = out.split(swap.real).join(swap.alias);
+  // Host FIRST: if the real id happens to be a substring of the hostname
+  // (possible with operator-configured openai-compatible endpoints), scrubbing
+  // the id first would mutate the hostname and make the host pass miss it. A
+  // hostname is never a substring of a model id, so this order is always safe.
   if (swap.realHost && out.includes(swap.realHost)) {
     out = out.split(swap.realHost).join(SCRUBBED_HOST_MARKER);
   }
+  if (out.includes(swap.real)) out = out.split(swap.real).join(swap.alias);
   return out;
 }
 
 /**
+ * Response headers forwarded to the caller from an upstream LLM provider.
+ * Shared posture for both inference data paths (the in-container sidecar
+ * proxy and the platform `/api/llm-proxy/*` gateway on aliased responses):
+ *
+ *   - `content-type` — required to parse the body
+ *   - `retry-after`, `RateLimit*` — required for backoff on 429
+ *   - `x-request-id` — provider-side error correlation
+ *
+ * Everything else (`server: cloudflare`, `cf-ray`, `anthropic-*`,
+ * `openai-organization`, Set-Cookie, hop-by-hop) is dropped — those headers
+ * fingerprint the backing provider and/or carry credentials.
+ */
+export const LLM_PASSTHROUGH_RESPONSE_HEADERS: readonly string[] = [
+  "content-type",
+  "retry-after",
+  "ratelimit-limit",
+  "ratelimit-remaining",
+  "ratelimit-reset",
+  "x-ratelimit-limit-requests",
+  "x-ratelimit-remaining-requests",
+  "x-ratelimit-reset-requests",
+  "x-ratelimit-limit-tokens",
+  "x-ratelimit-remaining-tokens",
+  "x-ratelimit-reset-tokens",
+  "x-request-id",
+];
+
+/**
  * True when a parsed SSE frame is an error event — Anthropic emits
- * `{"type":"error","error":{...}}`, OpenAI-family streams emit a top-level
- * `error` object. Error frames carry no generated content, so the blind
- * {@link scrubModelText} prose scrub is safe on them (and required: the real
- * id / hostname sits in free-form `error.message` prose the exact-field
- * rewrite can't reach).
+ * `{"type":"error","error":{...}}`, OpenAI-family streams emit a standalone
+ * top-level `error` object (no `choices` alongside). Error frames carry no
+ * generated content, so the blind {@link scrubModelText} prose scrub is safe
+ * on them (and required: the real id / hostname sits in free-form
+ * `error.message` prose the exact-field rewrite can't reach). The `choices`
+ * guard keeps any hybrid frame that also carries content on the exact-field
+ * path — generated content must never be blind-scrubbed.
  */
 function isSseErrorFrame(obj: unknown): boolean {
   if (!obj || typeof obj !== "object") return false;
   const o = obj as Record<string, unknown>;
-  return o["type"] === "error" || (typeof o["error"] === "object" && o["error"] !== null);
+  if (o["type"] === "error") return true;
+  const error = o["error"];
+  return typeof error === "object" && error !== null && !Array.isArray(error) && !("choices" in o);
 }
 
 /** Rewrite a single SSE line's `model` real→alias (data lines only). */

--- a/packages/core/src/model-swap.ts
+++ b/packages/core/src/model-swap.ts
@@ -141,10 +141,47 @@ export function swapResponseModelJson(bodyText: string, swap: ModelSwap): string
  * field swap misses it. An error body carries no generated content, so a blind
  * replace cannot clobber anything meaningful. No-op when the body doesn't
  * mention the real id (the common case).
+ *
+ * When `swap.realHost` is set, the backing hostname is masked the same way
+ * ("ConnectionRefused (api.deepseek.com)" identifies the provider as surely as
+ * the model id) — replaced with a neutral `upstream` marker, since there is no
+ * alias hostname to substitute.
  */
+export const SCRUBBED_HOST_MARKER = "upstream";
+
+/**
+ * Hostname of a base URL, for {@link ModelSwap.realHost}. Returns `undefined`
+ * on an unparsable URL — the swap then simply skips host scrubbing.
+ */
+export function hostnameOf(url: string): string | undefined {
+  try {
+    return new URL(url).hostname || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function scrubModelText(text: string, swap: ModelSwap): string {
-  if (!text.includes(swap.real)) return text;
-  return text.split(swap.real).join(swap.alias);
+  let out = text;
+  if (out.includes(swap.real)) out = out.split(swap.real).join(swap.alias);
+  if (swap.realHost && out.includes(swap.realHost)) {
+    out = out.split(swap.realHost).join(SCRUBBED_HOST_MARKER);
+  }
+  return out;
+}
+
+/**
+ * True when a parsed SSE frame is an error event — Anthropic emits
+ * `{"type":"error","error":{...}}`, OpenAI-family streams emit a top-level
+ * `error` object. Error frames carry no generated content, so the blind
+ * {@link scrubModelText} prose scrub is safe on them (and required: the real
+ * id / hostname sits in free-form `error.message` prose the exact-field
+ * rewrite can't reach).
+ */
+function isSseErrorFrame(obj: unknown): boolean {
+  if (!obj || typeof obj !== "object") return false;
+  const o = obj as Record<string, unknown>;
+  return o["type"] === "error" || (typeof o["error"] === "object" && o["error"] !== null);
 }
 
 /** Rewrite a single SSE line's `model` real→alias (data lines only). */
@@ -152,12 +189,18 @@ function rewriteSseLine(line: string, swap: ModelSwap): string {
   if (!line.startsWith("data:")) return line;
   const payload = line.slice("data:".length).trimStart();
   // Fast skip: the [DONE] sentinel and any chunk that doesn't mention the real
-  // id (the vast majority — content deltas) need no parse.
-  if (payload === "[DONE]" || !payload.includes(swap.real)) return line;
+  // id or host (the vast majority — content deltas) need no parse.
+  const mentionsBacking =
+    payload.includes(swap.real) || (swap.realHost !== undefined && payload.includes(swap.realHost));
+  if (payload === "[DONE]" || !mentionsBacking) return line;
   try {
     const obj = JSON.parse(payload);
     rewriteModelRealToAlias(obj, swap);
-    return `data: ${JSON.stringify(obj)}`;
+    const rewritten = JSON.stringify(obj);
+    // Mid-stream error frames name the backing in free-form prose — scrub the
+    // whole frame. Never blind-replace a non-error frame: generated content
+    // mentioning the real id must not be clobbered.
+    return `data: ${isSseErrorFrame(obj) ? scrubModelText(rewritten, swap) : rewritten}`;
   } catch {
     return line;
   }

--- a/packages/core/src/sidecar-types.ts
+++ b/packages/core/src/sidecar-types.ts
@@ -523,6 +523,13 @@ export interface ModelSwap {
   alias: string;
   /** Real upstream model id forwarded to the provider. */
   real: string;
+  /**
+   * Hostname of the real upstream base URL (e.g. `api.deepseek.com`). Used by
+   * {@link scrubModelText} to mask the backing host in error prose — provider
+   * error bodies and locally-synthesized fetch-failure messages can name the
+   * host, which identifies the backing as surely as the model id does.
+   */
+  realHost?: string;
 }
 
 export interface LlmProxyApiKeyConfig {

--- a/packages/db/src/schema/runs.ts
+++ b/packages/db/src/schema/runs.ts
@@ -457,6 +457,10 @@ export const llmUsage = pgTable(
     model: text("model"),
     // Upstream model id the proxy actually forwarded — resolved from the
     // preset via `loadModel()`. Optional on runner rows.
+    // SERVER-SIDE ONLY: for an aliased model this is the hidden backing id.
+    // Never serialize it on any caller-facing surface (route, DTO, SSE,
+    // webhook) — `listLlmUsageForRun` deliberately selects only
+    // id/costUsd/source. Same for `api` below (backing protocol family).
     realModel: text("real_model"),
     // Protocol family: "openai-completions", "anthropic-messages", …
     // Optional on runner rows.

--- a/runtime-pi/sidecar/app.ts
+++ b/runtime-pi/sidecar/app.ts
@@ -26,6 +26,7 @@ import {
   swapResponseModelJson,
   createSseModelSwapStream,
   scrubModelText,
+  SCRUBBED_HOST_MARKER,
 } from "./model-swap.ts";
 import { applyClaudeOauthGatewayHeaders } from "@appstrate/core/claude-oauth-gateway";
 import {
@@ -329,12 +330,23 @@ async function logOauthLlmResponse(
   return upstream;
 }
 
-function llmFetchErrorResponse(c: Context, targetUrl: string, err: unknown): Response {
+function llmFetchErrorResponse(
+  c: Context,
+  targetUrl: string,
+  err: unknown,
+  swap?: ModelSwap,
+): Response {
   const code = err instanceof Error && "code" in err ? (err as { code: string }).code : undefined;
   let domain: string | undefined;
   try {
     domain = new URL(targetUrl).hostname;
   } catch {}
+  // Model alias: the hostname IS the backing provider ("api.deepseek.com"
+  // identifies it as surely as the model id) — the agent must never see it.
+  // Replace with a neutral marker unconditionally when a swap is configured,
+  // not via scrubModelText, so the guarantee doesn't depend on `realHost`
+  // having been populated by the platform.
+  if (swap) domain = SCRUBBED_HOST_MARKER;
   const suffix = code ? `: ${code}` : "";
   const domainHint = domain ? ` (${domain})` : "";
   return c.json({ error: `LLM request failed${suffix}${domainHint}` }, 502);
@@ -631,7 +643,7 @@ export function createApp(deps: AppDeps): Hono {
         ...(body instanceof ReadableStream ? { duplex: "half" } : {}),
       });
     } catch (err) {
-      return llmFetchErrorResponse(c, targetUrl, err);
+      return llmFetchErrorResponse(c, targetUrl, err, apiKeyConfig.modelSwap);
     }
 
     return passUpstream(upstream, { targetUrl, authMode: "api_key" }, apiKeyConfig.modelSwap);
@@ -716,7 +728,7 @@ export function createApp(deps: AppDeps): Hono {
         targetUrl,
         error: err instanceof Error ? err.message : String(err),
       });
-      return llmFetchErrorResponse(c, targetUrl, err);
+      return llmFetchErrorResponse(c, targetUrl, err, llmConfig.modelSwap);
     }
 
     upstream = await logOauthLlmResponse(llmConfig.credentialId, targetUrl, upstream);

--- a/runtime-pi/sidecar/app.ts
+++ b/runtime-pi/sidecar/app.ts
@@ -27,6 +27,8 @@ import {
   createSseModelSwapStream,
   scrubModelText,
   SCRUBBED_HOST_MARKER,
+  hostnameOf,
+  LLM_PASSTHROUGH_RESPONSE_HEADERS,
 } from "./model-swap.ts";
 import { applyClaudeOauthGatewayHeaders } from "@appstrate/core/claude-oauth-gateway";
 import {
@@ -115,32 +117,6 @@ export interface AppDeps {
 }
 
 /**
- * Headers forwarded from the upstream LLM provider verbatim. Limited to
- * the ones the in-container agent legitimately needs to react to:
- *
- *   - `Content-Type` — required for the agent to parse the body
- *   - `Retry-After`, `RateLimit*` — required for backoff on 429
- *   - `x-request-id` — useful for cross-correlating provider-side errors
- *
- * Everything else (Set-Cookie, hop-by-hop, internal Anthropic headers) is
- * dropped to keep the sidecar↔agent boundary tight.
- */
-const PASSTHROUGH_RESPONSE_HEADERS = [
-  "content-type",
-  "retry-after",
-  "ratelimit-limit",
-  "ratelimit-remaining",
-  "ratelimit-reset",
-  "x-ratelimit-limit-requests",
-  "x-ratelimit-remaining-requests",
-  "x-ratelimit-reset-requests",
-  "x-ratelimit-limit-tokens",
-  "x-ratelimit-remaining-tokens",
-  "x-ratelimit-reset-tokens",
-  "x-request-id",
-];
-
-/**
  * Canonical casing for headers whose draft / standard spellings don't
  * match the naive Title-Case derivation. Generic Title-Casing turns
  * `ratelimit-limit` into `Ratelimit-Limit`, but the IETF RateLimit draft
@@ -178,8 +154,11 @@ async function passUpstream(
   observe?: LlmStreamObservation,
   swap?: ModelSwap,
 ): Promise<Response> {
+  // Shared allowlist — same posture as the platform gateway's aliased
+  // responses. Everything else (Set-Cookie, hop-by-hop, internal Anthropic
+  // headers) is dropped to keep the sidecar↔agent boundary tight.
   const responseHeaders: Record<string, string> = {};
-  for (const name of PASSTHROUGH_RESPONSE_HEADERS) {
+  for (const name of LLM_PASSTHROUGH_RESPONSE_HEADERS) {
     const value = upstream.headers.get(name);
     if (value !== null) {
       // Re-cased to preserve canonical HTTP form for the agent. Special-cased
@@ -337,16 +316,12 @@ function llmFetchErrorResponse(
   swap?: ModelSwap,
 ): Response {
   const code = err instanceof Error && "code" in err ? (err as { code: string }).code : undefined;
-  let domain: string | undefined;
-  try {
-    domain = new URL(targetUrl).hostname;
-  } catch {}
   // Model alias: the hostname IS the backing provider ("api.deepseek.com"
   // identifies it as surely as the model id) — the agent must never see it.
   // Replace with a neutral marker unconditionally when a swap is configured,
   // not via scrubModelText, so the guarantee doesn't depend on `realHost`
   // having been populated by the platform.
-  if (swap) domain = SCRUBBED_HOST_MARKER;
+  const domain = swap ? SCRUBBED_HOST_MARKER : hostnameOf(targetUrl);
   const suffix = code ? `: ${code}` : "";
   const domainHint = domain ? ` (${domain})` : "";
   return c.json({ error: `LLM request failed${suffix}${domainHint}` }, 502);

--- a/runtime-pi/sidecar/model-swap.ts
+++ b/runtime-pi/sidecar/model-swap.ts
@@ -14,4 +14,6 @@ export {
   scrubModelText,
   isAliasableApiShape,
   ALIASABLE_API_SHAPES,
+  SCRUBBED_HOST_MARKER,
+  hostnameOf,
 } from "@appstrate/core/model-swap";

--- a/runtime-pi/sidecar/model-swap.ts
+++ b/runtime-pi/sidecar/model-swap.ts
@@ -16,4 +16,5 @@ export {
   ALIASABLE_API_SHAPES,
   SCRUBBED_HOST_MARKER,
   hostnameOf,
+  LLM_PASSTHROUGH_RESPONSE_HEADERS,
 } from "@appstrate/core/model-swap";

--- a/runtime-pi/sidecar/test/model-swap-proxy.test.ts
+++ b/runtime-pi/sidecar/test/model-swap-proxy.test.ts
@@ -114,6 +114,74 @@ describe("/llm/* model-alias swap (api_key)", () => {
     expect(text).toContain("appstrate-medium");
   });
 
+  it("masks the upstream hostname in a fetch-level 502 (alias)", async () => {
+    // ConnectionRefused/DNS/TLS never produce a Response — the sidecar
+    // synthesizes the 502 body itself. With an alias, the real hostname
+    // ("api.deepseek.com") identifies the backing and must be masked.
+    const err = Object.assign(new Error("connect ECONNREFUSED"), { code: "ConnectionRefused" });
+    const fetchFn = mock(async () => {
+      throw err;
+    }) as unknown as typeof fetch;
+
+    const app = createApp(makeDeps(fetchFn));
+    const res = await app.request("/llm/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "appstrate-medium", messages: [] }),
+    });
+    expect(res.status).toBe(502);
+    const text = await res.text();
+    expect(text).not.toContain("deepseek");
+    expect(text).toContain("ConnectionRefused");
+    expect(text).toContain("(upstream)");
+  });
+
+  it("keeps the upstream hostname in a fetch-level 502 when NOT aliased", async () => {
+    const err = Object.assign(new Error("connect ECONNREFUSED"), { code: "ConnectionRefused" });
+    const fetchFn = mock(async () => {
+      throw err;
+    }) as unknown as typeof fetch;
+
+    const deps = makeDeps(fetchFn);
+    delete (deps.config.llm as { modelSwap?: unknown }).modelSwap;
+    const app = createApp(deps);
+    const res = await app.request("/llm/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "deepseek-chat", messages: [] }),
+    });
+    expect(res.status).toBe(502);
+    expect(await res.text()).toContain("api.deepseek.com");
+  });
+
+  it("scrubs the real hostname from an upstream error body when realHost is set", async () => {
+    const fetchFn = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            error: { message: "Upstream api.deepseek.com rejected the request" },
+          }),
+          { status: 503, headers: { "Content-Type": "application/json" } },
+        ),
+    ) as unknown as typeof fetch;
+
+    const deps = makeDeps(fetchFn);
+    (deps.config.llm as { modelSwap: unknown }).modelSwap = {
+      ...SWAP,
+      realHost: "api.deepseek.com",
+    };
+    const app = createApp(deps);
+    const res = await app.request("/llm/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "appstrate-medium", messages: [] }),
+    });
+    expect(res.status).toBe(503);
+    const text = await res.text();
+    expect(text).not.toContain("api.deepseek.com");
+    expect(text).toContain("upstream");
+  });
+
   it("rewrites the streaming (SSE) response model real→alias in every chunk", async () => {
     const sse =
       `data: {"object":"chat.completion.chunk","model":"deepseek-chat","choices":[]}\n\n` +

--- a/runtime-pi/sidecar/test/model-swap.test.ts
+++ b/runtime-pi/sidecar/test/model-swap.test.ts
@@ -258,6 +258,20 @@ describe("scrubModelText (error-body blind scrub)", () => {
     // No realHost — only the model id is scrubbed, and it isn't mentioned.
     expect(scrubModelText(body, swap)).toBe(body);
   });
+
+  it("masks the hostname even when the real id is a substring of it", () => {
+    // Operator-configured openai-compatible endpoint whose host literally
+    // contains the model id. Scrubbing the id first would mutate the hostname
+    // and skip the host pass — host must be scrubbed FIRST.
+    const hostSwap = { alias: "appstrate-fast", real: "qwen", realHost: "qwen.internal" };
+    const out = scrubModelText(
+      "ConnectionRefused (qwen.internal): model qwen unreachable",
+      hostSwap,
+    );
+    expect(out).not.toContain("qwen");
+    expect(out).toContain(`(${SCRUBBED_HOST_MARKER})`);
+    expect(out).toContain("appstrate-fast");
+  });
 });
 
 describe("hostnameOf", () => {
@@ -292,6 +306,16 @@ describe("createSseModelSwapStream — mid-stream error frames", () => {
     const input = `data: {"model":"deepseek-chat","choices":[{"delta":{"content":"I am deepseek-chat"}}]}\n\n`;
     const out = await pipeSse(input);
     // Exact-field rewritten, prose content preserved.
+    expect(out).toContain(`"model":"appstrate-medium"`);
+    expect(out).toContain("I am deepseek-chat");
+  });
+
+  it("keeps the exact-field path for a hybrid frame carrying an error object AND content", async () => {
+    // A frame with `choices` is a content frame regardless of any `error` key
+    // some non-standard upstream stamps on it — its prose must not be
+    // blind-scrubbed.
+    const input = `data: {"model":"deepseek-chat","error":{"message":"partial"},"choices":[{"delta":{"content":"I am deepseek-chat"}}]}\n\n`;
+    const out = await pipeSse(input);
     expect(out).toContain(`"model":"appstrate-medium"`);
     expect(out).toContain("I am deepseek-chat");
   });

--- a/runtime-pi/sidecar/test/model-swap.test.ts
+++ b/runtime-pi/sidecar/test/model-swap.test.ts
@@ -16,6 +16,8 @@ import {
   createSseModelSwapStream,
   scrubModelText,
   isAliasableApiShape,
+  hostnameOf,
+  SCRUBBED_HOST_MARKER,
 } from "../model-swap.ts";
 
 const swap = { alias: "appstrate-medium", real: "deepseek-chat" };
@@ -237,6 +239,61 @@ describe("scrubModelText (error-body blind scrub)", () => {
   it("no-ops cleanly when alias === real", () => {
     const noop = { alias: "deepseek-chat", real: "deepseek-chat" };
     expect(scrubModelText("model deepseek-chat down", noop)).toBe("model deepseek-chat down");
+  });
+
+  it("masks the real hostname when realHost is set", () => {
+    const hostSwap = { ...swap, realHost: "api.deepseek.com" };
+    const out = scrubModelText(
+      "ConnectionRefused (api.deepseek.com): model deepseek-chat unreachable",
+      hostSwap,
+    );
+    expect(out).not.toContain("api.deepseek.com");
+    expect(out).not.toContain("deepseek-chat");
+    expect(out).toContain(`(${SCRUBBED_HOST_MARKER})`);
+    expect(out).toContain("appstrate-medium");
+  });
+
+  it("leaves hostnames untouched when realHost is absent", () => {
+    const body = "ConnectionRefused (api.deepseek.com)";
+    // No realHost — only the model id is scrubbed, and it isn't mentioned.
+    expect(scrubModelText(body, swap)).toBe(body);
+  });
+});
+
+describe("hostnameOf", () => {
+  it("extracts the hostname from a base URL", () => {
+    expect(hostnameOf("https://api.deepseek.com/v1")).toBe("api.deepseek.com");
+  });
+
+  it("returns undefined on an unparsable URL", () => {
+    expect(hostnameOf("not a url")).toBeUndefined();
+    expect(hostnameOf("")).toBeUndefined();
+  });
+});
+
+describe("createSseModelSwapStream — mid-stream error frames", () => {
+  it("scrubs free-form prose in an Anthropic error frame", async () => {
+    const input =
+      `event: error\n` +
+      `data: {"type":"error","error":{"type":"overloaded_error","message":"model deepseek-chat is overloaded"}}\n\n`;
+    const out = await pipeSse(input);
+    expect(out).not.toContain("deepseek-chat");
+    expect(out).toContain("appstrate-medium");
+  });
+
+  it("scrubs an OpenAI-family top-level error frame", async () => {
+    const input = `data: {"error":{"message":"deepseek-chat quota exceeded","code":429}}\n\n`;
+    const out = await pipeSse(input);
+    expect(out).not.toContain("deepseek-chat");
+    expect(out).toContain("appstrate-medium");
+  });
+
+  it("still never clobbers the real id inside a content delta (non-error frame)", async () => {
+    const input = `data: {"model":"deepseek-chat","choices":[{"delta":{"content":"I am deepseek-chat"}}]}\n\n`;
+    const out = await pipeSse(input);
+    // Exact-field rewritten, prose content preserved.
+    expect(out).toContain(`"model":"appstrate-medium"`);
+    expect(out).toContain("I am deepseek-chat");
   });
 });
 


### PR DESCRIPTION
## Context

A run on an aliased model surfaced `502 "LLM request failed: ConnectionRefused (api.deepseek.com)"` in its run log — the real backing hostname reached the agent, the run log, and the UI. An alias's whole contract is that callers/agents never learn the backing provider. A full audit of the alias masking surface found this plus several sibling leak paths.

Root cause: `ModelSwap = {alias, real}` only knew the **model id** — no masking layer knew the backing hostname or provider id, so any error prose or locally-synthesized message naming them passed through unmasked by construction.

## Changes

**Root fix — hostname-aware scrub**
- `ModelSwap` gains optional `realHost` (`packages/core/src/sidecar-types.ts`); `scrubModelText` also masks the backing hostname (replaced with a neutral `upstream` marker). New `hostnameOf` helper.
- `realHost` populated at both swap construction sites: run launcher (`run-launcher/pi.ts`) and platform gateway (`llm-proxy/core.ts`).

**Sidecar (reported bug)**
- `llmFetchErrorResponse` masks the hostname in the synthesized 502 whenever a swap is configured — unconditional, does not depend on `realHost` being populated. Covers ConnectionRefused / DNS / TLS / 30-min timeout on both api_key and oauth paths. Non-aliased models keep the hostname (debugging value).

**Platform gateway (`/api/llm-proxy/*`)**
- SSRF-refusal 400 no longer embeds the resolved `baseUrl`; OAuth-subscription rejection no longer names the `providerId`; claude-code-sdk gateway preset-mismatch / SSRF messages likewise. All details stay in server logs.
- Aliased responses now forward a strict response-header allowlist (`content-type`, rate-limit family, `retry-after`, `x-request-id`) — previously `server: cloudflare`, `cf-ray`, `anthropic-*`, `openai-organization` fingerprinted the backing on every live response. Non-aliased behavior unchanged; mirrors the sidecar and cache-replay posture.
- Mid-stream SSE **error frames** (`type:"error"` or top-level `error` key) are prose-scrubbed; content deltas remain exact-field-only (generated text mentioning the real id is never clobbered).

**Finalize boundary (defense-in-depth)**
- `finalizeRun` scrubs the runner-supplied terminal error against every alias swap visible to the org (`listAliasSwapsForOrg`, metadata-only credential resolution, degrades to no-op on failure) before it fans out to `runs.error` → run DTO, `run_update` SSE, terminal run_log, and webhook payloads.

**Credentials & schema**
- Alias-only built-in credential label no longer falls back to the provider `displayName`/`providerId` (was naming the hidden backing on `GET /api/model-provider-credentials`).
- Never-serialize guard note on `llm_usage.real_model`/`api` (persisted server-side only; no route serializes them today).

## Known-accepted (not addressed here)

- `RUN_ADAPTER=process` inherits the full platform env into the agent process (documented "no isolation" posture) — aliasing offers no protection there; real fix is env filtering, separate work.
- `MODEL_API` (protocol shape) reveals the provider *family* to the agent — SDK contract, unavoidable.

## Tests

- Sidecar: 3 new proxy tests (alias 502 hostname masked / non-alias hostname kept / `realHost` error-body scrub) + unit tests for `hostnameOf`, host scrub, SSE error-frame scrub, content-delta anti-clobber. Suite: 621 pass.
- API: 3 new metering tests (alias header allowlist / non-alias passthrough / `realHost` body scrub). Unit + gateway: 1034 pass; integration (llm-proxy, claude-code-sdk, subscription-rejection, credentials, models routes): 74 pass; finalize path: 62 pass.
- `bun run check` green (typecheck, lint, prettier, OpenAPI, type-coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)