### PR TITLE
fix(web): make agent display_name optional at creation (#825)

### DIFF
--- a/apps/web/src/hooks/use-packages.ts
+++ b/apps/web/src/hooks/use-packages.ts
@@ -55,7 +55,9 @@ type PackageDetailMap = {
 function normalizeAgentDetail(d: components["schemas"]["AgentDetail"]): AgentDetail {
   return {
     ...d,
-    display_name: d.display_name ?? "",
+    // display_name is optional (agent editor no longer forces it, issue #825);
+    // fall back to the package id so labels never render blank.
+    display_name: d.display_name || d.id,
     description: d.description ?? "",
     scope: d.scope ?? null,
     version: d.version ?? null,
@@ -248,7 +250,8 @@ export function useAgents() {
       // list shape. `forked_from` is not returned by the list endpoint.
       return data!.data.map((a) => ({
         ...a,
-        display_name: a.display_name ?? "",
+        // Fall back to the package id when display_name is empty (issue #825).
+        display_name: a.display_name || a.id,
         description: a.description ?? "",
         schema_version: a.schema_version ?? "",
         author: a.author ?? "",

--- a/apps/web/src/locales/en/agents.json
+++ b/apps/web/src/locales/en/agents.json
@@ -224,7 +224,7 @@
   "schedule.statusActive": "Active",
   "editor.breadcrumbNew": "New agent",
   "editor.breadcrumbEdit": "Edit",
-  "editor.errorRequired": "Identifier and display name are required.",
+  "editor.errorRequired": "Identifier is required.",
   "editor.errorPrompt": "Prompt is required.",
   "editor.skillsEmpty": "No skills in packages. Add some from the Packages page.",
   "editor.integrationsEmpty": "No integrations imported. Visit the Integrations marketplace to import one.",

--- a/apps/web/src/locales/fr/agents.json
+++ b/apps/web/src/locales/fr/agents.json
@@ -224,7 +224,7 @@
   "schedule.statusActive": "Actif",
   "editor.breadcrumbNew": "Nouvel agent",
   "editor.breadcrumbEdit": "Modifier",
-  "editor.errorRequired": "Les champs identifiant et nom d'affichage sont requis.",
+  "editor.errorRequired": "Le champ identifiant est requis.",
   "editor.errorPrompt": "Le prompt est requis.",
   "editor.skillsEmpty": "Aucun skill dans les packages. Ajoutez-en depuis la page Packages.",
   "editor.integrationsEmpty": "Aucune intégration importée. Visitez le marketplace Intégrations pour en importer une.",

--- a/apps/web/src/pages/package-editor.tsx
+++ b/apps/web/src/pages/package-editor.tsx
@@ -103,7 +103,7 @@ function AgentEditorInner({
     toWireBody: (s) => ({ manifest: s.manifest, content: s.prompt }),
     validate: (s) => {
       const { id } = getManifestName(s.manifest);
-      if (!id || !s.manifest.display_name) {
+      if (!id) {
         return { error: t("editor.errorRequired"), tab: "general" };
       }
       if (!s.prompt.trim()) {
@@ -323,7 +323,7 @@ function PackageEditorInner({
     }),
     validate: (s) => {
       const { id } = getManifestName(s.manifest);
-      if (!id || !s.manifest.display_name) {
+      if (!id) {
         return { error: t("editor.errorRequired"), tab: "general" };
       }
       if (!s.content.trim()) {
@@ -436,7 +436,7 @@ function IntegrationEditorInner({
     }),
     validate: (s) => {
       const { id } = getManifestName(s.manifest);
-      if (!id || !s.manifest.display_name) {
+      if (!id) {
         return { error: t("editor.errorRequired"), tab: "general" };
       }
       return null;


### PR DESCRIPTION
Closes #825

## Problem

The agent editor forced `display_name` to be filled at creation, even though it is optional in every other layer (AFPS schema, backend create, render fallbacks). Pure friction.

## Changes

- **Drop the client-side validation** blocking empty `display_name` in the agent, skill, and integration editors (`package-editor.tsx`) — kept the `id`-required check.
- **Centralize the fallback**: normalize `display_name` to the package `id` at the API-hook boundary (`normalizeAgentDetail` + the `/api/agents` list mapper in `use-packages.ts`) instead of coercing to `""`. This covers the unguarded consumers surfaced by the issue's "verify" step — delete/uninstall confirms, run-options modal title, integration pin-agent `<option>` labels — via a single render-time fallback. **No id-derived value is ever written to the manifest** (per the issue's explicit warning).
- **Update `editor.errorRequired`** (fr/en) — no longer mentions the display name.

## Verify step (from the issue)

Grepped every `manifest.display_name` / `.display_name` read in `apps/web`. All list/detail consumers either already had a `?? id` fallback or now inherit one via the normalizers. The editor input still reads the **raw** `manifest.display_name` (separate from the normalized top-level field), so the id never leaks into the editable field.

## Testing

- `tsc --noEmit` (web) clean
- eslint + prettier clean on changed files
- `agent-editor/test/utils.test.ts` — 42 pass