### PR TITLE
feat(cli): prompt for public URL on install — --app-url / APPSTRATE_APP_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ curl -fsSL https://get.appstrate.dev | bash -s -- --tier 1 --dir ~/apps/appstrat
 
 `--tier`, `--dir`, and `--port` override the smart defaults. Equivalent env vars: `APPSTRATE_YES=1`, `APPSTRATE_PORT`, `APPSTRATE_BIN_DIR`.
 
+**Deploying on a remote host behind a reverse proxy?** Pass the public URL so OAuth redirects, CORS, and email links point at the right origin (`TRUST_PROXY` is enabled automatically for non-localhost URLs):
+
+```sh
+curl -fsSL https://get.appstrate.dev | bash -s -- --yes --app-url https://appstrate.example.com
+```
+
+Also honored via `APPSTRATE_APP_URL`. The installer does **not** provision the reverse proxy or TLS -- point your proxy (Caddy, nginx, Traefik) at `localhost:<port>` yourself; see [`examples/self-hosting/README.md`](./examples/self-hosting/README.md#production-considerations).
+
 **Want the interactive prompts?** Drop the binary without auto-launching, then run `install` yourself:
 
 ```sh

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -193,6 +193,10 @@ program
     "Host port the MinIO console binds to on Tier 3 (default: 9001). Also honored via APPSTRATE_MINIO_CONSOLE_PORT.",
   )
   .option(
+    "--app-url <url>",
+    "Public URL of the platform for remote deployments behind a reverse proxy, e.g. https://appstrate.example.com (origin only). Drives APP_URL + TRUSTED_ORIGINS and auto-enables TRUST_PROXY for non-localhost/https URLs. Independent of --port (the host bind port the proxy forwards to). Also honored via APPSTRATE_APP_URL. Default: http://localhost:<port>.",
+  )
+  .option(
     "--force",
     "Bypass the 'another Compose project is already running under this name' preflight. Only use if you have already backed up the other install's data.",
   )
@@ -223,6 +227,7 @@ program
       port: typeof opts.port === "string" ? opts.port : undefined,
       minioConsolePort:
         typeof opts.minioConsolePort === "string" ? opts.minioConsolePort : undefined,
+      appUrl: typeof opts.appUrl === "string" ? opts.appUrl : undefined,
       force: opts.force === true,
       autoConfirm,
     });

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -18,7 +18,9 @@ import { intro, outro, askText, confirm, spinner, exitWithError } from "../lib/u
 import {
   generateBootstrapToken,
   generateEnvForTier,
+  isRemoteAppUrl,
   isValidBootstrapEmail,
+  parseAppUrl,
   renderEnvFile,
   type BootstrapOverrides,
   type Tier,
@@ -77,6 +79,14 @@ export interface InstallOptions {
   port?: string;
   /** Override the host port the MinIO console binds to (Tier 3 only). */
   minioConsolePort?: string;
+  /**
+   * Public URL of the platform (issue #822) — what browsers, OAuth
+   * redirects, and email links use. Independent of `--port` (the host
+   * bind port / reverse-proxy upstream). Origin only, e.g.
+   * `https://appstrate.example.com`. Also honored via
+   * `APPSTRATE_APP_URL`. Defaults to `http://localhost:<port>`.
+   */
+  appUrl?: string;
   /**
    * Bypass the "another stack is already running under this project
    * name" preflight. Escape hatch for edge cases where the operator
@@ -257,10 +267,20 @@ export async function installCommand(opts: InstallOptions): Promise<void> {
       nonInteractive,
     });
 
+    // Public URL (issue #822) — flag/env/prompt, defaults to
+    // http://localhost:<port>. Resolved AFTER the port so the local
+    // default reflects the (possibly auto-picked) final port.
+    const appUrl = await resolveAppUrl(opts.appUrl, port, {
+      tier,
+      mode: installState.mode,
+      existing: installState.existing,
+      nonInteractive,
+    });
+
     if (tier === 0) {
-      await installTier0(dir, port, { autoConfirm, bootstrap });
+      await installTier0(dir, port, appUrl, { autoConfirm, bootstrap });
     } else {
-      await installDockerTier(dir, tier, port, minioConsolePort, {
+      await installDockerTier(dir, tier, port, minioConsolePort, appUrl, {
         force: opts.force ?? false,
         mode: installState.mode,
         existing: installState.existing,
@@ -381,6 +401,62 @@ export async function resolveBootstrapEmail(opts: {
 
 /** Default-shaped `ExistingInstall` used when the resolver is called without upgrade context. */
 const NO_EXISTING_INSTALL: ExistingInstall = { hasEnv: false, hasCompose: false, existingEnv: {} };
+
+/**
+ * Resolve the public app URL for the install (issue #822).
+ *
+ * Order of precedence:
+ *   1. Upgrade with an existing `APP_URL` in `.env` → inherit it.
+ *      `mergeEnv` preserves the existing value anyway (existing wins),
+ *      so honoring a divergent `--app-url` here would print banners
+ *      pointing at a URL the generated `.env` doesn't contain. Same
+ *      warn-and-inherit contract as `resolveAppstratePort`; the
+ *      documented way to change the URL is editing `<dir>/.env`.
+ *   2. `--app-url` flag / `APPSTRATE_APP_URL` env — the scripted and
+ *      `curl | APPSTRATE_APP_URL=… bash` path. Validated strictly
+ *      (throws) so a typo surfaces at install time, not as a broken
+ *      OAuth callback later.
+ *   3. Interactive prompt — Docker tiers only, fresh install. Tier 0
+ *      is local dev where a public URL is meaningless noise. Enter
+ *      keeps the local default (current behavior preserved).
+ *   4. `http://localhost:<port>` — the historical default.
+ */
+export async function resolveAppUrl(
+  raw: string | undefined,
+  port: number,
+  opts: { tier: Tier; mode: InstallMode; existing: ExistingInstall; nonInteractive: boolean },
+): Promise<string> {
+  const envValue = process.env.APPSTRATE_APP_URL?.trim();
+  const expressed = raw ?? (envValue === "" ? undefined : envValue);
+  const requested = expressed === undefined ? undefined : parseAppUrl(expressed);
+
+  if (opts.mode === "upgrade" && opts.existing.hasEnv) {
+    const inherited = opts.existing.existingEnv.APP_URL;
+    if (inherited) {
+      if (requested !== undefined && requested !== inherited) {
+        clack.log.warn(
+          `app URL ${requested} ignored on upgrade — existing .env pins APP_URL=${inherited}, and config is preserved across upgrades (see mergeEnv). Edit <dir>/.env manually (APP_URL + TRUSTED_ORIGINS + TRUST_PROXY) to change the public URL.`,
+        );
+      }
+      return inherited;
+    }
+  }
+
+  if (requested !== undefined) return requested;
+
+  const fallback = appUrlForPort(port);
+  // Tier 0 is local dev; non-interactive keeps the zero-prompt contract
+  // of `--yes` / `--tier N` (remote deploys pass --app-url explicitly).
+  if (opts.tier === 0 || opts.nonInteractive) return fallback;
+
+  clack.note(
+    `Remote deployment (behind a reverse proxy)? Enter the public URL users will\nhit, e.g. https://appstrate.example.com — it drives OAuth redirects, CORS\n(TRUSTED_ORIGINS), and email links. The reverse proxy itself (TLS, forwarding\nto localhost:${port}) is not provisioned by the installer.\nPress Enter to keep the local default.`,
+    "Public URL (optional)",
+  );
+  const answer = (await askText("Public URL", fallback)).trim();
+  if (!answer || answer === fallback) return fallback;
+  return parseAppUrl(answer);
+}
 
 /** DI seam for the cross-check with `docker compose ls` — tests inject a fake, production uses the real helper. */
 export interface PortResolverDeps {
@@ -786,9 +862,13 @@ export async function resolveDir(
 async function installTier0(
   dir: string,
   port: number,
+  appUrl: string,
   opts: { autoConfirm: boolean; bootstrap: BootstrapOverrides },
 ): Promise<void> {
-  const appUrl = appUrlForPort(port);
+  // The public URL may sit behind a not-yet-configured reverse proxy;
+  // everything that must reach the platform NOW (dev-server readiness
+  // poll, browser open) goes through the local bind address instead.
+  const localUrl = appUrlForPort(port);
   // Bun — either already present, or install it via the upstream script.
   // We only care whether a working Bun is reachable; the actual path
   // resolution happens inside `runBunInstall` / `spawnDevServer` via
@@ -852,10 +932,10 @@ async function installTier0(
 
   const devSpinner = spinner();
   devSpinner.start("Starting dev server");
-  const { pid } = await spawnDevServer(dir, appUrl);
+  const { pid } = await spawnDevServer(dir, localUrl);
   devSpinner.stop(`Dev server running (pid ${pid})`);
 
-  await openBrowser(appUrl);
+  await openBrowser(localUrl);
   printBootstrapFollowup(appUrl, opts.bootstrap);
   outro(`Appstrate is running at ${appUrl} (pid ${pid}).\nKill it with \`kill ${pid}\` when done.`);
 }
@@ -928,6 +1008,7 @@ async function installDockerTier(
   tier: 1 | 2 | 3,
   port: number,
   minioConsolePort: number | undefined,
+  appUrl: string,
   opts: {
     force: boolean;
     mode: InstallMode;
@@ -937,7 +1018,10 @@ async function installDockerTier(
     bootstrap: BootstrapOverrides;
   },
 ): Promise<void> {
-  const appUrl = appUrlForPort(port);
+  // Healthcheck + browser go through the local bind address: on a
+  // remote deployment the public URL only resolves once the operator's
+  // reverse proxy is configured, which happens AFTER the install.
+  const localUrl = appUrlForPort(port);
   // Docker.
   const dockerSpinner = spinner();
   dockerSpinner.start("Checking Docker");
@@ -1042,7 +1126,7 @@ async function installDockerTier(
       // Healthcheck.
       const healthSpinner = spinner();
       healthSpinner.start("Waiting for Appstrate to become healthy");
-      await waitForAppstrate(appUrl);
+      await waitForAppstrate(localUrl);
       healthSpinner.stop("Appstrate is healthy");
 
       // Persist the project-name binding on success. Written AFTER the
@@ -1063,7 +1147,18 @@ async function installDockerTier(
     },
   );
 
-  await openBrowser(appUrl);
+  await openBrowser(localUrl);
+  // Remote deployment: the installer wired APP_URL / TRUSTED_ORIGINS /
+  // TRUST_PROXY, but provisioning the reverse proxy (TLS, forwarding
+  // the public domain to the host port) is the operator's job — say so
+  // explicitly instead of letting a dead public URL look like a failed
+  // install.
+  if (isRemoteAppUrl(appUrl)) {
+    clack.note(
+      `The platform listens on ${localUrl} (host port ${port}).\nPoint your reverse proxy (Caddy, nginx, Traefik) at it so that\n${appUrl} → ${localUrl}. TLS termination happens at the proxy;\nTRUST_PROXY=true is already set in .env. Until the proxy is up,\nthe platform is reachable at ${localUrl} only.`,
+      "Reverse proxy required",
+    );
+  }
   printBootstrapFollowup(appUrl, opts.bootstrap);
   // The lifecycle commands (#343) read `<dir>/.appstrate/project.json`
   // to find the right `--project-name`, so the user never has to type

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -442,7 +442,10 @@ export async function resolveAppUrl(
     }
   }
 
-  if (requested !== undefined) return requested;
+  if (requested !== undefined) {
+    assertLoopbackPortMatches(requested, port);
+    return requested;
+  }
 
   const fallback = appUrlForPort(port);
   // Tier 0 is local dev; non-interactive keeps the zero-prompt contract
@@ -455,7 +458,34 @@ export async function resolveAppUrl(
   );
   const answer = (await askText("Public URL", fallback)).trim();
   if (!answer || answer === fallback) return fallback;
-  return parseAppUrl(answer);
+  const chosen = parseAppUrl(answer);
+  assertLoopbackPortMatches(chosen, port);
+  return chosen;
+}
+
+/**
+ * Reject a plain-http loopback app URL whose port disagrees with the
+ * host bind port. Such a URL is accessed directly — on localhost there
+ * is no reverse proxy to bridge the two ports — so every derived
+ * artifact (TRUSTED_ORIGINS/CORS, the /claim banner, email links) would
+ * point at a port nothing listens on, while the install itself looks
+ * green (the healthcheck polls the bind port). Fail fast with the fix.
+ *
+ * https loopback is deliberately allowed: TLS on localhost implies a
+ * local terminating proxy (e.g. Caddy on :8443 forwarding to the bind
+ * port), where diverging ports are the whole point. Exported for tests.
+ */
+export function assertLoopbackPortMatches(appUrl: string, port: number): void {
+  const url = new URL(appUrl);
+  if (url.protocol !== "http:") return;
+  const host = url.hostname;
+  if (host !== "localhost" && host !== "127.0.0.1" && host !== "[::1]") return;
+  const urlPort = url.port === "" ? 80 : Number(url.port);
+  if (urlPort !== port) {
+    throw new Error(
+      `App URL ${appUrl} doesn't match the platform bind port ${port} — a plain-http localhost URL is accessed directly (no reverse proxy), so the ports must agree. Did you mean \`--port ${urlPort}\` (without --app-url)?`,
+    );
+  }
 }
 
 /** DI seam for the cross-check with `docker compose ls` — tests inject a fake, production uses the real helper. */

--- a/apps/cli/src/lib/install/secrets.ts
+++ b/apps/cli/src/lib/install/secrets.ts
@@ -122,6 +122,63 @@ export function isValidBootstrapEmail(value: string): boolean {
 }
 
 /**
+ * Parse + normalize the public app URL (issue #822). Accepts an origin
+ * only — scheme http/https, optional port, no path/query/fragment —
+ * because APP_URL is consumed as an origin everywhere downstream
+ * (TRUSTED_ORIGINS/CORS, OAuth redirect URIs, email links). A subpath
+ * deployment is not supported by the platform, so rejecting it here
+ * surfaces the misconfiguration at install time instead of as a broken
+ * OAuth callback later.
+ *
+ * Returns the URL origin (trailing slash stripped, hostname lowercased
+ * by the URL parser). Throws with an actionable message on anything
+ * else.
+ */
+export function parseAppUrl(raw: string): string {
+  const trimmed = raw.trim();
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    throw new Error(
+      `Invalid app URL "${raw}". Expected an absolute URL like https://appstrate.example.com or http://localhost:3000.`,
+    );
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`Invalid app URL "${raw}". Only http:// and https:// schemes are supported.`);
+  }
+  if (url.username || url.password) {
+    throw new Error(`Invalid app URL "${raw}". Credentials in the URL are not supported.`);
+  }
+  if ((url.pathname !== "/" && url.pathname !== "") || url.search || url.hash) {
+    throw new Error(
+      `Invalid app URL "${raw}". Use the origin only (no path, query, or fragment) — Appstrate must be served at the domain root.`,
+    );
+  }
+  return url.origin;
+}
+
+/**
+ * True when the public URL points beyond the local machine — i.e. the
+ * install is a remote deployment sitting behind a reverse proxy. Two
+ * signals, either one suffices:
+ *   - non-loopback hostname (`example.com`, a LAN IP, …)
+ *   - https scheme — TLS is always terminated by a proxy in front of
+ *     the platform (the container itself only speaks plain HTTP), so
+ *     even `https://localhost` implies a proxy hop.
+ *
+ * Drives the automatic `TRUST_PROXY=true` in `generateEnvForTier` so
+ * client IPs and forwarded-proto are honored behind the proxy without
+ * a separate knob.
+ */
+export function isRemoteAppUrl(appUrl: string): boolean {
+  const url = new URL(appUrl);
+  if (url.protocol === "https:") return true;
+  const host = url.hostname;
+  return host !== "localhost" && host !== "127.0.0.1" && host !== "[::1]";
+}
+
+/**
  * Build the `.env` variable set for the given tier. All tiers share
  * the core Better Auth / connection-encryption secrets; Docker tiers
  * (1/2/3) add infra passwords.
@@ -140,6 +197,15 @@ export function generateEnvForTier(
     RUN_TOKEN_SECRET: hex32(),
     UPLOAD_SIGNING_SECRET: hex32(),
   };
+
+  // Remote deployment (issue #822): a non-localhost / https APP_URL
+  // means a reverse proxy terminates TLS in front of the platform, so
+  // client-IP and forwarded-proto must be read from X-Forwarded-*.
+  // Elided on local installs — same "defaults are not written" policy
+  // as PORT below.
+  if (isRemoteAppUrl(appUrl)) {
+    env.TRUST_PROXY = "true";
+  }
 
   if (ports.port !== undefined && ports.port !== 3000) {
     env.PORT = String(ports.port);

--- a/apps/cli/test/install.test.ts
+++ b/apps/cli/test/install.test.ts
@@ -30,6 +30,7 @@ import {
   resolveMinioConsolePort,
   resolveBootstrapEmail,
   resolveAppUrl,
+  assertLoopbackPortMatches,
   printBootstrapFollowup,
 } from "../src/commands/install.ts";
 import type { RunningComposeProject } from "../src/lib/install/tier123.ts";
@@ -1358,5 +1359,51 @@ describe("resolveAppUrl (issue #822) — non-interactive paths", () => {
         nonInteractive: true,
       }),
     ).toBe("http://localhost:3000");
+  });
+});
+
+describe("assertLoopbackPortMatches (issue #822) — loopback port-mismatch guard", () => {
+  it("throws when a plain-http localhost URL disagrees with the bind port", () => {
+    expect(() => assertLoopbackPortMatches("http://localhost:1234", 3000)).toThrow(
+      /doesn't match the platform bind port 3000/,
+    );
+    expect(() => assertLoopbackPortMatches("http://127.0.0.1:1234", 3000)).toThrow(/--port 1234/);
+    // Portless http://localhost means :80.
+    expect(() => assertLoopbackPortMatches("http://localhost", 3000)).toThrow(/--port 80/);
+  });
+
+  it("passes when the ports agree", () => {
+    expect(() => assertLoopbackPortMatches("http://localhost:8080", 8080)).not.toThrow();
+    expect(() => assertLoopbackPortMatches("http://localhost", 80)).not.toThrow();
+    expect(() => assertLoopbackPortMatches("http://[::1]:3000", 3000)).not.toThrow();
+  });
+
+  it("skips https loopback (local TLS-terminating proxy is legitimate)", () => {
+    expect(() => assertLoopbackPortMatches("https://localhost:8443", 3000)).not.toThrow();
+  });
+
+  it("skips remote URLs — the proxy bridges public port and bind port", () => {
+    expect(() => assertLoopbackPortMatches("http://example.com", 3000)).not.toThrow();
+    expect(() => assertLoopbackPortMatches("https://example.com", 3000)).not.toThrow();
+  });
+
+  it("is enforced by resolveAppUrl on the flag path", async () => {
+    await expect(
+      resolveAppUrl("http://localhost:1234", 3000, {
+        tier: 3,
+        mode: "fresh",
+        existing: NO_EXISTING,
+        nonInteractive: true,
+      }),
+    ).rejects.toThrow(/doesn't match the platform bind port/);
+    // Matching port stays accepted (equivalent to the derived default).
+    await expect(
+      resolveAppUrl("http://localhost:1234", 1234, {
+        tier: 3,
+        mode: "fresh",
+        existing: NO_EXISTING,
+        nonInteractive: true,
+      }),
+    ).resolves.toBe("http://localhost:1234");
   });
 });

--- a/apps/cli/test/install.test.ts
+++ b/apps/cli/test/install.test.ts
@@ -29,9 +29,13 @@ import {
   resolveAppstratePort,
   resolveMinioConsolePort,
   resolveBootstrapEmail,
+  resolveAppUrl,
   printBootstrapFollowup,
 } from "../src/commands/install.ts";
 import type { RunningComposeProject } from "../src/lib/install/tier123.ts";
+
+/** Fresh-install shape reused by the resolveAppUrl suite. */
+const NO_EXISTING = { hasEnv: false, hasCompose: false, existingEnv: {} };
 
 describe("resolveTier", () => {
   it("accepts '0', '1', '2', '3' as literal strings", async () => {
@@ -1248,5 +1252,111 @@ describe("printBootstrapFollowup (issue #228) — post-install action", () => {
     );
     expect(cap.calls[0]!.message).toContain("http://appstrate.acme.com/register");
     expect(cap.calls[0]!.message).not.toContain("localhost");
+  });
+});
+
+describe("resolveAppUrl (issue #822) — non-interactive paths", () => {
+  const SNAPSHOT = { APPSTRATE_APP_URL: process.env.APPSTRATE_APP_URL };
+  afterEach(() => {
+    if (SNAPSHOT.APPSTRATE_APP_URL === undefined) delete process.env.APPSTRATE_APP_URL;
+    else process.env.APPSTRATE_APP_URL = SNAPSHOT.APPSTRATE_APP_URL;
+  });
+
+  const FRESH = { mode: "fresh" as const, existing: NO_EXISTING, nonInteractive: true };
+
+  it("defaults to http://localhost:<port> when nothing is expressed", async () => {
+    expect(await resolveAppUrl(undefined, 3000, { tier: 3, ...FRESH })).toBe(
+      "http://localhost:3000",
+    );
+    expect(await resolveAppUrl(undefined, 8080, { tier: 3, ...FRESH })).toBe(
+      "http://localhost:8080",
+    );
+  });
+
+  it("elides the port when the platform binds :80 (matches appUrlForPort)", async () => {
+    expect(await resolveAppUrl(undefined, 80, { tier: 3, ...FRESH })).toBe("http://localhost");
+  });
+
+  it("honors the --app-url flag on a fresh install (normalized)", async () => {
+    expect(await resolveAppUrl("https://appstrate.example.com/", 3000, { tier: 3, ...FRESH })).toBe(
+      "https://appstrate.example.com",
+    );
+  });
+
+  it("honors APPSTRATE_APP_URL (curl|bash path), flag wins over env", async () => {
+    process.env.APPSTRATE_APP_URL = "https://env.example.com";
+    expect(await resolveAppUrl(undefined, 3000, { tier: 3, ...FRESH })).toBe(
+      "https://env.example.com",
+    );
+    expect(await resolveAppUrl("https://flag.example.com", 3000, { tier: 3, ...FRESH })).toBe(
+      "https://flag.example.com",
+    );
+  });
+
+  it("an empty APPSTRATE_APP_URL is treated as unset", async () => {
+    process.env.APPSTRATE_APP_URL = "   ";
+    expect(await resolveAppUrl(undefined, 3000, { tier: 3, ...FRESH })).toBe(
+      "http://localhost:3000",
+    );
+  });
+
+  it("applies the flag on Tier 0 too (no prompt, but scripted override works)", async () => {
+    expect(await resolveAppUrl("https://appstrate.example.com", 3000, { tier: 0, ...FRESH })).toBe(
+      "https://appstrate.example.com",
+    );
+  });
+
+  it("throws on an invalid --app-url (fail-fast at install time)", async () => {
+    await expect(resolveAppUrl("not a url", 3000, { tier: 3, ...FRESH })).rejects.toThrow(
+      /Expected an absolute URL/,
+    );
+    await expect(
+      resolveAppUrl("https://example.com/sub/path", 3000, { tier: 3, ...FRESH }),
+    ).rejects.toThrow(/origin only/);
+  });
+
+  it("upgrade inherits the existing APP_URL from .env (mergeEnv — existing wins)", async () => {
+    const existing = {
+      hasEnv: true,
+      hasCompose: true,
+      existingEnv: { APP_URL: "https://old.example.com" },
+    };
+    expect(
+      await resolveAppUrl(undefined, 3000, {
+        tier: 3,
+        mode: "upgrade",
+        existing,
+        nonInteractive: true,
+      }),
+    ).toBe("https://old.example.com");
+    // A divergent flag is warned about + ignored — same contract as --port.
+    expect(
+      await resolveAppUrl("https://new.example.com", 3000, {
+        tier: 3,
+        mode: "upgrade",
+        existing,
+        nonInteractive: true,
+      }),
+    ).toBe("https://old.example.com");
+  });
+
+  it("upgrade without APP_URL in the existing .env falls through to flag/default", async () => {
+    const existing = { hasEnv: true, hasCompose: true, existingEnv: {} };
+    expect(
+      await resolveAppUrl("https://new.example.com", 3000, {
+        tier: 3,
+        mode: "upgrade",
+        existing,
+        nonInteractive: true,
+      }),
+    ).toBe("https://new.example.com");
+    expect(
+      await resolveAppUrl(undefined, 3000, {
+        tier: 3,
+        mode: "upgrade",
+        existing,
+        nonInteractive: true,
+      }),
+    ).toBe("http://localhost:3000");
   });
 });

--- a/apps/cli/test/install/secrets.test.ts
+++ b/apps/cli/test/install/secrets.test.ts
@@ -13,7 +13,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import {
   generateEnvForTier,
+  isRemoteAppUrl,
   isValidBootstrapEmail,
+  parseAppUrl,
   renderEnvFile,
   type EnvVars,
 } from "../../src/lib/install/secrets.ts";
@@ -296,5 +298,87 @@ describe("isValidBootstrapEmail", () => {
     expect(isValidBootstrapEmail("trailing@")).toBe(false);
     expect(isValidBootstrapEmail("no-tld@example")).toBe(false);
     expect(isValidBootstrapEmail("white space@example.com")).toBe(false);
+  });
+});
+
+describe("parseAppUrl (issue #822)", () => {
+  it("accepts a bare https origin and returns it unchanged", () => {
+    expect(parseAppUrl("https://appstrate.example.com")).toBe("https://appstrate.example.com");
+  });
+
+  it("accepts http with an explicit port", () => {
+    expect(parseAppUrl("http://192.168.1.10:8080")).toBe("http://192.168.1.10:8080");
+  });
+
+  it("normalizes: strips a trailing slash and lowercases the host", () => {
+    expect(parseAppUrl("https://Appstrate.Example.COM/")).toBe("https://appstrate.example.com");
+  });
+
+  it("trims surrounding whitespace", () => {
+    expect(parseAppUrl("  https://example.com  ")).toBe("https://example.com");
+  });
+
+  it("drops a default port (URL origin semantics)", () => {
+    expect(parseAppUrl("https://example.com:443")).toBe("https://example.com");
+    expect(parseAppUrl("http://example.com:80")).toBe("http://example.com");
+  });
+
+  it("rejects a relative or garbage value", () => {
+    expect(() => parseAppUrl("example.com")).toThrow(/Expected an absolute URL/);
+    expect(() => parseAppUrl("not a url")).toThrow(/Expected an absolute URL/);
+    expect(() => parseAppUrl("")).toThrow(/Expected an absolute URL/);
+  });
+
+  it("rejects non-http(s) schemes", () => {
+    expect(() => parseAppUrl("ftp://example.com")).toThrow(/Only http/);
+    expect(() => parseAppUrl("ws://example.com")).toThrow(/Only http/);
+  });
+
+  it("rejects a path, query, or fragment (origin only — no subpath deploys)", () => {
+    expect(() => parseAppUrl("https://example.com/appstrate")).toThrow(/origin only/);
+    expect(() => parseAppUrl("https://example.com/?x=1")).toThrow(/origin only/);
+    expect(() => parseAppUrl("https://example.com/#frag")).toThrow(/origin only/);
+  });
+
+  it("rejects embedded credentials", () => {
+    expect(() => parseAppUrl("https://user:pass@example.com")).toThrow(/Credentials/);
+  });
+});
+
+describe("isRemoteAppUrl (issue #822)", () => {
+  it("localhost / 127.0.0.1 / [::1] over http are local", () => {
+    expect(isRemoteAppUrl("http://localhost:3000")).toBe(false);
+    expect(isRemoteAppUrl("http://localhost")).toBe(false);
+    expect(isRemoteAppUrl("http://127.0.0.1:3000")).toBe(false);
+    expect(isRemoteAppUrl("http://[::1]:3000")).toBe(false);
+  });
+
+  it("any non-loopback hostname is remote, even over plain http", () => {
+    expect(isRemoteAppUrl("http://appstrate.example.com")).toBe(true);
+    expect(isRemoteAppUrl("http://192.168.1.10:8080")).toBe(true);
+  });
+
+  it("https always implies a TLS-terminating proxy → remote", () => {
+    expect(isRemoteAppUrl("https://localhost")).toBe(true);
+    expect(isRemoteAppUrl("https://appstrate.example.com")).toBe(true);
+  });
+});
+
+describe("generateEnvForTier — TRUST_PROXY wiring (issue #822)", () => {
+  it("local default: no TRUST_PROXY key (defaults are elided)", () => {
+    const env = generateEnvForTier(3, "http://localhost:3000");
+    expect(env.TRUST_PROXY).toBeUndefined();
+  });
+
+  it("remote APP_URL sets TRUST_PROXY=true and mirrors the URL into TRUSTED_ORIGINS", () => {
+    const env = generateEnvForTier(3, "https://appstrate.example.com");
+    expect(env.APP_URL).toBe("https://appstrate.example.com");
+    expect(env.TRUSTED_ORIGINS).toBe("https://appstrate.example.com");
+    expect(env.TRUST_PROXY).toBe("true");
+  });
+
+  it("applies on Tier 0 too (flag-driven, no prompt there)", () => {
+    const env = generateEnvForTier(0, "https://appstrate.example.com");
+    expect(env.TRUST_PROXY).toBe("true");
   });
 });

--- a/examples/self-hosting/README.md
+++ b/examples/self-hosting/README.md
@@ -377,5 +377,24 @@ install dir itself, so use it only when you intend a full wipe.
 - Place a reverse proxy (nginx, Caddy, Traefik) in front of Appstrate for TLS termination
 - Set `APP_URL` to your public HTTPS URL
 - Set `TRUSTED_ORIGINS` to your public domain
+- Set `TRUST_PROXY=true` so client IPs and forwarded-proto are read from `X-Forwarded-*`
+
+The `appstrate install` CLI wires all three for you when you pass the public URL
+(`--app-url https://appstrate.example.com`, or `APPSTRATE_APP_URL` for the
+`curl | bash` one-liner). The public URL is independent of `--port`: `--port`
+stays the host bind port your reverse proxy forwards to, while `--app-url` is
+what browsers, OAuth redirects, and email links use (no port when TLS is
+terminated at the proxy). The installer does **not** provision the reverse
+proxy or TLS itself -- forwarding `appstrate.example.com -> localhost:<port>`
+is your responsibility. Minimal Caddy example:
+
+```
+appstrate.example.com {
+    reverse_proxy localhost:3000
+}
+```
+
+Other production notes:
+
 - Use strong, unique secrets for all `*_SECRET` and `*_PASSWORD` variables
 - Consider backing up the `pgdata` volume regularly


### PR DESCRIPTION
Closes #822

## Problem

`appstrate install` hardcoded `APP_URL=http://localhost:3000`. For any remote deployment behind a reverse proxy, everything derived from the public URL shipped broken — OAuth redirect URIs, `TRUSTED_ORIGINS` (CORS), email links, and the printed `/claim` bootstrap URL — until the operator hand-edited `.env`.

## What changed

The public URL is now a first-class install input, **independent of `--port`** (which stays the host bind port the proxy forwards to, per the issue's port-handling resolution):

- **`--app-url <url>` flag + `APPSTRATE_APP_URL` env** for non-interactive installs (`curl | bash`, CI). Validated strictly via `parseAppUrl` — http/https origin only, no path/query/fragment/credentials — so a typo fails at install time instead of surfacing as a broken OAuth callback later.
- **Interactive prompt** on fresh Docker-tier installs, defaulting to `http://localhost:<port>` (Enter preserves today's behavior exactly). Tier 0 stays prompt-free (local dev), but honors the flag/env for scripted use.
- **`APP_URL` and `TRUSTED_ORIGINS`** are both set from it (single value for now; comma-list can come later).
- **`TRUST_PROXY=true` auto-enabled** when the URL is non-localhost **or** https (`isRemoteAppUrl`) — TLS is always proxy-terminated in front of the platform, so forwarded-proto / client IP must be honored. Elided on local installs (defaults-not-written policy).
- **No `:PORT` appended** to a user-provided public URL — it only ever derives the port for the local default.
- **Upgrades inherit** the existing `APP_URL` (consistent with `mergeEnv`'s existing-wins semantics) and warn when a divergent `--app-url` is passed — the same contract as `--port` on upgrade.
- **Healthcheck, dev-server readiness poll, and browser open now target the local bind URL**, not the public URL: on a remote deploy the public domain doesn't route until the operator configures the proxy, which happens after the install. A post-install note states explicitly that the installer wires `APP_URL`/`TRUSTED_ORIGINS`/`TRUST_PROXY` but does **not** provision the reverse proxy/TLS, with the forwarding target spelled out.

## Scope note (per issue discussion)

Stays **single-URL**: no MinIO/S3 public-endpoint prompt. The storage follow-up (filesystem default for single-node, GitLab-style proxy-download as a separate issue) is intentionally out of scope here.

## Docs

- `examples/self-hosting/README.md` — Production Considerations rewritten around `--app-url`, the `--port` vs public-URL distinction, and a minimal Caddy example; explicit "the installer does not provision the proxy".
- Root `README.md` — remote-deploy one-liner with `--app-url`.

## Tests

- `parseAppUrl` (normalization, rejections), `isRemoteAppUrl` (loopback vs remote vs https), `generateEnvForTier` TRUST_PROXY wiring — `apps/cli/test/install/secrets.test.ts`
- `resolveAppUrl` precedence: flag > env > default, empty-env handling, tier-0 pass-through, invalid-URL fail-fast, upgrade inherit + divergent-flag warn — `apps/cli/test/install.test.ts`
- Full CLI suite: 1085 pass. `tsc --noEmit`, eslint, prettier clean; pre-push turbo gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)