### PR TITLE
fix(runs): engine-aware Output Format prompt — claude-code runs no longer mandated to call a nonexistent `output` tool

### DIFF
--- a/apps/api/src/services/run-launcher/pi.ts
+++ b/apps/api/src/services/run-launcher/pi.ts
@@ -136,8 +136,21 @@ async function runPlatformContainerImpl(
   const uploadBundle = input.uploadBundle ?? uploadRunBundle;
   const deleteWorkspace = input.deleteWorkspace ?? deleteRunWorkspace;
 
-  const prompt = await buildPlatformSystemPrompt(context, plan);
   const { llmConfig } = plan;
+
+  // Single source of truth for "what kind of credential is this and how is it
+  // delivered". Reads the provider→engine registry ONCE (plus the oauth-class
+  // flag for the engine-less refuse path); the delivery mode, the oauth-class
+  // boolean, and the resolved engine all flow from here. Resolved BEFORE the
+  // prompt build so the `## Output Format` section renders the delivery
+  // contract of the engine that will actually run (`output` tool on Pi,
+  // native `outputFormat` on the Claude Agent SDK — issue #824).
+  const delivery = resolveCredentialDelivery({
+    providerId: llmConfig.providerId,
+    hasCredentialId: !!llmConfig.credentialId,
+  });
+
+  const prompt = await buildPlatformSystemPrompt(context, plan, { engine: delivery.engine });
   // The container's MODEL_ID is the PUBLIC id: the alias for a model alias, the
   // real id otherwise. The agent sends it verbatim as the request `model`; the
   // sidecar swaps alias→real upstream. The real backing id never enters the
@@ -158,18 +171,6 @@ async function runPlatformContainerImpl(
   // is NOT a spawn failure) must not also emit a spawn data point.
   let spawnRecorded = false;
   try {
-    // Single source of truth for "what kind of credential is this and how is it
-    // delivered". Reads the provider→engine registry ONCE (plus the oauth-class
-    // flag for the engine-less refuse path); the delivery mode, the oauth-class
-    // boolean, and the resolved engine all flow from here, replacing the former
-    // parallel `isOAuthModelProvider` axis. Resolved up front so the fail-closed
-    // isolation guard below consumes the same struct instead of re-reading the
-    // registry.
-    const delivery = resolveCredentialDelivery({
-      providerId: llmConfig.providerId,
-      hasCredentialId: !!llmConfig.credentialId,
-    });
-
     // Fail-closed BEFORE provisioning any isolation boundary: a subscription
     // AGENT run (claude-code → Claude Agent SDK) must execute under the docker
     // orchestrator. The process orchestrator runs in-host and would expose the

--- a/apps/api/src/services/run-launcher/prompt-builder.ts
+++ b/apps/api/src/services/run-launcher/prompt-builder.ts
@@ -24,6 +24,7 @@
  */
 
 import type { AppstrateRunPlan } from "./types.ts";
+import type { RunEngine } from "./subscription-run-policy.ts";
 import type { ExecutionContext } from "@appstrate/afps-runtime/types";
 import {
   buildPlatformPromptInputs,
@@ -36,6 +37,17 @@ import { fetchIntegrationPromptDocs } from "../integration-service.ts";
 export async function buildPlatformSystemPrompt(
   context: ExecutionContext,
   plan: AppstrateRunPlan,
+  opts: {
+    /**
+     * The engine the run executes on, resolved by the launcher via
+     * `resolveCredentialDelivery` (provider→engine registry). Drives the
+     * `## Output Format` section: the `claude` engine has no `output`
+     * runtime tool — its deliverable is native via the Claude Agent SDK's
+     * `outputFormat` — so the prompt must not mandate an `output` tool
+     * call there (issue #824). Defaults to the Pi tool-call contract.
+     */
+    engine?: RunEngine;
+  } = {},
 ): Promise<string> {
   const uploads = plan.files?.map((f) => ({
     name: f.name,
@@ -66,6 +78,7 @@ export async function buildPlatformSystemPrompt(
   const inputs = buildPlatformPromptInputs(plan.bundle, context, {
     platformName: "Appstrate",
     timeoutSeconds: plan.timeout,
+    outputMode: opts.engine === "claude" ? "native" : "tool",
     ...(uploads ? { uploads } : {}),
     ...(integrations && integrations.length > 0 ? { integrations } : {}),
   });

--- a/apps/api/test/unit/prompt-builder.test.ts
+++ b/apps/api/test/unit/prompt-builder.test.ts
@@ -153,9 +153,12 @@ function splitLegacy(ctx: PromptContext): {
   return { context, plan };
 }
 
-function buildEnrichedPrompt(ctx: PromptContext): Promise<string> {
+function buildEnrichedPrompt(
+  ctx: PromptContext,
+  opts?: { engine?: "pi" | "claude" },
+): Promise<string> {
   const { context, plan } = splitLegacy(ctx);
-  return buildPlatformSystemPrompt(context, plan);
+  return buildPlatformSystemPrompt(context, plan, opts ?? {});
 }
 
 function baseContext(overrides?: Partial<PromptContext>): PromptContext {
@@ -551,6 +554,40 @@ describe("buildEnrichedPrompt — tools and skills", () => {
     const ctx = baseContext({ availableSkills: [] });
     const prompt = await buildEnrichedPrompt(ctx);
     expect(prompt).not.toContain("### Skills");
+  });
+});
+
+// ─── Output Format engine awareness (issue #824) ───────────
+
+describe("buildEnrichedPrompt — Output Format is engine-aware", () => {
+  const outputSchema = {
+    type: "object" as const,
+    required: ["answer"],
+    properties: { answer: { type: "string" as const } },
+  };
+
+  it("pi engine (default) mandates the terminal `output` tool call", async () => {
+    const prompt = await buildEnrichedPrompt(baseContext({ schemas: { output: outputSchema } }));
+    expect(prompt).toContain("## Output Format");
+    expect(prompt).toContain("call the `output` tool");
+  });
+
+  it("claude engine instructs a final JSON message — never a nonexistent `output` tool", async () => {
+    // The claude runner hosts log/note/pin/report only; the deliverable is
+    // native via SDK `outputFormat` → `structured_output`. The tool-call
+    // mandate would send the agent hunting for a tool that does not exist
+    // and the run never completes (issue #824).
+    const prompt = await buildEnrichedPrompt(baseContext({ schemas: { output: outputSchema } }), {
+      engine: "claude",
+    });
+    expect(prompt).toContain("## Output Format");
+    expect(prompt).toContain("FINAL message MUST be the run's deliverable");
+    expect(prompt).not.toContain("call the `output` tool");
+  });
+
+  it("claude engine with no output schema renders no Output Format section", async () => {
+    const prompt = await buildEnrichedPrompt(baseContext(), { engine: "claude" });
+    expect(prompt).not.toContain("## Output Format");
   });
 });
 

--- a/packages/afps-runtime/src/bundle/platform-prompt.ts
+++ b/packages/afps-runtime/src/bundle/platform-prompt.ts
@@ -96,6 +96,20 @@ export interface PlatformPromptOptions {
    * weaker models routinely call `output({})` before the correct shape.
    */
   outputSchema?: Record<string, unknown>;
+  /**
+   * How the agent delivers the structured output declared by
+   * `outputSchema`. Default `"tool"`.
+   *
+   * - `"tool"` — the Pi engine hosts an `output` runtime tool; the prompt
+   *   mandates one terminal `output` call.
+   * - `"native"` — the Claude Agent SDK engine has NO `output` tool; the
+   *   deliverable is captured natively (`outputFormat: json_schema` →
+   *   `structured_output`), so the prompt instructs the agent to end with
+   *   a final JSON message instead of a tool call. Rendering the tool
+   *   mandate here would send the agent hunting for a tool that does not
+   *   exist (issue #824).
+   */
+  outputMode?: "tool" | "native";
 
   /** Uploaded documents surfaced in `## Documents`. */
   uploads?: ReadonlyArray<PromptViewUpload>;
@@ -374,15 +388,30 @@ export function renderPlatformPrompt(opts: PlatformPromptOptions): string {
   // for why this duplicates the tool-level schema.
   if (opts.outputSchema && Object.keys(opts.outputSchema).length > 0) {
     sections.push("## Output Format\n");
-    sections.push(
-      "You MUST call the `output` tool **exactly once**, as your FINAL action, " +
-        "with a `data` parameter that satisfies the JSON Schema below. " +
-        "Provide ALL required fields in that single call — do not probe " +
-        "with `output({})` first, and do not split the payload across " +
-        "multiple calls. A successful `output` call ends the run immediately: " +
-        "finish all other work before calling it, and do not plan any message " +
-        "or step after it.\n",
-    );
+    if ((opts.outputMode ?? "tool") === "native") {
+      // Native delivery (Claude Agent SDK): there is NO `output` tool on
+      // this engine — the platform captures the run's structured output
+      // from the agent's final message. Mandating a tool call here sends
+      // the agent hunting for a tool that does not exist (issue #824).
+      sections.push(
+        "Your FINAL message MUST be the run's deliverable: a single JSON " +
+          "object that satisfies the JSON Schema below, with ALL required " +
+          "fields present. There is NO `output` tool on this runtime — do " +
+          "not try to call one; the platform captures your final message " +
+          "natively. Finish all other work first, then end the run with " +
+          "the JSON deliverable alone — no prose before or after it.\n",
+      );
+    } else {
+      sections.push(
+        "You MUST call the `output` tool **exactly once**, as your FINAL action, " +
+          "with a `data` parameter that satisfies the JSON Schema below. " +
+          "Provide ALL required fields in that single call — do not probe " +
+          "with `output({})` first, and do not split the payload across " +
+          "multiple calls. A successful `output` call ends the run immediately: " +
+          "finish all other work before calling it, and do not plan any message " +
+          "or step after it.\n",
+      );
+    }
 
     const required = Array.isArray(opts.outputSchema.required)
       ? (opts.outputSchema.required as readonly unknown[]).filter(

--- a/packages/afps-runtime/test/bundle/platform-prompt.test.ts
+++ b/packages/afps-runtime/test/bundle/platform-prompt.test.ts
@@ -527,6 +527,47 @@ describe("renderPlatformPrompt", () => {
       expect(sepIdx).toBeGreaterThan(outputIdx);
     });
 
+    it("defaults to the `output` tool mandate when outputMode is omitted", () => {
+      const out = renderPlatformPrompt({
+        template: "T",
+        context: ctx(),
+        outputSchema: schema,
+      });
+      expect(out).toContain("call the `output` tool");
+      expect(out).not.toContain("NO `output` tool");
+    });
+
+    it('outputMode: "tool" renders the terminal `output` tool mandate', () => {
+      const out = renderPlatformPrompt({
+        template: "T",
+        context: ctx(),
+        outputSchema: schema,
+        outputMode: "tool",
+      });
+      expect(out).toContain("call the `output` tool");
+      expect(out).toContain("exactly once");
+    });
+
+    it('outputMode: "native" instructs a final JSON message and never mandates an `output` tool call', () => {
+      // The claude engine has no `output` tool (deliverable is native via
+      // SDK `outputFormat`); mandating one sends the agent hunting for a
+      // nonexistent tool and the run never completes (issue #824).
+      const out = renderPlatformPrompt({
+        template: "T",
+        context: ctx(),
+        outputSchema: schema,
+        outputMode: "native",
+      });
+      expect(out).toContain("## Output Format");
+      expect(out).toContain("FINAL message MUST be the run's deliverable");
+      expect(out).toContain("NO `output` tool");
+      expect(out).not.toContain("call the `output` tool");
+      expect(out).not.toContain("output({})");
+      // Schema surfaces stay identical across modes.
+      expect(out).toContain("### Required shape");
+      expect(out).toContain("### Full JSON Schema");
+    });
+
     it("tolerates schemas without `properties` (list section skipped, full schema still shown)", () => {
       const out = renderPlatformPrompt({
         template: "T",


### PR DESCRIPTION
Fixes #824

## Problem

Any agent declaring `output.schema` received the same `## Output Format` prompt section regardless of engine: *"You MUST call the `output` tool exactly once, as your FINAL action…"*. On the Claude Agent SDK engine (`claude-code`), no `output` tool exists — the deliverable is native via SDK `outputFormat: json_schema` → `structured_output`. The agent obeyed the prompt, tried 8 tool-name variants (all `No such tool available`), fell back to sandbox introspection, and the run never completed on its own (observed in `run_c50214bb-…`).

## Fix

- **`packages/afps-runtime/src/bundle/platform-prompt.ts`** — new `outputMode: "tool" | "native"` option on `PlatformPromptOptions` (default `"tool"`). In `"native"` mode the `## Output Format` section instructs: final message MUST be a single JSON object satisfying the schema, explicitly states there is NO `output` tool, and forbids hunting for one. The schema surfaces (`### Required shape`, `### Full JSON Schema`) are identical across modes.
- **`apps/api/src/services/run-launcher/prompt-builder.ts`** — `buildPlatformSystemPrompt` accepts the resolved `engine` and maps `claude` → `native`, everything else → `tool`.
- **`apps/api/src/services/run-launcher/pi.ts`** — `resolveCredentialDelivery` is hoisted above the prompt build so one registry read drives the prompt's output mode, the subscription isolation guard, and `RUN_ENGINE` — no re-derivation, no drift.

The Pi path renders byte-identical output (default `"tool"`), so CLI/platform prompt parity is preserved (`platform-prompt-parity.test.ts` unchanged and green).

## Tests

- `packages/afps-runtime/test/bundle/platform-prompt.test.ts` — default/tool/native mode rendering (native never mentions calling an `output` tool, keeps schema blocks).
- `apps/api/test/unit/prompt-builder.test.ts` — engine `claude` → native instruction; default → tool mandate; no section without an output schema.
- Full `bun run check` green (33/33 tasks); launcher + prompt test suites pass.

## Not addressed here (secondary observation in the issue)

The tool-retry loop keeps `last_heartbeat_at` fresh, so the stall sweep can never catch a run stuck in a rejected-tool-call loop — only the manifest `timeout` or manual cancel ends it. That is a liveness-vs-progress watchdog design question, independent of this prompt fix; worth its own issue if we want a progress-based stall signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)