### PR TITLE
fix(models): synthesize neutral errors for aliased models instead of scrubbing

### DIFF
--- a/apps/api/src/routes/llm-proxy.ts
+++ b/apps/api/src/routes/llm-proxy.ts
@@ -234,9 +234,23 @@ async function handleProxy(
       throw invalidRequest(err.message);
     }
     if (err instanceof LlmProxyUnsupportedSubscriptionError) {
+      // The backing provider id is masked in the caller-facing message
+      // (alias masking) — log it server-side for diagnosability.
+      logger.warn("llm-proxy: rejected OAuth-subscription model", {
+        providerId: err.providerId,
+        orgId,
+      });
       throw invalidRequest(err.message, "model");
     }
     if (err instanceof LlmProxyModelApiMismatchError) {
+      // Same: for an aliased preset the message hides `actual` — keep the
+      // full mismatch detail in server logs.
+      logger.warn("llm-proxy: model/endpoint apiShape mismatch", {
+        presetId: err.presetId,
+        expected: err.expected,
+        actual: err.actual,
+        orgId,
+      });
       throw invalidRequest(err.message, "model");
     }
     // No `status`: the upstream attempt produced no response, which the

--- a/apps/api/src/services/llm-proxy/claude-code-sdk-gateway.ts
+++ b/apps/api/src/services/llm-proxy/claude-code-sdk-gateway.ts
@@ -137,9 +137,13 @@ async function resolveClaudeSubscriptionToken(
     throw invalidRequest(`Model preset "${presetId}" is not enabled for this org`);
   }
   if (resolved.providerId !== CLAUDE_CODE_PROVIDER_ID) {
-    throw invalidRequest(
-      `Model preset "${presetId}" is not a Claude Code subscription model (provider: ${resolved.providerId})`,
-    );
+    // The backing provider id must not be caller-facing (alias masking) —
+    // keep it in server logs only.
+    logger.warn(`${logLabel}: preset is not a claude-code subscription model`, {
+      presetId,
+      providerId: resolved.providerId,
+    });
+    throw invalidRequest(`Model preset "${presetId}" is not a Claude Code subscription model`);
   }
   if (!resolved.credentialId) {
     throw invalidRequest(`Model preset "${presetId}" has no OAuth credential to resolve`);
@@ -194,7 +198,15 @@ export async function handleClaudeCodeSdkGateway(
   // gateway becoming an SSRF hole if that flag is ever flipped, instead of the
   // protection silently depending on a provider def in another repo.
   if (isBlockedUrl(resolved.baseUrl)) {
-    throw invalidRequest(`Model base URL targets a blocked network: ${resolved.baseUrl}`);
+    // The resolved base URL is the real backing endpoint — server-log-only;
+    // the caller-facing message must not embed it.
+    logger.error("claude-code-sdk gateway: refused blocked upstream (SSRF)", {
+      presetId,
+      baseUrl: resolved.baseUrl,
+    });
+    throw invalidRequest(
+      `Model preset "${presetId}" resolves to a blocked address — refusing to proxy.`,
+    );
   }
 
   const buf = await c.req.arrayBuffer();

--- a/apps/api/src/services/llm-proxy/core.ts
+++ b/apps/api/src/services/llm-proxy/core.ts
@@ -61,9 +61,16 @@ export class LlmProxyModelApiMismatchError extends Error {
     public readonly presetId: string,
     public readonly expected: string,
     public readonly actual: string,
+    aliased = false,
   ) {
     super(
-      `Model "${presetId}" uses "${actual}"; this endpoint serves "${expected}". Use the corresponding /api/llm-proxy/<api>/… route.`,
+      // For an alias the backing apiShape is masked on the public DTO
+      // (`projectAliasedModel` nulls it), so naming `actual` here would leak
+      // the backing protocol family to the caller. `actual` stays a property
+      // for server-side logging; only non-aliased presets get the detail.
+      aliased
+        ? `Model "${presetId}" is not served by this endpoint.`
+        : `Model "${presetId}" uses "${actual}"; this endpoint serves "${expected}". Use the corresponding /api/llm-proxy/<api>/… route.`,
     );
     this.name = "LlmProxyModelApiMismatchError";
   }
@@ -79,9 +86,12 @@ export class LlmProxyModelApiMismatchError extends Error {
  * here — this gateway never forges).
  */
 export class LlmProxyUnsupportedSubscriptionError extends Error {
+  // `providerId` stays a public property for server-side logging, but the
+  // message must not name it — the backing provider of an aliased model is
+  // never caller-facing (alias masking).
   constructor(public readonly providerId: string) {
     super(
-      `Provider "${providerId}" is an OAuth subscription and cannot be served through ` +
+      `This model is backed by an OAuth subscription and cannot be served through ` +
         `this gateway (no fingerprint forging). Subscription chat is only available when ` +
         `the provider's subscription engine has a dedicated official-binary SDK gateway; ` +
         `this credential's engine has none. Use an API-key model instead.`,
@@ -160,7 +170,9 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
   // documented fail-closed consumer of `@appstrate/core/ssrf`.
   if (isBlockedUrl(upstreamUrl)) {
     logger.error("llm-proxy: refused blocked upstream (SSRF)", { presetId, upstreamUrl });
-    throw invalidRequest(`Refusing to proxy to a blocked address: ${resolved.baseUrl}`);
+    // The resolved base URL is the real backing endpoint — server-log-only
+    // (logged above); the caller-facing message must not embed it.
+    throw invalidRequest(`Model "${presetId}" resolves to a blocked address — refusing to proxy.`);
   }
 
   const upstreamHeaders = inputs.adapter.buildUpstreamHeaders(
@@ -221,7 +233,7 @@ async function resolvePresetForOrg(
     throw new LlmProxyUnsupportedModelError(presetId);
   }
   if (loaded.apiShape !== expectedApi) {
-    throw new LlmProxyModelApiMismatchError(presetId, expectedApi, loaded.apiShape);
+    throw new LlmProxyModelApiMismatchError(presetId, expectedApi, loaded.apiShape, loaded.aliased);
   }
   return loaded;
 }

--- a/apps/api/src/services/llm-proxy/metering.ts
+++ b/apps/api/src/services/llm-proxy/metering.ts
@@ -30,7 +30,8 @@ import type { ModelSwap } from "@appstrate/core/sidecar-types";
 import {
   swapResponseModelJson,
   createSseModelSwapStream,
-  scrubModelText,
+  syntheticAliasErrorBody,
+  LLM_PASSTHROUGH_RESPONSE_HEADERS,
 } from "@appstrate/core/model-swap";
 import { stripUpstreamResponseHeaders } from "@appstrate/connect/proxy-primitives";
 import type { ResolvedModel } from "../org-models.ts";
@@ -39,6 +40,26 @@ import type { LlmProxyAdapter, LlmProxyPrincipal, UpstreamUsage } from "./types.
 
 /** Clone upstream response headers, dropping hop-by-hop + stale content encoding/length. */
 export const cloneResponseHeaders = stripUpstreamResponseHeaders;
+
+/**
+ * Client-facing response headers for one upstream reply.
+ *
+ * No swap → the permissive {@link cloneResponseHeaders} (unchanged behavior).
+ * That clone forwards `server: cloudflare`, `cf-ray`, `anthropic-*`,
+ * `openai-organization`, … — headers that fingerprint the backing provider
+ * even when every body field is swapped. An aliased model therefore gets only
+ * the shared allowlist ({@link LLM_PASSTHROUGH_RESPONSE_HEADERS} — same
+ * posture as the sidecar), copying just the entries present upstream.
+ */
+export function buildClientHeaders(upstream: Headers, swap: ModelSwap | null | undefined): Headers {
+  if (!swap) return cloneResponseHeaders(upstream);
+  const headers = new Headers();
+  for (const name of LLM_PASSTHROUGH_RESPONSE_HEADERS) {
+    const value = upstream.get(name);
+    if (value !== null) headers.set(name, value);
+  }
+  return headers;
+}
 
 /**
  * Upper bound on usage-bearing frames retained by {@link tapSseUsage}.
@@ -175,10 +196,12 @@ export interface MeteredForwardContext {
 export interface MeteredForwardOptions {
   /**
    * Model-alias swap (issue #727). When set, the real upstream id echoed by the
-   * upstream is rewritten back to the alias on EVERY response branch (error
-   * prose, SSE frames, JSON body) so the caller never sees the backing model.
-   * The usage tap reads the untouched stream, so accounting still sees the real
-   * id. `null` (the subscription gateways) forwards verbatim.
+   * upstream is rewritten back to the alias on the success branches (SSE
+   * frames, JSON body), upstream error bodies are REPLACED with a synthetic
+   * neutral envelope, and response headers are reduced to the shared allowlist
+   * — so the caller never sees the backing model. The usage tap reads the
+   * untouched stream, so accounting still sees the real id. `null` (the
+   * subscription gateways) forwards verbatim.
    */
   swap?: ModelSwap | null;
   /**
@@ -293,14 +316,30 @@ export async function forwardMeteredResponse(
       durationMs: Date.now() - ctx.started,
     });
 
-  // Upstream errors: surface verbatim, never meter (no tokens produced). Error
-  // bodies are free-form prose that may name the real id — blind-scrub for aliases.
+  // Upstream errors: never meter (no tokens produced). No swap → forwarded
+  // verbatim. With a swap the error body is free-form prose that can name the
+  // backing anywhere (model id, hostname, provider vocabulary), so it is never
+  // forwarded — a synthetic neutral envelope replaces it (whitelist by
+  // construction); the upstream detail stays in server logs only.
   if (!upstream.ok) {
     options.onUpstreamError?.(upstream.status);
     const errorBody = await upstream.text();
-    const headers = cloneResponseHeaders(upstream.headers);
-    const clientBody = swap ? scrubModelText(errorBody, swap) : errorBody;
-    return new Response(clientBody, { status: upstream.status, headers });
+    const headers = buildClientHeaders(upstream.headers, swap);
+    if (swap) {
+      logger.warn(`${logLabel}: upstream error on aliased model — synthesized envelope`, {
+        status: upstream.status,
+        presetId: ctx.presetId,
+        runId: ctx.runId,
+        bodySample: errorBody.slice(0, 200),
+      });
+      // The synthesized body is JSON even when the upstream error wasn't.
+      headers.set("content-type", "application/json");
+      return new Response(syntheticAliasErrorBody(swap, upstream.status), {
+        status: upstream.status,
+        headers,
+      });
+    }
+    return new Response(errorBody, { status: upstream.status, headers });
   }
 
   const isSse = (upstream.headers.get("content-type") ?? "").includes("text/event-stream");
@@ -318,7 +357,7 @@ export async function forwardMeteredResponse(
           error: getErrorMessage(err),
         });
       });
-    const headers = cloneResponseHeaders(upstream.headers);
+    const headers = buildClientHeaders(upstream.headers, swap);
     // Guard the raw client branch FIRST (before the alias-swap pipe) so the
     // swapped stream is fed by a source that never errors — see
     // {@link guardSseTeardown} for why guarding after `pipeThrough` would leave
@@ -340,10 +379,25 @@ export async function forwardMeteredResponse(
   try {
     parsed = JSON.parse(bodyText);
   } catch {
-    // Non-JSON 2xx (unexpected) — forward without metering, scrubbing aliases.
-    const headers = cloneResponseHeaders(upstream.headers);
-    const clientBody = swap ? scrubModelText(bodyText, swap) : bodyText;
-    return new Response(clientBody, { status: upstream.status, headers });
+    // Non-JSON 2xx (unexpected) — forward without metering. With a swap the
+    // alias contract can't be upheld on an unparsable body (the echoed real
+    // model id can't be rewritten), so synthesize the neutral envelope and
+    // degrade the 2xx to a 502: a body the caller can't use as a completion
+    // must not masquerade as a success.
+    const headers = buildClientHeaders(upstream.headers, swap);
+    if (swap) {
+      logger.warn(`${logLabel}: non-JSON 2xx on aliased model — synthesized envelope`, {
+        status: upstream.status,
+        presetId: ctx.presetId,
+        runId: ctx.runId,
+      });
+      headers.set("content-type", "application/json");
+      return new Response(syntheticAliasErrorBody(swap, upstream.status), {
+        status: 502,
+        headers,
+      });
+    }
+    return new Response(bodyText, { status: upstream.status, headers });
   }
 
   // The upstream body is fully buffered, so awaiting the insert costs ~1ms and
@@ -351,7 +405,7 @@ export async function forwardMeteredResponse(
   // no-ops on null usage). Streaming uses `void` deliberately — already on wire.
   await meter(adapter.parseJsonUsage(parsed));
 
-  const headers = cloneResponseHeaders(upstream.headers);
+  const headers = buildClientHeaders(upstream.headers, swap);
   // Rewrite the echoed real id back to the alias BEFORE the body leaves the
   // server — and before caching, so a replay returns the alias too.
   const clientBody = swap ? swapResponseModelJson(bodyText, swap) : bodyText;

--- a/apps/api/src/services/llm-proxy/metering.ts
+++ b/apps/api/src/services/llm-proxy/metering.ts
@@ -51,7 +51,7 @@ export const cloneResponseHeaders = stripUpstreamResponseHeaders;
  * the shared allowlist ({@link LLM_PASSTHROUGH_RESPONSE_HEADERS} — same
  * posture as the sidecar), copying just the entries present upstream.
  */
-export function buildClientHeaders(upstream: Headers, swap: ModelSwap | null | undefined): Headers {
+function buildClientHeaders(upstream: Headers, swap: ModelSwap | null | undefined): Headers {
   if (!swap) return cloneResponseHeaders(upstream);
   const headers = new Headers();
   for (const name of LLM_PASSTHROUGH_RESPONSE_HEADERS) {
@@ -59,6 +59,25 @@ export function buildClientHeaders(upstream: Headers, swap: ModelSwap | null | u
     if (value !== null) headers.set(name, value);
   }
   return headers;
+}
+
+/**
+ * Synthesized neutral error response for an aliased model — the upstream
+ * body never reaches the caller (see {@link syntheticAliasErrorBody});
+ * `reason` and `logFields` carry the server-side detail instead.
+ */
+function syntheticAliasErrorResponse(
+  swap: ModelSwap,
+  upstream: Headers,
+  status: number,
+  reason: string,
+  logFields: Record<string, unknown>,
+): Response {
+  logger.warn(reason, logFields);
+  const headers = buildClientHeaders(upstream, swap);
+  // The synthesized body is JSON even when the upstream's wasn't.
+  headers.set("content-type", "application/json");
+  return new Response(syntheticAliasErrorBody(swap, status), { status, headers });
 }
 
 /**
@@ -324,22 +343,24 @@ export async function forwardMeteredResponse(
   if (!upstream.ok) {
     options.onUpstreamError?.(upstream.status);
     const errorBody = await upstream.text();
-    const headers = buildClientHeaders(upstream.headers, swap);
     if (swap) {
-      logger.warn(`${logLabel}: upstream error on aliased model — synthesized envelope`, {
-        status: upstream.status,
-        presetId: ctx.presetId,
-        runId: ctx.runId,
-        bodySample: errorBody.slice(0, 200),
-      });
-      // The synthesized body is JSON even when the upstream error wasn't.
-      headers.set("content-type", "application/json");
-      return new Response(syntheticAliasErrorBody(swap, upstream.status), {
-        status: upstream.status,
-        headers,
-      });
+      return syntheticAliasErrorResponse(
+        swap,
+        upstream.headers,
+        upstream.status,
+        `${logLabel}: upstream error on aliased model — synthesized envelope`,
+        {
+          status: upstream.status,
+          presetId: ctx.presetId,
+          runId: ctx.runId,
+          bodySample: errorBody.slice(0, 200),
+        },
+      );
     }
-    return new Response(errorBody, { status: upstream.status, headers });
+    return new Response(errorBody, {
+      status: upstream.status,
+      headers: cloneResponseHeaders(upstream.headers),
+    });
   }
 
   const isSse = (upstream.headers.get("content-type") ?? "").includes("text/event-stream");
@@ -384,20 +405,24 @@ export async function forwardMeteredResponse(
     // model id can't be rewritten), so synthesize the neutral envelope and
     // degrade the 2xx to a 502: a body the caller can't use as a completion
     // must not masquerade as a success.
-    const headers = buildClientHeaders(upstream.headers, swap);
     if (swap) {
-      logger.warn(`${logLabel}: non-JSON 2xx on aliased model — synthesized envelope`, {
-        status: upstream.status,
-        presetId: ctx.presetId,
-        runId: ctx.runId,
-      });
-      headers.set("content-type", "application/json");
-      return new Response(syntheticAliasErrorBody(swap, upstream.status), {
-        status: 502,
-        headers,
-      });
+      return syntheticAliasErrorResponse(
+        swap,
+        upstream.headers,
+        502,
+        `${logLabel}: non-JSON 2xx on aliased model — synthesized envelope`,
+        {
+          status: upstream.status,
+          presetId: ctx.presetId,
+          runId: ctx.runId,
+          bodySample: bodyText.slice(0, 200),
+        },
+      );
     }
-    return new Response(bodyText, { status: upstream.status, headers });
+    return new Response(bodyText, {
+      status: upstream.status,
+      headers: cloneResponseHeaders(upstream.headers),
+    });
   }
 
   // The upstream body is fully buffered, so awaiting the insert costs ~1ms and

--- a/apps/api/src/services/model-providers/credentials.ts
+++ b/apps/api/src/services/model-providers/credentials.ts
@@ -624,7 +624,12 @@ export async function listOrgModelProviderCredentials(
       const aliasOnly = aliasOnlySystemCredentials.has(id);
       return {
         id,
-        label: def.label ?? provider?.displayName ?? def.providerId,
+        // An alias-only credential must not fall back to the provider's
+        // display name / provider id — that would name the very backing this
+        // block hides (apiShape/baseUrl are nulled below for the same reason).
+        // Use a neutral fallback instead.
+        label:
+          def.label ?? (aliasOnly ? "System models" : (provider?.displayName ?? def.providerId)),
         apiShape: aliasOnly ? null : def.apiShape,
         baseUrl: aliasOnly ? null : def.baseUrl,
         source: "built-in",

--- a/apps/api/test/integration/routes/llm-proxy.test.ts
+++ b/apps/api/test/integration/routes/llm-proxy.test.ts
@@ -225,6 +225,28 @@ describe("POST /api/llm-proxy/openai-completions/v1/chat/completions", () => {
       }),
     });
     expect(res.status).toBe(400);
+    // Non-aliased presets keep the actionable detail — the message names the
+    // preset's actual protocol family so the caller can pick the right route.
+    expect(await res.text()).toContain("anthropic-messages");
+  });
+
+  it("masks the backing protocol family on an apiShape mismatch for an aliased preset", async () => {
+    // For an alias the public DTO nulls apiShape (`projectAliasedModel`), so
+    // the mismatch message must not name the backing family either.
+    const h = await buildHarness({ apiShape: "anthropic-messages", aliased: true });
+    mockUpstream(async () => new Response("should not be called", { status: 599 }));
+    const res = await app.request("/api/llm-proxy/openai-completions/v1/chat/completions", {
+      method: "POST",
+      headers: authHeaders(h),
+      body: JSON.stringify({
+        model: h.presetId,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+    expect(res.status).toBe(400);
+    const text = await res.text();
+    expect(text).not.toContain("anthropic");
+    expect(text).toContain("is not served by this endpoint");
   });
 
   it("forwards upstream errors verbatim without recording usage", async () => {
@@ -780,7 +802,10 @@ describe("POST /api/llm-proxy/* — model-alias swap", () => {
     expect(echoed).toContain(`"model":"${h.presetId}"`);
   });
 
-  it("scrubs the real id out of an upstream error body", async () => {
+  it("replaces an upstream error body with the synthetic envelope (never forwarded)", async () => {
+    // Error bodies are free-form prose that can name the backing anywhere, so
+    // for an alias they are synthesized (whitelist by construction), never
+    // forwarded-and-scrubbed: nothing of the upstream prose may survive.
     const h = await buildHarness({ aliased: true, modelId: "deepseek-chat-SECRET" });
     mockUpstream(
       async () =>
@@ -796,9 +821,12 @@ describe("POST /api/llm-proxy/* — model-alias swap", () => {
       body: JSON.stringify({ model: h.presetId, messages: [{ role: "user", content: "hi" }] }),
     });
 
+    // Status preserved for caller retry/backoff; body is the neutral envelope.
     expect(res.status).toBe(429);
     const text = await res.text();
-    expect(text).not.toContain("deepseek-chat-SECRET");
     expect(text).toContain(h.presetId);
+    expect(text).toContain("Upstream model error");
+    expect(text).not.toContain("deepseek-chat-SECRET");
+    expect(text).not.toContain("overloaded");
   });
 });

--- a/apps/api/test/unit/llm-proxy-metering.test.ts
+++ b/apps/api/test/unit/llm-proxy-metering.test.ts
@@ -122,6 +122,25 @@ async function readAll(stream: ReadableStream<Uint8Array>): Promise<string> {
   return out;
 }
 
+/**
+ * Minimal forwarding context. `resolved` is only read by the metering path,
+ * which no-ops when a branch never parses usage (error bodies, non-JSON) — a
+ * stand-in is sufficient for these pure forwarding tests.
+ */
+function makeCtx(overrides: Partial<MeteredForwardContext> = {}): MeteredForwardContext {
+  return {
+    principal: { kind: "jwt_user", userId: "u", orgId: "o" },
+    runId: null,
+    presetId: "preset",
+    resolved: {
+      modelId: "real-model",
+      apiShape: "anthropic-messages",
+    } as unknown as ResolvedModel,
+    started: 0,
+    ...overrides,
+  };
+}
+
 describe("guardSseTeardown", () => {
   it("passes frames through unchanged when the source closes normally", async () => {
     const seen: unknown[] = [];
@@ -178,20 +197,7 @@ describe("guardSseTeardown", () => {
       status: 200,
       headers: { "content-type": "text/event-stream" },
     });
-    const ctx: MeteredForwardContext = {
-      principal: { kind: "jwt_user", userId: "u", orgId: "o" },
-      runId: null,
-      presetId: "preset",
-      // Only read by the metering path, which no-ops on the null usage an
-      // errored stream yields — a minimal stand-in is sufficient here.
-      resolved: {
-        modelId: "real-model",
-        apiShape: "anthropic-messages",
-      } as unknown as ResolvedModel,
-      started: 0,
-    };
-
-    const res = await forwardMeteredResponse(upstream, anthropicMessagesAdapter, ctx, {
+    const res = await forwardMeteredResponse(upstream, anthropicMessagesAdapter, makeCtx(), {
       swap: { alias: "alias-model", real: "real-model" },
       logLabel: "test",
     });
@@ -218,5 +224,111 @@ describe("guardSseTeardown", () => {
     expect(cancelledWith).toBe("client gone");
     // A normal disconnect must NOT be reported as an upstream teardown.
     expect(seen).toEqual([]);
+  });
+});
+
+// Alias error synthesis + response-header allowlist (issue #727). For an
+// aliased model an upstream error body is never forwarded — it is REPLACED by
+// the neutral synthetic envelope — and response headers are reduced to the
+// shared allowlist, so neither prose nor headers can fingerprint the backing.
+// The no-swap path stays byte-for-byte permissive (subscription gateways).
+describe("forwardMeteredResponse — aliased error synthesis and header allowlist", () => {
+  const swap = { alias: "appstrate-medium", real: "deepseek-SECRET" };
+
+  it("replaces an aliased upstream error body with the synthetic envelope and strips fingerprinting headers", async () => {
+    const upstream = new Response(
+      JSON.stringify({
+        error: { message: "The model `deepseek-SECRET` is overloaded, try api.deepseek.com" },
+      }),
+      {
+        status: 529,
+        headers: {
+          "content-type": "application/json",
+          server: "cloudflare",
+          "cf-ray": "8f2a-CDG",
+          "anthropic-organization-id": "org_123",
+          "openai-organization": "org-abc",
+          "retry-after": "7",
+          "x-request-id": "req_1",
+        },
+      },
+    );
+
+    const res = await forwardMeteredResponse(upstream, anthropicMessagesAdapter, makeCtx(), {
+      swap,
+      logLabel: "test",
+    });
+
+    // Status flows for retry/backoff; the body is the neutral envelope —
+    // nothing of the upstream prose (nor the real id) survives.
+    expect(res.status).toBe(529);
+    expect(res.headers.get("content-type")).toBe("application/json");
+    const text = await res.text();
+    expect(text).toContain("appstrate-medium");
+    expect(text).toContain("Upstream model error");
+    expect(text).not.toContain("deepseek-SECRET");
+    expect(text).not.toContain("overloaded");
+
+    // Fingerprinting headers are dropped; allowlisted operational ones flow.
+    expect(res.headers.get("server")).toBeNull();
+    expect(res.headers.get("cf-ray")).toBeNull();
+    expect(res.headers.get("anthropic-organization-id")).toBeNull();
+    expect(res.headers.get("openai-organization")).toBeNull();
+    expect(res.headers.get("retry-after")).toBe("7");
+    expect(res.headers.get("x-request-id")).toBe("req_1");
+  });
+
+  it("forwards a no-swap upstream error verbatim with permissive headers", async () => {
+    const body = JSON.stringify({ error: { message: "rate limited" } });
+    const upstream = new Response(body, {
+      status: 529,
+      headers: { "content-type": "application/json", server: "cloudflare" },
+    });
+
+    const res = await forwardMeteredResponse(upstream, anthropicMessagesAdapter, makeCtx(), {
+      logLabel: "test",
+    });
+
+    expect(res.status).toBe(529);
+    // Permissive path intact: the fingerprinting header passes through.
+    expect(res.headers.get("server")).toBe("cloudflare");
+    expect(await res.text()).toBe(body);
+  });
+
+  it("synthesizes a 502 envelope for a non-JSON 2xx under a swap", async () => {
+    // An unparsable 2xx body can't have its echoed real id rewritten, so the
+    // alias contract can't be upheld — the gateway degrades it to a 502.
+    const upstream = new Response("<html>served by deepseek-SECRET</html>", {
+      status: 200,
+      headers: { "content-type": "text/html" },
+    });
+
+    const res = await forwardMeteredResponse(upstream, anthropicMessagesAdapter, makeCtx(), {
+      swap,
+      logLabel: "test",
+    });
+
+    expect(res.status).toBe(502);
+    expect(res.headers.get("content-type")).toBe("application/json");
+    const text = await res.text();
+    expect(text).toContain("appstrate-medium");
+    expect(text).toContain("Upstream model error");
+    expect(text).not.toContain("deepseek-SECRET");
+    expect(text).not.toContain("<html>");
+  });
+
+  it("keeps a no-swap non-JSON 2xx verbatim", async () => {
+    const upstream = new Response("plain text ok", {
+      status: 200,
+      headers: { "content-type": "text/plain", server: "cloudflare" },
+    });
+
+    const res = await forwardMeteredResponse(upstream, anthropicMessagesAdapter, makeCtx(), {
+      logLabel: "test",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("server")).toBe("cloudflare");
+    expect(await res.text()).toBe("plain text ok");
   });
 });

--- a/docs/architecture/MODEL_ALIASES.md
+++ b/docs/architecture/MODEL_ALIASES.md
@@ -19,9 +19,9 @@ the second.
 - **Threat B — the agent runtime (adversarial code inside the container).** The
   agent needs _some_ protocol/endpoint info to format requests, so the backing
   cannot be perfectly hidden from determined in-container code. **Reduced, not
-  eliminated** — the real `model` id, real upstream id in responses, and error
-  prose are swapped/scrubbed, but `MODEL_API` (protocol family) remains
-  observable.
+  eliminated** — the real `model` id is rewritten on success responses and
+  every error surface is synthesized (see below), but `MODEL_API` (protocol
+  family) remains observable.
 
 ## How resolution works
 
@@ -42,6 +42,50 @@ the alias never reaches upstream. Two layers hide the backing from users:
 The usage ledger (`llm_usage`) keeps the real id privately in `real_model` for
 billing/audit; the only service accessor (`listLlmUsageForRun`) projects just
 `id`/`costUsd`/`source`.
+
+## Error surfaces: synthesize, never scrub
+
+Success responses are rewritten by **exact field** (`model`, `message.model`,
+`response.model`) — generated content is never touched. Error surfaces are
+different: provider error bodies are free-form prose that can name the backing
+anywhere (model id, hostname, provider vocabulary). For an aliased model they
+are therefore **never forwarded at all** — each boundary REPLACES them with a
+neutral synthesized envelope (`syntheticAliasErrorBody`):
+
+```json
+{
+  "type": "error",
+  "error": {
+    "type": "upstream_error",
+    "message": "Upstream model error (model \"<alias>\", status 529)"
+  }
+}
+```
+
+This is a whitelist by construction — a scrub would be a blacklist where every
+forgotten surface is a new leak. Concretely:
+
+- **Non-2xx upstream bodies** (sidecar + gateway) → envelope at the upstream
+  status; the original body goes to server logs (truncated).
+- **Mid-stream SSE error frames** (Anthropic `type:"error"`, OpenAI-family
+  standalone top-level `error`, OpenAI Responses `response.failed`/
+  `response.incomplete` with a nested `response.error`) → replaced in-stream.
+  Frames carrying `choices` are content and stay on the exact-field path.
+- **Fetch-level failures** (ConnectionRefused / DNS / TLS, sidecar-synthesized 502) → the error `code` survives, the `(hostname)` hint is dropped.
+- **Response headers** → reduced to the shared allowlist
+  (`LLM_PASSTHROUGH_RESPONSE_HEADERS`: content-type, retry/RateLimit family,
+  x-request-id); `server`, `cf-ray`, `anthropic-*`, `openai-organization`, …
+  fingerprint the backing and are dropped.
+- **Locally-synthesized gateway messages** (protocol mismatch, SSRF refusal,
+  OAuth-subscription rejection, credential label fallback) name the alias only;
+  the backing detail is server-log-only.
+
+Status codes and the retry/backoff headers still flow, so client retry
+behavior is preserved. Non-aliased models keep full verbatim passthrough
+(bodies, headers, hostnames) — the opacity cost applies only to aliases, whose
+contract is precisely that opacity. The trade-off: aliased callers lose
+upstream error detail (e.g. a provider's "max_tokens too large" prose); the
+detail remains in server logs.
 
 ## Constraints
 

--- a/packages/core/src/model-swap.ts
+++ b/packages/core/src/model-swap.ts
@@ -174,7 +174,7 @@ export const LLM_PASSTHROUGH_RESPONSE_HEADERS: readonly string[] = [
  * every forgotten field is a new leak). The upstream detail stays in server
  * logs.
  */
-export const ALIAS_UPSTREAM_ERROR_MESSAGE = "Upstream model error";
+const ALIAS_UPSTREAM_ERROR_MESSAGE = "Upstream model error";
 
 /**
  * Caller-facing body replacing a non-2xx upstream response on an ALIASED
@@ -199,19 +199,29 @@ export function syntheticAliasErrorBody(swap: ModelSwap, status?: number): strin
   });
 }
 
+/** Non-null, non-array object — the only shape an error payload can take. */
+function isErrorObject(value: unknown): boolean {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /**
- * True when a parsed SSE frame is an error event — Anthropic emits
- * `{"type":"error","error":{...}}`, OpenAI-family streams emit a standalone
- * top-level `error` object (no `choices` alongside). The `choices` guard
- * keeps any hybrid frame that also carries generated content on the
- * exact-field path — content is never replaced.
+ * True when a parsed SSE frame is an error event:
+ *   - Anthropic: `{"type":"error","error":{...}}`,
+ *   - OpenAI-family: a standalone top-level `error` object (no `choices`
+ *     alongside — the `choices` guard keeps any hybrid frame that also
+ *     carries generated content on the exact-field path; content is never
+ *     replaced),
+ *   - OpenAI Responses terminal failures: `response.failed` /
+ *     `response.incomplete` nest it as `{"response":{"error":{...}}}` (a
+ *     successful snapshot carries `error: null`, which doesn't match).
  */
 function isSseErrorFrame(obj: unknown): boolean {
   if (!obj || typeof obj !== "object") return false;
   const o = obj as Record<string, unknown>;
   if (o["type"] === "error") return true;
-  const error = o["error"];
-  return typeof error === "object" && error !== null && !Array.isArray(error) && !("choices" in o);
+  if (isErrorObject(o["error"]) && !("choices" in o)) return true;
+  const response = o["response"];
+  return isErrorObject(response) && isErrorObject((response as Record<string, unknown>)["error"]);
 }
 
 /** Rewrite a single SSE line's `model` real→alias (data lines only). */

--- a/packages/core/src/model-swap.ts
+++ b/packages/core/src/model-swap.ts
@@ -28,10 +28,13 @@
  *     are aliasable, so this nesting MUST be covered or the real id leaks in
  *     the stream.
  *
- * The exception is {@link scrubModelText}: error bodies are free-form prose
- * ("the model `deepseek-chat` does not exist"), so the real id can sit anywhere.
- * There a blind substring replace is correct — an error body carries no
- * generated content to clobber.
+ * ERROR surfaces are handled differently: provider error bodies are free-form
+ * prose that can name the backing anywhere (model id, hostname, provider
+ * vocabulary), so for an aliased model they are never forwarded at all —
+ * {@link syntheticAliasErrorBody} REPLACES them with a neutral envelope
+ * (whitelist by construction; a scrub would be a blacklist where every
+ * forgotten surface is a new leak). Status code + allowlisted headers
+ * ({@link LLM_PASSTHROUGH_RESPONSE_HEADERS}) still flow for retry/backoff.
  */
 
 import type { ModelApiShape, ModelSwap } from "./sidecar-types.ts";
@@ -135,27 +138,102 @@ export function swapResponseModelJson(bodyText: string, swap: ModelSwap): string
 }
 
 /**
- * Blind substring replace of the real id with the alias, for ERROR bodies only.
- * Provider error payloads name the model in free-form prose
- * (`{"error":{"message":"model deepseek-chat is overloaded"}}`), so the exact-
- * field swap misses it. An error body carries no generated content, so a blind
- * replace cannot clobber anything meaningful. No-op when the body doesn't
- * mention the real id (the common case).
+ * Response headers forwarded to the caller from an upstream LLM provider.
+ * Shared posture for both inference data paths (the in-container sidecar
+ * proxy on every response, and the platform `/api/llm-proxy/*` gateway on
+ * aliased responses):
+ *
+ *   - `content-type` — required to parse the body
+ *   - `retry-after`, `RateLimit*` — required for backoff on 429
+ *   - `x-request-id` — provider-side error correlation
+ *
+ * Everything else (`server: cloudflare`, `cf-ray`, `anthropic-*`,
+ * `openai-organization`, Set-Cookie, hop-by-hop) is dropped — those headers
+ * fingerprint the backing provider and/or carry credentials.
  */
-export function scrubModelText(text: string, swap: ModelSwap): string {
-  if (!text.includes(swap.real)) return text;
-  return text.split(swap.real).join(swap.alias);
+export const LLM_PASSTHROUGH_RESPONSE_HEADERS: readonly string[] = [
+  "content-type",
+  "retry-after",
+  "ratelimit-limit",
+  "ratelimit-remaining",
+  "ratelimit-reset",
+  "x-ratelimit-limit-requests",
+  "x-ratelimit-remaining-requests",
+  "x-ratelimit-reset-requests",
+  "x-ratelimit-limit-tokens",
+  "x-ratelimit-remaining-tokens",
+  "x-ratelimit-reset-tokens",
+  "x-request-id",
+];
+
+/**
+ * Neutral message used in every synthesized error surface for an aliased
+ * model. Deliberately provider-agnostic: an alias's contract is that the
+ * caller never learns the backing, so error surfaces are SYNTHESIZED
+ * (whitelist by construction), never forwarded-and-scrubbed (blacklist —
+ * every forgotten field is a new leak). The upstream detail stays in server
+ * logs.
+ */
+export const ALIAS_UPSTREAM_ERROR_MESSAGE = "Upstream model error";
+
+/**
+ * Caller-facing body replacing a non-2xx upstream response on an ALIASED
+ * model. Nothing from the upstream body survives, so the backing (model id,
+ * hostname, provider error vocabulary) cannot leak regardless of what the
+ * provider wrote. The status code and the allowlisted headers
+ * ({@link LLM_PASSTHROUGH_RESPONSE_HEADERS} — `retry-after`, RateLimit
+ * family) still flow, so caller retry/backoff behavior is preserved.
+ *
+ * The envelope carries BOTH family discriminators — top-level
+ * `type: "error"` (Anthropic) and `error.message` (OpenAI family) — so a
+ * single shape parses in either SDK regardless of the aliased protocol.
+ */
+export function syntheticAliasErrorBody(swap: ModelSwap, status?: number): string {
+  const statusHint = status ? `, status ${status}` : "";
+  return JSON.stringify({
+    type: "error",
+    error: {
+      type: "upstream_error",
+      message: `${ALIAS_UPSTREAM_ERROR_MESSAGE} (model "${swap.alias}"${statusHint})`,
+    },
+  });
+}
+
+/**
+ * True when a parsed SSE frame is an error event — Anthropic emits
+ * `{"type":"error","error":{...}}`, OpenAI-family streams emit a standalone
+ * top-level `error` object (no `choices` alongside). The `choices` guard
+ * keeps any hybrid frame that also carries generated content on the
+ * exact-field path — content is never replaced.
+ */
+function isSseErrorFrame(obj: unknown): boolean {
+  if (!obj || typeof obj !== "object") return false;
+  const o = obj as Record<string, unknown>;
+  if (o["type"] === "error") return true;
+  const error = o["error"];
+  return typeof error === "object" && error !== null && !Array.isArray(error) && !("choices" in o);
 }
 
 /** Rewrite a single SSE line's `model` real→alias (data lines only). */
 function rewriteSseLine(line: string, swap: ModelSwap): string {
   if (!line.startsWith("data:")) return line;
   const payload = line.slice("data:".length).trimStart();
-  // Fast skip: the [DONE] sentinel and any chunk that doesn't mention the real
-  // id (the vast majority — content deltas) need no parse.
-  if (payload === "[DONE]" || !payload.includes(swap.real)) return line;
+  // Fast skip: the [DONE] sentinel and any chunk that mentions neither the
+  // real id nor an `"error"` key candidate (the vast majority — content
+  // deltas) need no parse. The `"error"` probe stays a plain substring check:
+  // a false positive just costs one parse, never a wrong rewrite.
+  if (payload === "[DONE]" || (!payload.includes(swap.real) && !payload.includes(`"error"`))) {
+    return line;
+  }
   try {
     const obj = JSON.parse(payload);
+    // Mid-stream error frames carry free-form prose that can name the backing
+    // (real id, hostname). Same posture as {@link syntheticAliasErrorBody}:
+    // REPLACE the frame wholesale, never forward-and-scrub. Error frames carry
+    // no generated content, so nothing meaningful is lost by the caller.
+    if (isSseErrorFrame(obj)) {
+      return `data: ${syntheticAliasErrorBody(swap)}`;
+    }
     rewriteModelRealToAlias(obj, swap);
     return `data: ${JSON.stringify(obj)}`;
   } catch {

--- a/packages/db/src/schema/runs.ts
+++ b/packages/db/src/schema/runs.ts
@@ -456,7 +456,11 @@ export const llmUsage = pgTable(
     // the preset id; `runs.model_label` is the canonical display name).
     model: text("model"),
     // Upstream model id the proxy actually forwarded — resolved from the
-    // preset via `loadModel()`. Optional on runner rows.
+    // preset via `loadModel()`. Optional on runner rows. SERVER-SIDE ONLY —
+    // for an aliased model this is the hidden backing id; never serialize it
+    // on any caller-facing surface (route, DTO, SSE, webhook) —
+    // `listLlmUsageForRun` deliberately selects only id/costUsd/source. Same
+    // for `api` below (backing protocol family).
     realModel: text("real_model"),
     // Protocol family: "openai-completions", "anthropic-messages", …
     // Optional on runner rows.

--- a/runtime-pi/sidecar/app.ts
+++ b/runtime-pi/sidecar/app.ts
@@ -25,7 +25,8 @@ import {
   swapRequestModel,
   swapResponseModelJson,
   createSseModelSwapStream,
-  scrubModelText,
+  syntheticAliasErrorBody,
+  LLM_PASSTHROUGH_RESPONSE_HEADERS,
 } from "./model-swap.ts";
 import { applyClaudeOauthGatewayHeaders } from "@appstrate/core/claude-oauth-gateway";
 import {
@@ -114,32 +115,6 @@ export interface AppDeps {
 }
 
 /**
- * Headers forwarded from the upstream LLM provider verbatim. Limited to
- * the ones the in-container agent legitimately needs to react to:
- *
- *   - `Content-Type` — required for the agent to parse the body
- *   - `Retry-After`, `RateLimit*` — required for backoff on 429
- *   - `x-request-id` — useful for cross-correlating provider-side errors
- *
- * Everything else (Set-Cookie, hop-by-hop, internal Anthropic headers) is
- * dropped to keep the sidecar↔agent boundary tight.
- */
-const PASSTHROUGH_RESPONSE_HEADERS = [
-  "content-type",
-  "retry-after",
-  "ratelimit-limit",
-  "ratelimit-remaining",
-  "ratelimit-reset",
-  "x-ratelimit-limit-requests",
-  "x-ratelimit-remaining-requests",
-  "x-ratelimit-reset-requests",
-  "x-ratelimit-limit-tokens",
-  "x-ratelimit-remaining-tokens",
-  "x-ratelimit-reset-tokens",
-  "x-request-id",
-];
-
-/**
  * Canonical casing for headers whose draft / standard spellings don't
  * match the naive Title-Case derivation. Generic Title-Casing turns
  * `ratelimit-limit` into `Ratelimit-Limit`, but the IETF RateLimit draft
@@ -178,7 +153,10 @@ async function passUpstream(
   swap?: ModelSwap,
 ): Promise<Response> {
   const responseHeaders: Record<string, string> = {};
-  for (const name of PASSTHROUGH_RESPONSE_HEADERS) {
+  // Shared upstream-response header allowlist (content-type, retry/backoff,
+  // x-request-id) — same posture as the platform LLM gateway; everything else
+  // is dropped to keep the sidecar↔agent boundary tight.
+  for (const name of LLM_PASSTHROUGH_RESPONSE_HEADERS) {
     const value = upstream.headers.get(name);
     if (value !== null) {
       // Re-cased to preserve canonical HTTP form for the agent. Special-cased
@@ -197,16 +175,31 @@ async function passUpstream(
 
   const contentType = (upstream.headers.get("content-type") ?? "").toLowerCase();
 
-  // Model-alias scrub for ERROR bodies. Provider error payloads name the model
-  // in free-form prose ("model `deepseek-chat` does not exist"), so the exact-
-  // field swap below misses it — and an alias's whole point is the agent never
-  // learns the backing id. An error body carries no generated content, so a
-  // blind substring replace is safe here (it isn't for 2xx). Applies to ANY
+  // Model-alias ERROR bodies are SYNTHESIZED, never forwarded. Provider error
+  // payloads are free-form prose that can name the backing anywhere (model id,
+  // hostname, provider vocabulary) — and an alias's whole point is the agent
+  // never learns the backing. So the upstream body stays server-side (logged
+  // for the operator, truncated) and the agent gets a neutral JSON envelope;
+  // status + allowlisted headers still flow for retry/backoff. Applies to ANY
   // content type on a non-2xx, mirroring the platform gateway (`llm-proxy/
   // core.ts`); errors are tiny, so buffering them costs nothing.
   if (swap && !upstream.ok) {
-    const text = await upstream.text();
-    return new Response(scrubModelText(text, swap), {
+    let bodySample = "";
+    try {
+      bodySample = await upstream.text();
+    } catch {
+      // body unreadable — log what we have
+    }
+    logger.warn("llm alias: upstream error body replaced by synthetic envelope", {
+      targetUrl: observe?.targetUrl,
+      status: upstream.status,
+      contentType: upstream.headers.get("content-type"),
+      bodySample: bodySample.length > 200 ? bodySample.slice(0, 200) + "…" : bodySample,
+    });
+    // The synthesized body is JSON even when the upstream error was text/html —
+    // the allowlist copied the upstream's content-type, so override it.
+    responseHeaders["Content-Type"] = "application/json";
+    return new Response(syntheticAliasErrorBody(swap, upstream.status), {
       status: upstream.status,
       headers: responseHeaders,
     });
@@ -329,14 +322,22 @@ async function logOauthLlmResponse(
   return upstream;
 }
 
-function llmFetchErrorResponse(c: Context, targetUrl: string, err: unknown): Response {
+function llmFetchErrorResponse(
+  c: Context,
+  targetUrl: string,
+  err: unknown,
+  swap?: ModelSwap,
+): Response {
   const code = err instanceof Error && "code" in err ? (err as { code: string }).code : undefined;
   let domain: string | undefined;
   try {
     domain = new URL(targetUrl).hostname;
   } catch {}
   const suffix = code ? `: ${code}` : "";
-  const domainHint = domain ? ` (${domain})` : "";
+  // The hostname identifies the backing provider; with an alias it must never
+  // reach the agent. The error `code` (e.g. ConnectionRefused) is generic and
+  // stays — it's useful and names nothing.
+  const domainHint = domain && !swap ? ` (${domain})` : "";
   return c.json({ error: `LLM request failed${suffix}${domainHint}` }, 502);
 }
 
@@ -631,7 +632,7 @@ export function createApp(deps: AppDeps): Hono {
         ...(body instanceof ReadableStream ? { duplex: "half" } : {}),
       });
     } catch (err) {
-      return llmFetchErrorResponse(c, targetUrl, err);
+      return llmFetchErrorResponse(c, targetUrl, err, apiKeyConfig.modelSwap);
     }
 
     return passUpstream(upstream, { targetUrl, authMode: "api_key" }, apiKeyConfig.modelSwap);
@@ -716,7 +717,7 @@ export function createApp(deps: AppDeps): Hono {
         targetUrl,
         error: err instanceof Error ? err.message : String(err),
       });
-      return llmFetchErrorResponse(c, targetUrl, err);
+      return llmFetchErrorResponse(c, targetUrl, err, llmConfig.modelSwap);
     }
 
     upstream = await logOauthLlmResponse(llmConfig.credentialId, targetUrl, upstream);

--- a/runtime-pi/sidecar/model-swap.ts
+++ b/runtime-pi/sidecar/model-swap.ts
@@ -14,6 +14,5 @@ export {
   syntheticAliasErrorBody,
   isAliasableApiShape,
   ALIASABLE_API_SHAPES,
-  ALIAS_UPSTREAM_ERROR_MESSAGE,
   LLM_PASSTHROUGH_RESPONSE_HEADERS,
 } from "@appstrate/core/model-swap";

--- a/runtime-pi/sidecar/model-swap.ts
+++ b/runtime-pi/sidecar/model-swap.ts
@@ -11,7 +11,9 @@ export {
   swapRequestModel,
   swapResponseModelJson,
   createSseModelSwapStream,
-  scrubModelText,
+  syntheticAliasErrorBody,
   isAliasableApiShape,
   ALIASABLE_API_SHAPES,
+  ALIAS_UPSTREAM_ERROR_MESSAGE,
+  LLM_PASSTHROUGH_RESPONSE_HEADERS,
 } from "@appstrate/core/model-swap";

--- a/runtime-pi/sidecar/test/model-swap-proxy.test.ts
+++ b/runtime-pi/sidecar/test/model-swap-proxy.test.ts
@@ -91,14 +91,14 @@ describe("/llm/* model-alias swap (api_key)", () => {
     expect(text).not.toContain("deepseek-chat");
   });
 
-  it("scrubs the real id from an upstream error body (free-form prose)", async () => {
-    // Provider 4xx names the model in prose, not a top-level `model` field —
-    // the exact-field swap would miss it, so the sidecar must blind-scrub.
+  it("replaces an upstream error body with the synthetic envelope (never forwarded)", async () => {
+    // Provider 4xx names the model in free-form prose — for an alias the body
+    // is never forwarded at all; the agent gets a neutral synthesized envelope.
     const fetchFn = mock(
       async () =>
         new Response(
           JSON.stringify({ error: { message: "The model `deepseek-chat` does not exist" } }),
-          { status: 404, headers: { "Content-Type": "application/json" } },
+          { status: 404, headers: { "Content-Type": "text/plain" } },
         ),
     ) as unknown as typeof fetch;
 
@@ -109,9 +109,51 @@ describe("/llm/* model-alias swap (api_key)", () => {
       body: JSON.stringify({ model: "appstrate-medium", messages: [] }),
     });
     expect(res.status).toBe(404);
+    // The synthesized body is JSON regardless of the upstream content-type.
+    expect(res.headers.get("content-type")).toBe("application/json");
     const text = await res.text();
-    expect(text).not.toContain("deepseek-chat");
     expect(text).toContain("appstrate-medium");
+    expect(text).toContain("Upstream model error");
+    expect(text).not.toContain("deepseek-chat");
+    expect(text).not.toContain("does not exist");
+  });
+
+  it("omits the upstream hostname from a fetch-level 502 when a swap is configured", async () => {
+    const fetchFn = mock(async () => {
+      throw Object.assign(new Error("connect ECONNREFUSED"), { code: "ConnectionRefused" });
+    }) as unknown as typeof fetch;
+
+    const app = createApp(makeDeps(fetchFn));
+    const res = await app.request("/llm/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "appstrate-medium", messages: [] }),
+    });
+    expect(res.status).toBe(502);
+    const text = await res.text();
+    // The generic error code stays useful; the hostname would name the backing.
+    expect(text).toContain("ConnectionRefused");
+    expect(text).not.toContain("deepseek");
+  });
+
+  it("keeps the upstream hostname in a fetch-level 502 when NO swap is configured", async () => {
+    const fetchFn = mock(async () => {
+      throw Object.assign(new Error("connect ECONNREFUSED"), { code: "ConnectionRefused" });
+    }) as unknown as typeof fetch;
+
+    const deps = makeDeps(fetchFn);
+    delete (deps.config.llm as { modelSwap?: unknown }).modelSwap;
+    const app = createApp(deps);
+    const res = await app.request("/llm/v1/chat/completions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: "appstrate-medium", messages: [] }),
+    });
+    expect(res.status).toBe(502);
+    const text = await res.text();
+    // No alias to protect — the hostname keeps its debugging value.
+    expect(text).toContain("ConnectionRefused");
+    expect(text).toContain("api.deepseek.com");
   });
 
   it("rewrites the streaming (SSE) response model real→alias in every chunk", async () => {

--- a/runtime-pi/sidecar/test/model-swap.test.ts
+++ b/runtime-pi/sidecar/test/model-swap.test.ts
@@ -14,8 +14,9 @@ import {
   swapRequestModel,
   swapResponseModelJson,
   createSseModelSwapStream,
-  scrubModelText,
+  syntheticAliasErrorBody,
   isAliasableApiShape,
+  ALIAS_UPSTREAM_ERROR_MESSAGE,
 } from "../model-swap.ts";
 
 const swap = { alias: "appstrate-medium", real: "deepseek-chat" };
@@ -217,26 +218,60 @@ describe("createSseModelSwapStream (real→alias, streaming)", () => {
     expect(out).toContain(`"model":"gpt-4o"`);
     expect(out).not.toContain("appstrate-small");
   });
+
+  it("replaces an Anthropic error frame with the synthetic envelope", async () => {
+    const input = `data: {"type":"error","error":{"type":"overloaded_error","message":"model deepseek-chat is overloaded"}}\n\n`;
+    const out = await pipeSse(input);
+    // Nothing from the upstream frame survives — not the id, not the prose.
+    expect(out).not.toContain("deepseek-chat");
+    expect(out).not.toContain("overloaded");
+    expect(out).toContain("appstrate-medium");
+    expect(out).toContain("upstream_error");
+  });
+
+  it("replaces an OpenAI-family standalone error frame with the synthetic envelope", async () => {
+    const input = `data: {"error":{"message":"deepseek-chat quota exceeded","code":429}}\n\n`;
+    const out = await pipeSse(input);
+    expect(out).not.toContain("deepseek-chat");
+    expect(out).not.toContain("quota");
+    expect(out).toContain("appstrate-medium");
+    expect(out).toContain("upstream_error");
+  });
+
+  it("keeps content-delta prose intact — only the model field is rewritten", async () => {
+    const input = `data: {"model":"deepseek-chat","choices":[{"delta":{"content":"I am deepseek-chat"}}]}\n\n`;
+    const out = await pipeSse(input);
+    expect(out).toContain(`"model":"appstrate-medium"`);
+    expect(out).toContain("I am deepseek-chat");
+  });
+
+  it("does NOT replace a hybrid frame carrying both an error object and choices content", async () => {
+    // A frame with generated content is never replaced wholesale — the
+    // `choices` guard keeps it on the exact-field rewrite path.
+    const input = `data: {"model":"deepseek-chat","error":{"message":"partial failure"},"choices":[{"delta":{"content":"kept text"}}]}\n\n`;
+    const out = await pipeSse(input);
+    expect(out).toContain("kept text");
+    expect(out).toContain(`"model":"appstrate-medium"`);
+    expect(out).not.toContain("upstream_error");
+  });
 });
 
-describe("scrubModelText (error-body blind scrub)", () => {
-  it("replaces every real-id mention in free-form error prose", () => {
-    const body = JSON.stringify({
-      error: { message: "The model `deepseek-chat` does not exist (deepseek-chat)" },
-    });
-    const out = scrubModelText(body, swap);
+describe("syntheticAliasErrorBody", () => {
+  it("names the alias and the neutral message, never the real id", () => {
+    const out = syntheticAliasErrorBody(swap);
+    expect(out).toContain("appstrate-medium");
+    expect(out).toContain(ALIAS_UPSTREAM_ERROR_MESSAGE);
     expect(out).not.toContain("deepseek-chat");
-    expect(out.match(/appstrate-medium/g)?.length).toBe(2);
   });
 
-  it("is a no-op when the body never mentions the real id", () => {
-    const body = "upstream unavailable";
-    expect(scrubModelText(body, swap)).toBe(body);
+  it("includes the upstream status when given", () => {
+    expect(syntheticAliasErrorBody(swap, 429)).toContain("429");
   });
 
-  it("no-ops cleanly when alias === real", () => {
-    const noop = { alias: "deepseek-chat", real: "deepseek-chat" };
-    expect(scrubModelText("model deepseek-chat down", noop)).toBe("model deepseek-chat down");
+  it("parses as a JSON error envelope (type + error.message)", () => {
+    const parsed = JSON.parse(syntheticAliasErrorBody(swap, 503));
+    expect(parsed.type).toBe("error");
+    expect(typeof parsed.error.message).toBe("string");
   });
 });
 

--- a/runtime-pi/sidecar/test/model-swap.test.ts
+++ b/runtime-pi/sidecar/test/model-swap.test.ts
@@ -16,7 +16,6 @@ import {
   createSseModelSwapStream,
   syntheticAliasErrorBody,
   isAliasableApiShape,
-  ALIAS_UPSTREAM_ERROR_MESSAGE,
 } from "../model-swap.ts";
 
 const swap = { alias: "appstrate-medium", real: "deepseek-chat" };
@@ -238,6 +237,26 @@ describe("createSseModelSwapStream (real→alias, streaming)", () => {
     expect(out).toContain("upstream_error");
   });
 
+  it("replaces an OpenAI Responses terminal-failure frame (nested response.error)", async () => {
+    // `response.failed` / `response.incomplete` nest the error one level down —
+    // the prose there names the backing just like a top-level error frame.
+    const input =
+      `event: response.failed\n` +
+      `data: {"type":"response.failed","response":{"model":"deepseek-chat","error":{"code":"server_error","message":"deepseek-chat unavailable at api.deepseek.com"}}}\n\n`;
+    const out = await pipeSse(input);
+    expect(out).not.toContain("deepseek");
+    expect(out).toContain("appstrate-medium");
+    expect(out).toContain("upstream_error");
+  });
+
+  it("does NOT replace a response snapshot whose error is null (success case)", async () => {
+    const input = `data: {"type":"response.completed","response":{"model":"deepseek-chat","error":null,"usage":{"total_tokens":5}}}\n\n`;
+    const out = await pipeSse(input);
+    expect(out).toContain(`"model":"appstrate-medium"`);
+    expect(out).toContain("total_tokens");
+    expect(out).not.toContain("upstream_error");
+  });
+
   it("keeps content-delta prose intact — only the model field is rewritten", async () => {
     const input = `data: {"model":"deepseek-chat","choices":[{"delta":{"content":"I am deepseek-chat"}}]}\n\n`;
     const out = await pipeSse(input);
@@ -260,7 +279,7 @@ describe("syntheticAliasErrorBody", () => {
   it("names the alias and the neutral message, never the real id", () => {
     const out = syntheticAliasErrorBody(swap);
     expect(out).toContain("appstrate-medium");
-    expect(out).toContain(ALIAS_UPSTREAM_ERROR_MESSAGE);
+    expect(out).toContain("Upstream model error");
     expect(out).not.toContain("deepseek-chat");
   });
 


### PR DESCRIPTION
## Context

Supersedes #817 (closed). A run on an aliased model surfaced `502 "LLM request failed: ConnectionRefused (api.deepseek.com)"` in its run log — the real backing hostname reached the agent, the run log, and the UI. An audit found sibling leaks: fingerprinting response headers (`server: cloudflare`, `cf-ray`, `anthropic-*`, `openai-organization`) forwarded on every aliased call, and gateway messages embedding the backing `providerId` / `apiShape` / `baseUrl`.

#817 fixed these by **scrubbing** upstream surfaces (hostname-aware blind replace, per-swap loops, finalize-time org-wide scrub). Review conclusion: a scrub is a blacklist — every forgotten surface is a new leak, and the mechanism kept growing (substring ordering, SSE frame classification, cross-swap collisions). This PR inverts the design.

## Design: synthesize, don't scrub

For an **aliased** model, error surfaces are never forwarded — they are **replaced** with a neutral envelope, so a leak is impossible by construction:

```json
{ "type": "error", "error": { "type": "upstream_error", "message": "Upstream model error (model \"<alias>\", status 529)" } }
```

The envelope carries both family discriminators (Anthropic top-level `type:"error"` + OpenAI-family `error.message`) so either SDK parses it. Status code and the shared header allowlist (`retry-after`, RateLimit family, `x-request-id`, `content-type`) still flow, so retry/backoff behavior is preserved. Upstream detail (truncated body sample, status, target) goes to server logs only. **Non-aliased models are byte-for-byte unchanged** — full error bodies, permissive headers, hostname in synthesized 502s.

## Changes

**Core (`@appstrate/core/model-swap`)**
- `syntheticAliasErrorBody(swap, status?)` + `ALIAS_UPSTREAM_ERROR_MESSAGE`.
- `scrubModelText` **deleted** — nothing upstream is forwarded on alias error paths, so there is nothing to scrub.
- `createSseModelSwapStream` replaces mid-stream error frames (Anthropic `type:"error"`, OpenAI-family standalone top-level `error`) with the envelope; any frame carrying `choices` is content and stays on the exact-field rewrite — generated prose is never touched.
- `LLM_PASSTHROUGH_RESPONSE_HEADERS`: single shared response-header allowlist (was duplicated verbatim in the sidecar; the gateway had none).

**Sidecar**
- Non-2xx upstream on an aliased model → envelope (upstream body logged server-side, truncated; `content-type: application/json` forced).
- Fetch-level 502 (ConnectionRefused / DNS / TLS): keeps the error `code`, drops the `(hostname)` hint when aliased — closes the reported leak. Non-aliased keeps the hostname (debugging value).

**Platform gateway (`/api/llm-proxy/*`)**
- Same envelope replacement on the error branch and the non-JSON-2xx branch (degraded to 502 — an unparsable body can't uphold the alias contract).
- Aliased responses forward only the shared header allowlist; non-aliased keep the permissive clone.
- Locally-synthesized messages stop naming the backing: OAuth-subscription rejection (`providerId`), protocol mismatch for aliased presets (`apiShape` — the DTO already nulls it), SSRF refusals (`baseUrl`), and the claude-code-sdk gateway equivalents. Details move to `logger.warn`/`logger.error`.

**Credentials & schema**
- Alias-only built-in credential label no longer falls back to the provider `displayName`/`providerId`.
- Never-serialize guard note on `llm_usage.real_model`/`api`.

## What #817 had that this PR deliberately drops

- `ModelSwap.realHost` + hostname scrubbing — unnecessary: no upstream prose is forwarded.
- Finalize-time org-wide scrub (`listAliasSwapsForOrg` on every errored run) — unnecessary: the LLM data paths can no longer emit backing-naming prose and the agent container only ever knows the alias. Also removes that design's false-positive rewrites and per-finalize DB work.

## Trade-off

Aliased callers lose upstream error detail (e.g. a provider's `max_tokens too large` prose). That is the alias contract — opacity — and the detail remains in server logs. Non-aliased models keep full passthrough.

## Tests

- Sidecar: 30 pass — envelope shape, SSE error-frame replacement (both families), hybrid `error`+`choices` frame anti-clobber, content-delta prose preservation, 502 hostname masked when aliased / kept when not, upstream error body replaced with `content-type` forced to JSON.
- API: metering unit 16 pass — header allowlist vs permissive path, envelope on error and non-JSON-2xx branches; llm-proxy integration — envelope end-to-end, protocol-mismatch masking (aliased) vs detail (non-aliased).
- `bun run check` green (33 tasks); 1767 tests pass across the touched suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)