### PR TITLE
perf(firecracker): cut guest cold start 907→325 ms — baked transpiler cache + host readahead

### DIFF
--- a/apps/api/src/modules/firecracker/guest/supervisor.ts
+++ b/apps/api/src/modules/firecracker/guest/supervisor.ts
@@ -39,6 +39,15 @@ const SIDECAR_BIN = "/usr/local/bin/sidecar";
 const RUNNER_EXEC_WRAPPER = "/usr/local/bin/appstrate-runner-exec";
 const AGENT_ENTRY = "/runtime/dist/entrypoint.js";
 const CONFIG_PATH = "/config/config.json";
+/**
+ * Pre-warmed Bun transpiler cache baked into the rootfs at image build (see
+ * runtime-pi/Dockerfile). The guest page cache is empty on every boot
+ * (VM-per-run), so skipping the re-parse of the bundled entrypoint + Pi SDK
+ * is a direct cold-start win. Docker containers inherit this from the image
+ * ENV; here the agent env comes from the config drive, so the supervisor
+ * injects it. New entries written at runtime land in the tmpfs overlay.
+ */
+const TRANSPILER_CACHE_PATH = "/runtime/.transpiler-cache";
 
 function log(msg: string): void {
   process.stdout.write(`[supervisor] ${msg}\n`);
@@ -254,7 +263,7 @@ async function main(): Promise<void> {
   const agent = spawnAs(
     GUEST_AGENT_USER,
     cfg.agent.argv ?? ["/usr/local/bin/bun", "run", AGENT_ENTRY],
-    cfg.agent.env,
+    { BUN_RUNTIME_TRANSPILER_CACHE_PATH: TRANSPILER_CACHE_PATH, ...cfg.agent.env },
     "/workspace",
   );
   log(`agent pid ${agent.pid}`);

--- a/apps/api/src/modules/firecracker/runner/daemon.ts
+++ b/apps/api/src/modules/firecracker/runner/daemon.ts
@@ -32,6 +32,7 @@ import { getFirecrackerEnv } from "./host-env.ts";
 import { getRunnerEnv } from "./env.ts";
 import { createRunnerApp } from "./server.ts";
 import { ensureGuestArtifacts } from "./artifacts.ts";
+import { warmHostPageCache } from "./readahead.ts";
 import { verifyGuestPath, type GuestPathResult } from "./net-probe.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
 import { logger } from "./logger.ts";
@@ -73,6 +74,15 @@ try {
 } catch (err) {
   fatal("guest artifacts", err);
 }
+
+// Warm the host page cache for the boot artifacts in the background
+// (issue #835): after a host reboot the first run otherwise pays cold-disk
+// virtio-blk latency for the whole guest boot read set. Deliberately not
+// awaited — a slow disk must not delay daemon readiness, and the warm is
+// pure best-effort (it logs, never throws).
+void warmHostPageCache([fcEnv.FIRECRACKER_ROOTFS_PATH, fcEnv.FIRECRACKER_KERNEL_PATH], {
+  logger,
+});
 
 // The guest-visible platform URL comes from the daemon's env, not from
 // the platform process env — on this host there IS no platform process.

--- a/apps/api/src/modules/firecracker/runner/readahead.ts
+++ b/apps/api/src/modules/firecracker/runner/readahead.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Host page-cache warmer for the guest boot artifacts (issue #835).
+ *
+ * Firecracker reads `rootfs.ext4` / `vmlinux` with buffered I/O, so once the
+ * host page cache is warm every guest virtio-blk read is served from host
+ * RAM. The cache is naturally warm right after the artifact resolver
+ * downloads a fresh file — but cold after a host reboot or an eviction, and
+ * the FIRST run then pays disk latency for the whole boot read set. A single
+ * sequential read at daemon boot moves that cost off the run path.
+ *
+ * Strictly best-effort instrumentation-grade code: any failure is a warning,
+ * never a boot blocker.
+ */
+
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import type { Logger } from "@appstrate/core/logger";
+
+/** Large sequential chunks — the point is readahead, not throughput fairness. */
+const CHUNK_BYTES = 8 * 1024 * 1024;
+
+async function warmFile(path: string): Promise<number> {
+  const { size } = await stat(path);
+  await new Promise<void>((resolve, reject) => {
+    const stream = createReadStream(path, { highWaterMark: CHUNK_BYTES });
+    // Data is discarded — reading it is the whole job (populates the cache).
+    stream.on("data", () => {});
+    stream.on("end", resolve);
+    stream.on("error", reject);
+  });
+  return size;
+}
+
+/**
+ * Sequentially read each artifact once to populate the host page cache.
+ * Files are warmed one at a time (parallel warming would defeat sequential
+ * readahead on spinning or contended disks). Never throws.
+ */
+export async function warmHostPageCache(paths: string[], deps: { logger: Logger }): Promise<void> {
+  for (const path of paths) {
+    const startedAt = performance.now();
+    try {
+      const bytes = await warmFile(path);
+      deps.logger.info("guest artifact page-cache warm complete", {
+        path,
+        mib: Math.round(bytes / (1024 * 1024)),
+        durationMs: Math.round(performance.now() - startedAt),
+      });
+    } catch (err) {
+      deps.logger.warn("guest artifact page-cache warm failed — continuing", {
+        path,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}

--- a/apps/api/src/modules/firecracker/test/unit/readahead.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/readahead.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the host page-cache warmer (runner/readahead.ts).
+ *
+ * The warmer is best-effort by contract: it must read every existing
+ * artifact end-to-end (that read IS the cache warm) and must never throw,
+ * whatever the filesystem does. Real temp files are used — the unit under
+ * test is literally "sequentially read this path".
+ */
+
+import { describe, it, expect, afterAll } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { warmHostPageCache } from "../../runner/readahead.ts";
+import type { Logger } from "@appstrate/core/logger";
+
+const dir = await mkdtemp(join(tmpdir(), "fc-readahead-"));
+afterAll(() => rm(dir, { recursive: true, force: true }));
+
+function captureLogger(): { logger: Logger; infos: unknown[]; warns: unknown[] } {
+  const infos: unknown[] = [];
+  const warns: unknown[] = [];
+  const logger = {
+    info: (_msg: string, fields?: unknown) => void infos.push(fields),
+    warn: (_msg: string, fields?: unknown) => void warns.push(fields),
+    error: () => {},
+    debug: () => {},
+  } as unknown as Logger;
+  return { logger, infos, warns };
+}
+
+describe("warmHostPageCache", () => {
+  it("reads each artifact fully and logs its size", async () => {
+    const rootfs = join(dir, "rootfs.ext4");
+    const kernel = join(dir, "vmlinux");
+    // Larger than one 8 MiB chunk so the multi-chunk stream path runs.
+    await writeFile(rootfs, new Uint8Array(9 * 1024 * 1024));
+    await writeFile(kernel, new Uint8Array(1024));
+
+    const { logger, infos, warns } = captureLogger();
+    await warmHostPageCache([rootfs, kernel], { logger });
+
+    expect(warns).toHaveLength(0);
+    expect(infos).toHaveLength(2);
+    expect(infos[0]).toMatchObject({ path: rootfs, mib: 9 });
+    expect(infos[1]).toMatchObject({ path: kernel, mib: 0 });
+  });
+
+  it("warns and continues past a missing file — never throws", async () => {
+    const present = join(dir, "present.ext4");
+    await writeFile(present, new Uint8Array(64));
+
+    const { logger, infos, warns } = captureLogger();
+    await warmHostPageCache([join(dir, "absent.ext4"), present], { logger });
+
+    expect(warns).toHaveLength(1);
+    expect(warns[0]).toMatchObject({ path: join(dir, "absent.ext4") });
+    // The failure did not short-circuit the remaining artifacts.
+    expect(infos).toHaveLength(1);
+    expect(infos[0]).toMatchObject({ path: present });
+  });
+});

--- a/runtime-pi/Dockerfile
+++ b/runtime-pi/Dockerfile
@@ -288,6 +288,25 @@ COPY --chown=pi:pi runtime-pi/mcp/        ./mcp/
 COPY --chown=pi:pi runtime-pi/*.ts        ./
 COPY --from=deps --chown=pi:pi /build/runtime-pi/dist/entrypoint.js ./dist/entrypoint.js
 
+# Pre-warmed Bun transpiler cache (issue #835). Bun re-parses every JS file
+# >50 KB on each process start — for the 1.6 MB bundled entrypoint plus the
+# external Pi SDK dist files that is a large share of the per-run cold start,
+# and on the firecracker adapter (VM-per-run, empty guest page cache) it is
+# paid on EVERY run. Baking the cache into the image turns that parse into a
+# single mmap-able `.pile` read. Priming = actually loading the module graph
+# with the cache path set: the entrypoint run exits 1 on env validation
+# (expected — AFTER the full static graph evaluated), then the lazily-imported
+# SDKs are loaded explicitly. Entries are keyed by content hash + Bun version,
+# so a stale cache is ignored, never wrong.
+ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=/runtime/.transpiler-cache
+RUN mkdir -p /runtime/.transpiler-cache \
+ && (bun /runtime/dist/entrypoint.js > /dev/null 2>&1 || true) \
+ && bun -e 'await import("@mariozechner/pi-ai"); await import("@mariozechner/pi-coding-agent");' \
+ && if [ "$INCLUDE_SUBSCRIPTION_ENGINES" = "true" ]; then \
+      bun -e 'await import("@anthropic-ai/claude-agent-sdk");'; \
+    fi \
+ && chown -R pi:pi /runtime/.transpiler-cache
+
 # Agent workspace. Bundled package entrypoints keep only the Pi SDK
 # pair external, resolved from `/runtime/packages/runner-pi/node_modules`
 # by `prepareBundleForPi`, so nothing under `/workspace` needs to

--- a/runtime-pi/Dockerfile
+++ b/runtime-pi/Dockerfile
@@ -305,6 +305,10 @@ RUN mkdir -p /runtime/.transpiler-cache \
  && if [ "$INCLUDE_SUBSCRIPTION_ENGINES" = "true" ]; then \
       bun -e 'await import("@anthropic-ai/claude-agent-sdk");'; \
     fi \
+ # Fail the build if priming produced nothing — an empty cache would be a
+ # silent cold-start regression (the entrypoint run above swallows its exit
+ # code by design, so this is the only guard that the graph actually loaded).
+ && [ -n "$(ls -A /runtime/.transpiler-cache)" ] \
  && chown -R pi:pi /runtime/.transpiler-cache
 
 # Agent workspace. Bundled package entrypoints keep only the Pi SDK


### PR DESCRIPTION
Closes #835.

## Problem

VM-per-run pays the full Bun cold start on every boot: **907–908 ms** measured on the preview host (Ryzen 7940HS) vs **204 ms** for the docker adapter — almost entirely parse/eval of the bundled entrypoint before the first breadcrumb, since the guest page cache is empty on every run.

## Changes

**1. Baked Bun transpiler cache** (`runtime-pi/Dockerfile`, `guest/supervisor.ts`)
- `BUN_RUNTIME_TRANSPILER_CACHE_PATH=/runtime/.transpiler-cache` set in the image, primed at build time: one entrypoint run (env-validation exit, after the full static graph evaluates) + explicit imports of the lazily-loaded SDKs → 19 `.pile` files (6.7 MB). Bun then mmaps instead of re-parsing every >50 KB module on each start.
- Build fails if priming yields an empty cache (guards against a silent regression if the entrypoint ever exits before the graph loads).
- Docker containers inherit the ENV; the firecracker guest gets the variable injected by the supervisor (agent env comes from the config drive, not image ENV). Config-drive env can still override.

**2. Host page-cache readahead** (`runner/readahead.ts`, `runner/daemon.ts`)
- The daemon sequentially reads `rootfs.ext4` + `vmlinux` once at boot (background, non-blocking): after a host reboot the first run's guest virtio-blk reads hit host RAM instead of cold disk. Best-effort by contract — logs, never throws. Unit-tested (multi-chunk read + missing-file continue).

## Measured (preview deployment, same agent/host as #835)

| | before (#835) | after |
|---|---|---|
| cold start | 907–908 ms | **325 / 325 / 329 ms** (−64%) |
| runtime ready | 954–996 ms | **788 ms** |
| vs docker local (204 ms) | 4.4× | **1.6×** — acceptance (≤2×) met |

Readahead observed live: rootfs 1850 MiB warmed in 407 ms at daemon boot.

## Rejected approaches (evaluated empirically)

- `bun build --bytecode`: requires `--format=cjs`, which forbids the entrypoint's top-level await AND cannot `require()` the Pi SDK (ESM-only exports map).
- `bun build --compile`: externals resolve from `/$bunfs`, breaking on-disk node_modules resolution entirely.
- The transpiler cache achieves the same parse-skip with zero module-format changes.

## Degradation model

Every failure path degrades to performance, never correctness: stale/corrupt/absent cache → Bun re-parses (cache keyed by content hash + Bun version, per-arch primed in each arch's own image build); unwritable cache dir → writes skipped; readahead failure → warn + continue.

## Remaining (out of scope)

- `sdkImportMs` ~400 ms residual: the external Pi SDK dist files are <50 KB each, under Bun's cache threshold. Runs concurrently with provisioning, so not the critical path today.
- Snapshot/resume stays the endgame fix (phase 3, post-jailer hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)