### PR TITLE
fix(docker): resolve egress network by name at use time so runs self-heal

### DIFF
--- a/apps/api/src/services/docker.ts
+++ b/apps/api/src/services/docker.ts
@@ -27,6 +27,20 @@ export const EXEC_NETWORK_PREFIX = "appstrate-exec-";
  */
 export const WORKSPACE_VOLUME_PREFIX = "appstrate-ws-";
 
+/**
+ * Name of the shared egress network sidecars (and `skipSidecar` agents)
+ * attach to for DNS + internet access. Durable infrastructure: it is
+ * resolved **by name at use time** (`ensureNetwork`), never removed by
+ * `shutdown()` nor by the boot orphan sweep — several API processes may
+ * share one Docker daemon (dev server + integration test app, blue/green
+ * deploys), and any of them deleting the network breaks every run of the
+ * others until their cached state is refreshed (#834). Docker itself
+ * refuses to delete a network with attached endpoints, but the network is
+ * empty between runs, so a name-based sweep still races; the only safe
+ * policy is to never delete it at all.
+ */
+export const EGRESS_NETWORK_NAME = "appstrate-egress";
+
 // Support both unix socket (/var/run/docker.sock) and TCP (http://host:port).
 // Bun supports fetch() with unix: option for Unix sockets.
 // Pass timeoutMs=false for long-running calls (streamLogs, waitForExit).
@@ -418,6 +432,52 @@ export async function createNetwork(
   return data.Id;
 }
 
+/**
+ * Resolve a network to its ID, creating it if it doesn't exist.
+ *
+ * This is the single access path for durable infra networks (the shared
+ * `appstrate-egress`): resolving **by name at use time** instead of caching
+ * an ID at boot means the platform self-heals when the network disappears
+ * under a live process — `docker network prune`, a daemon restart, or a
+ * concurrent Appstrate instance tearing it down (#834). The next run simply
+ * recreates it instead of failing every container create with
+ * `network <staleId> not found` until the API is restarted.
+ *
+ * Inspect-first keeps the steady-state cost to one GET (the network exists
+ * for the process's entire lifetime after the first run). The loop absorbs
+ * both races: two processes creating concurrently (409 duplicate → re-
+ * inspect picks up the winner's network) and inspect/create interleaving
+ * with an external delete. Three attempts is plenty — each iteration
+ * requires an external actor to flip the network's existence in a
+ * millisecond window; genuine failures (pool exhaustion, daemon down)
+ * throw immediately via `assertDockerOk`.
+ */
+export async function ensureNetwork(name: string): Promise<string> {
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const inspect = await dockerFetch(`/networks/${encodeURIComponent(name)}`);
+    if (inspect.ok) {
+      const data = (await inspect.json()) as { Id: string };
+      return data.Id;
+    }
+    await assertDockerOk(inspect, `inspect network ${name}`, [404]);
+
+    const create = await dockerFetch("/networks/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ Name: name, CheckDuplicate: true }),
+    });
+    if (create.ok) {
+      const data = (await create.json()) as { Id: string };
+      return data.Id;
+    }
+    // 409 = a concurrent creator won the race — loop back to inspect and
+    // adopt their network. Anything else (pool exhausted, daemon error) is
+    // a real failure and throws with the pool-exhaustion classification.
+    await assertDockerOk(create, `create network ${name}`, [409]);
+  }
+  throw new Error(`Docker ensure network ${name} failed: inspect/create raced 3 times`);
+}
+
 export async function connectContainerToNetwork(
   networkId: string,
   containerId: string,
@@ -669,30 +729,17 @@ export async function cleanupOrphanedContainers(): Promise<{
 }
 
 /**
- * List all Docker networks matching `appstrate-exec-*` or the shared
- * `appstrate-egress` infra network and remove them. Only safe to call at
- * startup because no runs should be running — egress is actively reused
- * across runs, so tearing it down mid-operation breaks egress routing.
- *
- * For opportunistic recovery during a live operation, use
- * {@link cleanupOrphanedRunNetworks} instead, which is strictly scoped to
- * per-run networks.
- */
-export async function cleanupOrphanedNetworks(): Promise<number> {
-  return removeNetworksMatching(
-    (name) => name.startsWith(EXEC_NETWORK_PREFIX) || name === "appstrate-egress",
-  );
-}
-
-/**
  * Remove orphan per-run networks (`appstrate-exec-*`) without touching the
- * shared infra networks. Safe to call mid-operation: Docker refuses to delete
- * networks that still have attached endpoints (live runs), so only truly
- * abandoned networks from crashed runs get reclaimed. Used as the opportunistic
+ * shared infra networks — {@link EGRESS_NETWORK_NAME} is durable and never
+ * swept (#834: a second API process booting against the same daemon used to
+ * delete it out from under the first one's live runs). Safe to call
+ * mid-operation: Docker refuses to delete networks that still have attached
+ * endpoints (live runs), so only truly abandoned networks from crashed runs
+ * get reclaimed. Called from the boot sweep and as the opportunistic
  * recovery path when `createNetwork` hits address-pool exhaustion —
  * reclaiming even one orphan is often enough to unblock the retry.
  */
-export async function cleanupOrphanedRunNetworks(): Promise<number> {
+export async function cleanupOrphanedNetworks(): Promise<number> {
   return removeNetworksMatching((name) => name.startsWith(EXEC_NETWORK_PREFIX));
 }
 

--- a/apps/api/src/services/orchestrator/docker-orchestrator.ts
+++ b/apps/api/src/services/orchestrator/docker-orchestrator.ts
@@ -52,7 +52,6 @@ export function sidecarSocketOverrides(
 }
 
 export class DockerOrchestrator implements ContainerOrchestrator {
-  private egressNetworkId: string | null = null;
   /**
    * Set of sidecar container IDs whose exit is expected (run is being
    * torn down). The {@link watchSidecarExit} watcher consults this set
@@ -80,22 +79,26 @@ export class DockerOrchestrator implements ContainerOrchestrator {
     // already masks the warm-image sidecar boot, so a pre-warmed pool buys
     // nothing extra on the user-visible latency.
     const env = getEnv();
-    const [, , , egressId] = await Promise.all([
+    await Promise.all([
       docker.ensureImage(env.PI_IMAGE),
       docker.ensureImage(env.SIDECAR_IMAGE),
       docker.detectPlatformNetwork(),
-      docker.createNetwork("appstrate-egress"),
+      // Warm the shared egress network so the first run doesn't pay the
+      // create. The ID is deliberately NOT cached: it is re-resolved by
+      // name on every use (createSidecar / createWorkload) so the process
+      // self-heals when the network disappears mid-lifetime (#834).
+      docker.ensureNetwork(docker.EGRESS_NETWORK_NAME),
     ]);
     this.verifiedImages.add(env.PI_IMAGE);
     this.verifiedImages.add(env.SIDECAR_IMAGE);
-    this.egressNetworkId = egressId;
   }
 
   async shutdown(): Promise<void> {
-    if (this.egressNetworkId) {
-      await docker.removeNetwork(this.egressNetworkId).catch(() => {});
-      this.egressNetworkId = null;
-    }
+    // The egress network is intentionally left in place: it is durable
+    // infra shared with any other Appstrate process on this daemon (#834).
+    // Removing it here used to break the runs of a concurrently-running
+    // instance, whose cached network ID went stale.
+    //
     // Drop any residual entries — long-lived API processes accumulate
     // one per timed-out / aborted run because `removeWorkload` always
     // re-adds after `stopWorkload` consumed the watcher's match.
@@ -135,7 +138,7 @@ export class DockerOrchestrator implements ContainerOrchestrator {
     const [networkResult, volumeResult] = await Promise.allSettled([
       createNetworkWithPoolRetry(
         () => docker.createNetwork(name, { internal: true }),
-        () => docker.cleanupOrphanedRunNetworks(),
+        () => docker.cleanupOrphanedNetworks(),
         logger,
       ),
       (async () => {
@@ -260,9 +263,14 @@ export class DockerOrchestrator implements ContainerOrchestrator {
     spec: SidecarLaunchSpec,
   ): Promise<WorkloadHandle> {
     const env = getEnv();
-    const [platformApiUrl, platformNetwork] = await Promise.all([
+    // Resolve the egress network by name on every use (not a boot-time
+    // cached ID): if it vanished mid-lifetime (`docker network prune`,
+    // daemon restart, another Appstrate process), ensureNetwork recreates
+    // it and the run proceeds instead of 404ing until an API restart (#834).
+    const [platformApiUrl, platformNetwork, egressNetworkId] = await Promise.all([
       this.resolvePlatformApiUrl(),
       docker.detectPlatformNetwork(),
+      docker.ensureNetwork(docker.EGRESS_NETWORK_NAME),
     ]);
 
     const sidecarEnv: Record<string, string> = {
@@ -308,7 +316,7 @@ export class DockerOrchestrator implements ContainerOrchestrator {
       adapterName: "sidecar",
       memory: SIDECAR_MEMORY_BYTES,
       nanoCpus: SIDECAR_NANO_CPUS,
-      networkId: this.egressNetworkId!,
+      networkId: egressNetworkId,
       extraHosts: platformNetwork ? [] : ["host.docker.internal:host-gateway"],
       ...sidecarSocketOverrides(spec),
     });
@@ -402,7 +410,14 @@ export class DockerOrchestrator implements ContainerOrchestrator {
     // as the sidecar (egress network primary + host-gateway / platform net)
     // instead of the internal-only isolation boundary, which has no route
     // out and would fail the agent's first `emitRuntimeReady` POST.
-    const platformNetwork = spec.egress ? await docker.detectPlatformNetwork() : null;
+    // Same by-name resolution as createSidecar: never trust a cached
+    // network ID across the process lifetime (#834).
+    const [platformNetwork, egressNetworkId] = spec.egress
+      ? await Promise.all([
+          docker.detectPlatformNetwork(),
+          docker.ensureNetwork(docker.EGRESS_NETWORK_NAME),
+        ])
+      : [null, null];
 
     // Mount the per-run workspace into the agent container at
     // /workspace (already exists as the agent's CWD, chowned to `pi`
@@ -422,7 +437,7 @@ export class DockerOrchestrator implements ContainerOrchestrator {
       memory: spec.resources.memoryBytes,
       nanoCpus: spec.resources.nanoCpus,
       pidsLimit: spec.resources.pidsLimit,
-      networkId: spec.egress ? this.egressNetworkId! : boundary.id,
+      networkId: egressNetworkId ?? boundary.id,
       networkAlias: spec.role,
       ...(workspaceBinds.length > 0 ? { binds: workspaceBinds } : {}),
       ...(spec.egress

--- a/apps/api/test/integration/services/docker-api.test.ts
+++ b/apps/api/test/integration/services/docker-api.test.ts
@@ -11,12 +11,13 @@ import {
   removeContainer,
   stopContainer,
   createNetwork,
+  ensureNetwork,
   connectContainerToNetwork,
   removeNetwork,
   cleanupOrphanedContainers,
   cleanupOrphanedNetworks,
-  cleanupOrphanedRunNetworks,
   cleanupOrphanedVolumes,
+  EGRESS_NETWORK_NAME,
   createVolume,
   removeVolume,
   runEphemeralCommand,
@@ -564,22 +565,22 @@ describeRequiresDocker("cleanupOrphanedNetworks", () => {
     },
     TIMEOUT,
   );
-});
 
-// ─── cleanupOrphanedRunNetworks ──────────────────────────────
-
-describeRequiresDocker("cleanupOrphanedRunNetworks", () => {
+  // Regression #834: the sweep used to also match `appstrate-egress` by
+  // name, so a second API process booting against the same daemon deleted
+  // the shared egress network out from under the first one's live runs.
+  // The egress network is durable infra — never swept.
   it(
-    "only reclaims appstrate-exec-* — leaves egress alone",
+    "leaves the shared egress network alone (#834)",
     async () => {
       await cleanupOrphanedNetworks();
 
       const execOrphan = await createNetwork(`appstrate-exec-orphan-${uid()}`);
       // Simulate the shared infra network the orchestrator stands up at boot.
-      const egress = await createNetwork("appstrate-egress");
+      const egress = await ensureNetwork(EGRESS_NETWORK_NAME);
       trackNetwork(egress);
 
-      const reclaimed = await cleanupOrphanedRunNetworks();
+      const reclaimed = await cleanupOrphanedNetworks();
       expect(reclaimed).toBeGreaterThanOrEqual(1);
 
       const execGone = await fetch(`${DOCKER_URL}/networks/${execOrphan}`);
@@ -587,6 +588,76 @@ describeRequiresDocker("cleanupOrphanedRunNetworks", () => {
 
       const egressStill = await fetch(`${DOCKER_URL}/networks/${egress}`);
       expect(egressStill.status).toBe(200);
+    },
+    TIMEOUT,
+  );
+});
+
+// ─── ensureNetwork ───────────────────────────────────────────
+
+describeRequiresDocker("ensureNetwork", () => {
+  it(
+    "creates the network when absent and returns its ID",
+    async () => {
+      const name = `appstrate-test-ensure-${uid()}`;
+      const id = trackNetwork(await ensureNetwork(name));
+
+      const res = await fetch(`${DOCKER_URL}/networks/${id}`);
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { Name: string };
+      expect(data.Name).toBe(name);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "is idempotent — returns the existing network's ID without recreating",
+    async () => {
+      const name = `appstrate-test-ensure-${uid()}`;
+      const first = trackNetwork(await ensureNetwork(name));
+      const second = await ensureNetwork(name);
+
+      expect(second).toBe(first);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "self-heals after the network is deleted under a live process (#834)",
+    async () => {
+      // Repro of the issue: resolve once (boot), delete the network out of
+      // band (`docker network rm` / concurrent instance shutdown), resolve
+      // again at next use — must yield a fresh, working network instead of
+      // a stale ID that 404s every subsequent container create.
+      const name = `appstrate-test-ensure-${uid()}`;
+      const staleId = await ensureNetwork(name);
+      await removeNetwork(staleId);
+
+      const freshId = trackNetwork(await ensureNetwork(name));
+      expect(freshId).not.toBe(staleId);
+
+      const res = await fetch(`${DOCKER_URL}/networks/${freshId}`);
+      expect(res.status).toBe(200);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "converges concurrent callers onto a single network (create race)",
+    async () => {
+      // Two API processes booting simultaneously both ensure the egress
+      // network; the 409 loser must adopt the winner's network via
+      // re-inspect, not fail the boot.
+      const name = `appstrate-test-ensure-${uid()}`;
+      const ids = await Promise.all([
+        ensureNetwork(name),
+        ensureNetwork(name),
+        ensureNetwork(name),
+        ensureNetwork(name),
+      ]);
+      trackNetwork(ids[0]!);
+
+      expect(new Set(ids).size).toBe(1);
     },
     TIMEOUT,
   );

--- a/apps/api/test/integration/services/docker-orchestrator-egress.test.ts
+++ b/apps/api/test/integration/services/docker-orchestrator-egress.test.ts
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Regression #834 — orchestrator-level: the DockerOrchestrator used to cache
+ * the egress network's ID at boot and reuse it for every run. When the
+ * network disappeared mid-lifetime (concurrent Appstrate instance shutting
+ * down, `docker network prune`, daemon restart) every subsequent run failed
+ * with `network <staleId> not found` until the API was restarted.
+ *
+ * The fix resolves the egress network **by name at use time** (create-or-get
+ * via `ensureNetwork`), so a run launched after the network vanished simply
+ * recreates it. These tests exercise the exact repro from the issue against
+ * the real Docker daemon (DinD).
+ */
+
+import { expect, it, afterEach } from "bun:test";
+import { describeRequiresDocker } from "../../helpers/tier.ts";
+import { DockerOrchestrator } from "../../../src/services/orchestrator/docker-orchestrator.ts";
+import {
+  ensureNetwork,
+  removeNetwork,
+  removeContainersByRun,
+  EGRESS_NETWORK_NAME,
+} from "../../../src/services/docker.ts";
+import type { IsolationBoundary, WorkloadHandle } from "@appstrate/core/platform-types";
+
+const DOCKER_URL = "http://localhost:2375";
+const IMAGE = "alpine:3.20";
+const TIMEOUT = 30_000;
+
+function uid(): string {
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+const orchestrator = new DockerOrchestrator();
+
+// Per-test resources reclaimed even on assertion failure.
+const runsToCleanup: string[] = [];
+const boundariesToCleanup: IsolationBoundary[] = [];
+
+afterEach(async () => {
+  await Promise.allSettled(runsToCleanup.map((runId) => removeContainersByRun(runId)));
+  runsToCleanup.length = 0;
+  await Promise.allSettled(boundariesToCleanup.map((b) => orchestrator.removeIsolationBoundary(b)));
+  boundariesToCleanup.length = 0;
+});
+
+async function inspectContainerNetworks(containerId: string): Promise<Record<string, unknown>> {
+  const res = await fetch(`${DOCKER_URL}/containers/${containerId}/json`);
+  expect(res.status).toBe(200);
+  const data = (await res.json()) as {
+    NetworkSettings: { Networks: Record<string, unknown> };
+  };
+  return data.NetworkSettings.Networks;
+}
+
+describeRequiresDocker("DockerOrchestrator egress network resilience (#834)", () => {
+  it(
+    "launches an egress workload after the egress network was deleted out of band",
+    async () => {
+      const runId = `egress-heal-${uid()}`;
+      runsToCleanup.push(runId);
+
+      // Boot-equivalent: the network exists (a previous run / initialize
+      // created it)...
+      const staleId = await ensureNetwork(EGRESS_NETWORK_NAME);
+
+      const boundary = await orchestrator.createIsolationBoundary(runId);
+      boundariesToCleanup.push(boundary);
+
+      // ...then a concurrent instance's shutdown (or `docker network rm
+      // appstrate-egress`) deletes it while this process is still alive.
+      await removeNetwork(staleId);
+
+      // Next run must self-heal: create + START must succeed (the issue's
+      // failure mode was `Docker start container failed: 404 network not
+      // found` — create alone doesn't prove the wiring works).
+      const handle: WorkloadHandle = await orchestrator.createWorkload(
+        {
+          runId,
+          role: "agent",
+          image: IMAGE,
+          env: {},
+          resources: { memoryBytes: 64 * 1024 * 1024, nanoCpus: 500_000_000 },
+          egress: true,
+        },
+        boundary,
+      );
+      await orchestrator.startWorkload(handle);
+      const exitCode = await orchestrator.waitForExit(handle);
+      expect(exitCode).toBe(0);
+
+      // The workload landed on a *fresh* egress network, not the stale ID.
+      const networks = await inspectContainerNetworks(handle.id);
+      const egressEndpoint = networks[EGRESS_NETWORK_NAME] as { NetworkID: string } | undefined;
+      expect(egressEndpoint).toBeDefined();
+      expect(egressEndpoint!.NetworkID).not.toBe(staleId);
+    },
+    TIMEOUT,
+  );
+
+  it(
+    "shutdown() leaves the shared egress network in place for other instances",
+    async () => {
+      const egressId = await ensureNetwork(EGRESS_NETWORK_NAME);
+
+      await orchestrator.shutdown();
+
+      const res = await fetch(`${DOCKER_URL}/networks/${egressId}`);
+      expect(res.status).toBe(200);
+    },
+    TIMEOUT,
+  );
+});


### PR DESCRIPTION
Closes #834

## Problem

`DockerOrchestrator` created the shared `appstrate-egress` network at boot and cached its **ID** for the process lifetime. When the network disappeared under a live API — a concurrent instance's `shutdown()` removing it, a second instance's boot sweep matching it by name, `docker network prune`, or a daemon restart — the cached ID went stale and **every subsequent run failed** with `network <id> not found` until the API was restarted. The dev setup hit this routinely (integration test app + `bun run dev` sharing one daemon).

## Root cause (one level above the symptom)

The egress network was treated as a process-owned ephemeral resource (create at init, delete at shutdown, sweep at boot) while it is actually **durable infrastructure shared across API processes** on the same Docker daemon. The stale-ID crash is just the visible consequence of that ownership mismatch.

## Fix

- **`ensureNetwork(name)`** (new, `docker.ts`): create-or-get, inspect-first, race-safe (409 loser adopts the winner's network via re-inspect). The orchestrator resolves the egress network **by name on every use** (`createSidecar`, egress `createWorkload`) instead of trusting a boot-time cached ID — so a vanished network is recreated transparently on the next run. Steady-state cost: one `GET`, resolved in parallel with the per-run Docker calls already on that path (zero added latency).
- **`shutdown()` no longer deletes `appstrate-egress`** — doing so broke the runs of any concurrently-running instance.
- **Boot orphan sweep no longer matches `appstrate-egress`** — it is strictly scoped to per-run `appstrate-exec-*` networks. `cleanupOrphanedRunNetworks` and `cleanupOrphanedNetworks` became identical and are collapsed into one.

Deliberately **not** included (kept minimal per the issue triage): retry-wrapping container create/start on 404 — with by-name resolution per run, the only residual window is an external delete in the milliseconds between resolve and start, and the very next run self-heals; and sweeping `Created`-state containers — the boot sweep already force-removes all `appstrate.managed=true` containers with `all=true`.

## Tests (DinD)

- `ensureNetwork`: creates when absent, idempotent, self-heals after out-of-band delete (issue repro), converges 4 concurrent callers onto a single network.
- `cleanupOrphanedNetworks`: reclaims `appstrate-exec-*`, **leaves egress alone** (regression test for the boot-sweep kill path).
- New `docker-orchestrator-egress.test.ts`: orchestrator-level repro — delete egress out of band, then `createWorkload(egress: true)` + **start** succeeds on a fresh network (the issue's failure mode was at start); `shutdown()` leaves the shared network in place.

## Validation

- `bun run check`: 33/33 tasks pass
- `TEST_DOCKER=1 bun test apps/api/test`: 2806 pass, 0 fail (245 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)