### PR TITLE
fix(firecracker): resolve PR #838 review blockers + should-fixes

### DIFF
--- a/.github/workflows/firecracker.yml
+++ b/.github/workflows/firecracker.yml
@@ -20,6 +20,8 @@ on:
       - "packages/core/**"
       - "packages/env/**"
       - "runtime-pi/Dockerfile"
+      - "runtime-pi/entrypoint.ts"
+      - "packages/runner-pi/**"
       - "runtime-pi/sidecar/**"
       - ".github/workflows/firecracker.yml"
   pull_request:
@@ -33,6 +35,8 @@ on:
       - "packages/core/**"
       - "packages/env/**"
       - "runtime-pi/Dockerfile"
+      - "runtime-pi/entrypoint.ts"
+      - "packages/runner-pi/**"
       - "runtime-pi/sidecar/**"
       - ".github/workflows/firecracker.yml"
   workflow_dispatch:

--- a/apps/api/src/modules/firecracker/credential-split.ts
+++ b/apps/api/src/modules/firecracker/credential-split.ts
@@ -11,40 +11,41 @@
  * merges it back over the drive maps (see guest/supervisor.ts).
  *
  * Why a split, not a wholesale move: the drive still carries the run's
- * non-secret configuration (URLs, ids, feature flags), and MMDS has a hard
- * size ceiling. INTEGRATIONS_TO_SPAWN_JSON in particular can be large
- * (bundle bytes + live spawn env) — larger than the MMDS store limit. So
- * the split ENFORCES the ceiling: if the serialized payload would overflow,
- * the largest offending secret keys spill BACK onto the drive (least-bad:
- * that key rides the drive like before, everything else stays brokered)
- * and their NAMES are reported so the caller can warn (never their values).
+ * non-secret configuration (URLs, ids, feature flags) — only secrets need
+ * the in-memory path.
  *
- * No I/O here — the caller logs the spill and PUTs the payload.
+ * A known secret NEVER falls back onto the drive. When the serialized
+ * payload exceeds Firecracker's default 50 KiB store, the orchestrator
+ * raises the VMM's store/API payload limits at spawn
+ * (`--mmds-size-limit` / `--http-api-max-payload-size`) up to
+ * FIRECRACKER_MMDS_MAX_BYTES, and FAIL-CLOSES the run beyond that ceiling
+ * — silently degrading a known secret to at-rest storage is worse than
+ * failing the run loudly.
+ *
+ * No I/O here — the caller PUTs the payload.
  */
 
 /**
  * Firecracker's MMDS data store is bounded by `--mmds-size-limit`, which
  * defaults to `--http-api-max-payload-size` = 51200 bytes when neither is
- * set (we pass neither — the store keeps the 50 KiB default). The stored
- * blob is exactly the JSON we PUT, so this is the ceiling our payload must
- * fit under.
+ * set. The stored blob is exactly the JSON we PUT; payloads above this
+ * default make the orchestrator pass both flags explicitly.
  */
 export const MMDS_STORE_LIMIT_BYTES = 51_200;
 
 /**
- * Headroom kept below {@link MMDS_STORE_LIMIT_BYTES}: the V2 session-token
- * bookkeeping shares the same HTTP payload budget, and Firecracker's
- * internal representation is not byte-identical to our serialized JSON.
- * A conservative margin so a payload that unit-fits also fits live.
+ * Headroom added on top of the serialized payload when sizing the VMM's
+ * store: the V2 session-token bookkeeping shares the same HTTP payload
+ * budget, and Firecracker's internal representation is not byte-identical
+ * to our serialized JSON. A conservative margin so a payload that
+ * unit-fits also fits live.
  */
 export const MMDS_SAFETY_MARGIN_BYTES = 4_096;
 
-/** Effective budget the serialized MMDS payload must not exceed. */
-export const MMDS_PAYLOAD_BUDGET_BYTES = MMDS_STORE_LIMIT_BYTES - MMDS_SAFETY_MARGIN_BYTES;
-
 /**
  * Sidecar-env keys that carry secrets (LLM keys, run token, OAuth config,
- * per-integration spawn env with live credentials, cookie-session logins).
+ * per-integration spawn env with live credentials, cookie-session logins,
+ * the forward-proxy URL — it can embed `user:pass@host` credentials).
  * Everything else in the sidecar env is non-secret configuration.
  */
 export const SIDECAR_SECRET_KEYS: readonly string[] = [
@@ -53,10 +54,16 @@ export const SIDECAR_SECRET_KEYS: readonly string[] = [
   "PI_LLM_OAUTH_CONFIG_JSON",
   "CONNECT_LOGIN_JSON",
   "INTEGRATIONS_TO_SPAWN_JSON",
+  "PROXY_URL",
 ];
 
-/** Agent-env keys that carry secrets (the HMAC sink signing secret). */
-export const AGENT_SECRET_KEYS: readonly string[] = ["APPSTRATE_SINK_SECRET"];
+/**
+ * Agent-env keys that carry secrets: the HMAC sink signing secret, and —
+ * on skipSidecar (direct-provider) runs — the REAL model API key
+ * (sidecar-backed runs only ever put the placeholder in the agent env,
+ * which is harmless to broker too).
+ */
+export const AGENT_SECRET_KEYS: readonly string[] = ["APPSTRATE_SINK_SECRET", "MODEL_API_KEY"];
 
 /** MMDS store contents (snake_case wire — the guest supervisor reads these). */
 export interface MmdsPayload {
@@ -67,33 +74,26 @@ export interface MmdsPayload {
 export interface CredentialSplit {
   /**
    * Sidecar env for the config drive — the input minus the brokered
-   * secrets (plus any that spilled back). `undefined` when the input
-   * sidecar env was `undefined` (skipSidecar runs).
+   * secrets. `undefined` when the input sidecar env was `undefined`
+   * (skipSidecar runs).
    */
   driveSidecarEnv: Record<string, string> | undefined;
   /** Agent env for the config drive — the input minus the brokered secrets. */
   driveAgentEnv: Record<string, string>;
   /** Secrets served in-memory via MMDS. */
   mmdsPayload: MmdsPayload;
-  /**
-   * Names (never values) of secret keys that had to spill back onto the
-   * drive because the MMDS payload exceeded the budget. Empty on the
-   * common path. The caller logs these at warn level.
-   */
-  spilledKeys: string[];
 }
 
 /** Serialized byte length of the MMDS payload as it will be PUT. */
-function payloadBytes(payload: MmdsPayload): number {
+export function mmdsPayloadBytes(payload: MmdsPayload): number {
   return Buffer.byteLength(JSON.stringify(payload));
 }
 
 /**
  * Split the run's env maps into a config-drive part and an MMDS part.
- * Known-secret keys move to MMDS; if the serialized MMDS payload exceeds
- * {@link MMDS_PAYLOAD_BUDGET_BYTES}, the largest offending secrets spill
- * back to the drive (largest-first) until it fits. Non-secret keys never
- * enter MMDS.
+ * Known-secret keys move to MMDS unconditionally; non-secret keys never
+ * enter MMDS. Capacity enforcement is the caller's job (see the module
+ * doc-comment) — this function never moves a secret back to the drive.
  */
 export function splitCredentials(
   sidecarEnv: Record<string, string> | undefined,
@@ -118,41 +118,5 @@ export function splitCredentials(
     }
   }
 
-  // Spill the largest brokered secrets back to the drive until the payload
-  // fits. "Largest" = serialized value bytes: shedding the biggest key
-  // reclaims the most budget per spill, so the fewest keys leave MMDS.
-  const spilledKeys: string[] = [];
-  while (payloadBytes(payload) > MMDS_PAYLOAD_BUDGET_BYTES) {
-    const candidates: Array<{ map: "sidecar_env" | "agent_env"; key: string; bytes: number }> = [];
-    for (const key of Object.keys(payload.sidecar_env)) {
-      candidates.push({
-        map: "sidecar_env",
-        key,
-        bytes: Buffer.byteLength(payload.sidecar_env[key] as string),
-      });
-    }
-    for (const key of Object.keys(payload.agent_env)) {
-      candidates.push({
-        map: "agent_env",
-        key,
-        bytes: Buffer.byteLength(payload.agent_env[key] as string),
-      });
-    }
-    if (candidates.length === 0) break; // Nothing left to shed — payload is irreducible.
-    candidates.sort((a, b) => b.bytes - a.bytes);
-    const largest = candidates[0] as { map: "sidecar_env" | "agent_env"; key: string };
-    if (largest.map === "sidecar_env") {
-      // A sidecar secret can only spill onto a sidecar drive map.
-      const value = payload.sidecar_env[largest.key] as string;
-      delete payload.sidecar_env[largest.key];
-      if (driveSidecarEnv) driveSidecarEnv[largest.key] = value;
-    } else {
-      const value = payload.agent_env[largest.key] as string;
-      delete payload.agent_env[largest.key];
-      driveAgentEnv[largest.key] = value;
-    }
-    spilledKeys.push(largest.key);
-  }
-
-  return { driveSidecarEnv, driveAgentEnv, mmdsPayload: payload, spilledKeys };
+  return { driveSidecarEnv, driveAgentEnv, mmdsPayload: payload };
 }

--- a/apps/api/src/modules/firecracker/jail.ts
+++ b/apps/api/src/modules/firecracker/jail.ts
@@ -107,16 +107,20 @@ export function jailChrootBase(dataDir: string): string {
 
 /**
  * Jailer ids must match `^[a-zA-Z0-9-]{1,64}$` (stricter than our
- * RUN_ID_RE, which also admits `_` and `.`). Sanitizing alone could
- * collide two live runs (`run_1` / `run.1` → `run-1`), and a shared
- * chroot dir between runs would be catastrophic — so the id always
- * carries the run's subnet index, unique among this host's live VMs.
- * The runId → jailId mapping is persisted in the run's state.json.
+ * RUN_ID_RE, which also admits `_` and `.`). The id is a SHORT digest of
+ * the runId, not the runId itself: the jailId rides the host-side API
+ * socket path (`<base>/<exec>/<jailId>/root/run/firecracker.socket`),
+ * which AF_UNIX caps at ~108 bytes — a real `run_<uuid>` id (40 chars)
+ * under the production data dir (`/var/lib/appstrate-runner/runs`)
+ * blows the cap and would refuse 100% of jailed runs. The digest also
+ * collision-proofs runs whose ids only differ outside the jailer
+ * charset (`run_1` / `run.1`); the subnet index — unique among this
+ * host's live VMs — is appended as a second guarantee. The runId →
+ * jailId mapping is persisted in the run's state.json.
  */
 export function deriveJailId(runId: string, subnetIndex: number): string {
-  const suffix = `-${subnetIndex}`;
-  const sanitized = runId.replace(/[^a-zA-Z0-9-]/g, "-");
-  return sanitized.slice(0, 64 - suffix.length) + suffix;
+  const digest = new Bun.CryptoHasher("sha256").update(runId).digest("hex").slice(0, 12);
+  return `fc-${digest}-${subnetIndex}`;
 }
 
 /**
@@ -176,6 +180,13 @@ export interface BuildJailerArgvInput {
    * losing the jail itself).
    */
   cgroups?: { memoryMaxBytes: number; pidsMax: number };
+  /**
+   * Extra flags forwarded to the exec'd firecracker (after the `--`
+   * separator, before the fixed api-sock/config-file pair) — e.g. the
+   * MMDS store-size overrides when a run's brokered payload exceeds the
+   * 50 KiB Firecracker default.
+   */
+  extraFcArgs?: string[];
 }
 
 /**
@@ -221,11 +232,34 @@ export function buildJailerArgv(input: BuildJailerArgvInput): string[] {
   return [
     ...argv,
     "--",
+    ...(input.extraFcArgs ?? []),
     "--api-sock",
     CHROOT_API_SOCKET_PATH,
     "--config-file",
     CHROOT_VMCONFIG_PATH,
   ];
+}
+
+/**
+ * Enforce upstream's hard requirement that `jailer` and `firecracker`
+ * come from the SAME release: compare the semver each `--version` line
+ * reports and throw when they differ. An env override pointing at a
+ * mismatched pair (bypassing the installer's lockstep) would otherwise
+ * only surface as an opaque first-run failure. Lines whose version
+ * cannot be parsed are rejected too — an unparseable probe is not proof
+ * of parity.
+ */
+export function assertJailerVersionParity(fcVersionLine: string, jailerVersionLine: string): void {
+  const fc = /v?(\d+\.\d+\.\d+)/.exec(fcVersionLine)?.[1];
+  const jailer = /v?(\d+\.\d+\.\d+)/.exec(jailerVersionLine)?.[1];
+  if (!fc || !jailer || fc !== jailer) {
+    throw new Error(
+      `Firecracker jailer: version parity check failed — firecracker reports ` +
+        `"${fcVersionLine}" and jailer reports "${jailerVersionLine}". The two binaries ` +
+        `MUST come from the same upstream release; reinstall them together ` +
+        `(\`appstrate runner install\` keeps them in lockstep).`,
+    );
+  }
 }
 
 /**

--- a/apps/api/src/modules/firecracker/orchestrator.ts
+++ b/apps/api/src/modules/firecracker/orchestrator.ts
@@ -95,9 +95,16 @@ import {
   parseExitMarker,
   vmSizing,
 } from "./vm-config.ts";
-import { splitCredentials, type MmdsPayload } from "./credential-split.ts";
+import {
+  mmdsPayloadBytes,
+  splitCredentials,
+  MMDS_SAFETY_MARGIN_BYTES,
+  MMDS_STORE_LIMIT_BYTES,
+  type MmdsPayload,
+} from "./credential-split.ts";
 import { RUN_ID_RE } from "./runner/protocol.ts";
 import {
+  assertJailerVersionParity,
   buildJailerArgv,
   computeJailPaths,
   defaultJailFs,
@@ -204,6 +211,16 @@ interface VmRecord {
   teardownReason?: TeardownReason;
   /** Jailer confinement layout — set when FIRECRACKER_JAILER=on. */
   jail?: JailPaths;
+  /**
+   * Settles when {@link FirecrackerOrchestrator.killVm} abandons a
+   * D-state VMM after the bounded post-SIGKILL reap. `proc.exited` never
+   * resolves for such a process, so every waiter (waitForExit — the
+   * promise pi.ts blocks a whole run on) must race against this signal
+   * instead of hanging behind one wedged kernel ioctl.
+   */
+  reapAbandoned: Promise<void>;
+  /** Resolver for {@link reapAbandoned}. */
+  abandonReap: () => void;
 }
 
 /** Per-run state persisted for the boot-time orphan sweep. */
@@ -305,6 +322,9 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
   /** FIRECRACKER_BIN resolved to an absolute path (jailer `--exec-file`). */
   private fcBinResolved: string | null = null;
 
+  /** FIRECRACKER_JAILER_BIN resolved to an absolute path (spawned argv[0]). */
+  private jailerBinResolved: string | null = null;
+
   /**
    * Bound on the post-SIGKILL `proc.exited` wait (see killVm): a VMM
    * wedged in D-state (broken KVM ioctl) never reaps, and an unbounded
@@ -380,8 +400,12 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
       );
     }
 
+    // Data dir before the jailer gates — initializeJailer validates the
+    // directory chain it lives in.
+    await mkdir(resolve(fcEnv.FIRECRACKER_DATA_DIR), { recursive: true, mode: 0o700 });
+
     if (fcEnv.FIRECRACKER_JAILER === "on") {
-      await this.initializeJailer(fcEnv);
+      await this.initializeJailer(fcEnv, version);
     } else {
       logger.warn(
         "FIRECRACKER_JAILER=off — VMMs will run UNJAILED (no chroot, no per-VM uid drop, " +
@@ -390,7 +414,6 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
       );
     }
 
-    await mkdir(resolve(fcEnv.FIRECRACKER_DATA_DIR), { recursive: true, mode: 0o700 });
     await this.acquireHostLock(resolve(fcEnv.FIRECRACKER_DATA_DIR));
     await setupHostNetwork(this.hostExec, {
       subnetCidr: fcEnv.FIRECRACKER_SUBNET_CIDR,
@@ -412,11 +435,13 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
 
   /**
    * Jailer-mode boot gates (FIRECRACKER_JAILER=on): root, a working
-   * jailer binary, the chroot base, and world-readable artifacts. Runs
-   * before the host lock so a misconfigured host fails loudly at boot,
-   * never at the first run.
+   * jailer binary FROM THE SAME RELEASE as firecracker, a cgroup-v2
+   * hierarchy when cgroup bounds are on, trustworthy jailer inputs
+   * (binaries + directory chains), the chroot base, and world-readable
+   * artifacts. Runs before the host lock so a misconfigured host fails
+   * loudly at boot, never at the first run.
    */
-  private async initializeJailer(fcEnv: FirecrackerEnv): Promise<void> {
+  private async initializeJailer(fcEnv: FirecrackerEnv, fcVersion: string): Promise<void> {
     if (process.getuid?.() !== 0) {
       throw new Error(
         "FIRECRACKER_JAILER=on (the default) requires the daemon to run as root — the " +
@@ -428,17 +453,45 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
     }
     // Fails loudly here (not at first run) when the jailer binary is
     // absent/broken — same pattern as the firecracker version probe.
-    // jailer and firecracker ship in the same upstream release tarball
-    // and MUST come from the same release; the installer keeps the two
-    // binaries in lockstep under <dataDir>/bin.
     const jailerVersion =
       (await this.execLocal([fcEnv.FIRECRACKER_JAILER_BIN, "--version"])).split("\n")[0] ?? "";
-    // `--exec-file` needs a real path; resolve the (possibly bare) bin
-    // name now so a PATH problem also surfaces at boot.
-    this.resolveFcBinPath(fcEnv);
+    // jailer and firecracker ship in the same upstream release tarball and
+    // MUST come from the same release (upstream requirement). The installer
+    // keeps the two in lockstep under <dataDir>/bin, but env overrides can
+    // bypass it — enforce, don't assume.
+    assertJailerVersionParity(fcVersion, jailerVersion);
+    // Both binaries need real paths: `--exec-file` requires one, and the
+    // trust checks below stat the resolved chain. A PATH problem surfaces
+    // at boot, not at the first run.
+    const fcBin = this.resolveFcBinPath(fcEnv);
+    const jailerBin = this.resolveJailerBinPath(fcEnv);
+    // cgroup-v2 probe: with FIRECRACKER_JAIL_CGROUPS=on the jailer writes
+    // memory.max/pids.max under the unified hierarchy and exits with
+    // CgroupHierarchyMissing on a v1/hybrid host — at the FIRST RUN, long
+    // after initialize() reported green. Probe here instead.
+    if (fcEnv.FIRECRACKER_JAIL_CGROUPS === "on") {
+      await this.assertCgroupV2Controllers(["memory", "pids"]);
+    }
+    // Jailer input trust (upstream places this on the operator): the two
+    // binaries must be root-owned and not group/world-writable along their
+    // whole path chain — the jailer copies --exec-file into every chroot
+    // and runs it as the VMM. The chroot base / data dir chains must not
+    // be world-writable (an attacker-writable parent lets the jail tree be
+    // swapped out from under the daemon). Ownership of the dirs is not
+    // enforced: dev/CI layouts legitimately live under user homes.
+    await this.assertTrustedPathChain(fcBin, "FIRECRACKER_BIN", { requireRootOwned: true });
+    await this.assertTrustedPathChain(jailerBin, "FIRECRACKER_JAILER_BIN", {
+      requireRootOwned: true,
+    });
     // Chroot base: sibling of the runs dir, same filesystem as the
     // artifacts (hardlink constraint — see jail.ts).
     await mkdir(jailChrootBase(fcEnv.FIRECRACKER_DATA_DIR), { recursive: true, mode: 0o700 });
+    await this.assertTrustedPathChain(jailChrootBase(fcEnv.FIRECRACKER_DATA_DIR), "jail base", {
+      requireRootOwned: false,
+    });
+    await this.assertTrustedPathChain(resolve(fcEnv.FIRECRACKER_DATA_DIR), "FIRECRACKER_DATA_DIR", {
+      requireRootOwned: false,
+    });
     // The kernel/rootfs are hardlinked into every VM's chroot and read
     // by unprivileged per-VM uids → they must be root:root 0644. They
     // are not secret (public release artifacts); enforce, don't document.
@@ -476,6 +529,87 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
     }
     this.fcBinResolved = resolved;
     return resolved;
+  }
+
+  /** Resolve FIRECRACKER_JAILER_BIN to an absolute path (cached). */
+  private resolveJailerBinPath(fcEnv: FirecrackerEnv): string {
+    if (this.jailerBinResolved) return this.jailerBinResolved;
+    const bin = fcEnv.FIRECRACKER_JAILER_BIN;
+    const resolved = bin.includes("/") ? resolve(bin) : Bun.which(bin);
+    if (!resolved) {
+      throw new Error(`Firecracker jailer: FIRECRACKER_JAILER_BIN "${bin}" was not found on PATH`);
+    }
+    this.jailerBinResolved = resolved;
+    return resolved;
+  }
+
+  /**
+   * Boot probe for the unified cgroup-v2 hierarchy: the named controllers
+   * must appear in /sys/fs/cgroup/cgroup.controllers. On a v1/hybrid host
+   * (or without delegation) the file is absent or lacks them — fail HERE
+   * with the escape hatch spelled out, not at the first run as an opaque
+   * jailer CgroupHierarchyMissing crash.
+   */
+  private async assertCgroupV2Controllers(needed: string[]): Promise<void> {
+    const controllers = await Bun.file("/sys/fs/cgroup/cgroup.controllers")
+      .text()
+      .catch(() => null);
+    const available = controllers?.trim().split(/\s+/) ?? [];
+    const missing = needed.filter((c) => !available.includes(c));
+    if (controllers === null || missing.length > 0) {
+      throw new Error(
+        `Firecracker jailer: FIRECRACKER_JAIL_CGROUPS=on requires the cgroup-v2 unified ` +
+          `hierarchy with the ${needed.join("+")} controllers, but ` +
+          (controllers === null
+            ? `/sys/fs/cgroup/cgroup.controllers is not readable (cgroup v1/hybrid host?)`
+            : `controller(s) ${missing.join(", ")} are not enabled at the root`) +
+          `. Enable cgroup v2 on this host, or set FIRECRACKER_JAIL_CGROUPS=off to keep ` +
+          `the jail without resource bounds.`,
+      );
+    }
+  }
+
+  /**
+   * Walk `path` and every parent up to `/`, enforcing the jailer-input
+   * trust rules (upstream explicitly delegates these to the operator):
+   * no component may be world-writable, and — for the binaries the jailer
+   * will copy into chroots and exec — every component must be root-owned
+   * and not group-writable either. The sticky bit does not exempt a dir:
+   * jailer inputs have no business living under /tmp-style directories.
+   */
+  private async assertTrustedPathChain(
+    path: string,
+    what: string,
+    opts: { requireRootOwned: boolean },
+  ): Promise<void> {
+    let current = resolve(path);
+    for (;;) {
+      const st = await stat(current).catch((err: unknown) => {
+        throw new Error(
+          `Firecracker jailer: cannot stat "${current}" while validating ${what}: ` +
+            getErrorMessage(err),
+        );
+      });
+      const badModeBits = opts.requireRootOwned ? 0o022 : 0o002;
+      if ((st.mode & badModeBits) !== 0) {
+        throw new Error(
+          `Firecracker jailer: "${current}" (in the path of ${what}) is ` +
+            `${opts.requireRootOwned ? "group/world" : "world"}-writable ` +
+            `(mode ${(st.mode & 0o7777).toString(8)}) — a writable component lets an ` +
+            `unprivileged user swap the jailer's inputs. Tighten its permissions.`,
+        );
+      }
+      if (opts.requireRootOwned && st.uid !== 0) {
+        throw new Error(
+          `Firecracker jailer: "${current}" (in the path of ${what}) is owned by uid ` +
+            `${st.uid}, not root — the jailer executes this input as the VMM; only ` +
+            `root-owned chains are trusted.`,
+        );
+      }
+      const parent = dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
   }
 
   async shutdown(): Promise<void> {
@@ -568,10 +702,20 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
       // Reclaim the run's jail tree (chrootPath = <jailDir>/root — remove
       // the whole <jailDir>). Hardlinks only drop a link count; the
       // shared artifacts survive. Best-effort like every step here.
+      // Containment first: this is a recursive root rm whose target comes
+      // from an on-disk JSON file — a corrupted state.json must never aim
+      // it outside the jail base (chrootPath:"/x" would rm "/").
       if (state?.chrootPath) {
-        await rm(dirname(resolve(state.chrootPath)), { recursive: true, force: true }).catch(
-          () => {},
-        );
+        const jailBase = jailChrootBase(fcEnv.FIRECRACKER_DATA_DIR);
+        const jailDir = dirname(resolve(state.chrootPath));
+        if (jailDir.startsWith(jailBase + sep)) {
+          await rm(jailDir, { recursive: true, force: true }).catch(() => {});
+        } else {
+          logger.warn(
+            "Orphan sweep: state.json chrootPath resolves outside the jail base — skipping rm",
+            { runId: state.runId, chrootPath: state.chrootPath, jailBase },
+          );
+        }
         if (state.jailId) await this.removeJailCgroup(state.jailId);
       }
       // Preserve the crashed run's console before its workspace is reclaimed
@@ -603,6 +747,13 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
     // and the pre-spawn state write, or a wiped data dir): a firecracker
     // whose /proc root points under OUR chroot base is positively ours.
     workloads += await this.sweepJailBase();
+
+    // Empty per-VM cgroup dirs orphaned by a reap-timeout teardown: when a
+    // D-state VMM outlives its runDir/state.json, nothing above reaches its
+    // cgroup — once the kernel finally releases the process the dir sits
+    // empty under appstrate-fc/ forever. rmdir(2) only: a still-populated
+    // group fails and is left alone.
+    await this.sweepJailCgroups();
 
     // Sweep TAP devices with no backing run dir (crash between TAP create
     // and state write). The platform owns the `afc<n>` namespace.
@@ -730,6 +881,10 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
       // host lo alias — the noProxy exemption must track whichever one the
       // sink POSTs actually target.
       const platformIp = this.platformForward?.ip ?? platformAliasIp(fcEnv.FIRECRACKER_SUBNET_CIDR);
+      let abandonReap!: () => void;
+      const reapAbandoned = new Promise<void>((resolveAbandon) => {
+        abandonReap = resolveAbandon;
+      });
       this.vms.set(runId, {
         runId,
         subnet,
@@ -738,6 +893,8 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
         apiSocketPath,
         proc: null,
         stopping: false,
+        reapAbandoned,
+        abandonReap,
         ...(jail ? { jail } : {}),
       });
 
@@ -867,6 +1024,25 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
     await rmdir(join("/sys/fs/cgroup", JAIL_PARENT_CGROUP, jailId)).catch(() => {});
   }
 
+  /**
+   * Boot-time sweep of EVERY per-VM cgroup dir under the appstrate-fc
+   * slice (see cleanupOrphans). rmdir(2) only — cgroupfs refuses to remove
+   * a populated group, so a dir that still hosts a live VMM survives.
+   */
+  private async sweepJailCgroups(): Promise<void> {
+    const base = join("/sys/fs/cgroup", JAIL_PARENT_CGROUP);
+    let dirents;
+    try {
+      dirents = await readdir(base, { withFileTypes: true });
+    } catch {
+      return; // Slice absent — the jailer never ran with cgroups on this host.
+    }
+    for (const dirent of dirents) {
+      if (!dirent.isDirectory()) continue;
+      await rmdir(join(base, dirent.name)).catch(() => {});
+    }
+  }
+
   // -------------------------------------------------------------------------
   // Workloads
   // -------------------------------------------------------------------------
@@ -933,13 +1109,19 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
           driveSidecarEnv: sidecarEnv,
           driveAgentEnv: agentSpec.env,
           mmdsPayload: { sidecar_env: {}, agent_env: {} } satisfies MmdsPayload,
-          spilledKeys: [] as string[],
         };
-    if (split.spilledKeys.length > 0) {
-      logger.warn(
-        "Firecracker MMDS payload exceeded the store budget — spilled the largest " +
-          "secret(s) back onto the config drive (names only, never values)",
-        { runId: handle.runId, spilledKeys: split.spilledKeys },
+    // Capacity, fail-closed: a known secret NEVER falls back onto the
+    // config drive. Payloads above Firecracker's 50 KiB store default get
+    // the VMM's limits raised at spawn (see mmdsSpawnArgs); beyond the
+    // operator ceiling the run fails loudly instead of silently degrading
+    // the at-rest guarantee.
+    const mmdsBytes = mmdsMode ? mmdsPayloadBytes(split.mmdsPayload) : 0;
+    if (mmdsMode && mmdsBytes > fcEnv.FIRECRACKER_MMDS_MAX_BYTES) {
+      throw new Error(
+        `Firecracker orchestrator: the run's brokered credential payload is ${mmdsBytes} bytes, ` +
+          `above FIRECRACKER_MMDS_MAX_BYTES (${fcEnv.FIRECRACKER_MMDS_MAX_BYTES}) — refusing to ` +
+          `start run ${handle.runId} rather than write known secrets to the config drive. ` +
+          `Raise the ceiling, or shrink the run's integration payload.`,
       );
     }
 
@@ -963,7 +1145,12 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
     await this.buildConfigDrive(vm.runDir, configDrivePath, guestConfig);
 
     const sizing = vmSizing(agentSpec.resources, sidecarEnv !== undefined);
-    const proc = await this.spawnVmm(vm, configDrivePath, sizing, mmdsMode);
+    const proc = await this.spawnVmm(
+      vm,
+      configDrivePath,
+      sizing,
+      mmdsMode ? { payloadBytes: mmdsBytes } : null,
+    );
     vm.proc = proc;
     vm.bootedAt = Date.now();
     drainStream(proc, `fc:${handle.runId}`);
@@ -982,12 +1169,10 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
       });
     } catch (err) {
       vm.stopping = true;
-      try {
-        proc.kill("SIGKILL");
-      } catch {
-        // Already dead.
-      }
-      await proc.exited.catch(() => {});
+      // Bounded kill+reap (killVm), NOT a raw `await proc.exited`: a VMM
+      // wedged in D-state never settles `exited` even after SIGKILL, and
+      // an unbounded await here would hang the run's start path forever.
+      await this.killVm(vm, 0).catch(() => {});
       vm.proc = null;
       throw new Error(
         `Firecracker orchestrator: failed to persist the VMM pid for run ${handle.runId} — ` +
@@ -1061,7 +1246,23 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
   async waitForExit(handle: WorkloadHandle): Promise<number> {
     const vm = this.vms.get(handle.runId);
     if (!vm?.proc) return 1;
-    await vm.proc.exited;
+    // Race the exit against the D-state abandon signal: after a timeout or
+    // cancel, killVm SIGKILLs and reaps with a bound — but a VMM wedged in
+    // an uninterruptible KVM/block ioctl never settles `exited`, and this
+    // is the promise pi.ts blocks the whole run on. When killVm gives up,
+    // resolve with the killed/crashed semantics instead of hanging.
+    const outcome = await Promise.race([
+      vm.proc.exited.then(
+        () => "exited" as const,
+        () => "exited" as const,
+      ),
+      vm.reapAbandoned.then(() => "abandoned" as const),
+    ]);
+    if (outcome === "abandoned") {
+      // The leaked VMM cannot have printed an exit marker (the guest is
+      // wedged with it) — killed vs crashed is decided by intent.
+      return vm.stopping ? 137 : 1;
+    }
     // The VMM exiting 0 only means the guest powered off — the workload
     // outcome is the supervisor's nonce-authenticated exit marker on the
     // serial console (the console is shared with workload stdout, so an
@@ -1127,7 +1328,7 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
     vm: VmRecord,
     configDrivePath: string,
     sizing: { vcpuCount: number; memSizeMib: number },
-    mmds: boolean,
+    mmds: { payloadBytes: number } | null,
   ): Promise<BunProcess> {
     const argv = vm.jail
       ? await this.prepareJailedSpawn(vm, vm.jail, configDrivePath, sizing, mmds)
@@ -1144,12 +1345,28 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
     });
   }
 
+  /**
+   * MMDS store-size flags for the firecracker argv. Firecracker bounds
+   * both the in-VMM store (`--mmds-size-limit`, default = the HTTP API
+   * payload cap) and the PUT body itself (`--http-api-max-payload-size`,
+   * default 51200) — a brokered payload above the default needs BOTH
+   * raised or the credential PUT 400s and the run fail-closes for the
+   * wrong reason. The startWorkload ceiling has already bounded
+   * `payloadBytes` by FIRECRACKER_MMDS_MAX_BYTES.
+   */
+  private mmdsSpawnArgs(mmds: { payloadBytes: number } | null): string[] {
+    if (!mmds) return [];
+    const needed = mmds.payloadBytes + MMDS_SAFETY_MARGIN_BYTES;
+    if (needed <= MMDS_STORE_LIMIT_BYTES) return [];
+    return ["--mmds-size-limit", String(needed), "--http-api-max-payload-size", String(needed)];
+  }
+
   /** Direct (unjailed) spawn plan — host-absolute paths, dev only. */
   private async prepareDirectSpawn(
     vm: VmRecord,
     configDrivePath: string,
     sizing: { vcpuCount: number; memSizeMib: number },
-    mmds: boolean,
+    mmds: { payloadBytes: number } | null,
   ): Promise<string[]> {
     const fcEnv = getFirecrackerEnv();
     const vmConfig = buildVmConfig({
@@ -1160,11 +1377,18 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
       subnet: vm.subnet,
       vcpuCount: sizing.vcpuCount,
       memSizeMib: sizing.memSizeMib,
-      mmds,
+      mmds: mmds !== null,
     });
     const vmConfigPath = join(vm.runDir, "vmconfig.json");
     await writeFile(vmConfigPath, JSON.stringify(vmConfig, null, 2), { mode: 0o600 });
-    return [fcEnv.FIRECRACKER_BIN, "--api-sock", vm.apiSocketPath, "--config-file", vmConfigPath];
+    return [
+      fcEnv.FIRECRACKER_BIN,
+      ...this.mmdsSpawnArgs(mmds),
+      "--api-sock",
+      vm.apiSocketPath,
+      "--config-file",
+      vmConfigPath,
+    ];
   }
 
   /**
@@ -1178,7 +1402,7 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
     jail: JailPaths,
     configDrivePath: string,
     sizing: { vcpuCount: number; memSizeMib: number },
-    mmds: boolean,
+    mmds: { payloadBytes: number } | null,
   ): Promise<string[]> {
     const fcEnv = getFirecrackerEnv();
     await prepareChrootArtifacts(
@@ -1208,16 +1432,17 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
       subnet: vm.subnet,
       vcpuCount: sizing.vcpuCount,
       memSizeMib: sizing.memSizeMib,
-      mmds,
+      mmds: mmds !== null,
     });
     await writeChrootVmConfig(
       { rootDir: jail.rootDir, vmConfig, uid: jail.uid, gid: jail.gid },
       this.jailFs,
     );
     return buildJailerArgv({
-      jailerBin: fcEnv.FIRECRACKER_JAILER_BIN,
+      jailerBin: this.resolveJailerBinPath(fcEnv),
       fcBin: this.resolveFcBinPath(fcEnv),
       jail,
+      ...(this.mmdsSpawnArgs(mmds).length > 0 ? { extraFcArgs: this.mmdsSpawnArgs(mmds) } : {}),
       ...(fcEnv.FIRECRACKER_JAIL_CGROUPS === "on"
         ? {
             cgroups: {
@@ -1331,6 +1556,9 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
           "its resources will be swept at next boot",
         { runId: vm.runId, pid: proc.pid },
       );
+      // Unblock every waiter racing on this signal (waitForExit): the
+      // leaked process's `exited` promise may never settle.
+      vm.abandonReap();
     }
   }
 
@@ -1446,21 +1674,42 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
   }
 
   /**
-   * argv[0]'s BASENAME contains "firecracker" — i.e. the process was
-   * exec'd as the VMM binary itself. Deliberately argv[0]-only (stricter
-   * than {@link pidIsOurVmm}'s full-argv scan): the jail sweep pairs
-   * this gate with a uid/chroot match, and a full-argv scan would match
-   * any process whose ARGUMENTS merely mention a firecracker path — the
+   * argv[0]'s BASENAME is the configured firecracker binary's basename,
+   * or contains "firecracker" — i.e. the process was exec'd as the VMM
+   * binary itself. Deliberately argv[0]-only (stricter than
+   * {@link pidIsOurVmm}'s full-argv scan): the jail sweep pairs this gate
+   * with a per-run identity match, and a full-argv scan would match any
+   * process whose ARGUMENTS merely mention a firecracker path — the
    * `bun test …/modules/firecracker/…` runner included — turning the
-   * uid branch into a self-kill.
+   * sweep into a self-kill. The configured-basename branch keeps the
+   * gate working when FIRECRACKER_BIN points at a renamed binary.
    */
   private async pidLooksLikeVmmBinary(pid: number): Promise<boolean> {
     try {
       const cmdline = await Bun.file(`/proc/${pid}/cmdline`).text();
       const argv0 = cmdline.split("\0")[0] ?? "";
-      return (argv0.split("/").pop() ?? "").includes("firecracker");
+      const base = argv0.split("/").pop() ?? "";
+      return (
+        base.includes("firecracker") || base === fcExecName(getFirecrackerEnv().FIRECRACKER_BIN)
+      );
     } catch {
       return false; // Process already gone.
+    }
+  }
+
+  /**
+   * The `--id` value in a process's argv, or null. The jailer always
+   * injects `--id <jailId>` into the firecracker argv it exec()s, so this
+   * is a positive PER-RUN identity for jailed VMMs — immune to pid reuse
+   * and to same-uid neighbours, unlike a bare uid match.
+   */
+  private async procJailArgvId(pid: number): Promise<string | null> {
+    try {
+      const argv = (await Bun.file(`/proc/${pid}/cmdline`).text()).split("\0");
+      const flagIndex = argv.indexOf("--id");
+      return flagIndex >= 0 ? (argv[flagIndex + 1] ?? null) : null;
+    } catch {
+      return null;
     }
   }
 
@@ -1473,38 +1722,25 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
     }
   }
 
-  /** Real uid from /proc/<pid>/status; null when unreadable. */
-  private async procUid(pid: number): Promise<number | null> {
-    try {
-      const status = await Bun.file(`/proc/${pid}/status`).text();
-      const match = /^Uid:\s+(\d+)/m.exec(status);
-      return match ? Number(match[1]) : null;
-    } catch {
-      return null;
-    }
-  }
-
   /**
    * Kill a jailed run's VMM by JAIL identity: a process exec'd as the
    * firecracker binary (argv[0] gate — see pidLooksLikeVmmBinary) whose
-   * /proc root IS the recorded chroot, or whose uid IS the run's
-   * reserved jail uid. Both are positive identities (the chroot path is
-   * per-run; the uid range is reserved for this host's VMs) and both
-   * are immune to pid reuse. The argv[0] gate always applies — the
-   * sweep must never mass-kill by uid alone on a host where the
-   * reserved range turns out to be occupied.
+   * jailer-injected `--id` IS the recorded jailId, or whose /proc root
+   * IS the recorded chroot. Both are positive PER-RUN identities immune
+   * to pid reuse. Deliberately NO bare-uid branch: a uid match alone
+   * would false-kill an unrelated same-uid process (the jail uid range
+   * being "reserved" is an operator promise, not a kernel guarantee),
+   * and every jailed VMM carries the `--id` in its argv anyway.
    */
   private async sweepJailedVmm(state: RunStateFile): Promise<number> {
-    // Fail-closed sanity: never uid-match below the unprivileged floor —
-    // a corrupted state file must not aim the sweep at system uids.
-    const jailUid = state.jailUid !== undefined && state.jailUid >= 1000 ? state.jailUid : null;
     const chrootPath = state.chrootPath !== undefined ? resolve(state.chrootPath) : null;
+    const jailId = state.jailId ?? null;
     let killed = 0;
     for (const pid of await this.listProcPids()) {
       if (!(await this.pidLooksLikeVmmBinary(pid))) continue;
+      const idMatch = jailId !== null && (await this.procJailArgvId(pid)) === jailId;
       const rootMatch = chrootPath !== null && (await this.procRoot(pid)) === chrootPath;
-      const uidMatch = jailUid !== null && (await this.procUid(pid)) === jailUid;
-      if (!rootMatch && !uidMatch) continue;
+      if (!idMatch && !rootMatch) continue;
       try {
         process.kill(pid, "SIGKILL");
         killed++;

--- a/apps/api/src/modules/firecracker/runner/artifacts.ts
+++ b/apps/api/src/modules/firecracker/runner/artifacts.ts
@@ -59,8 +59,15 @@ import { logger as defaultLogger } from "./logger.ts";
  * (a supervisor bugfix, a new optional field the daemon does not require).
  * A bump is a lockstep release: publish artifacts at protocol N together
  * with the daemon that speaks N.
+ *
+ * History:
+ *   2 — MMDS credential broker (config-drive `credentials.source: "mmds"`
+ *       strips RUN_TOKEN/APPSTRATE_SINK_SECRET off the drive; a protocol-1
+ *       supervisor ignores the field, never fetches MMDS, and boots the
+ *       run without credentials).
+ *   1 — initial config-drive contract.
  */
-export const GUEST_PROTOCOL_VERSION = 1;
+export const GUEST_PROTOCOL_VERSION = 2;
 
 /** GitHub Release download base for this repo (versioned + `latest`). */
 export const DEFAULT_ARTIFACTS_BASE_URL = "https://github.com/appstrate/appstrate/releases";
@@ -304,14 +311,24 @@ export async function ensureGuestArtifacts(
 
   const present = (await fs.exists(config.kernelPath)) && (await fs.exists(config.rootfsPath));
   const markerPath = join(dirname(config.rootfsPath), VERSION_MARKER_NAME);
-  const installedVersion = await readMarker(fs, markerPath);
+  const installed = await readMarker(fs, markerPath);
 
-  // Skip: artifacts present and either no version pinned, or the marker
-  // already matches the pinned version.
-  if (present && (!config.version || installedVersion === config.version)) {
+  // The skip fast-path (and the keep-existing network-failure fallback
+  // below) require the on-disk install to speak THIS daemon's guest
+  // protocol. A daemon upgraded in place next to a stale rootfs must
+  // re-download — a protocol-N-1 supervisor booting under a protocol-N
+  // daemon fails in confusing, run-level ways (e.g. it ignores
+  // `credentials.source: "mmds"` and comes up with no credentials).
+  // No marker at all (pre-marker install, hand-copied files) counts as
+  // unverifiable, not as compatible.
+  const installedProtocolOk = installed?.guestProtocol === GUEST_PROTOCOL_VERSION;
+
+  // Skip: artifacts present, protocol verified, and either no version
+  // pinned or the marker already matches the pinned version.
+  if (present && installedProtocolOk && (!config.version || installed.version === config.version)) {
     log.info("Firecracker artifacts: present, skipping download", {
       arch,
-      installedVersion: installedVersion ?? "(unknown)",
+      installedVersion: installed.version,
       requestedVersion: config.version ?? "(none)",
     });
     return;
@@ -337,8 +354,12 @@ export async function ensureGuestArtifacts(
     if (err instanceof FatalArtifactsError) {
       throw err;
     }
-    // Network/transient failure with artifacts already on disk: keep them.
-    if (present) {
+    // Network/transient failure with artifacts already on disk: keep them
+    // — but ONLY when the installed protocol is verified compatible. A
+    // stale-protocol install must never be "kept" through a download
+    // failure; that would resurrect exactly the daemon-upgraded-next-to-
+    // old-rootfs state the protocol gate exists to prevent.
+    if (present && installedProtocolOk) {
       log.warn("Firecracker artifacts: download failed, using existing on-disk artifacts", {
         error: getErrorMessage(err),
         kernelPath: config.kernelPath,
@@ -346,9 +367,10 @@ export async function ensureGuestArtifacts(
       });
       return;
     }
-    // Nothing on disk and we could not fetch: the daemon cannot run VMs.
+    // Nothing usable on disk (absent, or present at an incompatible guest
+    // protocol) and we could not fetch: the daemon cannot run VMs.
     throw new Error(
-      `Firecracker guest artifacts are missing and could not be downloaded: ${getErrorMessage(err)}. ` +
+      `Firecracker guest artifacts are ${present ? `installed at an incompatible guest protocol (daemon speaks ${GUEST_PROTOCOL_VERSION})` : "missing"} and could not be downloaded: ${getErrorMessage(err)}. ` +
         `Set FIRECRACKER_ARTIFACTS_BASE_URL / FIRECRACKER_ARTIFACTS_VERSION to a reachable release, ` +
         `build them locally with \`bun run firecracker:build\` (then set FIRECRACKER_ARTIFACTS_LOCAL=1), ` +
         `or check network access to ${baseUrl}.`,
@@ -489,12 +511,21 @@ async function installAtomic(fs: ArtifactsFs, finalPath: string, bytes: Uint8Arr
   }
 }
 
-async function readMarker(fs: ArtifactsFs, markerPath: string): Promise<string | null> {
+interface InstalledMarker {
+  version: string;
+  /** Absent on markers written before the protocol was recorded. */
+  guestProtocol: number | undefined;
+}
+
+async function readMarker(fs: ArtifactsFs, markerPath: string): Promise<InstalledMarker | null> {
   const text = await fs.readText(markerPath);
   if (!text) return null;
   try {
-    const parsed = z.object({ version: z.string() }).safeParse(JSON.parse(text));
-    return parsed.success ? parsed.data.version : null;
+    const parsed = z
+      .object({ version: z.string(), guest_protocol: z.number().int().optional() })
+      .safeParse(JSON.parse(text));
+    if (!parsed.success) return null;
+    return { version: parsed.data.version, guestProtocol: parsed.data.guest_protocol };
   } catch {
     return null;
   }

--- a/apps/api/src/modules/firecracker/runner/host-env.ts
+++ b/apps/api/src/modules/firecracker/runner/host-env.ts
@@ -37,8 +37,22 @@ const firecrackerEnvSchema = z.object({
   // Base of the per-VM uid/gid range: VM with subnet index N runs as
   // uid/gid BASE+N. The range BASE..BASE+FIRECRACKER_MAX_CONCURRENT_VMS
   // (worst case BASE+16319, the allocator ceiling) must be unallocated
-  // on the host — no /etc/passwd entries are needed or created.
-  FIRECRACKER_JAIL_UID_BASE: z.coerce.number().int().min(1000).default(64000),
+  // on the host — no /etc/passwd entries are needed or created. The
+  // default sits ABOVE the 16-bit uid space so the range can never
+  // collide with nobody (65534/65535) or the systemd DynamicUser pool
+  // (61184–65519) — a VMM silently running as `nobody` would cross an
+  // unrelated trust domain. Ranges intersecting 61184–65535 are rejected
+  // at boot (see the superRefine below).
+  FIRECRACKER_JAIL_UID_BASE: z.coerce.number().int().min(1000).default(200_000),
+  // Ceiling on the per-run MMDS credential payload (serialized bytes).
+  // Above Firecracker's 50 KiB store default the daemon raises the VMM's
+  // --mmds-size-limit/--http-api-max-payload-size to fit the payload;
+  // above THIS ceiling the run FAILS instead — a known secret is never
+  // silently written to the config drive (fail-closed). Default 16 MiB:
+  // INTEGRATIONS_TO_SPAWN_JSON carries bundle bytes + live tokens and
+  // can legitimately reach several MiB; the store lives in VMM memory,
+  // covered by the jail's memory slack.
+  FIRECRACKER_MMDS_MAX_BYTES: z.coerce.number().int().positive().default(16_777_216),
   // cgroup-v2 bounds (memory.max / pids.max under the appstrate-fc
   // slice) passed to the jailer. The jailer fails HARD when it cannot
   // write the cgroup files — "off" lets hosts without cgroup-v2
@@ -130,6 +144,37 @@ const firecrackerEnvSchema = z.object({
   FIRECRACKER_NET_VERIFY: z.enum(["warn", "strict"]).default("warn"),
 });
 
+/**
+ * Reserved uid interval no jail uid may fall into: systemd DynamicUser
+ * (61184–65519) plus nobody/overflow (65534/65535). A VMM allocated one
+ * of these uids would share an identity with unrelated system services —
+ * file ownership, TAP ownership and the orphan sweep all key on the uid.
+ */
+const RESERVED_UID_RANGE = { lo: 61_184, hi: 65_535 } as const;
+
+/** Allocator index ceiling (see subnet.ts MAX_INDEX) — the worst-case uid span. */
+const MAX_JAIL_UID_SPAN = 16_319;
+
+const firecrackerEnvSchemaChecked = firecrackerEnvSchema.superRefine((env, ctx) => {
+  // The uid range actually reachable: with admission control on, the
+  // lowest-free allocator keeps indexes <= the VM cap; without a cap
+  // (explicit 0) the full allocator ceiling applies.
+  const span =
+    env.FIRECRACKER_MAX_CONCURRENT_VMS > 0 ? env.FIRECRACKER_MAX_CONCURRENT_VMS : MAX_JAIL_UID_SPAN;
+  const lo = env.FIRECRACKER_JAIL_UID_BASE;
+  const hi = env.FIRECRACKER_JAIL_UID_BASE + span;
+  if (lo <= RESERVED_UID_RANGE.hi && hi >= RESERVED_UID_RANGE.lo) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["FIRECRACKER_JAIL_UID_BASE"],
+      message:
+        `jail uid range ${lo}..${hi} intersects the reserved interval ` +
+        `${RESERVED_UID_RANGE.lo}..${RESERVED_UID_RANGE.hi} (systemd DynamicUser + nobody) — ` +
+        `pick a base whose whole range clears it (e.g. the default 200000)`,
+    });
+  }
+});
+
 export type FirecrackerEnv = z.infer<typeof firecrackerEnvSchema>;
 
 let cached: FirecrackerEnv | undefined;
@@ -137,7 +182,7 @@ let cached: FirecrackerEnv | undefined;
 /** Parse (once) and return the module's environment. Throws on invalid values. */
 export function getFirecrackerEnv(): FirecrackerEnv {
   if (!cached) {
-    cached = firecrackerEnvSchema.parse(process.env);
+    cached = firecrackerEnvSchemaChecked.parse(process.env);
   }
   return cached;
 }

--- a/apps/api/src/modules/firecracker/scripts/dev/smoke.ts
+++ b/apps/api/src/modules/firecracker/scripts/dev/smoke.ts
@@ -50,6 +50,13 @@ const BROKER = process.env.FIRECRACKER_CREDENTIAL_BROKER ?? "mmds";
  * drive-inspection assertion below greps the staged ext4 image for it.
  */
 const FAKE_RUN_TOKEN = "smoke-fake-secret-DEADBEEFCAFE";
+/**
+ * Distinctive fake model API key pushed through the AGENT env. In MMDS
+ * mode it must be brokered too (skipSidecar/direct-provider runs put the
+ * REAL provider key in the agent env — regression guard for it landing
+ * on the config drive).
+ */
+const FAKE_MODEL_KEY = "sk-smoke-fake-model-key-0DEFACED";
 
 function fail(msg: string): never {
   console.error(`SMOKE FAIL: ${msg}`);
@@ -177,8 +184,13 @@ const PROBE_SCRIPT = [
   'if dd if=/dev/vdb of=/dev/null count=1 2>/dev/null; then echo "smoke-vdb=readable"; else echo "smoke-vdb=blocked"; fi',
   // Credential broker: after the supervisor fetched the secrets, the guest
   // firewall drops all access to the MMDS metadata address for EVERY uid.
-  // A workload reaching it would be a credential-store leak.
-  `if wget -q -T 3 -O /dev/null http://169.254.169.254/latest/meta-data/ 2>/dev/null; then echo "smoke-mmds=reachable"; else echo "smoke-mmds=blocked"; fi`,
+  // A workload reaching it would be a credential-store leak. The probe
+  // performs the REAL V2 handshake step (token PUT) via bun: a tokenless
+  // wget GET would 401 under MMDS V2 even with NO firewall rule at all,
+  // reading as "blocked" and making the assertion tautological. The token
+  // PUT succeeds whenever MMDS is reachable — only the firewall DROP
+  // (connect timeout) makes it fail.
+  `if bun -e "const ok=await fetch('http://169.254.169.254/latest/api/token',{method:'PUT',headers:{'X-metadata-token-ttl-seconds':'60'},signal:AbortSignal.timeout(3000)}).then(r=>r.ok,()=>false);process.exit(ok?0:1)" >/dev/null 2>&1; then echo "smoke-mmds=reachable"; else echo "smoke-mmds=blocked"; fi`,
   // In-guest sidecar liveness: /health must answer 200 (wget fails on
   // 503). The sidecar cold-starts in parallel with the agent, so retry
   // for up to 30s — a sidecar that crashed at ms 1 never answers.
@@ -229,7 +241,7 @@ try {
       runId: RUN_ID,
       role: "agent",
       image: "unused-by-firecracker",
-      env: { SMOKE: "1" },
+      env: { SMOKE: "1", MODEL_API_KEY: FAKE_MODEL_KEY },
       resources: { memoryBytes: 512 * 1024 * 1024, nanoCpus: 1_000_000_000 },
     },
     boundary,
@@ -255,6 +267,9 @@ try {
         ? join(state.chrootPath, "config.img")
         : join(boundary.id, "config.img");
     await assertConfigDriveOmitsSecret(imagePath, FAKE_RUN_TOKEN);
+    // Agent-env secret: the model API key (real on direct-provider runs)
+    // must be brokered off the drive too.
+    await assertConfigDriveOmitsSecret(imagePath, FAKE_MODEL_KEY);
   }
 
   const exitCode = await Promise.race([

--- a/apps/api/src/modules/firecracker/subnet.ts
+++ b/apps/api/src/modules/firecracker/subnet.ts
@@ -92,14 +92,19 @@ function hex(n: number): string {
  */
 export class SubnetAllocator {
   private readonly inUse = new Set<number>();
-  private next = 1;
 
   constructor(private readonly cidr: string) {}
 
+  /**
+   * Lowest-free scan, NOT round-robin: the index also derives the run's
+   * jail uid (FIRECRACKER_JAIL_UID_BASE + index), so it must stay bounded
+   * by the number of CONCURRENT runs — a round-robin cursor walks the
+   * whole 1..16319 space over the host's lifetime and eventually hands
+   * out uids colliding with foreign uid ranges. Immediate reuse is safe:
+   * an index is only released after its TAP device is confirmed deleted.
+   */
   allocate(): RunSubnet {
-    for (let scanned = 0; scanned <= MAX_INDEX; scanned++) {
-      const candidate = this.next > MAX_INDEX ? 1 : this.next;
-      this.next = candidate + 1;
+    for (let candidate = 1; candidate <= MAX_INDEX; candidate++) {
       if (!this.inUse.has(candidate)) {
         this.inUse.add(candidate);
         return subnetForIndex(this.cidr, candidate);

--- a/apps/api/src/modules/firecracker/test/unit/artifacts.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/artifacts.test.ts
@@ -277,11 +277,15 @@ describe("ensureGuestArtifacts — checksum verification", () => {
 });
 
 describe("ensureGuestArtifacts — skip when present", () => {
-  it("does not fetch when artifacts exist and no version is pinned", async () => {
+  it("does not fetch when artifacts exist with a protocol-matching marker and no version pinned", async () => {
     const s = scenario();
     const { fs } = makeFs({
       [KERNEL_PATH]: new Uint8Array([1]),
       [ROOTFS_PATH]: new Uint8Array([2]),
+      [MARKER_PATH]: JSON.stringify({
+        version: "1.2.3",
+        guest_protocol: GUEST_PROTOCOL_VERSION,
+      }),
     });
 
     await ensureGuestArtifacts(
@@ -297,7 +301,10 @@ describe("ensureGuestArtifacts — skip when present", () => {
     const { fs } = makeFs({
       [KERNEL_PATH]: new Uint8Array([1]),
       [ROOTFS_PATH]: new Uint8Array([2]),
-      [MARKER_PATH]: JSON.stringify({ version: "1.2.3", guest_protocol: 1 }),
+      [MARKER_PATH]: JSON.stringify({
+        version: "1.2.3",
+        guest_protocol: GUEST_PROTOCOL_VERSION,
+      }),
     });
 
     await ensureGuestArtifacts(
@@ -314,12 +321,57 @@ describe("ensureGuestArtifacts — skip when present", () => {
     expect(s.calls).toHaveLength(0);
   });
 
+  it("re-downloads when the installed marker records a STALE guest protocol (B-4)", async () => {
+    // Daemon upgraded in place next to an old rootfs: the skip path must
+    // not keep a supervisor that cannot speak this daemon's protocol
+    // (e.g. one that ignores `credentials.source: "mmds"` and boots the
+    // run without credentials).
+    const s = scenario();
+    const { fs, files } = makeFs({
+      [KERNEL_PATH]: new Uint8Array([1]),
+      [ROOTFS_PATH]: new Uint8Array([2]),
+      [MARKER_PATH]: JSON.stringify({
+        version: "1.2.3",
+        guest_protocol: GUEST_PROTOCOL_VERSION - 1,
+      }),
+    });
+
+    await ensureGuestArtifacts(
+      { kernelPath: KERNEL_PATH, rootfsPath: ROOTFS_PATH, baseUrl: BASE_URL, local: false },
+      { fetchFn: s.fetchFn, fs, decompressZstd: s.decompressZstd, arch: "x86_64" },
+    );
+
+    expect(s.calls.length).toBeGreaterThan(0);
+    expect(files.get(KERNEL_PATH)).toEqual(s.kernelBytes);
+    expect(JSON.parse(files.get(MARKER_PATH) as string).guest_protocol).toBe(
+      GUEST_PROTOCOL_VERSION,
+    );
+  });
+
+  it("re-downloads when artifacts exist WITHOUT a marker (unverifiable protocol)", async () => {
+    const s = scenario();
+    const { fs } = makeFs({
+      [KERNEL_PATH]: new Uint8Array([1]),
+      [ROOTFS_PATH]: new Uint8Array([2]),
+    });
+
+    await ensureGuestArtifacts(
+      { kernelPath: KERNEL_PATH, rootfsPath: ROOTFS_PATH, baseUrl: BASE_URL, local: false },
+      { fetchFn: s.fetchFn, fs, decompressZstd: s.decompressZstd, arch: "x86_64" },
+    );
+
+    expect(s.calls.length).toBeGreaterThan(0);
+  });
+
   it("re-downloads when the pinned version differs from the installed marker", async () => {
     const s = scenario({ version: "2.0.0" });
     const { fs, files } = makeFs({
       [KERNEL_PATH]: new Uint8Array([1]),
       [ROOTFS_PATH]: new Uint8Array([2]),
-      [MARKER_PATH]: JSON.stringify({ version: "1.2.3", guest_protocol: 1 }),
+      [MARKER_PATH]: JSON.stringify({
+        version: "1.2.3",
+        guest_protocol: GUEST_PROTOCOL_VERSION,
+      }),
     });
 
     await ensureGuestArtifacts(
@@ -405,10 +457,14 @@ describe("ensureGuestArtifacts — arch not published", () => {
 });
 
 describe("ensureGuestArtifacts — network failure policy", () => {
-  it("warns and continues when download fails but artifacts are already present", async () => {
+  it("warns and continues when download fails but PROTOCOL-COMPATIBLE artifacts are present", async () => {
     const { fs } = makeFs({
       [KERNEL_PATH]: new Uint8Array([1]),
       [ROOTFS_PATH]: new Uint8Array([2]),
+      [MARKER_PATH]: JSON.stringify({
+        version: "1.2.3",
+        guest_protocol: GUEST_PROTOCOL_VERSION,
+      }),
     });
 
     // Pinned version forces a download attempt; fetch throws.
@@ -424,6 +480,27 @@ describe("ensureGuestArtifacts — network failure policy", () => {
         { fetchFn: throwingFetch, fs, arch: "x86_64" },
       ),
     ).resolves.toBeUndefined();
+  });
+
+  it("does NOT keep a stale-protocol install through a download failure (B-4)", async () => {
+    // Present artifacts whose marker records an older protocol: the
+    // keep-existing fallback must not resurrect exactly the incompatible
+    // state the protocol gate exists to prevent.
+    const { fs } = makeFs({
+      [KERNEL_PATH]: new Uint8Array([1]),
+      [ROOTFS_PATH]: new Uint8Array([2]),
+      [MARKER_PATH]: JSON.stringify({
+        version: "1.2.3",
+        guest_protocol: GUEST_PROTOCOL_VERSION - 1,
+      }),
+    });
+
+    await expect(
+      ensureGuestArtifacts(
+        { kernelPath: KERNEL_PATH, rootfsPath: ROOTFS_PATH, baseUrl: BASE_URL, local: false },
+        { fetchFn: throwingFetch, fs, arch: "x86_64" },
+      ),
+    ).rejects.toThrow(/incompatible guest protocol.*could not be downloaded/);
   });
 
   it("is fatal with an actionable message when download fails and nothing is on disk", async () => {

--- a/apps/api/src/modules/firecracker/test/unit/credential-split.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/credential-split.test.ts
@@ -3,19 +3,21 @@
 /**
  * Unit tests for the credential broker split (credential-split.ts): the
  * pure function that moves KNOWN-SECRET keys off the config drive and into
- * the MMDS payload, enforcing the MMDS store budget by spilling the largest
- * offending secrets back to the drive when the payload would overflow.
+ * the MMDS payload. A known secret NEVER falls back onto the drive —
+ * oversized payloads are the orchestrator's job (raise the VMM store
+ * limits, fail-closed beyond the ceiling), not this function's.
  */
 
 import { describe, it, expect } from "bun:test";
 import {
+  mmdsPayloadBytes,
   splitCredentials,
-  MMDS_PAYLOAD_BUDGET_BYTES,
+  MMDS_STORE_LIMIT_BYTES,
   SIDECAR_SECRET_KEYS,
   AGENT_SECRET_KEYS,
 } from "../../credential-split.ts";
 
-describe("splitCredentials — all secrets fit", () => {
+describe("splitCredentials — secret routing", () => {
   it("moves every known-secret key to MMDS and leaves non-secret keys on the drive", () => {
     const sidecarEnv = {
       RUN_TOKEN: "tok",
@@ -23,11 +25,13 @@ describe("splitCredentials — all secrets fit", () => {
       PI_LLM_OAUTH_CONFIG_JSON: "{}",
       CONNECT_LOGIN_JSON: "{}",
       INTEGRATIONS_TO_SPAWN_JSON: "[]",
+      PROXY_URL: "http://user:pass@proxy.example:8080",
       PLATFORM_API_URL: "http://10.0.0.1:3000", // non-secret
       SIDECAR_PORT: "8080", // non-secret
     };
     const agentEnv = {
       APPSTRATE_SINK_SECRET: "hmac",
+      MODEL_API_KEY: "sk-real-provider-key",
       AGENT_PROMPT: "do the thing", // non-secret
       MODEL_ID: "gpt-x", // non-secret
     };
@@ -45,14 +49,29 @@ describe("splitCredentials — all secrets fit", () => {
     for (const key of SIDECAR_SECRET_KEYS) {
       expect(split.driveSidecarEnv?.[key]).toBeUndefined();
     }
-    expect(split.driveAgentEnv.APPSTRATE_SINK_SECRET).toBeUndefined();
+    for (const key of AGENT_SECRET_KEYS) {
+      expect(split.driveAgentEnv[key]).toBeUndefined();
+    }
     // Non-secret keys stay on the drive, never in MMDS.
     expect(split.driveSidecarEnv?.PLATFORM_API_URL).toBe("http://10.0.0.1:3000");
     expect(split.driveSidecarEnv?.SIDECAR_PORT).toBe("8080");
     expect(split.driveAgentEnv.AGENT_PROMPT).toBe("do the thing");
     expect(split.mmdsPayload.sidecar_env.PLATFORM_API_URL).toBeUndefined();
     expect(split.mmdsPayload.agent_env.AGENT_PROMPT).toBeUndefined();
-    expect(split.spilledKeys).toEqual([]);
+  });
+
+  it("brokers PROXY_URL (it can embed user:pass credentials) — S-2 regression", () => {
+    const split = splitCredentials({ PROXY_URL: "http://u:p@h:1" }, {});
+    expect(split.driveSidecarEnv?.PROXY_URL).toBeUndefined();
+    expect(split.mmdsPayload.sidecar_env.PROXY_URL).toBe("http://u:p@h:1");
+  });
+
+  it("brokers MODEL_API_KEY off the agent drive env (skipSidecar real key) — B-3 regression", () => {
+    // skipSidecar/direct-provider runs put the REAL provider key in the
+    // agent env; it must never be materialised on the config drive.
+    const split = splitCredentials(undefined, { MODEL_API_KEY: "sk-real" });
+    expect(split.driveAgentEnv.MODEL_API_KEY).toBeUndefined();
+    expect(split.mmdsPayload.agent_env.MODEL_API_KEY).toBe("sk-real");
   });
 
   it("does not mutate the input maps", () => {
@@ -73,59 +92,33 @@ describe("splitCredentials — empty / skipSidecar", () => {
     expect(split.driveAgentEnv).toEqual({});
   });
 
-  it("handles empty maps — empty payload, empty drive, no spill", () => {
+  it("handles empty maps — empty payload, empty drive", () => {
     const split = splitCredentials({}, {});
     expect(split.mmdsPayload).toEqual({ sidecar_env: {}, agent_env: {} });
     expect(split.driveSidecarEnv).toEqual({});
     expect(split.driveAgentEnv).toEqual({});
-    expect(split.spilledKeys).toEqual([]);
   });
 });
 
-describe("splitCredentials — oversized payload spills largest-first", () => {
-  it("spills the largest offending secret back onto the drive until it fits", () => {
-    // INTEGRATIONS_TO_SPAWN_JSON alone exceeds the budget — it must spill,
-    // the smaller secrets stay in MMDS.
-    const huge = "x".repeat(MMDS_PAYLOAD_BUDGET_BYTES + 1_000);
-    const sidecarEnv = {
-      RUN_TOKEN: "tok",
-      INTEGRATIONS_TO_SPAWN_JSON: huge,
-      PLATFORM_API_URL: "http://10.0.0.1:3000",
-    };
-    const split = splitCredentials(sidecarEnv, {});
-
-    // The oversized key spilled back to the drive; its name is reported.
-    expect(split.spilledKeys).toContain("INTEGRATIONS_TO_SPAWN_JSON");
-    expect(split.driveSidecarEnv?.INTEGRATIONS_TO_SPAWN_JSON).toBe(huge);
-    expect(split.mmdsPayload.sidecar_env.INTEGRATIONS_TO_SPAWN_JSON).toBeUndefined();
-    // Smaller secret still brokered.
-    expect(split.mmdsPayload.sidecar_env.RUN_TOKEN).toBe("tok");
-    // Non-secret untouched.
-    expect(split.driveSidecarEnv?.PLATFORM_API_URL).toBe("http://10.0.0.1:3000");
-    // Resulting payload is within budget.
-    expect(Buffer.byteLength(JSON.stringify(split.mmdsPayload))).toBeLessThanOrEqual(
-      MMDS_PAYLOAD_BUDGET_BYTES,
+describe("splitCredentials — no spill, ever", () => {
+  it("keeps an oversized secret in MMDS instead of degrading it to the drive", () => {
+    // Larger than Firecracker's default store — the orchestrator raises
+    // the VMM limits (or fail-closes); the split NEVER moves the secret
+    // back onto the drive.
+    const huge = "x".repeat(MMDS_STORE_LIMIT_BYTES + 10_000);
+    const split = splitCredentials(
+      { INTEGRATIONS_TO_SPAWN_JSON: huge, RUN_TOKEN: "tok", PLATFORM_API_URL: "http://p" },
+      {},
     );
+    expect(split.driveSidecarEnv?.INTEGRATIONS_TO_SPAWN_JSON).toBeUndefined();
+    expect(split.mmdsPayload.sidecar_env.INTEGRATIONS_TO_SPAWN_JSON).toBe(huge);
+    expect(split.mmdsPayload.sidecar_env.RUN_TOKEN).toBe("tok");
+    expect(split.driveSidecarEnv?.PLATFORM_API_URL).toBe("http://p");
+    expect(mmdsPayloadBytes(split.mmdsPayload)).toBeGreaterThan(MMDS_STORE_LIMIT_BYTES);
   });
 
-  it("spills the biggest key first, keeping the most secrets in MMDS", () => {
-    // Two keys each ~60% of budget: exactly one must spill (the larger),
-    // and the smaller must remain brokered.
-    const big = "b".repeat(Math.floor(MMDS_PAYLOAD_BUDGET_BYTES * 0.6));
-    const bigger = "a".repeat(Math.floor(MMDS_PAYLOAD_BUDGET_BYTES * 0.65));
-    const sidecarEnv = {
-      PI_API_KEY: big,
-      INTEGRATIONS_TO_SPAWN_JSON: bigger,
-      RUN_TOKEN: "tok",
-    };
-    const split = splitCredentials(sidecarEnv, {});
-    // The larger key spilled; the smaller two remain in MMDS.
-    expect(split.spilledKeys).toEqual(["INTEGRATIONS_TO_SPAWN_JSON"]);
-    expect(split.mmdsPayload.sidecar_env.PI_API_KEY).toBe(big);
-    expect(split.mmdsPayload.sidecar_env.RUN_TOKEN).toBe("tok");
-    expect(split.driveSidecarEnv?.INTEGRATIONS_TO_SPAWN_JSON).toBe(bigger);
-    expect(Buffer.byteLength(JSON.stringify(split.mmdsPayload))).toBeLessThanOrEqual(
-      MMDS_PAYLOAD_BUDGET_BYTES,
-    );
+  it("mmdsPayloadBytes measures the exact serialized PUT body", () => {
+    const payload = { sidecar_env: { A: "é" }, agent_env: {} };
+    expect(mmdsPayloadBytes(payload)).toBe(Buffer.byteLength(JSON.stringify(payload)));
   });
 });

--- a/apps/api/src/modules/firecracker/test/unit/firecracker-lifecycle.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/firecracker-lifecycle.test.ts
@@ -344,25 +344,28 @@ describe("cleanupOrphans positive kill path", () => {
   );
 
   // Jailed orphan identity: inside the chroot every VMM shares the same
-  // argv, so the sweep matches "firecracker in argv AND (chroot root OR
-  // reserved jail uid)". An unprivileged test cannot chroot, but it CAN
-  // exercise the uid branch by recording its OWN uid as the jail uid —
-  // the sweep's >=1000 floor makes this Linux-CI-only (runner uid 1000).
-  it.skipIf(process.platform !== "linux" || (process.getuid?.() ?? 0) < 1000)(
-    "kills a jailed orphan matched by the recorded jail uid (argv gate still required)",
+  // exec path, so the sweep matches "exec'd as firecracker (argv[0] gate)
+  // AND (jailer-injected `--id` == recorded jailId OR /proc root == the
+  // recorded chroot)". The `--id` branch is exercisable unprivileged: a
+  // decoy carrying the flag pair in its argv.
+  it.skipIf(process.platform !== "linux")(
+    "kills a jailed orphan matched by the jailer-injected --id (argv gate still required)",
     async () => {
       const binDir = await mkdtemp(join(tmpdir(), "fc-decoy-jail-"));
       extraDirs.push(binDir);
       const decoyBin = join(binDir, "firecracker");
       await Bun.write(decoyBin, Bun.file("/bin/sh"));
       await chmod(decoyBin, 0o755);
-      const decoy = Bun.spawn([decoyBin, "-c", "sleep 30"]);
+      // Positional args after `-c <script>` land in the decoy's cmdline —
+      // mirroring the `--id <jailId>` the jailer injects into every VMM.
+      const decoy = Bun.spawn([decoyBin, "-c", "sleep 30", "sh", "--id", "fc-abcdef123456-3"]);
       spawned.push(decoy);
 
       const cmdlineReady = async (): Promise<boolean> => {
         try {
           const cmdline = await Bun.file(`/proc/${decoy.pid}/cmdline`).text();
-          return cmdline.split("\0").some((a) => a.includes("firecracker"));
+          const argv = cmdline.split("\0");
+          return argv.some((a) => a.includes("firecracker")) && argv.includes("--id");
         } catch {
           return false;
         }
@@ -379,8 +382,8 @@ describe("cleanupOrphans positive kill path", () => {
         JSON.stringify({
           runId: "run_jailed_orphan",
           tapDevice: "afc13",
-          jailId: "run-jailed-orphan-3",
-          jailUid: process.getuid?.() ?? 0,
+          jailId: "fc-abcdef123456-3",
+          jailUid: 64_003,
           chrootPath: join(binDir, "nonexistent-chroot", "root"),
         }),
       );
@@ -395,18 +398,58 @@ describe("cleanupOrphans positive kill path", () => {
     },
   );
 
-  it("refuses to uid-match a jailed orphan below the unprivileged floor (fail-closed)", async () => {
-    // A corrupted state file recording a system uid (here: 0) must never
-    // aim the sweep at system processes — no /proc match is attempted
-    // for uids < 1000 and the chroot path matches nothing.
-    const runDir = join(dataDir, "run_bad_uid");
+  it.skipIf(process.platform !== "linux")(
+    "never kills by uid alone — a same-uid firecracker-argv0 process without the run's --id survives",
+    async () => {
+      // The old sweep uid branch would false-kill this decoy (same uid as
+      // the recorded jailUid, argv0 gate satisfied, but a DIFFERENT run).
+      const binDir = await mkdtemp(join(tmpdir(), "fc-decoy-samuid-"));
+      extraDirs.push(binDir);
+      const decoyBin = join(binDir, "firecracker");
+      await Bun.write(decoyBin, Bun.file("/bin/sh"));
+      await chmod(decoyBin, 0o755);
+      const decoy = Bun.spawn([decoyBin, "-c", "sleep 30", "sh", "--id", "fc-000000000000-9"]);
+      spawned.push(decoy);
+      for (let i = 0; i < 40; i++) {
+        const ready = await Bun.file(`/proc/${decoy.pid}/cmdline`)
+          .text()
+          .then((c) => c.includes("firecracker"))
+          .catch(() => false);
+        if (ready) break;
+        await new Promise((r) => setTimeout(r, 25));
+      }
+
+      const runDir = join(dataDir, "run_other");
+      await mkdir(runDir, { recursive: true });
+      await writeFile(
+        join(runDir, "state.json"),
+        JSON.stringify({
+          runId: "run_other",
+          tapDevice: "afc15",
+          jailId: "fc-111111111111-2",
+          jailUid: process.getuid?.() ?? 0,
+          chrootPath: join(dataDir, "nonexistent", "root"),
+        }),
+      );
+
+      const { exec } = fakeExec();
+      const orch = readyOrchestrator(exec);
+      const report = await orch.cleanupOrphans();
+
+      expect(report.workloads).toBe(0); // decoy untouched
+      expect(decoy.signalCode).toBe(null);
+    },
+  );
+
+  it("kills nothing on a corrupted state file whose identities match no process", async () => {
+    const runDir = join(dataDir, "run_bad_state");
     await mkdir(runDir, { recursive: true });
     await writeFile(
       join(runDir, "state.json"),
       JSON.stringify({
-        runId: "run_bad_uid",
+        runId: "run_bad_state",
         tapDevice: "afc14",
-        jailId: "run-bad-uid-4",
+        jailId: "fc-deadbeef0000-4",
         jailUid: 0,
         chrootPath: join(dataDir, "nonexistent", "root"),
       }),
@@ -442,5 +485,89 @@ describe("bounded VMM reap after SIGKILL (D-state guard)", () => {
     const result = await orch.stopByRunId("run_dstate", 0);
     expect(result).toBe("stopped");
     expect(vm.stopping).toBe(true);
+  });
+
+  it("waitForExit unblocks with killed semantics when the reap is abandoned (B-1)", async () => {
+    const { exec } = fakeExec();
+    const orch = readyOrchestrator(exec);
+    await orch.createIsolationBoundary("run_dstate_wait");
+    const vm = getVm(orch, "run_dstate_wait");
+    Reflect.set(orch, "vmmReapTimeoutMs", 50);
+    // `exited` NEVER settles — the production hang: pi.ts awaits
+    // waitForExit for the whole run, the timeout fires stopWorkload, the
+    // kill path gives up on the D-state VMM… and the old waitForExit kept
+    // awaiting `proc.exited` forever.
+    vm.proc = {
+      pid: 999_998,
+      exitCode: null,
+      signalCode: null,
+      kill() {},
+      exited: new Promise<number>(() => {}),
+    } as unknown as BunProcess;
+
+    const handle = {
+      id: "fc-run_dstate_wait-agent",
+      runId: "run_dstate_wait",
+      role: "agent" as const,
+    };
+    const exitPromise = orch.waitForExit(handle);
+    await orch.stopByRunId("run_dstate_wait", 0);
+    // Must resolve (bounded), with the killed code — not hang.
+    expect(await exitPromise).toBe(137);
+  });
+
+  it("the failed-state-write kill path is bounded too (startWorkload catch → killVm)", async () => {
+    // Direct unit of the same guarantee for the second unbounded waiter
+    // the review flagged: killVm(vm, 0) on a never-reaping proc returns
+    // within the (shrunk) reap bound instead of awaiting `exited` raw.
+    const { exec } = fakeExec();
+    const orch = readyOrchestrator(exec);
+    await orch.createIsolationBoundary("run_dstate_kill");
+    const vm = getVm(orch, "run_dstate_kill");
+    Reflect.set(orch, "vmmReapTimeoutMs", 50);
+    vm.proc = {
+      pid: 999_997,
+      exitCode: null,
+      signalCode: null,
+      kill() {},
+      exited: new Promise<number>(() => {}),
+    } as unknown as BunProcess;
+    const killVm = Reflect.get(orch, "killVm") as (v: unknown, g: number) => Promise<void>;
+    const start = Date.now();
+    await killVm.call(orch, vm, 0);
+    expect(Date.now() - start).toBeLessThan(5_000);
+  });
+});
+
+describe("orphan sweep containment (S-10)", () => {
+  it("refuses to rm a chrootPath outside the jail base (corrupted state.json)", async () => {
+    // A directory OUTSIDE the data dir tree, referenced by a corrupted
+    // state file — the recursive root rm must be contained to the jail
+    // base, never aimed at arbitrary host paths.
+    const outsideDir = await mkdtemp(join(tmpdir(), "fc-outside-"));
+    extraDirs.push(outsideDir);
+    await mkdir(join(outsideDir, "root"), { recursive: true });
+    await writeFile(join(outsideDir, "canary.txt"), "still here");
+
+    const runDir = join(dataDir, "run_escape");
+    await mkdir(runDir, { recursive: true });
+    await writeFile(
+      join(runDir, "state.json"),
+      JSON.stringify({
+        runId: "run_escape",
+        tapDevice: "afc16",
+        jailId: "fc-222222222222-1",
+        jailUid: 64_001,
+        chrootPath: join(outsideDir, "root"),
+      }),
+    );
+
+    const { exec } = fakeExec();
+    const orch = readyOrchestrator(exec);
+    await orch.cleanupOrphans();
+
+    // The out-of-base tree survived; the run dir itself was reclaimed.
+    expect(await Bun.file(join(outsideDir, "canary.txt")).text()).toBe("still here");
+    expect(await Bun.file(join(runDir, "state.json")).exists()).toBe(false);
   });
 });

--- a/apps/api/src/modules/firecracker/test/unit/firecracker-orchestrator.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/firecracker-orchestrator.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { _resetFirecrackerEnvCacheForTesting as _resetCacheForTesting } from "../../runner/host-env.ts";
 import { FirecrackerOrchestrator, type FirecrackerOrchestratorDeps } from "../../orchestrator.ts";
+import { deriveJailId } from "../../jail.ts";
 import type { HostExec } from "../../host-net.ts";
 
 interface RecordedCall {
@@ -87,9 +88,9 @@ function readyOrchestrator(
 }
 
 /**
- * The allocator is round-robin (a released index is only re-drawn after a
- * full wrap), so "which index does the next run get" cannot observe a
- * release. The reserved-set is the actual accounting — read it directly.
+ * The reserved-set is the allocator's actual accounting — read it
+ * directly rather than inferring releases from "which index does the
+ * next run get".
  */
 function reservedIndexes(orch: FirecrackerOrchestrator): Set<number> {
   const allocator = Reflect.get(orch, "allocator") as object;
@@ -466,15 +467,16 @@ describe("jailer-mode boundary (FIRECRACKER_JAILER=on)", () => {
     const state = JSON.parse(
       await Bun.file(join(jailTestRoot, "runs", "run_1", "state.json")).text(),
     ) as Record<string, unknown>;
-    // jailId = sanitized runId ("_" is outside the jailer's charset) +
-    // the run's subnet index (collision-proofing).
-    expect(state.jailId).toBe("run-1-1");
-    expect(state.jailUid).toBe(64_001); // FIRECRACKER_JAIL_UID_BASE default + index 1
-    const expectedRoot = join(jailTestRoot, "jail", "firecracker", "run-1-1", "root");
+    // jailId = short runId digest + the run's subnet index (jailer charset,
+    // AF_UNIX socket-path budget, collision-proofing).
+    const jailId = deriveJailId("run_1", 1);
+    expect(state.jailId).toBe(jailId);
+    expect(state.jailUid).toBe(200_001); // FIRECRACKER_JAIL_UID_BASE default + index 1
+    const expectedRoot = join(jailTestRoot, "jail", "firecracker", jailId, "root");
     expect(state.chrootPath).toBe(expectedRoot);
     expect(state.apiSocketPath).toBe(join(expectedRoot, "run", "firecracker.socket"));
     // The unprivileged jailed VMM can only TUNSETIFF a TAP born as its own.
-    expect(calls[0]?.stdin).toContain("tuntap add dev afc1 mode tap user 64001\n");
+    expect(calls[0]?.stdin).toContain("tuntap add dev afc1 mode tap user 200001\n");
     expect(boundary.name).toBe("firecracker-run_1");
   });
 
@@ -497,7 +499,7 @@ describe("jailer-mode boundary (FIRECRACKER_JAILER=on)", () => {
     const boundary = await orch.createIsolationBoundary("run_1");
 
     // Simulate the chroot a spawn would have populated.
-    const jailDir = join(jailTestRoot, "jail", "firecracker", "run-1-1");
+    const jailDir = join(jailTestRoot, "jail", "firecracker", deriveJailId("run_1", 1));
     await mkdir(join(jailDir, "root", "run"), { recursive: true });
     await writeFile(join(jailDir, "root", "vmconfig.json"), "{}");
 

--- a/apps/api/src/modules/firecracker/test/unit/guest-protocol-pin.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/guest-protocol-pin.test.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Guest-protocol compatibility pin: the config-drive wire shape
+ * (buildGuestConfig output — what the in-guest supervisor parses) is
+ * snapshotted PER GUEST_PROTOCOL_VERSION. Changing the shape without
+ * bumping the version fails here — exactly the drift that shipped the
+ * MMDS `credentials.source` field under protocol 1 and let an upgraded
+ * daemon boot a supervisor that silently ignored it (review B-4).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { buildGuestConfig } from "../../vm-config.ts";
+import { GUEST_PROTOCOL_VERSION } from "../../runner/artifacts.ts";
+
+/** Sorted deep key paths of a JSON value — a structural fingerprint. */
+function keyPaths(value: unknown, prefix = ""): string[] {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return [];
+  const paths: string[] = [];
+  for (const key of Object.keys(value as Record<string, unknown>)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    paths.push(path, ...keyPaths((value as Record<string, unknown>)[key], path));
+  }
+  return paths.sort();
+}
+
+/**
+ * The config-drive contract per protocol version. Adding/renaming/removing
+ * a field the supervisor reads = a host↔guest contract change:
+ *   1. bump GUEST_PROTOCOL_VERSION in runner/artifacts.ts (see its BUMP
+ *      RULES — a lockstep artifact release),
+ *   2. add the new version's fingerprint here (keep the old entries).
+ */
+const CONTRACT_BY_PROTOCOL: Record<number, string[]> = {
+  2: [
+    "agent",
+    "agent.argv",
+    "agent.env",
+    "agent.env.MODEL_API_KEY",
+    "agent.unrestricted_egress",
+    "credentials",
+    "credentials.source",
+    "exit_marker_nonce",
+    "network",
+    "network.platform_ip",
+    "network.platform_port",
+    "run_id",
+    "sidecar",
+    "sidecar.enabled",
+    "sidecar.env",
+    "sidecar.env.RUN_TOKEN",
+  ],
+};
+
+describe("guest config ↔ GUEST_PROTOCOL_VERSION pin", () => {
+  it("the config-drive shape matches the snapshot recorded for the current protocol", () => {
+    const expected = CONTRACT_BY_PROTOCOL[GUEST_PROTOCOL_VERSION];
+    if (!expected) {
+      throw new Error(
+        `No config-drive fingerprint recorded for GUEST_PROTOCOL_VERSION=${GUEST_PROTOCOL_VERSION} ` +
+          `— add one to CONTRACT_BY_PROTOCOL in this test (and publish artifacts in lockstep).`,
+      );
+    }
+    const config = buildGuestConfig({
+      runId: "run_pin",
+      exitMarkerNonce: "00ff",
+      platformIp: "10.231.255.1",
+      platformPort: 3000,
+      sidecarEnv: { RUN_TOKEN: "tok" },
+      agentEnv: { MODEL_API_KEY: "sk-x" },
+      agentUnrestrictedEgress: false,
+      credentialSource: "mmds",
+      agentArgv: ["/bin/sh", "-c", "true"],
+    });
+    expect(keyPaths(config)).toEqual(expected);
+  });
+});

--- a/apps/api/src/modules/firecracker/test/unit/host-env.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/host-env.test.ts
@@ -76,12 +76,14 @@ describe("jailer confinement surface (FIRECRACKER_JAILER* / FIRECRACKER_JAIL_*)"
     return getFirecrackerEnv();
   }
 
-  it("defaults to the production posture: jailer ON, PATH binary, uid base 64000, cgroups ON", () => {
+  it("defaults to the production posture: jailer ON, PATH binary, uid base 200000, cgroups ON", () => {
     for (const k of JAIL_KEYS) delete process.env[k];
     const env = freshEnv();
     expect(env.FIRECRACKER_JAILER).toBe("on");
     expect(env.FIRECRACKER_JAILER_BIN).toBe("jailer");
-    expect(env.FIRECRACKER_JAIL_UID_BASE).toBe(64_000);
+    // Above the whole 16-bit uid space: the per-VM range must never cross
+    // nobody (65534/65535) or the systemd DynamicUser pool (61184–65519).
+    expect(env.FIRECRACKER_JAIL_UID_BASE).toBe(200_000);
     expect(env.FIRECRACKER_JAIL_CGROUPS).toBe("on");
   });
 
@@ -108,6 +110,33 @@ describe("jailer confinement surface (FIRECRACKER_JAILER* / FIRECRACKER_JAIL_*)"
     process.env.FIRECRACKER_JAIL_UID_BASE = "500";
     _resetFirecrackerEnvCacheForTesting();
     expect(() => getFirecrackerEnv()).toThrow();
+  });
+
+  it("rejects uid ranges intersecting nobody / systemd DynamicUser (S-3)", () => {
+    // Base inside the DynamicUser pool (61184–65519).
+    process.env.FIRECRACKER_JAIL_UID_BASE = "64000";
+    _resetFirecrackerEnvCacheForTesting();
+    expect(() => getFirecrackerEnv()).toThrow(/DynamicUser/);
+    // Base below the pool whose range CROSSES into it (default 16 VMs).
+    process.env.FIRECRACKER_JAIL_UID_BASE = "61180";
+    _resetFirecrackerEnvCacheForTesting();
+    expect(() => getFirecrackerEnv()).toThrow(/DynamicUser/);
+    // Just past nobody: clean.
+    process.env.FIRECRACKER_JAIL_UID_BASE = "65536";
+    expect(freshEnv().FIRECRACKER_JAIL_UID_BASE).toBe(65_536);
+  });
+
+  it("validates the uid range against the ALLOCATOR ceiling when the VM cap is unlimited", () => {
+    // With FIRECRACKER_MAX_CONCURRENT_VMS=0 the reachable index span is the
+    // full 16319 — a base of 50000 then crosses 61184.
+    process.env.FIRECRACKER_JAIL_UID_BASE = "50000";
+    process.env.FIRECRACKER_MAX_CONCURRENT_VMS = "0";
+    _resetFirecrackerEnvCacheForTesting();
+    try {
+      expect(() => getFirecrackerEnv()).toThrow(/DynamicUser/);
+    } finally {
+      delete process.env.FIRECRACKER_MAX_CONCURRENT_VMS;
+    }
   });
 });
 

--- a/apps/api/src/modules/firecracker/test/unit/jail.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/jail.test.ts
@@ -12,6 +12,7 @@ import { describe, it, expect } from "bun:test";
 import { join } from "node:path";
 import {
   assertApiSocketPathLength,
+  assertJailerVersionParity,
   buildJailerArgv,
   computeJailPaths,
   deriveJailId,
@@ -81,27 +82,22 @@ function fakeJailFs(fail?: { op: keyof JailFs; code: string; oncePath?: string }
 }
 
 describe("deriveJailId", () => {
-  it("keeps jailer-charset runIds and appends the subnet index", () => {
-    expect(deriveJailId("abc-123", 7)).toBe("abc-123-7");
-  });
-
-  it("replaces characters outside the jailer charset ([a-zA-Z0-9-])", () => {
-    // RUN_ID_RE also admits `_` and `.` — the jailer does not.
-    expect(deriveJailId("run_1.alpha", 2)).toBe("run-1-alpha-2");
-  });
-
-  it("always differs across runs that sanitize identically (index suffix)", () => {
-    // "run_1" and "run.1" both sanitize to "run-1" — a shared chroot
-    // between two live runs would be catastrophic; the per-run subnet
-    // index keeps the ids distinct.
-    expect(deriveJailId("run_1", 3)).not.toBe(deriveJailId("run.1", 4));
-  });
-
-  it("caps the id at 64 chars including the suffix", () => {
-    const id = deriveJailId("x".repeat(200), 16319);
-    expect(id.length).toBe(64);
-    expect(id.endsWith("-16319")).toBe(true);
+  it("derives a short, deterministic, jailer-charset id (digest + subnet index)", () => {
+    const id = deriveJailId("run_9f0c2b1a-1234-5678-9abc-def012345678", 7);
+    expect(id).toBe(deriveJailId("run_9f0c2b1a-1234-5678-9abc-def012345678", 7));
+    expect(/^fc-[0-9a-f]{12}-7$/.test(id)).toBe(true);
     expect(/^[a-zA-Z0-9-]{1,64}$/.test(id)).toBe(true);
+  });
+
+  it("differs across distinct runIds and across indexes", () => {
+    expect(deriveJailId("run_1", 3)).not.toBe(deriveJailId("run.1", 3));
+    expect(deriveJailId("run_1", 3)).not.toBe(deriveJailId("run_1", 4));
+  });
+
+  it("stays short regardless of the runId length (socket-path budget)", () => {
+    const id = deriveJailId("x".repeat(200), 16319);
+    expect(id.length).toBeLessThanOrEqual(3 + 12 + 1 + 5);
+    expect(id.endsWith("-16319")).toBe(true);
   });
 });
 
@@ -113,23 +109,39 @@ describe("computeJailPaths", () => {
     subnetIndex: 5,
     uidBase: 64_000,
   };
+  const jailId = deriveJailId("run_42", 5);
 
   it("lays out the jailer-conventional chroot tree beside the runs dir", () => {
     const paths = computeJailPaths(input);
-    expect(paths.jailId).toBe("run-42-5");
+    expect(paths.jailId).toBe(jailId);
     expect(paths.uid).toBe(64_005);
     expect(paths.gid).toBe(64_005);
     expect(paths.chrootBaseDir).toBe("/var/lib/fc/jail");
-    expect(paths.jailDir).toBe("/var/lib/fc/jail/firecracker/run-42-5");
-    expect(paths.rootDir).toBe("/var/lib/fc/jail/firecracker/run-42-5/root");
+    expect(paths.jailDir).toBe(`/var/lib/fc/jail/firecracker/${jailId}`);
+    expect(paths.rootDir).toBe(`/var/lib/fc/jail/firecracker/${jailId}/root`);
     expect(paths.apiSocketHostPath).toBe(
-      "/var/lib/fc/jail/firecracker/run-42-5/root/run/firecracker.socket",
+      `/var/lib/fc/jail/firecracker/${jailId}/root/run/firecracker.socket`,
     );
   });
 
   it("nests the chroot under the exec-file basename (jailer layout contract)", () => {
     const paths = computeJailPaths({ ...input, fcExecName: "firecracker-v1.16.0" });
-    expect(paths.jailDir).toBe("/var/lib/fc/jail/firecracker-v1.16.0/run-42-5");
+    expect(paths.jailDir).toBe(`/var/lib/fc/jail/firecracker-v1.16.0/${jailId}`);
+  });
+
+  it("fits the AF_UNIX socket cap with a REAL run id under the production layout (B-2)", () => {
+    // Installer defaults (/var/lib/appstrate-runner/runs) + the platform's
+    // actual `run_<uuid>` id shape — the pre-digest jailId derivation blew
+    // the ~108-byte sun_path cap here and refused 100% of jailed prod runs.
+    // Only toy ids like "run-42" kept the old tests green.
+    const paths = computeJailPaths({
+      dataDir: "/var/lib/appstrate-runner/runs",
+      fcExecName: "firecracker",
+      runId: `run_${crypto.randomUUID()}`,
+      subnetIndex: 16319,
+      uidBase: 200_000,
+    });
+    expect(Buffer.byteLength(paths.apiSocketHostPath)).toBeLessThan(MAX_API_SOCKET_PATH_BYTES);
   });
 
   it("throws the operator-facing error when the socket path would exceed the AF_UNIX cap", () => {
@@ -204,6 +216,30 @@ describe("buildJailerArgv", () => {
     expect(argv).toContain("--");
   });
 
+  it("forwards extra firecracker flags after the -- separator (MMDS size overrides)", () => {
+    const argv = buildJailerArgv({
+      jailerBin: "jailer",
+      fcBin: "/x/firecracker",
+      jail,
+      extraFcArgs: ["--mmds-size-limit", "123456", "--http-api-max-payload-size", "123456"],
+    });
+    const sep = argv.indexOf("--");
+    expect(sep).toBeGreaterThan(0);
+    expect(argv.slice(sep + 1, sep + 5)).toEqual([
+      "--mmds-size-limit",
+      "123456",
+      "--http-api-max-payload-size",
+      "123456",
+    ]);
+    // The fixed api-sock/config-file pair still closes the argv.
+    expect(argv.slice(-4)).toEqual([
+      "--api-sock",
+      CHROOT_API_SOCKET_PATH,
+      "--config-file",
+      CHROOT_VMCONFIG_PATH,
+    ]);
+  });
+
   it("never detaches the VMM from the spawn handle (no daemonize / pid-ns / netns)", () => {
     // --daemonize redirects stdio to /dev/null and setsid()s; with
     // --new-pid-ns the PARENT jailer exits 0 immediately without
@@ -213,6 +249,25 @@ describe("buildJailerArgv", () => {
     expect(argv).not.toContain("--daemonize");
     expect(argv).not.toContain("--new-pid-ns");
     expect(argv).not.toContain("--netns");
+  });
+});
+
+describe("assertJailerVersionParity", () => {
+  it("accepts matching releases regardless of the surrounding text", () => {
+    expect(() => assertJailerVersionParity("Firecracker v1.16.0", "Jailer v1.16.0")).not.toThrow();
+  });
+
+  it("rejects a version mismatch (env override bypassing the installer lockstep)", () => {
+    expect(() => assertJailerVersionParity("Firecracker v1.16.0", "Jailer v1.15.1")).toThrow(
+      /same upstream release/,
+    );
+  });
+
+  it("rejects unparseable probes — no parity proof, no pass", () => {
+    expect(() => assertJailerVersionParity("Firecracker v1.16.0", "garbage")).toThrow(
+      /version parity/,
+    );
+    expect(() => assertJailerVersionParity("", "Jailer v1.16.0")).toThrow(/version parity/);
   });
 });
 

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -363,7 +363,14 @@ async function finalizeRunImpl(input: FinalizeRunInput): Promise<void> {
   // the CAS on `sink_closed_at` guarantees a terminal usage arriving
   // after this finalize can never re-open the run.
   let validatedUsage = validateFinalizeUsage(result.usage, run.id);
-  if (validatedUsage === null && status !== "success") {
+  // Non-success without runner-posted usage: the run-row column must keep
+  // whatever cumulative snapshot the `appstrate.metric` side-channel last
+  // wrote. The COLUMN preservation happens atomically in the CAS below
+  // (SQL COALESCE) — a JS read-then-write here would race a concurrent
+  // metric event and clobber a newer snapshot with the stale read. The
+  // read below only feeds the ledger-row fallback (result.cost > 0).
+  const preserveLastKnownUsage = validatedUsage === null && status !== "success";
+  if (preserveLastKnownUsage) {
     validatedUsage = await readLastKnownUsage(run.id);
   }
   if (validatedUsage === null) {
@@ -500,9 +507,13 @@ async function finalizeRunImpl(input: FinalizeRunInput): Promise<void> {
       // The finalize body is the authoritative terminal usage. Metric events
       // may still update this column before finalize for live charts, but the
       // close path writes the terminal value exactly once. When a non-success
-      // terminal carried no usage, `validatedUsage` is the preserved
-      // last-known snapshot — never a masking zero.
-      tokenUsage: validatedUsage,
+      // terminal carried no usage, the column keeps its last-known snapshot
+      // ATOMICALLY (COALESCE evaluates in the UPDATE itself — a metric event
+      // landing between the JS read above and this CAS cannot be clobbered
+      // by a stale value); zeros only when nothing was ever recorded.
+      tokenUsage: preserveLastKnownUsage
+        ? sql`COALESCE(${runs.tokenUsage}, ${JSON.stringify({ input_tokens: 0, output_tokens: 0 })}::jsonb)`
+        : validatedUsage,
       ...(metadata ? { metadata } : {}),
     })
     .where(and(eq(runs.id, run.id), sql`sink_closed_at IS NULL`))

--- a/apps/api/test/integration/routes/runs-events-ingestion.test.ts
+++ b/apps/api/test/integration/routes/runs-events-ingestion.test.ts
@@ -709,6 +709,89 @@ describe("POST /api/runs/:runId/events/finalize — complete result persistence"
     expect(row?.tokenUsage).toEqual({ input_tokens: 12, output_tokens: 3 });
   });
 
+  // B2 preservation semantics: a NON-success terminal that carries no
+  // runner-posted usage must keep the cumulative snapshot the
+  // `appstrate.metric` side-channel wrote during the run — done atomically
+  // in SQL (COALESCE in the CAS UPDATE), so a metric event racing the
+  // finalize can never be clobbered by a stale JS read (review S-9).
+  it("preserves the last-known metric snapshot on a non-success finalize without usage", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/final-agent", {
+      tokenUsage: { input_tokens: 50, output_tokens: 25 },
+    });
+
+    const run = await getRunSinkContext(runId);
+    expect(run).not.toBeNull();
+    const result = emptyRunResult();
+    result.status = "failed";
+    result.error = { message: "container crashed", code: "crash" };
+    // No result.usage at all — the watchdog-kill / crash shape.
+
+    await finalizeRun({ run: run!, result });
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    expect(row?.sinkClosedAt).not.toBeNull();
+    // The side-channel snapshot survives — never masked by zeros.
+    expect(row?.tokenUsage).toEqual({ input_tokens: 50, output_tokens: 25 });
+  });
+
+  it("malformed usage on a NON-success finalize also preserves the snapshot (B2)", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/final-agent", {
+      tokenUsage: { input_tokens: 7, output_tokens: 2 },
+    });
+
+    const run = await getRunSinkContext(runId);
+    expect(run).not.toBeNull();
+    const result = emptyRunResult();
+    result.status = "failed";
+    result.error = { message: "boom", code: "crash" };
+    // Bypass the route schema deliberately — exercise the service boundary.
+    (result as { usage?: unknown }).usage = { input_tokens: "lots", bogus: true };
+
+    await finalizeRun({ run: run!, result });
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    expect(row?.tokenUsage).toEqual({ input_tokens: 7, output_tokens: 2 });
+  });
+
+  it("zero-fills a non-success finalize when NO usage was ever recorded", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/final-agent", { tokenUsage: null });
+
+    const run = await getRunSinkContext(runId);
+    expect(run).not.toBeNull();
+    const result = emptyRunResult();
+    result.status = "failed";
+    result.error = { message: "died at boot", code: "crash" };
+
+    await finalizeRun({ run: run!, result });
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    expect(row?.tokenUsage).toEqual({ input_tokens: 0, output_tokens: 0 });
+  });
+
+  it("does not throw on a corrupt tokenUsage JSONB during a non-success finalize", async () => {
+    // readLastKnownUsage's tolerant Zod boundary: a corrupt column value
+    // degrades to null for the ledger fallback, and the finalize still
+    // closes the run — never a crash mid-terminal-transition.
+    const runId = await seedRunWithSink(ctx, "@test/final-agent", {
+      tokenUsage: { input_tokens: "corrupt" } as unknown as Record<string, number>,
+    });
+
+    const run = await getRunSinkContext(runId);
+    expect(run).not.toBeNull();
+    const result = emptyRunResult();
+    result.status = "failed";
+    result.error = { message: "boom", code: "crash" };
+
+    await finalizeRun({ run: run!, result });
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    expect(row?.sinkClosedAt).not.toBeNull();
+  });
+
   // Zod boundary on `runs.result` (runResultSchema, 512 KiB cap): an
   // over-cap payload degrades to `result: null` + a warn log — it must
   // never fail the terminal transition of an already-completed run.

--- a/apps/cli/src/commands/runner.ts
+++ b/apps/cli/src/commands/runner.ts
@@ -493,12 +493,20 @@ export async function runnerDoctor(opts: RunnerDoctorOptions = {}): Promise<Runn
     }
   }
 
-  // Jailer presence — informational (the daemon itself refuses to boot
-  // without it when FIRECRACKER_JAILER=on, which the health line shows).
+  // Jailer presence. Counted in `ok` whenever the jailer is required
+  // (FIRECRACKER_JAILER unset or "on"): the daemon refuses to boot without
+  // it in that mode, so a green doctor next to a missing jailer would lie
+  // about the next restart.
   const jailerPath = runnerDataPaths(dataDir).jailerBin;
   const jailer = { installed: await d.fs.exists(jailerPath), path: jailerPath };
+  const jailerRequired = (env.FIRECRACKER_JAILER ?? "on") !== "off";
 
-  const ok = preflight.ok && service.active && health.reachable && health.status === 200;
+  const ok =
+    preflight.ok &&
+    service.active &&
+    health.reachable &&
+    health.status === 200 &&
+    (!jailerRequired || jailer.installed);
   return { preflight, service, health, artifacts, jailer, ok };
 }
 

--- a/apps/cli/test/runner.test.ts
+++ b/apps/cli/test/runner.test.ts
@@ -439,13 +439,14 @@ describe("enableService", () => {
 // ─── doctor assembly ───────────────────────────────────────────────────────
 
 describe("runnerDoctor", () => {
-  it("reports healthy when preflight + systemd + health + artifacts all pass", async () => {
+  it("reports healthy when preflight + systemd + health + artifacts + jailer all pass", async () => {
     const envText = renderRunnerEnvFile(config);
     const marker = runnerDataPaths(config.dataDir).artifactsMarker;
     const { fs } = fakeFs({
       "/etc/appstrate-runner/env": envText,
       "/etc/systemd/system/appstrate-runner.service": "unit",
       [marker]: JSON.stringify({ version: "1.2.3", guest_protocol: 1 }),
+      [runnerDataPaths(config.dataDir).jailerBin]: "<installed>",
     });
     const { exec } = fakeExec({
       "systemctl is-active": () => ({ ok: true, exitCode: 0, stdout: "active\n", stderr: "" }),
@@ -468,28 +469,57 @@ describe("runnerDoctor", () => {
     expect(report.health.status).toBe(200);
     expect(report.artifacts.version).toBe("1.2.3");
     expect(report.artifacts.guestProtocol).toBe(1);
-    // Jailer presence is surfaced (informational — the daemon's own boot
-    // gate is what fails hard when it is missing with FIRECRACKER_JAILER=on).
     expect(report.jailer.path).toBe(`${config.dataDir}/bin/jailer`);
-    expect(report.jailer.installed).toBe(false);
+    expect(report.jailer.installed).toBe(true);
   });
 
-  it("reports the jailer as installed when the binary exists", async () => {
-    const jailerPath = runnerDataPaths(config.dataDir).jailerBin;
+  it("reports NOT-ok when the jailer is required but missing (S-11)", async () => {
+    // Everything else green — but FIRECRACKER_JAILER defaults to "on" and
+    // the binary is absent: the daemon would refuse its next boot, so a
+    // green doctor here would lie.
+    const marker = runnerDataPaths(config.dataDir).artifactsMarker;
     const { fs } = fakeFs({
       "/etc/appstrate-runner/env": renderRunnerEnvFile(config),
-      [jailerPath]: "<installed>",
+      "/etc/systemd/system/appstrate-runner.service": "unit",
+      [marker]: JSON.stringify({ version: "1.2.3", guest_protocol: 1 }),
     });
-    const { exec } = fakeExec();
+    const { exec } = fakeExec({
+      "systemctl is-active": () => ({ ok: true, exitCode: 0, stdout: "active\n", stderr: "" }),
+      "systemctl is-enabled": () => ({ ok: true, exitCode: 0, stdout: "enabled\n", stderr: "" }),
+    });
     const report = await runnerDoctor({
       deps: {
         fs,
         exec,
-        http: fakeHttp({}),
+        http: fakeHttp({ health: { status: 200, body: { protocol: 1, initialized: true } } }),
         preflight: async () => ({ ok: true, arch: "x86_64", checks: [] }),
       },
     });
-    expect(report.jailer.installed).toBe(true);
+    expect(report.jailer.installed).toBe(false);
+    expect(report.ok).toBe(false);
+  });
+
+  it("stays ok without the jailer when FIRECRACKER_JAILER=off in the env file", async () => {
+    const marker = runnerDataPaths(config.dataDir).artifactsMarker;
+    const { fs } = fakeFs({
+      "/etc/appstrate-runner/env": `${renderRunnerEnvFile(config)}\nFIRECRACKER_JAILER=off\n`,
+      "/etc/systemd/system/appstrate-runner.service": "unit",
+      [marker]: JSON.stringify({ version: "1.2.3", guest_protocol: 1 }),
+    });
+    const { exec } = fakeExec({
+      "systemctl is-active": () => ({ ok: true, exitCode: 0, stdout: "active\n", stderr: "" }),
+      "systemctl is-enabled": () => ({ ok: true, exitCode: 0, stdout: "enabled\n", stderr: "" }),
+    });
+    const report = await runnerDoctor({
+      deps: {
+        fs,
+        exec,
+        http: fakeHttp({ health: { status: 200, body: { protocol: 1, initialized: true } } }),
+        preflight: async () => ({ ok: true, arch: "x86_64", checks: [] }),
+      },
+    });
+    expect(report.jailer.installed).toBe(false);
+    expect(report.ok).toBe(true);
   });
 
   it("reports not-ok when the daemon is unreachable", async () => {

--- a/docs/architecture/FIRECRACKER.md
+++ b/docs/architecture/FIRECRACKER.md
@@ -202,12 +202,13 @@ security review first — the backend has not yet had one. Hardening status:
    (a) after injection the secrets still live in the sidecar's process
    memory/env inside the guest — a guest-kernel LPE can read _that_ run's
    credentials via `/proc` (the per-run VM still protects the host and
-   every other run); (b) an oversized `INTEGRATIONS_TO_SPAWN_JSON` that
-   exceeds the ~50 KiB MMDS store limit spills back onto the config drive
-   with a boot-time `logger.warn` (names only) — that one key then rides the
-   drive as before. `FIRECRACKER_CREDENTIAL_BROKER=config-drive` restores
-   the pre-MMDS behavior (all secrets on the drive) for bisecting a boot
-   regression.
+   every other run). A known secret NEVER falls back onto the drive: a
+   payload above Firecracker's 50 KiB store default gets the VMM's
+   `--mmds-size-limit`/`--http-api-max-payload-size` raised at spawn, and
+   beyond `FIRECRACKER_MMDS_MAX_BYTES` (default 16 MiB) the run FAILS
+   fail-closed instead of silently degrading the at-rest guarantee.
+   `FIRECRACKER_CREDENTIAL_BROKER=config-drive` restores the pre-MMDS
+   behavior (all secrets on the drive) for bisecting a boot regression.
 
 To be explicit about what defends what: **the security boundary is the
 per-run VM (KVM)**. The in-guest uid + nftables separation is
@@ -381,10 +382,14 @@ combined manifest to each `v*` GitHub Release.
   the SAME release tarball as `firecracker` — the two must come from one
   release; `appstrate runner install` keeps them in lockstep at
   `<data-dir>/bin/`). Per VM: chroot at
-  `<FIRECRACKER_DATA_DIR>/../jail/<vmm-name>/<jailId>/root`, privilege
+  `<FIRECRACKER_DATA_DIR>/../jail/<vmm-name>/<jailId>/root` (the jailId
+  is a short digest of the runId + the subnet index, keeping the
+  host-side API socket path under the AF_UNIX ~108-byte cap), privilege
   drop to uid/gid `FIRECRACKER_JAIL_UID_BASE + <subnet index>` (default
-  base 64000 — the range `base..base+16319` worst-case must be
-  unallocated on the host; no /etc/passwd entries are created or needed),
+  base 200000, above the 16-bit uid space — ranges intersecting nobody
+  65534/65535 or the systemd DynamicUser pool 61184–65519 are rejected at
+  boot; the range must be unallocated on the host and no /etc/passwd
+  entries are created or needed),
   and cgroup-v2 `memory.max`/`pids.max` bounds under the `appstrate-fc`
   parent slice (`FIRECRACKER_JAIL_CGROUPS=off` drops the bounds — not the
   jail — on hosts without cgroup-v2 delegation). Same-filesystem
@@ -507,9 +512,10 @@ boots on a bare KVM host with only these variables.
 | `FIRECRACKER_BIN`                | `firecracker`                    | VMM binary                                                                                                                               |
 | `FIRECRACKER_JAILER`             | `on`                             | per-VM jailer confinement (chroot + uid drop + cgroups); `off` = unjailed direct spawn, unprivileged dev ONLY                            |
 | `FIRECRACKER_JAILER_BIN`         | `jailer`                         | jailer binary — must come from the SAME release as `FIRECRACKER_BIN`                                                                     |
-| `FIRECRACKER_JAIL_UID_BASE`      | `64000`                          | per-VM uid/gid = base + subnet index; range must be unallocated on the host (min 1000)                                                   |
+| `FIRECRACKER_JAIL_UID_BASE`      | `200000`                         | per-VM uid/gid = base + subnet index; range must be unallocated and must not intersect 61184–65535 (min 1000)                            |
 | `FIRECRACKER_JAIL_CGROUPS`       | `on`                             | cgroup-v2 `memory.max`/`pids.max` per VM; `off` keeps the jail, drops the bounds (hosts without cgroup-v2 delegation)                    |
 | `FIRECRACKER_CREDENTIAL_BROKER`  | `mmds`                           | how run secrets reach the guest: `mmds` (in-memory MMDS store, off the config drive) or `config-drive` (pre-MMDS behavior, escape hatch) |
+| `FIRECRACKER_MMDS_MAX_BYTES`     | `16777216`                       | ceiling on the brokered credential payload; above the 50 KiB Firecracker default the VMM store limit is raised, above THIS the run fails |
 | `FIRECRACKER_KERNEL_PATH`        | `./data/firecracker/vmlinux`     | guest kernel                                                                                                                             |
 | `FIRECRACKER_ROOTFS_PATH`        | `./data/firecracker/rootfs.ext4` | shared read-only rootfs                                                                                                                  |
 | `FIRECRACKER_DATA_DIR`           | `./data/firecracker/runs`        | per-run state (tmpfs recommended — jailer mode then needs the artifacts on the same tmpfs, see _Requirements_)                           |


### PR DESCRIPTION
## Summary

Addresses the consolidated review of #838 (3 reviewers + external agent): all 4 blockers, all 11 should-fixes, and the 7 test/CI gaps.

### Blockers

- **B-1 — unbounded `waitForExit` under D-state**: `VmRecord` now carries a `reapAbandoned` signal resolved by `killVm` when the bounded reap times out. `waitForExit` races on it and returns 137/1 instead of hanging forever on `proc.exited`. The state-write failure path in `startWorkload` also goes through bounded `killVm` instead of a raw `await proc.exited`.
- **B-2 — socket-path guard failed on all jailed runs in prod layout**: `deriveJailId` now returns `fc-<sha256(runId)[:12]>-<idx>` (~20 chars). Real `run_<uuid>` id + installer layout yields ~91 bytes < 100 (`MAX_API_SOCKET_PATH_BYTES`). Regression test uses the real run-id format and prod paths.
- **B-3 — real `MODEL_API_KEY` on the config drive in skip-sidecar mode**: `MODEL_API_KEY` moved to `AGENT_SECRET_KEYS`, so it is brokered via MMDS and never written to the drive. Smoke test injects a fake model key and asserts it is absent from `config.img`.
- **B-4 — MMDS contract change without protocol bump**: `GUEST_PROTOCOL_VERSION` bumped to 2 (with documented history). The artifacts skip-path AND the keep-existing-on-network-failure fallback now require `marker.guest_protocol === 2`; a missing marker means unverifiable and forces re-download. `release.yml` greps the constant, so the next release manifest ships protocol 2 automatically (lockstep enforced: a v2 daemon refuses to boot on v1 artifacts).

### Should-fixes

- **S-1**: credential spill to the config drive is removed entirely. When the MMDS payload exceeds Firecracker's 50 KiB default, spawn passes `--mmds-size-limit`/`--http-api-max-payload-size` sized to the payload; fail-closed above `FIRECRACKER_MMDS_MAX_BYTES` (new env, default 16 MiB).
- **S-2**: `PROXY_URL` added to `SIDECAR_SECRET_KEYS` (brokered, redacted).
- **S-3**: subnet allocator switched from round-robin to lowest-free (uid bound by concurrency, not host lifetime); default `FIRECRACKER_JAIL_UID_BASE` 64000 → 200000; boot-time validation rejects any uid range intersecting 61184–65535 (systemd DynamicUser / nobody).
- **S-4**: boot-time gate asserting cgroup-v2 `memory` + `pids` controllers when `FIRECRACKER_JAIL_CGROUPS=on`, with an actionable hint.
- **S-5**: orphan cleanup sweeps leftover `/sys/fs/cgroup/appstrate-fc/*` dirs at boot.
- **S-6**: `assertJailerVersionParity` — firecracker and jailer binary versions must match at boot.
- **S-7**: `assertTrustedPathChain` on both binaries (full chain root-owned, not group/world-writable, hard fail) and on jail base + data dir (world-writable rejected; root-ownership not required to keep dev/CI layouts under $HOME working).
- **S-8**: orphan-sweep kill-by-uid removed. Identity is the jailer-injected `--id <jailId>` argv pair OR the `/proc/<pid>/root` chroot match. Test proves a same-uid process with the wrong `--id` survives.
- **S-9**: `runs.tokenUsage` preservation on non-success finalize now uses `COALESCE` inside the CAS UPDATE (atomic, no read-then-write window).
- **S-10**: orphan jail-dir removal is contained to `jailBase` (`startsWith` guard, warn + skip otherwise).
- **S-11**: `runner doctor` reports not-ok when the jailer binary is missing, unless `FIRECRACKER_JAILER=off`.

### Test/CI gaps

- jailId test uses the real `run_<uuid>` format + prod filesystem layout.
- smoke.ts MMDS firewall probe replaced: real MMDS V2 token PUT (the old token-less wget got a 401 even without the nft rule — tautological).
- New `guest-protocol-pin.test.ts`: structural fingerprint of `buildGuestConfig` keyed by `GUEST_PROTOCOL_VERSION` — changing the guest contract without bumping the version fails with instructions.
- D-state coverage: `waitForExit` resolves via abandon signal; `killVm` bounded.
- Redaction tests for `MODEL_API_KEY`/`PROXY_URL`, version parity, uid ranges, doctor.
- `firecracker.yml` path filters now include `runtime-pi/entrypoint.ts` + `packages/runner-pi/**`.
- Ingestion tests: usage preservation on non-success, malformed usage, corrupt JSONB.

### Operational notes

- **Artifact lockstep**: `GUEST_PROTOCOL_VERSION=2` requires publishing protocol-2 artifacts with the daemon release; `release.yml` handles this automatically.
- **Breaking (intentional)**: hosts overriding `FIRECRACKER_JAIL_UID_BASE` with a range crossing 61184–65535 will refuse to boot with an explicit message.
- No live KVM boot run locally (macOS); the `firecracker.yml` CI smoke job exercises the jailed boot, MMDS broker, and the new boot gates.

## Test plan

- [x] `bun run check` (33 tasks, OpenAPI + prettier)
- [x] 278 firecracker module tests + 34 CLI tests
- [x] 59 ingestion integration tests
- [ ] CI `firecracker.yml` smoke (jailed boot + MMDS) on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)