### PR TITLE
docs: surface the Firecracker execution backend across user-facing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,6 +86,8 @@ bun run build-sidecar    # sidecar proxy image
 | `bun run db:migrate`           | Apply database migrations                           |
 | `bun run verify:openapi`       | OpenAPI spec validation                             |
 
+**Working on the Firecracker execution backend?** It's an opt-in built-in module (`apps/api/src/modules/firecracker/`, not in the default `MODULES`). The privileged engine runs as the `appstrate-runner` daemon (`bun run firecracker:runner`) and needs a Linux KVM host (`/dev/kvm`) — on macOS, run it inside a Lima VM with nested virtualization. Guest artifacts build via `bun run firecracker:build:{kernel,rootfs}`. Architecture + dev workflow: [`docs/architecture/FIRECRACKER.md`](./docs/architecture/FIRECRACKER.md).
+
 ### Branch Naming
 
 - `feat/short-description` — New features

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Agents are **prompt-driven**: the AI coding agent inside the container interpret
 - **Autonomous AI agents** — Each run executes in an isolated Docker container with a Pi Coding Agent
 - **Flexible authentication** — Connect external services with OAuth 2.0 (RFC 8414 discovery + RFC 8707 resource indicators + PKCE), API key, basic auth, mTLS, and custom credential flows
 - **Sandboxed runs** — Containers are created, run, and destroyed per run
+- **Hardware-isolated execution** (opt-in) — Run each agent in a dedicated [Firecracker](https://firecracker-microvm.github.io/) microVM for a KVM hardware boundary around the whole run, instead of a shared-kernel container. A workload escape compromises a throwaway guest kernel, not the host. See [Firecracker architecture](./docs/architecture/FIRECRACKER.md)
 - **Sidecar isolation** — Credential injection via a sidecar proxy (agent never sees raw credentials)
 - **Cron scheduling** — Schedule agents with cron expressions, distributed lock prevents duplicates
 - **Package import** — Import agents, skills, MCP servers, and integrations from ZIP/AFPS files
@@ -138,6 +139,8 @@ Appstrate adapts to your infrastructure. Start minimal and add services as you g
 Tiers 0-2 run agents as Bun subprocesses — each concurrent run adds ~50-100 MB. On constrained hardware, limit parallel runs accordingly.
 
 **Tier 0** is ideal for personal use, small devices (Raspberry Pi 4+, NAS), or getting started with zero dependencies. **Tiers 1-2** suit small teams and constrained servers. **Tier 3** is for production with full container isolation.
+
+> **Stronger isolation for untrusted workloads?** The execution backend is pluggable. Beyond the built-in Bun-subprocess and Docker-container backends, an opt-in **Firecracker** backend (`RUN_ADAPTER=firecracker`) runs each agent in a dedicated microVM behind a KVM hardware boundary — the standard control-plane / host-daemon split used by AWS, Fly.io, and E2B. It ships as a built-in module (not in the default `MODULES` set, zero footprint when absent) and requires a KVM host running the `appstrate-runner` daemon. See [Firecracker architecture](./docs/architecture/FIRECRACKER.md).
 
 > **Raspberry Pi**: Bun supports ARM64 natively. A Raspberry Pi 4 (4 GB) handles Tiers 0-1 with 2-3 concurrent runs. A Pi 5 (8 GB) can run Tier 2 comfortably or Tier 3 with sequential runs.
 
@@ -283,6 +286,8 @@ Browser (React SPA)              Platform (Bun + Hono :3000)
 - **Parallel setup**: Sidecar + agent creation run concurrently
 - **Credential isolation**: Agent calls sidecar proxy; never sees raw credentials
 - **Output validation**: Native LLM schema enforcement + AJV post-validation against output schema
+
+Deeper design notes — the [Firecracker microVM backend](./docs/architecture/FIRECRACKER.md), [sidecar protocol](./docs/architecture/SIDECAR.md), integrations runtime, run-cost tracking, and more — live in [`docs/architecture/`](./docs/architecture/README.md).
 
 ## Environment Variables
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -50,6 +50,7 @@ See [`examples/self-hosting/README.md`](../../examples/self-hosting/README.md#ve
 | `appstrate api`       | Authenticated HTTP passthrough to the Appstrate API.                            |
 | `appstrate openapi`   | Explore the active profile's OpenAPI schema without flooding stdout.            |
 | `appstrate run`       | Execute an agent locally — by package id or from a `.afps`/`.afps-bundle` path. |
+| `appstrate runner`    | Install and manage the Firecracker runner daemon on a KVM host.                 |
 
 All commands accept `--profile <name>` to target a specific profile (see [Profiles](#profiles)).
 
@@ -67,10 +68,13 @@ appstrate install --tier 0 --dir ~/demo-appstrate
 
 **Flags**
 
-| Flag           | Values       | Description                                 |
-| -------------- | ------------ | ------------------------------------------- |
-| `-t`, `--tier` | `0\|1\|2\|3` | Skip the interactive tier prompt.           |
-| `-d`, `--dir`  | path         | Install directory (default: `~/appstrate`). |
+| Flag             | Values                | Description                                                                                                                                                                                                                                           |
+| ---------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `-t`, `--tier`   | `0\|1\|2\|3`          | Skip the interactive tier prompt.                                                                                                                                                                                                                     |
+| `-d`, `--dir`    | path                  | Install directory (default: `~/appstrate`).                                                                                                                                                                                                           |
+| `--run-adapter`  | `docker\|firecracker` | Agent execution backend (default `docker`). `firecracker` runs each agent in a microVM on a KVM host running the appstrate-runner daemon; Docker tiers only. Also `APPSTRATE_RUN_ADAPTER`. Writes `RUN_ADAPTER` / `MODULES` / `FIRECRACKER_RUNNER_*`. |
+| `--runner-url`   | url                   | Firecracker (remote): URL of an existing appstrate-runner daemon, e.g. `http://10.0.0.9:3100`. Implies the remote topology.                                                                                                                           |
+| `--runner-token` | token                 | Firecracker: shared bearer token for the runner daemon (default: generate one).                                                                                                                                                                       |
 
 **Tiers**
 
@@ -568,6 +572,36 @@ The full flag set is documented under `appstrate run --help`.
 **Connection readiness**
 
 Connection readiness is enforced server-side at run-trigger time: a run that targets an integration without a healthy connection is rejected with HTTP 412 (`missing_integration_connection`) before the container launches. Connect or repair the connection from the dashboard's connectors panel (`${instance}/preferences/connectors`).
+
+---
+
+### `appstrate runner`
+
+Install and manage the **Firecracker runner daemon** (`appstrate-runner`) on a KVM host. The daemon owns the privileged surface — KVM, TAP devices, nftables — and boots one microVM per run; the containerized platform stays a thin HTTP client (`RUN_ADAPTER=firecracker`, `FIRECRACKER_RUNNER_URL`/`_TOKEN`). This is the same control-plane / host-daemon split AWS, Fly.io, and E2B use. Architecture: [`../../docs/architecture/FIRECRACKER.md`](../../docs/architecture/FIRECRACKER.md).
+
+Runs on a Linux KVM host (not macOS). Requires `/dev/kvm` and root (systemd).
+
+```sh
+appstrate runner install --platform-url http://10.0.0.5:3000   # preflight + install + start via systemd
+appstrate runner doctor                                         # preflight + systemd state + daemon health + artifacts version
+appstrate runner doctor --json                                  # machine-readable
+appstrate runner update                                         # re-download the daemon for this CLI's version, verify, swap, restart
+appstrate runner status                                         # systemctl status appstrate-runner
+appstrate runner logs -f                                        # journalctl -u appstrate-runner
+```
+
+**`appstrate runner install` flags**
+
+| Flag             | Description                                                                           |
+| ---------------- | ------------------------------------------------------------------------------------- |
+| `--platform-url` | IPv4 URL the guests reach the platform on (e.g. `http://10.0.0.5:3000`).              |
+| `--token`        | Shared bearer token (default: preserve existing, else generate one).                  |
+| `--port`         | Daemon listen port (default: `3100`).                                                 |
+| `--data-dir`     | State root for kernel/rootfs/runs/firecracker (default: `/var/lib/appstrate-runner`). |
+| `--host`         | Daemon bind address (default: `0.0.0.0`).                                             |
+| `-y`, `--yes`    | Skip prompts (requires `--platform-url`).                                             |
+
+Point the platform at the daemon by setting `RUN_ADAPTER=firecracker`, adding `firecracker` to `MODULES`, and exporting `FIRECRACKER_RUNNER_URL` / `FIRECRACKER_RUNNER_TOKEN` — or pass `--run-adapter firecracker` to `appstrate install`, which writes these for you.
 
 ## Profiles
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,26 @@
+# Architecture
+
+Design notes for Appstrate's internal subsystems. Each document is the canonical
+reference for its topic — the code and top-level `CLAUDE.md` link here rather than
+duplicating the detail.
+
+## Run execution
+
+- [**FIRECRACKER.md**](./FIRECRACKER.md) — Firecracker execution backend (`RUN_ADAPTER=firecracker`). One microVM per run behind a KVM hardware boundary; the platform → `appstrate-runner` host-daemon split. Opt-in built-in module.
+- [**SIDECAR.md**](./SIDECAR.md) — Sidecar protocol. Credential-isolating MCP server that injects secrets the agent never sees.
+- [**INTEGRATIONS_RUNTIME.md**](./INTEGRATIONS_RUNTIME.md) — AFPS integrations runtime: per-integration runner containers, MITM credential proxy, remote HTTP/SSE MCP transport.
+- [**RUN_COST.md**](./RUN_COST.md) — Run cost tracking. The `llm_usage` ledger and single `computeRunCost` read path.
+
+## Models & providers
+
+- [**MODEL_ALIASES.md**](./MODEL_ALIASES.md) — LLM-gateway model-alias pattern (masking real model ids across the two inference paths).
+- [**SUBSCRIPTION_COMPLIANCE.md**](./SUBSCRIPTION_COMPLIANCE.md) — Subscription credential compliance posture for the opt-in codex / claude-code provider modules.
+
+## Platform posture
+
+- [**OBSERVABILITY.md**](./OBSERVABILITY.md) — OpenTelemetry traces, metrics, and logs.
+- [**SUPPLY_CHAIN.md**](./SUPPLY_CHAIN.md) — Supply-chain posture for the single-vendor Pi SDK dependency.
+
+---
+
+Env vars → [`../ENV.md`](../ENV.md) · Casing policy → [`../CASING_CONVENTIONS.md`](../CASING_CONVENTIONS.md)


### PR DESCRIPTION
## Why

The opt-in **Firecracker** execution backend (`RUN_ADAPTER=firecracker` — one microVM per run behind a KVM boundary) was documented only in `docs/architecture/FIRECRACKER.md`, `docs/ENV.md`, and the self-hosting guide. Two user-facing entry points ignored it entirely:

- **`README.md`** — zero mentions; only sold Docker-container isolation.
- **`apps/cli/README.md`** — omitted the whole `appstrate runner` daemon command group (`install`/`doctor`/`update`/`status`/`logs`) **and** the `install --run-adapter firecracker` flag, even though the CLI ships all of it.

Surfaced by a test/CI audit (see #843 for the companion CI cleanup).

## Changes

- **`README.md`** — Features bullet (hardware-isolated microVM execution) + Progressive-Infrastructure callout (pluggable backend, opt-in module, KVM host + `appstrate-runner` daemon, zero footprint when absent) + a discoverability link to `docs/architecture/`.
- **`apps/cli/README.md`** — `appstrate runner` command-table row, the firecracker `install` flags (`--run-adapter` / `--runner-url` / `--runner-token`), and a dedicated `appstrate runner` section documenting the daemon lifecycle commands.
- **`CONTRIBUTING.md`** — dev pointer: opt-in built-in module, `bun run firecracker:runner`, KVM host (Lima-on-macOS for nested virt), artifact build scripts.
- **`docs/architecture/README.md`** *(new)* — index for the 8 architecture docs, grouped Run-execution / Models / Platform-posture, so they're reachable by browsing.

## Scope

Docs only — no code, no behavior change. Framing keeps Firecracker honestly positioned as an **opt-in** stronger-isolation option, not the default (Docker containers remain the default run path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)