### PR TITLE
feat(cli): stream binary downloads with progress + add `runner uninstall`

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -68,6 +68,7 @@ import {
   runnerUpdateCommand,
   runnerStatusCommand,
   runnerLogsCommand,
+  runnerUninstallCommand,
 } from "./commands/runner.ts";
 import { internalInfoCommand } from "./commands/internal.ts";
 import {
@@ -830,6 +831,25 @@ runnerGroup
   .option("-f, --follow", "Stream new lines as they arrive.")
   .action(async (opts) => {
     await runnerLogsCommand({ follow: opts.follow === true });
+  });
+
+runnerGroup
+  .command("uninstall")
+  .description(
+    "Stop + remove the appstrate-runner daemon, unit, config, and (unless --keep-data) its state dir. Destructive — prompts unless --yes / APPSTRATE_YES=1.",
+  )
+  .option("--keep-data", "Preserve the state dir (kernel/rootfs/runs/firecracker binaries).")
+  .option(
+    "--data-dir <path>",
+    "State root to remove (default: recovered from the install, else /var/lib/appstrate-runner).",
+  )
+  .option("-y, --yes", "Skip the destructive confirmation. Equivalent to APPSTRATE_YES=1.")
+  .action(async (opts) => {
+    await runnerUninstallCommand({
+      keepData: opts.keepData === true,
+      yes: opts.yes === true,
+      dataDir: typeof opts.dataDir === "string" ? opts.dataDir : undefined,
+    });
   });
 
 // Hidden command: machine-readable introspection for `doctor` to call across binaries.

--- a/apps/cli/src/commands/runner.ts
+++ b/apps/cli/src/commands/runner.ts
@@ -18,7 +18,8 @@
  */
 
 import * as clack from "@clack/prompts";
-import { intro, outro, askText, exitWithError } from "../lib/ui.ts";
+import { dirname } from "node:path";
+import { intro, outro, askText, confirm, exitWithError } from "../lib/ui.ts";
 import { CLI_VERSION, DEV_CLI_VERSION } from "../lib/version.ts";
 import {
   RUNNER_BIN_PATH,
@@ -52,6 +53,7 @@ import {
   type RunnerConfig,
 } from "../lib/runner/config-files.ts";
 import { downloadDaemon, installFirecracker } from "../lib/runner/download.ts";
+import { formatProgress } from "../lib/download.ts";
 import { parseIpv4HttpUrl } from "../lib/install/os.ts";
 
 /** Shared DI surface for every runner subcommand. */
@@ -242,19 +244,23 @@ async function downloadAndInstallBinaries(
   await d.fs.mkdirp(paths.binDir);
 
   const daemonSpin = clack.spinner();
-  daemonSpin.start(`Downloading runner daemon ${version} (${arch})`);
-  const daemonBytes = await downloadDaemon({
+  const daemonLabel = `Downloading runner daemon ${version} (${arch})`;
+  daemonSpin.start(daemonLabel);
+  const { stagedPath } = await downloadDaemon({
     http: d.http,
     exec: d.exec,
     fs: d.fs,
     version,
     arch,
+    destPath: RUNNER_BIN_PATH,
+    onProgress: (p) => daemonSpin.message(`${daemonLabel} — ${formatProgress(p)}`),
   });
-  await d.fs.installAtomic(RUNNER_BIN_PATH, daemonBytes, 0o755);
+  await d.fs.promoteFile(stagedPath, RUNNER_BIN_PATH, 0o755);
   daemonSpin.stop(`Installed daemon → ${RUNNER_BIN_PATH}`);
 
   const fcSpin = clack.spinner();
-  fcSpin.start(`Downloading firecracker + jailer v${FIRECRACKER_VERSION} (${arch})`);
+  const fcLabel = `Downloading firecracker + jailer v${FIRECRACKER_VERSION} (${arch})`;
+  fcSpin.start(fcLabel);
   await installFirecracker({
     http: d.http,
     exec: d.exec,
@@ -265,6 +271,7 @@ async function downloadAndInstallBinaries(
     // Same verified tarball — the daemon requires firecracker + jailer
     // to come from one release (FIRECRACKER_JAILER=on confinement).
     jailerDestPath: paths.jailerBin,
+    onProgress: (p) => fcSpin.message(`${fcLabel} — ${formatProgress(p)}`),
   });
   fcSpin.stop(`Installed firecracker → ${paths.firecrackerBin} (+ jailer → ${paths.jailerBin})`);
 }
@@ -579,11 +586,20 @@ export async function runnerUpdateCommand(opts: RunnerUpdateOptions = {}): Promi
     const version = resolveDaemonVersion();
 
     const spin = clack.spinner();
-    spin.start(`Downloading runner daemon ${version} (${arch})`);
-    const bytes = await downloadDaemon({ http: d.http, exec: d.exec, fs: d.fs, version, arch });
+    const label = `Downloading runner daemon ${version} (${arch})`;
+    spin.start(label);
+    const { stagedPath } = await downloadDaemon({
+      http: d.http,
+      exec: d.exec,
+      fs: d.fs,
+      version,
+      arch,
+      destPath: RUNNER_BIN_PATH,
+      onProgress: (p) => spin.message(`${label} — ${formatProgress(p)}`),
+    });
     // Atomic swap over the live binary — rename(2) keeps the running
     // process's fd valid; the restart below picks up the new inode.
-    await d.fs.installAtomic(RUNNER_BIN_PATH, bytes, 0o755);
+    await d.fs.promoteFile(stagedPath, RUNNER_BIN_PATH, 0o755);
     spin.stop(`Installed daemon → ${RUNNER_BIN_PATH}`);
 
     // Re-pin the guest artifacts to the new daemon version BEFORE the restart:
@@ -638,4 +654,121 @@ export async function runnerLogsCommand(opts: RunnerLogsOptions = {}): Promise<v
   const res = await d.exec.run("journalctl", args, { stdio: "inherit" });
   // Ctrl-C on `-f` exits 130 — a clean user stop, not an error.
   if (!res.ok && res.exitCode !== 130) process.exitCode = res.exitCode === -1 ? 1 : res.exitCode;
+}
+
+// ─── uninstall ──────────────────────────────────────────────────────────────
+
+export interface RunnerUninstallOptions {
+  /** Preserve the state dir (kernel/rootfs/runs/firecracker). */
+  keepData?: boolean;
+  /** Skip the destructive confirmation (or set APPSTRATE_YES=1). */
+  yes?: boolean;
+  /** State root to remove; recovered from the env file or defaulted otherwise. */
+  dataDir?: string;
+  deps?: RunnerDeps;
+}
+
+/**
+ * Recover the install's state root: an explicit `--data-dir` wins, else the
+ * `FIRECRACKER_KERNEL_PATH` pin in the env file (`<dataDir>/vmlinux`), else the
+ * compiled default. This makes `uninstall` remove the SAME dir a non-default
+ * `install --data-dir` created.
+ */
+async function resolveUninstallDataDir(
+  explicit: string | undefined,
+  d: ResolvedDeps,
+): Promise<string> {
+  if (explicit) return explicit;
+  const envText = await d.fs.readFile(RUNNER_ENV_PATH);
+  if (envText) {
+    const kernel = parseRunnerEnvFile(envText).FIRECRACKER_KERNEL_PATH;
+    if (kernel && kernel.endsWith("/vmlinux")) return dirname(kernel);
+  }
+  return RUNNER_DATA_DIR;
+}
+
+/**
+ * Tear down an `appstrate runner install`: stop + disable the unit, remove the
+ * binary / unit / drop-ins / config (bearer token), and — unless
+ * `--keep-data` — the state dir. Every step is best-effort and idempotent (a
+ * partial or already-removed install never errors), so it doubles as a repair
+ * for a half-finished install. Issue #821.
+ */
+export async function runnerUninstallCommand(opts: RunnerUninstallOptions = {}): Promise<void> {
+  intro("Appstrate runner uninstall");
+  const d = resolve(opts.deps ?? {});
+  try {
+    requireRoot(d.getuid, "uninstall");
+
+    const dataDir = await resolveUninstallDataDir(opts.dataDir, d);
+    const removeData = opts.keepData !== true;
+    const willRemove = [
+      `  • systemd unit ${RUNNER_SERVICE_NAME} (stop + disable)`,
+      `  • ${RUNNER_BIN_PATH}`,
+      `  • ${RUNNER_UNIT_PATH} (+ drop-ins)`,
+      `  • ${RUNNER_ETC_DIR} (config + bearer token)`,
+      removeData
+        ? `  • ${dataDir} (kernel, rootfs, runs, firecracker)`
+        : `  • keeping ${dataDir} (--keep-data)`,
+    ].join("\n");
+
+    // Destructive: this removes the bearer token and (by default) all guest
+    // state. Confirm unless --yes/APPSTRATE_YES=1; in a non-interactive context
+    // without that flag, refuse rather than block on a prompt.
+    const bypass = opts.yes === true || process.env.APPSTRATE_YES === "1";
+    if (!bypass) {
+      if (!process.stdin.isTTY) {
+        throw new Error(
+          `Refusing to uninstall without confirmation in a non-interactive context. ` +
+            `This removes:\n${willRemove}\n\nRe-run with --yes (or APPSTRATE_YES=1) to proceed.`,
+        );
+      }
+      clack.note(willRemove, "This will remove");
+      if (!(await confirm(`Remove the ${RUNNER_SERVICE_NAME} daemon?`, false))) {
+        outro("Uninstall cancelled — nothing was removed.");
+        return;
+      }
+    }
+
+    const spin = clack.spinner();
+    spin.start("Removing appstrate-runner");
+
+    // 1. Stop + disable the unit. Both tolerate an absent/inactive unit
+    //    (systemctl exits non-zero, which we intentionally ignore here).
+    await d.exec.run("systemctl", ["stop", RUNNER_SERVICE_NAME]);
+    await d.exec.run("systemctl", ["disable", RUNNER_SERVICE_NAME]);
+
+    // 2. Remove the unit + any drop-in dir, reload, and clear a lingering
+    //    failed state so a later reinstall starts clean. `remove` is
+    //    rm -rf (force) → removing a missing path is a no-op.
+    const removed: string[] = [];
+    for (const p of [RUNNER_UNIT_PATH, `${RUNNER_UNIT_PATH}.d`]) {
+      await d.fs.remove(p);
+      removed.push(p);
+    }
+    await d.exec.run("systemctl", ["daemon-reload"]);
+    await d.exec.run("systemctl", ["reset-failed", RUNNER_SERVICE_NAME]);
+
+    // 3. Binary + config (token).
+    for (const p of [RUNNER_BIN_PATH, RUNNER_ETC_DIR]) {
+      await d.fs.remove(p);
+      removed.push(p);
+    }
+
+    // 4. State dir — only when not preserving it.
+    if (removeData) {
+      await d.fs.remove(dataDir);
+      removed.push(dataDir);
+    }
+
+    spin.stop("appstrate-runner removed");
+    clack.note(removed.map((p) => `  • ${p}`).join("\n"), "Removed");
+    outro(
+      removeData
+        ? "Runner fully uninstalled."
+        : `Runner uninstalled — state preserved at ${dataDir}.`,
+    );
+  } catch (err) {
+    exitWithError(err);
+  }
 }

--- a/apps/cli/src/commands/self-update.ts
+++ b/apps/cli/src/commands/self-update.ts
@@ -12,6 +12,7 @@
 import * as clack from "@clack/prompts";
 import { INSTALL_SOURCE, upgradeHint, type InstallSource } from "../lib/install-source.ts";
 import { CLI_VERSION } from "../lib/version.ts";
+import { formatProgress, type ProgressFn } from "../lib/download.ts";
 import {
   detectPlatform,
   performCurlUpdate,
@@ -38,6 +39,8 @@ export interface SelfUpdateOptions {
   platform?: PlatformInfo;
   /** Logger override for tests; production uses `console.error`. */
   log?: (line: string) => void;
+  /** Download-progress sink; the command wrapper wires a spinner. */
+  onProgress?: ProgressFn;
 }
 
 /**
@@ -124,6 +127,7 @@ export async function runSelfUpdate(opts: SelfUpdateOptions = {}): Promise<SelfU
       deps,
       currentVersion: opts.currentVersion,
       log: opts.log,
+      onProgress: opts.onProgress,
     });
   } catch (err) {
     return {
@@ -152,7 +156,22 @@ export async function runSelfUpdate(opts: SelfUpdateOptions = {}): Promise<SelfU
  */
 export async function selfUpdateCommand(opts: SelfUpdateOptions = {}): Promise<never> {
   clack.intro(`Appstrate self-update`);
-  const result = await runSelfUpdate(opts);
+  // Live download progress so a 113 MB binary is not a silent multi-minute gap
+  // (issue #821). The spinner starts on the first byte-tick and stops once the
+  // run finishes; it degrades to a static line on a non-TTY (piped installs).
+  const spin = clack.spinner();
+  let spinning = false;
+  const onProgress: ProgressFn = (p) => {
+    if (!spinning) {
+      spin.start("Downloading appstrate binary");
+      spinning = true;
+    }
+    spin.message(`Downloading appstrate binary — ${formatProgress(p)}`);
+  };
+  const result = await runSelfUpdate({ ...opts, onProgress });
+  if (spinning) {
+    spin.stop(result.exitCode === SELF_UPDATE_EXIT.OK ? "Download complete" : "Download failed");
+  }
   if (result.exitCode === SELF_UPDATE_EXIT.OK) {
     clack.outro(result.message);
   } else {

--- a/apps/cli/src/lib/download.ts
+++ b/apps/cli/src/lib/download.ts
@@ -27,6 +27,7 @@
  */
 
 import { rm } from "node:fs/promises";
+import { formatBytes } from "@appstrate/core/format";
 
 /** Progress tick. `total` is null when the server sent no `Content-Length`. */
 export interface DownloadProgress {
@@ -214,23 +215,11 @@ function explainAbort(
   return err instanceof Error ? err : new Error(String(err));
 }
 
-/** Human-readable byte count, e.g. `113.4 MB`. */
-export function formatBytes(n: number): string {
-  if (n < 1024) return `${n} B`;
-  const units = ["KB", "MB", "GB"];
-  let v = n / 1024;
-  let i = 0;
-  while (v >= 1024 && i < units.length - 1) {
-    v /= 1024;
-    i++;
-  }
-  return `${v.toFixed(1)} ${units[i]}`;
-}
-
 /**
  * Format a progress tick for a spinner line, e.g.
- * `42.1 MB / 113.4 MB (37%) · 4.2 MB/s`. Percent is omitted when the total is
- * unknown (no Content-Length behind a CDN).
+ * `42.1 MB / 113 MB (37%) · 4.2 MB/s`. Percent is omitted when the total is
+ * unknown (no Content-Length behind a CDN). Byte magnitudes use the shared
+ * `@appstrate/core/format` formatter.
  */
 export function formatProgress(p: DownloadProgress): string {
   const rate = `${formatBytes(p.rateBytesPerSec)}/s`;

--- a/apps/cli/src/lib/download.ts
+++ b/apps/cli/src/lib/download.ts
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Streamed binary download with progress, a stall watchdog, and a hard
+ * total-time backstop — shared by every large-asset fetch in the CLI
+ * (`self-update` CLI binary, `runner install/update` daemon binary, and the
+ * firecracker tarball).
+ *
+ * The problem it solves (issue #821): the previous downloads buffered the
+ * whole response via `await res.arrayBuffer()` with no `AbortSignal` and no
+ * progress. A 113 MB CLI binary or ~70 MB daemon was a silent multi-minute
+ * gap in the terminal, and a stalled GitHub→CDN redirect would hang the
+ * process forever with zero feedback.
+ *
+ * This helper instead:
+ *   - streams the response body to disk chunk-by-chunk (peak memory ≈ one
+ *     chunk + the SHA-256 hasher state, not the whole artifact);
+ *   - computes the hex SHA-256 on the fly so the caller verifies without a
+ *     second read;
+ *   - reports byte/percent/rate progress (throttled) for a live spinner;
+ *   - aborts with an actionable error if no bytes arrive for `stallTimeoutMs`
+ *     (stall watchdog) or the whole transfer exceeds `totalTimeoutMs`;
+ *   - never leaves a partial file behind — the destination is unlinked on any
+ *     failure or abort.
+ *
+ * It is UI-free: callers wire `onProgress` to a spinner / log sink.
+ */
+
+import { rm } from "node:fs/promises";
+
+/** Progress tick. `total` is null when the server sent no `Content-Length`. */
+export interface DownloadProgress {
+  received: number;
+  total: number | null;
+  rateBytesPerSec: number;
+}
+
+export type ProgressFn = (p: DownloadProgress) => void;
+
+/** The subset of `fetch` this helper uses — lets tests inject a plain function. */
+export type FetchLike = (url: string, init?: RequestInit) => Promise<Response>;
+
+export interface StreamDownloadOptions {
+  onProgress?: ProgressFn;
+  /**
+   * Abort if no bytes arrive for this many ms. This is the primary watchdog —
+   * a slow-but-alive link is fine, a wedged redirect is not. Default 30_000.
+   */
+  stallTimeoutMs?: number;
+  /** Hard ceiling on the whole transfer as a backstop. Default 20 minutes. */
+  totalTimeoutMs?: number;
+  headers?: Record<string, string>;
+  /** Injected in tests; defaults to the global `fetch`. */
+  fetchImpl?: FetchLike;
+}
+
+export interface StreamDownloadResult {
+  bytesWritten: number;
+  /** Lowercase hex SHA-256 of the downloaded bytes. */
+  sha256: string;
+}
+
+const DEFAULT_STALL_MS = 30_000;
+const DEFAULT_TOTAL_MS = 20 * 60_000;
+/** Never fire `onProgress` more than once per this interval (plus a final tick). */
+const PROGRESS_THROTTLE_MS = 250;
+
+/** Reason tags carried on the AbortController so the catch can explain itself. */
+const STALL = Symbol("stall");
+const TOTAL = Symbol("total");
+
+/**
+ * Download `url` to `destPath`, streaming to disk. Returns the byte count and
+ * the on-the-fly SHA-256. Throws an actionable Error on a non-2xx status, a
+ * stall, a total-timeout, or any network/disk failure — and removes a partial
+ * `destPath` first.
+ */
+export async function streamDownload(
+  url: string,
+  destPath: string,
+  opts: StreamDownloadOptions = {},
+): Promise<StreamDownloadResult> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const stallMs = opts.stallTimeoutMs ?? DEFAULT_STALL_MS;
+  const totalMs = opts.totalTimeoutMs ?? DEFAULT_TOTAL_MS;
+
+  const controller = new AbortController();
+  let abortKind: symbol | null = null;
+  // A rejection that fires the moment a watchdog aborts. Racing it against
+  // each `reader.read()` guarantees a prompt teardown even if the underlying
+  // stream does not honour the fetch signal (some runtimes / injected fetches
+  // do not) — the network signal is still passed so the socket tears down too.
+  const makeAbortError = () => explainAbort(new Error("aborted"), abortKind, url, stallMs, totalMs);
+  const aborted = new Promise<never>((_, reject) => {
+    controller.signal.addEventListener("abort", () => reject(makeAbortError()), { once: true });
+  });
+  // Swallow the terminal rejection so a resolved race never surfaces as an
+  // unhandled promise rejection once the timers are cleared.
+  aborted.catch(() => {});
+
+  let stallTimer: ReturnType<typeof setTimeout> | undefined;
+  const armStall = () => {
+    clearTimeout(stallTimer);
+    stallTimer = setTimeout(() => {
+      abortKind = STALL;
+      controller.abort();
+    }, stallMs);
+  };
+  const totalTimer = setTimeout(() => {
+    abortKind = TOTAL;
+    controller.abort();
+  }, totalMs);
+
+  const hasher = new Bun.CryptoHasher("sha256");
+  // Opened lazily AFTER the response is validated so an early throw (non-2xx,
+  // stall before headers) never leaves an empty file at `destPath`.
+  let sink: ReturnType<ReturnType<typeof Bun.file>["writer"]> | null = null;
+  let received = 0;
+  const startedAt = Date.now();
+  let lastTick = 0;
+  const emit = (force: boolean, total: number | null) => {
+    if (!opts.onProgress) return;
+    const now = Date.now();
+    if (!force && now - lastTick < PROGRESS_THROTTLE_MS) return;
+    lastTick = now;
+    const elapsed = Math.max(1, now - startedAt) / 1000;
+    opts.onProgress({ received, total, rateBytesPerSec: received / elapsed });
+  };
+
+  try {
+    armStall();
+    const res = await Promise.race([
+      fetchImpl(url, { redirect: "follow", headers: opts.headers, signal: controller.signal }),
+      aborted,
+    ]);
+    if (!res.ok) {
+      // Keep the `HTTP <status>` shape — callers regex it (e.g. the runner's
+      // asRunnerAssetError turns a 404 into a "release shipped no runner
+      // assets" hint).
+      throw new Error(
+        `GET ${url} → HTTP ${res.status}${res.statusText ? ` ${res.statusText}` : ""}`,
+      );
+    }
+    const lenHeader = res.headers.get("content-length");
+    const total = lenHeader && /^\d+$/.test(lenHeader) ? Number(lenHeader) : null;
+    if (!res.body) {
+      throw new Error(`GET ${url} → empty response body`);
+    }
+
+    sink = Bun.file(destPath).writer();
+    const reader = res.body.getReader();
+    armStall();
+    try {
+      for (;;) {
+        const chunk = await Promise.race([reader.read(), aborted]);
+        if (chunk.done) break;
+        armStall();
+        const bytes = chunk.value;
+        hasher.update(bytes);
+        sink.write(bytes);
+        received += bytes.byteLength;
+        emit(false, total);
+      }
+    } catch (err) {
+      await reader.cancel().catch(() => {});
+      throw err;
+    } finally {
+      reader.releaseLock?.();
+    }
+    emit(true, total);
+    await sink.end();
+    sink = null; // successfully flushed; do not unlink below
+
+    return { bytesWritten: received, sha256: hasher.digest("hex") };
+  } catch (err) {
+    // Flush/close the sink best-effort, then remove any file we opened so a
+    // retry or the caller's verification never sees a truncated artifact.
+    if (sink) {
+      try {
+        await sink.end();
+      } catch {
+        /* ignore */
+      }
+      await rm(destPath, { force: true }).catch(() => {});
+    }
+    throw err;
+  } finally {
+    clearTimeout(stallTimer);
+    clearTimeout(totalTimer);
+  }
+}
+
+/** Map a raw fetch/read rejection to an actionable message when we aborted it. */
+function explainAbort(
+  err: unknown,
+  kind: symbol | null,
+  url: string,
+  stallMs: number,
+  totalMs: number,
+): Error {
+  if (kind === STALL) {
+    return new Error(
+      `Download stalled: no data from ${url} for ${Math.round(stallMs / 1000)}s. ` +
+        `The connection wedged (often a slow/broken GitHub→CDN redirect). ` +
+        `Check the host's network and retry.`,
+    );
+  }
+  if (kind === TOTAL) {
+    return new Error(
+      `Download timed out after ${Math.round(totalMs / 60_000)} min (${url}). ` +
+        `The link is too slow to complete; retry on a better connection.`,
+    );
+  }
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+/** Human-readable byte count, e.g. `113.4 MB`. */
+export function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  const units = ["KB", "MB", "GB"];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i++;
+  }
+  return `${v.toFixed(1)} ${units[i]}`;
+}
+
+/**
+ * Format a progress tick for a spinner line, e.g.
+ * `42.1 MB / 113.4 MB (37%) · 4.2 MB/s`. Percent is omitted when the total is
+ * unknown (no Content-Length behind a CDN).
+ */
+export function formatProgress(p: DownloadProgress): string {
+  const rate = `${formatBytes(p.rateBytesPerSec)}/s`;
+  if (p.total && p.total > 0) {
+    const pct = Math.min(100, Math.floor((p.received / p.total) * 100));
+    return `${formatBytes(p.received)} / ${formatBytes(p.total)} (${pct}%) · ${rate}`;
+  }
+  return `${formatBytes(p.received)} · ${rate}`;
+}

--- a/apps/cli/src/lib/runner/download.ts
+++ b/apps/cli/src/lib/runner/download.ts
@@ -99,38 +99,34 @@ export async function downloadDaemon(opts: {
   const asset = daemonAssetName(opts.arch);
   const stagedPath = join(dirname(opts.destPath), `.${asset}.download-${process.pid}`);
 
-  // 1. Stream the daemon binary to disk. A 404 here almost always means this
-  //    release shipped WITHOUT runner assets — the firecracker/daemon build
-  //    jobs are decoupled from the core release (release.yml) and may have
-  //    failed for this tag. Turn the opaque "HTTP 404" into an actionable fix.
+  // 1. Fetch + verify the small signed manifest BEFORE the large binary
+  //    stream: it fails fast on a bad/missing signature without pulling the
+  //    ~70 MB daemon, and it keeps the stream off the parallel path so a
+  //    sidecar reject can never run cleanup while the stream is still writing
+  //    `stagedPath`. A 404 here almost always means this release shipped
+  //    WITHOUT runner assets — the firecracker/daemon build jobs are decoupled
+  //    from the core release (release.yml) and may have failed for this tag.
+  let checksumsTxt: string;
+  let checksumsSig: Uint8Array;
+  try {
+    [checksumsTxt, checksumsSig] = await Promise.all([
+      opts.http.fetchText(urls.checksums),
+      opts.http.fetchBinary(urls.checksumsSig),
+    ]);
+  } catch (err) {
+    throw asRunnerAssetError(err, opts.version, asset);
+  }
+  await verifyDaemonSignature({ exec: opts.exec, fs: opts.fs, checksumsTxt, checksumsSig });
+
+  // 2. Stream the daemon binary to disk, then verify its streamed digest
+  //    against the (now trusted) manifest line for this asset.
   let actual: string;
   try {
     ({ sha256: actual } = await opts.http.fetchToFile(urls.binary, stagedPath, opts.onProgress));
   } catch (err) {
     throw asRunnerAssetError(err, opts.version, asset);
   }
-
   try {
-    // 2. The signed checksums manifest + its minisign signature (small).
-    let checksumsTxt: string;
-    let checksumsSig: Uint8Array;
-    try {
-      [checksumsTxt, checksumsSig] = await Promise.all([
-        opts.http.fetchText(urls.checksums),
-        opts.http.fetchBinary(urls.checksumsSig),
-      ]);
-    } catch (err) {
-      throw asRunnerAssetError(err, opts.version, asset);
-    }
-
-    // 3. Verify the manifest signature, then the streamed digest against the
-    //    (now trusted) manifest line for this asset.
-    await verifyDaemonSignature({
-      exec: opts.exec,
-      fs: opts.fs,
-      checksumsTxt,
-      checksumsSig,
-    });
     const expected = parseChecksumLine(checksumsTxt, asset);
     if (actual !== expected) {
       throw new Error(
@@ -262,14 +258,14 @@ export async function installFirecracker(opts: {
   const urls = firecrackerUrls(opts.version, opts.arch);
   const work = await mkdtemp(join(tmpdir(), "appstrate-firecracker-"));
   try {
-    // Stream the tarball to the work dir (verified below, then extracted — it
-    // is never renamed onto a live target, so the temp dir is fine).
+    // Fetch the small checksum sidecar FIRST, then stream the tarball — keeping
+    // the big stream off the parallel path (a Promise.all reject would run the
+    // `finally` rm(work) while the stream is still writing into it) and failing
+    // fast if the sidecar is missing. Extracted below, never renamed onto a
+    // live target, so the temp dir is fine.
+    const expected = parseSha256(await opts.http.fetchText(urls.sha256));
     const tgzPath = join(work, "firecracker.tgz");
-    const [{ sha256: actual }, sumText] = await Promise.all([
-      opts.http.fetchToFile(urls.tarball, tgzPath, opts.onProgress),
-      opts.http.fetchText(urls.sha256),
-    ]);
-    const expected = parseSha256(sumText);
+    const { sha256: actual } = await opts.http.fetchToFile(urls.tarball, tgzPath, opts.onProgress);
     if (actual !== expected) {
       throw new Error(
         `firecracker tarball SHA-256 mismatch: expected ${expected}, got ${actual} — ` +

--- a/apps/cli/src/lib/runner/download.ts
+++ b/apps/cli/src/lib/runner/download.ts
@@ -17,7 +17,7 @@
 
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import {
   APPSTRATE_RELEASE_BASE,
   FIRECRACKER_RELEASE_BASE,
@@ -25,6 +25,7 @@ import {
   type RunnerArch,
 } from "./constants.ts";
 import type { RunnerExec, RunnerFs, RunnerHttp } from "./exec.ts";
+import type { ProgressFn } from "../download.ts";
 import { APPSTRATE_MINISIGN_PUBKEY, parseChecksumLine } from "../self-update.ts";
 
 /** Hex SHA-256 of a byte buffer via Bun's baked-in hasher. */
@@ -68,10 +69,15 @@ export function daemonUrls(
 }
 
 /**
- * Download the daemon binary and verify it against the release's
- * minisign-signed `checksums.txt`, then return the bytes. Never writes the
- * binary to disk — the caller installs atomically at the destination it
- * controls (so `update` can swap over the live binary).
+ * Stream the daemon binary to a staged file next to `destPath` and verify it
+ * against the release's minisign-signed `checksums.txt`. Returns the staged
+ * path; the caller promotes it atomically onto `destPath` (so `update` can
+ * swap over the live binary) — or, on any verification failure, the staged
+ * file is removed and this throws.
+ *
+ * Streaming (not buffering the whole ~70 MB into memory) gives a live progress
+ * spinner and a stall watchdog: a wedged GitHub→CDN redirect aborts with an
+ * actionable error instead of hanging forever (issue #821).
  *
  * minisign is REQUIRED (fail-closed, matching `self-update` and
  * `scripts/bootstrap-runner.sh`): a signed-checksum check the host cannot
@@ -85,51 +91,61 @@ export async function downloadDaemon(opts: {
   fs: RunnerFs;
   version: string;
   arch: RunnerArch;
-}): Promise<Uint8Array> {
+  /** Final install path; the staged download lands in the same directory. */
+  destPath: string;
+  onProgress?: ProgressFn;
+}): Promise<{ stagedPath: string }> {
   const urls = daemonUrls(opts.version, opts.arch);
   const asset = daemonAssetName(opts.arch);
+  const stagedPath = join(dirname(opts.destPath), `.${asset}.download-${process.pid}`);
 
-  // 1. The daemon binary. A 404 here almost always means this release shipped
-  //    WITHOUT runner assets — the firecracker/daemon build jobs are decoupled
-  //    from the core release (release.yml) and may have failed for this tag.
-  //    Turn the opaque "HTTP 404" into an actionable fix.
-  let bytes: Uint8Array;
+  // 1. Stream the daemon binary to disk. A 404 here almost always means this
+  //    release shipped WITHOUT runner assets — the firecracker/daemon build
+  //    jobs are decoupled from the core release (release.yml) and may have
+  //    failed for this tag. Turn the opaque "HTTP 404" into an actionable fix.
+  let actual: string;
   try {
-    bytes = await opts.http.fetchBinary(urls.binary);
+    ({ sha256: actual } = await opts.http.fetchToFile(urls.binary, stagedPath, opts.onProgress));
   } catch (err) {
     throw asRunnerAssetError(err, opts.version, asset);
   }
 
-  // 2. The signed checksums manifest + its minisign signature.
-  let checksumsTxt: string;
-  let checksumsSig: Uint8Array;
   try {
-    [checksumsTxt, checksumsSig] = await Promise.all([
-      opts.http.fetchText(urls.checksums),
-      opts.http.fetchBinary(urls.checksumsSig),
-    ]);
+    // 2. The signed checksums manifest + its minisign signature (small).
+    let checksumsTxt: string;
+    let checksumsSig: Uint8Array;
+    try {
+      [checksumsTxt, checksumsSig] = await Promise.all([
+        opts.http.fetchText(urls.checksums),
+        opts.http.fetchBinary(urls.checksumsSig),
+      ]);
+    } catch (err) {
+      throw asRunnerAssetError(err, opts.version, asset);
+    }
+
+    // 3. Verify the manifest signature, then the streamed digest against the
+    //    (now trusted) manifest line for this asset.
+    await verifyDaemonSignature({
+      exec: opts.exec,
+      fs: opts.fs,
+      checksumsTxt,
+      checksumsSig,
+    });
+    const expected = parseChecksumLine(checksumsTxt, asset);
+    if (actual !== expected) {
+      throw new Error(
+        `daemon binary SHA-256 mismatch: expected ${expected}, got ${actual} — ` +
+          `the download does NOT match the signed checksums manifest. ` +
+          `Refusing to install (broken release or tampering).`,
+      );
+    }
   } catch (err) {
-    throw asRunnerAssetError(err, opts.version, asset);
+    // Never leave an unverified staged binary behind.
+    await opts.fs.remove(stagedPath).catch(() => {});
+    throw err;
   }
 
-  // 3. Verify the manifest signature, then the binary's digest against the
-  //    (now trusted) manifest line for this asset.
-  await verifyDaemonSignature({
-    exec: opts.exec,
-    fs: opts.fs,
-    checksumsTxt,
-    checksumsSig,
-  });
-  const expected = parseChecksumLine(checksumsTxt, asset);
-  const actual = sha256Hex(bytes);
-  if (actual !== expected) {
-    throw new Error(
-      `daemon binary SHA-256 mismatch: expected ${expected}, got ${actual} — ` +
-        `the download does NOT match the signed checksums manifest. ` +
-        `Refusing to install (broken release or tampering).`,
-    );
-  }
-  return bytes;
+  return { stagedPath };
 }
 
 /**
@@ -241,25 +257,26 @@ export async function installFirecracker(opts: {
   arch: RunnerArch;
   destPath: string;
   jailerDestPath: string;
+  onProgress?: ProgressFn;
 }): Promise<void> {
   const urls = firecrackerUrls(opts.version, opts.arch);
-  const [tgz, sumText] = await Promise.all([
-    opts.http.fetchBinary(urls.tarball),
-    opts.http.fetchText(urls.sha256),
-  ]);
-  const expected = parseSha256(sumText);
-  const actual = sha256Hex(tgz);
-  if (actual !== expected) {
-    throw new Error(
-      `firecracker tarball SHA-256 mismatch: expected ${expected}, got ${actual} — ` +
-        `refusing to install (broken download or tampering).`,
-    );
-  }
-
   const work = await mkdtemp(join(tmpdir(), "appstrate-firecracker-"));
   try {
+    // Stream the tarball to the work dir (verified below, then extracted — it
+    // is never renamed onto a live target, so the temp dir is fine).
     const tgzPath = join(work, "firecracker.tgz");
-    await opts.fs.writeFile(tgzPath, tgz);
+    const [{ sha256: actual }, sumText] = await Promise.all([
+      opts.http.fetchToFile(urls.tarball, tgzPath, opts.onProgress),
+      opts.http.fetchText(urls.sha256),
+    ]);
+    const expected = parseSha256(sumText);
+    if (actual !== expected) {
+      throw new Error(
+        `firecracker tarball SHA-256 mismatch: expected ${expected}, got ${actual} — ` +
+          `refusing to install (broken download or tampering).`,
+      );
+    }
+
     const untar = await opts.exec.run("tar", ["-xzf", tgzPath, "-C", work]);
     if (!untar.ok) {
       throw new Error(

--- a/apps/cli/src/lib/runner/exec.ts
+++ b/apps/cli/src/lib/runner/exec.ts
@@ -23,6 +23,7 @@ import {
 } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { runCommand, commandExists, type CommandResult } from "../install/os.ts";
+import { streamDownload, type ProgressFn } from "../download.ts";
 
 export interface RunnerExec {
   /** Run `cmd args…`; never throws on non-zero (returns `ok:false`). */
@@ -49,10 +50,22 @@ export interface RunnerFs {
   remove(path: string): Promise<void>;
   /** Atomic install of bytes at `dest` (tmp write in the same dir + rename). */
   installAtomic(dest: string, bytes: Uint8Array, mode: number): Promise<void>;
+  /**
+   * Promote an already-streamed staged file onto `dest`: chmod then atomic
+   * `rename(2)`. `staged` MUST already live in `dest`'s directory (same
+   * filesystem) so the rename works over a live binary.
+   */
+  promoteFile(staged: string, dest: string, mode: number): Promise<void>;
 }
 
 export interface RunnerHttp {
-  /** GET → bytes (throws on non-2xx). */
+  /**
+   * Stream a URL to `dest` on disk and return its on-the-fly SHA-256. Used for
+   * the large daemon binary + firecracker tarball so a stalled download aborts
+   * (instead of hanging) and progress feeds a spinner. Throws on non-2xx.
+   */
+  fetchToFile(url: string, dest: string, onProgress?: ProgressFn): Promise<{ sha256: string }>;
+  /** GET → bytes (throws on non-2xx). Small artefacts only (checksums sig). */
   fetchBinary(url: string): Promise<Uint8Array>;
   /** GET → text (throws on non-2xx). */
   fetchText(url: string): Promise<string>;
@@ -134,9 +147,17 @@ export const defaultRunnerFs: RunnerFs = {
       throw err;
     }
   },
+  async promoteFile(staged, dest, mode) {
+    await mkdir(dirname(dest), { recursive: true });
+    await chmod(staged, mode);
+    await rename(staged, dest);
+  },
 };
 
 export const defaultRunnerHttp: RunnerHttp = {
+  fetchToFile(url, dest, onProgress) {
+    return streamDownload(url, dest, { onProgress });
+  },
   async fetchBinary(url) {
     const res = await fetch(url, { redirect: "follow" });
     if (!res.ok) throw new Error(`GET ${url} → HTTP ${res.status}`);

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -261,12 +261,10 @@ export interface SelfUpdateDeps {
   promoteFile(staged: string, dest: string): Promise<void>;
   /** Working directory for downloaded artefacts (checksums + sig). */
   makeWorkDir(): Promise<string>;
-  /** Cleanup helper. */
+  /** Best-effort `rm -rf` — cleans the work dir and the staged download. */
   removeDir(path: string): Promise<void>;
   /** Write a file (used in the work dir for minisign input). */
   writeFile(path: string, data: Uint8Array | string): Promise<void>;
-  /** Remove a single file (staged download cleanup). Best-effort. */
-  removeFile(path: string): Promise<void>;
 }
 
 export const defaultSelfUpdateDeps: SelfUpdateDeps = {
@@ -324,9 +322,6 @@ export const defaultSelfUpdateDeps: SelfUpdateDeps = {
   },
   writeFile(path, data) {
     return writeFile(path, data);
-  },
-  removeFile(path) {
-    return rm(path, { force: true });
   },
 };
 
@@ -507,8 +502,9 @@ export async function performCurlUpdate(
     return { status: "updated", version: target, destination: dest };
   } finally {
     // Remove the staged download if it survived (verification/promotion failed
-    // before the rename consumed it), then the small-artefact work dir.
-    await deps.removeFile(staged).catch(() => {});
+    // before the rename consumed it), then the small-artefact work dir. Both
+    // go through the same best-effort `rm -rf`.
+    await deps.removeDir(staged).catch(() => {});
     await deps.removeDir(workDir).catch(() => {});
   }
 }

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -459,13 +459,15 @@ export async function performCurlUpdate(
     const urls = releaseUrls(target, opts.platform);
     const asset = assetName(opts.platform);
 
-    log(`→ Downloading Appstrate CLI ${target} (${asset})`);
-    const [{ sha256: actual }, checksumsTxt, checksumsSig] = await Promise.all([
-      deps.fetchToFile(urls.binary, staged, opts.onProgress),
+    // Fetch + verify the small signed manifest FIRST, before the large binary
+    // stream. Two reasons: (1) it fails fast on a bad/missing signature without
+    // pulling ~113 MB; (2) it avoids running the big stream concurrently with
+    // the sidecars — a Promise.all reject would run cleanup while the stream is
+    // still writing `staged`, leaving an orphan download behind.
+    const [checksumsTxt, checksumsSig] = await Promise.all([
       deps.fetchText(urls.checksums),
       deps.fetchBinary(urls.checksumsSig),
     ]);
-
     const sumsPath = join(workDir, "checksums.txt");
     const sigPath = join(workDir, "checksums.txt.minisig");
     await deps.writeFile(sumsPath, checksumsTxt);
@@ -485,6 +487,9 @@ export async function performCurlUpdate(
           `Refusing to install. Report at https://github.com/appstrate/appstrate/issues`,
       );
     }
+
+    log(`→ Downloading Appstrate CLI ${target} (${asset})`);
+    const { sha256: actual } = await deps.fetchToFile(urls.binary, staged, opts.onProgress);
 
     log(`→ Verifying binary integrity (SHA-256)`);
     const expected = parseChecksumLine(checksumsTxt, asset);

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -17,11 +17,12 @@
  *     this binary, so we cannot prove the update target matches.
  */
 
-import { mkdtemp, rename, rm, writeFile, chmod, mkdir } from "node:fs/promises";
+import { mkdtemp, rename, rm, writeFile, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { runCommand, type CommandResult } from "./install/os.ts";
 import { CLI_USER_AGENT, CLI_VERSION, DEV_CLI_VERSION } from "./version.ts";
+import { streamDownload, type ProgressFn } from "./download.ts";
 
 /** Pubkey baked into the curl bootstrap (`scripts/bootstrap.sh`). Same key signs every release. */
 export const APPSTRATE_MINISIGN_PUBKEY = "RWT6xCZCCP/yHolAgDuDqBssxUflw7gInlZlaXEfQ4cFi5XN0KCtKr0e";
@@ -237,31 +238,44 @@ export function normalizeVersion(raw: string): string {
 }
 
 export interface SelfUpdateDeps {
-  /** GET a URL and return the body as bytes. Throws on HTTP error. */
+  /**
+   * Stream a URL to `dest` on disk and return its on-the-fly SHA-256. Used for
+   * the large CLI binary — progress ticks feed a spinner, and a stalled
+   * download aborts instead of hanging forever. Throws on HTTP error.
+   */
+  fetchToFile(url: string, dest: string, onProgress?: ProgressFn): Promise<{ sha256: string }>;
+  /** GET a URL and return the body as bytes (small artefacts: the minisig). */
   fetchBinary(url: string): Promise<Uint8Array>;
-  /** GET a URL and return the body as text. */
+  /** GET a URL and return the body as text (small artefact: checksums.txt). */
   fetchText(url: string): Promise<string>;
-  /** Compute hex SHA-256 of bytes. */
-  sha256Hex(data: Uint8Array): Promise<string>;
   /** Run a subprocess; same shape as `runCommand`. */
   runCommand(cmd: string, args: string[]): Promise<CommandResult>;
   /** `process.execPath` — the running binary path that gets atomic-renamed over. */
   execPath(): string;
   /**
-   * Atomically install `bytes` at `dest`. The default impl writes to a same-
-   * directory temp file, chmods +x, and `rename(2)`s on top of `dest`. Tests
-   * stub this entirely to avoid touching the real binary.
+   * Atomically promote an already-downloaded staged file onto `dest`: chmod +x
+   * then `rename(2)` on top. The staged file MUST already live in `dest`'s
+   * directory (same filesystem) so the rename is atomic and works over the
+   * running binary. Tests stub this to avoid touching the real binary.
    */
-  atomicReplace(bytes: Uint8Array, dest: string): Promise<void>;
-  /** Working directory for downloaded artefacts (binary + checksums + sig). */
+  promoteFile(staged: string, dest: string): Promise<void>;
+  /** Working directory for downloaded artefacts (checksums + sig). */
   makeWorkDir(): Promise<string>;
   /** Cleanup helper. */
   removeDir(path: string): Promise<void>;
   /** Write a file (used in the work dir for minisign input). */
   writeFile(path: string, data: Uint8Array | string): Promise<void>;
+  /** Remove a single file (staged download cleanup). Best-effort. */
+  removeFile(path: string): Promise<void>;
 }
 
 export const defaultSelfUpdateDeps: SelfUpdateDeps = {
+  fetchToFile(url, dest, onProgress) {
+    return streamDownload(url, dest, {
+      headers: { "User-Agent": CLI_USER_AGENT },
+      onProgress,
+    });
+  },
   async fetchBinary(url) {
     const res = await fetch(url, {
       headers: { "User-Agent": CLI_USER_AGENT },
@@ -292,32 +306,15 @@ export const defaultSelfUpdateDeps: SelfUpdateDeps = {
     }
     return res.text();
   },
-  async sha256Hex(data) {
-    // Bun.CryptoHasher is available in the bundled binary (Bun runtime baked in).
-    const hasher = new Bun.CryptoHasher("sha256");
-    hasher.update(data);
-    return hasher.digest("hex");
-  },
   runCommand,
   execPath: () => process.execPath,
-  async atomicReplace(bytes, dest) {
+  async promoteFile(staged, dest) {
     // POSIX rename(2) on the same filesystem is atomic and works on the
     // running binary: the kernel detaches the inode but keeps the open fd
-    // in this process valid. The temp file MUST live in the same dir as
-    // dest (same fs by construction).
-    const dir = dirname(dest);
-    await mkdir(dir, { recursive: true });
-    const stagedDir = await mkdtemp(`${dest}.staging.`);
-    try {
-      const staged = join(stagedDir, "appstrate.new");
-      await writeFile(staged, bytes);
-      await chmod(staged, 0o755);
-      await rename(staged, dest);
-    } finally {
-      // Best-effort cleanup. If rename succeeded the staging dir is empty;
-      // if it failed we still want the (possibly large) staged file gone.
-      await rm(stagedDir, { recursive: true, force: true }).catch(() => {});
-    }
+    // in this process valid. `staged` is created same-dir as `dest` by the
+    // caller (streamed there), so the rename never crosses a filesystem.
+    await chmod(staged, 0o755);
+    await rename(staged, dest);
   },
   makeWorkDir() {
     return mkdtemp(join(tmpdir(), "appstrate-self-update-"));
@@ -327,6 +324,9 @@ export const defaultSelfUpdateDeps: SelfUpdateDeps = {
   },
   writeFile(path, data) {
     return writeFile(path, data);
+  },
+  removeFile(path) {
+    return rm(path, { force: true });
   },
 };
 
@@ -399,6 +399,8 @@ export interface PerformCurlUpdateOptions {
   deps?: SelfUpdateDeps;
   /** Logger sink — defaults to `console.error` so tests can collect output. */
   log?: (line: string) => void;
+  /** Download-progress sink for the CLI binary (bytes/percent/rate). */
+  onProgress?: ProgressFn;
 }
 
 export interface PerformCurlUpdateResult {
@@ -454,13 +456,17 @@ export async function performCurlUpdate(
 
   const dest = deps.execPath();
   const workDir = await deps.makeWorkDir();
+  // Stage the (large) binary in the SAME directory as `dest` so the final
+  // promotion is an atomic same-filesystem rename over the running binary.
+  // The small checksums + signature live in the throwaway work dir.
+  const staged = join(dirname(dest), `.appstrate.download.${process.pid}`);
   try {
     const urls = releaseUrls(target, opts.platform);
     const asset = assetName(opts.platform);
 
     log(`→ Downloading Appstrate CLI ${target} (${asset})`);
-    const [binary, checksumsTxt, checksumsSig] = await Promise.all([
-      deps.fetchBinary(urls.binary),
+    const [{ sha256: actual }, checksumsTxt, checksumsSig] = await Promise.all([
+      deps.fetchToFile(urls.binary, staged, opts.onProgress),
       deps.fetchText(urls.checksums),
       deps.fetchBinary(urls.checksumsSig),
     ]);
@@ -487,7 +493,6 @@ export async function performCurlUpdate(
 
     log(`→ Verifying binary integrity (SHA-256)`);
     const expected = parseChecksumLine(checksumsTxt, asset);
-    const actual = await deps.sha256Hex(binary);
     if (actual !== expected) {
       throw new Error(
         `SHA-256 mismatch for ${asset}: expected ${expected}, got ${actual}. ` +
@@ -497,10 +502,13 @@ export async function performCurlUpdate(
     }
 
     log(`→ Installing ${asset} → ${dest}`);
-    await deps.atomicReplace(binary, dest);
+    await deps.promoteFile(staged, dest);
 
     return { status: "updated", version: target, destination: dest };
   } finally {
+    // Remove the staged download if it survived (verification/promotion failed
+    // before the rename consumed it), then the small-artefact work dir.
+    await deps.removeFile(staged).catch(() => {});
     await deps.removeDir(workDir).catch(() => {});
   }
 }

--- a/apps/cli/test/download.test.ts
+++ b/apps/cli/test/download.test.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  streamDownload,
+  formatBytes,
+  formatProgress,
+  type DownloadProgress,
+} from "../src/lib/download.ts";
+
+const workDirs: string[] = [];
+async function tmpDest(name = "download.bin"): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "appstrate-dl-test-"));
+  workDirs.push(dir);
+  return join(dir, name);
+}
+afterEach(async () => {
+  for (const d of workDirs.splice(0)) await rm(d, { recursive: true, force: true }).catch(() => {});
+});
+
+/** A Response streaming `chunks`, with an optional explicit Content-Length. */
+function streamingResponse(
+  chunks: Uint8Array[],
+  opts: { contentLength?: number | null } = {},
+): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(ctrl) {
+      for (const c of chunks) ctrl.enqueue(c);
+      ctrl.close();
+    },
+  });
+  const headers = new Headers();
+  const len =
+    opts.contentLength === undefined
+      ? chunks.reduce((a, c) => a + c.byteLength, 0)
+      : opts.contentLength;
+  if (len !== null) headers.set("content-length", String(len));
+  return new Response(body, { status: 200, headers });
+}
+
+/** SHA-256 hex of bytes via Bun (the value streamDownload should return). */
+function sha(bytes: Uint8Array): string {
+  return new Bun.CryptoHasher("sha256").update(bytes).digest("hex");
+}
+
+describe("streamDownload", () => {
+  it("writes the file, returns bytesWritten + on-the-fly sha256", async () => {
+    const dest = await tmpDest();
+    const payload = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
+    const res = await streamDownload("https://example/asset", dest, {
+      fetchImpl: async () => streamingResponse([payload.subarray(0, 4), payload.subarray(4)]),
+    });
+    expect(res.bytesWritten).toBe(8);
+    expect(res.sha256).toBe(sha(payload));
+    expect(new Uint8Array(await readFile(dest))).toEqual(payload);
+  });
+
+  it("reports progress with total from Content-Length", async () => {
+    const dest = await tmpDest();
+    const chunks = [new Uint8Array(10), new Uint8Array(10)];
+    const ticks: DownloadProgress[] = [];
+    await streamDownload("https://example/asset", dest, {
+      fetchImpl: async () => streamingResponse(chunks, { contentLength: 20 }),
+      onProgress: (p) => ticks.push(p),
+    });
+    // A final forced tick always fires; it must report the full byte count + total.
+    const last = ticks.at(-1)!;
+    expect(last.received).toBe(20);
+    expect(last.total).toBe(20);
+  });
+
+  it("reports progress with null total when Content-Length is absent", async () => {
+    const dest = await tmpDest();
+    const ticks: DownloadProgress[] = [];
+    await streamDownload("https://example/asset", dest, {
+      fetchImpl: async () => streamingResponse([new Uint8Array(5)], { contentLength: null }),
+      onProgress: (p) => ticks.push(p),
+    });
+    expect(ticks.at(-1)!.total).toBeNull();
+  });
+
+  it("throws GET … HTTP <status> on a non-2xx and writes nothing", async () => {
+    const dest = await tmpDest();
+    await expect(
+      streamDownload("https://example/missing", dest, {
+        fetchImpl: async () => new Response("nope", { status: 404, statusText: "Not Found" }),
+      }),
+    ).rejects.toThrow(/HTTP 404/);
+    expect(await Bun.file(dest).exists()).toBe(false);
+  });
+
+  it("aborts with a stall error and removes the partial file", async () => {
+    const dest = await tmpDest();
+    // Stream: one chunk, then hang forever → the stall watchdog fires.
+    const body = new ReadableStream<Uint8Array>({
+      start(ctrl) {
+        ctrl.enqueue(new Uint8Array([1, 2, 3]));
+        // never close / enqueue again
+      },
+    });
+    await expect(
+      streamDownload("https://example/slow", dest, {
+        stallTimeoutMs: 20,
+        fetchImpl: async () => new Response(body, { status: 200 }),
+      }),
+    ).rejects.toThrow(/stalled: no data/);
+    expect(await Bun.file(dest).exists()).toBe(false);
+  });
+
+  it("aborts with a total-timeout error when the whole transfer runs long", async () => {
+    const dest = await tmpDest();
+    // A chunk every 15ms keeps the stall watchdog happy, but the total cap (30ms) trips.
+    const body = new ReadableStream<Uint8Array>({
+      async pull(ctrl) {
+        await new Promise((r) => setTimeout(r, 15));
+        ctrl.enqueue(new Uint8Array([0]));
+      },
+    });
+    await expect(
+      streamDownload("https://example/long", dest, {
+        stallTimeoutMs: 500,
+        totalTimeoutMs: 30,
+        fetchImpl: async () => new Response(body, { status: 200 }),
+      }),
+    ).rejects.toThrow(/timed out/);
+    expect(await Bun.file(dest).exists()).toBe(false);
+  });
+
+  it("propagates a network error from fetch", async () => {
+    const dest = await tmpDest();
+    await expect(
+      streamDownload("https://example/asset", dest, {
+        fetchImpl: async () => {
+          throw new Error("ECONNREFUSED");
+        },
+      }),
+    ).rejects.toThrow(/ECONNREFUSED/);
+  });
+});
+
+describe("formatBytes / formatProgress", () => {
+  it("formats byte magnitudes", () => {
+    expect(formatBytes(512)).toBe("512 B");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+    expect(formatBytes(113 * 1024 * 1024)).toBe("113.0 MB");
+  });
+
+  it("includes percent when total is known", () => {
+    const s = formatProgress({
+      received: 5 * 1024 * 1024,
+      total: 10 * 1024 * 1024,
+      rateBytesPerSec: 1024 * 1024,
+    });
+    expect(s).toContain("(50%)");
+    expect(s).toContain("MB/s");
+  });
+
+  it("omits percent when total is unknown", () => {
+    const s = formatProgress({ received: 1024, total: null, rateBytesPerSec: 512 });
+    expect(s).not.toContain("%");
+  });
+});

--- a/apps/cli/test/download.test.ts
+++ b/apps/cli/test/download.test.ts
@@ -4,12 +4,8 @@ import { describe, it, expect, afterEach } from "bun:test";
 import { mkdtemp, rm, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import {
-  streamDownload,
-  formatBytes,
-  formatProgress,
-  type DownloadProgress,
-} from "../src/lib/download.ts";
+import { streamDownload, formatProgress } from "../src/lib/download.ts";
+import type { DownloadProgress } from "../src/lib/download.ts";
 
 const workDirs: string[] = [];
 async function tmpDest(name = "download.bin"): Promise<string> {
@@ -141,13 +137,7 @@ describe("streamDownload", () => {
   });
 });
 
-describe("formatBytes / formatProgress", () => {
-  it("formats byte magnitudes", () => {
-    expect(formatBytes(512)).toBe("512 B");
-    expect(formatBytes(1536)).toBe("1.5 KB");
-    expect(formatBytes(113 * 1024 * 1024)).toBe("113.0 MB");
-  });
-
+describe("formatProgress", () => {
   it("includes percent when total is known", () => {
     const s = formatProgress({
       received: 5 * 1024 * 1024,

--- a/apps/cli/test/runner.test.ts
+++ b/apps/cli/test/runner.test.ts
@@ -33,12 +33,17 @@ import {
   runnerDataPaths,
   daemonAssetName,
   RUNNER_ENV_PATH,
+  RUNNER_BIN_PATH,
+  RUNNER_UNIT_PATH,
+  RUNNER_ETC_DIR,
+  RUNNER_DATA_DIR,
   APPSTRATE_RELEASE_BASE,
 } from "../src/lib/runner/constants.ts";
 import {
   resolveDaemonVersion,
   resolveInstallConfig,
   runnerUpdateCommand,
+  runnerUninstallCommand,
   runnerDoctor,
   pollHealth,
   enableService,
@@ -74,10 +79,12 @@ function fakeExec(
 function fakeFs(seed: Record<string, string> = {}): {
   fs: RunnerFs;
   installed: { dest: string; bytes: Uint8Array; mode: number }[];
+  removed: string[];
   files: Record<string, string>;
 } {
   const files: Record<string, string> = { ...seed };
   const installed: { dest: string; bytes: Uint8Array; mode: number }[] = [];
+  const removed: string[] = [];
   const fs: RunnerFs = {
     async writeFile(path, data) {
       files[path] = typeof data === "string" ? data : "<bytes>";
@@ -97,13 +104,23 @@ function fakeFs(seed: Record<string, string> = {}): {
       return true;
     },
     async rename() {},
-    async remove() {},
+    async remove(path) {
+      removed.push(path);
+      delete files[path];
+    },
     async installAtomic(dest, bytes, mode) {
       installed.push({ dest, bytes, mode });
       files[dest] = "<installed>";
     },
+    async promoteFile(staged, dest, mode) {
+      // The streamed daemon binary is promoted here (not installAtomic); record
+      // it into the same `installed` list so existing assertions still hold.
+      installed.push({ dest, bytes: new Uint8Array(), mode });
+      files[dest] = "<installed>";
+      delete files[staged];
+    },
   };
-  return { fs, installed, files };
+  return { fs, installed, removed, files };
 }
 
 function fakeHttp(opts: {
@@ -111,9 +128,16 @@ function fakeHttp(opts: {
   sha?: string;
   health?: { status: number; body: unknown };
 }): RunnerHttp {
+  const binary = opts.binary ?? new Uint8Array([1, 2, 3]);
   return {
+    async fetchToFile(_url, _dest, onProgress) {
+      // The daemon binary streams through here; return its on-the-fly digest so
+      // downloadDaemon can compare it to the signed checksums line.
+      onProgress?.({ received: binary.byteLength, total: binary.byteLength, rateBytesPerSec: 1 });
+      return { sha256: sha256Hex(binary) };
+    },
     async fetchBinary() {
-      return opts.binary ?? new Uint8Array([1, 2, 3]);
+      return binary;
     },
     async fetchText() {
       return opts.sha ?? "";
@@ -125,6 +149,9 @@ function fakeHttp(opts: {
     },
   };
 }
+
+/** Default install path passed to downloadDaemon in the unit tests. */
+const TEST_DAEMON_DEST = "/usr/local/bin/appstrate-runner";
 
 // ─── preflight ──────────────────────────────────────────────────────────
 
@@ -376,31 +403,51 @@ describe("url builders", () => {
 });
 
 describe("downloadDaemon", () => {
-  it("returns the bytes when the signed checksum matches", async () => {
+  it("returns a staged path next to dest when the signed checksum matches", async () => {
     const bytes = new Uint8Array([9, 8, 7, 6]);
     const sha = sha256Hex(bytes);
     // `sha` doubles as the checksums.txt body (fetchText) — one line for the asset.
     const http = fakeHttp({ binary: bytes, sha: `${sha}  appstrate-runner-x86_64` });
     const { fs } = fakeFs();
     const { exec } = fakeExec(); // default minisign probe + -Vm both `ok`.
-    const out = await downloadDaemon({ http, exec, fs, version: "1.0.0", arch: "x86_64" });
-    expect(out).toEqual(bytes);
+    const out = await downloadDaemon({
+      http,
+      exec,
+      fs,
+      version: "1.0.0",
+      arch: "x86_64",
+      destPath: TEST_DAEMON_DEST,
+    });
+    // Staged next to the destination (same dir → atomic promote).
+    expect(out.stagedPath.startsWith("/usr/local/bin/")).toBe(true);
+    expect(out.stagedPath).toContain("appstrate-runner-x86_64");
   });
 
-  it("throws on a sha256 mismatch (never returns tampered bytes)", async () => {
+  it("throws on a sha256 mismatch and removes the staged file", async () => {
     const bytes = new Uint8Array([1, 1, 1]);
     const http = fakeHttp({ binary: bytes, sha: `${"b".repeat(64)}  appstrate-runner-x86_64` });
-    const { fs } = fakeFs();
+    const { fs, removed } = fakeFs();
     const { exec } = fakeExec();
     await expect(
-      downloadDaemon({ http, exec, fs, version: "1.0.0", arch: "x86_64" }),
+      downloadDaemon({
+        http,
+        exec,
+        fs,
+        version: "1.0.0",
+        arch: "x86_64",
+        destPath: TEST_DAEMON_DEST,
+      }),
     ).rejects.toThrow(/mismatch/);
+    // The unverified staged download must be cleaned up, never left on disk.
+    expect(removed.some((p) => p.includes("appstrate-runner-x86_64"))).toBe(true);
   });
 
   it("gives an actionable error when the release omitted runner assets (404)", async () => {
-    const bytes = new Uint8Array([1, 2, 3]);
     const http: RunnerHttp = {
-      // Mirror defaultRunnerHttp's non-2xx message shape.
+      // Mirror defaultRunnerHttp's non-2xx message shape (now on fetchToFile).
+      async fetchToFile(url) {
+        throw new Error(`GET ${url} → HTTP 404`);
+      },
       async fetchBinary(url) {
         throw new Error(`GET ${url} → HTTP 404`);
       },
@@ -414,10 +461,15 @@ describe("downloadDaemon", () => {
     const { fs } = fakeFs();
     const { exec } = fakeExec();
     await expect(
-      downloadDaemon({ http, exec, fs, version: "1.2.3", arch: "x86_64" }),
+      downloadDaemon({
+        http,
+        exec,
+        fs,
+        version: "1.2.3",
+        arch: "x86_64",
+        destPath: TEST_DAEMON_DEST,
+      }),
     ).rejects.toThrow(/published WITHOUT runner assets/);
-    // Sanity: the raw bytes are never leaked when the fetch failed.
-    expect(bytes).toBeDefined();
   });
 
   it("fails closed when minisign is not installed", async () => {
@@ -430,7 +482,14 @@ describe("downloadDaemon", () => {
       minisign: () => ({ ok: false, exitCode: -1, stdout: "", stderr: "" }),
     });
     await expect(
-      downloadDaemon({ http, exec, fs, version: "1.0.0", arch: "x86_64" }),
+      downloadDaemon({
+        http,
+        exec,
+        fs,
+        version: "1.0.0",
+        arch: "x86_64",
+        destPath: TEST_DAEMON_DEST,
+      }),
     ).rejects.toThrow(/minisign is required/);
   });
 
@@ -445,7 +504,14 @@ describe("downloadDaemon", () => {
       "minisign -Vm": () => ({ ok: false, exitCode: 1, stdout: "", stderr: "bad sig" }),
     });
     await expect(
-      downloadDaemon({ http, exec, fs, version: "1.0.0", arch: "x86_64" }),
+      downloadDaemon({
+        http,
+        exec,
+        fs,
+        version: "1.0.0",
+        arch: "x86_64",
+        destPath: TEST_DAEMON_DEST,
+      }),
     ).rejects.toThrow(/Signature verification FAILED/);
   });
 });
@@ -690,5 +756,63 @@ describe("pollHealth", () => {
     const { exec } = fakeExec();
     // timeoutMs 0 → the loop never enters; no 3s sleeps in the test.
     expect(await pollHealth(cfg, { exec, http }, 0)).toBe(false);
+  });
+});
+
+// ─── uninstall ──────────────────────────────────────────────────────────────
+
+describe("runnerUninstallCommand", () => {
+  it("stops+disables the unit and removes binary, unit, drop-in, config, and data (--yes)", async () => {
+    const { fs, removed } = fakeFs();
+    const { exec, calls } = fakeExec();
+    await runnerUninstallCommand({ yes: true, deps: { getuid: () => 0, fs, exec } });
+
+    // systemctl lifecycle: stop → disable → daemon-reload → reset-failed.
+    expect(calls).toContainEqual(["systemctl", "stop", "appstrate-runner"]);
+    expect(calls).toContainEqual(["systemctl", "disable", "appstrate-runner"]);
+    expect(calls).toContainEqual(["systemctl", "daemon-reload"]);
+    expect(calls).toContainEqual(["systemctl", "reset-failed", "appstrate-runner"]);
+
+    // Every install artefact is removed, including the drop-in dir and the
+    // default state root.
+    expect(removed).toContain(RUNNER_UNIT_PATH);
+    expect(removed).toContain(`${RUNNER_UNIT_PATH}.d`);
+    expect(removed).toContain(RUNNER_BIN_PATH);
+    expect(removed).toContain(RUNNER_ETC_DIR);
+    expect(removed).toContain(RUNNER_DATA_DIR);
+  });
+
+  it("preserves the state dir with --keep-data", async () => {
+    const { fs, removed } = fakeFs();
+    const { exec } = fakeExec();
+    await runnerUninstallCommand({
+      yes: true,
+      keepData: true,
+      deps: { getuid: () => 0, fs, exec },
+    });
+
+    expect(removed).toContain(RUNNER_BIN_PATH);
+    expect(removed).toContain(RUNNER_ETC_DIR);
+    // The state root (kernel/rootfs/runs) is intentionally kept.
+    expect(removed).not.toContain(RUNNER_DATA_DIR);
+  });
+
+  it("recovers a non-default data dir from the env file (FIRECRACKER_KERNEL_PATH)", async () => {
+    const { fs, removed } = fakeFs({
+      [RUNNER_ENV_PATH]: "FIRECRACKER_KERNEL_PATH=/srv/runner/vmlinux\n",
+    });
+    const { exec } = fakeExec();
+    await runnerUninstallCommand({ yes: true, deps: { getuid: () => 0, fs, exec } });
+
+    expect(removed).toContain("/srv/runner");
+    expect(removed).not.toContain(RUNNER_DATA_DIR);
+  });
+
+  it("is idempotent — removing an absent install never throws", async () => {
+    const { fs, removed } = fakeFs(); // empty: nothing on disk
+    const { exec } = fakeExec();
+    await runnerUninstallCommand({ yes: true, deps: { getuid: () => 0, fs, exec } });
+    // Still targets the canonical paths (remove is rm -rf → no-op on missing).
+    expect(removed).toContain(RUNNER_BIN_PATH);
   });
 });

--- a/apps/cli/test/runner.test.ts
+++ b/apps/cli/test/runner.test.ts
@@ -472,6 +472,41 @@ describe("downloadDaemon", () => {
     ).rejects.toThrow(/published WITHOUT runner assets/);
   });
 
+  it("does not stream the daemon binary when the signed manifest fetch fails", async () => {
+    let fetchToFileCalled = false;
+    const http: RunnerHttp = {
+      async fetchToFile() {
+        fetchToFileCalled = true;
+        return { sha256: "unused" };
+      },
+      async fetchBinary(url) {
+        throw new Error(`GET ${url} → HTTP 500`);
+      },
+      async fetchText(url) {
+        throw new Error(`GET ${url} → HTTP 500`);
+      },
+      async getJson() {
+        return { reachable: false, error: "n/a" };
+      },
+    };
+    const { fs, removed } = fakeFs();
+    const { exec } = fakeExec();
+    await expect(
+      downloadDaemon({
+        http,
+        exec,
+        fs,
+        version: "1.0.0",
+        arch: "x86_64",
+        destPath: TEST_DAEMON_DEST,
+      }),
+    ).rejects.toThrow();
+    // The manifest is fetched first; its failure aborts before the ~70 MB
+    // stream ever starts, so nothing is staged and nothing needs cleanup.
+    expect(fetchToFileCalled).toBe(false);
+    expect(removed).toEqual([]);
+  });
+
   it("fails closed when minisign is not installed", async () => {
     const bytes = new Uint8Array([5, 5, 5]);
     const sha = sha256Hex(bytes);

--- a/apps/cli/test/self-update.test.ts
+++ b/apps/cli/test/self-update.test.ts
@@ -290,9 +290,6 @@ function makeFakeDeps(state: FakeDepsState): SelfUpdateDeps {
         bytes: typeof data === "string" ? data.length : data.byteLength,
       });
     },
-    async removeFile() {
-      // no-op
-    },
   };
 }
 

--- a/apps/cli/test/self-update.test.ts
+++ b/apps/cli/test/self-update.test.ts
@@ -224,6 +224,8 @@ interface FakeDepsState {
   checksumsSig: Uint8Array;
   /** SHA-256 returned by the fake fetchToFile — must match parseChecksumLine output for happy path. */
   hashOverride?: string;
+  /** When set, the small manifest fetch (fetchText) rejects with this message. */
+  checksumsError?: string;
   minisignAvailable: boolean;
   minisignOk: boolean;
   execPath: string;
@@ -260,6 +262,7 @@ function makeFakeDeps(state: FakeDepsState): SelfUpdateDeps {
     },
     async fetchText(url) {
       state.fetched.push(url);
+      if (state.checksumsError) throw new Error(state.checksumsError);
       return state.checksumsTxt;
     },
     async runCommand(cmd, args) {
@@ -357,10 +360,11 @@ describe("runSelfUpdate — curl flow", () => {
 
     expect(out.exitCode).toBe(SELF_UPDATE_EXIT.OK);
     expect(out.message).toContain("Updated appstrate to 1.2.3");
+    // Signed manifest first (checksums + sig), then the large binary stream.
     expect(state.fetched).toEqual([
-      "https://github.com/appstrate/appstrate/releases/download/v1.2.3/appstrate-linux-x64",
       "https://github.com/appstrate/appstrate/releases/download/v1.2.3/checksums.txt",
       "https://github.com/appstrate/appstrate/releases/download/v1.2.3/checksums.txt.minisig",
+      "https://github.com/appstrate/appstrate/releases/download/v1.2.3/appstrate-linux-x64",
     ]);
     expect(state.commands.find((c) => c.cmd === "minisign" && c.args[0] === "-Vm")).toBeTruthy();
     expect(state.replaced).toEqual([{ dest: "/home/user/.local/bin/appstrate" }]);
@@ -424,6 +428,25 @@ describe("runSelfUpdate — curl flow", () => {
     });
     expect(out.exitCode).toBe(SELF_UPDATE_EXIT.UPDATE_FAILED);
     expect(out.message).toContain("Signature verification FAILED");
+    expect(state.replaced).toEqual([]);
+  });
+
+  it("never starts the binary stream when the manifest fetch fails (no orphan staged download)", async () => {
+    const state = freshState({ checksumsError: "GET checksums.txt → HTTP 500" });
+    const binaryUrl =
+      "https://github.com/appstrate/appstrate/releases/download/v1.2.3/appstrate-linux-x64";
+    const out = await runSelfUpdate({
+      source: "curl",
+      platform: { platform: "linux", arch: "x64" },
+      log: () => {},
+      version: "1.2.3",
+      currentVersion: "1.0.0",
+      deps: makeFakeDeps(state),
+    });
+    expect(out.exitCode).toBe(SELF_UPDATE_EXIT.UPDATE_FAILED);
+    // The large binary is fetched AFTER the signed manifest, so a manifest
+    // failure means the stream never started — nothing to leak on disk.
+    expect(state.fetched).not.toContain(binaryUrl);
     expect(state.replaced).toEqual([]);
   });
 

--- a/apps/cli/test/self-update.test.ts
+++ b/apps/cli/test/self-update.test.ts
@@ -222,20 +222,37 @@ interface FakeDepsState {
   binary: Uint8Array;
   checksumsTxt: string;
   checksumsSig: Uint8Array;
-  /** Hash returned by the fake sha256Hex — must match parseChecksumLine output for happy path. */
+  /** SHA-256 returned by the fake fetchToFile — must match parseChecksumLine output for happy path. */
   hashOverride?: string;
   minisignAvailable: boolean;
   minisignOk: boolean;
   execPath: string;
   /** Side effects collected for assertions. */
   written: Array<{ path: string; bytes: number }>;
-  replaced: Array<{ dest: string; bytes: number }>;
+  replaced: Array<{ dest: string }>;
   fetched: string[];
   commands: Array<{ cmd: string; args: string[] }>;
 }
 
+/** Deterministic content-dependent fake SHA (matches the checksumsTxt fixtures). */
+function fakeSha(data: Uint8Array): string {
+  let n = 0;
+  for (const b of data) n = (n + b) | 0;
+  return `${"f".repeat(60)}${(n & 0xffff).toString(16).padStart(4, "0")}`;
+}
+
 function makeFakeDeps(state: FakeDepsState): SelfUpdateDeps {
   return {
+    async fetchToFile(url, _dest, onProgress) {
+      state.fetched.push(url);
+      onProgress?.({
+        received: state.binary.byteLength,
+        total: state.binary.byteLength,
+        rateBytesPerSec: 1,
+      });
+      // Simulate a tampered download by overriding the streamed digest.
+      return { sha256: state.hashOverride ?? fakeSha(state.binary) };
+    },
     async fetchBinary(url) {
       state.fetched.push(url);
       if (url.endsWith(".minisig")) return state.checksumsSig;
@@ -244,15 +261,6 @@ function makeFakeDeps(state: FakeDepsState): SelfUpdateDeps {
     async fetchText(url) {
       state.fetched.push(url);
       return state.checksumsTxt;
-    },
-    async sha256Hex(data) {
-      // Either return the override (used to simulate mismatch) or produce a deterministic hash.
-      if (state.hashOverride) return state.hashOverride;
-      // Sum bytes for a stable, content-dependent fake hash. Tests inject the
-      // matching value into checksumsTxt so the round-trip succeeds.
-      let n = 0;
-      for (const b of data) n = (n + b) | 0;
-      return `${"f".repeat(60)}${(n & 0xffff).toString(16).padStart(4, "0")}`;
     },
     async runCommand(cmd, args) {
       state.commands.push({ cmd, args });
@@ -267,8 +275,8 @@ function makeFakeDeps(state: FakeDepsState): SelfUpdateDeps {
       return { ok: true, exitCode: 0, stdout: "", stderr: "" };
     },
     execPath: () => state.execPath,
-    async atomicReplace(bytes, dest) {
-      state.replaced.push({ dest, bytes: bytes.byteLength });
+    async promoteFile(_staged, dest) {
+      state.replaced.push({ dest });
     },
     async makeWorkDir() {
       return "/tmp/fake-work";
@@ -281,6 +289,9 @@ function makeFakeDeps(state: FakeDepsState): SelfUpdateDeps {
         path,
         bytes: typeof data === "string" ? data.length : data.byteLength,
       });
+    },
+    async removeFile() {
+      // no-op
     },
   };
 }
@@ -355,7 +366,7 @@ describe("runSelfUpdate — curl flow", () => {
       "https://github.com/appstrate/appstrate/releases/download/v1.2.3/checksums.txt.minisig",
     ]);
     expect(state.commands.find((c) => c.cmd === "minisign" && c.args[0] === "-Vm")).toBeTruthy();
-    expect(state.replaced).toEqual([{ dest: "/home/user/.local/bin/appstrate", bytes: 5 }]);
+    expect(state.replaced).toEqual([{ dest: "/home/user/.local/bin/appstrate" }]);
   });
 
   it("reports already-up-to-date and skips replace when versions match", async () => {


### PR DESCRIPTION
Closes #821.

Both frictions surfaced during a real `beta.35` runner reinstall on a bare KVM host (PR #818 installer-firecracker work).

## 1. Streamed downloads — no more silent multi-minute hang

`self-update` and `runner install/update` buffered the whole response via `await res.arrayBuffer()` with **no `AbortSignal` and no progress**. A 113 MB CLI binary / ~70 MB daemon was a silent gap in the terminal, and a wedged GitHub→CDN redirect would hang the process forever.

New shared helper `lib/download.ts` — `streamDownload(url, dest, { onProgress, stallTimeoutMs, totalTimeoutMs })`:

- streams the body **to disk** (peak memory ≈ one chunk + hasher, not the whole artifact) and computes the SHA-256 **on the fly**;
- reports throttled **byte / percent / rate** progress for a live spinner;
- aborts with an actionable error if **no bytes arrive for 30 s** (stall watchdog) or the transfer exceeds a **20 min** backstop — the abort is raced against each read so teardown is prompt even if the stream ignores the fetch signal;
- **never leaves a partial file** behind (destination unlinked on any failure/abort).

All three consumers route through it via the existing DI seams (`fetchToFile` on `SelfUpdateDeps` / `RunnerHttp`). The large binary is staged **same-filesystem** as its destination and promoted with an atomic `rename(2)`, so the minisign + SHA-256 verification chain is unchanged (now verified from the streamed digest, no second read). Progress is wired to the clack spinner in the command layer; the helper stays UI-free.

## 2. `appstrate runner uninstall`

No supported teardown existed — a clean removal meant hand-rolling seven `systemctl`/`rm` commands. New `runner uninstall [--keep-data] [--yes] [--data-dir]` mirrors `install`:

- stop + disable the unit, `daemon-reload`, `reset-failed`;
- remove binary / unit / drop-in dir / `/etc/appstrate-runner` (config + bearer token);
- unless `--keep-data`, remove the state dir (recovered from the env file's kernel pin, else the default `/var/lib/appstrate-runner`).

Every step is best-effort and idempotent, so it also repairs a half-finished install. Destructive → confirms unless `--yes` / `APPSTRATE_YES=1`, and **refuses** (rather than hangs) in a non-interactive context without the flag. Distinct from the existing top-level `appstrate uninstall` (Docker stack teardown).

## Tests

- New `download.test.ts` — progress ticks, stall + total-timeout abort, partial-file cleanup, non-2xx, network error.
- Updated self-update / runner fakes for the `fetchToFile` + `promoteFile` seams.
- New `runner uninstall` coverage — full removal, `--keep-data`, env-based data-dir recovery, idempotency on an absent install.

Full CLI suite: **1213 pass**. tsc / eslint / prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)