### PR TITLE
fix(runs): capture claude-engine native structured output into RunResult.output

### DIFF
--- a/apps/api/src/openapi/paths/runs.ts
+++ b/apps/api/src/openapi/paths/runs.ts
@@ -1224,6 +1224,12 @@ export const runsPaths = {
                   type: "string",
                   enum: ["success", "failed", "timeout", "cancelled"],
                 },
+                outputMode: {
+                  type: "string",
+                  enum: ["tool", "native"],
+                  description:
+                    "How the runner delivers structured output — `native` (Claude Agent SDK `StructuredOutput`) vs `tool` (the `output` runtime tool). Drives the wording of output-validation failures; absent means `tool`.",
+                },
                 durationMs: { type: "integer", minimum: 0 },
                 usage: {
                   type: "object",

--- a/apps/api/src/routes/runs-events.ts
+++ b/apps/api/src/routes/runs-events.ts
@@ -118,6 +118,12 @@ const RunResultSchema = z
       })
       .optional(),
     status: z.enum(["success", "failed", "timeout", "cancelled"]).optional(),
+    // How the runner delivers structured output — `"native"` (Claude Agent
+    // SDK `StructuredOutput`) vs `"tool"` (the `output` runtime tool).
+    // Drives the wording of output-validation failures only (issue #833);
+    // cosmetic-grade, degrades to absent (= `"tool"`, the historical
+    // default) on a bad value.
+    outputMode: z.enum(["tool", "native"]).optional().catch(undefined),
     durationMs: z.number().int().nonnegative().optional().catch(undefined),
     // Authoritative token usage for finalize liveness and the terminal
     // `runs.tokenUsage` write. Missing/malformed usage is tolerated by the
@@ -213,6 +219,7 @@ export function createRunsEventsRouter() {
       logs: d.logs,
       ...(d.error ? { error: d.error } : {}),
       ...(d.status ? { status: d.status } : {}),
+      ...(d.outputMode !== undefined ? { outputMode: d.outputMode } : {}),
       ...(d.durationMs !== undefined ? { durationMs: d.durationMs } : {}),
       ...(d.usage !== undefined ? { usage: d.usage } : {}),
       ...(d.cost !== undefined ? { cost: d.cost } : {}),

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -319,11 +319,21 @@ async function finalizeRunImpl(input: FinalizeRunInput): Promise<void> {
     );
     if (!validation.valid) {
       status = "failed";
+      // The never-emitted wording must name the mechanism the engine
+      // actually had (issue #833): `result.outputMode === "native"` (Claude
+      // Agent SDK) has no `output` tool — its deliverable goes through the
+      // SDK's `StructuredOutput` channel. Absent outputMode means "tool"
+      // (the historical default; older runners never set it).
       errorMessage = outputEmitted
         ? `Output validation failed: ${validation.errors.join("; ")}`
-        : "Agent finished without calling the required `output` tool. This agent " +
-          "declares an output schema, so it must call `output` exactly once before " +
-          `finishing with all required fields (missing: ${validation.errors.join("; ")}).`;
+        : result.outputMode === "native"
+          ? "Agent finished without delivering the required structured output. " +
+            "This agent declares an output schema, so it must call `StructuredOutput` " +
+            "exactly once before finishing with all required fields " +
+            `(missing: ${validation.errors.join("; ")}).`
+          : "Agent finished without calling the required `output` tool. This agent " +
+            "declares an output schema, so it must call `output` exactly once before " +
+            `finishing with all required fields (missing: ${validation.errors.join("; ")}).`;
       outputValidationErrors = validation.errors;
     }
   }

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -321,19 +321,16 @@ async function finalizeRunImpl(input: FinalizeRunInput): Promise<void> {
       status = "failed";
       // The never-emitted wording must name the mechanism the engine
       // actually had (issue #833): `result.outputMode === "native"` (Claude
-      // Agent SDK) has no `output` tool — its deliverable goes through the
-      // SDK's `StructuredOutput` channel. Absent outputMode means "tool"
-      // (the historical default; older runners never set it).
+      // Agent SDK) delivers through the SDK's `StructuredOutput` tool, not
+      // the `output` runtime tool. Absent outputMode means "tool" (the
+      // historical default; older runners never set it).
+      const missing = validation.errors.join("; ");
+      const tool = result.outputMode === "native" ? "StructuredOutput" : "output";
       errorMessage = outputEmitted
-        ? `Output validation failed: ${validation.errors.join("; ")}`
-        : result.outputMode === "native"
-          ? "Agent finished without delivering the required structured output. " +
-            "This agent declares an output schema, so it must call `StructuredOutput` " +
-            "exactly once before finishing with all required fields " +
-            `(missing: ${validation.errors.join("; ")}).`
-          : "Agent finished without calling the required `output` tool. This agent " +
-            "declares an output schema, so it must call `output` exactly once before " +
-            `finishing with all required fields (missing: ${validation.errors.join("; ")}).`;
+        ? `Output validation failed: ${missing}`
+        : `Agent finished without calling the required \`${tool}\` tool. This agent ` +
+          `declares an output schema, so it must call \`${tool}\` exactly once before ` +
+          `finishing with all required fields (missing: ${missing}).`;
       outputValidationErrors = validation.errors;
     }
   }
@@ -751,6 +748,13 @@ export async function synthesiseFinalize(
     status: "success" | "failed" | "timeout" | "cancelled";
     error?: { message: string; stack?: string };
     durationMs?: number;
+    /**
+     * Delivery mechanism of the engine that ran, when the caller knows it
+     * (execute-background carries it off the container lifecycle). Keeps
+     * the output-validation wording engine-accurate on synthesised
+     * closures too (issue #833); absent means `"tool"` downstream.
+     */
+    outputMode?: "tool" | "native";
   },
 ): Promise<void> {
   const run = await getRunSinkContext(runId);
@@ -763,6 +767,7 @@ export async function synthesiseFinalize(
   result.status = terminal.status;
   if (terminal.error) result.error = terminal.error;
   if (terminal.durationMs !== undefined) result.durationMs = terminal.durationMs;
+  if (terminal.outputMode !== undefined) result.outputMode = terminal.outputMode;
 
   // The synthesis path carries no runner-posted `result.usage` (the container
   // exited without POSTing its own finalize). Reconstruct the terminal usage

--- a/apps/api/src/services/run-launcher/execute-background.ts
+++ b/apps/api/src/services/run-launcher/execute-background.ts
@@ -207,9 +207,12 @@ async function executeAgentInBackgroundImpl(input: ExecuteAgentInBackgroundInput
     // called finalize itself. Defensively synthesise success so a
     // container that forgot to finalise still reaches a terminal state;
     // the CAS makes this a no-op when the container did call finalize.
+    // `outputMode` rides along so a schema-declaring run closed by THIS
+    // synthesis still gets the engine-accurate validation wording (#833).
     await synthesiseFinalize(runId, {
       status: "success",
       durationMs: Date.now() - startTime,
+      outputMode: lifecycle.outputMode,
     });
   } catch (err) {
     if (signal.aborted) return;

--- a/apps/api/src/services/run-launcher/pi.ts
+++ b/apps/api/src/services/run-launcher/pi.ts
@@ -74,6 +74,14 @@ export interface PlatformContainerResult {
   timedOut: boolean;
   /** Whether the run was cancelled by the caller's `AbortSignal`. */
   cancelled: boolean;
+  /**
+   * Structured-output delivery mechanism of the engine that ran (from the
+   * resolved `delivery.engine`). Carried so a platform-SYNTHESISED finalize
+   * (runner never posted its own) phrases output-validation failures with
+   * the right mechanism — without it, a claude run closed by synthesis
+   * would resurface the wrong `output`-tool wording (issue #833).
+   */
+  outputMode: "tool" | "native";
 }
 
 export interface RunPlatformContainerInput {
@@ -442,7 +450,7 @@ async function runPlatformContainerImpl(
     recordContainerSpawn(Date.now() - spawnStart, { sidecar: !skipSidecar });
     spawnRecorded = true;
 
-    return await waitForWorkload(
+    const lifecycle = await waitForWorkload(
       orch,
       agent,
       sidecar,
@@ -450,6 +458,7 @@ async function runPlatformContainerImpl(
       signal,
       input.timeoutBootGraceMs ?? PLATFORM_TIMEOUT_BOOT_GRACE_MS,
     );
+    return { ...lifecycle, outputMode: delivery.engine === "claude" ? "native" : "tool" };
   } catch (err) {
     // SOTA per OTel "Recording errors": the spawn histogram covers failures too,
     // tagged with a bounded `error.type` naming the phase that failed (no
@@ -511,7 +520,7 @@ async function waitForWorkload(
   timeoutSeconds: number,
   signal: AbortSignal | undefined,
   bootGraceMs: number,
-): Promise<PlatformContainerResult> {
+): Promise<Omit<PlatformContainerResult, "outputMode">> {
   await orch.startWorkload(agent);
 
   // Ring-buffer the agent's stdout+stderr so a non-zero exit can be

--- a/apps/api/src/services/run-launcher/prompt-builder.ts
+++ b/apps/api/src/services/run-launcher/prompt-builder.ts
@@ -42,9 +42,10 @@ export async function buildPlatformSystemPrompt(
      * The engine the run executes on, resolved by the launcher via
      * `resolveCredentialDelivery` (provider→engine registry). Drives the
      * `## Output Format` section: the `claude` engine has no `output`
-     * runtime tool — its deliverable is native via the Claude Agent SDK's
-     * `outputFormat` — so the prompt must not mandate an `output` tool
-     * call there (issue #824). Defaults to the Pi tool-call contract.
+     * runtime tool — its deliverable goes through the Claude Agent SDK's
+     * `outputFormat`, i.e. the CLI-injected `StructuredOutput` tool — so
+     * the prompt must mandate THAT call, not an `output` tool call
+     * (issues #824, #833). Defaults to the Pi tool-call contract.
      */
     engine?: RunEngine;
   } = {},

--- a/apps/api/test/integration/routes/runs-events-ingestion.test.ts
+++ b/apps/api/test/integration/routes/runs-events-ingestion.test.ts
@@ -43,6 +43,7 @@ import {
   capUtf8Text,
   finalizeRun,
   getRunSinkContext,
+  synthesiseFinalize,
 } from "../../../src/services/run-event-ingestion.ts";
 import { emptyRunResult } from "@appstrate/afps-runtime/runner";
 import type { AppstrateModule, RunStatusChangeParams } from "@appstrate/core/module";
@@ -1905,9 +1906,27 @@ describe("POST /api/runs/:runId/events/finalize — output-schema validation per
 
     const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
     expect(row?.status).toBe("failed");
-    expect(row?.error).toMatch(/without delivering the required structured output/);
-    expect(row?.error).toMatch(/`StructuredOutput`/);
-    expect(row?.error).not.toMatch(/call `output`/);
+    expect(row?.error).toMatch(/without calling the required `StructuredOutput` tool/);
+    expect(row?.error).not.toMatch(/required `output` tool/);
+  });
+
+  it("a platform-SYNTHESISED success carries outputMode so crash-path closures keep the engine-accurate wording", async () => {
+    // Lost finalize POST + container exit 0: execute-background synthesises
+    // success and forwards the engine's delivery mode off the container
+    // lifecycle — without it, a claude run closed by synthesis would
+    // resurface the wrong `output`-tool wording (issue #833).
+    const runId = await seedRunWithSink(ctx, "@test/schema-agent");
+
+    await synthesiseFinalize(runId, {
+      status: "success",
+      durationMs: 100,
+      outputMode: "native",
+    });
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    expect(row?.error).toMatch(/without calling the required `StructuredOutput` tool/);
+    expect(row?.error).not.toMatch(/required `output` tool/);
   });
 
   it("a malformed outputMode degrades to the tool wording instead of failing finalize", async () => {

--- a/apps/api/test/integration/routes/runs-events-ingestion.test.ts
+++ b/apps/api/test/integration/routes/runs-events-ingestion.test.ts
@@ -1887,6 +1887,44 @@ describe("POST /api/runs/:runId/events/finalize — output-schema validation per
     expect(row?.error).toMatch(/without calling the required `output` tool/);
     expect(row?.error).not.toMatch(/^Output validation failed/);
   });
+
+  it('native-mode runs (outputMode: "native") get the StructuredOutput wording, never the `output` tool one (issue #833)', async () => {
+    const runId = await seedRunWithSink(ctx, "@test/schema-agent");
+
+    // A claude-engine run has no `output` runtime tool — telling the user it
+    // "must call `output`" points at a tool that does not exist on that
+    // engine. The runner states its mechanism via `outputMode` and the
+    // failure message follows it.
+    const res = await postFinalize(runId, {
+      status: "success",
+      outputMode: "native",
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    expect(row?.error).toMatch(/without delivering the required structured output/);
+    expect(row?.error).toMatch(/`StructuredOutput`/);
+    expect(row?.error).not.toMatch(/call `output`/);
+  });
+
+  it("a malformed outputMode degrades to the tool wording instead of failing finalize", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/schema-agent");
+
+    const res = await postFinalize(runId, {
+      status: "success",
+      outputMode: "banana",
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    expect(row?.error).toMatch(/without calling the required `output` tool/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/api/test/unit/prompt-builder.test.ts
+++ b/apps/api/test/unit/prompt-builder.test.ts
@@ -572,16 +572,18 @@ describe("buildEnrichedPrompt — Output Format is engine-aware", () => {
     expect(prompt).toContain("call the `output` tool");
   });
 
-  it("claude engine instructs a final JSON message — never a nonexistent `output` tool", async () => {
-    // The claude runner hosts log/note/pin/report only; the deliverable is
-    // native via SDK `outputFormat` → `structured_output`. The tool-call
+  it("claude engine mandates one terminal `StructuredOutput` call — never a nonexistent `output` tool", async () => {
+    // The claude runner hosts log/note/pin/report only; the deliverable goes
+    // through the SDK's `outputFormat`, i.e. the CLI-injected
+    // `StructuredOutput` tool — the ONLY channel captured into
+    // `result.structured_output` (issue #833). The `output` tool-call
     // mandate would send the agent hunting for a tool that does not exist
     // and the run never completes (issue #824).
     const prompt = await buildEnrichedPrompt(baseContext({ schemas: { output: outputSchema } }), {
       engine: "claude",
     });
     expect(prompt).toContain("## Output Format");
-    expect(prompt).toContain("FINAL message MUST be the run's deliverable");
+    expect(prompt).toContain("call `StructuredOutput` **exactly once**");
     expect(prompt).not.toContain("call the `output` tool");
   });
 

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -18138,6 +18138,11 @@ export interface operations {
                     };
                     /** @enum {string} */
                     status?: "success" | "failed" | "timeout" | "cancelled";
+                    /**
+                     * @description How the runner delivers structured output — `native` (Claude Agent SDK `StructuredOutput`) vs `tool` (the `output` runtime tool). Drives the wording of output-validation failures; absent means `tool`.
+                     * @enum {string}
+                     */
+                    outputMode?: "tool" | "native";
                     durationMs?: number;
                     /** @description Authoritative terminal token usage written to the `runs` row. */
                     usage?: {

--- a/packages/afps-runtime/src/bundle/platform-prompt.ts
+++ b/packages/afps-runtime/src/bundle/platform-prompt.ts
@@ -102,12 +102,14 @@ export interface PlatformPromptOptions {
    *
    * - `"tool"` — the Pi engine hosts an `output` runtime tool; the prompt
    *   mandates one terminal `output` call.
-   * - `"native"` — the Claude Agent SDK engine has NO `output` tool; the
-   *   deliverable is captured natively (`outputFormat: json_schema` →
-   *   `structured_output`), so the prompt instructs the agent to end with
-   *   a final JSON message instead of a tool call. Rendering the tool
-   *   mandate here would send the agent hunting for a tool that does not
-   *   exist (issue #824).
+   * - `"native"` — the Claude Agent SDK engine has NO MCP `output` tool;
+   *   the deliverable is captured via the SDK's `outputFormat: json_schema`,
+   *   which on the current CLI injects a client-side `StructuredOutput`
+   *   tool — the ONLY channel that populates `result.structured_output`
+   *   (a schema-conforming final text message is NOT captured, issue #833).
+   *   The prompt therefore mandates one terminal `StructuredOutput` call.
+   *   Rendering the `output` tool mandate instead would send the agent
+   *   hunting for a tool that does not exist (issue #824).
    */
   outputMode?: "tool" | "native";
 
@@ -389,17 +391,22 @@ export function renderPlatformPrompt(opts: PlatformPromptOptions): string {
   if (opts.outputSchema && Object.keys(opts.outputSchema).length > 0) {
     sections.push("## Output Format\n");
     if ((opts.outputMode ?? "tool") === "native") {
-      // Native delivery (Claude Agent SDK): there is NO `output` tool on
-      // this engine — the platform captures the run's structured output
-      // from the agent's final message. Mandating a tool call here sends
-      // the agent hunting for a tool that does not exist (issue #824).
+      // Native delivery (Claude Agent SDK): the deliverable goes through the
+      // CLI-injected `StructuredOutput` tool — the ONLY channel the SDK
+      // captures into `result.structured_output` (a schema-conforming final
+      // text message is NOT captured, issue #833). There is still no MCP
+      // `output` tool on this engine; mandating one sends the agent hunting
+      // for a tool that does not exist (issue #824), and forbidding tool
+      // delivery outright makes the agent skip `StructuredOutput` too (#833).
       sections.push(
-        "Your FINAL message MUST be the run's deliverable: a single JSON " +
-          "object that satisfies the JSON Schema below, with ALL required " +
-          "fields present. There is NO `output` tool on this runtime — do " +
-          "not try to call one; the platform captures your final message " +
-          "natively. Finish all other work first, then end the run with " +
-          "the JSON deliverable alone — no prose before or after it.\n",
+        "The runtime provides a `StructuredOutput` tool for the run's " +
+          "deliverable. You MUST call `StructuredOutput` **exactly once**, as " +
+          "your FINAL action, with a payload that satisfies the JSON Schema " +
+          "below — provide ALL required fields in that single call. Do not " +
+          "look for an `output` tool (it does not exist on this runtime); " +
+          "`StructuredOutput` is how the platform captures the run's " +
+          "structured output. Finish all other work first, then call it — " +
+          "do not plan any message or step after it.\n",
       );
     } else {
       sections.push(

--- a/packages/afps-runtime/src/bundle/platform-prompt.ts
+++ b/packages/afps-runtime/src/bundle/platform-prompt.ts
@@ -398,6 +398,10 @@ export function renderPlatformPrompt(opts: PlatformPromptOptions): string {
       // `output` tool on this engine; mandating one sends the agent hunting
       // for a tool that does not exist (issue #824), and forbidding tool
       // delivery outright makes the agent skip `StructuredOutput` too (#833).
+      // The last sentence is the version-drift escape hatch: if the CLI ever
+      // stops injecting a tool by that name, the model degrades to the lone-
+      // JSON final message the runner's fallback parser captures — and it
+      // shapes that message parseably (no surrounding prose).
       sections.push(
         "The runtime provides a `StructuredOutput` tool for the run's " +
           "deliverable. You MUST call `StructuredOutput` **exactly once**, as " +
@@ -406,7 +410,9 @@ export function renderPlatformPrompt(opts: PlatformPromptOptions): string {
           "look for an `output` tool (it does not exist on this runtime); " +
           "`StructuredOutput` is how the platform captures the run's " +
           "structured output. Finish all other work first, then call it — " +
-          "do not plan any message or step after it.\n",
+          "do not plan any message or step after it. If no `StructuredOutput` " +
+          "tool is available, end the run with the JSON deliverable alone as " +
+          "your FINAL message — no prose before or after it.\n",
       );
     } else {
       sections.push(

--- a/packages/afps-runtime/src/types/run-result.ts
+++ b/packages/afps-runtime/src/types/run-result.ts
@@ -50,6 +50,16 @@ export interface RunResult {
   /** Elapsed wall-clock time in milliseconds. Runners populate this. */
   durationMs?: number;
   /**
+   * How this runner delivers the structured output declared by the agent's
+   * output schema. `"tool"` — the `output` runtime tool (Pi engine);
+   * `"native"` — the engine's own structured-output channel (Claude Agent
+   * SDK `outputFormat` → `StructuredOutput`). Consumers use it to phrase
+   * output-validation failures in terms of the mechanism the agent actually
+   * had (issue #833). Optional — absent means `"tool"` (the historical
+   * default; older runners never set it).
+   */
+  outputMode?: "tool" | "native";
+  /**
    * Authoritative token usage for the run. When present, downstream
    * consumers MUST treat this as the source of truth — the field exists
    * so finalize is self-contained and does not race with the side-channel

--- a/packages/afps-runtime/test/bundle/platform-prompt.test.ts
+++ b/packages/afps-runtime/test/bundle/platform-prompt.test.ts
@@ -534,7 +534,7 @@ describe("renderPlatformPrompt", () => {
         outputSchema: schema,
       });
       expect(out).toContain("call the `output` tool");
-      expect(out).not.toContain("NO `output` tool");
+      expect(out).not.toContain("StructuredOutput");
     });
 
     it('outputMode: "tool" renders the terminal `output` tool mandate', () => {
@@ -548,10 +548,13 @@ describe("renderPlatformPrompt", () => {
       expect(out).toContain("exactly once");
     });
 
-    it('outputMode: "native" instructs a final JSON message and never mandates an `output` tool call', () => {
-      // The claude engine has no `output` tool (deliverable is native via
-      // SDK `outputFormat`); mandating one sends the agent hunting for a
-      // nonexistent tool and the run never completes (issue #824).
+    it('outputMode: "native" mandates one terminal `StructuredOutput` call and never the `output` tool', () => {
+      // The claude engine has no MCP `output` tool (mandating one sends the
+      // agent hunting for a nonexistent tool, issue #824). Its deliverable
+      // is captured ONLY through the SDK's CLI-injected `StructuredOutput`
+      // tool — a schema-conforming final text message is never captured into
+      // `result.structured_output`, so the prompt must not steer the agent
+      // away from tool delivery (issue #833).
       const out = renderPlatformPrompt({
         template: "T",
         context: ctx(),
@@ -559,8 +562,8 @@ describe("renderPlatformPrompt", () => {
         outputMode: "native",
       });
       expect(out).toContain("## Output Format");
-      expect(out).toContain("FINAL message MUST be the run's deliverable");
-      expect(out).toContain("NO `output` tool");
+      expect(out).toContain("call `StructuredOutput` **exactly once**");
+      expect(out).toContain("does not exist on this runtime");
       expect(out).not.toContain("call the `output` tool");
       expect(out).not.toContain("output({})");
       // Schema surfaces stay identical across modes.

--- a/packages/afps-runtime/test/bundle/platform-prompt.test.ts
+++ b/packages/afps-runtime/test/bundle/platform-prompt.test.ts
@@ -564,6 +564,10 @@ describe("renderPlatformPrompt", () => {
       expect(out).toContain("## Output Format");
       expect(out).toContain("call `StructuredOutput` **exactly once**");
       expect(out).toContain("does not exist on this runtime");
+      // Version-drift escape hatch: a CLI without the injected tool degrades
+      // to the lone-JSON final message the runner's fallback parser captures.
+      expect(out).toContain("If no `StructuredOutput` tool is available");
+      expect(out).toContain("JSON deliverable alone");
       expect(out).not.toContain("call the `output` tool");
       expect(out).not.toContain("output({})");
       // Schema surfaces stay identical across modes.

--- a/packages/runner-claude/src/claude-agent-runner.ts
+++ b/packages/runner-claude/src/claude-agent-runner.ts
@@ -45,6 +45,7 @@ import {
 } from "@appstrate/afps-runtime/runner";
 import { buildClaudeSdkEnv, CLAUDE_SDK_HARDENING } from "./claude-binary.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
+import { asRecordOrNull } from "@appstrate/core/safe-json";
 import { drainAndEmitInto, type RuntimeEventDrainer } from "@appstrate/core/runtime-event-drain";
 import { SdkRunEventMapper, type SdkRunMessage } from "./sdk-event-mapper.ts";
 
@@ -123,22 +124,27 @@ function resolveStartMessage(context: ExecutionContext): string {
  * the fallback structured-deliverable source when the SDK's
  * `result.structured_output` is absent (issue #833: the model wrote a
  * schema-conforming JSON final message instead of calling the CLI's
- * `StructuredOutput` tool). Tolerates a single markdown code fence around
- * the object. Returns `undefined` when the text is not a lone JSON object —
- * the caller then leaves the run output-less and platform-side validation
- * reports the miss.
+ * `StructuredOutput` tool). Tolerates a single wrapping markdown code fence
+ * (any info tag, any casing, closing fence on the JSON's own line or not).
+ * Returns `undefined` when the text is not a lone JSON object — the caller
+ * then leaves the run output-less and platform-side validation reports the
+ * miss.
  */
 export function parseFinalJsonObject(text: string | null): Record<string, unknown> | undefined {
   if (!text) return undefined;
   let candidate = text.trim();
-  const fenced = /^```(?:json)?\s*\n([\s\S]*?)\n\s*```$/.exec(candidate);
-  if (fenced?.[1]) candidate = fenced[1].trim();
+  // Fence stripping by index math, not a regex — a lazy/greedy fence regex
+  // backtracks superlinearly on a large message that opens a fence and never
+  // closes it, and misses common variants (```JSON, closing ``` glued to the
+  // JSON) that this handles for free.
+  if (candidate.startsWith("```") && candidate.endsWith("```")) {
+    const open = candidate.indexOf("\n");
+    const close = candidate.lastIndexOf("```");
+    if (open !== -1 && open < close) candidate = candidate.slice(open + 1, close).trim();
+  }
   if (!candidate.startsWith("{")) return undefined;
   try {
-    const parsed: unknown = JSON.parse(candidate);
-    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
-      ? (parsed as Record<string, unknown>)
-      : undefined;
+    return asRecordOrNull(JSON.parse(candidate)) ?? undefined;
   } catch {
     return undefined;
   }
@@ -395,12 +401,17 @@ export class ClaudeAgentRunner implements Runner {
     // BEFORE awaiting the sink, so `reduceEvents` + the finalize POST already
     // carry the output; a dead sink here must not throw out and flip an
     // otherwise-succeeded run to failed (a truly dead sink surfaces at finalize).
-    const structuredOutput =
-      terminal?.structuredOutput !== undefined
-        ? terminal.structuredOutput
-        : this.opts.outputSchema && terminal?.status === "success"
-          ? parseFinalJsonObject(mapper.lastAssistantText())
-          : undefined;
+    // `?? undefined`: a null SDK value means "not delivered" (the schema
+    // mandates an object), so it must not suppress the fallback nor emit a
+    // null deliverable.
+    let structuredOutput = terminal?.structuredOutput ?? undefined;
+    if (
+      structuredOutput === undefined &&
+      this.opts.outputSchema &&
+      terminal?.status === "success"
+    ) {
+      structuredOutput = parseFinalJsonObject(mapper.lastAssistantText());
+    }
     if (structuredOutput !== undefined) {
       try {
         await emit({

--- a/packages/runner-claude/src/claude-agent-runner.ts
+++ b/packages/runner-claude/src/claude-agent-runner.ts
@@ -118,6 +118,32 @@ function resolveStartMessage(context: ExecutionContext): string {
   return runInputToText(context.input) || "Begin the task according to your instructions.";
 }
 
+/**
+ * Best-effort parse of the agent's final text message as a JSON object —
+ * the fallback structured-deliverable source when the SDK's
+ * `result.structured_output` is absent (issue #833: the model wrote a
+ * schema-conforming JSON final message instead of calling the CLI's
+ * `StructuredOutput` tool). Tolerates a single markdown code fence around
+ * the object. Returns `undefined` when the text is not a lone JSON object —
+ * the caller then leaves the run output-less and platform-side validation
+ * reports the miss.
+ */
+export function parseFinalJsonObject(text: string | null): Record<string, unknown> | undefined {
+  if (!text) return undefined;
+  let candidate = text.trim();
+  const fenced = /^```(?:json)?\s*\n([\s\S]*?)\n\s*```$/.exec(candidate);
+  if (fenced?.[1]) candidate = fenced[1].trim();
+  if (!candidate.startsWith("{")) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(candidate);
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export class ClaudeAgentRunner implements Runner {
   readonly name = "claude-agent-runner";
 
@@ -357,17 +383,31 @@ export class ClaudeAgentRunner implements Runner {
 
     // Native structured deliverable → one `output.emitted` so the reducer sets
     // RunResult.output (no `output` runtime tool is involved on this path).
+    // Primary source is the SDK's `result.structured_output` (the model called
+    // the CLI-injected `StructuredOutput` tool). Fallback (issue #833): when a
+    // SUCCESSFUL schema-declaring run ends without it — the model wrote the
+    // JSON deliverable as its final text message instead of calling the tool —
+    // parse that final message. A non-JSON final message yields nothing and
+    // platform-side output validation reports the miss; a wrong-shape object
+    // fails the same validation, so the fallback can only rescue runs, never
+    // mask a genuine failure.
     // Best-effort emit, like the final drain above: `emit` pushes onto `events`
     // BEFORE awaiting the sink, so `reduceEvents` + the finalize POST already
     // carry the output; a dead sink here must not throw out and flip an
     // otherwise-succeeded run to failed (a truly dead sink surfaces at finalize).
-    if (terminal?.structuredOutput !== undefined) {
+    const structuredOutput =
+      terminal?.structuredOutput !== undefined
+        ? terminal.structuredOutput
+        : this.opts.outputSchema && terminal?.status === "success"
+          ? parseFinalJsonObject(mapper.lastAssistantText())
+          : undefined;
+    if (structuredOutput !== undefined) {
       try {
         await emit({
           type: "output.emitted",
           timestamp: now(),
           runId,
-          data: terminal.structuredOutput,
+          data: structuredOutput,
         });
       } catch {
         /* swallowed: run outcome decided elsewhere */
@@ -375,6 +415,11 @@ export class ClaudeAgentRunner implements Runner {
     }
 
     const result: RunResult = events.length === 0 ? emptyRunResult() : reduceEvents(events);
+    // This engine delivers structured output natively (`StructuredOutput` /
+    // final-message fallback above) — never via an `output` runtime tool.
+    // Finalize reads this to phrase output-validation failures in terms of
+    // the mechanism the agent actually had (issue #833).
+    result.outputMode = "native";
     if (terminal) {
       result.status = terminal.status;
       if (terminal.error) result.error = terminal.error;

--- a/packages/runner-claude/src/sdk-event-mapper.ts
+++ b/packages/runner-claude/src/sdk-event-mapper.ts
@@ -72,6 +72,8 @@ export interface SdkAssistantMessage {
   message?: { content?: SdkContentBlock[] | unknown; usage?: TokenUsage };
   /** Per-turn assistant error (e.g. mid-loop provider failure the agent may recover from). */
   error?: { message?: string } | string;
+  /** Set on subagent/sidechain turns (SDK `Task` tool) — not the run's own thread. */
+  parent_tool_use_id?: string | null;
 }
 export interface SdkUserMessage {
   type: "user";
@@ -176,11 +178,14 @@ export class SdkRunEventMapper {
   }
 
   /**
-   * Last non-empty assistant text seen on the stream — the run's final
-   * message once the stream has ended. Fallback source for the structured
-   * deliverable when the SDK's `result.structured_output` is absent (the
-   * model wrote the JSON as text instead of calling `StructuredOutput`,
-   * issue #833). `null` until an assistant turn produces text.
+   * Text of the FINAL main-thread assistant message once the stream has
+   * ended — fallback source for the structured deliverable when the SDK's
+   * `result.structured_output` is absent (the model wrote the JSON as text
+   * instead of calling `StructuredOutput`, issue #833). Every main-thread
+   * assistant message resets the slot — a later tool_use-only turn clears
+   * stale text, so a mid-run draft can never be promoted to the run's
+   * deliverable — and subagent/sidechain turns never count. `null` when the
+   * final assistant message carried no text.
    */
   lastAssistantText(): string | null {
     return this.lastText;
@@ -197,16 +202,24 @@ export class SdkRunEventMapper {
     const errMessage = assistantErrorMessage(msg.error);
     if (errMessage) events.push(buildError(base, errMessage));
 
-    const blocks = asContentBlocks(msg.message?.content);
-    const text = blocks
-      .filter((b): b is SdkTextBlock => b.type === "text")
-      .map((b) => b.text ?? "")
-      .join("\n")
-      .trim();
-    if (text) {
-      this.lastText = text;
-      events.push(buildProgress(base, text));
-    }
+    const content = msg.message?.content;
+    const blocks = asContentBlocks(content);
+    // Plain-string content is a legal API shape; treat it as one text block
+    // so neither the progress stream nor the final-message fallback goes
+    // blind on it.
+    const text = (
+      typeof content === "string"
+        ? content
+        : blocks
+            .filter((b): b is SdkTextBlock => b.type === "text")
+            .map((b) => b.text ?? "")
+            .join("\n")
+    ).trim();
+    // Final-message tracking (see lastAssistantText): reset on EVERY
+    // main-thread assistant message — including text-less tool_use-only
+    // turns — and ignore subagent/sidechain turns entirely.
+    if (msg.parent_tool_use_id == null) this.lastText = text || null;
+    if (text) events.push(buildProgress(base, text));
 
     for (const b of blocks) {
       if (b.type !== "tool_use") continue;

--- a/packages/runner-claude/src/sdk-event-mapper.ts
+++ b/packages/runner-claude/src/sdk-event-mapper.ts
@@ -139,6 +139,7 @@ function assistantErrorMessage(error: SdkAssistantMessage["error"]): string | un
 export class SdkRunEventMapper {
   private readonly liveUsage = zeroTokenUsage();
   private terminalState: SdkTerminal | null = null;
+  private lastText: string | null = null;
 
   constructor(
     private readonly runId: string,
@@ -174,6 +175,17 @@ export class SdkRunEventMapper {
     return { ...this.liveUsage };
   }
 
+  /**
+   * Last non-empty assistant text seen on the stream — the run's final
+   * message once the stream has ended. Fallback source for the structured
+   * deliverable when the SDK's `result.structured_output` is absent (the
+   * model wrote the JSON as text instead of calling `StructuredOutput`,
+   * issue #833). `null` until an assistant turn produces text.
+   */
+  lastAssistantText(): string | null {
+    return this.lastText;
+  }
+
   private mapAssistant(msg: SdkAssistantMessage): RunEvent[] {
     const events: RunEvent[] = [];
     const base = { runId: this.runId, timestamp: this.now() };
@@ -191,7 +203,10 @@ export class SdkRunEventMapper {
       .map((b) => b.text ?? "")
       .join("\n")
       .trim();
-    if (text) events.push(buildProgress(base, text));
+    if (text) {
+      this.lastText = text;
+      events.push(buildProgress(base, text));
+    }
 
     for (const b of blocks) {
       if (b.type !== "tool_use") continue;

--- a/packages/runner-claude/test/claude-agent-runner.test.ts
+++ b/packages/runner-claude/test/claude-agent-runner.test.ts
@@ -183,6 +183,76 @@ describe("ClaudeAgentRunner — final-message output fallback (issue #833)", () 
     expect(m.result?.output).toEqual({ numbers: [] });
   });
 
+  it("does not promote a stale mid-run draft: a later tool_use-only turn clears the final-message slot", async () => {
+    // The fallback must read the run's FINAL message, not the last text ever
+    // seen — otherwise a mid-run JSON draft becomes the deliverable and a
+    // loose schema silently validates wrong output.
+    const { fn } = fakeQuery([
+      { type: "assistant", message: { content: [{ type: "text", text: '{"numbers": [9, 9]}' }] } },
+      {
+        type: "assistant",
+        message: { content: [{ type: "tool_use", id: "t1", name: "mcp__appstrate__log" }] },
+      },
+      successResult,
+    ]);
+    const m = memorySink();
+    await new ClaudeAgentRunner(baseOpts({ query: fn, outputSchema })).run({
+      context: ctx,
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+    expect(m.result?.output).toBeNull();
+    expect(m.events.map((e) => e.type)).not.toContain("output.emitted");
+  });
+
+  it("ignores subagent/sidechain text — a subagent's JSON is never the run's deliverable", async () => {
+    const { fn } = fakeQuery([
+      { type: "assistant", message: { content: [{ type: "text", text: "delegating" }] } },
+      {
+        type: "assistant",
+        parent_tool_use_id: "task_1",
+        message: { content: [{ type: "text", text: '{"numbers": [7]}' }] },
+      },
+      successResult,
+    ]);
+    const m = memorySink();
+    await new ClaudeAgentRunner(baseOpts({ query: fn, outputSchema })).run({
+      context: ctx,
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+    // Main thread's final message is "delegating" (not JSON) → no capture.
+    expect(m.result?.output).toBeNull();
+  });
+
+  it("treats structured_output: null as not delivered — the fallback still engages", async () => {
+    const { fn } = fakeQuery([
+      { type: "assistant", message: { content: [{ type: "text", text: '{"numbers": [4]}' }] } },
+      { ...successResult, structured_output: null } as SdkRunMessage,
+    ]);
+    const m = memorySink();
+    await new ClaudeAgentRunner(baseOpts({ query: fn, outputSchema })).run({
+      context: ctx,
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+    expect(m.result?.output).toEqual({ numbers: [4] });
+  });
+
+  it("captures a plain-string-content final message", async () => {
+    const { fn } = fakeQuery([
+      { type: "assistant", message: { content: '{"numbers": [5]}' } },
+      successResult,
+    ]);
+    const m = memorySink();
+    await new ClaudeAgentRunner(baseOpts({ query: fn, outputSchema })).run({
+      context: ctx,
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+    expect(m.result?.output).toEqual({ numbers: [5] });
+  });
+
   it("prefers the SDK's structured_output over the final text message", async () => {
     const { fn } = fakeQuery([
       { type: "assistant", message: { content: [{ type: "text", text: '{"numbers": [9]}' }] } },
@@ -250,6 +320,16 @@ describe("parseFinalJsonObject", () => {
   it("parses a fenced JSON object (with or without the json language tag)", () => {
     expect(parseFinalJsonObject('```json\n{"a": 1}\n```')).toEqual({ a: 1 });
     expect(parseFinalJsonObject('```\n{"a": 1}\n```')).toEqual({ a: 1 });
+  });
+  it("tolerates fence variants: uppercase tag, closing fence glued to the JSON", () => {
+    expect(parseFinalJsonObject('```JSON\n{"a": 1}\n```')).toEqual({ a: 1 });
+    expect(parseFinalJsonObject('```json\n{"a": 1}```')).toEqual({ a: 1 });
+  });
+  it("rejects an unclosed fence without pathological scanning", () => {
+    const big = "```json\n" + "{\n".padEnd(200_000, " \n");
+    const start = performance.now();
+    expect(parseFinalJsonObject(big)).toBeUndefined();
+    expect(performance.now() - start).toBeLessThan(500);
   });
   it("rejects arrays, scalars, prose, malformed JSON, and empty input", () => {
     expect(parseFinalJsonObject("[1, 2]")).toBeUndefined();

--- a/packages/runner-claude/test/claude-agent-runner.test.ts
+++ b/packages/runner-claude/test/claude-agent-runner.test.ts
@@ -6,6 +6,7 @@ import type { RunEvent } from "@appstrate/afps-runtime/types";
 import type { RunResult } from "@appstrate/afps-runtime/runner";
 import {
   ClaudeAgentRunner,
+  parseFinalJsonObject,
   type ClaudeAgentRunnerOptions,
   type ClaudeQueryInput,
 } from "../src/claude-agent-runner.ts";
@@ -87,6 +88,9 @@ describe("ClaudeAgentRunner — happy path", () => {
     expect(types).toContain("appstrate.progress");
     expect(types).toContain("appstrate.metric");
     expect(types).toContain("output.emitted");
+    // The claude engine always states its native delivery mechanism so
+    // finalize phrases output-validation failures correctly (issue #833).
+    expect(m.result?.outputMode).toBe("native");
   });
 
   it("passes outputFormat, the sidecar MCP server (no in-process server), native tools, and curated env", async () => {
@@ -122,6 +126,138 @@ describe("ClaudeAgentRunner — happy path", () => {
     expect(opts.env.ANTHROPIC_BASE_URL).toBe("http://sidecar:8088/llm");
     expect(opts.env.ANTHROPIC_API_KEY).toBe("");
     expect(calls[0]!.prompt).toBe("do the thing");
+  });
+});
+
+describe("ClaudeAgentRunner — final-message output fallback (issue #833)", () => {
+  const outputSchema = {
+    type: "object",
+    properties: { numbers: { type: "array" } },
+    required: ["numbers"],
+  };
+  const successResult: SdkRunMessage = {
+    type: "result",
+    subtype: "success",
+    is_error: false,
+    usage: { input_tokens: 10, output_tokens: 5 },
+  };
+
+  it("captures a schema-declaring run's final JSON text message when structured_output is absent", async () => {
+    // The #833 shape: the model wrote the deliverable as its final text
+    // message instead of calling `StructuredOutput` → the SDK result carries
+    // no `structured_output`, but the run must still end with output.
+    const { fn } = fakeQuery([
+      { type: "assistant", message: { content: [{ type: "text", text: "working on it" }] } },
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: '{"numbers": [1, 2, 3]}' }] },
+      },
+      successResult,
+    ]);
+    const m = memorySink();
+    await new ClaudeAgentRunner(baseOpts({ query: fn, outputSchema })).run({
+      context: ctx,
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+
+    expect(m.result?.status).toBe("success");
+    expect(m.result?.output).toEqual({ numbers: [1, 2, 3] });
+    expect(m.events.map((e) => e.type)).toContain("output.emitted");
+  });
+
+  it("captures a fenced ```json final message", async () => {
+    const { fn } = fakeQuery([
+      {
+        type: "assistant",
+        message: { content: [{ type: "text", text: '```json\n{"numbers": []}\n```' }] },
+      },
+      successResult,
+    ]);
+    const m = memorySink();
+    await new ClaudeAgentRunner(baseOpts({ query: fn, outputSchema })).run({
+      context: ctx,
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+    expect(m.result?.output).toEqual({ numbers: [] });
+  });
+
+  it("prefers the SDK's structured_output over the final text message", async () => {
+    const { fn } = fakeQuery([
+      { type: "assistant", message: { content: [{ type: "text", text: '{"numbers": [9]}' }] } },
+      { ...successResult, structured_output: { numbers: [1] } } as SdkRunMessage,
+    ]);
+    const m = memorySink();
+    await new ClaudeAgentRunner(baseOpts({ query: fn, outputSchema })).run({
+      context: ctx,
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+    expect(m.result?.output).toEqual({ numbers: [1] });
+  });
+
+  it("leaves the run output-less when the final message is not a JSON object", async () => {
+    const { fn } = fakeQuery([
+      { type: "assistant", message: { content: [{ type: "text", text: "All done, boss!" }] } },
+      successResult,
+    ]);
+    const m = memorySink();
+    await new ClaudeAgentRunner(baseOpts({ query: fn, outputSchema })).run({
+      context: ctx,
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+    expect(m.result?.output).toBeNull();
+    expect(m.events.map((e) => e.type)).not.toContain("output.emitted");
+  });
+
+  it("does not fall back when the run declares no output schema", async () => {
+    const { fn } = fakeQuery([
+      { type: "assistant", message: { content: [{ type: "text", text: '{"numbers": [1]}' }] } },
+      successResult,
+    ]);
+    const m = memorySink();
+    await new ClaudeAgentRunner(baseOpts({ query: fn })).run({
+      context: ctx,
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+    expect(m.result?.output).toBeNull();
+    expect(m.events.map((e) => e.type)).not.toContain("output.emitted");
+  });
+
+  it("does not fall back on a failed terminal", async () => {
+    const { fn } = fakeQuery([
+      { type: "assistant", message: { content: [{ type: "text", text: '{"numbers": [1]}' }] } },
+      { type: "result", subtype: "error_max_turns", is_error: true, usage: {} },
+    ]);
+    const m = memorySink();
+    await new ClaudeAgentRunner(baseOpts({ query: fn, outputSchema })).run({
+      context: ctx,
+      eventSink: m.sink,
+      bundle: undefined as never,
+    });
+    expect(m.result?.status).toBe("failed");
+    expect(m.result?.output).toBeNull();
+  });
+});
+
+describe("parseFinalJsonObject", () => {
+  it("parses a bare JSON object", () => {
+    expect(parseFinalJsonObject('{"a": 1}')).toEqual({ a: 1 });
+  });
+  it("parses a fenced JSON object (with or without the json language tag)", () => {
+    expect(parseFinalJsonObject('```json\n{"a": 1}\n```')).toEqual({ a: 1 });
+    expect(parseFinalJsonObject('```\n{"a": 1}\n```')).toEqual({ a: 1 });
+  });
+  it("rejects arrays, scalars, prose, malformed JSON, and empty input", () => {
+    expect(parseFinalJsonObject("[1, 2]")).toBeUndefined();
+    expect(parseFinalJsonObject('"str"')).toBeUndefined();
+    expect(parseFinalJsonObject('Done! {"a": 1}')).toBeUndefined();
+    expect(parseFinalJsonObject('{"a": ')).toBeUndefined();
+    expect(parseFinalJsonObject("")).toBeUndefined();
+    expect(parseFinalJsonObject(null)).toBeUndefined();
   });
 });
 

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -341,6 +341,11 @@ export class PiRunner implements Runner {
     // instead of having the platform reconstruct it from the `run_logs`
     // adapter-error trail post-hoc (issue: run_fd977eb6).
     const result: RunResult = events.length === 0 ? emptyRunResult() : reduceEvents(events);
+    // This engine delivers structured output via the `output` runtime tool.
+    // Explicit (though it matches the absent-field default) so both runners
+    // state their delivery mechanism — finalize phrases output-validation
+    // failures from it (issue #833).
+    result.outputMode = "tool";
     const terminalError = bridgeRef.current?.getTerminalError();
     if (terminalError) {
       result.status = "failed";

--- a/packages/runner-pi/test/pi-runner.test.ts
+++ b/packages/runner-pi/test/pi-runner.test.ts
@@ -68,6 +68,7 @@ describe("PiRunner.run — event forwarding", () => {
     expect(sink.finalized).toEqual({
       ...emptyRunResult(),
       status: "success",
+      outputMode: "tool",
       usage: {
         input_tokens: 0,
         output_tokens: 0,


### PR DESCRIPTION
Closes #833.

## Root cause (diagnosed, empirically verified)

The plumbing was sound end-to-end — `OUTPUT_SCHEMA` reaches the guest verbatim (config drive → supervisor → agent env), and the SDK does transmit `outputFormat` to the CLI (both as `--json-schema` argv and in the `initialize` control request; verified by hooking the SDK's spawn and by replaying the runner's exact options against a mock API).

The break is a **mechanism mismatch between the platform prompt and the CLI**: on CLI 2.1.183 there is no native constrained decoding on this path — `structured_output` is populated **only** when the model calls the CLI-injected client-side `StructuredOutput` tool. The #828 native prompt explicitly forbade tool delivery ("There is NO `output` tool on this runtime — do not try to call one") and mandated a final JSON text message. The model obeyed → `StructuredOutput` never called → `result.structured_output: undefined` → `RunResult.output: null` → output validation failed with the tool-mode message, despite a valid schema-conforming final message. Exactly the symptom in #833 (reproduced on a mock; counter-proved live with a neutral prompt, where the tool IS called and `structured_output` is populated).

## Fix

1. **Prompt (root cause, platform-side — effective on deploy)** — `platform-prompt.ts` native branch now mandates one terminal `StructuredOutput` call, keeping the #824 guard against the nonexistent MCP `output` tool instead of forbidding tool delivery outright.
2. **Runner fallback (defense-in-depth, runtime-image-side)** — a *successful* schema-declaring claude run whose SDK result carries no `structured_output` falls back to parsing the final assistant text message (bare or fenced JSON object) as the deliverable. Platform-side schema validation still gates correctness, so the fallback can only rescue runs (e.g. model disobedience, CLI drift), never mask a failure. Non-object/malformed final text yields nothing, failed terminals never fall back.
3. **Engine-aware validation message (issue's independent fix)** — additive `RunResult.outputMode: "tool" | "native"`; each runner states its delivery mechanism (Pi → `"tool"`, Claude → `"native"`), the finalize route accepts it (cosmetic-grade, degrades to absent on bad values), and `finalizeRun` phrases the never-emitted failure accordingly. Native runs no longer get the misleading "must call `output` exactly once" wording; absent field keeps the historical tool wording (older runners).

## Acceptance (from #833)

- ✅ A claude-engine run of a schema-declaring agent ends `success` with `runs.result.output` populated — via `StructuredOutput` (prompt fix) or the final-message fallback.
- ✅ Output-validation failure messages match the engine's actual output mechanism (`outputMode`).

## Notes

- OpenAPI: `outputMode` added to the finalize request body; SPA types regenerated.
- Deploy: prompt + finalize message are platform-side (immediate). The runner fallback + `outputMode` stamp ship with the next runtime image / guest-rootfs rebuild (usual lockstep).
- Tests: prompt native-branch reworded assertions, 6 new runner fallback tests + `parseFinalJsonObject` unit tests, 2 new finalize integration tests (native wording, malformed `outputMode` degradation). Full `bun run check` green; touched-package suites 814/814, ingestion suite 63/63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)