### PR TITLE
fix(oidc): survive cross-context resume of the PKCE flow (invite signup state mismatch)

### DIFF
--- a/apps/web/src/modules/oidc/lib/oidc.ts
+++ b/apps/web/src/modules/oidc/lib/oidc.ts
@@ -40,8 +40,47 @@ export async function calculateCodeChallenge(verifier: string): Promise<string> 
   return base64url(new Uint8Array(digest));
 }
 
-export function generateState(): string {
-  return base64url(crypto.getRandomValues(new Uint8Array(16)));
+/**
+ * OAuth `state` — CSRF nonce + post-login redirect carrier.
+ *
+ * The state is a base64url-encoded JSON payload `{ n, r? }`: `n` is a random
+ * nonce (the CSRF property), `r` the optional post-login redirect path. The
+ * authorize endpoint echoes `state` verbatim, so `r` survives server-side
+ * detours that a new browsing context cannot: the email-verification flow
+ * (`POST /api/oauth/register` with SMTP → "check your email" → link opens in
+ * a NEW tab/device where `sessionStorage` is empty) resumes the OAuth flow
+ * via the pinned `callbackURL` and still lands on `/auth/callback` with this
+ * state — the only surviving carrier of where the user was headed.
+ */
+export function generateState(redirectTo?: string): string {
+  const payload: { n: string; r?: string } = {
+    n: base64url(crypto.getRandomValues(new Uint8Array(16))),
+  };
+  if (redirectTo) payload.r = redirectTo;
+  return base64url(new TextEncoder().encode(JSON.stringify(payload)));
+}
+
+/**
+ * Extract the post-login redirect from an echoed `state` parameter.
+ *
+ * Returns `undefined` for anything that is not a same-origin relative path —
+ * malformed base64/JSON (including legacy opaque random states), absolute
+ * URLs, and protocol-relative `//host` forms — so a crafted callback URL can
+ * never turn this into an open redirect.
+ */
+export function decodeStateRedirect(state: string): string | undefined {
+  try {
+    const b64 = state.replace(/-/g, "+").replace(/_/g, "/");
+    const bytes = Uint8Array.from(atob(b64), (ch) => ch.charCodeAt(0));
+    const parsed: unknown = JSON.parse(new TextDecoder().decode(bytes));
+    if (typeof parsed !== "object" || parsed === null) return undefined;
+    const r = (parsed as Record<string, unknown>).r;
+    if (typeof r !== "string") return undefined;
+    if (!r.startsWith("/") || r.startsWith("//") || r.includes("\\")) return undefined;
+    return r;
+  } catch {
+    return undefined;
+  }
 }
 
 const OIDC_STATE_KEY = "appstrate_oidc_state";
@@ -64,7 +103,7 @@ async function initPkceFlow(
   redirectTo: string | undefined,
   loginHint?: string,
 ): Promise<URLSearchParams> {
-  const state = generateState();
+  const state = generateState(redirectTo);
   const codeVerifier = generateCodeVerifier();
   const codeChallenge = await calculateCodeChallenge(codeVerifier);
 
@@ -137,10 +176,27 @@ export async function startOidcSignup(redirectTo?: string, loginHint?: string): 
 /**
  * Handle the callback from the OIDC authorize endpoint.
  *
- * Validates the state, exchanges the code for tokens (to properly complete
+ * Same-context flow (the common case): validates the state against the
+ * `sessionStorage` copy, exchanges the code for tokens (to properly complete
  * the OIDC flow and prevent the code from being replayed), and returns the
  * post-login redirect path. The tokens themselves are discarded — the real
  * auth is the Better Auth session cookie set during login.
+ *
+ * Cross-context resume: the email-verification flow pauses the OAuth dance
+ * ("check your email") and resumes it via the link in the email — which
+ * opens in a NEW tab or device where `sessionStorage` is empty (it is
+ * per-tab). There is then no stored state to compare and no PKCE verifier to
+ * exchange with, but neither is needed: Better Auth's
+ * `autoSignInAfterVerification` already set the session cookie, and the SPA
+ * discards the tokens anyway. So when NO state was ever stored in this
+ * context we skip the exchange and recover the redirect from the echoed
+ * `state` payload. The caller MUST validate the session afterwards
+ * (`refreshAuth()` in `auth-callback.tsx` throws when no session exists) —
+ * that session check is what authenticates this path. A crafted callback URL
+ * gains nothing here: the attacker-supplied code is never exchanged, and the
+ * decoded redirect is constrained to a same-origin relative path.
+ *
+ * A PRESENT-but-different stored state remains a hard failure (CSRF guard).
  */
 export async function handleOidcCallback(): Promise<{ redirectTo: string }> {
   const config = getOidcConfig();
@@ -165,6 +221,14 @@ export async function handleOidcCallback(): Promise<{ redirectTo: string }> {
   sessionStorage.removeItem(OIDC_STATE_KEY);
   sessionStorage.removeItem(OIDC_VERIFIER_KEY);
   sessionStorage.removeItem(OIDC_REDIRECT_KEY);
+
+  if (storedState === null) {
+    // Cross-context resume (see the function doc): nothing was ever stored
+    // in this tab, so there is no verifier to exchange with. Skip the token
+    // exchange — the BA session cookie is the real auth, and the caller
+    // validates it right after. The unexchanged code simply expires.
+    return { redirectTo: decodeStateRedirect(state) ?? "/" };
+  }
 
   if (state !== storedState) {
     throw new Error("State mismatch — possible CSRF attack");

--- a/apps/web/src/modules/oidc/lib/test/oidc.test.ts
+++ b/apps/web/src/modules/oidc/lib/test/oidc.test.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach } from "bun:test";
+
+/**
+ * DOM-less bun runtime: install Map-backed sessionStorage and a minimal
+ * `window` (config + location) BEFORE importing the module, mirroring the
+ * pairing-store test pattern. `fetch` is stubbed per-test.
+ */
+class FakeStorage {
+  private m = new Map<string, string>();
+  get length() {
+    return this.m.size;
+  }
+  getItem(key: string): string | null {
+    return this.m.has(key) ? (this.m.get(key) as string) : null;
+  }
+  setItem(key: string, value: string): void {
+    this.m.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.m.delete(key);
+  }
+  clear(): void {
+    this.m.clear();
+  }
+  key(i: number): string | null {
+    return [...this.m.keys()][i] ?? null;
+  }
+}
+
+const fakeSession = new FakeStorage();
+(globalThis as { sessionStorage?: Storage }).sessionStorage = fakeSession;
+
+const fakeWindow = {
+  __APP_CONFIG__: {
+    oidc: {
+      clientId: "client_test",
+      issuer: "http://localhost:3000/api/auth",
+      callbackUrl: "http://localhost:3000/auth/callback",
+    },
+  },
+  location: { search: "" },
+};
+(globalThis as { window?: unknown }).window = fakeWindow;
+
+const { generateState, decodeStateRedirect, handleOidcCallback } = await import("../oidc");
+
+const STATE_KEY = "appstrate_oidc_state";
+const VERIFIER_KEY = "appstrate_oidc_verifier";
+const REDIRECT_KEY = "appstrate_oidc_redirect";
+
+/** Install a fetch stub; returns the recorded calls. */
+function stubFetch(response: () => Response): Array<{ url: string; body: string }> {
+  const calls: Array<{ url: string; body: string }> = [];
+  (globalThis as { fetch: typeof fetch }).fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => {
+    calls.push({ url: String(input), body: String(init?.body ?? "") });
+    return response();
+  }) as typeof fetch;
+  return calls;
+}
+
+beforeEach(() => {
+  fakeSession.clear();
+  fakeWindow.location.search = "";
+  stubFetch(() => new Response("{}", { status: 200 }));
+});
+
+describe("generateState / decodeStateRedirect", () => {
+  it("round-trips the redirect path", () => {
+    const state = generateState("/invite/tok_123");
+    expect(decodeStateRedirect(state)).toBe("/invite/tok_123");
+  });
+
+  it("is unique per call (random nonce)", () => {
+    expect(generateState("/a")).not.toBe(generateState("/a"));
+  });
+
+  it("returns undefined when no redirect was encoded", () => {
+    expect(decodeStateRedirect(generateState())).toBeUndefined();
+  });
+
+  it("returns undefined for legacy opaque random states", () => {
+    // Pre-change format: 16 random bytes, base64url — not JSON.
+    expect(decodeStateRedirect("qfz0eKZcRAxZ2-tk0dpwEw")).toBeUndefined();
+  });
+
+  it("rejects non-relative redirect targets (open redirect guard)", () => {
+    const encode = (r: unknown) => Buffer.from(JSON.stringify({ n: "x", r })).toString("base64url");
+    expect(decodeStateRedirect(encode("https://evil.example"))).toBeUndefined();
+    expect(decodeStateRedirect(encode("//evil.example"))).toBeUndefined();
+    expect(decodeStateRedirect(encode("/\\evil.example"))).toBeUndefined();
+    expect(decodeStateRedirect(encode(42))).toBeUndefined();
+    expect(decodeStateRedirect(encode("relative/no-slash"))).toBeUndefined();
+  });
+});
+
+describe("handleOidcCallback — same-context flow", () => {
+  it("exchanges the code and returns the stored redirect", async () => {
+    const state = generateState("/invite/tok_123");
+    fakeSession.setItem(STATE_KEY, state);
+    fakeSession.setItem(VERIFIER_KEY, "verifier_abc");
+    fakeSession.setItem(REDIRECT_KEY, "/invite/tok_123");
+    fakeWindow.location.search = `?code=code_1&state=${encodeURIComponent(state)}`;
+    const calls = stubFetch(() => new Response("{}", { status: 200 }));
+
+    const { redirectTo } = await handleOidcCallback();
+
+    expect(redirectTo).toBe("/invite/tok_123");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe("/api/auth/oauth2/token");
+    expect(calls[0]!.body).toContain("code_verifier=verifier_abc");
+    // One-shot: keys consumed.
+    expect(fakeSession.getItem(STATE_KEY)).toBeNull();
+    expect(fakeSession.getItem(VERIFIER_KEY)).toBeNull();
+  });
+
+  it("throws on a present-but-different stored state (CSRF guard)", async () => {
+    fakeSession.setItem(STATE_KEY, generateState());
+    fakeSession.setItem(VERIFIER_KEY, "verifier_abc");
+    fakeWindow.location.search = `?code=code_1&state=${encodeURIComponent(generateState())}`;
+    const calls = stubFetch(() => new Response("{}", { status: 200 }));
+
+    await expect(handleOidcCallback()).rejects.toThrow("State mismatch");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("throws when the verifier is missing but the state matches", async () => {
+    const state = generateState();
+    fakeSession.setItem(STATE_KEY, state);
+    fakeWindow.location.search = `?code=code_1&state=${encodeURIComponent(state)}`;
+
+    await expect(handleOidcCallback()).rejects.toThrow("Missing code verifier");
+  });
+});
+
+describe("handleOidcCallback — cross-context resume (email verification link)", () => {
+  it("skips the exchange and recovers the redirect from the echoed state", async () => {
+    // New tab/device: sessionStorage is empty, state arrives only via URL.
+    const state = generateState("/invite/tok_123");
+    fakeWindow.location.search = `?code=code_1&state=${encodeURIComponent(state)}`;
+    const calls = stubFetch(() => new Response("{}", { status: 200 }));
+
+    const { redirectTo } = await handleOidcCallback();
+
+    expect(redirectTo).toBe("/invite/tok_123");
+    expect(calls).toHaveLength(0); // no verifier → no token exchange
+  });
+
+  it("falls back to / when the echoed state carries no redirect", async () => {
+    fakeWindow.location.search = `?code=code_1&state=${encodeURIComponent(generateState())}`;
+
+    const { redirectTo } = await handleOidcCallback();
+
+    expect(redirectTo).toBe("/");
+  });
+
+  it("falls back to / on a crafted non-relative redirect", async () => {
+    const evil = Buffer.from(JSON.stringify({ n: "x", r: "https://evil.example" })).toString(
+      "base64url",
+    );
+    fakeWindow.location.search = `?code=code_1&state=${encodeURIComponent(evil)}`;
+
+    const { redirectTo } = await handleOidcCallback();
+
+    expect(redirectTo).toBe("/");
+  });
+
+  it("still reports the provider error before attempting recovery", async () => {
+    fakeWindow.location.search = `?error=access_denied&state=x`;
+
+    await expect(handleOidcCallback()).rejects.toThrow("OIDC error: access_denied");
+  });
+});


### PR DESCRIPTION
## Problem

Invited **new** users on SMTP-enabled instances frequently hit **"State mismatch — possible CSRF attack"** when joining an org through signup.

Deterministic chain:

1. Invite page picks the `signup` starter → `initPkceFlow` stores the OAuth `state` + PKCE verifier in `sessionStorage`, redirects to `/api/oauth/register`.
2. SMTP configured (necessarily — the invite itself arrived by email) → Better Auth `requireEmailVerification: true` → no session cookie after sign-up → "check your email" interstitial. The OAuth dance pauses.
3. The verification link opens in a **new tab or device**. `sessionStorage` is per-tab → empty there. BA auto-signs-in and resumes the flow via the pinned `callbackURL` → `/auth/callback?code&state=S1`.
4. `storedState === null` ≠ `S1` → throw. (Even past that, the PKCE verifier is equally absent, so the token exchange was doomed too.)

## Fix

Two complementary changes in `apps/web/src/modules/oidc/lib/oidc.ts`:

- **Encode the post-login redirect inside the OAuth `state`** — `base64url({ n: nonce, r: redirectTo })`. OAuth guarantees the authorize endpoint echoes `state` verbatim, so the target (e.g. `/invite/:token`) survives the server-side detour that no client-side storage can.
- **Cross-context resume branch in `handleOidcCallback`** — distinguish two cases previously conflated:
  - `storedState` present but different → **hard failure, unchanged** (real CSRF guard).
  - `storedState` never stored in this context → skip the token exchange (impossible without the verifier, unnecessary since the SPA discards tokens — the BA session cookie is the real auth) and recover the redirect from the echoed state, constrained to a same-origin relative path.

## Security analysis of the resume branch

- The `code` is **never exchanged** there → no code injection / session fixation surface. The unconsumed code simply expires.
- The caller (`auth-callback.tsx`) already runs `refreshAuth()`, which throws when no BA session exists — that session check is what authenticates the path.
- Decoded redirect is validated: relative, starts with `/`, rejects `//host` and `\` forms → no open redirect. A crafted callback URL yields at most an in-app navigation for an already-authenticated user.
- Legacy opaque states decode to `undefined` → fallback `/`.

## Coverage

| Scenario | Before | After |
|---|---|---|
| Same-tab login/signup (no SMTP pause) | OK | OK (strict path unchanged) |
| Invite signup + SMTP, link in new tab | ❌ State mismatch | ✅ lands on `/invite/:token`, accept button |
| Invite signup + SMTP, link on another device | ❌ | ✅ (BA cookie set on that device) |
| Forged `state` in same tab | rejected | rejected (unchanged) |
| Forged callback URL in fresh tab | error page | in-app navigation at most, code never used |

## Tests

New `apps/web/src/modules/oidc/lib/test/oidc.test.ts` (12 tests, DOM-less fakes following the `pairing-store.test.ts` pattern): state round-trip, nonce uniqueness, legacy-state tolerance, open-redirect guard, strict same-context exchange, CSRF rejection, missing-verifier rejection, resume-without-exchange, crafted-redirect fallback, provider-error precedence.

`bun test` ✅ · `tsc --noEmit` ✅ · eslint ✅ · prettier ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)