### PR TITLE
fix(runtime-pi): route node MCP servers through the sandbox egress proxy (#779)

### DIFF
--- a/runtime-pi/runners/node/Dockerfile
+++ b/runtime-pi/runners/node/Dockerfile
@@ -23,6 +23,15 @@
 #     runtime-pi/runners/node
 
 ARG RUNTIME_IMAGE=alpine:3.21.3
+
+# Build the universal egress proxy shim's deps (appstrate/appstrate#779).
+# Pure-JS packages, portable across node minor versions to the runtime stage.
+FROM node:20-alpine AS proxydeps
+WORKDIR /opt/appstrate/proxy
+RUN npm init -y >/dev/null 2>&1 && \
+    npm install --omit=dev --no-audit --no-fund \
+      undici@6 https-proxy-agent@7 http-proxy-agent@7
+
 FROM ${RUNTIME_IMAGE} AS runtime
 
 ARG BUILD_VERSION=unknown
@@ -51,6 +60,15 @@ RUN apk add --no-cache nodejs ca-certificates && \
     adduser -D -u 1001 -G runner -s /bin/sh runner && \
     mkdir -p /bundle && \
     chown runner:runner /bundle
+
+# Universal egress proxy shim (appstrate/appstrate#779): preloaded into EVERY
+# node integration via NODE_OPTIONS so any HTTP client (fetch/undici, axios,
+# request, native http) traverses the sandbox CONNECT egress. NODE_PATH lets the
+# shim resolve its deps; harmless to the (self-contained) integration bundle.
+COPY --from=proxydeps /opt/appstrate/proxy/node_modules /opt/appstrate/proxy/node_modules
+COPY proxy-preload.cjs /opt/appstrate/proxy/proxy-preload.cjs
+ENV NODE_OPTIONS=--require=/opt/appstrate/proxy/proxy-preload.cjs \
+    NODE_PATH=/opt/appstrate/proxy/node_modules
 
 USER runner:runner
 WORKDIR /bundle

--- a/runtime-pi/runners/node/proxy-preload.cjs
+++ b/runtime-pi/runners/node/proxy-preload.cjs
@@ -1,0 +1,55 @@
+'use strict';
+/*
+ * Appstrate universal egress preload (Node runner).
+ *
+ * The sandbox's only outbound path is a CONNECT-style egress proxy handed to
+ * the runner via HTTPS_PROXY/HTTP_PROXY. But third-party MCP servers use a zoo
+ * of HTTP clients, most of which DON'T traverse that proxy correctly by default:
+ *   - native fetch / undici  → ignore HTTP(S)_PROXY entirely
+ *   - axios (built-in proxy) → sends a non-CONNECT request → 405 on a CONNECT-only proxy
+ *   - request / native http  → tunnel correctly via env, but break if we drop env
+ * Per-server patching is untenable (see appstrate/appstrate#779), so this preload
+ * — injected via NODE_OPTIONS=--require for EVERY node integration — normalises
+ * all of them onto the proxy, regardless of the library the server chose.
+ *
+ * Fail-open: any error here must never prevent the MCP server from starting.
+ */
+try {
+  const proxy =
+    process.env.HTTPS_PROXY || process.env.https_proxy ||
+    process.env.HTTP_PROXY || process.env.http_proxy;
+
+  if (proxy) {
+    // 1) native fetch / undici — ignores env proxy; give it an explicit dispatcher.
+    //    ProxyAgent CONNECT-tunnels, so it works against a CONNECT-only egress.
+    try {
+      const { setGlobalDispatcher, ProxyAgent } = require('undici');
+      setGlobalDispatcher(new ProxyAgent(proxy));
+    } catch (e) { /* undici unavailable — skip */ }
+
+    // 2) native http(s) default agents — CONNECT-tunnel. Covers native http,
+    //    `request`/`node-fetch`, and axios instances that fall back to the
+    //    global agent (see step 3).
+    try {
+      const http = require('http');
+      const https = require('https');
+      const { HttpsProxyAgent } = require('https-proxy-agent');
+      const { HttpProxyAgent } = require('http-proxy-agent');
+      https.globalAgent = new HttpsProxyAgent(proxy);
+      http.globalAgent = new HttpProxyAgent(proxy);
+    } catch (e) { /* agents unavailable — skip */ }
+
+    // 3) Neutralise libraries' OWN env-proxy handling. axios' built-in support
+    //    issues a non-CONNECT request over the HTTP proxy (→ 405 here); with the
+    //    env vars gone it falls back to the now-tunneling https.globalAgent from
+    //    step 2. undici already captured the URL in step 1, so this is safe.
+    //    NO_PROXY is kept so sidecar-internal / loopback stays direct.
+    for (const k of ['HTTP_PROXY', 'HTTPS_PROXY', 'http_proxy', 'https_proxy']) {
+      delete process.env[k];
+    }
+  }
+} catch (e) {
+  try {
+    process.stderr.write('[appstrate-proxy-preload] non-fatal: ' + (e && e.message) + '\n');
+  } catch (_) { /* ignore */ }
+}


### PR DESCRIPTION
Fixes #779.

## Problem

A `source.kind: local` integration runs its MCP server inside the sandbox, whose only outbound path is a **CONNECT-style egress proxy** handed to the runner via `HTTPS_PROXY`/`HTTP_PROXY`. But third-party MCP servers use a wide range of HTTP clients, most of which don't traverse that proxy correctly by default:

- **native `fetch` / undici** — ignore `HTTP(S)_PROXY` entirely
- **axios** (built-in proxy) — issues a non-CONNECT request over the HTTP proxy → **405** on a CONNECT-only egress
- **`request` / native http** — tunnel correctly, but break if the env vars are dropped

So a server's outbound calls silently fail and the agent only sees a generic `MCP error -32001: Request timed out`. Per-server patching is untenable (survey in #779: the client spread across mainstream MCP servers spans fetch/undici, axios, cross-fetch, gaxios, vendor SDKs, …).

## Fix

A tiny preload (`runtime-pi/runners/node/proxy-preload.cjs`, ~55 lines) is baked into the node runner image and injected into **every** node integration via `NODE_OPTIONS=--require`. When a proxy is present it normalises all client families onto it:

- undici / native `fetch` → `setGlobalDispatcher(new ProxyAgent(proxy))`
- native `http`/`https` (covers `request`, native http, and axios-via-global-agent) → `globalAgent = HttpsProxyAgent/HttpProxyAgent` (CONNECT tunnel)
- axios' own (broken) env-proxy path → neutralised by removing the `*_PROXY` env vars, so it falls back to the now-tunneling global agent (`NO_PROXY` kept)

Fail-open: any error in the preload is swallowed so it can never prevent a server from starting. The three deps (`undici`, `https-proxy-agent`, `http-proxy-agent`) are built in a dedicated Docker stage and copied into the runtime image; `NODE_PATH` lets the shim resolve them without affecting the (self-contained) integration bundle.

## Validation

Exercised end-to-end against a real third-party server — Intuit's official QuickBooks Online MCP server, which mixes **axios** (OAuth refresh) and **`request`** (API calls), i.e. the hardest case. Before: `405` → refresh fails → 30 s timeout. After: the call tunnels through the egress and returns live data. The undici/`fetch` path uses the standard `setGlobalDispatcher` mechanism.

## Scope

Node runner only. The same idea applies to the python/binary runners and, for full client-agnosticism (Chromium, cert-pinning clients, non-node runtimes), a transparent network-layer redirect — both discussed in #779 as follow-ups.
