### PR TITLE
feat: display deployed build version in app

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,6 +143,11 @@ jobs:
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64,linux/arm64
           push: true
+          # Stamp the deployed build identity into the image. Only the main
+          # Dockerfile declares these ARGs; other matrix images ignore them.
+          build-args: |
+            APP_VERSION=${{ github.ref_name }}
+            GIT_SHA=${{ github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,13 @@ EXPOSE 3000
 
 ENV NODE_ENV=production
 
+# Deployed build identity — fed by the release workflow's build-args, surfaced
+# read-only via /health and the SPA footer. Default "dev" for local builds.
+ARG APP_VERSION=dev
+ARG GIT_SHA=""
+ENV APP_VERSION=${APP_VERSION}
+ENV GIT_SHA=${GIT_SHA}
+
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
   CMD wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1
 

--- a/apps/api/src/lib/app-config.ts
+++ b/apps/api/src/lib/app-config.ts
@@ -3,6 +3,7 @@
 import { getEnv } from "@appstrate/env";
 import { applyModuleFeatures } from "./modules/module-loader.ts";
 import { isBootstrapTokenPending } from "./bootstrap-token.ts";
+import { getVersionInfo } from "./version.ts";
 import type { AppConfig } from "@appstrate/shared-types";
 
 // Platform config — computed once at boot, injected into SPA HTML.
@@ -47,6 +48,7 @@ export function buildAppConfig(): AppConfig {
       : {}),
     ...(bootstrapEmail ? { bootstrapOwnerEmail: bootstrapEmail } : {}),
     trustedOrigins: env.TRUSTED_ORIGINS,
+    version: getVersionInfo(),
   };
 }
 

--- a/apps/api/src/lib/version.ts
+++ b/apps/api/src/lib/version.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { getEnv } from "@appstrate/env";
+
+export interface VersionInfo {
+  /** Semver/tag of the deployed build (e.g. "v1.0.0-beta.38"). "dev" for source runs. */
+  app: string;
+  /** Short git SHA of the build commit. Omitted when unknown. */
+  commit?: string;
+}
+
+/**
+ * Deployed build identity, read from the image's build-time env
+ * (`APP_VERSION` / `GIT_SHA`, stamped by the release workflow). Falls back to
+ * "dev" with no commit when running from source. Single source of truth for
+ * both the /health endpoint and the SPA footer (via `buildAppConfig`).
+ */
+export function getVersionInfo(): VersionInfo {
+  const env = getEnv();
+  const commit = env.GIT_SHA ? env.GIT_SHA.slice(0, 7) : undefined;
+  return {
+    app: env.APP_VERSION ?? "dev",
+    ...(commit ? { commit } : {}),
+  };
+}

--- a/apps/api/src/openapi/paths/health.ts
+++ b/apps/api/src/openapi/paths/health.ts
@@ -17,6 +17,14 @@ export const healthPaths = {
                 type: "object",
                 properties: {
                   status: { type: "string", enum: ["healthy", "degraded", "unhealthy"] },
+                  version: {
+                    type: "object",
+                    properties: {
+                      app: { type: "string" },
+                      commit: { type: "string" },
+                    },
+                    required: ["app"],
+                  },
                   uptime_ms: { type: "number" },
                   checks: {
                     type: "object",
@@ -40,6 +48,7 @@ export const healthPaths = {
               },
               example: {
                 status: "healthy",
+                version: { app: "v1.0.0-beta.38", commit: "5bbe1d9" },
                 uptime_ms: 3600000,
                 checks: {
                   database: { status: "healthy", latency_ms: 2.3 },

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { sql } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
 import { getSystemPackagesByType } from "../services/system-packages.ts";
+import { getVersionInfo } from "../lib/version.ts";
 
 const startedAt = Date.now();
 
@@ -38,6 +39,7 @@ healthRouter.get("/health", async (c) => {
   return c.json(
     {
       status,
+      version: getVersionInfo(),
       uptime_ms: Date.now() - startedAt,
       checks,
     },

--- a/apps/api/test/integration/routes/health.test.ts
+++ b/apps/api/test/integration/routes/health.test.ts
@@ -52,6 +52,19 @@ describe("GET /health", () => {
     expect(body.uptime_ms).toBeGreaterThanOrEqual(0);
   });
 
+  it("includes deployed build identity under version", async () => {
+    const res = await app.request("/health");
+    const body = (await res.json()) as any;
+
+    expect(body).toHaveProperty("version");
+    expect(typeof body.version.app).toBe("string");
+    expect(body.version.app.length).toBeGreaterThan(0);
+    // commit is optional (absent on source runs without GIT_SHA)
+    if (body.version.commit !== undefined) {
+      expect(typeof body.version.commit).toBe("string");
+    }
+  });
+
   it("checks object contains database and agents sub-checks", async () => {
     const res = await app.request("/health");
     const body = (await res.json()) as any;

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -19214,6 +19214,10 @@ export interface operations {
                     /**
                      * @example {
                      *       "status": "healthy",
+                     *       "version": {
+                     *         "app": "v1.0.0-beta.38",
+                     *         "commit": "5bbe1d9"
+                     *       },
                      *       "uptime_ms": 3600000,
                      *       "checks": {
                      *         "database": {
@@ -19229,6 +19233,10 @@ export interface operations {
                     "application/json": {
                         /** @enum {string} */
                         status?: "healthy" | "degraded" | "unhealthy";
+                        version?: {
+                            app: string;
+                            commit?: string;
+                        };
                         uptime_ms?: number;
                         checks?: {
                             database?: {

--- a/apps/web/src/components/app-version.tsx
+++ b/apps/web/src/components/app-version.tsx
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useAppConfig } from "../hooks/use-app-config";
+
+/**
+ * Discreet display of the deployed build identity (version + git SHA), read
+ * from the injected app config — no API call. Renders nothing when the build
+ * identity is absent (source runs without a stamped version).
+ */
+export function AppVersion({ className }: { className?: string }) {
+  const { version } = useAppConfig();
+
+  if (!version) return null;
+
+  const label = version.commit ? `${version.app} · ${version.commit}` : version.app;
+
+  return (
+    <span
+      className={`text-muted-foreground font-mono text-xs ${className ?? ""}`}
+      title={version.commit ? `${version.app} (${version.commit})` : version.app}
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/web/src/components/settings-layout.tsx
+++ b/apps/web/src/components/settings-layout.tsx
@@ -5,6 +5,7 @@ import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import type { LucideIcon } from "lucide-react";
 import { PageHeader, type BreadcrumbEntry } from "./page-header";
 import { SidebarNavLink } from "./sidebar-nav-link";
+import { AppVersion } from "./app-version";
 import { useSidebarStore } from "../stores/sidebar-store";
 import {
   Sidebar,
@@ -103,6 +104,9 @@ export function SettingsLayout({ sections, title, emoji, breadcrumbs }: Settings
               </SidebarMenu>
             </SidebarGroup>
           ))}
+          <div className="mt-auto px-4 py-3">
+            <AppVersion />
+          </div>
         </SidebarContent>
       </Sidebar>
 

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -48,6 +48,13 @@ const envSchema = z
   .object({
     // Node environment — gates production-only invariants (e.g. APP_URL https)
     NODE_ENV: z.enum(["development", "production", "test"]).default("development"),
+    // Deployed build identity — stamped into the image at build time
+    // (Dockerfile ARG → ENV, fed by the release workflow). Surfaced read-only
+    // via /health and the SPA footer so operators can see which build is live.
+    // Absent in dev/source runs → the UI falls back to "dev".
+    APP_VERSION: z.string().optional(),
+    // Short git SHA of the build commit (companion to APP_VERSION).
+    GIT_SHA: z.string().optional(),
     // Trust proxy hops: "false" (default, ignore XFF) | "true" (=1) | "N" (N trusted hops)
     TRUST_PROXY: z
       .string()

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -207,6 +207,15 @@ export interface AppConfig {
    */
   bootstrapOwnerEmail?: string;
   trustedOrigins: string[];
+  /**
+   * Deployed build identity (APP_VERSION / GIT_SHA stamped into the image at
+   * build time). Surfaced so the SPA can show which build is live. Absent on
+   * source/dev runs → the UI falls back to "dev".
+   */
+  version?: {
+    app: string;
+    commit?: string;
+  };
 }
 
 // --- Package Types ---


### PR DESCRIPTION
## What

Surface the **deployed build identity** (semver tag + git SHA) read-only in the app, so it's clear which build is live in production — useful when a prod bug needs to be tied to a specific release.

## Best practice

Follows the standard Docker approach: stamp version + commit into the image at build time via `--build-arg` → `ENV`, expose at runtime via an endpoint. OCI image labels (`org.opencontainers.image.revision`/`.version`) are already emitted by `docker/metadata-action`, so this adds the runtime-readable surface on top.

Sources:
- [Baeldung — Get the commit hash in a running Docker container](https://www.baeldung.com/ops/docker-obtain-commit-hash-active-container)
- [Scott Lowe — Tag Docker images with git commit info](https://blog.scottlowe.org/2017/11/08/how-tag-docker-images-git-commit-information/)
- [OneUptime — Docker build args & env variables](https://oneuptime.com/blog/post/2026-01-06-docker-build-args-env-variables/view)

## Changes

- **Dockerfile**: `ARG`/`ENV APP_VERSION` + `GIT_SHA` (default `dev` for local builds)
- **release.yml**: pass `APP_VERSION=${{ github.ref_name }}`, `GIT_SHA=${{ github.sha }}` as build-args (main image only; other matrix images ignore them)
- **env**: `APP_VERSION` + `GIT_SHA` optional vars (no defaults → no compose-defaults mirror needed)
- **lib/version.ts**: single source of truth (`getVersionInfo`) shared by `/health` and the SPA config
- **/health**: new `version: { app, commit }` field (machine-readable, for monitoring/CI) + OpenAPI schema
- **AppConfig.version**: injected via `buildAppConfig` → `window.__APP_CONFIG__` (no fetch, no DB hit) → `<AppVersion>` shown discreetly in the settings footer

## Verification

- `bun run check` ✅ (tsc + eslint + prettier + verify:openapi, 34 tasks)
- `bun test health.test.ts` ✅ (8 pass, incl. new version-field assertion)
- `bun test openapi-response-validation.test.ts` ✅ (25 pass — live responses match spec)

Source runs show `dev`; released images show e.g. `v1.0.0-beta.38 · 5bbe1d9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)