### PR TITLE
chore(storage): drop MinIO admin console + stop publishing S3 port

### DIFF
--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -197,10 +197,6 @@ program
     "Host port the Appstrate platform binds to (default: 3000). Also honored via APPSTRATE_PORT.",
   )
   .option(
-    "--minio-console-port <port>",
-    "Host port the MinIO console binds to on Tier 3 (default: 9001). Also honored via APPSTRATE_MINIO_CONSOLE_PORT.",
-  )
-  .option(
     "--app-url <url>",
     "Public URL of the platform for remote deployments behind a reverse proxy, e.g. https://appstrate.example.com (origin only). Drives APP_URL + TRUSTED_ORIGINS and auto-enables TRUST_PROXY for non-localhost/https URLs. Independent of --port (the host bind port the proxy forwards to). Also honored via APPSTRATE_APP_URL. Default: http://localhost:<port>.",
   )
@@ -249,8 +245,6 @@ program
       tier: typeof opts.tier === "string" ? opts.tier : undefined,
       dir: typeof opts.dir === "string" ? opts.dir : undefined,
       port: typeof opts.port === "string" ? opts.port : undefined,
-      minioConsolePort:
-        typeof opts.minioConsolePort === "string" ? opts.minioConsolePort : undefined,
       appUrl: typeof opts.appUrl === "string" ? opts.appUrl : undefined,
       force: opts.force === true,
       autoConfirm,

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -89,8 +89,6 @@ export interface InstallOptions {
   dir?: string;
   /** Override the host port the platform binds to (Tier 0/1/2/3). */
   port?: string;
-  /** Override the host port the MinIO console binds to (Tier 3 only). */
-  minioConsolePort?: string;
   /**
    * Public URL of the platform (issue #822) — what browsers, OAuth
    * redirects, and email links use. Independent of `--port` (the host
@@ -139,7 +137,6 @@ export interface InstallOptions {
 }
 
 const DEFAULT_PORT = 3000;
-const DEFAULT_MINIO_CONSOLE_PORT = 9001;
 
 function appUrlForPort(port: number): string {
   return port === 80 ? "http://localhost" : `http://localhost:${port}`;
@@ -310,19 +307,6 @@ export async function installCommand(opts: InstallOptions): Promise<void> {
       project?.name,
       { autoPick: autoConfirm },
     );
-    const minioConsolePort =
-      tier === 3
-        ? await resolveMinioConsolePort(
-            opts.minioConsolePort,
-            nonInteractive,
-            installState.mode,
-            installState.existing,
-            dir,
-            project?.name,
-            { autoPick: autoConfirm },
-          )
-        : undefined;
-
     // Closed-mode bootstrap (issue #228) — env var > prompt > undefined.
     // Skipped on upgrades (mergeEnv preserves whatever the user had) and
     // on Tier 0 interactive (local dev — invitation-only is meaningless).
@@ -357,7 +341,7 @@ export async function installCommand(opts: InstallOptions): Promise<void> {
         appPort: port,
         nonInteractive,
       });
-      await installDockerTier(dir, tier, port, minioConsolePort, appUrl, {
+      await installDockerTier(dir, tier, port, appUrl, {
         force: opts.force ?? false,
         mode: installState.mode,
         existing: installState.existing,
@@ -697,50 +681,6 @@ export async function resolveAppstratePort(
     "APPSTRATE_PORT",
     "--port",
     "Appstrate",
-    nonInteractive,
-    deps.autoPick ?? false,
-  );
-}
-
-/** Resolve the MinIO console port (Tier 3); preflight-skip additionally gated on MINIO_ROOT_PASSWORD so a Tier 1/2 → 3 upgrade still probes the net-new port. */
-export async function resolveMinioConsolePort(
-  raw: string | undefined,
-  nonInteractive: boolean,
-  mode: InstallMode = "fresh",
-  existing: ExistingInstall = NO_EXISTING_INSTALL,
-  dir?: string,
-  projectName?: string,
-  deps: PortResolverDeps = {},
-): Promise<number> {
-  const envValue = process.env.APPSTRATE_MINIO_CONSOLE_PORT;
-  const requested = parsePort(raw, envValue, DEFAULT_MINIO_CONSOLE_PORT, "--minio-console-port");
-  // MINIO_ROOT_PASSWORD presence is the unambiguous signal that the
-  // previous install actually ran MinIO — absence means MinIO is
-  // net-new on this upgrade and its port must genuinely be free.
-  const minioWasPresent =
-    existing.hasEnv && typeof existing.existingEnv.MINIO_ROOT_PASSWORD === "string";
-  if (mode === "upgrade" && minioWasPresent) {
-    const findRunning = deps.findRunningComposeProject ?? findRunningComposeProjectImport;
-    if (await ourStackOwnsPort(dir, projectName, findRunning)) {
-      const inherited = readExistingPort(
-        existing.existingEnv,
-        "MINIO_CONSOLE_PORT",
-        DEFAULT_MINIO_CONSOLE_PORT,
-      );
-      const userExpressed = (raw ?? envValue ?? "") !== "";
-      if (userExpressed && requested !== inherited) {
-        clack.log.warn(
-          `port ${requested} ignored on upgrade — existing .env pins MINIO_CONSOLE_PORT=${inherited}. Edit <dir>/.env manually to change the port.`,
-        );
-      }
-      return inherited;
-    }
-  }
-  return ensurePortFree(
-    requested,
-    "APPSTRATE_MINIO_CONSOLE_PORT",
-    "--minio-console-port",
-    "MinIO console",
     nonInteractive,
     deps.autoPick ?? false,
   );
@@ -1639,7 +1579,6 @@ async function installDockerTier(
   dir: string,
   tier: 1 | 2 | 3,
   port: number,
-  minioConsolePort: number | undefined,
   appUrl: string,
   opts: {
     force: boolean;
@@ -1754,13 +1693,7 @@ async function installDockerTier(
         mode === "upgrade" ? "Rewriting compose + merging .env" : "Writing compose + .env",
       );
       await writeComposeFile(dir, tier);
-      const fresh = generateEnvForTier(
-        tier,
-        appUrl,
-        { port, minioConsolePort },
-        opts.bootstrap,
-        runBackendEnv,
-      );
+      const fresh = generateEnvForTier(tier, appUrl, { port }, opts.bootstrap, runBackendEnv);
       let envVars = mode === "upgrade" ? mergeEnv(existing.existingEnv, fresh) : fresh;
       // Firecracker pairing token/URL must track the CURRENT install, not
       // whatever `mergeEnv` happened to keep: `runSameHostRunnerInstall` below

--- a/apps/cli/src/lib/install/secrets.ts
+++ b/apps/cli/src/lib/install/secrets.ts
@@ -80,16 +80,13 @@ export function generateBootstrapToken(): string {
 /**
  * Optional host-port overrides written into `.env`. `port` goes in as
  * `PORT=...`; compose files interpolate it via `${PORT:-3000}`, Bun
- * picks it up automatically on `bun run dev`. `minioConsolePort` is
- * only meaningful on Tier 3 (`${MINIO_CONSOLE_PORT:-9001}`); it is
- * ignored on lower tiers to avoid polluting `.env` with dead keys.
+ * picks it up automatically on `bun run dev`.
  *
  * Defaults are elided (not written) so a vanilla install produces the
  * same `.env` as before — no churn, no diff noise.
  */
 export interface PortOverrides {
   port?: number;
-  minioConsolePort?: number;
 }
 
 /**
@@ -293,9 +290,6 @@ export function generateEnvForTier(
     env.MINIO_ROOT_PASSWORD = base64urlPassword24();
     env.S3_BUCKET = "appstrate";
     env.S3_REGION = "us-east-1";
-    if (ports.minioConsolePort !== undefined && ports.minioConsolePort !== 9001) {
-      env.MINIO_CONSOLE_PORT = String(ports.minioConsolePort);
-    }
   }
 
   // Firecracker execution backend (Docker tiers only — never reached on

--- a/apps/cli/test/install.test.ts
+++ b/apps/cli/test/install.test.ts
@@ -27,7 +27,6 @@ import {
   resolveDir,
   parsePort,
   resolveAppstratePort,
-  resolveMinioConsolePort,
   resolveBootstrapEmail,
   resolveAppUrl,
   assertLoopbackPortMatches,
@@ -377,14 +376,11 @@ describe("parsePort", () => {
 describe("resolveAppstratePort (non-interactive preflight)", () => {
   const servers: Server[] = [];
   const originalEnvPort = process.env.APPSTRATE_PORT;
-  const originalEnvMinio = process.env.APPSTRATE_MINIO_CONSOLE_PORT;
 
   afterEach(async () => {
     for (const srv of servers.splice(0)) await new Promise((r) => srv.close(() => r(undefined)));
     if (originalEnvPort === undefined) delete process.env.APPSTRATE_PORT;
     else process.env.APPSTRATE_PORT = originalEnvPort;
-    if (originalEnvMinio === undefined) delete process.env.APPSTRATE_MINIO_CONSOLE_PORT;
-    else process.env.APPSTRATE_MINIO_CONSOLE_PORT = originalEnvMinio;
   });
 
   it("returns the requested port when it is free", async () => {
@@ -552,44 +548,6 @@ describe("resolveAppstratePort auto-pick (--yes path)", () => {
         { autoPick: true },
       ),
     ).rejects.toThrow();
-  });
-});
-
-describe("resolveMinioConsolePort (non-interactive preflight)", () => {
-  const servers: Server[] = [];
-  afterEach(async () => {
-    for (const srv of servers.splice(0)) await new Promise((r) => srv.close(() => r(undefined)));
-  });
-
-  it("surfaces the MinIO label in the error message", async () => {
-    const port = await holdEphemeralPort(servers);
-    await expect(resolveMinioConsolePort(String(port), true)).rejects.toThrow(
-      /MinIO console.*--minio-console-port|APPSTRATE_MINIO_CONSOLE_PORT/,
-    );
-  });
-
-  it("auto-picks the next free port under --yes (parity with resolveAppstratePort)", async () => {
-    // The MinIO console port conflict is rarer than the main :3000
-    // conflict, but the user contract is identical under --yes:
-    // don't fail fast, just pick a free port. Parity test so any
-    // future divergence between the two resolvers is caught here.
-    const held = await holdEphemeralPort(servers);
-    const out = await resolveMinioConsolePort(
-      String(held),
-      true,
-      "fresh",
-      undefined,
-      undefined,
-      undefined,
-      { autoPick: true },
-    );
-    expect(out).toBeGreaterThan(held);
-    expect(out).toBeLessThanOrEqual(65535);
-  });
-
-  it("strict fail-fast remains the default without autoPick (explicit --tier 3)", async () => {
-    const port = await holdEphemeralPort(servers);
-    await expect(resolveMinioConsolePort(String(port), true)).rejects.toThrow(/MinIO console/);
   });
 });
 
@@ -806,209 +764,6 @@ describe("resolveAppstratePort upgrade cross-check (findRunningComposeProject)",
       true,
       "upgrade",
       existingWith({ PORT: String(port) }),
-      dir,
-      "myproject",
-      {
-        findRunningComposeProject: fakeFinder({
-          name: "myproject",
-          configFiles: [join(dir, "docker-compose.yml")],
-        }),
-      },
-    );
-    expect(out).toBe(port);
-  });
-});
-
-describe("resolveMinioConsolePort on upgrade (gated on MINIO_ROOT_PASSWORD presence)", () => {
-  const servers: Server[] = [];
-
-  afterEach(async () => {
-    for (const srv of servers.splice(0)) await new Promise((r) => srv.close(() => r(undefined)));
-  });
-
-  function existingWith(existingEnv: Record<string, string>) {
-    return { hasEnv: true, hasCompose: true, existingEnv };
-  }
-
-  it("skips preflight when MinIO was in the previous install", async () => {
-    // Tier 3 → Tier 3 re-run: MINIO_ROOT_PASSWORD present → console
-    // port is held by the existing MinIO → must skip preflight.
-    const port = await holdEphemeralPort(servers);
-    const out = await resolveMinioConsolePort(
-      undefined,
-      true,
-      "upgrade",
-      existingWith({ MINIO_ROOT_PASSWORD: "existing-secret", MINIO_CONSOLE_PORT: String(port) }),
-    );
-    expect(out).toBe(port);
-  });
-
-  it("inherits the MinIO default 9001 when MINIO_CONSOLE_PORT is absent", async () => {
-    // Default port (9001) is elided by `generateEnvForTier`. With
-    // MINIO_ROOT_PASSWORD present we know MinIO is running, so 9001
-    // is held by us — skip preflight and return 9001.
-    const out = await resolveMinioConsolePort(
-      undefined,
-      true,
-      "upgrade",
-      existingWith({ MINIO_ROOT_PASSWORD: "existing-secret" }),
-    );
-    expect(out).toBe(9001);
-  });
-
-  it("PREFLIGHTS on a tier 1 → tier 3 transition (MinIO is net-new)", async () => {
-    // The existing install was tier 1 or 2 — no MINIO_ROOT_PASSWORD.
-    // Adding MinIO for the first time means its console port must
-    // actually be free; we don't get to trust `.env` here.
-    const port = await holdEphemeralPort(servers);
-    await expect(
-      resolveMinioConsolePort(
-        String(port),
-        true,
-        "upgrade",
-        existingWith({ BETTER_AUTH_SECRET: "tier-1-secret" }),
-      ),
-    ).rejects.toThrow(/MinIO console/);
-  });
-
-  it("PREFLIGHTS when hasEnv is false (stray compose file, no .env to prove MinIO was present)", async () => {
-    // Same edge case as the main resolver: `mode=upgrade` can fire on
-    // hasCompose alone. Without a `.env` we can't claim MinIO was
-    // running, so any port we pick must actually be free.
-    const port = await holdEphemeralPort(servers);
-    await expect(
-      resolveMinioConsolePort(String(port), true, "upgrade", {
-        hasEnv: false,
-        hasCompose: true,
-        existingEnv: {},
-      }),
-    ).rejects.toThrow(/MinIO console/);
-  });
-
-  it("ignores --minio-console-port on an existing-MinIO upgrade", async () => {
-    const port = await holdEphemeralPort(servers);
-    const out = await resolveMinioConsolePort(
-      "9500",
-      true,
-      "upgrade",
-      existingWith({ MINIO_ROOT_PASSWORD: "existing-secret", MINIO_CONSOLE_PORT: String(port) }),
-    );
-    expect(out).toBe(port);
-  });
-});
-
-describe("resolveMinioConsolePort upgrade cross-check (findRunningComposeProject)", () => {
-  const servers: Server[] = [];
-  const dirs: string[] = [];
-  const originalEnvMinio = process.env.APPSTRATE_MINIO_CONSOLE_PORT;
-
-  afterEach(async () => {
-    for (const srv of servers.splice(0)) await new Promise((r) => srv.close(() => r(undefined)));
-    for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
-    if (originalEnvMinio === undefined) delete process.env.APPSTRATE_MINIO_CONSOLE_PORT;
-    else process.env.APPSTRATE_MINIO_CONSOLE_PORT = originalEnvMinio;
-  });
-
-  function makeDir(): string {
-    const d = mkdtempSync(join(tmpdir(), "appstrate-cli-minio-"));
-    dirs.push(d);
-    return d;
-  }
-
-  function existingWithMinio(extra: Record<string, string> = {}) {
-    return {
-      hasEnv: true,
-      hasCompose: true,
-      existingEnv: { MINIO_ROOT_PASSWORD: "existing-secret", ...extra },
-    };
-  }
-
-  function fakeFinder(result: RunningComposeProject | null) {
-    return async (_name: string) => result;
-  }
-
-  it("skips preflight when the running compose project's configFiles match this dir", async () => {
-    const port = await holdEphemeralPort(servers);
-    const dir = makeDir();
-    const out = await resolveMinioConsolePort(
-      undefined,
-      true,
-      "upgrade",
-      existingWithMinio({ MINIO_CONSOLE_PORT: String(port) }),
-      dir,
-      "myproject",
-      {
-        findRunningComposeProject: fakeFinder({
-          name: "myproject",
-          configFiles: [join(dir, "docker-compose.yml")],
-        }),
-      },
-    );
-    expect(out).toBe(port);
-  });
-
-  it("PREFLIGHTS when the compose project is down (findRunning returns null)", async () => {
-    const port = await holdEphemeralPort(servers);
-    const dir = makeDir();
-    await expect(
-      resolveMinioConsolePort(
-        String(port),
-        true,
-        "upgrade",
-        existingWithMinio({ MINIO_CONSOLE_PORT: String(port) }),
-        dir,
-        "myproject",
-        { findRunningComposeProject: fakeFinder(null) },
-      ),
-    ).rejects.toThrow(/MinIO console/);
-  });
-
-  it("PREFLIGHTS when the running project belongs to a DIFFERENT dir", async () => {
-    const port = await holdEphemeralPort(servers);
-    const dir = makeDir();
-    const otherDir = makeDir();
-    await expect(
-      resolveMinioConsolePort(
-        String(port),
-        true,
-        "upgrade",
-        existingWithMinio({ MINIO_CONSOLE_PORT: String(port) }),
-        dir,
-        "myproject",
-        {
-          findRunningComposeProject: fakeFinder({
-            name: "myproject",
-            configFiles: [join(otherDir, "docker-compose.yml")],
-          }),
-        },
-      ),
-    ).rejects.toThrow(/MinIO console/);
-  });
-
-  it("skips preflight when projectName is undefined (no compose concept)", async () => {
-    // MinIO is docker-only so this case is unlikely in practice, but
-    // the resolver must stay consistent with resolveAppstratePort.
-    const port = await holdEphemeralPort(servers);
-    const out = await resolveMinioConsolePort(
-      undefined,
-      true,
-      "upgrade",
-      existingWithMinio({ MINIO_CONSOLE_PORT: String(port) }),
-      undefined,
-      undefined,
-    );
-    expect(out).toBe(port);
-  });
-
-  it("returns inherited when $APPSTRATE_MINIO_CONSOLE_PORT diverges from existing .env", async () => {
-    const port = await holdEphemeralPort(servers);
-    const dir = makeDir();
-    process.env.APPSTRATE_MINIO_CONSOLE_PORT = "9500";
-    const out = await resolveMinioConsolePort(
-      undefined,
-      true,
-      "upgrade",
-      existingWithMinio({ MINIO_CONSOLE_PORT: String(port) }),
       dir,
       "myproject",
       {

--- a/apps/cli/test/install/secrets.test.ts
+++ b/apps/cli/test/install/secrets.test.ts
@@ -146,15 +146,9 @@ describe("generateEnvForTier — port overrides", () => {
     expect(env.PORT).toBe("5000");
   });
 
-  it("emits MINIO_CONSOLE_PORT only on Tier 3 + only when non-default", () => {
-    const t3 = generateEnvForTier(3, "http://localhost:3000", { minioConsolePort: 9100 });
-    expect(t3.MINIO_CONSOLE_PORT).toBe("9100");
-
-    const t3Default = generateEnvForTier(3, "http://localhost:3000", { minioConsolePort: 9001 });
-    expect(t3Default.MINIO_CONSOLE_PORT).toBeUndefined();
-
-    const t1 = generateEnvForTier(1, "http://localhost:3000", { minioConsolePort: 9100 });
-    expect(t1.MINIO_CONSOLE_PORT).toBeUndefined();
+  it("never emits MINIO_CONSOLE_PORT (console disabled, MinIO fully private)", () => {
+    const t3 = generateEnvForTier(3, "http://localhost:3000", { port: 3000 });
+    expect(t3.MINIO_CONSOLE_PORT).toBeUndefined();
   });
 });
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -57,14 +57,15 @@ services:
   minio:
     image: minio/minio:RELEASE.2025-03-12T18-04-18Z
     profiles: ["full"]
-    command: server /data --console-address ":9001"
+    command: server /data
     ports:
       - "${MINIO_PORT:-9000}:9000"
-      - "${MINIO_CONSOLE_PORT:-9001}:9001"
     restart: unless-stopped
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
+      # Admin web console disabled — inspect buckets via `docker compose exec minio mc ...`
+      MINIO_BROWSER: "off"
     volumes:
       - miniodata:/data
     healthcheck:

--- a/docker-compose.override.example.yml
+++ b/docker-compose.override.example.yml
@@ -28,16 +28,17 @@ services:
   # ── MinIO for local S3-compatible storage ─────────────────────
   appstrate-minio:
     image: minio/minio:RELEASE.2025-03-12T18-04-18Z
-    command: server /data --console-address ":9001"
+    command: server /data
     networks:
       - appstrate-data
       - default
     ports:
       - "9000:9000"
-      - "9001:9001"
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
+      # Admin web console disabled — inspect buckets via `docker compose exec appstrate-minio mc ...`
+      MINIO_BROWSER: "off"
     volumes:
       - miniodata:/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,19 +81,26 @@ services:
       timeout: 5s
       retries: 5
 
+  # Deliberately PRIVATE: no host ports are published. In proxy-upload
+  # mode (S3_PUBLIC_ENDPOINT unset — the default below) the platform
+  # streams upload bytes to MinIO server-side over the internal
+  # `appstrate-data` network, so the S3 API (:9000) needs no host
+  # exposure. The admin web console is disabled entirely
+  # (MINIO_BROWSER=off); inspect buckets via
+  # `docker compose exec appstrate-minio mc ...`. Only publish :9000
+  # (add a `ports:` mapping) if you opt into direct-to-bucket presign by
+  # setting S3_PUBLIC_ENDPOINT to a public MinIO domain.
   appstrate-minio:
     image: minio/minio:RELEASE.2025-03-12T18-04-18Z
     networks:
       - appstrate-data
-    command: server /data --console-address ":9001"
-    ports:
-      - "${MINIO_PORT:-9000}:9000"
-      - "${MINIO_CONSOLE_PORT:-9001}:9001"
+    command: server /data
     restart: unless-stopped
     mem_limit: 512m
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in .env}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in .env}
+      MINIO_BROWSER: "off"
     volumes:
       - miniodata:/data
     healthcheck:

--- a/examples/self-hosting/docker-compose.tier3.yml
+++ b/examples/self-hosting/docker-compose.tier3.yml
@@ -53,15 +53,17 @@ services:
       retries: 5
 
   # ── MinIO (S3-compatible storage) ───────────────────────────
-  # Deliberately PRIVATE: the S3 API port (:9000) is never published.
-  # Browser uploads proxy through the platform on APP_URL (issue #829 —
-  # the platform signs app-domain upload URLs and streams the bytes to
-  # MinIO server-side), so MinIO needs no public FQDN and no exposed
-  # S3 port. Only the admin console (:9001) is published on the host.
-  # To presign direct-to-bucket URLs instead (multi-node offload), expose
-  # the S3 API publicly at a domain ROOT (SigV4 signs the full path —
-  # subpath proxying is unsupported, minio/minio#7857) and set
-  # S3_PUBLIC_ENDPOINT on the appstrate service.
+  # Deliberately PRIVATE: no host ports are published at all. The S3 API
+  # (:9000) is unreachable from outside the compose network — browser
+  # uploads proxy through the platform on APP_URL (issue #829 — the
+  # platform signs app-domain upload URLs and streams the bytes to MinIO
+  # server-side), so MinIO needs no public FQDN and no exposed port. The
+  # admin web console is disabled entirely (MINIO_BROWSER=off); inspect
+  # buckets with `docker compose exec minio mc ...`. To presign
+  # direct-to-bucket URLs instead (multi-node offload), expose the S3 API
+  # publicly at a domain ROOT (SigV4 signs the full path — subpath
+  # proxying is unsupported, minio/minio#7857) and set S3_PUBLIC_ENDPOINT
+  # on the appstrate service.
   minio:
     # Pinned to a verified RELEASE tag so `docker compose pull` doesn't
     # drag in a silently-incompatible server binary. Bump in lockstep
@@ -70,13 +72,12 @@ services:
     image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     networks:
       - appstrate-data
-    command: server /data --console-address ":9001"
-    ports:
-      - "${MINIO_CONSOLE_PORT:-9001}:9001"
+    command: server /data
     restart: unless-stopped
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in .env}
+      MINIO_BROWSER: "off"
     volumes:
       - miniodata:/data
     healthcheck:

--- a/examples/self-hosting/docker-compose.yml
+++ b/examples/self-hosting/docker-compose.yml
@@ -53,15 +53,17 @@ services:
       retries: 5
 
   # ── MinIO (S3-compatible storage) ───────────────────────────
-  # Deliberately PRIVATE: the S3 API port (:9000) is never published.
-  # Browser uploads proxy through the platform on APP_URL (issue #829 —
-  # the platform signs app-domain upload URLs and streams the bytes to
-  # MinIO server-side), so MinIO needs no public FQDN and no exposed
-  # S3 port. Only the admin console (:9001) is published on the host.
-  # To presign direct-to-bucket URLs instead (multi-node offload), expose
-  # the S3 API publicly at a domain ROOT (SigV4 signs the full path —
-  # subpath proxying is unsupported, minio/minio#7857) and set
-  # S3_PUBLIC_ENDPOINT on the appstrate service.
+  # Deliberately PRIVATE: no host ports are published at all. The S3 API
+  # (:9000) is unreachable from outside the compose network — browser
+  # uploads proxy through the platform on APP_URL (issue #829 — the
+  # platform signs app-domain upload URLs and streams the bytes to MinIO
+  # server-side), so MinIO needs no public FQDN and no exposed port. The
+  # admin web console is disabled entirely (MINIO_BROWSER=off); inspect
+  # buckets with `docker compose exec minio mc ...`. To presign
+  # direct-to-bucket URLs instead (multi-node offload), expose the S3 API
+  # publicly at a domain ROOT (SigV4 signs the full path — subpath
+  # proxying is unsupported, minio/minio#7857) and set S3_PUBLIC_ENDPOINT
+  # on the appstrate service.
   minio:
     # Pinned to a verified release (digest-locked) — matches the tier3
     # `docker-compose.yml`. `:latest` would let `docker compose pull`
@@ -69,13 +71,12 @@ services:
     image: minio/minio:RELEASE.2025-03-12T18-04-18Z@sha256:46b3009bf7041eefbd90bd0d2b38c6ddc24d20a35d609551a1802c558c1c958f
     networks:
       - appstrate-data
-    command: server /data --console-address ":9001"
-    ports:
-      - "${MINIO_CONSOLE_PORT:-9001}:9001"
+    command: server /data
     restart: unless-stopped
     environment:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in .env}
+      MINIO_BROWSER: "off"
     volumes:
       - miniodata:/data
     healthcheck:

--- a/test/setup/docker-compose.test.yml
+++ b/test/setup/docker-compose.test.yml
@@ -58,7 +58,8 @@ services:
     environment:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
-    command: server /data --console-address ":9001"
+      MINIO_BROWSER: "off"
+    command: server /data
     tmpfs:
       - /data
     healthcheck:


### PR DESCRIPTION
## Contexte

Depuis le flip presign→proxy (#830), MinIO n'a besoin d'**aucun port host** en configuration par défaut :
- Uploads navigateur → streamés par la plateforme sur `APP_URL` (le sink signe des URLs app-domain et push les bytes server-side).
- La plateforme joint MinIO en interne via le réseau `appstrate-data`.

La console web d'admin (`:9001`) et l'API S3 (`:9000`) publiées n'étaient donc que de la surface d'attaque sans usage fonctionnel.

## Changements

### Composes — MinIO privé
- **Console désactivée partout** : `MINIO_BROWSER=off` + suppression de `--console-address`. Inspection buckets → `docker compose exec … mc …`.
- Templates self-hosting + composes dev : port console `:9001` retiré.
- **Root prod `docker-compose.yml`** : arrête aussi de publier l'API S3 `:9000` (proxy = défaut, `S3_PUBLIC_ENDPOINT` non défini). **Ferme un P2 du security review** : la console root MinIO était exposée sur `0.0.0.0` (brute-force creds root → R/W tous bundles/uploads/artefacts). Les opérateurs qui optent pour le presign direct ré-ajoutent le mapping (documenté en commentaire).
- Harness de test : console désactivée aussi.

### CLI — plumbing mort retiré
- Flag `--minio-console-port` supprimé.
- Fonction preflight `resolveMinioConsolePort` supprimée.
- Émission `MINIO_CONSOLE_PORT` dans `.env` retirée.
- Tests associés supprimés.

**Bénéfice DX** : le prompt d'install qui demandait un port console (source de conflits, ex. OrbStack sur `:9001`) disparaît.

## Laissé volontairement
- Composes **dev** publient encore `:9000` (S3 API) — convenance locale, non exposé en prod.
- Clé `MINIO_CONSOLE_PORT` orpheline dans un `.env` d'ancien install custom-port → clé morte inoffensive (compose ignore var inconnue).

## Vérification
- ✅ `tsc --noEmit` (CLI)
- ✅ 161 tests d'install CLI verts
- ✅ 7 composes passent `docker compose config -q` (dont override+base mergé)

Net : **51 insertions, 369 suppressions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)