### PR TITLE
feat(cli): auto-open /register after install

### DIFF
--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -169,6 +169,26 @@ function writeToTty(line: string): void {
 }
 
 /**
+ * Post-install browser deep-link. A fresh install has no session and no
+ * account yet, so the first thing the operator needs is the signup form —
+ * open `/register` directly instead of the bare root (which only bounces
+ * there after an extra redirect). One carve-out: the **bootstrap token**
+ * flow (unattended closed install) claims ownership at `/claim` by pasting
+ * the printed token, NOT at `/register`, so it keeps the root landing and
+ * the follow-up note points the operator at `/claim`.
+ *
+ * `localUrl` (not `appUrl`) because the browser runs on the install host
+ * and must hit the local bind port; a remote `appUrl` is unreachable until
+ * the operator wires their reverse proxy. The named-owner email is already
+ * pre-filled + locked server-side (app config), so no query param is
+ * needed on the URL.
+ */
+export function postInstallBrowserUrl(localUrl: string, bootstrap: BootstrapOverrides): string {
+  if (bootstrap.bootstrapToken) return localUrl;
+  return `${localUrl}/register`;
+}
+
+/**
  * Print the closed-mode follow-up note. Two flavors:
  *   - **Named owner** (#228, `APPSTRATE_BOOTSTRAP_OWNER_EMAIL`) — the
  *     dashboard pre-fills + locks the email field, the operator just
@@ -195,7 +215,7 @@ export function printBootstrapFollowup(
   const email = bootstrap.bootstrapOwnerEmail;
   if (email) {
     note(
-      `Open  ${appUrl}/register\nSign up as  ${email}  (the form is pre-filled and locked)\nPick any password — the org "${bootstrap.bootstrapOrgName ?? "Default"}" is created automatically.`,
+      `Opened  ${appUrl}/register  in your browser.\nSign up as  ${email}  (the form is pre-filled and locked)\nPick any password — the org "${bootstrap.bootstrapOrgName ?? "Default"}" is created automatically.`,
       "Next: create your owner account",
     );
     return;
@@ -1473,7 +1493,7 @@ async function installTier0(
   const { pid } = await spawnDevServer(dir, localUrl);
   devSpinner.stop(`Dev server running (pid ${pid})`);
 
-  await openBrowser(localUrl);
+  await openBrowser(postInstallBrowserUrl(localUrl, opts.bootstrap));
   printBootstrapFollowup(appUrl, opts.bootstrap);
   outro(`Appstrate is running at ${appUrl} (pid ${pid}).\nKill it with \`kill ${pid}\` when done.`);
 }
@@ -1765,7 +1785,7 @@ async function installDockerTier(
     );
   }
 
-  await openBrowser(localUrl);
+  await openBrowser(postInstallBrowserUrl(localUrl, opts.bootstrap));
   // Remote deployment: the installer wired APP_URL / TRUSTED_ORIGINS /
   // TRUST_PROXY, but provisioning the reverse proxy (TLS, forwarding
   // the public domain to the host port) is the operator's job — say so

--- a/apps/cli/test/install.test.ts
+++ b/apps/cli/test/install.test.ts
@@ -31,6 +31,7 @@ import {
   resolveAppUrl,
   assertLoopbackPortMatches,
   printBootstrapFollowup,
+  postInstallBrowserUrl,
   resolveRunBackend,
   readRawRunAdapter,
   assertRunAdapterCompatibleWithTier,
@@ -1017,6 +1018,32 @@ describe("printBootstrapFollowup (issue #228) — post-install action", () => {
     );
     expect(cap.calls[0]!.message).toContain("http://appstrate.acme.com/register");
     expect(cap.calls[0]!.message).not.toContain("localhost");
+  });
+});
+
+describe("postInstallBrowserUrl — post-install browser deep-link", () => {
+  it("opens /register for a named-owner install (email pre-filled server-side)", () => {
+    expect(
+      postInstallBrowserUrl("http://localhost:3000", { bootstrapOwnerEmail: "admin@acme.com" }),
+    ).toBe("http://localhost:3000/register");
+  });
+
+  it("opens /register for an open-mode install (no email, no token)", () => {
+    expect(postInstallBrowserUrl("http://localhost:3000", {})).toBe(
+      "http://localhost:3000/register",
+    );
+  });
+
+  it("keeps the root landing for a bootstrap-token install (claim flow at /claim)", () => {
+    expect(postInstallBrowserUrl("http://localhost:3000", { bootstrapToken: "tok_abc123" })).toBe(
+      "http://localhost:3000",
+    );
+  });
+
+  it("respects the localUrl argument verbatim (alternate ports)", () => {
+    expect(postInstallBrowserUrl("http://localhost:3001", {})).toBe(
+      "http://localhost:3001/register",
+    );
   });
 });
 

--- a/examples/self-hosting/AUTH_MODES.md
+++ b/examples/self-hosting/AUTH_MODES.md
@@ -201,19 +201,20 @@ curl -fsSL https://get.appstrate.dev | bash
 Same result, no prompt. The env vars are read by the installer and
 written into the generated `.env`.
 
-After install, the CLI prints the exact next step:
+After install, the CLI opens `/register` in your browser and prints the
+next step:
 
 ```
 ┌  Next: create your owner account
 │
-│  Open  http://localhost:3000/register
+│  Opened  http://localhost:3000/register  in your browser.
 │  Sign up as  admin@acme.com  (the form is pre-filled and locked)
 │  Pick any password — the org "Acme" is created automatically.
 │
 └
 ```
 
-Open the URL — `/register` is rendered with the email field already
+`/register` is rendered with the email field already
 filled in and disabled (so a typo can't diverge you from the configured
 bootstrap account). Pick a password, submit. The org is created
 synchronously by the signup after-hook, then you're routed through the

--- a/examples/self-hosting/README.md
+++ b/examples/self-hosting/README.md
@@ -101,9 +101,9 @@ APPSTRATE_BOOTSTRAP_OWNER_EMAIL=admin@example.com \
   curl -fsSL https://get.appstrate.dev | bash -s -- --yes
 ```
 
-Now the bootstrap owner signs up at `/register` (form pre-fills + locks
-the email field) — see [AUTH_MODES.md](./AUTH_MODES.md) for the full
-matrix of closed-mode options.
+The installer opens `/register` in your browser and the bootstrap owner
+signs up there (form pre-fills + locks the email field) — see
+[AUTH_MODES.md](./AUTH_MODES.md) for the full matrix of closed-mode options.
 
 Legacy `APPSTRATE_AUTO_INSTALL=1` is preserved as an escape hatch for
 existing scripted provisioning that depended on the previous "always


### PR DESCRIPTION
## Problème

`appstrate install` ouvrait le navigateur à la racine (`localUrl`) puis affichait une note manuelle « Open `<url>/register` … pick any password ». L'opérateur devait naviguer lui-même.

## Changement

Ouvre directement le formulaire d'inscription.

- **`postInstallBrowserUrl(localUrl, bootstrap)`** : named-owner + open-mode → deep-link `/register` ; flux bootstrap-token → reste racine (l'ownership se réclame à `/claim`, pas `/register`).
- Câblé dans les 2 appels `openBrowser` (Tier 0 + Docker-tier).
- Note named-owner reformulée « Open » → « Opened … in your browser » (l'installeur l'ouvre désormais).

L'email owner est **déjà pré-rempli + verrouillé côté serveur** via app config (`AUTH_BOOTSTRAP_OWNER_EMAIL` → `register.tsx`), donc aucun query param ajouté à l'URL.

## Tests

- `apps/cli/test/install.test.ts` : 4 tests `postInstallBrowserUrl` (named-owner/open-mode → `/register`, token → racine, port alternatif).
- `bun test install.test.ts` : 119 pass.
- `bun run check` : 34/34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)