### PR TITLE
feat(firecracker): unix-domain-socket transport for co-located runner daemon

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           bun test --coverage --coverage-reporter=lcov --coverage-dir=coverage \
             apps/api/test/unit/ \
+            apps/api/src/modules/firecracker/test/unit/ \
             apps/api/src/modules/mcp/test/unit/ \
             apps/api/src/modules/oidc/test/unit/ \
             apps/api/src/modules/webhooks/test/unit/ \

--- a/apps/api/src/modules/firecracker/README.md
+++ b/apps/api/src/modules/firecracker/README.md
@@ -9,9 +9,14 @@ Platform side (the container) reads only these four variables:
 ```sh
 MODULES=oidc,webhooks,mcp,core-providers,@appstrate/module-chat,firecracker   # add "firecracker"
 RUN_ADAPTER=firecracker
-FIRECRACKER_RUNNER_URL=http://<runner-host>:3100
+# Co-located daemon (same host) — Unix domain socket, recommended:
+FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock
+# Remote KVM host — TLS behind a reverse proxy:
+# FIRECRACKER_RUNNER_URL=https://<runner-host>:3100
 FIRECRACKER_RUNNER_TOKEN=<shared secret, >=16 chars>
 ```
+
+The wire carries the bearer token and per-run credentials, so a plaintext `http://` URL to a non-loopback host is refused fail-closed at boot (loopback `http://` and `unix://` are exempt).
 
 The host-side `FIRECRACKER_*` / `FIRECRACKER_RUNNER_*` variables are **daemon-only** — never parsed platform-side. Install the daemon on a fresh KVM host with the CLI (no checkout, no bun, no on-host build):
 

--- a/apps/api/src/modules/firecracker/remote-env.ts
+++ b/apps/api/src/modules/firecracker/remote-env.ts
@@ -55,7 +55,19 @@ export function parseRunnerTransport(rawUrl: string): RunnerTransport {
           `unix:///run/appstrate-runner/runner.sock (you wrote ${rawUrl})`,
       );
     }
-    return { kind: "unix", socketPath: parsed.pathname };
+    // A `?query` or `#fragment` has no meaning for a filesystem node — URL
+    // parsing would silently drop it from `pathname` and we would dial a
+    // DIFFERENT path than the operator wrote. Refuse, same policy as the
+    // two-slash typo above.
+    if (parsed.search !== "" || parsed.hash !== "") {
+      throw new Error(
+        `unix:// runner URL must be a bare socket path — remove the ` +
+          `"${parsed.search || parsed.hash}" suffix (you wrote ${rawUrl})`,
+      );
+    }
+    // `pathname` is percent-ENCODED (a space is "%20") — decode so the path
+    // we dial is byte-identical to the filesystem node the operator meant.
+    return { kind: "unix", socketPath: decodeURIComponent(parsed.pathname) };
   }
   if (parsed.protocol === "http:" || parsed.protocol === "https:") {
     return { kind: "tcp", url: rawUrl.replace(/\/+$/, "") };

--- a/apps/api/src/modules/firecracker/remote-env.ts
+++ b/apps/api/src/modules/firecracker/remote-env.ts
@@ -14,15 +14,72 @@
  */
 
 import { z } from "zod";
+import { getErrorMessage } from "@appstrate/core/errors";
 import { logger } from "./runner/logger.ts";
 
+/**
+ * How the platform reaches the daemon: over TCP (http/https base URL) or
+ * over a Unix domain socket (co-located daemon — the wire never touches
+ * the network, so the SEC-2 plaintext gate does not apply).
+ */
+export type RunnerTransport = { kind: "unix"; socketPath: string } | { kind: "tcp"; url: string };
+
+/**
+ * Classify a runner URL into its transport. Pure — throws an actionable
+ * Error on malformed input (the schema surfaces it as the Zod issue).
+ * `unix:///abs/path.sock` → unix; `http(s)://…` → tcp with trailing
+ * slashes stripped (route concatenation must never produce `//v1/...`,
+ * which some proxies refuse to route). A unix socket path stays VERBATIM
+ * — stripping would change which filesystem node we dial.
+ */
+export function parseRunnerTransport(rawUrl: string): RunnerTransport {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error(`not a valid URL: ${rawUrl}`);
+  }
+  if (parsed.protocol === "unix:") {
+    // `unix://var/run/x.sock` parses "var" as a HOSTNAME and silently
+    // drops the first path segment — the classic two-slash typo. Refuse
+    // loudly instead of dialing the wrong socket.
+    if (parsed.hostname !== "") {
+      throw new Error(
+        `unix:// runner URL has a host component ("${parsed.hostname}") — a socket path ` +
+          `needs THREE slashes: unix:///${parsed.hostname}${parsed.pathname} (you wrote ${rawUrl})`,
+      );
+    }
+    if (!parsed.pathname || !parsed.pathname.startsWith("/")) {
+      throw new Error(
+        `unix:// runner URL must carry an absolute socket path, e.g. ` +
+          `unix:///run/appstrate-runner/runner.sock (you wrote ${rawUrl})`,
+      );
+    }
+    return { kind: "unix", socketPath: parsed.pathname };
+  }
+  if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+    return { kind: "tcp", url: rawUrl.replace(/\/+$/, "") };
+  }
+  throw new Error(
+    `unsupported protocol ${parsed.protocol}// — use http(s):// (TCP daemon) or ` +
+      `unix:///path.sock (co-located daemon over a Unix socket)`,
+  );
+}
+
 const remoteEnvSchema = z.object({
-  // Base URL of the appstrate-runner daemon. http(s) only. Trailing
-  // slashes are stripped so route concatenation can never produce
-  // `//v1/...` (which some proxies refuse to route).
-  FIRECRACKER_RUNNER_URL: z
-    .url({ protocol: /^https?$/ })
-    .transform((url) => url.replace(/\/+$/, "")),
+  // Base URL of the appstrate-runner daemon: http(s) (TCP) or
+  // unix:///abs/path.sock (co-located daemon over a Unix domain socket).
+  // Normalization lives in parseRunnerTransport (trailing-slash strip for
+  // http(s) only; a unix path stays verbatim).
+  FIRECRACKER_RUNNER_URL: z.string().transform((raw, ctx) => {
+    try {
+      const transport = parseRunnerTransport(raw);
+      return transport.kind === "tcp" ? transport.url : raw;
+    } catch (err) {
+      ctx.addIssue({ code: "custom", message: getErrorMessage(err) });
+      return z.NEVER;
+    }
+  }),
   // Shared bearer secret between platform and daemon. The daemon fronts
   // run credentials (sidecar launch specs carry the run token), so a
   // trivially guessable token is refused outright.
@@ -45,7 +102,10 @@ const remoteEnvSchema = z.object({
     }),
 });
 
-export type RemoteRunnerEnv = z.infer<typeof remoteEnvSchema>;
+export type RemoteRunnerEnv = z.infer<typeof remoteEnvSchema> & {
+  /** Derived from FIRECRACKER_RUNNER_URL — computed once at parse time. */
+  transport: RunnerTransport;
+};
 
 /** Loopback hosts exempt from the plaintext-transport gate. */
 const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
@@ -53,9 +113,13 @@ const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
 /**
  * Enforce the plaintext-transport policy on the runner URL. Pure —
  * exported for unit tests; getRemoteEnv() applies it with the module
- * logger. `https://` and loopback `http://` always pass; non-loopback
- * `http://` is REFUSED by default (`tlsRequired`) and only downgraded to a
- * loud warning when the escape (`FIRECRACKER_RUNNER_TLS_REQUIRED=0`) is set.
+ * logger. `unix://` always passes silently (the RECOMMENDED co-located
+ * transport — the wire never crosses the network, so there is nothing to
+ * capture on-path). `https://` and loopback `http://` always pass;
+ * non-loopback `http://` is REFUSED by default (`tlsRequired`) and only
+ * downgraded to a loud warning when the escape
+ * (`FIRECRACKER_RUNNER_TLS_REQUIRED=0`) is set — RFC1918 is never
+ * auto-trusted, the refusal stays fail-closed.
  */
 export function assertRunnerTransportSecurity(
   runnerUrl: string,
@@ -63,6 +127,9 @@ export function assertRunnerTransportSecurity(
   warn: (message: string) => void = (message) => logger.warn(message),
 ): void {
   const parsed = new URL(runnerUrl);
+  // UDS first, before any TCP reasoning: no network path exists, so no
+  // TLS requirement and no warning — regardless of tlsRequired.
+  if (parsed.protocol === "unix:") return;
   if (parsed.protocol !== "http:") return;
   if (LOOPBACK_HOSTNAMES.has(parsed.hostname)) return;
   const message =
@@ -100,7 +167,9 @@ export function getRemoteEnv(): RemoteRunnerEnv {
       parsed.FIRECRACKER_RUNNER_URL,
       parsed.FIRECRACKER_RUNNER_TLS_REQUIRED,
     );
-    cached = parsed;
+    // Derive the transport once — the orchestrator branches on it per
+    // call, so re-parsing the URL on every request would be pure waste.
+    cached = { ...parsed, transport: parseRunnerTransport(parsed.FIRECRACKER_RUNNER_URL) };
   }
   return cached;
 }

--- a/apps/api/src/modules/firecracker/remote-orchestrator.ts
+++ b/apps/api/src/modules/firecracker/remote-orchestrator.ts
@@ -103,8 +103,12 @@ function parseLogLine(raw: string): string | undefined {
 }
 
 export interface RemoteOrchestratorDeps {
-  /** Injected by tests — canned Response objects, no network. */
-  fetchFn?: typeof fetch;
+  /**
+   * Injected by tests — canned Response objects, no network. The init is
+   * widened with Bun's `unix` extension: over a UDS runner URL every call
+   * dials the socket instead of a TCP host.
+   */
+  fetchFn?: (input: string | URL, init?: RequestInit & { unix?: string }) => Promise<Response>;
   /**
    * Initial backoff (ms) for waitForExit retries and streamLogs
    * reconnect pauses. Injectable so tests exercise the retry paths
@@ -132,7 +136,10 @@ export interface RemoteOrchestratorDeps {
 }
 
 export class RemoteFirecrackerOrchestrator implements RunOrchestrator {
-  private readonly fetchFn: (input: string | URL, init?: RequestInit) => Promise<Response>;
+  private readonly fetchFn: (
+    input: string | URL,
+    init?: RequestInit & { unix?: string },
+  ) => Promise<Response>;
   private readonly retryBaseMs: number;
   private readonly heartbeatIntervalMs: number;
   private readonly recordBootHeartbeat:
@@ -164,7 +171,8 @@ export class RemoteFirecrackerOrchestrator implements RunOrchestrator {
     } catch (err) {
       throw new Error(
         `firecracker backend is not configured: set FIRECRACKER_RUNNER_URL ` +
-          `(http(s) address of the appstrate-runner daemon) and FIRECRACKER_RUNNER_TOKEN ` +
+          `(http(s) address of the appstrate-runner daemon, or unix:///path.sock ` +
+          `for a co-located daemon over a Unix socket) and FIRECRACKER_RUNNER_TOKEN ` +
           `(shared bearer secret, at least 16 chars). See ` +
           `apps/api/src/modules/firecracker/README.md. (${getErrorMessage(err)})`,
       );
@@ -193,9 +201,14 @@ export class RemoteFirecrackerOrchestrator implements RunOrchestrator {
     if (signal) signals.push(signal);
     if (timeoutMs !== null) signals.push(AbortSignal.timeout(timeoutMs));
 
+    // UDS: fetch still needs an http URL for routing/headers, but the
+    // AUTHORITY is ignored — the connection dials the socket via Bun's
+    // `unix` init. The fixed placeholder host keeps request lines stable.
+    const baseUrl =
+      env.transport.kind === "unix" ? "http://appstrate-runner" : env.FIRECRACKER_RUNNER_URL;
     let res: Response;
     try {
-      res = await this.fetchFn(`${env.FIRECRACKER_RUNNER_URL}${route}`, {
+      res = await this.fetchFn(`${baseUrl}${route}`, {
         method,
         headers: {
           authorization: `Bearer ${env.FIRECRACKER_RUNNER_TOKEN}`,
@@ -203,6 +216,7 @@ export class RemoteFirecrackerOrchestrator implements RunOrchestrator {
         },
         body: body === undefined ? undefined : JSON.stringify(body),
         signal: signals.length === 1 ? signals[0] : AbortSignal.any(signals),
+        ...(env.transport.kind === "unix" ? { unix: env.transport.socketPath } : {}),
       });
     } catch (err) {
       throw new Error(

--- a/apps/api/src/modules/firecracker/runner/daemon.ts
+++ b/apps/api/src/modules/firecracker/runner/daemon.ts
@@ -26,12 +26,13 @@
  * health with the guest→platform reachability facts.
  */
 
-import { chmod, mkdir, unlink } from "node:fs/promises";
+import { chmod, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 import { FirecrackerOrchestrator } from "../orchestrator.ts";
 import { createHostExec } from "../host-net.ts";
 import { getFirecrackerEnv } from "./host-env.ts";
 import { getRunnerEnv, resolveListenConfig } from "./env.ts";
+import { removeStaleSocket, unlinkSocketIfPresent } from "./socket-file.ts";
 import { createRunnerApp } from "./server.ts";
 import { ensureGuestArtifacts } from "./artifacts.ts";
 import { warmHostPageCache } from "./readahead.ts";
@@ -166,10 +167,12 @@ if (listen.kind === "unix") {
     );
   }
   // The socket's directory may not exist on a fresh host (/run subdirs
-  // are tmpfs, gone after reboot); a stale socket FILE from a crashed
-  // daemon must be unlinked too — Bun.serve refuses to bind over one.
+  // are tmpfs, gone after reboot); a stale socket from a crashed daemon
+  // must be removed too — Bun.serve refuses to bind over one. The removal
+  // is type-guarded (socket-only): a root daemon must never delete a
+  // non-socket node a misconfigured env points at.
   await mkdir(dirname(listen.socketPath), { recursive: true });
-  await unlink(listen.socketPath).catch(() => {});
+  await removeStaleSocket(listen.socketPath);
 }
 
 // idleTimeout: 0 disables Bun's idle timeout entirely on BOTH branches:
@@ -177,19 +180,31 @@ if (listen.kind === "unix") {
 // whole run — either would be severed by the 10s default. (@types/bun
 // only declares idleTimeout on the TCP options branch, but the runtime
 // honors it per-connection regardless of transport — hence the cast.)
-const server =
-  listen.kind === "unix"
-    ? Bun.serve({
-        unix: listen.socketPath,
-        fetch: app.fetch,
-        idleTimeout: 0,
-      } as unknown as Parameters<typeof Bun.serve>[0])
-    : Bun.serve({
-        hostname: listen.host,
-        port: listen.port,
-        fetch: app.fetch,
-        idleTimeout: 0,
-      });
+//
+// The unix bind runs under a tightened umask (0177 → socket created 0600)
+// so there is no window between bind and the chmod below where the node is
+// wider than the configured mode. Restored right after — the daemon
+// creates other files later (run state, artifacts) with normal modes.
+let server: ReturnType<typeof Bun.serve>;
+if (listen.kind === "unix") {
+  const previousUmask = process.umask(0o177);
+  try {
+    server = Bun.serve({
+      unix: listen.socketPath,
+      fetch: app.fetch,
+      idleTimeout: 0,
+    } as unknown as Parameters<typeof Bun.serve>[0]);
+  } finally {
+    process.umask(previousUmask);
+  }
+} else {
+  server = Bun.serve({
+    hostname: listen.host,
+    port: listen.port,
+    fetch: app.fetch,
+    idleTimeout: 0,
+  });
+}
 
 if (listen.kind === "unix") {
   // chmod AFTER bind (the node only exists then). Default 0660 —
@@ -215,10 +230,11 @@ async function shutdown(signal: string): Promise<void> {
   // order would let the platform start a run into a dying daemon.
   server.stop();
   // Best-effort socket cleanup — a leftover node would force the NEXT
-  // boot through the stale-socket unlink path anyway, but tidying here
-  // keeps `ls` honest. Never throws (shutdown must reach exit(0)).
+  // boot through the stale-socket removal path anyway, but tidying here
+  // keeps `ls` honest. Type-guarded + never throws (shutdown must reach
+  // exit(0)).
   if (listen.kind === "unix") {
-    await unlink(listen.socketPath).catch(() => {});
+    await unlinkSocketIfPresent(listen.socketPath);
   }
   try {
     await orchestrator.shutdown();

--- a/apps/api/src/modules/firecracker/runner/daemon.ts
+++ b/apps/api/src/modules/firecracker/runner/daemon.ts
@@ -26,10 +26,12 @@
  * health with the guest→platform reachability facts.
  */
 
+import { chmod, mkdir, unlink } from "node:fs/promises";
+import { dirname } from "node:path";
 import { FirecrackerOrchestrator } from "../orchestrator.ts";
 import { createHostExec } from "../host-net.ts";
 import { getFirecrackerEnv } from "./host-env.ts";
-import { getRunnerEnv } from "./env.ts";
+import { getRunnerEnv, resolveListenConfig } from "./env.ts";
 import { createRunnerApp } from "./server.ts";
 import { ensureGuestArtifacts } from "./artifacts.ts";
 import { warmHostPageCache } from "./readahead.ts";
@@ -144,27 +146,80 @@ const app = createRunnerApp({
   health,
 });
 
-const server = Bun.serve({
-  hostname: runnerEnv.FIRECRACKER_RUNNER_HOST,
-  port: runnerEnv.FIRECRACKER_RUNNER_PORT,
-  fetch: app.fetch,
-  // 0 disables Bun's idle timeout entirely: the exit route long-polls
-  // 45s and the log route streams NDJSON for the whole run — either
-  // would be severed by the 10s default.
-  idleTimeout: 0,
-});
+// Listen transport (issue #868): a Unix socket when
+// FIRECRACKER_RUNNER_SOCKET is set (co-located platform container
+// bind-mounts the socket dir — the wire never touches the network),
+// TCP host:port otherwise.
+const listen = resolveListenConfig(runnerEnv);
+if (listen.kind === "unix") {
+  // Host/port always have schema defaults, so only RAW process.env
+  // reveals whether the operator set them explicitly — worth a heads-up
+  // that the socket takes precedence, silence would look like a hang on
+  // the port they expected.
+  if (
+    process.env.FIRECRACKER_RUNNER_HOST !== undefined ||
+    process.env.FIRECRACKER_RUNNER_PORT !== undefined
+  ) {
+    logger.info(
+      "FIRECRACKER_RUNNER_SOCKET is set — ignoring FIRECRACKER_RUNNER_HOST/FIRECRACKER_RUNNER_PORT",
+      { socket: listen.socketPath },
+    );
+  }
+  // The socket's directory may not exist on a fresh host (/run subdirs
+  // are tmpfs, gone after reboot); a stale socket FILE from a crashed
+  // daemon must be unlinked too — Bun.serve refuses to bind over one.
+  await mkdir(dirname(listen.socketPath), { recursive: true });
+  await unlink(listen.socketPath).catch(() => {});
+}
 
-logger.info("appstrate-runner listening", {
-  host: runnerEnv.FIRECRACKER_RUNNER_HOST,
-  port: runnerEnv.FIRECRACKER_RUNNER_PORT,
-  platformUrl: runnerEnv.FIRECRACKER_RUNNER_PLATFORM_URL,
-});
+// idleTimeout: 0 disables Bun's idle timeout entirely on BOTH branches:
+// the exit route long-polls 45s and the log route streams NDJSON for the
+// whole run — either would be severed by the 10s default. (@types/bun
+// only declares idleTimeout on the TCP options branch, but the runtime
+// honors it per-connection regardless of transport — hence the cast.)
+const server =
+  listen.kind === "unix"
+    ? Bun.serve({
+        unix: listen.socketPath,
+        fetch: app.fetch,
+        idleTimeout: 0,
+      } as unknown as Parameters<typeof Bun.serve>[0])
+    : Bun.serve({
+        hostname: listen.host,
+        port: listen.port,
+        fetch: app.fetch,
+        idleTimeout: 0,
+      });
+
+if (listen.kind === "unix") {
+  // chmod AFTER bind (the node only exists then). Default 0660 —
+  // root-owned; the platform container typically runs uid 0, so
+  // root:root 0660 works on plain Docker. Bearer-token auth in
+  // server.ts stays enforced regardless — this is defense-in-depth.
+  await chmod(listen.socketPath, listen.mode);
+  logger.info("appstrate-runner listening (unix socket)", {
+    socket: listen.socketPath,
+    platformUrl: runnerEnv.FIRECRACKER_RUNNER_PLATFORM_URL,
+  });
+} else {
+  logger.info("appstrate-runner listening", {
+    host: listen.host,
+    port: listen.port,
+    platformUrl: runnerEnv.FIRECRACKER_RUNNER_PLATFORM_URL,
+  });
+}
 
 async function shutdown(signal: string): Promise<void> {
   logger.info("appstrate-runner shutting down", { signal });
   // Stop accepting new requests first, then tear down VMs — the reverse
   // order would let the platform start a run into a dying daemon.
   server.stop();
+  // Best-effort socket cleanup — a leftover node would force the NEXT
+  // boot through the stale-socket unlink path anyway, but tidying here
+  // keeps `ls` honest. Never throws (shutdown must reach exit(0)).
+  if (listen.kind === "unix") {
+    await unlink(listen.socketPath).catch(() => {});
+  }
   try {
     await orchestrator.shutdown();
   } catch (err) {

--- a/apps/api/src/modules/firecracker/runner/env.ts
+++ b/apps/api/src/modules/firecracker/runner/env.ts
@@ -27,6 +27,29 @@ const runnerEnvSchema = z.object({
   // interface or 127.0.0.1 behind a reverse proxy) and firewalling the
   // port: the bearer token is the only lock on this door.
   FIRECRACKER_RUNNER_HOST: z.string().default("0.0.0.0"),
+  // Unix-domain-socket listen path (issue #868). When set, the daemon
+  // binds this socket INSTEAD of host:port — the recommended co-located
+  // transport: a containerized platform bind-mounts the socket's
+  // directory and the platform↔daemon wire (bearer token + per-run
+  // credentials) never touches the network. Must be absolute: the daemon
+  // may be launched from any cwd (systemd, installer), so a relative
+  // path would bind a different node per launch.
+  FIRECRACKER_RUNNER_SOCKET: z
+    .string()
+    .refine((v) => v.startsWith("/"), {
+      message:
+        "must be an absolute path (e.g. /run/appstrate-runner/runner.sock) — " +
+        "a relative socket path would resolve against the daemon's cwd",
+    })
+    .optional(),
+  // Filesystem mode applied to the socket after bind (chmod). Octal
+  // string, "0660" or "660" — default 0660: owner+group only, no world
+  // access. The bearer-token auth stays enforced regardless; this is
+  // defense-in-depth at the filesystem layer.
+  FIRECRACKER_RUNNER_SOCKET_MODE: z
+    .string()
+    .regex(/^0?[0-7]{3}$/, 'must be a 3-digit octal mode like "0660" or "660"')
+    .default("0660"),
   // Base URL guest workloads use to reach the platform API, e.g.
   // "http://10.0.0.5:3000". REQUIRED and IPv4-literal-only — the daemon
   // cannot guess where the platform lives when it runs in a container on
@@ -44,6 +67,28 @@ const runnerEnvSchema = z.object({
 });
 
 export type RunnerEnv = z.infer<typeof runnerEnvSchema>;
+
+/** Where the daemon listens — a UDS (socket wins when set) or a TCP host:port. */
+export type RunnerListenConfig =
+  | { kind: "unix"; socketPath: string; mode: number }
+  | { kind: "tcp"; host: string; port: number };
+
+/**
+ * Resolve the daemon's listen configuration. Pure — the socket, when
+ * set, WINS over host/port (both always carry defaults, so presence of
+ * the socket var is the only meaningful precedence signal). The octal
+ * mode string is parsed here so daemon.ts chmods with a plain number.
+ */
+export function resolveListenConfig(env: RunnerEnv): RunnerListenConfig {
+  if (env.FIRECRACKER_RUNNER_SOCKET !== undefined) {
+    return {
+      kind: "unix",
+      socketPath: env.FIRECRACKER_RUNNER_SOCKET,
+      mode: parseInt(env.FIRECRACKER_RUNNER_SOCKET_MODE, 8),
+    };
+  }
+  return { kind: "tcp", host: env.FIRECRACKER_RUNNER_HOST, port: env.FIRECRACKER_RUNNER_PORT };
+}
 
 let cached: RunnerEnv | undefined;
 

--- a/apps/api/src/modules/firecracker/runner/socket-file.ts
+++ b/apps/api/src/modules/firecracker/runner/socket-file.ts
@@ -12,14 +12,50 @@
 import { lstat, unlink } from "node:fs/promises";
 
 /**
+ * Probe whether something is still ACCEPTING connections on the socket —
+ * the unix-domain equivalent of TCP's EADDRINUSE, which filesystem binds
+ * don't get for free (the node outlives its listener). ECONNREFUSED (or
+ * any other connect failure) means no listener: the node is a stale
+ * leftover. Fail-closed on ambiguity: a wedged peer that accepts nothing
+ * within the timeout is still treated as alive — never delete a socket we
+ * are not sure is dead.
+ */
+async function isSocketAlive(path: string, timeoutMs = 1_000): Promise<boolean> {
+  return await new Promise<boolean>((resolve) => {
+    const timer = setTimeout(() => resolve(true), timeoutMs);
+    Bun.connect({
+      unix: path,
+      socket: {
+        data() {},
+        open(socket) {
+          clearTimeout(timer);
+          socket.end();
+          resolve(true);
+        },
+        error() {},
+        connectError() {
+          clearTimeout(timer);
+          resolve(false);
+        },
+      },
+    }).catch(() => {
+      clearTimeout(timer);
+      resolve(false);
+    });
+  });
+}
+
+/**
  * Remove a stale socket node at `path` so a fresh bind can succeed
  * (Bun.serve refuses to bind over an existing node). Fail-closed:
  *
  * - nothing at `path` (ENOENT) → fine, nothing to do;
- * - a socket → unlinked (the stale leftover of a crashed daemon — a LIVE
- *   daemon on the same path is refused earlier by systemd's single-instance
- *   model, and stealing it silently is exactly what TCP's EADDRINUSE
- *   prevents, so this stays scoped to what we can check: the node type);
+ * - a socket nobody answers on → unlinked (the leftover of a crashed
+ *   predecessor — SIGKILL and hard reboots never reach shutdown cleanup);
+ * - a socket a live process is ACCEPTING on → throw. systemd's
+ *   single-instance model covers the nominal path, but a manual second
+ *   launch (or a unit-name mixup) must fail like TCP's EADDRINUSE would,
+ *   not silently steal a running daemon's socket;
  * - anything else (regular file, directory, device, …) → throw with the
  *   offending path, NEVER delete. A root daemon must not destroy operator
  *   data because of an env-file typo.
@@ -37,6 +73,13 @@ export async function removeStaleSocket(path: string): Promise<void> {
       `FIRECRACKER_RUNNER_SOCKET points at ${path}, which exists and is NOT a ` +
         `unix socket — refusing to delete it. Point the variable at a socket ` +
         `path (e.g. /run/appstrate-runner/runner.sock) or remove the node yourself.`,
+    );
+  }
+  if (await isSocketAlive(path)) {
+    throw new Error(
+      `A live process is already accepting connections on ${path} — refusing to ` +
+        `steal its socket. Stop the other daemon first (systemctl stop ` +
+        `appstrate-runner) or point FIRECRACKER_RUNNER_SOCKET at a different path.`,
     );
   }
   await unlink(path);

--- a/apps/api/src/modules/firecracker/runner/socket-file.ts
+++ b/apps/api/src/modules/firecracker/runner/socket-file.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unix-socket filesystem guard for the daemon's UDS listen path (#868).
+ *
+ * The daemon runs as root, so an unconditional `unlink(path)` before bind
+ * would delete WHATEVER a misconfigured FIRECRACKER_RUNNER_SOCKET points
+ * at (`/etc/important.conf`, a data file, …). The guard here is the whole
+ * point of this module: only a node that IS a socket may be removed.
+ */
+
+import { lstat, unlink } from "node:fs/promises";
+
+/**
+ * Remove a stale socket node at `path` so a fresh bind can succeed
+ * (Bun.serve refuses to bind over an existing node). Fail-closed:
+ *
+ * - nothing at `path` (ENOENT) → fine, nothing to do;
+ * - a socket → unlinked (the stale leftover of a crashed daemon — a LIVE
+ *   daemon on the same path is refused earlier by systemd's single-instance
+ *   model, and stealing it silently is exactly what TCP's EADDRINUSE
+ *   prevents, so this stays scoped to what we can check: the node type);
+ * - anything else (regular file, directory, device, …) → throw with the
+ *   offending path, NEVER delete. A root daemon must not destroy operator
+ *   data because of an env-file typo.
+ */
+export async function removeStaleSocket(path: string): Promise<void> {
+  let stats;
+  try {
+    stats = await lstat(path);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return;
+    throw err;
+  }
+  if (!stats.isSocket()) {
+    throw new Error(
+      `FIRECRACKER_RUNNER_SOCKET points at ${path}, which exists and is NOT a ` +
+        `unix socket — refusing to delete it. Point the variable at a socket ` +
+        `path (e.g. /run/appstrate-runner/runner.sock) or remove the node yourself.`,
+    );
+  }
+  await unlink(path);
+}
+
+/**
+ * Best-effort shutdown cleanup: unlink `path` only if it is (still) a
+ * socket, swallow every error — shutdown must reach exit(0), and a
+ * leftover node is handled by {@link removeStaleSocket} on the next boot.
+ */
+export async function unlinkSocketIfPresent(path: string): Promise<void> {
+  try {
+    const stats = await lstat(path);
+    if (stats.isSocket()) await unlink(path);
+  } catch {
+    // ENOENT or a racing replacement — nothing worth failing shutdown over.
+  }
+}

--- a/apps/api/src/modules/firecracker/test/unit/remote-env.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/remote-env.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, afterEach } from "bun:test";
 import {
   assertRunnerTransportSecurity,
   getRemoteEnv,
+  parseRunnerTransport,
   _resetRemoteEnvCacheForTesting,
 } from "../../remote-env.ts";
 
@@ -30,6 +31,43 @@ afterEach(() => {
     else process.env[k] = saved[k];
   }
   _resetRemoteEnvCacheForTesting();
+});
+
+describe("parseRunnerTransport", () => {
+  it("classifies unix:///abs/path.sock as a unix transport with the verbatim path", () => {
+    expect(parseRunnerTransport("unix:///run/appstrate-runner/runner.sock")).toEqual({
+      kind: "unix",
+      socketPath: "/run/appstrate-runner/runner.sock",
+    });
+  });
+
+  it("classifies http(s) as tcp, stripping trailing slashes (http only concern)", () => {
+    expect(parseRunnerTransport("http://127.0.0.1:3100/")).toEqual({
+      kind: "tcp",
+      url: "http://127.0.0.1:3100",
+    });
+    expect(parseRunnerTransport("https://runner.internal:3100")).toEqual({
+      kind: "tcp",
+      url: "https://runner.internal:3100",
+    });
+  });
+
+  it("rejects the two-slash typo (host component) with the three-slash hint", () => {
+    // unix://var/run/x.sock parses "var" as a hostname — dialing
+    // /run/x.sock instead of /var/run/x.sock would be a silent misroute.
+    expect(() => parseRunnerTransport("unix://var/run/x.sock")).toThrow(/THREE slashes/);
+    expect(() => parseRunnerTransport("unix://var/run/x.sock")).toThrow(
+      /unix:\/\/\/var\/run\/x\.sock/,
+    );
+  });
+
+  it("rejects a unix:// URL without a socket path", () => {
+    expect(() => parseRunnerTransport("unix://")).toThrow(/absolute socket path/);
+  });
+
+  it("rejects unsupported protocols with the accepted alternatives", () => {
+    expect(() => parseRunnerTransport("ftp://runner:3100")).toThrow(/http\(s\)/);
+  });
 });
 
 describe("assertRunnerTransportSecurity", () => {
@@ -64,6 +102,16 @@ describe("assertRunnerTransportSecurity", () => {
     expect(() => assertRunnerTransportSecurity("http://10.0.0.5:3100", true)).toThrow(
       /FIRECRACKER_RUNNER_TLS_REQUIRED/,
     );
+  });
+
+  it("passes a unix:// URL silently even with tlsRequired — no network path exists", () => {
+    const warnings: string[] = [];
+    expect(() =>
+      assertRunnerTransportSecurity("unix:///run/appstrate-runner/runner.sock", true, (m) =>
+        warnings.push(m),
+      ),
+    ).not.toThrow();
+    expect(warnings).toEqual([]);
   });
 });
 
@@ -105,5 +153,33 @@ describe("getRemoteEnv transport gate (end-to-end)", () => {
     const env = getRemoteEnv();
     expect(env.FIRECRACKER_RUNNER_URL).toBe("https://runner.internal:3100");
     expect(env.FIRECRACKER_RUNNER_TLS_REQUIRED).toBe(true);
+  });
+
+  it("derives a tcp transport for an http(s) URL", () => {
+    setEnv("https://runner.internal:3100");
+    expect(getRemoteEnv().transport).toEqual({ kind: "tcp", url: "https://runner.internal:3100" });
+  });
+
+  it("accepts unix:/// with tlsRequired defaulted on — the gate never applies to a UDS", () => {
+    // The exact self-host topology the transport exists for: no escape
+    // hatch, no warning, straight through the fail-closed default.
+    setEnv("unix:///run/appstrate-runner/runner.sock");
+    const env = getRemoteEnv();
+    expect(env.FIRECRACKER_RUNNER_URL).toBe("unix:///run/appstrate-runner/runner.sock");
+    expect(env.FIRECRACKER_RUNNER_TLS_REQUIRED).toBe(true);
+    expect(env.transport).toEqual({
+      kind: "unix",
+      socketPath: "/run/appstrate-runner/runner.sock",
+    });
+  });
+
+  it("rejects the two-slash unix typo at parse time with the three-slash hint", () => {
+    setEnv("unix://var/run/x.sock");
+    expect(() => getRemoteEnv()).toThrow(/THREE slashes/);
+  });
+
+  it("rejects a unix:// URL with an empty socket path", () => {
+    setEnv("unix://");
+    expect(() => getRemoteEnv()).toThrow(/absolute socket path/);
   });
 });

--- a/apps/api/src/modules/firecracker/test/unit/remote-env.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/remote-env.test.ts
@@ -65,6 +65,20 @@ describe("parseRunnerTransport", () => {
     expect(() => parseRunnerTransport("unix://")).toThrow(/absolute socket path/);
   });
 
+  it("decodes a percent-encoded socket path (URL pathname is encoded)", () => {
+    // "/run/my dir/runner.sock" round-trips through URL as "%20" — the
+    // path we dial must be byte-identical to the filesystem node.
+    expect(parseRunnerTransport("unix:///run/my%20dir/runner.sock")).toEqual({
+      kind: "unix",
+      socketPath: "/run/my dir/runner.sock",
+    });
+  });
+
+  it("rejects a unix:// URL carrying a query or fragment (silently dropped otherwise)", () => {
+    expect(() => parseRunnerTransport("unix:///run/x.sock?foo=1")).toThrow(/bare socket path/);
+    expect(() => parseRunnerTransport("unix:///run/x.sock#frag")).toThrow(/bare socket path/);
+  });
+
   it("rejects unsupported protocols with the accepted alternatives", () => {
     expect(() => parseRunnerTransport("ftp://runner:3100")).toThrow(/http\(s\)/);
   });

--- a/apps/api/src/modules/firecracker/test/unit/remote-orchestrator.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/remote-orchestrator.test.ts
@@ -83,6 +83,10 @@ function authHeaderOf(call: RecordedCall): string | undefined {
   return (call.init?.headers as Record<string, string> | undefined)?.authorization;
 }
 
+function unixOf(call: RecordedCall): string | undefined {
+  return (call.init as { unix?: string } | undefined)?.unix;
+}
+
 function ndjsonBody(chunks: string[]): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
   let i = 0;
@@ -346,6 +350,58 @@ describe("RemoteFirecrackerOrchestrator.streamLogs", () => {
     const end = await generator.next();
     expect(end.done).toBe(true);
     expect(calls).toHaveLength(1);
+  });
+});
+
+describe("RemoteFirecrackerOrchestrator UDS transport", () => {
+  const SOCKET = "/run/appstrate-runner/runner.sock";
+
+  it("dials the socket via init.unix with a fixed http base (authority ignored over UDS)", async () => {
+    process.env.FIRECRACKER_RUNNER_URL = `unix://${SOCKET}`;
+    _resetRemoteEnvCacheForTesting();
+    const { fn, calls } = fetchStub(() => json({}));
+    const orchestrator = new RemoteFirecrackerOrchestrator({ fetchFn: fn });
+
+    await orchestrator.startWorkload(HANDLE);
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(`http://appstrate-runner${RUNNER_ROUTES.startWorkload}`);
+    expect(unixOf(calls[0] as RecordedCall)).toBe(SOCKET);
+    // Bearer auth is unchanged over UDS — the socket mode is
+    // defense-in-depth, not a substitute for the token.
+    expect(authHeaderOf(calls[0] as RecordedCall)).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it("keeps init.unix undefined over a TCP (https) runner URL", async () => {
+    process.env.FIRECRACKER_RUNNER_URL = "https://runner.internal:3100";
+    _resetRemoteEnvCacheForTesting();
+    const { fn, calls } = fetchStub(() => json({}));
+    const orchestrator = new RemoteFirecrackerOrchestrator({ fetchFn: fn });
+
+    await orchestrator.startWorkload(HANDLE);
+
+    expect(calls[0]?.url).toBe(`https://runner.internal:3100${RUNNER_ROUTES.startWorkload}`);
+    expect(unixOf(calls[0] as RecordedCall)).toBeUndefined();
+    expect(calls[0]?.init && "unix" in calls[0].init).toBe(false);
+  });
+
+  it("keeps error messages readable with the unix:// URL when the socket is unreachable", async () => {
+    process.env.FIRECRACKER_RUNNER_URL = `unix://${SOCKET}`;
+    _resetRemoteEnvCacheForTesting();
+    const fn = (async () => {
+      throw new TypeError("Unable to connect");
+    }) as unknown as typeof fetch;
+    const orchestrator = new RemoteFirecrackerOrchestrator({ fetchFn: fn });
+
+    const error = await orchestrator.startWorkload(HANDLE).then(
+      () => undefined,
+      (err: unknown) => err as Error,
+    );
+
+    // The operator-facing message interpolates the env URL — a unix://
+    // path names the socket, which is exactly "which daemon?".
+    expect(error?.message).toContain(`unix://${SOCKET}`);
+    expect(error?.message).toContain("running and reachable");
   });
 });
 

--- a/apps/api/src/modules/firecracker/test/unit/runner-listen-config.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/runner-listen-config.test.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the daemon's listen-config resolution (runner/env.ts,
+ * issue #868): FIRECRACKER_RUNNER_SOCKET (UDS) wins over host/port when
+ * set — the co-located transport where the platform↔daemon wire never
+ * touches the network — and the octal socket-mode string is validated
+ * and parsed here, so daemon.ts chmods with a plain number.
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import {
+  getRunnerEnv,
+  resolveListenConfig,
+  _resetRunnerEnvCacheForTesting,
+} from "../../runner/env.ts";
+
+const KEYS = [
+  "FIRECRACKER_RUNNER_TOKEN",
+  "FIRECRACKER_RUNNER_PORT",
+  "FIRECRACKER_RUNNER_HOST",
+  "FIRECRACKER_RUNNER_PLATFORM_URL",
+  "FIRECRACKER_RUNNER_SOCKET",
+  "FIRECRACKER_RUNNER_SOCKET_MODE",
+] as const;
+const saved = Object.fromEntries(KEYS.map((k) => [k, process.env[k]]));
+
+afterEach(() => {
+  for (const k of KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+  _resetRunnerEnvCacheForTesting();
+});
+
+/** Minimal valid daemon env + per-test overrides; undefined = unset. */
+function setEnv(overrides: Partial<Record<(typeof KEYS)[number], string | undefined>> = {}): void {
+  const base: Record<string, string | undefined> = {
+    FIRECRACKER_RUNNER_TOKEN: "0123456789abcdef",
+    FIRECRACKER_RUNNER_PLATFORM_URL: "http://10.0.0.5:3000",
+    FIRECRACKER_RUNNER_PORT: undefined,
+    FIRECRACKER_RUNNER_HOST: undefined,
+    FIRECRACKER_RUNNER_SOCKET: undefined,
+    FIRECRACKER_RUNNER_SOCKET_MODE: undefined,
+    ...overrides,
+  };
+  for (const [k, v] of Object.entries(base)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  _resetRunnerEnvCacheForTesting();
+}
+
+describe("resolveListenConfig", () => {
+  it("resolves tcp host:port when no socket is set (defaults)", () => {
+    setEnv();
+    expect(resolveListenConfig(getRunnerEnv())).toEqual({
+      kind: "tcp",
+      host: "0.0.0.0",
+      port: 3100,
+    });
+  });
+
+  it("socket wins over explicitly set host/port", () => {
+    setEnv({
+      FIRECRACKER_RUNNER_SOCKET: "/run/appstrate-runner/runner.sock",
+      FIRECRACKER_RUNNER_HOST: "10.0.0.9",
+      FIRECRACKER_RUNNER_PORT: "3200",
+    });
+    expect(resolveListenConfig(getRunnerEnv())).toEqual({
+      kind: "unix",
+      socketPath: "/run/appstrate-runner/runner.sock",
+      mode: 0o660,
+    });
+  });
+
+  it("defaults the socket mode to 0660 (owner+group only)", () => {
+    setEnv({ FIRECRACKER_RUNNER_SOCKET: "/tmp/runner.sock" });
+    const listen = resolveListenConfig(getRunnerEnv());
+    expect(listen.kind).toBe("unix");
+    expect(listen.kind === "unix" && listen.mode).toBe(0o660);
+  });
+
+  it('accepts both "666" and "0666" mode spellings (parsed as octal)', () => {
+    for (const raw of ["666", "0666"]) {
+      setEnv({
+        FIRECRACKER_RUNNER_SOCKET: "/tmp/runner.sock",
+        FIRECRACKER_RUNNER_SOCKET_MODE: raw,
+      });
+      const listen = resolveListenConfig(getRunnerEnv());
+      expect(listen.kind === "unix" && listen.mode).toBe(0o666);
+    }
+  });
+
+  it('rejects a non-octal mode like "999"', () => {
+    setEnv({
+      FIRECRACKER_RUNNER_SOCKET: "/tmp/runner.sock",
+      FIRECRACKER_RUNNER_SOCKET_MODE: "999",
+    });
+    expect(() => getRunnerEnv()).toThrow(/octal/);
+  });
+
+  it("rejects a relative socket path with an actionable message", () => {
+    // A relative path would bind a different node per launch cwd
+    // (systemd vs installer vs manual) — refuse instead of surprising.
+    setEnv({ FIRECRACKER_RUNNER_SOCKET: "run/runner.sock" });
+    expect(() => getRunnerEnv()).toThrow(/absolute path/);
+  });
+});

--- a/apps/api/src/modules/firecracker/test/unit/runner-socket-file.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/runner-socket-file.test.ts
@@ -24,11 +24,21 @@ afterEach(async () => {
   await rm(dir, { recursive: true, force: true });
 });
 
-/** Bind + immediately stop a unix listener — Bun leaves the node behind,
- *  which is exactly the crashed-daemon stale-socket scenario. */
-function createStaleSocket(path: string): void {
+/**
+ * Bind a unix listener so a REAL socket node exists at `path`, run `fn`
+ * against it, then stop the listener. The listener is kept open for the
+ * duration on purpose: whether `stop()` unlinks the node varies across
+ * Bun versions, and the guard under test only inspects the NODE TYPE —
+ * unlinking a path out from under a bound fd is exactly what the daemon
+ * does to a crashed predecessor's leftover.
+ */
+async function withSocketNode(path: string, fn: () => Promise<void>): Promise<void> {
   const listener = Bun.listen({ unix: path, socket: { data() {} } });
-  listener.stop(true);
+  try {
+    await fn();
+  } finally {
+    listener.stop(true);
+  }
 }
 
 describe("removeStaleSocket", () => {
@@ -36,12 +46,13 @@ describe("removeStaleSocket", () => {
     await expect(removeStaleSocket(join(dir, "missing.sock"))).resolves.toBeUndefined();
   });
 
-  it("unlinks a stale socket node so a fresh bind can succeed", async () => {
+  it("unlinks a socket node so a fresh bind can succeed", async () => {
     const path = join(dir, "stale.sock");
-    createStaleSocket(path);
-    expect(existsSync(path)).toBe(true);
-    await removeStaleSocket(path);
-    expect(existsSync(path)).toBe(false);
+    await withSocketNode(path, async () => {
+      expect(existsSync(path)).toBe(true);
+      await removeStaleSocket(path);
+      expect(existsSync(path)).toBe(false);
+    });
   });
 
   it("REFUSES to delete a regular file (misconfigured env) and leaves it intact", async () => {
@@ -62,9 +73,10 @@ describe("removeStaleSocket", () => {
 describe("unlinkSocketIfPresent", () => {
   it("removes a socket node", async () => {
     const path = join(dir, "shutdown.sock");
-    createStaleSocket(path);
-    await unlinkSocketIfPresent(path);
-    expect(existsSync(path)).toBe(false);
+    await withSocketNode(path, async () => {
+      await unlinkSocketIfPresent(path);
+      expect(existsSync(path)).toBe(false);
+    });
   });
 
   it("leaves a non-socket node alone and never throws", async () => {

--- a/apps/api/src/modules/firecracker/test/unit/runner-socket-file.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/runner-socket-file.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the daemon's socket filesystem guard (runner/socket-file.ts,
+ * #868 follow-up): the root daemon must only ever delete a node that IS a
+ * unix socket — a misconfigured FIRECRACKER_RUNNER_SOCKET pointing at a
+ * regular file (or anything else) must be refused loudly, never unlinked.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { removeStaleSocket, unlinkSocketIfPresent } from "../../runner/socket-file.ts";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), "appstrate-socket-file-"));
+});
+
+afterEach(async () => {
+  await rm(dir, { recursive: true, force: true });
+});
+
+/** Bind + immediately stop a unix listener — Bun leaves the node behind,
+ *  which is exactly the crashed-daemon stale-socket scenario. */
+function createStaleSocket(path: string): void {
+  const listener = Bun.listen({ unix: path, socket: { data() {} } });
+  listener.stop(true);
+}
+
+describe("removeStaleSocket", () => {
+  it("is a no-op when nothing exists at the path", async () => {
+    await expect(removeStaleSocket(join(dir, "missing.sock"))).resolves.toBeUndefined();
+  });
+
+  it("unlinks a stale socket node so a fresh bind can succeed", async () => {
+    const path = join(dir, "stale.sock");
+    createStaleSocket(path);
+    expect(existsSync(path)).toBe(true);
+    await removeStaleSocket(path);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("REFUSES to delete a regular file (misconfigured env) and leaves it intact", async () => {
+    const path = join(dir, "important.conf");
+    await writeFile(path, "precious operator data\n");
+    await expect(removeStaleSocket(path)).rejects.toThrow(/NOT a unix socket/);
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("REFUSES to delete a directory and leaves it intact", async () => {
+    const path = join(dir, "a-directory");
+    await mkdir(path);
+    await expect(removeStaleSocket(path)).rejects.toThrow(/NOT a unix socket/);
+    expect(existsSync(path)).toBe(true);
+  });
+});
+
+describe("unlinkSocketIfPresent", () => {
+  it("removes a socket node", async () => {
+    const path = join(dir, "shutdown.sock");
+    createStaleSocket(path);
+    await unlinkSocketIfPresent(path);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("leaves a non-socket node alone and never throws", async () => {
+    const path = join(dir, "not-a-socket.txt");
+    await writeFile(path, "keep me\n");
+    await expect(unlinkSocketIfPresent(path)).resolves.toBeUndefined();
+    expect(existsSync(path)).toBe(true);
+  });
+
+  it("never throws on a missing path", async () => {
+    await expect(unlinkSocketIfPresent(join(dir, "gone.sock"))).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/modules/firecracker/test/unit/runner-socket-file.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/runner-socket-file.test.ts
@@ -3,8 +3,9 @@
 /**
  * Unit tests for the daemon's socket filesystem guard (runner/socket-file.ts,
  * #868 follow-up): the root daemon must only ever delete a node that IS a
- * unix socket — a misconfigured FIRECRACKER_RUNNER_SOCKET pointing at a
- * regular file (or anything else) must be refused loudly, never unlinked.
+ * unix socket AND that nobody is accepting on — a misconfigured
+ * FIRECRACKER_RUNNER_SOCKET pointing at a regular file must be refused
+ * loudly, and a live daemon's socket must never be stolen out from under it.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
@@ -25,12 +26,10 @@ afterEach(async () => {
 });
 
 /**
- * Bind a unix listener so a REAL socket node exists at `path`, run `fn`
- * against it, then stop the listener. The listener is kept open for the
- * duration on purpose: whether `stop()` unlinks the node varies across
- * Bun versions, and the guard under test only inspects the NODE TYPE —
- * unlinking a path out from under a bound fd is exactly what the daemon
- * does to a crashed predecessor's leftover.
+ * Bind a unix listener so a LIVE socket node exists at `path` (something
+ * is accepting on it), run `fn` against it, then stop the listener. The
+ * listener is kept open for the duration on purpose: whether `stop()`
+ * unlinks the node varies across Bun versions.
  */
 async function withSocketNode(path: string, fn: () => Promise<void>): Promise<void> {
   const listener = Bun.listen({ unix: path, socket: { data() {} } });
@@ -41,17 +40,42 @@ async function withSocketNode(path: string, fn: () => Promise<void>): Promise<vo
   }
 }
 
+/**
+ * Leave a genuinely STALE socket node at `path`: a child process binds it,
+ * then SIGKILLs itself — the kernel closes the fd but never unlinks the
+ * node, exactly what a crashed daemon leaves behind. (Binding in THIS
+ * process and stopping the listener won't do: some Bun versions unlink the
+ * node on stop, and a clean stop is the one path that never strands one.)
+ */
+async function createStaleSocketNode(path: string): Promise<void> {
+  const script =
+    `Bun.listen({ unix: ${JSON.stringify(path)}, socket: { data() {} } });` +
+    `process.kill(process.pid, "SIGKILL");`;
+  const proc = Bun.spawn([process.execPath, "-e", script], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  await proc.exited;
+  expect(existsSync(path)).toBe(true);
+}
+
 describe("removeStaleSocket", () => {
   it("is a no-op when nothing exists at the path", async () => {
     await expect(removeStaleSocket(join(dir, "missing.sock"))).resolves.toBeUndefined();
   });
 
-  it("unlinks a socket node so a fresh bind can succeed", async () => {
+  it("unlinks a stale socket node (crashed predecessor) so a fresh bind can succeed", async () => {
     const path = join(dir, "stale.sock");
+    await createStaleSocketNode(path);
+    await removeStaleSocket(path);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  it("REFUSES to unlink a socket a live process is accepting on", async () => {
+    const path = join(dir, "live.sock");
     await withSocketNode(path, async () => {
+      await expect(removeStaleSocket(path)).rejects.toThrow(/accepting connections/);
       expect(existsSync(path)).toBe(true);
-      await removeStaleSocket(path);
-      expect(existsSync(path)).toBe(false);
     });
   });
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -781,6 +781,10 @@ runnerGroup
     "State root for kernel/rootfs/runs/firecracker (default: /var/lib/appstrate-runner)",
   )
   .option("--host <addr>", "Daemon bind address (default: 0.0.0.0)")
+  .option(
+    "--socket <path>",
+    "Serve the daemon API on a unix socket at this absolute path instead of a TCP port (same-host topology — the platform dials unix://<path>). Mutually exclusive with --port/--host.",
+  )
   .option("-y, --yes", "Skip prompts (requires --platform-url).")
   .action(async (opts) => {
     await runnerInstallCommand({
@@ -789,6 +793,7 @@ runnerGroup
       port: typeof opts.port === "string" ? opts.port : undefined,
       dataDir: typeof opts.dataDir === "string" ? opts.dataDir : undefined,
       host: typeof opts.host === "string" ? opts.host : undefined,
+      socket: typeof opts.socket === "string" ? opts.socket : undefined,
       yes: opts.yes === true,
     });
   });

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -210,7 +210,7 @@ program
   )
   .option(
     "--runner-url <url>",
-    "Firecracker (remote): URL of an existing appstrate-runner daemon on a KVM host, e.g. http://10.0.0.9:3100. Implies the remote topology.",
+    "Firecracker (remote): URL of an existing appstrate-runner daemon on a KVM host, e.g. https://runner.example.com:3100 (TLS reverse proxy in front of the daemon). Plaintext http:// to a non-loopback host is refused at platform boot. Implies the remote topology.",
   )
   .option(
     "--runner-token <token>",

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -210,7 +210,7 @@ program
   )
   .option(
     "--runner-url <url>",
-    "Firecracker (remote): URL of an existing appstrate-runner daemon on a KVM host, e.g. https://runner.example.com:3100 (TLS reverse proxy in front of the daemon). Plaintext http:// to a non-loopback host is refused at platform boot. Implies the remote topology.",
+    "Firecracker (remote): URL of an existing appstrate-runner daemon on a KVM host, e.g. https://runner.example.com:3100 (TLS reverse proxy in front of the daemon). Passing plaintext http:// to a non-loopback host opts in to plaintext transport: the install warns and writes FIRECRACKER_RUNNER_TLS_REQUIRED=0 (only safe on a VPN/WireGuard link). Implies the remote topology.",
   )
   .option(
     "--runner-token <token>",

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -52,7 +52,6 @@ import {
   describeProcessOnPort,
   detectLanIpv4,
   isIpv4,
-  parseIpv4HttpUrl,
   runCommand,
 } from "../lib/install/os.ts";
 import { generateRunnerToken } from "../lib/runner/config-files.ts";
@@ -994,11 +993,12 @@ export type RunBackendConfig =
       adapter: "firecracker";
       /**
        * FIRECRACKER_RUNNER_URL written to the platform `.env`. Remote:
-       * `http://<runner-ip>:3100` (TCP). Same-host: `unix://<socket path>` —
-       * the platform container dials the daemon's unix socket through a
-       * bind-mount of /run/appstrate-runner (shipped compose templates
-       * include it), so no port, no plaintext network wire, and the
-       * fail-closed non-loopback-http guard never applies.
+       * `http(s)://<runner-host>:3100` (TCP). Same-host: `unix://<socket
+       * path>` — the platform container dials the daemon's unix socket
+       * through a bind-mount of /run/appstrate-runner (the compose templates
+       * mount it from the installer-written APPSTRATE_RUNNER_SOCKET_DIR), so
+       * no port, no plaintext network wire, and the fail-closed
+       * non-loopback-http guard never applies.
        */
       runnerUrl: string;
       /** Shared bearer token between platform and daemon. */
@@ -1044,6 +1044,57 @@ export interface RunBackendResolverDeps {
   askText?: typeof askText;
   detectLanIpv4?: () => string | null;
   generateToken?: () => string;
+  /** Loud-warning sink — injectable so tests can assert the plaintext warning. */
+  warn?: (message: string) => void;
+}
+
+/** Loopback hosts the platform's plaintext-transport gate exempts. */
+const LOOPBACK_RUNNER_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+
+/**
+ * Validate a remote runner URL: `http(s)://<host>[:port]`, where host may
+ * be a HOSTNAME (the platform→daemon leg runs on the host network with
+ * normal DNS — an https:// reverse proxy usually sits behind a name) or an
+ * IPv4 literal. A dotted-quad that is NOT a valid IPv4 (`300.0.0.1`) is
+ * still rejected — it would never resolve, and the old IPv4-only validator
+ * caught exactly that typo. Only `--platform-url` stays IPv4-only (guests
+ * have no DNS); the runner URL never reaches a guest.
+ */
+function parseRunnerHttpUrl(raw: string): { url: string; protocol: string; host: string } | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  const host = parsed.hostname;
+  if (host === "") return null;
+  if (/^\d+(\.\d+){3}$/.test(host) && !isIpv4(host)) return null;
+  return { url: raw.replace(/\/+$/, ""), protocol: parsed.protocol, host };
+}
+
+/**
+ * The platform refuses a plaintext `http://` runner URL to a non-loopback
+ * host at boot (fail-closed, see the firecracker module's
+ * assertRunnerTransportSecurity). The installer cannot know whether the
+ * operator plans the `FIRECRACKER_RUNNER_TLS_REQUIRED=0` escape hatch
+ * (VPN/WireGuard link), so it warns loudly instead of refusing — but the
+ * warning carries the exact remediation so the boot refusal is never a
+ * surprise.
+ */
+function warnIfPlaintextRunnerUrl(
+  parsed: { url: string; protocol: string; host: string },
+  warn: (message: string) => void,
+): void {
+  if (parsed.protocol !== "http:" || LOOPBACK_RUNNER_HOSTNAMES.has(parsed.host)) return;
+  warn(
+    `FIRECRACKER_RUNNER_URL=${parsed.url} is plaintext http:// to a non-loopback host — ` +
+      `the platform REFUSES this at boot (the wire carries run credentials). Use ` +
+      `https:// behind a TLS reverse proxy, or — only for a link already encrypted at a ` +
+      `lower layer (VPN/WireGuard) — set FIRECRACKER_RUNNER_TLS_REQUIRED=0 in the ` +
+      `platform .env.`,
+  );
 }
 
 /** Resolve + validate the runner token (flag > freshly minted). */
@@ -1115,6 +1166,7 @@ export async function resolveRunBackend(
   const promptText = deps.askText ?? askText;
   const detectIp = deps.detectLanIpv4 ?? detectLanIpv4;
   const mintToken = deps.generateToken ?? generateRunnerToken;
+  const warn = deps.warn ?? ((message: string) => clack.log.warn(message));
   const { appPort, nonInteractive } = inputs;
 
   // 1. Which adapter? Flag > env > prompt (interactive) > docker.
@@ -1232,28 +1284,42 @@ export async function resolveRunBackend(
   }
 
   // topology === "remote"
-  // Runner daemon URL: flag (full URL) > interactive prompt for the KVM host IP.
+  // Runner daemon URL: flag (full URL) > interactive prompt (full URL, or a
+  // bare IPv4 kept for muscle memory). Hostnames are ACCEPTED — a split-host
+  // daemon should sit behind an https:// reverse proxy, which usually means
+  // a DNS name; the guests-need-IPv4 rule applies to --platform-url only.
   let runnerUrl = inputs.runnerUrl?.trim();
   if (runnerUrl) {
-    // One shared validator with `runner install --platform-url`: it rejects a
-    // non-IPv4 host AND out-of-range octets (`300.0.0.1`, `256.256.256.256`),
-    // so a bogus literal fails here with the DNS hint, not inside a guest —
-    // and never writes a config the daemon then refuses at boot.
-    const parsed = parseIpv4HttpUrl(runnerUrl);
+    const parsed = parseRunnerHttpUrl(runnerUrl);
     if (!parsed) {
       throw new Error(
-        `Invalid --runner-url "${runnerUrl}" — must be http(s)://<IPv4>[:port]. ${IPV4_HINT}`,
+        `Invalid --runner-url "${runnerUrl}" — must be http(s)://<host>[:port], e.g. ` +
+          `https://runner.example.com:${RUNNER_DEFAULT_PORT} (TLS reverse proxy in front ` +
+          `of the daemon) or http://10.0.0.9:${RUNNER_DEFAULT_PORT}.`,
       );
     }
+    warnIfPlaintextRunnerUrl(parsed, warn);
     runnerUrl = parsed.url;
   } else {
-    const runnerIp = (await promptText("Runner (KVM host) LAN IPv4", "")).trim();
-    if (!isIpv4(runnerIp)) {
+    const answer = (
+      await promptText(
+        `Runner (KVM host) URL — https://<host>:${RUNNER_DEFAULT_PORT} recommended, or a bare LAN IPv4`,
+        "",
+      )
+    ).trim();
+    // A bare IPv4 keeps the pre-UDS ergonomics (`10.0.0.9` → http://…:3100);
+    // anything else must be a full http(s) URL.
+    const parsed = isIpv4(answer)
+      ? parseRunnerHttpUrl(`http://${answer}:${RUNNER_DEFAULT_PORT}`)
+      : parseRunnerHttpUrl(answer);
+    if (!parsed) {
       throw new Error(
-        `Invalid runner IP "${runnerIp}" — must be an IPv4 literal (e.g. 10.0.0.9). ${IPV4_HINT}`,
+        `Invalid runner URL "${answer}" — must be http(s)://<host>[:port] or a bare ` +
+          `IPv4 literal (e.g. 10.0.0.9).`,
       );
     }
-    runnerUrl = `http://${runnerIp}:${RUNNER_DEFAULT_PORT}`;
+    warnIfPlaintextRunnerUrl(parsed, warn);
+    runnerUrl = parsed.url;
   }
 
   const token = resolveRunnerToken(inputs.runnerToken, mintToken);
@@ -1360,7 +1426,8 @@ export function firecrackerFollowupNote(
     lines.push(
       `The platform reaches the daemon over a unix socket (${rb.runnerUrl}) —`,
       `no network port, no TLS to configure. The platform container bind-mounts`,
-      `${RUNNER_RUNTIME_DIR} for it (the shipped compose templates include the mount).`,
+      `${RUNNER_RUNTIME_DIR} for it (the compose templates mount it when the`,
+      `installer-written APPSTRATE_RUNNER_SOCKET_DIR is set in .env).`,
       "",
     );
   }

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -56,7 +56,12 @@ import {
   runCommand,
 } from "../lib/install/os.ts";
 import { generateRunnerToken } from "../lib/runner/config-files.ts";
-import { RUNNER_DEFAULT_PORT, RUNNER_TOKEN_ENV } from "../lib/runner/constants.ts";
+import {
+  RUNNER_DEFAULT_PORT,
+  RUNNER_DEFAULT_SOCKET_PATH,
+  RUNNER_RUNTIME_DIR,
+  RUNNER_TOKEN_ENV,
+} from "../lib/runner/constants.ts";
 import {
   detectInstallMode,
   inferInstalledTier,
@@ -987,7 +992,14 @@ export type RunBackendConfig =
   | { adapter: "docker" }
   | {
       adapter: "firecracker";
-      /** FIRECRACKER_RUNNER_URL written to the platform `.env` (http://<runner-ip>:3100). */
+      /**
+       * FIRECRACKER_RUNNER_URL written to the platform `.env`. Remote:
+       * `http://<runner-ip>:3100` (TCP). Same-host: `unix://<socket path>` —
+       * the platform container dials the daemon's unix socket through a
+       * bind-mount of /run/appstrate-runner (shipped compose templates
+       * include it), so no port, no plaintext network wire, and the
+       * fail-closed non-loopback-http guard never applies.
+       */
       runnerUrl: string;
       /** Shared bearer token between platform and daemon. */
       token: string;
@@ -995,7 +1007,12 @@ export type RunBackendConfig =
       tokenSource: "flag" | "generated";
       /** Daemon lives on this host, or a separate KVM host. */
       topology: "same-host" | "remote";
-      /** This host's LAN IPv4 — the address the daemon/guests reach the platform on. */
+      /**
+       * This host's LAN IPv4 — the address the GUESTS reach the platform on.
+       * Still required for same-host UDS installs: the socket only carries
+       * platform↔daemon traffic; guest→platform egress rides the LAN via
+       * `platformUrl`.
+       */
       hostIp: string;
       /** Full platform URL for `runner install --platform-url` (http://<hostIp>:<appPort>). */
       platformUrl: string;
@@ -1200,7 +1217,12 @@ export async function resolveRunBackend(
     const token = resolveRunnerToken(inputs.runnerToken, mintToken);
     return {
       adapter: "firecracker",
-      runnerUrl: `http://${ip}:${RUNNER_DEFAULT_PORT}`,
+      // Same-host = UDS transport: the daemon binds the canonical socket
+      // (`runner install --socket`, appended in buildRunnerInstallArgs) and
+      // the platform dials it — no TCP port, so beta.38's fail-closed
+      // "plaintext http to a non-loopback host" guard never trips. The LAN
+      // IP is still collected: it feeds platformUrl (guest→platform).
+      runnerUrl: `unix://${RUNNER_DEFAULT_SOCKET_PATH}`,
       token: token.value,
       tokenSource: token.source,
       topology: "same-host",
@@ -1292,9 +1314,11 @@ export function resolveCliInvocation(
 
 /**
  * Build the argv (excluding the leading `sudo`) for the same-host runner
- * install: `<cli> runner install --platform-url <url> --token <token> --yes`.
- * The token is a secret but must appear here — it is how the daemon pairs
- * with the platform.
+ * install: `<cli> runner install --platform-url <url> --token <token>
+ * --socket <canonical sock> --yes`. The token is a secret but must appear
+ * here — it is how the daemon pairs with the platform. `--socket` puts the
+ * daemon in UDS mode (same-host transport); the platform side was already
+ * written as `FIRECRACKER_RUNNER_URL=unix://…` by `resolveRunBackend`.
  */
 export function buildRunnerInstallArgs(
   cliInvocation: string[],
@@ -1309,6 +1333,8 @@ export function buildRunnerInstallArgs(
     platformUrl,
     "--token",
     token,
+    "--socket",
+    RUNNER_DEFAULT_SOCKET_PATH,
     "--yes",
   ];
 }
@@ -1328,6 +1354,13 @@ export function firecrackerFollowupNote(
       "Run this on your KVM host to install + pair the runner daemon:",
       "",
       `  curl -fsSL https://get.appstrate.dev/runner | bash -s -- --platform-url ${rb.platformUrl} --token ${rb.token}`,
+      "",
+    );
+  } else {
+    lines.push(
+      `The platform reaches the daemon over a unix socket (${rb.runnerUrl}) —`,
+      `no network port, no TLS to configure. The platform container bind-mounts`,
+      `${RUNNER_RUNTIME_DIR} for it (the shipped compose templates include the mount).`,
       "",
     );
   }
@@ -1395,6 +1428,10 @@ export async function runSameHostRunnerInstall(
     "install",
     "--platform-url",
     rb.platformUrl,
+    // Same-host = UDS mode: the daemon binds the canonical socket instead of
+    // a TCP port, matching the unix:// runner URL already in the platform .env.
+    "--socket",
+    RUNNER_DEFAULT_SOCKET_PATH,
     "--yes",
   ];
   const prevToken = process.env[RUNNER_TOKEN_ENV];

--- a/apps/cli/src/commands/install.ts
+++ b/apps/cli/src/commands/install.ts
@@ -1016,6 +1016,15 @@ export type RunBackendConfig =
       hostIp: string;
       /** Full platform URL for `runner install --platform-url` (http://<hostIp>:<appPort>). */
       platformUrl: string;
+      /**
+       * The operator accepted a plaintext `http://` runner URL to a
+       * non-loopback host (flag passed explicitly, or interactive confirm).
+       * The platform refuses that transport at boot by default, so the
+       * install writes the `FIRECRACKER_RUNNER_TLS_REQUIRED=0` escape hatch
+       * alongside — otherwise the installer would produce a config the
+       * platform rejects until the operator hand-edits `.env`.
+       */
+      plaintextOptIn: boolean;
     };
 
 export interface RunBackendInputs {
@@ -1042,6 +1051,7 @@ export interface RunBackendResolverDeps {
   select?: typeof clack.select;
   isCancel?: typeof clack.isCancel;
   askText?: typeof askText;
+  confirm?: typeof clack.confirm;
   detectLanIpv4?: () => string | null;
   generateToken?: () => string;
   /** Loud-warning sink — injectable so tests can assert the plaintext warning. */
@@ -1077,23 +1087,23 @@ function parseRunnerHttpUrl(raw: string): { url: string; protocol: string; host:
 /**
  * The platform refuses a plaintext `http://` runner URL to a non-loopback
  * host at boot (fail-closed, see the firecracker module's
- * assertRunnerTransportSecurity). The installer cannot know whether the
- * operator plans the `FIRECRACKER_RUNNER_TLS_REQUIRED=0` escape hatch
- * (VPN/WireGuard link), so it warns loudly instead of refusing — but the
- * warning carries the exact remediation so the boot refusal is never a
- * surprise.
+ * assertRunnerTransportSecurity). When the operator opts in anyway, the
+ * install must ALSO write `FIRECRACKER_RUNNER_TLS_REQUIRED=0` — warning
+ * without writing the escape hatch would ship a `.env` the platform
+ * rejects at boot, a broken install until hand-edited.
  */
-function warnIfPlaintextRunnerUrl(
-  parsed: { url: string; protocol: string; host: string },
-  warn: (message: string) => void,
-): void {
-  if (parsed.protocol !== "http:" || LOOPBACK_RUNNER_HOSTNAMES.has(parsed.host)) return;
-  warn(
-    `FIRECRACKER_RUNNER_URL=${parsed.url} is plaintext http:// to a non-loopback host — ` +
-      `the platform REFUSES this at boot (the wire carries run credentials). Use ` +
-      `https:// behind a TLS reverse proxy, or — only for a link already encrypted at a ` +
-      `lower layer (VPN/WireGuard) — set FIRECRACKER_RUNNER_TLS_REQUIRED=0 in the ` +
-      `platform .env.`,
+function isPlaintextNonLoopback(parsed: { protocol: string; host: string }): boolean {
+  return parsed.protocol === "http:" && !LOOPBACK_RUNNER_HOSTNAMES.has(parsed.host);
+}
+
+function plaintextRunnerWarning(url: string): string {
+  return (
+    `FIRECRACKER_RUNNER_URL=${url} is plaintext http:// to a non-loopback host — ` +
+    `the platform↔daemon wire carries run credentials (model API keys, sink secrets); ` +
+    `anyone on the network path can capture and replay them. The install writes ` +
+    `FIRECRACKER_RUNNER_TLS_REQUIRED=0 so the platform accepts this transport — put a ` +
+    `TLS reverse proxy in front of the daemon and switch to https:// unless the link ` +
+    `is already encrypted at a lower layer (VPN/WireGuard).`
   );
 }
 
@@ -1164,6 +1174,7 @@ export async function resolveRunBackend(
   const select = deps.select ?? clack.select;
   const isCancel = deps.isCancel ?? clack.isCancel;
   const promptText = deps.askText ?? askText;
+  const confirmPrompt = deps.confirm ?? clack.confirm;
   const detectIp = deps.detectLanIpv4 ?? detectLanIpv4;
   const mintToken = deps.generateToken ?? generateRunnerToken;
   const warn = deps.warn ?? ((message: string) => clack.log.warn(message));
@@ -1280,6 +1291,7 @@ export async function resolveRunBackend(
       topology: "same-host",
       hostIp: ip,
       platformUrl: `http://${ip}:${appPort}`,
+      plaintextOptIn: false,
     };
   }
 
@@ -1289,6 +1301,7 @@ export async function resolveRunBackend(
   // daemon should sit behind an https:// reverse proxy, which usually means
   // a DNS name; the guests-need-IPv4 rule applies to --platform-url only.
   let runnerUrl = inputs.runnerUrl?.trim();
+  let plaintextOptIn = false;
   if (runnerUrl) {
     const parsed = parseRunnerHttpUrl(runnerUrl);
     if (!parsed) {
@@ -1298,7 +1311,13 @@ export async function resolveRunBackend(
           `of the daemon) or http://10.0.0.9:${RUNNER_DEFAULT_PORT}.`,
       );
     }
-    warnIfPlaintextRunnerUrl(parsed, warn);
+    // An explicit plaintext --runner-url IS the opt-in (flags must stay
+    // scriptable — a confirm prompt here would break unattended installs):
+    // warn loudly and write the escape hatch so the platform actually boots.
+    if (isPlaintextNonLoopback(parsed)) {
+      warn(plaintextRunnerWarning(parsed.url));
+      plaintextOptIn = true;
+    }
     runnerUrl = parsed.url;
   } else {
     const answer = (
@@ -1318,7 +1337,28 @@ export async function resolveRunBackend(
           `IPv4 literal (e.g. 10.0.0.9).`,
       );
     }
-    warnIfPlaintextRunnerUrl(parsed, warn);
+    // Interactive typo ≠ informed choice: a bare IP typed at the prompt gets
+    // an explicit confirm before the install commits to plaintext transport.
+    if (isPlaintextNonLoopback(parsed)) {
+      warn(plaintextRunnerWarning(parsed.url));
+      const proceed = await confirmPrompt({
+        message:
+          "Proceed over plaintext http:// and write FIRECRACKER_RUNNER_TLS_REQUIRED=0 " +
+          "to the platform .env? (only safe on a link already encrypted — VPN/WireGuard)",
+        initialValue: false,
+      });
+      if (isCancel(proceed)) {
+        clack.cancel("Cancelled.");
+        process.exit(130);
+      }
+      if (!proceed) {
+        throw new Error(
+          `Plaintext runner URL declined — put a TLS reverse proxy in front of the ` +
+            `daemon and re-run with https://<host>:${RUNNER_DEFAULT_PORT}.`,
+        );
+      }
+      plaintextOptIn = true;
+    }
     runnerUrl = parsed.url;
   }
 
@@ -1354,6 +1394,7 @@ export async function resolveRunBackend(
     topology: "remote",
     hostIp,
     platformUrl: `http://${platformHost}:${appPort}`,
+    plaintextOptIn,
   };
 }
 
@@ -1724,7 +1765,12 @@ async function installDockerTier(
   // would leave platform and daemon paired on different secrets.
   const runBackendEnv: RunBackendEnv =
     runBackend.adapter === "firecracker"
-      ? { adapter: "firecracker", runnerUrl: runBackend.runnerUrl, runnerToken: runBackend.token }
+      ? {
+          adapter: "firecracker",
+          runnerUrl: runBackend.runnerUrl,
+          runnerToken: runBackend.token,
+          plaintextOptIn: runBackend.plaintextOptIn,
+        }
       : { adapter: "docker" };
   // Healthcheck + browser go through the local bind address: on a
   // remote deployment the public URL only resolves once the operator's
@@ -1829,6 +1875,12 @@ async function installDockerTier(
           FIRECRACKER_RUNNER_URL: runBackend.runnerUrl,
           FIRECRACKER_RUNNER_TOKEN: runBackend.token,
         };
+        // The plaintext escape hatch tracks the CURRENT runner URL. Carrying
+        // a stale `=0` forward after the operator moved to https:// (or to
+        // the unix socket) would silently keep the plaintext door open for
+        // the next http:// misconfiguration.
+        if (runBackend.plaintextOptIn) envVars.FIRECRACKER_RUNNER_TLS_REQUIRED = "0";
+        else delete envVars.FIRECRACKER_RUNNER_TLS_REQUIRED;
       }
       await writeComposeEnv(dir, renderEnvFile(envVars));
       writeSpinner.stop(

--- a/apps/cli/src/commands/runner.ts
+++ b/apps/cli/src/commands/runner.ts
@@ -547,7 +547,8 @@ function printPostInstall(config: RunnerConfig, source: TokenSource, healthy: bo
         ``,
         `Unix socket transport — no network port exposed, no firewall rule needed.`,
         `The platform container must bind-mount ${dirname(config.socketPath)} to dial`,
-        `the socket (the shipped compose templates include it).`,
+        `the socket (set APPSTRATE_RUNNER_SOCKET_DIR=${dirname(config.socketPath)} in the`,
+        `platform .env — the shipped compose templates mount it from that variable).`,
       ]
     : [
         `  FIRECRACKER_RUNNER_URL=http://<this-host>:${config.port}`,

--- a/apps/cli/src/commands/runner.ts
+++ b/apps/cli/src/commands/runner.ts
@@ -29,6 +29,7 @@ import {
   RUNNER_UNIT_PATH,
   RUNNER_DATA_DIR,
   RUNNER_DEFAULT_PORT,
+  RUNNER_DEFAULT_SOCKET_PATH,
   RUNNER_TOKEN_ENV,
   FIRECRACKER_VERSION,
   resolveRunnerArch,
@@ -57,11 +58,50 @@ import { downloadDaemon, installFirecracker } from "../lib/runner/download.ts";
 import { formatProgress } from "../lib/download.ts";
 import { parseIpv4HttpUrl } from "../lib/install/os.ts";
 
+/** Result shape shared by the TCP (`RunnerHttp.getJson`) and UDS probes. */
+type GetJsonResult =
+  | { reachable: true; status: number; body: unknown }
+  | { reachable: false; error: string };
+
+/**
+ * GET a JSON endpoint over a unix socket. Separate seam from
+ * `RunnerHttp.getJson` (URL-based) because the UDS transport has no URL —
+ * Bun's `fetch(…, { unix })` dials the socket and only uses the http://
+ * authority for the Host header.
+ */
+export type RunnerUnixGetJson = (
+  socketPath: string,
+  path: string,
+  token: string,
+) => Promise<GetJsonResult>;
+
+const defaultUnixGetJson: RunnerUnixGetJson = async (socketPath, path, token) => {
+  try {
+    // `appstrate-runner` is a placeholder authority — with `unix` set, Bun
+    // never resolves it; it only feeds the Host header.
+    const res = await fetch(`http://appstrate-runner${path}`, {
+      unix: socketPath,
+      headers: { authorization: `Bearer ${token}` },
+    });
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      body = null;
+    }
+    return { reachable: true, status: res.status, body };
+  } catch (err) {
+    return { reachable: false, error: err instanceof Error ? err.message : String(err) };
+  }
+};
+
 /** Shared DI surface for every runner subcommand. */
 export interface RunnerDeps {
   exec?: RunnerExec;
   fs?: RunnerFs;
   http?: RunnerHttp;
+  /** UDS health probe — overridable so tests never dial a real socket. */
+  unixGetJson?: RunnerUnixGetJson;
   /** `process.getuid` — overridable so tests can exercise the root gate. */
   getuid?: () => number;
   /** Preflight override (tests inject a deterministic matrix). */
@@ -72,6 +112,7 @@ interface ResolvedDeps {
   exec: RunnerExec;
   fs: RunnerFs;
   http: RunnerHttp;
+  unixGetJson: RunnerUnixGetJson;
   getuid: () => number;
   preflight: () => Promise<PreflightResult>;
 }
@@ -81,6 +122,7 @@ function resolve(deps: RunnerDeps): ResolvedDeps {
     exec: deps.exec ?? defaultRunnerExec,
     fs: deps.fs ?? defaultRunnerFs,
     http: deps.http ?? defaultRunnerHttp,
+    unixGetJson: deps.unixGetJson ?? defaultUnixGetJson,
     getuid: deps.getuid ?? (() => (typeof process.getuid === "function" ? process.getuid() : 0)),
     preflight: (deps.preflight as () => Promise<PreflightResult>) ?? (() => runPreflight()),
   };
@@ -110,6 +152,12 @@ export interface RunnerInstallOptions {
   port?: string;
   dataDir?: string;
   host?: string;
+  /**
+   * `--socket <abs path>` — serve the daemon API on a unix socket instead
+   * of a TCP port (same-host topology). Mutually exclusive with
+   * `--port`/`--host`.
+   */
+  socket?: string;
   yes?: boolean;
   deps?: RunnerDeps;
 }
@@ -183,6 +231,30 @@ export async function resolveInstallConfig(
 
   const port = parsePort(opts.port);
 
+  // Transport: unix socket (same-host, no network listener) vs TCP (remote).
+  // `--socket` replaces the whole TCP listen surface, so combining it with
+  // the TCP flags is a contradiction — fail loudly instead of guessing.
+  const hasPortFlag = opts.port !== undefined && opts.port !== "";
+  const hasHostFlag = (opts.host?.trim() ?? "") !== "";
+  let socketPath: string | undefined;
+  if (opts.socket !== undefined) {
+    if (hasPortFlag || hasHostFlag) {
+      throw new Error(
+        `--socket is mutually exclusive with --port/--host: the unix socket replaces ` +
+          `the TCP listener entirely. Drop ${hasPortFlag ? "--port" : "--host"} (UDS) ` +
+          `or --socket (TCP).`,
+      );
+    }
+    const trimmed = opts.socket.trim();
+    if (!trimmed.startsWith("/")) {
+      throw new Error(
+        `Invalid --socket "${opts.socket}" — must be an absolute path the daemon binds ` +
+          `its unix socket at, e.g. --socket ${RUNNER_DEFAULT_SOCKET_PATH}.`,
+      );
+    }
+    socketPath = trimmed;
+  }
+
   // Platform URL: flag > prompt (interactive) > error.
   let platformUrl = opts.platformUrl?.trim();
   if (!platformUrl) {
@@ -202,6 +274,41 @@ export async function resolveInstallConfig(
     );
   }
   platformUrl = parsedPlatformUrl.url;
+
+  // Transport prompt (interactive only): no --socket and no TCP flag means
+  // the operator has not chosen yet. Same-host (platform container on this
+  // box) should use the socket — it sidesteps the platform's fail-closed
+  // plaintext-http-to-non-loopback guard by having no network wire at all.
+  // Non-interactive stays TCP, exactly the pre-UDS behavior.
+  if (
+    socketPath === undefined &&
+    !hasPortFlag &&
+    !hasHostFlag &&
+    !opts.yes &&
+    process.stdin.isTTY
+  ) {
+    const chosen = await clack.select<"unix" | "tcp">({
+      message: "How does the platform reach this daemon?",
+      initialValue: "unix",
+      options: [
+        {
+          value: "unix",
+          label: `Unix socket at ${RUNNER_DEFAULT_SOCKET_PATH}`,
+          hint: "Same host — the platform container bind-mounts /run/appstrate-runner; no network port",
+        },
+        {
+          value: "tcp",
+          label: `TCP port ${RUNNER_DEFAULT_PORT}`,
+          hint: "Remote platform — reachable over the network",
+        },
+      ],
+    });
+    if (clack.isCancel(chosen)) {
+      clack.cancel("Cancelled.");
+      process.exit(130);
+    }
+    if (chosen === "unix") socketPath = RUNNER_DEFAULT_SOCKET_PATH;
+  }
 
   // Token: flag > APPSTRATE_RUNNER_TOKEN env > existing env file > freshly
   // generated (printed once). The env-var channel lets the same-host
@@ -239,7 +346,10 @@ export async function resolveInstallConfig(
     existingVars.FIRECRACKER_ARTIFACTS_PUBKEY ||
     undefined;
 
-  return { config: { token, platformUrl, port, host, dataDir, artifactsPubkey }, tokenSource };
+  return {
+    config: { token, platformUrl, port, host, dataDir, artifactsPubkey, socketPath },
+    tokenSource,
+  };
 }
 
 function parsePort(raw: string | undefined): number {
@@ -350,14 +460,19 @@ export async function enableService(d: ResolvedDeps): Promise<void> {
  * exec + http seams only.
  */
 export async function pollHealth(
-  config: { port: number; token: string },
-  d: { exec: RunnerExec; http: RunnerHttp },
+  config: { port: number; token: string; socketPath?: string },
+  d: { exec: RunnerExec; http: RunnerHttp; unixGetJson?: RunnerUnixGetJson },
   timeoutMs: number,
 ): Promise<boolean> {
-  const url = `http://127.0.0.1:${config.port}/v1/health`;
+  // UDS installs have no TCP listener — probe through the socket instead.
+  const { socketPath } = config;
+  const probe = (): Promise<GetJsonResult> =>
+    socketPath
+      ? (d.unixGetJson ?? defaultUnixGetJson)(socketPath, "/v1/health", config.token)
+      : d.http.getJson(`http://127.0.0.1:${config.port}/v1/health`, config.token);
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const res = await d.http.getJson(url, config.token);
+    const res = await probe();
     if (res.reachable && res.status === 200) return true;
 
     const parked = await unitParkedState(d.exec);
@@ -415,7 +530,6 @@ function printPreflight(pf: PreflightResult): void {
 }
 
 function printPostInstall(config: RunnerConfig, source: TokenSource, healthy: boolean): void {
-  const fw = detectFirewallCommands(config.port);
   const tokenBlock =
     source === "generated"
       ? `\n\nRunner token (shown once — also in ${RUNNER_ENV_PATH}, mode 0600):\n  ${config.token}\n` +
@@ -424,18 +538,33 @@ function printPostInstall(config: RunnerConfig, source: TokenSource, healthy: bo
         ? `\n\nExisting runner token preserved (see ${RUNNER_ENV_PATH}).`
         : "";
 
+  // UDS transport: no port was opened, so the whole firewall/TLS section is
+  // moot — the platform dials the socket through a bind-mount instead.
+  const transportLines = config.socketPath
+    ? [
+        `  FIRECRACKER_RUNNER_URL=unix://${config.socketPath}`,
+        `  FIRECRACKER_RUNNER_TOKEN=<token above>`,
+        ``,
+        `Unix socket transport — no network port exposed, no firewall rule needed.`,
+        `The platform container must bind-mount ${dirname(config.socketPath)} to dial`,
+        `the socket (the shipped compose templates include it).`,
+      ]
+    : [
+        `  FIRECRACKER_RUNNER_URL=http://<this-host>:${config.port}`,
+        `  FIRECRACKER_RUNNER_TOKEN=<token above>`,
+        ``,
+        `Open the daemon port for the platform:`,
+        ...detectFirewallCommands(config.port).commands.map((c) => `  ${c}`),
+        ``,
+        `Platform on a DIFFERENT host? Put TLS in front of this daemon (reverse proxy)`,
+        `and use https:// in FIRECRACKER_RUNNER_URL — the wire carries run credentials.`,
+      ];
+
   clack.note(
     [
       `Platform config (set on the containerized platform):`,
       `  RUN_ADAPTER=firecracker`,
-      `  FIRECRACKER_RUNNER_URL=http://<this-host>:${config.port}`,
-      `  FIRECRACKER_RUNNER_TOKEN=<token above>`,
-      ``,
-      `Open the daemon port for the platform:`,
-      ...fw.commands.map((c) => `  ${c}`),
-      ``,
-      `Platform on a DIFFERENT host? Put TLS in front of this daemon (reverse proxy)`,
-      `and use https:// in FIRECRACKER_RUNNER_URL — the wire carries run credentials.`,
+      ...transportLines,
       ``,
       `Guest egress uses the host's own TAP/nft path (set up by the daemon) —`,
       `no extra ufw/firewalld rule is needed for guest→platform traffic.`,
@@ -470,6 +599,8 @@ export interface RunnerDoctorReport {
     protocol?: number;
     initialized?: boolean;
     error?: string;
+    /** Probed endpoint — `127.0.0.1:<port>` (TCP) or the unix socket path. */
+    endpoint?: string;
   };
   artifacts: { version?: string; guestProtocol?: number };
   /** Jailer binary presence (FIRECRACKER_JAILER=on needs it at boot). */
@@ -496,14 +627,20 @@ export async function runnerDoctor(opts: RunnerDoctorOptions = {}): Promise<Runn
   const envText = await d.fs.readFile(RUNNER_ENV_PATH);
   const env = envText ? parseRunnerEnvFile(envText) : {};
   const token = env.FIRECRACKER_RUNNER_TOKEN ?? "";
+  // UDS install (FIRECRACKER_RUNNER_SOCKET) has no TCP listener — the health
+  // probe must dial the socket the daemon actually binds.
+  const socketPath = env.FIRECRACKER_RUNNER_SOCKET;
   const port = Number(env.FIRECRACKER_RUNNER_PORT ?? RUNNER_DEFAULT_PORT) || RUNNER_DEFAULT_PORT;
+  const endpoint = socketPath ?? `127.0.0.1:${port}`;
   const dataDir = env.FIRECRACKER_ROOTFS_PATH
     ? env.FIRECRACKER_ROOTFS_PATH.replace(/\/rootfs\.ext4$/, "")
     : RUNNER_DATA_DIR;
 
   let health: RunnerDoctorReport["health"];
   if (token) {
-    const res = await d.http.getJson(`http://127.0.0.1:${port}/v1/health`, token);
+    const res = socketPath
+      ? await d.unixGetJson(socketPath, "/v1/health", token)
+      : await d.http.getJson(`http://127.0.0.1:${port}/v1/health`, token);
     if (res.reachable) {
       const body = (res.body ?? {}) as { protocol?: number; initialized?: boolean };
       health = {
@@ -511,12 +648,13 @@ export async function runnerDoctor(opts: RunnerDoctorOptions = {}): Promise<Runn
         status: res.status,
         protocol: body.protocol,
         initialized: body.initialized,
+        endpoint,
       };
     } else {
-      health = { reachable: false, error: res.error };
+      health = { reachable: false, error: res.error, endpoint };
     }
   } else {
-    health = { reachable: false, error: `no token found in ${RUNNER_ENV_PATH}` };
+    health = { reachable: false, error: `no token found in ${RUNNER_ENV_PATH}`, endpoint };
   }
 
   // Artifact marker (written by runner/artifacts.ts next to the rootfs).
@@ -563,11 +701,14 @@ export async function runnerDoctorCommand(opts: RunnerDoctorOptions = {}): Promi
   const svc = report.service;
   const svcLine = `${svc.active ? "✓" : "✗"} systemd: ${svc.state}${svc.enabled ? " (enabled)" : svc.installed ? " (not enabled)" : " (unit not installed)"}`;
   const health = report.health;
+  // Show WHERE the probe went — the socket path for a UDS install, host:port
+  // for TCP — so a wrong-transport misconfig is visible at a glance.
+  const at = health.endpoint ? ` (${health.endpoint})` : "";
   const healthLine = health.reachable
-    ? `${health.status === 200 ? "✓" : "✗"} daemon /v1/health: HTTP ${health.status}` +
+    ? `${health.status === 200 ? "✓" : "✗"} daemon /v1/health${at}: HTTP ${health.status}` +
       (health.protocol !== undefined ? `, protocol ${health.protocol}` : "") +
       (health.initialized ? ", initialized" : "")
-    : `✗ daemon /v1/health: unreachable${health.error ? ` (${health.error})` : ""}`;
+    : `✗ daemon /v1/health${at}: unreachable${health.error ? ` (${health.error})` : ""}`;
   const artLine = report.artifacts.version
     ? `✓ guest artifacts: ${report.artifacts.version} (protocol ${report.artifacts.guestProtocol ?? "?"})`
     : "• guest artifacts: not yet installed (daemon downloads them on first boot)";

--- a/apps/cli/src/lib/doctor.ts
+++ b/apps/cli/src/lib/doctor.ts
@@ -334,16 +334,42 @@ export async function defaultProbeFirecracker(
   token: string,
   fetchImpl: typeof fetch = fetch,
 ): Promise<FirecrackerHealth> {
-  const base = url.replace(/\/+$/, "");
+  // A unix:// URL stays VERBATIM (its path names a filesystem node —
+  // stripping a trailing slash would change which node we dial); the
+  // trailing-slash normalization is an http(s)-only concern.
+  const isUnix = url.startsWith("unix://");
+  const base = isUnix ? url : url.replace(/\/+$/, "");
+  let socketPath: string | undefined;
+  if (isUnix) {
+    // Same policy as the platform's parseRunnerTransport: the two-slash
+    // typo (`unix://var/run/x.sock`) parses "var" as a hostname and would
+    // silently probe the WRONG socket — refuse instead. (The platform
+    // refuses the same URL at boot; the doctor must not contradict it.)
+    let parsed: URL;
+    try {
+      parsed = new URL(base);
+    } catch {
+      return { status: "unreachable", url: base, detail: "not a valid unix:// URL" };
+    }
+    if (parsed.hostname !== "") {
+      return {
+        status: "unreachable",
+        url: base,
+        detail:
+          `unix:// URL has a host component ("${parsed.hostname}") — a socket path ` +
+          `needs THREE slashes: unix:///${parsed.hostname}${parsed.pathname}`,
+      };
+    }
+    socketPath = decodeURIComponent(parsed.pathname);
+  }
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 3000);
   try {
     // UDS: the http:// authority is a placeholder (feeds only the Host
     // header); Bun dials the socket instead of the network.
-    const isUnix = base.startsWith("unix://");
     const target = isUnix ? "http://appstrate-runner/v1/health" : `${base}/v1/health`;
     const res = await fetchImpl(target, {
-      ...(isUnix ? { unix: new URL(base).pathname } : {}),
+      ...(isUnix ? { unix: socketPath } : {}),
       headers: token ? { authorization: `Bearer ${token}` } : {},
       signal: controller.signal,
     });
@@ -353,11 +379,15 @@ export async function defaultProbeFirecracker(
     if (res.ok) return { status: "ok", url: base };
     return { status: "unreachable", url: base, detail: `HTTP ${res.status}` };
   } catch (err) {
-    return {
-      status: "unreachable",
-      url: base,
-      detail: err instanceof Error ? err.message : String(err),
-    };
+    const message = err instanceof Error ? err.message : String(err);
+    // A permission error on the socket is the rootless-doctor false
+    // negative: the daemon is likely fine, this process just cannot open
+    // a 0660 root:root node — say so instead of reporting "daemon down".
+    const detail =
+      isUnix && /EACCES|permission denied/i.test(message)
+        ? `${message} — the socket is root-owned (mode 0660 by default); re-run with sudo`
+        : message;
+    return { status: "unreachable", url: base, detail };
   } finally {
     clearTimeout(timer);
   }

--- a/apps/cli/src/lib/doctor.ts
+++ b/apps/cli/src/lib/doctor.ts
@@ -321,16 +321,29 @@ async function defaultReadEnvFile(dir: string): Promise<string | null> {
  * any other status or connection error → unreachable. Never throws (a
  * connection failure is the common "daemon down" case, reported as
  * `unreachable`). The deep check is `appstrate runner doctor`.
+ *
+ * `unix://<abs path>` URLs (same-host UDS transport) are dialed through
+ * Bun's `fetch(…, { unix })` — the CLI runs on the host, so it can open the
+ * daemon's socket directly, with the same token/status interpretation as
+ * TCP. The socket path is the URL's pathname (three-slash form:
+ * `unix:///run/appstrate-runner/runner.sock`), matching how the platform
+ * parses FIRECRACKER_RUNNER_URL. `fetchImpl` is injectable for tests only.
  */
 export async function defaultProbeFirecracker(
   url: string,
   token: string,
+  fetchImpl: typeof fetch = fetch,
 ): Promise<FirecrackerHealth> {
   const base = url.replace(/\/+$/, "");
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 3000);
   try {
-    const res = await fetch(`${base}/v1/health`, {
+    // UDS: the http:// authority is a placeholder (feeds only the Host
+    // header); Bun dials the socket instead of the network.
+    const isUnix = base.startsWith("unix://");
+    const target = isUnix ? "http://appstrate-runner/v1/health" : `${base}/v1/health`;
+    const res = await fetchImpl(target, {
+      ...(isUnix ? { unix: new URL(base).pathname } : {}),
       headers: token ? { authorization: `Bearer ${token}` } : {},
       signal: controller.signal,
     });

--- a/apps/cli/src/lib/install/secrets.ts
+++ b/apps/cli/src/lib/install/secrets.ts
@@ -306,6 +306,16 @@ export function generateEnvForTier(
     env.MODULES = FIRECRACKER_MODULES;
     if (runBackend.runnerUrl) env.FIRECRACKER_RUNNER_URL = runBackend.runnerUrl;
     if (runBackend.runnerToken) env.FIRECRACKER_RUNNER_TOKEN = runBackend.runnerToken;
+    // UDS transport: the compose templates mount
+    // ${APPSTRATE_RUNNER_SOCKET_DIR:-./data/appstrate-runner} at
+    // /run/appstrate-runner in the platform container. Point the host side
+    // at the daemon's real socket dir — without this key the mount falls
+    // back to an empty local dir and the platform would dial a socket that
+    // never appears.
+    if (runBackend.runnerUrl?.startsWith("unix://")) {
+      const socketPath = runBackend.runnerUrl.slice("unix://".length);
+      env.APPSTRATE_RUNNER_SOCKET_DIR = socketPath.slice(0, socketPath.lastIndexOf("/")) || "/";
+    }
   }
 
   return env;

--- a/apps/cli/src/lib/install/secrets.ts
+++ b/apps/cli/src/lib/install/secrets.ts
@@ -122,6 +122,13 @@ export interface RunBackendEnv {
   runnerUrl?: string;
   /** FIRECRACKER_RUNNER_TOKEN — shared bearer secret. Only for the firecracker adapter. */
   runnerToken?: string;
+  /**
+   * Operator explicitly accepted a plaintext `http://` runner URL to a
+   * non-loopback host. The platform refuses that transport at boot by
+   * default, so the install writes `FIRECRACKER_RUNNER_TLS_REQUIRED=0`
+   * alongside — otherwise the generated `.env` would not boot.
+   */
+  plaintextOptIn?: boolean;
 }
 
 export interface BootstrapOverrides {
@@ -306,6 +313,11 @@ export function generateEnvForTier(
     env.MODULES = FIRECRACKER_MODULES;
     if (runBackend.runnerUrl) env.FIRECRACKER_RUNNER_URL = runBackend.runnerUrl;
     if (runBackend.runnerToken) env.FIRECRACKER_RUNNER_TOKEN = runBackend.runnerToken;
+    // Plaintext http:// to a non-loopback daemon is REFUSED by the platform
+    // at boot unless this escape hatch is set — the operator opted in during
+    // the install (VPN/WireGuard link), so write it or the install ships a
+    // `.env` that never boots.
+    if (runBackend.plaintextOptIn) env.FIRECRACKER_RUNNER_TLS_REQUIRED = "0";
     // UDS transport: the compose templates mount
     // ${APPSTRATE_RUNNER_SOCKET_DIR:-./data/appstrate-runner} at
     // /run/appstrate-runner in the platform container. Point the host side

--- a/apps/cli/src/lib/install/secrets.ts
+++ b/apps/cli/src/lib/install/secrets.ts
@@ -114,7 +114,11 @@ export interface PortOverrides {
  */
 export interface RunBackendEnv {
   adapter: "docker" | "firecracker";
-  /** FIRECRACKER_RUNNER_URL — http://<ip>:3100. Only for the firecracker adapter. */
+  /**
+   * FIRECRACKER_RUNNER_URL — `http://<ip>:3100` (remote KVM host) or
+   * `unix:///run/appstrate-runner/runner.sock` (same-host UDS transport).
+   * Only for the firecracker adapter.
+   */
   runnerUrl?: string;
   /** FIRECRACKER_RUNNER_TOKEN — shared bearer secret. Only for the firecracker adapter. */
   runnerToken?: string;
@@ -295,7 +299,8 @@ export function generateEnvForTier(
   // Firecracker execution backend (Docker tiers only — never reached on
   // tier 0, which returns above). Switches RUN_ADAPTER away from the
   // compose default `docker` and loads the `firecracker` module so the
-  // platform talks to the runner daemon over HTTP.
+  // platform talks to the runner daemon — over TCP (remote KVM host) or
+  // the co-located unix socket (same-host, unix:// runner URL).
   if (runBackend.adapter === "firecracker") {
     env.RUN_ADAPTER = "firecracker";
     env.MODULES = FIRECRACKER_MODULES;

--- a/apps/cli/src/lib/runner/config-files.ts
+++ b/apps/cli/src/lib/runner/config-files.ts
@@ -239,7 +239,7 @@ export function parseRunnerEnvFile(text: string): Record<string, string> {
  *                                makes /run read-only, so the daemon could
  *                                not bind its socket there. For the canonical
  *                                /run/appstrate-runner location we let systemd
- *                                own the dir (created 0770 at start).
+ *                                own the dir (created 0771 at start).
  *                                RuntimeDirectoryPreserve=yes is REQUIRED:
  *                                the platform container bind-mounts this dir,
  *                                and a bind mount pins the directory INODE —
@@ -255,10 +255,10 @@ export function parseRunnerEnvFile(text: string): Record<string, string> {
 export function renderRunnerUnit(config: RunnerConfig): string {
   // UDS transport: the socket's parent dir must be writable under
   // ProtectSystem=strict. The canonical /run/appstrate-runner location gets
-  // the systemd RuntimeDirectory treatment (create 0770, PRESERVED across
+  // the systemd RuntimeDirectory treatment (create 0771, PRESERVED across
   // restarts — see the doc-comment: the platform container's bind mount pins
-  // the dir inode); any other parent is the operator's own dir — just carve
-  // it writable.
+  // the dir inode); any other parent is the operator's own dir — pre-create
+  // it (privileged ExecStartPre) and carve it writable.
   const socketDirLines: string[] = [];
   if (config.socketPath) {
     const socketDir = dirname(config.socketPath);
@@ -267,13 +267,19 @@ export function renderRunnerUnit(config: RunnerConfig): string {
         "# UDS transport: systemd owns the socket dir (strict /run is read-only).",
         "# Preserve=yes: the platform container bind-mounts this dir — recreating",
         "# it on restart would strand the container on the old directory inode.",
+        "# Mode 0771 (o=x, not o=rwx): a rootless / userns-remapped platform",
+        "# container needs TRAVERSAL to reach the socket; the socket's own mode",
+        "# (FIRECRACKER_RUNNER_SOCKET_MODE) + the bearer token stay the gates.",
         `RuntimeDirectory=${RUNNER_RUNTIME_DIR.replace(/^\/run\//, "")}`,
-        "RuntimeDirectoryMode=0770",
+        "RuntimeDirectoryMode=0771",
         "RuntimeDirectoryPreserve=yes",
       );
     } else {
       socketDirLines.push(
-        "# UDS transport: custom socket dir carved writable (strict FS otherwise).",
+        "# UDS transport: custom socket dir — pre-created OUTSIDE the sandbox",
+        "# (`+` prefix; ReadWritePaths on a missing dir is a no-op and the daemon",
+        "# cannot mkdir a parent under ProtectSystem=strict), then carved writable.",
+        `ExecStartPre=+/bin/mkdir -p ${socketDir}`,
         `ReadWritePaths=${socketDir}`,
       );
     }

--- a/apps/cli/src/lib/runner/config-files.ts
+++ b/apps/cli/src/lib/runner/config-files.ts
@@ -8,9 +8,11 @@
  */
 
 import { randomBytes } from "node:crypto";
+import { dirname } from "node:path";
 import {
   RUNNER_BIN_PATH,
   RUNNER_ENV_PATH,
+  RUNNER_RUNTIME_DIR,
   RUNNER_SERVICE_NAME,
   runnerDataPaths,
 } from "./constants.ts";
@@ -25,6 +27,14 @@ export interface RunnerConfig {
   port: number;
   /** Bind address (default 0.0.0.0). */
   host: string;
+  /**
+   * UDS transport (same-host topology): absolute path the daemon binds its
+   * unix socket at instead of a TCP listener. Mutually exclusive with the
+   * TCP listen surface — when set, the host/port lines are NOT rendered
+   * (the daemon treats FIRECRACKER_RUNNER_SOCKET as authoritative). The
+   * platform dials it as `FIRECRACKER_RUNNER_URL=unix://<path>`.
+   */
+  socketPath?: string;
   /** State root — kernel/rootfs/runs/firecracker all live under here. */
   dataDir: string;
   /**
@@ -87,6 +97,7 @@ export function renderRunnerEnvFile(config: RunnerConfig): string {
   rejectNewline("token", config.token);
   rejectNewline("platformUrl", config.platformUrl);
   rejectNewline("host", config.host);
+  rejectNewline("socketPath", config.socketPath);
   rejectNewline("artifactsVersion", config.artifactsVersion);
   rejectNewline("FIRECRACKER_ARTIFACTS_PUBKEY", config.artifactsPubkey);
 
@@ -111,8 +122,11 @@ export function renderRunnerEnvFile(config: RunnerConfig): string {
     "# --- Daemon listen/link surface (runner/env.ts) ---",
     `FIRECRACKER_RUNNER_TOKEN=${config.token}`,
     `FIRECRACKER_RUNNER_PLATFORM_URL=${config.platformUrl}`,
-    `FIRECRACKER_RUNNER_HOST=${config.host}`,
-    `FIRECRACKER_RUNNER_PORT=${config.port}`,
+    // UDS transport replaces the TCP listen surface entirely: the daemon
+    // binds the socket (mode 0660 by default) and never opens a port.
+    ...(config.socketPath
+      ? [`FIRECRACKER_RUNNER_SOCKET=${config.socketPath}`]
+      : [`FIRECRACKER_RUNNER_HOST=${config.host}`, `FIRECRACKER_RUNNER_PORT=${config.port}`]),
     "",
     "# --- Engine host config (runner/host-env.ts) — absolute paths so the",
     "#     compiled daemon does not depend on its launch working directory. ---",
@@ -221,8 +235,49 @@ export function parseRunnerEnvFile(text: string): Record<string, string> {
  *                                in /usr/sbin://sbin, which systemd's default
  *                                unit PATH omits. Without this the daemon
  *                                spawns fail with ENOENT at first run.
+ *   - RuntimeDirectory=…       → UDS transport only: ProtectSystem=strict
+ *                                makes /run read-only, so the daemon could
+ *                                not bind its socket there. For the canonical
+ *                                /run/appstrate-runner location we let systemd
+ *                                own the dir (created 0770 at start).
+ *                                RuntimeDirectoryPreserve=yes is REQUIRED:
+ *                                the platform container bind-mounts this dir,
+ *                                and a bind mount pins the directory INODE —
+ *                                if systemd removed and recreated the dir on
+ *                                a daemon restart (the default), the container
+ *                                would keep the orphaned inode and never see
+ *                                the new socket until its own restart. The
+ *                                tmpfs still clears it on reboot (when the
+ *                                container remounts anyway). A custom socket
+ *                                parent gets a plain ReadWritePaths carve-out
+ *                                instead.
  */
 export function renderRunnerUnit(config: RunnerConfig): string {
+  // UDS transport: the socket's parent dir must be writable under
+  // ProtectSystem=strict. The canonical /run/appstrate-runner location gets
+  // the systemd RuntimeDirectory treatment (create 0770, PRESERVED across
+  // restarts — see the doc-comment: the platform container's bind mount pins
+  // the dir inode); any other parent is the operator's own dir — just carve
+  // it writable.
+  const socketDirLines: string[] = [];
+  if (config.socketPath) {
+    const socketDir = dirname(config.socketPath);
+    if (socketDir === RUNNER_RUNTIME_DIR) {
+      socketDirLines.push(
+        "# UDS transport: systemd owns the socket dir (strict /run is read-only).",
+        "# Preserve=yes: the platform container bind-mounts this dir — recreating",
+        "# it on restart would strand the container on the old directory inode.",
+        `RuntimeDirectory=${RUNNER_RUNTIME_DIR.replace(/^\/run\//, "")}`,
+        "RuntimeDirectoryMode=0770",
+        "RuntimeDirectoryPreserve=yes",
+      );
+    } else {
+      socketDirLines.push(
+        "# UDS transport: custom socket dir carved writable (strict FS otherwise).",
+        `ReadWritePaths=${socketDir}`,
+      );
+    }
+  }
   return [
     "[Unit]",
     "Description=Appstrate Firecracker runner daemon",
@@ -270,6 +325,7 @@ export function renderRunnerUnit(config: RunnerConfig): string {
     // `ip netns add` writes under /run/netns — carve just that path writable
     // (paired with the ExecStartPre above that guarantees the dir exists).
     "ReadWritePaths=/run/netns",
+    ...socketDirLines,
     "ProtectHome=true",
     "ProtectClock=true",
     "",

--- a/apps/cli/src/lib/runner/constants.ts
+++ b/apps/cli/src/lib/runner/constants.ts
@@ -60,6 +60,25 @@ export const RUNNER_DATA_DIR = "/var/lib/appstrate-runner";
 export const RUNNER_DEFAULT_PORT = 3100;
 
 /**
+ * Runtime dir for the co-located (same-host) UDS transport. The daemon can
+ * serve its /v1 API over a unix socket instead of TCP: when the platform
+ * container and the daemon share one box, the socket removes the network
+ * listener entirely — no port, no firewall rule, and no plaintext-HTTP
+ * wire for the fail-closed non-loopback guard to refuse. The systemd unit
+ * declares `RuntimeDirectory=appstrate-runner` so systemd creates/cleans
+ * this tmpfs dir (`ProtectSystem=strict` makes /run read-only otherwise).
+ */
+export const RUNNER_RUNTIME_DIR = "/run/appstrate-runner";
+
+/**
+ * Canonical socket path for the UDS transport. The daemon binds it
+ * (FIRECRACKER_RUNNER_SOCKET, mode 0660 by default); the platform container
+ * bind-mounts {@link RUNNER_RUNTIME_DIR} and dials
+ * `FIRECRACKER_RUNNER_URL=unix://<this path>`.
+ */
+export const RUNNER_DEFAULT_SOCKET_PATH = "/run/appstrate-runner/runner.sock";
+
+/**
  * Firecracker VMM version the daemon is validated against. The engine
  * enforces `>= 1.16` at initialize() (older releases are exposed to
  * CVE-2026-5747); pin the exact release the repo's build scripts already

--- a/apps/cli/test/doctor.test.ts
+++ b/apps/cli/test/doctor.test.ts
@@ -643,6 +643,46 @@ describe("defaultProbeFirecracker — unix:// runner URL (UDS transport, #868)",
     expect(health.status).toBe("unauthorized");
     expect(health.detail).toBe("HTTP 401");
   });
+
+  it("refuses the two-slash unix typo instead of probing the wrong socket", async () => {
+    // unix://var/run/x.sock parses "var" as a hostname — probing
+    // /run/x.sock would contradict the platform's boot refusal of the
+    // same URL. No fetch must happen.
+    const { calls, fetchImpl } = capturingFetch(200);
+    const health = await defaultProbeFirecracker(
+      "unix://var/run/x.sock",
+      "tok-abcdef1234567890",
+      fetchImpl,
+    );
+    expect(health.status).toBe("unreachable");
+    expect(health.detail).toContain("THREE slashes");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("keeps a unix:// URL verbatim — no trailing-slash strip on a socket path", async () => {
+    const { calls, fetchImpl } = capturingFetch(200);
+    await defaultProbeFirecracker(
+      // A trailing slash on a unix path names a DIFFERENT node — the
+      // http(s)-only normalization must not touch it.
+      "unix:///run/appstrate-runner/runner.sock/",
+      "tok-abcdef1234567890",
+      fetchImpl,
+    );
+    expect(calls[0]!.init?.unix).toBe("/run/appstrate-runner/runner.sock/");
+  });
+
+  it("appends a sudo hint when the socket probe fails with EACCES (rootless doctor)", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("EACCES: permission denied, connect");
+    }) as unknown as typeof fetch;
+    const health = await defaultProbeFirecracker(
+      "unix:///run/appstrate-runner/runner.sock",
+      "tok-abcdef1234567890",
+      fetchImpl,
+    );
+    expect(health.status).toBe("unreachable");
+    expect(health.detail).toContain("re-run with sudo");
+  });
 });
 
 describe("internal info payload", () => {

--- a/apps/cli/test/doctor.test.ts
+++ b/apps/cli/test/doctor.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect } from "bun:test";
 import {
+  defaultProbeFirecracker,
   formatDoctorReport,
   runDoctor,
   type FirecrackerHealth,
@@ -588,6 +589,59 @@ describe("runDoctor — Firecracker runner reachability (#819)", () => {
     });
     expect(report.firecracker).toBeUndefined();
     expect(probed).toBe(false);
+  });
+});
+
+describe("defaultProbeFirecracker — unix:// runner URL (UDS transport, #868)", () => {
+  /** Fake fetch capturing the target + init so we can assert the unix option. */
+  function capturingFetch(status: number) {
+    const calls: Array<{ input: string; init?: RequestInit & { unix?: string } }> = [];
+    const fetchImpl = (async (input: unknown, init?: RequestInit & { unix?: string }) => {
+      calls.push({ input: String(input), init });
+      return new Response("{}", { status });
+    }) as unknown as typeof fetch;
+    return { calls, fetchImpl };
+  }
+
+  it("dials the socket via the fetch `unix` option (path from the three-slash URL)", async () => {
+    const { calls, fetchImpl } = capturingFetch(200);
+    const health = await defaultProbeFirecracker(
+      "unix:///run/appstrate-runner/runner.sock",
+      "tok-abcdef1234567890",
+      fetchImpl,
+    );
+    expect(health).toEqual({ status: "ok", url: "unix:///run/appstrate-runner/runner.sock" });
+    expect(calls).toHaveLength(1);
+    // The authority is a placeholder; the socket path is what gets dialed.
+    expect(calls[0]!.input).toBe("http://appstrate-runner/v1/health");
+    expect(calls[0]!.init?.unix).toBe("/run/appstrate-runner/runner.sock");
+    // Same bearer-token behavior as the TCP probe.
+    expect((calls[0]!.init?.headers as Record<string, string>).authorization).toBe(
+      "Bearer tok-abcdef1234567890",
+    );
+  });
+
+  it("keeps the TCP path untouched: no unix option, URL dialed directly", async () => {
+    const { calls, fetchImpl } = capturingFetch(200);
+    const health = await defaultProbeFirecracker(
+      "http://10.0.0.9:3100",
+      "tok-abcdef1234567890",
+      fetchImpl,
+    );
+    expect(health.status).toBe("ok");
+    expect(calls[0]!.input).toBe("http://10.0.0.9:3100/v1/health");
+    expect(calls[0]!.init?.unix).toBeUndefined();
+  });
+
+  it("classifies a 401 over the socket as unauthorized (status logic unchanged)", async () => {
+    const { fetchImpl } = capturingFetch(401);
+    const health = await defaultProbeFirecracker(
+      "unix:///run/appstrate-runner/runner.sock",
+      "wrong-token-1234567890",
+      fetchImpl,
+    );
+    expect(health.status).toBe("unauthorized");
+    expect(health.detail).toBe("HTTP 401");
   });
 });
 

--- a/apps/cli/test/install.test.ts
+++ b/apps/cli/test/install.test.ts
@@ -1226,17 +1226,21 @@ describe("resolveRunBackend — non-interactive firecracker validation matrix", 
 });
 
 describe("resolveRunBackend — firecracker same-host", () => {
-  it("builds runner + platform URLs and mints a token from --host-ip", async () => {
+  it("uses the unix-socket runner URL and still builds the LAN platform URL from --host-ip", async () => {
     const cfg = await resolveRunBackend(
       { runAdapter: "firecracker", hostIp: "10.0.0.5", appPort: 8080, nonInteractive: true },
       { generateToken: () => "generated-token-abcdef1234" },
     );
     expect(cfg).toEqual({
       adapter: "firecracker",
-      runnerUrl: "http://10.0.0.5:3100",
+      // Same-host = UDS: no TCP port, no plaintext wire — the beta.38
+      // fail-closed http-to-non-loopback guard has nothing to refuse.
+      runnerUrl: "unix:///run/appstrate-runner/runner.sock",
       token: "generated-token-abcdef1234",
       tokenSource: "generated",
       topology: "same-host",
+      // hostIp is STILL collected: guests reach the platform over the LAN
+      // (platformUrl) — only the platform↔daemon leg moved onto the socket.
       hostIp: "10.0.0.5",
       platformUrl: "http://10.0.0.5:8080",
     } satisfies RunBackendConfig);
@@ -1339,7 +1343,7 @@ describe("runner-install command builder + follow-up", () => {
     ).toEqual(["/opt/homebrew/bin/bun", "/repo/apps/cli/src/cli.ts"]);
   });
 
-  it("buildRunnerInstallArgs carries --platform-url and --token", () => {
+  it("buildRunnerInstallArgs carries --platform-url, --token, and the UDS --socket", () => {
     const args = buildRunnerInstallArgs(
       ["/usr/local/bin/appstrate"],
       "http://10.0.0.5:3000",
@@ -1353,6 +1357,8 @@ describe("runner-install command builder + follow-up", () => {
       "http://10.0.0.5:3000",
       "--token",
       "the-token",
+      "--socket",
+      "/run/appstrate-runner/runner.sock",
       "--yes",
     ]);
   });
@@ -1373,10 +1379,10 @@ describe("runner-install command builder + follow-up", () => {
     expect(note).toContain("appstrate runner status");
   });
 
-  it("firecrackerFollowupNote (same-host) prints lifecycle hints, no curl one-liner", () => {
+  it("firecrackerFollowupNote (same-host) explains the socket + bind-mount, no curl one-liner", () => {
     const note = firecrackerFollowupNote({
       adapter: "firecracker",
-      runnerUrl: "http://10.0.0.5:3100",
+      runnerUrl: "unix:///run/appstrate-runner/runner.sock",
       token: "tok-123456",
       tokenSource: "generated",
       topology: "same-host",
@@ -1384,6 +1390,9 @@ describe("runner-install command builder + follow-up", () => {
       platformUrl: "http://10.0.0.5:3000",
     });
     expect(note).not.toContain("curl -fsSL");
+    expect(note).toContain("unix:///run/appstrate-runner/runner.sock");
+    expect(note).toContain("bind-mount");
+    expect(note).toContain("/run/appstrate-runner");
     expect(note).toContain("appstrate runner logs -f");
   });
 });
@@ -1391,7 +1400,7 @@ describe("runner-install command builder + follow-up", () => {
 describe("runSameHostRunnerInstall", () => {
   const rb = {
     adapter: "firecracker",
-    runnerUrl: "http://10.0.0.5:3100",
+    runnerUrl: "unix:///run/appstrate-runner/runner.sock",
     token: "pairing-token-123456",
     tokenSource: "generated",
     topology: "same-host",
@@ -1399,7 +1408,7 @@ describe("runSameHostRunnerInstall", () => {
     platformUrl: "http://10.0.0.5:3000",
   } satisfies RunBackendConfig;
 
-  it("interactive + exit 0: spawns sudo, no warning, no manual-command note", async () => {
+  it("interactive + exit 0: spawns sudo in UDS mode, no warning, no manual-command note", async () => {
     const runCalls: Array<{ cmd: string; args: string[] }> = [];
     const notes: string[] = [];
     const warns: string[] = [];
@@ -1416,6 +1425,11 @@ describe("runSameHostRunnerInstall", () => {
     });
     expect(runCalls).toHaveLength(1);
     expect(runCalls[0]?.cmd).toBe("sudo");
+    // Same-host installs the daemon in UDS mode — the sudo argv carries the
+    // canonical socket so the daemon matches the unix:// URL in the .env.
+    const argv = runCalls[0]?.args ?? [];
+    expect(argv).toContain("--socket");
+    expect(argv[argv.indexOf("--socket") + 1]).toBe("/run/appstrate-runner/runner.sock");
     expect(warns).toHaveLength(0);
     expect(notes).toHaveLength(0);
   });
@@ -1435,6 +1449,7 @@ describe("runSameHostRunnerInstall", () => {
     expect(warning).toContain("sudo /usr/local/bin/appstrate runner install");
     expect(warning).toContain("--platform-url http://10.0.0.5:3000");
     expect(warning).toContain("--token pairing-token-123456");
+    expect(warning).toContain("--socket /run/appstrate-runner/runner.sock");
   });
 
   it("non-interactive: never spawns, prints the manual sudo command instead", async () => {
@@ -1457,6 +1472,7 @@ describe("runSameHostRunnerInstall", () => {
     expect(note).toContain("sudo /usr/local/bin/appstrate runner install");
     expect(note).toContain("--platform-url http://10.0.0.5:3000");
     expect(note).toContain("--token pairing-token-123456");
+    expect(note).toContain("--socket /run/appstrate-runner/runner.sock");
   });
 });
 

--- a/apps/cli/test/install.test.ts
+++ b/apps/cli/test/install.test.ts
@@ -1210,10 +1210,12 @@ describe("resolveRunBackend — non-interactive firecracker validation matrix", 
     expect(warnings).toEqual([]);
   });
 
-  it("warns loudly on a plaintext http:// --runner-url to a non-loopback host", async () => {
-    // The platform refuses this URL at boot (fail-closed) — the installer
-    // must say so at write time, with the exact remediation, instead of
-    // letting the operator discover a crash-looping platform later.
+  it("warns AND opts in on a plaintext http:// --runner-url to a non-loopback host", async () => {
+    // The platform refuses this transport at boot (fail-closed). An explicit
+    // plaintext --runner-url counts as the opt-in (flags stay scriptable), so
+    // the resolver flags plaintextOptIn — generateEnvForTier then writes
+    // FIRECRACKER_RUNNER_TLS_REQUIRED=0, otherwise the install ships a .env
+    // the platform rejects until hand-edited.
     const warnings: string[] = [];
     const cfg = await resolveRunBackend(
       {
@@ -1226,14 +1228,15 @@ describe("resolveRunBackend — non-interactive firecracker validation matrix", 
       { warn: (m) => warnings.push(m), detectLanIpv4: () => "10.0.0.5" },
     );
     expect(cfg.adapter === "firecracker" && cfg.runnerUrl).toBe("http://10.0.0.9:3100");
+    expect(cfg.adapter === "firecracker" && cfg.plaintextOptIn).toBe(true);
     expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain("REFUSES this at boot");
     expect(warnings[0]).toContain("FIRECRACKER_RUNNER_TLS_REQUIRED=0");
+    expect(warnings[0]).toContain("https://");
   });
 
   it("does not warn on a loopback http:// --runner-url (gate exempts loopback)", async () => {
     const warnings: string[] = [];
-    await resolveRunBackend(
+    const cfg = await resolveRunBackend(
       {
         runAdapter: "firecracker",
         runnerUrl: "http://127.0.0.1:3100",
@@ -1244,6 +1247,7 @@ describe("resolveRunBackend — non-interactive firecracker validation matrix", 
       { warn: (m) => warnings.push(m), detectLanIpv4: () => "10.0.0.5" },
     );
     expect(warnings).toEqual([]);
+    expect(cfg.adapter === "firecracker" && cfg.plaintextOptIn).toBe(false);
   });
 
   it("rejects an out-of-range-octet --runner-url (dotted-quad shape, bad octets)", async () => {
@@ -1299,6 +1303,7 @@ describe("resolveRunBackend — firecracker same-host", () => {
       // (platformUrl) — only the platform↔daemon leg moved onto the socket.
       hostIp: "10.0.0.5",
       platformUrl: "http://10.0.0.5:8080",
+      plaintextOptIn: false,
     } satisfies RunBackendConfig);
   });
 
@@ -1380,6 +1385,82 @@ describe("resolveRunBackend — interactive prompts", () => {
     expect(cfg.hostIp).toBe("10.1.2.3");
     expect(prompts.some((p) => p.endsWith("::10.1.2.3"))).toBe(true);
   });
+
+  it("remote bare-IP prompt + confirmed plaintext → warns and opts in to TLS_REQUIRED=0", async () => {
+    const warnings: string[] = [];
+    const confirms: string[] = [];
+    const askText = (async (msg: string, initial?: string) =>
+      msg.includes("Runner (KVM host) URL") ? "10.0.0.9" : (initial ?? "")) as unknown as AskText;
+    const cfg = await resolveRunBackend(
+      { appPort: 3000, nonInteractive: false, runnerToken: "x".repeat(16) },
+      {
+        select: asSelect(async (opts) =>
+          opts.message.toLowerCase().includes("backend") ? "firecracker" : "remote",
+        ),
+        isCancel: noCancel,
+        askText,
+        confirm: (async (opts: { message: string }) => {
+          confirms.push(opts.message);
+          return true;
+        }) as unknown as typeof import("@clack/prompts").confirm,
+        detectLanIpv4: () => "192.168.1.20",
+        warn: (m) => warnings.push(m),
+      },
+    );
+    if (cfg.adapter !== "firecracker") throw new Error("expected firecracker");
+    expect(cfg.runnerUrl).toBe("http://10.0.0.9:3100");
+    expect(cfg.plaintextOptIn).toBe(true);
+    expect(warnings).toHaveLength(1);
+    expect(confirms).toHaveLength(1);
+    expect(confirms[0]).toContain("FIRECRACKER_RUNNER_TLS_REQUIRED=0");
+  });
+
+  it("remote plaintext prompt DECLINED → throws with the https remediation", async () => {
+    const askText = (async (msg: string, initial?: string) =>
+      msg.includes("Runner (KVM host) URL") ? "10.0.0.9" : (initial ?? "")) as unknown as AskText;
+    await expect(
+      resolveRunBackend(
+        { appPort: 3000, nonInteractive: false, runnerToken: "x".repeat(16) },
+        {
+          select: asSelect(async (opts) =>
+            opts.message.toLowerCase().includes("backend") ? "firecracker" : "remote",
+          ),
+          isCancel: noCancel,
+          askText,
+          confirm: (async () => false) as unknown as typeof import("@clack/prompts").confirm,
+          detectLanIpv4: () => "192.168.1.20",
+          warn: () => {},
+        },
+      ),
+    ).rejects.toThrow(/https:\/\/<host>/);
+  });
+
+  it("remote https URL at the prompt → no confirm, no opt-in", async () => {
+    const askText = (async (msg: string, initial?: string) =>
+      msg.includes("Runner (KVM host) URL")
+        ? "https://runner.example.com:3100"
+        : (initial ?? "")) as unknown as AskText;
+    const cfg = await resolveRunBackend(
+      { appPort: 3000, nonInteractive: false, runnerToken: "x".repeat(16) },
+      {
+        select: asSelect(async (opts) =>
+          opts.message.toLowerCase().includes("backend") ? "firecracker" : "remote",
+        ),
+        isCancel: noCancel,
+        askText,
+        confirm: (async () => {
+          throw new Error("confirm must not be called for https");
+        }) as unknown as typeof import("@clack/prompts").confirm,
+        detectLanIpv4: () => "192.168.1.20",
+        warn: (m) => {
+          throw new Error(`unexpected warning: ${m}`);
+        },
+      },
+    );
+    if (cfg.adapter !== "firecracker") throw new Error("expected firecracker");
+    expect(cfg.runnerUrl).toBe("https://runner.example.com:3100");
+    expect(cfg.plaintextOptIn).toBe(false);
+  });
 });
 
 describe("runner-install command builder + follow-up", () => {
@@ -1428,6 +1509,7 @@ describe("runner-install command builder + follow-up", () => {
       topology: "remote",
       hostIp: "192.168.1.20",
       platformUrl: "http://192.168.1.20:3000",
+      plaintextOptIn: true,
     });
     expect(note).toContain("curl -fsSL https://get.appstrate.dev/runner");
     expect(note).toContain("--platform-url http://192.168.1.20:3000");
@@ -1444,6 +1526,7 @@ describe("runner-install command builder + follow-up", () => {
       topology: "same-host",
       hostIp: "10.0.0.5",
       platformUrl: "http://10.0.0.5:3000",
+      plaintextOptIn: false,
     });
     expect(note).not.toContain("curl -fsSL");
     expect(note).toContain("unix:///run/appstrate-runner/runner.sock");
@@ -1462,6 +1545,7 @@ describe("runSameHostRunnerInstall", () => {
     topology: "same-host",
     hostIp: "10.0.0.5",
     platformUrl: "http://10.0.0.5:3000",
+    plaintextOptIn: false,
   } satisfies RunBackendConfig;
 
   it("interactive + exit 0: spawns sudo in UDS mode, no warning, no manual-command note", async () => {

--- a/apps/cli/test/install.test.ts
+++ b/apps/cli/test/install.test.ts
@@ -1190,24 +1190,65 @@ describe("resolveRunBackend — non-interactive firecracker validation matrix", 
     ).rejects.toThrow(/IPv4 literal/);
   });
 
-  it("rejects a non-IPv4 --runner-url", async () => {
-    await expect(
-      resolveRunBackend(
-        {
-          runAdapter: "firecracker",
-          runnerUrl: "http://runner.local:3100",
-          runnerToken: "x".repeat(16),
-          appPort: 3000,
-          nonInteractive: true,
-        },
-        {},
-      ),
-    ).rejects.toThrow(/must be http\(s\):\/\/<IPv4>/);
+  it("accepts an https hostname --runner-url (TLS reverse proxy) with no warning", async () => {
+    // The runner URL never reaches a guest, so the guests-need-IPv4 rule
+    // does not apply — a split-host daemon normally sits behind a TLS
+    // reverse proxy, which means a DNS name.
+    const warnings: string[] = [];
+    const cfg = await resolveRunBackend(
+      {
+        runAdapter: "firecracker",
+        runnerUrl: "https://runner.example.com:3100",
+        runnerToken: "x".repeat(16),
+        appPort: 3000,
+        nonInteractive: true,
+      },
+      { warn: (m) => warnings.push(m), detectLanIpv4: () => "10.0.0.5" },
+    );
+    expect(cfg.adapter).toBe("firecracker");
+    expect(cfg.adapter === "firecracker" && cfg.runnerUrl).toBe("https://runner.example.com:3100");
+    expect(warnings).toEqual([]);
   });
 
-  it("rejects an out-of-range-octet --runner-url (shared IPv4 validator)", async () => {
-    // The old `IPV4_URL_RE` regex accepted these dotted-quad-shaped hosts;
-    // the shared parseIpv4HttpUrl (like the daemon) range-checks each octet.
+  it("warns loudly on a plaintext http:// --runner-url to a non-loopback host", async () => {
+    // The platform refuses this URL at boot (fail-closed) — the installer
+    // must say so at write time, with the exact remediation, instead of
+    // letting the operator discover a crash-looping platform later.
+    const warnings: string[] = [];
+    const cfg = await resolveRunBackend(
+      {
+        runAdapter: "firecracker",
+        runnerUrl: "http://10.0.0.9:3100",
+        runnerToken: "x".repeat(16),
+        appPort: 3000,
+        nonInteractive: true,
+      },
+      { warn: (m) => warnings.push(m), detectLanIpv4: () => "10.0.0.5" },
+    );
+    expect(cfg.adapter === "firecracker" && cfg.runnerUrl).toBe("http://10.0.0.9:3100");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("REFUSES this at boot");
+    expect(warnings[0]).toContain("FIRECRACKER_RUNNER_TLS_REQUIRED=0");
+  });
+
+  it("does not warn on a loopback http:// --runner-url (gate exempts loopback)", async () => {
+    const warnings: string[] = [];
+    await resolveRunBackend(
+      {
+        runAdapter: "firecracker",
+        runnerUrl: "http://127.0.0.1:3100",
+        runnerToken: "x".repeat(16),
+        appPort: 3000,
+        nonInteractive: true,
+      },
+      { warn: (m) => warnings.push(m), detectLanIpv4: () => "10.0.0.5" },
+    );
+    expect(warnings).toEqual([]);
+  });
+
+  it("rejects an out-of-range-octet --runner-url (dotted-quad shape, bad octets)", async () => {
+    // "300.0.0.1" would pass as a plausible hostname but never resolves —
+    // a dotted-quad-shaped host must still be a VALID IPv4.
     for (const runnerUrl of ["http://300.0.0.1:3100", "http://256.256.256.256:3000"]) {
       await expect(
         resolveRunBackend(
@@ -1220,8 +1261,23 @@ describe("resolveRunBackend — non-interactive firecracker validation matrix", 
           },
           {},
         ),
-      ).rejects.toThrow(/must be http\(s\):\/\/<IPv4>/);
+      ).rejects.toThrow(/must be http\(s\):\/\/<host>/);
     }
+  });
+
+  it("rejects a non-http(s) --runner-url", async () => {
+    await expect(
+      resolveRunBackend(
+        {
+          runAdapter: "firecracker",
+          runnerUrl: "ftp://runner.example.com:3100",
+          runnerToken: "x".repeat(16),
+          appPort: 3000,
+          nonInteractive: true,
+        },
+        {},
+      ),
+    ).rejects.toThrow(/must be http\(s\):\/\/<host>/);
   });
 });
 

--- a/apps/cli/test/install/secrets.test.ts
+++ b/apps/cli/test/install/secrets.test.ts
@@ -305,6 +305,26 @@ describe("generateEnvForTier — Firecracker backend (#819)", () => {
     expect(env.MODULES).toBe("oidc,webhooks,mcp,core-providers,@appstrate/module-chat,firecracker");
     expect(env.FIRECRACKER_RUNNER_URL).toBe("http://10.0.0.5:3100");
     expect(env.FIRECRACKER_RUNNER_TOKEN).toBe("tok-abcdef1234567890");
+    // TCP transport — the compose socket-dir mount keeps its harmless default.
+    expect(env.APPSTRATE_RUNNER_SOCKET_DIR).toBeUndefined();
+  });
+
+  it("points the compose socket-dir mount at the daemon's dir for a unix:// runner URL", () => {
+    const env = generateEnvForTier(
+      3,
+      "http://localhost:3000",
+      {},
+      {},
+      {
+        adapter: "firecracker",
+        runnerUrl: "unix:///run/appstrate-runner/runner.sock",
+        runnerToken: "tok-abcdef1234567890",
+      },
+    );
+    expect(env.FIRECRACKER_RUNNER_URL).toBe("unix:///run/appstrate-runner/runner.sock");
+    // Without this key the compose mount falls back to an empty local dir
+    // and the platform would dial a socket that never appears.
+    expect(env.APPSTRATE_RUNNER_SOCKET_DIR).toBe("/run/appstrate-runner");
   });
 
   it("never emits firecracker keys on Tier 0 (option is Docker-tier only)", () => {

--- a/apps/cli/test/install/secrets.test.ts
+++ b/apps/cli/test/install/secrets.test.ts
@@ -307,6 +307,28 @@ describe("generateEnvForTier — Firecracker backend (#819)", () => {
     expect(env.FIRECRACKER_RUNNER_TOKEN).toBe("tok-abcdef1234567890");
     // TCP transport — the compose socket-dir mount keeps its harmless default.
     expect(env.APPSTRATE_RUNNER_SOCKET_DIR).toBeUndefined();
+    // No plaintext opt-in flag → the fail-closed boot guard stays armed.
+    expect(env.FIRECRACKER_RUNNER_TLS_REQUIRED).toBeUndefined();
+  });
+
+  it("writes the TLS escape hatch when the operator opted in to plaintext http", () => {
+    // Without this key the platform REFUSES the http://<lan-ip> URL at boot
+    // (assertRunnerTransportSecurity) and the install ships a .env that
+    // never boots — warn-only was the PR #874 review's P1.
+    const env = generateEnvForTier(
+      3,
+      "http://localhost:3000",
+      {},
+      {},
+      {
+        adapter: "firecracker",
+        runnerUrl: "http://10.0.0.5:3100",
+        runnerToken: "tok-abcdef1234567890",
+        plaintextOptIn: true,
+      },
+    );
+    expect(env.FIRECRACKER_RUNNER_URL).toBe("http://10.0.0.5:3100");
+    expect(env.FIRECRACKER_RUNNER_TLS_REQUIRED).toBe("0");
   });
 
   it("points the compose socket-dir mount at the daemon's dir for a unix:// runner URL", () => {

--- a/apps/cli/test/runner.test.ts
+++ b/apps/cli/test/runner.test.ts
@@ -440,12 +440,15 @@ describe("renderRunnerUnit", () => {
   it("UDS at the canonical /run location: systemd owns the socket dir (RuntimeDirectory)", () => {
     const unit = renderRunnerUnit({ ...config, socketPath: RUNNER_DEFAULT_SOCKET_PATH });
     // ProtectSystem=strict makes /run read-only — RuntimeDirectory is what
-    // lets the daemon bind its socket there (created 0770). Preserve=yes is
-    // load-bearing: the platform container bind-mounts the dir, and a
-    // remove+recreate on daemon restart would strand the container on the
-    // orphaned directory inode (new socket invisible until container restart).
+    // lets the daemon bind its socket there. Mode 0771 (not 0770): a
+    // rootless / userns-remapped platform container needs o=x TRAVERSAL to
+    // reach the socket — the socket mode + bearer token stay the gates.
+    // Preserve=yes is load-bearing: the platform container bind-mounts the
+    // dir, and a remove+recreate on daemon restart would strand the
+    // container on the orphaned directory inode (new socket invisible
+    // until container restart).
     expect(unit).toContain("RuntimeDirectory=appstrate-runner");
-    expect(unit).toContain("RuntimeDirectoryMode=0770");
+    expect(unit).toContain("RuntimeDirectoryMode=0771");
     expect(unit).toContain("RuntimeDirectoryPreserve=yes");
     expect(unit).not.toContain("ReadWritePaths=/run/appstrate-runner");
     // The rest of the hardening posture is untouched.
@@ -453,8 +456,12 @@ describe("renderRunnerUnit", () => {
     expect(unit).toContain(`ReadWritePaths=${config.dataDir}`);
   });
 
-  it("UDS at a custom parent dir: carves it writable via ReadWritePaths instead", () => {
+  it("UDS at a custom parent dir: pre-creates it (privileged) and carves it writable", () => {
     const unit = renderRunnerUnit({ ...config, socketPath: "/srv/sockets/runner.sock" });
+    // ReadWritePaths on a missing dir is a no-op and the sandboxed daemon
+    // cannot mkdir it under ProtectSystem=strict — the `+` ExecStartPre is
+    // what guarantees the dir exists on a fresh host.
+    expect(unit).toContain("ExecStartPre=+/bin/mkdir -p /srv/sockets");
     expect(unit).toContain("ReadWritePaths=/srv/sockets");
     expect(unit).not.toContain("RuntimeDirectory=");
     expect(unit).not.toContain("RuntimeDirectoryMode=");

--- a/apps/cli/test/runner.test.ts
+++ b/apps/cli/test/runner.test.ts
@@ -37,6 +37,7 @@ import {
   RUNNER_UNIT_PATH,
   RUNNER_ETC_DIR,
   RUNNER_DATA_DIR,
+  RUNNER_DEFAULT_SOCKET_PATH,
   APPSTRATE_RELEASE_BASE,
 } from "../src/lib/runner/constants.ts";
 import {
@@ -257,6 +258,58 @@ describe("resolveInstallConfig — --platform-url validation", () => {
   });
 });
 
+// ─── install config: --socket (UDS transport) ─────────────────────────────
+
+describe("resolveInstallConfig — --socket (UDS transport)", () => {
+  const deps = () =>
+    ({
+      exec: fakeExec().exec,
+      fs: fakeFs().fs,
+      http: fakeHttp({}),
+      getuid: () => 0,
+      preflight: async () => ({ ok: true, arch: "x86_64", checks: [] }),
+    }) as unknown as Parameters<typeof resolveInstallConfig>[1];
+  const base = { platformUrl: "http://10.0.0.5:3000", token: "x".repeat(16), yes: true };
+
+  it("accepts an absolute --socket and records it as the transport", async () => {
+    const { config } = await resolveInstallConfig(
+      { ...base, socket: RUNNER_DEFAULT_SOCKET_PATH },
+      deps(),
+    );
+    expect(config.socketPath).toBe(RUNNER_DEFAULT_SOCKET_PATH);
+  });
+
+  it("errors loudly when --socket is combined with --port (mutually exclusive)", async () => {
+    await expect(
+      resolveInstallConfig({ ...base, socket: RUNNER_DEFAULT_SOCKET_PATH, port: "3200" }, deps()),
+    ).rejects.toThrow(/--socket is mutually exclusive with --port\/--host/);
+  });
+
+  it("errors loudly when --socket is combined with --host (mutually exclusive)", async () => {
+    await expect(
+      resolveInstallConfig(
+        { ...base, socket: RUNNER_DEFAULT_SOCKET_PATH, host: "10.0.0.5" },
+        deps(),
+      ),
+    ).rejects.toThrow(/--socket is mutually exclusive with --port\/--host/);
+  });
+
+  it("rejects a relative or empty --socket with an actionable message", async () => {
+    for (const socket of ["runner.sock", "./runner.sock", "", "   "]) {
+      await expect(resolveInstallConfig({ ...base, socket }, deps())).rejects.toThrow(
+        /must be an absolute path/,
+      );
+    }
+  });
+
+  it("non-interactive without --socket stays TCP (backward compatible)", async () => {
+    const { config } = await resolveInstallConfig(base, deps());
+    expect(config.socketPath).toBeUndefined();
+    expect(config.port).toBe(3100);
+    expect(config.host).toBe("0.0.0.0");
+  });
+});
+
 // ─── config files ─────────────────────────────────────────────────────────
 
 const config: RunnerConfig = {
@@ -297,6 +350,25 @@ describe("renderRunnerEnvFile / parseRunnerEnvFile", () => {
   it("pins the artifacts version to the daemon release when set", () => {
     const env = parseRunnerEnvFile(renderRunnerEnvFile({ ...config, artifactsVersion: "1.2.3" }));
     expect(env.FIRECRACKER_ARTIFACTS_VERSION).toBe("1.2.3");
+  });
+
+  it("UDS transport: renders FIRECRACKER_RUNNER_SOCKET and drops the HOST/PORT lines", () => {
+    const text = renderRunnerEnvFile({ ...config, socketPath: RUNNER_DEFAULT_SOCKET_PATH });
+    const env = parseRunnerEnvFile(text);
+    expect(env.FIRECRACKER_RUNNER_SOCKET).toBe(RUNNER_DEFAULT_SOCKET_PATH);
+    // The socket REPLACES the TCP listen surface — no dual-listener ambiguity.
+    expect(text).not.toContain("FIRECRACKER_RUNNER_HOST=");
+    expect(text).not.toContain("FIRECRACKER_RUNNER_PORT=");
+    // Everything else is identical to a TCP render.
+    expect(env.FIRECRACKER_RUNNER_TOKEN).toBe(config.token);
+    expect(env.FIRECRACKER_RUNNER_PLATFORM_URL).toBe(config.platformUrl);
+    expect(env.FIRECRACKER_KERNEL_PATH).toBe(runnerDataPaths(config.dataDir).kernelPath);
+  });
+
+  it("rejects a newline-injected socketPath (env-file line smuggling)", () => {
+    expect(() =>
+      renderRunnerEnvFile({ ...config, socketPath: "/run/x.sock\nFIRECRACKER_ARTIFACTS_LOCAL=1" }),
+    ).toThrow(/must not contain a newline/);
   });
 });
 
@@ -361,6 +433,31 @@ describe("renderRunnerUnit", () => {
     expect(unit).not.toContain("PrivateDevices=");
     expect(unit).not.toContain("ProtectKernelTunables=true");
     expect(unit).not.toContain("RestrictAddressFamilies=");
+    // TCP install: no UDS-only directives leak into the unit.
+    expect(unit).not.toContain("RuntimeDirectory=");
+  });
+
+  it("UDS at the canonical /run location: systemd owns the socket dir (RuntimeDirectory)", () => {
+    const unit = renderRunnerUnit({ ...config, socketPath: RUNNER_DEFAULT_SOCKET_PATH });
+    // ProtectSystem=strict makes /run read-only — RuntimeDirectory is what
+    // lets the daemon bind its socket there (created 0770). Preserve=yes is
+    // load-bearing: the platform container bind-mounts the dir, and a
+    // remove+recreate on daemon restart would strand the container on the
+    // orphaned directory inode (new socket invisible until container restart).
+    expect(unit).toContain("RuntimeDirectory=appstrate-runner");
+    expect(unit).toContain("RuntimeDirectoryMode=0770");
+    expect(unit).toContain("RuntimeDirectoryPreserve=yes");
+    expect(unit).not.toContain("ReadWritePaths=/run/appstrate-runner");
+    // The rest of the hardening posture is untouched.
+    expect(unit).toContain("ProtectSystem=strict");
+    expect(unit).toContain(`ReadWritePaths=${config.dataDir}`);
+  });
+
+  it("UDS at a custom parent dir: carves it writable via ReadWritePaths instead", () => {
+    const unit = renderRunnerUnit({ ...config, socketPath: "/srv/sockets/runner.sock" });
+    expect(unit).toContain("ReadWritePaths=/srv/sockets");
+    expect(unit).not.toContain("RuntimeDirectory=");
+    expect(unit).not.toContain("RuntimeDirectoryMode=");
   });
 });
 
@@ -622,6 +719,7 @@ describe("enableService", () => {
     exec,
     fs: fakeFs().fs,
     http: fakeHttp({}),
+    unixGetJson: async () => ({ reachable: false as const, error: "no fake socket" }),
     getuid: () => 0,
     preflight: async () => ({ ok: true, arch: "x86_64" as const, checks: [] }),
   });
@@ -733,6 +831,49 @@ describe("runnerDoctor", () => {
     expect(report.ok).toBe(true);
   });
 
+  it("UDS install: probes /v1/health through the socket and reports it as the endpoint", async () => {
+    const udsConfig: RunnerConfig = { ...config, socketPath: RUNNER_DEFAULT_SOCKET_PATH };
+    const marker = runnerDataPaths(config.dataDir).artifactsMarker;
+    const { fs } = fakeFs({
+      "/etc/appstrate-runner/env": renderRunnerEnvFile(udsConfig),
+      "/etc/systemd/system/appstrate-runner.service": "unit",
+      [marker]: JSON.stringify({ version: "1.2.3", guest_protocol: 1 }),
+      [runnerDataPaths(config.dataDir).jailerBin]: "<installed>",
+    });
+    const { exec } = fakeExec({
+      "systemctl is-active": () => ({ ok: true, exitCode: 0, stdout: "active\n", stderr: "" }),
+      "systemctl is-enabled": () => ({ ok: true, exitCode: 0, stdout: "enabled\n", stderr: "" }),
+    });
+    let tcpProbed = false;
+    const unixCalls: Array<{ socketPath: string; path: string; token: string }> = [];
+    const report = await runnerDoctor({
+      deps: {
+        fs,
+        exec,
+        http: {
+          ...fakeHttp({}),
+          async getJson() {
+            tcpProbed = true;
+            return { reachable: false, error: "should not be dialed" };
+          },
+        },
+        unixGetJson: async (socketPath, path, token) => {
+          unixCalls.push({ socketPath, path, token });
+          return { reachable: true, status: 200, body: { protocol: 1, initialized: true } };
+        },
+        preflight: async () => ({ ok: true, arch: "x86_64", checks: [] }),
+      },
+    });
+    expect(tcpProbed).toBe(false);
+    expect(unixCalls).toEqual([
+      { socketPath: RUNNER_DEFAULT_SOCKET_PATH, path: "/v1/health", token: config.token },
+    ]);
+    expect(report.ok).toBe(true);
+    expect(report.health.status).toBe(200);
+    // The report shows the socket path where a TCP install shows host:port.
+    expect(report.health.endpoint).toBe(RUNNER_DEFAULT_SOCKET_PATH);
+  });
+
   it("reports not-ok when the daemon is unreachable", async () => {
     const { fs } = fakeFs({ "/etc/appstrate-runner/env": renderRunnerEnvFile(config) });
     const { exec } = fakeExec({
@@ -791,6 +932,36 @@ describe("pollHealth", () => {
     const { exec } = fakeExec();
     // timeoutMs 0 → the loop never enters; no 3s sleeps in the test.
     expect(await pollHealth(cfg, { exec, http }, 0)).toBe(false);
+  });
+
+  it("UDS install: probes through the unix socket, never the TCP seam", async () => {
+    const unixCalls: Array<{ socketPath: string; path: string; token: string }> = [];
+    let tcpProbed = false;
+    const http: RunnerHttp = {
+      ...fakeHttp({}),
+      async getJson() {
+        tcpProbed = true;
+        return { reachable: false, error: "should not be dialed" };
+      },
+    };
+    const { exec } = fakeExec();
+    const ok = await pollHealth(
+      { ...cfg, socketPath: RUNNER_DEFAULT_SOCKET_PATH },
+      {
+        exec,
+        http,
+        unixGetJson: async (socketPath, path, token) => {
+          unixCalls.push({ socketPath, path, token });
+          return { reachable: true, status: 200, body: {} };
+        },
+      },
+      5000,
+    );
+    expect(ok).toBe(true);
+    expect(tcpProbed).toBe(false);
+    expect(unixCalls).toEqual([
+      { socketPath: RUNNER_DEFAULT_SOCKET_PATH, path: "/v1/health", token: cfg.token },
+    ]);
   });
 });
 

--- a/docs/architecture/FIRECRACKER.md
+++ b/docs/architecture/FIRECRACKER.md
@@ -100,7 +100,10 @@ security decision. Decision matrix:
   hatch `FIRECRACKER_RUNNER_TLS_REQUIRED=0` (platform-side) downgrades
   the refusal to a warning; reserve it for a link that is already
   encrypted and authenticated at a lower layer (VPN / WireGuard), never
-  as a plain-LAN convenience.
+  as a plain-LAN convenience. The installer treats an explicit plaintext
+  `http://` runner URL (flag, or interactive prompt + confirm) as that
+  opt-in: it warns loudly and writes the escape hatch itself — otherwise
+  it would generate a `.env` the platform refuses to boot.
 - **Loopback `http://`** (`127.0.0.1` / `localhost`) is allowed as
   before — the wire never leaves the host.
 

--- a/docs/architecture/FIRECRACKER.md
+++ b/docs/architecture/FIRECRACKER.md
@@ -28,7 +28,10 @@ Zero footprint when absent: no env vars read, no backend registered.
 # Platform (container)
 MODULES=oidc,webhooks,mcp,core-providers,@appstrate/module-chat,firecracker
 RUN_ADAPTER=firecracker
-FIRECRACKER_RUNNER_URL=http://<runner-host>:3100
+# Co-located daemon (same host) — Unix domain socket, recommended:
+FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock
+# Remote KVM host — TLS behind a reverse proxy:
+# FIRECRACKER_RUNNER_URL=https://<runner-host>:3100
 FIRECRACKER_RUNNER_TOKEN=<shared secret, >=16 chars>
 ```
 
@@ -36,10 +39,10 @@ Setting `RUN_ADAPTER=firecracker` without the module is a fatal boot error
 listing the registered backends; a stale `RUN_ADAPTER=firecracker-remote`
 (the id before the in-process backend was removed) gets a targeted "renamed to
 `firecracker`" error. Platform-side only `FIRECRACKER_RUNNER_URL`/`_TOKEN` are
-read (validated lazily, on the first `initialize()`), plus the opt-in
-`FIRECRACKER_RUNNER_TLS_REQUIRED=1` — also platform-side, NOT a daemon
-variable — which turns the plaintext-`http://`-to-non-loopback-host boot
-warning into a hard refusal (see _Transport & auth_). The host-side
+read (validated lazily, on the first `initialize()`), plus the escape hatch
+`FIRECRACKER_RUNNER_TLS_REQUIRED=0` — also platform-side, NOT a daemon
+variable — which downgrades the plaintext-`http://`-to-non-loopback-host hard
+boot refusal to a warning (last resort, see _Transport & auth_). The host-side
 `FIRECRACKER_*` variables (kernel/rootfs, subnet CIDR, …) are **daemon-only** —
 never parsed platform-side. None of these are part of the `@appstrate/env`
 schema.
@@ -60,13 +63,42 @@ ip:port ahead of the egress-deny CIDRs. Capabilities: `isolatesWorkloads: true`
 process), `supportsSidecarOnly: false`.
 
 **Transport & auth.** The wire carries the bearer token and per-run
-credential bundles (`POST /v1/sidecars`). Same machine or a genuinely
-private network is acceptable; for any **split-host** deployment TLS (a
-reverse proxy in front of the daemon) is REQUIRED, not advised. The
-platform enforces the posture at boot: a plaintext `http://`
-`FIRECRACKER_RUNNER_URL` pointing at a non-loopback host logs a loud
-warning, and setting `FIRECRACKER_RUNNER_TLS_REQUIRED=1` (platform-side)
-turns it into a hard boot refusal. Auth is a single shared
+credential bundles (`POST /v1/sidecars`), so the transport choice is a
+security decision. Decision matrix:
+
+- **Co-located (daemon and platform on the same host) — Unix domain
+  socket, RECOMMENDED.**
+  `FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock`
+  (three slashes — absolute socket path). The wire never touches the
+  network: no TLS needed, no boot guard involved. The daemon binds the
+  socket instead of a TCP port when `FIRECRACKER_RUNNER_SOCKET` is set
+  (`appstrate runner install --socket …`; the systemd unit uses
+  `RuntimeDirectory=appstrate-runner` for the canonical
+  `/run/appstrate-runner/runner.sock` path). A containerized platform
+  reaches it through a bind-mount of the socket directory
+  (`/run/appstrate-runner:/run/appstrate-runner` in the
+  `examples/self-hosting` compose templates). Socket permissions default
+  to `0660 root:root` — sufficient for the stock platform image, whose
+  container process runs as root; a rootless / userns-remapped platform
+  container needs `FIRECRACKER_RUNNER_SOCKET_MODE=0666` on the daemon
+  (the bearer token is still enforced on every request, so the wider
+  mode grants transport reachability, not auth). This replaces the old
+  co-located workaround of pointing the containerized platform at the
+  host LAN IP over plaintext `http://`, which the boot guard refuses.
+- **Split host (separate KVM box) — `https://` behind a TLS reverse
+  proxy in front of the daemon, REQUIRED.** The platform enforces this
+  fail-closed at boot: a plaintext `http://` `FIRECRACKER_RUNNER_URL`
+  pointing at a non-loopback host is REFUSED. RFC1918/private addresses
+  are never auto-trusted — "it's my LAN" is not a trust boundary
+  (zero-trust posture, NIST 800-207 aligned). The last-resort escape
+  hatch `FIRECRACKER_RUNNER_TLS_REQUIRED=0` (platform-side) downgrades
+  the refusal to a warning; reserve it for a link that is already
+  encrypted and authenticated at a lower layer (VPN / WireGuard), never
+  as a plain-LAN convenience.
+- **Loopback `http://`** (`127.0.0.1` / `localhost`) is allowed as
+  before — the wire never leaves the host.
+
+Auth is a single shared
 token compared in constant time; run **one platform per daemon** (the orphan
 sweep is daemon-wide). The protocol is JSON over HTTP (`runner/protocol.ts`,
 versioned — the client refuses a daemon speaking another major version); logs
@@ -85,6 +117,13 @@ curl -fsSL https://get.appstrate.dev/runner | sudo bash -s -- \
 # Or, if the CLI is already installed:
 sudo appstrate runner install --platform-url http://<PLATFORM_IPV4>:3000
 ```
+
+For a co-located install (platform container on the same host) add
+`--socket /run/appstrate-runner/runner.sock`: the daemon then binds a Unix
+domain socket instead of a TCP port (the generated systemd unit uses
+`RuntimeDirectory=appstrate-runner`) and the platform is pointed at
+`unix:///run/appstrate-runner/runner.sock` — see _Transport & auth_. The
+platform installer's same-host topology does both automatically.
 
 `appstrate runner install` (`apps/cli/src/commands/runner.ts`):
 
@@ -142,7 +181,8 @@ across upgrades by `mergeEnv` like every other secret):
 ```sh
 RUN_ADAPTER=firecracker
 MODULES=oidc,webhooks,mcp,core-providers,@appstrate/module-chat,firecracker
-FIRECRACKER_RUNNER_URL=http://<runner-ip>:3100
+# Same host: unix:///run/appstrate-runner/runner.sock — remote: http(s)://<runner-ip>:3100
+FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock
 FIRECRACKER_RUNNER_TOKEN=<minted or --runner-token>
 ```
 
@@ -154,16 +194,23 @@ FIRECRACKER_RUNNER_TOKEN=<minted or --runner-token>
 The main install itself stays **rootless** — it never sudo's. Two topologies:
 
 - **Same host** — the runner daemon runs on the install host. The installer
-  detects the host LAN IPv4 (confirm/override interactively, or `--host-ip`),
-  mints a runner token, brings up the platform, and _then_ runs
-  `sudo appstrate runner install --platform-url http://<host-ip>:<port> --token <token> --yes`
+  detects the host LAN IPv4 (confirm/override interactively, or `--host-ip` —
+  guests still reach the platform over the network, so
+  `FIRECRACKER_RUNNER_PLATFORM_URL` needs it), mints a runner token, writes
+  `FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock` into the
+  platform `.env` (UDS transport — the compose templates bind-mount
+  `/run/appstrate-runner` into the platform container), brings up the
+  platform, and _then_ runs
+  `sudo appstrate runner install --socket /run/appstrate-runner/runner.sock --platform-url http://<host-ip>:<port> --token <token> --yes`
   as a subprocess (sudo prompts on the same TTY). If that step fails — or the
   install is non-interactive (`--host-ip` + `--yes`, which can't sudo-prompt) —
   it prints the exact command to run by hand. A runner-install hiccup is a
   warning, never a rollback: the platform is already healthy.
 - **Remote KVM host** — the runner daemon runs elsewhere. Provide
-  `--runner-url http://<kvm-ip>:3100 --runner-token <token>` (or answer the
-  prompts). The installer writes the platform `.env`, then prints the one-liner
+  `--runner-url https://<kvm-host>:3100 --runner-token <token>` (or answer the
+  prompts) — `https://` behind a TLS reverse proxy; a plaintext `http://` URL
+  to a non-loopback host is refused at platform boot (see _Transport &
+  auth_). The installer writes the platform `.env`, then prints the one-liner
   to run on the KVM host:
   `curl -fsSL https://get.appstrate.dev/runner | bash -s -- --platform-url http://<this-host-ip>:<port> --token <token>`.
 
@@ -590,8 +637,10 @@ boots on a bare KVM host with only these variables.
 | Variable                          | Default   | Notes                                                                                                                                                                  |
 | --------------------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `FIRECRACKER_RUNNER_TOKEN`        | —         | REQUIRED, ≥16 chars. Shared bearer secret; every request must present it. Must match the platform's `FIRECRACKER_RUNNER_TOKEN`                                         |
-| `FIRECRACKER_RUNNER_PORT`         | `3100`    | Daemon listen port                                                                                                                                                     |
-| `FIRECRACKER_RUNNER_HOST`         | `0.0.0.0` | Bind narrowly / firewall the port — the launch spec carries run credentials                                                                                            |
+| `FIRECRACKER_RUNNER_PORT`         | `3100`    | Daemon listen port (TCP mode; ignored when `FIRECRACKER_RUNNER_SOCKET` is set)                                                                                         |
+| `FIRECRACKER_RUNNER_HOST`         | `0.0.0.0` | Bind narrowly / firewall the port — the launch spec carries run credentials (TCP mode; ignored when `FIRECRACKER_RUNNER_SOCKET` is set)                                |
+| `FIRECRACKER_RUNNER_SOCKET`       | —         | Absolute path of a Unix domain socket to bind INSTEAD of HOST/PORT (UDS transport — see _Transport & auth_). Canonical: `/run/appstrate-runner/runner.sock`            |
+| `FIRECRACKER_RUNNER_SOCKET_MODE`  | `0660`    | Octal file mode of the bound socket. `0666` for a rootless / userns-remapped platform container (bearer token remains enforced)                                        |
 | `FIRECRACKER_RUNNER_PLATFORM_URL` | —         | REQUIRED. `http(s)://<IPv4>[:port]` guests use to reach the platform (IP literal — no DNS in guests). The daemon opens an explicit nft accept for exactly this ip:port |
 
 ### Engine host config — `FIRECRACKER_*` (`runner/host-env.ts`)

--- a/docs/architecture/FIRECRACKER.md
+++ b/docs/architecture/FIRECRACKER.md
@@ -75,14 +75,20 @@ security decision. Decision matrix:
   (`appstrate runner install --socket …`; the systemd unit uses
   `RuntimeDirectory=appstrate-runner` for the canonical
   `/run/appstrate-runner/runner.sock` path). A containerized platform
-  reaches it through a bind-mount of the socket directory
-  (`/run/appstrate-runner:/run/appstrate-runner` in the
-  `examples/self-hosting` compose templates). Socket permissions default
-  to `0660 root:root` — sufficient for the stock platform image, whose
-  container process runs as root; a rootless / userns-remapped platform
-  container needs `FIRECRACKER_RUNNER_SOCKET_MODE=0666` on the daemon
-  (the bearer token is still enforced on every request, so the wider
-  mode grants transport reachability, not auth). This replaces the old
+  reaches it through a bind-mount of the socket directory: the
+  `examples/self-hosting` compose templates mount
+  `${APPSTRATE_RUNNER_SOCKET_DIR:-./data/appstrate-runner}` at
+  `/run/appstrate-runner` — the firecracker installer sets
+  `APPSTRATE_RUNNER_SOCKET_DIR=/run/appstrate-runner` in the platform
+  `.env`; without it the mount falls back to a harmless empty local dir
+  (so non-Firecracker installs never touch host `/run`, which Docker
+  Desktop's default file sharing does not cover). Socket permissions
+  default to `0660 root:root` — sufficient for the stock platform image,
+  whose container process runs as root; a rootless / userns-remapped
+  platform container needs `FIRECRACKER_RUNNER_SOCKET_MODE=0666` on the
+  daemon (the socket dir is created `0771`, so any uid can traverse it;
+  the bearer token is still enforced on every request, so the wider mode
+  grants transport reachability, not auth). This replaces the old
   co-located workaround of pointing the containerized platform at the
   host LAN IP over plaintext `http://`, which the boot guard refuses.
 - **Split host (separate KVM box) — `https://` behind a TLS reverse
@@ -197,9 +203,10 @@ The main install itself stays **rootless** — it never sudo's. Two topologies:
   detects the host LAN IPv4 (confirm/override interactively, or `--host-ip` —
   guests still reach the platform over the network, so
   `FIRECRACKER_RUNNER_PLATFORM_URL` needs it), mints a runner token, writes
-  `FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock` into the
-  platform `.env` (UDS transport — the compose templates bind-mount
-  `/run/appstrate-runner` into the platform container), brings up the
+  `FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock` plus
+  `APPSTRATE_RUNNER_SOCKET_DIR=/run/appstrate-runner` into the platform
+  `.env` (UDS transport — the compose templates bind-mount the socket dir
+  into the platform container from that variable), brings up the
   platform, and _then_ runs
   `sudo appstrate runner install --socket /run/appstrate-runner/runner.sock --platform-url http://<host-ip>:<port> --token <token> --yes`
   as a subprocess (sudo prompts on the same TTY). If that step fails — or the

--- a/examples/self-hosting/.env.example
+++ b/examples/self-hosting/.env.example
@@ -97,6 +97,12 @@ POSTGRES_PASSWORD=<generate-with-openssl-rand-base64-32>
 # macOS Docker Desktop: 0 (root) — the socket is rewritten in containers.
 # DOCKER_GID=0
 
+# Firecracker (co-located UDS transport only): HOST directory holding the
+# runner daemon's unix socket, bind-mounted at /run/appstrate-runner inside
+# the platform container. Set by the firecracker installer; leave unset
+# otherwise — the compose templates fall back to a harmless empty local dir.
+# APPSTRATE_RUNNER_SOCKET_DIR=/run/appstrate-runner
+
 # ─── Modules ──────────────────────────────────────────────────────
 
 # Comma-separated module specifiers loaded at boot. Default ships

--- a/examples/self-hosting/README.md
+++ b/examples/self-hosting/README.md
@@ -328,18 +328,18 @@ It never touches `.env` or runs Docker; restart the stack afterwards
 
 See `.env.example` for all available environment variables. Key settings:
 
-| Variable                                  | Description                                                             |
-| ----------------------------------------- | ----------------------------------------------------------------------- |
-| `POSTGRES_USER` / `POSTGRES_PASSWORD`     | Database credentials                                                    |
-| `BETTER_AUTH_SECRET`                      | Session signing secret (32 bytes hex)                                   |
-| `CONNECTION_ENCRYPTION_KEY`               | Credential encryption key (32 bytes base64)                             |
-| `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` | MinIO admin credentials                                                 |
-| `APP_URL`                                 | Public URL (for OAuth callbacks, email links)                           |
-| `TRUSTED_ORIGINS`                         | CORS origins (comma-separated)                                          |
-| `SYSTEM_PROVIDER_KEYS`                    | Pre-configured LLM provider credentials (JSON array)                    |
-| `LOG_LEVEL`                               | Logging verbosity: `debug`, `info`, `warn`, `error`                     |
-| `RUN_ADAPTER`                             | Agent execution backend: `docker` (default) or `firecracker` (microVMs) |
-| `FIRECRACKER_RUNNER_URL` / `_TOKEN`       | Firecracker only: appstrate-runner daemon URL + shared bearer token     |
+| Variable                                  | Description                                                                                                                                    |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `POSTGRES_USER` / `POSTGRES_PASSWORD`     | Database credentials                                                                                                                           |
+| `BETTER_AUTH_SECRET`                      | Session signing secret (32 bytes hex)                                                                                                          |
+| `CONNECTION_ENCRYPTION_KEY`               | Credential encryption key (32 bytes base64)                                                                                                    |
+| `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` | MinIO admin credentials                                                                                                                        |
+| `APP_URL`                                 | Public URL (for OAuth callbacks, email links)                                                                                                  |
+| `TRUSTED_ORIGINS`                         | CORS origins (comma-separated)                                                                                                                 |
+| `SYSTEM_PROVIDER_KEYS`                    | Pre-configured LLM provider credentials (JSON array)                                                                                           |
+| `LOG_LEVEL`                               | Logging verbosity: `debug`, `info`, `warn`, `error`                                                                                            |
+| `RUN_ADAPTER`                             | Agent execution backend: `docker` (default) or `firecracker` (microVMs)                                                                        |
+| `FIRECRACKER_RUNNER_URL` / `_TOKEN`       | Firecracker only: appstrate-runner daemon URL (`unix:///run/appstrate-runner/runner.sock` co-located, `https://` remote) + shared bearer token |
 
 ### Firecracker execution backend (optional)
 
@@ -347,7 +347,13 @@ To run agents in microVMs instead of Docker containers, pass
 `--run-adapter firecracker` to `appstrate install`. It writes the
 `RUN_ADAPTER` / `MODULES` / `FIRECRACKER_RUNNER_*` keys above and either drives
 the runner-daemon install on this host (`--host-ip <ipv4>`) or prints the
-one-liner to run on a remote KVM host (`--runner-url` + `--runner-token`). See
+one-liner to run on a remote KVM host (`--runner-url` + `--runner-token`). On
+the same-host topology the daemon binds a Unix domain socket and the installer
+sets `FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock` — the
+compose templates bind-mount `/run/appstrate-runner` into the platform
+container so the socket is reachable from inside it. A remote daemon stays on
+TCP: use `https://` behind a TLS reverse proxy (plaintext `http://` to a
+non-loopback host is refused at boot). See
 [`../../docs/architecture/FIRECRACKER.md`](../../docs/architecture/FIRECRACKER.md)
 → "Installer integration".
 

--- a/examples/self-hosting/README.md
+++ b/examples/self-hosting/README.md
@@ -349,9 +349,11 @@ To run agents in microVMs instead of Docker containers, pass
 the runner-daemon install on this host (`--host-ip <ipv4>`) or prints the
 one-liner to run on a remote KVM host (`--runner-url` + `--runner-token`). On
 the same-host topology the daemon binds a Unix domain socket and the installer
-sets `FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock` — the
-compose templates bind-mount `/run/appstrate-runner` into the platform
-container so the socket is reachable from inside it. A remote daemon stays on
+sets `FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock` plus
+`APPSTRATE_RUNNER_SOCKET_DIR=/run/appstrate-runner` — the compose templates
+bind-mount the socket dir into the platform container from that variable
+(unset, it falls back to a harmless empty local dir, so non-Firecracker
+installs never mount host `/run`). A remote daemon stays on
 TCP: use `https://` behind a TLS reverse proxy (plaintext `http://` to a
 non-loopback host is refused at boot). See
 [`../../docs/architecture/FIRECRACKER.md`](../../docs/architecture/FIRECRACKER.md)

--- a/examples/self-hosting/docker-compose.tier1.yml
+++ b/examples/self-hosting/docker-compose.tier1.yml
@@ -175,6 +175,11 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - storagedata:/data/storage
+      # Co-located Firecracker runner socket dir (UDS transport). The dir
+      # is bind-mounted so FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock
+      # works from inside the container. Harmless when Firecracker is not
+      # used — the directory is simply empty.
+      - /run/appstrate-runner:/run/appstrate-runner
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1"]
       interval: 30s

--- a/examples/self-hosting/docker-compose.tier1.yml
+++ b/examples/self-hosting/docker-compose.tier1.yml
@@ -175,11 +175,14 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - storagedata:/data/storage
-      # Co-located Firecracker runner socket dir (UDS transport). The dir
-      # is bind-mounted so FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock
-      # works from inside the container. Harmless when Firecracker is not
-      # used — the directory is simply empty.
-      - /run/appstrate-runner:/run/appstrate-runner
+      # Co-located Firecracker runner socket dir (UDS transport): mounted at
+      # /run/appstrate-runner in the container so
+      # FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock works.
+      # The HOST side is env-driven: the firecracker installer sets
+      # APPSTRATE_RUNNER_SOCKET_DIR=/run/appstrate-runner in .env; without it
+      # the mount falls back to a harmless empty local dir (never touches
+      # /run — Docker Desktop's default file sharing does not cover it).
+      - ${APPSTRATE_RUNNER_SOCKET_DIR:-./data/appstrate-runner}:/run/appstrate-runner
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1"]
       interval: 30s

--- a/examples/self-hosting/docker-compose.tier2.yml
+++ b/examples/self-hosting/docker-compose.tier2.yml
@@ -186,6 +186,11 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - storagedata:/data/storage
+      # Co-located Firecracker runner socket dir (UDS transport). The dir
+      # is bind-mounted so FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock
+      # works from inside the container. Harmless when Firecracker is not
+      # used — the directory is simply empty.
+      - /run/appstrate-runner:/run/appstrate-runner
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1"]
       interval: 30s

--- a/examples/self-hosting/docker-compose.tier2.yml
+++ b/examples/self-hosting/docker-compose.tier2.yml
@@ -186,11 +186,14 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - storagedata:/data/storage
-      # Co-located Firecracker runner socket dir (UDS transport). The dir
-      # is bind-mounted so FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock
-      # works from inside the container. Harmless when Firecracker is not
-      # used — the directory is simply empty.
-      - /run/appstrate-runner:/run/appstrate-runner
+      # Co-located Firecracker runner socket dir (UDS transport): mounted at
+      # /run/appstrate-runner in the container so
+      # FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock works.
+      # The HOST side is env-driven: the firecracker installer sets
+      # APPSTRATE_RUNNER_SOCKET_DIR=/run/appstrate-runner in .env; without it
+      # the mount falls back to a harmless empty local dir (never touches
+      # /run — Docker Desktop's default file sharing does not cover it).
+      - ${APPSTRATE_RUNNER_SOCKET_DIR:-./data/appstrate-runner}:/run/appstrate-runner
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1"]
       interval: 30s

--- a/examples/self-hosting/docker-compose.tier3.yml
+++ b/examples/self-hosting/docker-compose.tier3.yml
@@ -248,6 +248,11 @@ services:
       - OTEL_EXPORTER_OTLP_PROTOCOL
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Co-located Firecracker runner socket dir (UDS transport). The dir
+      # is bind-mounted so FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock
+      # works from inside the container. Harmless when Firecracker is not
+      # used — the directory is simply empty.
+      - /run/appstrate-runner:/run/appstrate-runner
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1"]
       interval: 30s

--- a/examples/self-hosting/docker-compose.tier3.yml
+++ b/examples/self-hosting/docker-compose.tier3.yml
@@ -248,11 +248,14 @@ services:
       - OTEL_EXPORTER_OTLP_PROTOCOL
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      # Co-located Firecracker runner socket dir (UDS transport). The dir
-      # is bind-mounted so FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock
-      # works from inside the container. Harmless when Firecracker is not
-      # used — the directory is simply empty.
-      - /run/appstrate-runner:/run/appstrate-runner
+      # Co-located Firecracker runner socket dir (UDS transport): mounted at
+      # /run/appstrate-runner in the container so
+      # FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock works.
+      # The HOST side is env-driven: the firecracker installer sets
+      # APPSTRATE_RUNNER_SOCKET_DIR=/run/appstrate-runner in .env; without it
+      # the mount falls back to a harmless empty local dir (never touches
+      # /run — Docker Desktop's default file sharing does not cover it).
+      - ${APPSTRATE_RUNNER_SOCKET_DIR:-./data/appstrate-runner}:/run/appstrate-runner
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1"]
       interval: 30s

--- a/examples/self-hosting/docker-compose.yml
+++ b/examples/self-hosting/docker-compose.yml
@@ -240,6 +240,11 @@ services:
       - OTEL_EXPORTER_OTLP_PROTOCOL
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      # Co-located Firecracker runner socket dir (UDS transport). The dir
+      # is bind-mounted so FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock
+      # works from inside the container. Harmless when Firecracker is not
+      # used — the directory is simply empty.
+      - /run/appstrate-runner:/run/appstrate-runner
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1"]
       interval: 30s

--- a/examples/self-hosting/docker-compose.yml
+++ b/examples/self-hosting/docker-compose.yml
@@ -240,11 +240,14 @@ services:
       - OTEL_EXPORTER_OTLP_PROTOCOL
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      # Co-located Firecracker runner socket dir (UDS transport). The dir
-      # is bind-mounted so FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock
-      # works from inside the container. Harmless when Firecracker is not
-      # used — the directory is simply empty.
-      - /run/appstrate-runner:/run/appstrate-runner
+      # Co-located Firecracker runner socket dir (UDS transport): mounted at
+      # /run/appstrate-runner in the container so
+      # FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock works.
+      # The HOST side is env-driven: the firecracker installer sets
+      # APPSTRATE_RUNNER_SOCKET_DIR=/run/appstrate-runner in .env; without it
+      # the mount falls back to a harmless empty local dir (never touches
+      # /run — Docker Desktop's default file sharing does not cover it).
+      - ${APPSTRATE_RUNNER_SOCKET_DIR:-./data/appstrate-runner}:/run/appstrate-runner
     healthcheck:
       test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1"]
       interval: 30s

--- a/scripts/bootstrap-runner.sh
+++ b/scripts/bootstrap-runner.sh
@@ -13,6 +13,13 @@
 #   curl -fsSL https://get.appstrate.dev/runner | bash -s -- \
 #     --platform-url http://<PLATFORM_IPV4>:3000 --token <TOKEN>
 #
+#   Co-located install (platform container on the same host) — bind a Unix
+#   domain socket instead of a TCP port (platform then uses
+#   FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock):
+#   curl -fsSL https://get.appstrate.dev/runner | bash -s -- \
+#     --platform-url http://<PLATFORM_IPV4>:3000 --token <TOKEN> \
+#     --socket /run/appstrate-runner/runner.sock
+#
 # Env overrides (mirror scripts/bootstrap.sh):
 #   APPSTRATE_VERSION        Pin a release tag (default: pinned or "latest").
 #   APPSTRATE_BIN_DIR        CLI install location (default: /usr/local/bin —


### PR DESCRIPTION
Closes #868.

## Problem

beta.38's fail-closed transport guard (refusing plaintext `http://` to a non-loopback daemon) false-alarms on the most common self-host topology: a **containerized platform cannot reach a same-host daemon via `127.0.0.1`** (that's the container, not the host), so operators pointed `FIRECRACKER_RUNNER_URL` at the host LAN IP — tripping the guard and getting pushed toward `FIRECRACKER_RUNNER_TLS_REQUIRED=0`, which institutionalizes plaintext-on-LAN.

## Fix: UDS transport (issue item 1)

When platform and daemon share a host, the wire now never touches the network at all — a Unix domain socket bind-mounted into the platform container. The fail-closed guard for TCP is **unchanged**: RFC1918 is still never auto-trusted.

### Platform (`modules/firecracker`)
- `FIRECRACKER_RUNNER_URL` accepts `unix:///abs/path.sock` (three-slash form; the `unix://var/run/x.sock` two-slash typo is rejected with an actionable hint — URL parsing would silently treat `var` as a hostname and dial the wrong socket)
- `parseRunnerTransport()` derives the transport once at env parse; the orchestrator dials Bun's `fetch(…, { unix })` with a placeholder `http://` authority
- `assertRunnerTransportSecurity()`: `unix:` exempt (no network path exists); http/https logic byte-identical

### Daemon (`appstrate-runner`)
- `FIRECRACKER_RUNNER_SOCKET` (absolute path) binds a UDS instead of host:port (explicit HOST/PORT logged as overridden); `FIRECRACKER_RUNNER_SOCKET_MODE` (octal, default `0660`)
- Stale-socket unlink before bind, chmod after, best-effort unlink on shutdown
- Bearer-token auth enforced regardless of transport (defense-in-depth)

### CLI installer
- `appstrate runner install --socket <path>` (mutually exclusive with `--port`/`--host`), interactive transport select, firewall step skipped for UDS ("no network port exposed")
- `doctor`/`status`/health polling dial the socket when the env file carries `FIRECRACKER_RUNNER_SOCKET`
- Platform install **same-host topology** now writes `FIRECRACKER_RUNNER_URL=unix:///run/appstrate-runner/runner.sock` and drives `runner install --socket` automatically; remote topology unchanged
- systemd unit: `RuntimeDirectory=appstrate-runner` `0770` + **`RuntimeDirectoryPreserve=yes`** — load-bearing: the platform container bind-mounts the dir, and systemd's default remove+recreate on daemon restart would strand the container on the orphaned directory inode (new socket invisible until container restart)

### Deploy + docs
- All four `examples/self-hosting` compose templates bind-mount `/run/appstrate-runner` into the platform container (harmless empty dir when firecracker is unused)
- `docs/architecture/FIRECRACKER.md`: transport decision matrix — co-located → UDS (recommended), split host → `https://` behind TLS, `FIRECRACKER_RUNNER_TLS_REQUIRED=0` documented as a last-resort trusted-link override
- Socket perms note: `0660 root:root` fits the stock platform image (container runs as root); rootless/userns → `FIRECRACKER_RUNNER_SOCKET_MODE=0666` with the bearer token still enforced

## Acceptance (from #868)
- ✅ Co-located deploys work over UDS with no plaintext-over-network and no `TLS_REQUIRED=0`
- ✅ Fail-closed plaintext-non-loopback guard unchanged; RFC1918 not auto-trusted
- ✅ Docs: co-located → UDS; separate KVM host → TLS; `TLS_REQUIRED=0` as last resort

Items 2 (easy-TLS tooling for split-host) and 3 (mTLS / request-bound tokens) from #868 are intentionally out of scope — follow-ups.

## Verification
- firecracker module unit tests: **312 pass, 0 fail** (new: transport parsing, guard exemption, UDS fetch wiring, listen-config resolution)
- CLI suite: **1227 pass, 0 fail** (new: `--socket` validation/conflicts, env-file + unit rendering, UDS doctor/health probes, same-host backend resolution)
- `bun run check`: 34/34 tasks (tsc + eslint + prettier + OpenAPI)
- `docker compose config` validates all four templates
- Bun runtime smoke: `Bun.serve({ unix })` + `fetch({ unix })` round-trip with bearer header + `chmod 0660` verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)