### PR TITLE
fix(test): retry truncateAll on transient lock conflicts (40P01 deadlocks)

### DIFF
--- a/apps/api/test/helpers/db.ts
+++ b/apps/api/test/helpers/db.ts
@@ -11,6 +11,7 @@ import { sql } from "drizzle-orm";
 import type { Db } from "@appstrate/db/client";
 import { readdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
+import { withDeadlockRetry } from "./deadlock-retry.ts";
 
 export { db, closeDb };
 export type { Db };
@@ -136,13 +137,34 @@ function buildTruncateSql(): string {
  * Order is children → parents (module tables first, since they reference
  * core tables).
  *
+ * The single transaction narrows the FK-violation race but does not remove
+ * the concurrency: a background transaction inserting a child row takes a
+ * KEY SHARE lock on its parent `organizations` row while this block is
+ * deleting that same row — a lock cycle Postgres breaks with a 40P01
+ * deadlock at `deadlock_timeout` (issue #883, observed as one random red
+ * test at ~1005ms under load). The race is a harness artifact (unawaited
+ * fire-and-forget work), so the deadlock class is retried a couple of times
+ * via {@link withDeadlockRetry}; each retry is surfaced with a warning so
+ * the signal stays countable. Any other error still fails immediately.
+ *
  * Also resets the filesystem storage namespace (tier0 / FS mode) so storage
  * isolation between test files matches DB isolation — see {@link resetFsStorage}.
  *
  * Call this in beforeEach() for full test isolation.
  */
 export async function truncateAll(): Promise<void> {
-  cachedTruncateSql ??= buildTruncateSql();
-  await db.execute(sql.raw(cachedTruncateSql));
+  const truncateSql = (cachedTruncateSql ??= buildTruncateSql());
+  await withDeadlockRetry(() => db.execute(sql.raw(truncateSql)), {
+    onRetry: (err, attempt) => {
+      // Drizzle's wrapper message embeds the whole DO block — the driver
+      // error underneath ("deadlock detected") is the useful line.
+      const root = err instanceof Error && err.cause instanceof Error ? err.cause : err;
+      const message = root instanceof Error ? root.message : String(root);
+      // Keep the count greppable in suite output (issue #883).
+      console.warn(
+        `[truncateAll] transient lock conflict (attempt ${attempt}), retrying: ${message}`,
+      );
+    },
+  });
   resetFsStorage();
 }

--- a/apps/api/test/helpers/db.ts
+++ b/apps/api/test/helpers/db.ts
@@ -160,9 +160,10 @@ export async function truncateAll(): Promise<void> {
       // error underneath ("deadlock detected") is the useful line.
       const root = err instanceof Error && err.cause instanceof Error ? err.cause : err;
       const message = root instanceof Error ? root.message : String(root);
-      // Keep the count greppable in suite output (issue #883).
+      const code = (root as { code?: unknown } | null)?.code;
+      // Keep the SQLSTATE count greppable in suite output (issue #883).
       console.warn(
-        `[truncateAll] transient lock conflict (attempt ${attempt}), retrying: ${message}`,
+        `[truncateAll] transient lock conflict (attempt ${attempt}), retrying: ${message}${typeof code === "string" ? ` [${code}]` : ""}`,
       );
     },
   });

--- a/apps/api/test/helpers/deadlock-retry.ts
+++ b/apps/api/test/helpers/deadlock-retry.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Retry-on-deadlock helper for the test harness (issue #883).
+ *
+ * `truncateAll()` runs its DELETEs in a single implicit transaction that
+ * takes row locks across every table, `organizations` among the last. A
+ * previous test's fire-and-forget async work (e.g. `executeAgentInBackground`
+ * writing to `runs`/`run_logs`, or `ensureDefaultProfile` from middleware)
+ * can still be in flight: its INSERT takes a `KEY SHARE` lock on the parent
+ * `organizations` row (FK enforcement) while the truncate transaction wants
+ * to delete that same row and already holds locks the background transaction
+ * needs next. Postgres breaks the cycle at `deadlock_timeout` (1s) by
+ * aborting one side with SQLSTATE 40P01 — which lands on whichever test
+ * happened to call `truncateAll()`.
+ *
+ * The race is a test-harness artifact (unawaited background work), not
+ * production behavior, so retrying the aborted cleanup is honest: the
+ * background transaction wins the first round, commits or aborts, and the
+ * retry runs against a quiesced database.
+ *
+ * This module is dependency-free on purpose: unit tests exercise the retry
+ * loop and SQLSTATE detection without importing the DB client.
+ */
+
+/**
+ * SQLSTATEs that mark a transient lock/serialization conflict where retrying
+ * the statement is expected to succeed:
+ * - 40P01 deadlock_detected — the observed failure mode (issue #883)
+ * - 40001 serialization_failure — same class, retry-safe by definition
+ * - 55P03 lock_not_available — raised instead of 40P01 when a lock_timeout
+ *   is configured shorter than deadlock_timeout
+ */
+const TRANSIENT_LOCK_SQLSTATES: ReadonlySet<string> = new Set(["40P01", "40001", "55P03"]);
+
+/** How deep to walk an error's `cause` chain before giving up. */
+const MAX_CAUSE_DEPTH = 5;
+
+/**
+ * True when a DB error is a transient lock/serialization conflict (deadlock,
+ * serialization failure, lock timeout) that is safe to retry.
+ *
+ * Matches on the SQLSTATE `code` property and walks the `cause` chain, since
+ * Drizzle wraps the driver error in a `DrizzleQueryError` (same pattern as
+ * `isInvalidTextRepresentation` in `lib/db-helpers.ts`). Covers both the
+ * Tier-0 embedded driver (PGlite) and a real server (postgres.js).
+ */
+export function isTransientLockError(err: unknown): boolean {
+  let current: unknown = err;
+  for (
+    let depth = 0;
+    current !== null && current !== undefined && depth < MAX_CAUSE_DEPTH;
+    depth++
+  ) {
+    if (typeof current !== "object") break;
+    const code = (current as { code?: unknown }).code;
+    if (typeof code === "string" && TRANSIENT_LOCK_SQLSTATES.has(code)) return true;
+    current = (current as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+export interface DeadlockRetryOptions {
+  /** Total attempts including the first one. Default 3. */
+  maxAttempts?: number;
+  /**
+   * Delay before retry attempt `attempt` (2-based: called before the 2nd,
+   * 3rd, … attempt), in milliseconds. Default grows linearly (50ms, 100ms) —
+   * enough for the winning background transaction to finish. Tests inject
+   * `() => 0` to keep the suite fast.
+   */
+  delayMs?: (attempt: number) => number;
+  /**
+   * Called after a transient failure, before the next attempt. Use it to
+   * surface the retry (the deadlock is a real signal worth counting — see
+   * issue #883) without failing the test.
+   */
+  onRetry?: (err: unknown, attempt: number) => void;
+}
+
+/**
+ * Run `fn`, retrying when it fails with a transient lock error
+ * ({@link isTransientLockError}). Any other error — and the last transient
+ * one once attempts are exhausted — is rethrown unchanged.
+ */
+export async function withDeadlockRetry<T>(
+  fn: () => Promise<T>,
+  options: DeadlockRetryOptions = {},
+): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? 3;
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new RangeError(`maxAttempts must be a positive integer, got ${maxAttempts}`);
+  }
+  const delayMs = options.delayMs ?? ((attempt) => (attempt - 1) * 50);
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= maxAttempts || !isTransientLockError(err)) throw err;
+      options.onRetry?.(err, attempt);
+      const delay = delayMs(attempt + 1);
+      if (delay > 0) await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}

--- a/apps/api/test/integration/services/truncate-deadlock.test.ts
+++ b/apps/api/test/integration/services/truncate-deadlock.test.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * End-to-end test for truncateAll()'s retry-on-deadlock behavior (issue #883).
+ *
+ * The flake this guards against: truncateAll()'s single-transaction DO block
+ * takes row locks across every table while a previous test's fire-and-forget
+ * work is still writing — a lock cycle Postgres breaks with SQLSTATE 40P01
+ * after `deadlock_timeout`, failing whichever test happened to be cleaning up.
+ *
+ * This test manufactures that cycle deterministically instead of hoping for
+ * load: a background transaction locks an `organizations` row (step 1), and
+ * once truncateAll() is blocked on it, touches an `applications` row the
+ * truncate has already deleted uncommitted (step 2). Both sides then wait on
+ * each other — the only exit is Postgres aborting one of them with a
+ * deadlock. Whichever side is the victim, truncateAll() must come out clean:
+ * either it won and the background transaction absorbed the 40P01, or it was
+ * the victim and its retry ran against the then-quiesced database.
+ *
+ * Postgres-only: PGlite (tier0) is single-connection, so two concurrent
+ * transactions — and therefore this deadlock — cannot exist there.
+ */
+import { it, expect, spyOn } from "bun:test";
+import { sql } from "drizzle-orm";
+import { db, truncateAll } from "../../helpers/db.ts";
+import { isTransientLockError } from "../../helpers/deadlock-retry.ts";
+import { describeRequiresPostgres } from "../../helpers/tier.ts";
+import { organizations, applications } from "@appstrate/db/schema";
+
+describeRequiresPostgres("truncateAll deadlock resilience (issue #883)", () => {
+  it(
+    "survives a concurrent transaction deadlocking with the truncate",
+    async () => {
+      await truncateAll();
+
+      const [org] = await db
+        .insert(organizations)
+        .values({ name: "deadlock-test", slug: `deadlock-${crypto.randomUUID()}` })
+        .returning();
+      if (!org) throw new Error("failed to seed organization");
+      const appId = `app_deadlock_${crypto.randomUUID().slice(0, 8)}`;
+      await db.insert(applications).values({ id: appId, orgId: org.id, name: "deadlock-app" });
+
+      const warnSpy = spyOn(console, "warn");
+      try {
+        // Background transaction, playing the part of a previous test's
+        // unawaited fire-and-forget work.
+        const background: Promise<"committed" | { err: unknown }> = db
+          .transaction(async (tx) => {
+            // Step 1 — lock the org row. truncateAll()'s DELETE FROM
+            // organizations will block on this.
+            await tx.execute(sql`SELECT id FROM ${organizations} WHERE id = ${org.id} FOR UPDATE`);
+            // Give truncateAll() time to delete `applications` (uncommitted)
+            // and block on our org-row lock.
+            await Bun.sleep(400);
+            // Step 2 — touch the applications row the truncate already
+            // deleted uncommitted. Now each side waits on the other: a lock
+            // cycle only the deadlock detector can break.
+            await tx.execute(sql`UPDATE ${applications} SET name = 'poke' WHERE id = ${appId}`);
+          })
+          .then(
+            () => "committed" as const,
+            (err: unknown) => ({ err }),
+          );
+
+        // Start the truncate after the background transaction holds its lock.
+        await Bun.sleep(50);
+        const truncatePromise = truncateAll();
+
+        // truncateAll() must resolve — victim or not.
+        const [backgroundOutcome] = await Promise.all([background, truncatePromise]);
+
+        const truncateRetried = warnSpy.mock.calls.some(
+          (call) => typeof call[0] === "string" && call[0].includes("[truncateAll]"),
+        );
+        if (backgroundOutcome === "committed") {
+          // Background won ⇒ the truncate was the deadlock victim and must
+          // have recovered through a retry.
+          expect(truncateRetried).toBe(true);
+        } else {
+          // Truncate won ⇒ the background transaction absorbed the abort,
+          // and it must be the transient lock class our retry targets.
+          expect(isTransientLockError(backgroundOutcome.err)).toBe(true);
+        }
+        // The cycle is structural — one side MUST have hit the deadlock.
+        expect(truncateRetried || backgroundOutcome !== "committed").toBe(true);
+
+        // Whatever the outcome, the database ends up clean.
+        expect(await db.select({ id: organizations.id }).from(organizations)).toHaveLength(0);
+        expect(await db.select({ id: applications.id }).from(applications)).toHaveLength(0);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    },
+    // Deadlock detection fires at deadlock_timeout (1s) + retry backoff —
+    // leave generous headroom for a loaded machine.
+    { timeout: 15_000 },
+  );
+});

--- a/apps/api/test/unit/deadlock-retry.test.ts
+++ b/apps/api/test/unit/deadlock-retry.test.ts
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the truncateAll retry-on-deadlock helper (issue #883).
+ *
+ * Pure logic — no DB. The helper is exercised with injected failures shaped
+ * like the real driver errors: postgres.js raises a `PostgresError` with a
+ * SQLSTATE `code` property, and Drizzle wraps it in a `DrizzleQueryError`
+ * whose `cause` is the driver error.
+ */
+import { describe, it, expect } from "bun:test";
+import { isTransientLockError, withDeadlockRetry } from "../helpers/deadlock-retry.ts";
+
+/** Error shaped like postgres.js / PGlite driver errors (SQLSTATE on `code`). */
+function pgError(code: string, message = `SQLSTATE ${code}`): Error {
+  const err = new Error(message);
+  (err as Error & { code: string }).code = code;
+  return err;
+}
+
+/** Error shaped like Drizzle's `DrizzleQueryError` — driver error on `cause`. */
+function drizzleWrapped(code: string): Error {
+  return new Error("Failed query: DO $$ BEGIN ... END $$", { cause: pgError(code) });
+}
+
+const NO_DELAY = () => 0;
+
+describe("isTransientLockError", () => {
+  it("detects a deadlock (40P01) on the error itself", () => {
+    expect(isTransientLockError(pgError("40P01"))).toBe(true);
+  });
+
+  it("detects a serialization failure (40001)", () => {
+    expect(isTransientLockError(pgError("40001"))).toBe(true);
+  });
+
+  it("detects lock_not_available (55P03)", () => {
+    expect(isTransientLockError(pgError("55P03"))).toBe(true);
+  });
+
+  it("detects a deadlock wrapped in a DrizzleQueryError cause", () => {
+    expect(isTransientLockError(drizzleWrapped("40P01"))).toBe(true);
+  });
+
+  it("detects a deadlock nested two causes deep", () => {
+    const doubleWrapped = new Error("outer", { cause: drizzleWrapped("40P01") });
+    expect(isTransientLockError(doubleWrapped)).toBe(true);
+  });
+
+  it("rejects non-retryable SQLSTATEs (unique violation, FK violation)", () => {
+    expect(isTransientLockError(pgError("23505"))).toBe(false);
+    expect(isTransientLockError(drizzleWrapped("23503"))).toBe(false);
+  });
+
+  it("rejects plain errors, non-string codes, and non-error values", () => {
+    expect(isTransientLockError(new Error("boom"))).toBe(false);
+    const numericCode = new Error("boom");
+    (numericCode as Error & { code: number }).code = 40001;
+    expect(isTransientLockError(numericCode)).toBe(false);
+    expect(isTransientLockError("40P01")).toBe(false);
+    expect(isTransientLockError(null)).toBe(false);
+    expect(isTransientLockError(undefined)).toBe(false);
+    expect(isTransientLockError(40)).toBe(false);
+  });
+
+  it("gives up on a cause chain deeper than the walk limit", () => {
+    // 6 wrappers around the coded error — one past MAX_CAUSE_DEPTH (5).
+    let err: Error = pgError("40P01");
+    for (let i = 0; i < 6; i++) err = new Error(`wrap ${i}`, { cause: err });
+    expect(isTransientLockError(err)).toBe(false);
+  });
+
+  it("survives a self-referencing cause cycle", () => {
+    const err = new Error("cyclic");
+    (err as Error & { cause: unknown }).cause = err;
+    expect(isTransientLockError(err)).toBe(false);
+  });
+});
+
+describe("withDeadlockRetry", () => {
+  it("returns the result without retrying on success", async () => {
+    let calls = 0;
+    const result = await withDeadlockRetry(async () => {
+      calls++;
+      return "ok";
+    });
+    expect(result).toBe("ok");
+    expect(calls).toBe(1);
+  });
+
+  it("retries a deadlock and succeeds on a later attempt", async () => {
+    let calls = 0;
+    const result = await withDeadlockRetry(
+      async () => {
+        calls++;
+        if (calls < 3) throw drizzleWrapped("40P01");
+        return "recovered";
+      },
+      { delayMs: NO_DELAY },
+    );
+    expect(result).toBe("recovered");
+    expect(calls).toBe(3);
+  });
+
+  it("rethrows a non-retryable error immediately", async () => {
+    let calls = 0;
+    const boom = pgError("23505");
+    await expect(
+      withDeadlockRetry(
+        async () => {
+          calls++;
+          throw boom;
+        },
+        { delayMs: NO_DELAY },
+      ),
+    ).rejects.toBe(boom);
+    expect(calls).toBe(1);
+  });
+
+  it("rethrows the last error once attempts are exhausted", async () => {
+    let calls = 0;
+    const errors = [
+      pgError("40P01", "first"),
+      pgError("40P01", "second"),
+      pgError("40P01", "third"),
+    ];
+    await expect(
+      withDeadlockRetry(
+        async () => {
+          throw errors[calls++];
+        },
+        { maxAttempts: 3, delayMs: NO_DELAY },
+      ),
+    ).rejects.toBe(errors[2]);
+    expect(calls).toBe(3);
+  });
+
+  it("respects maxAttempts: 1 (no retry at all)", async () => {
+    let calls = 0;
+    await expect(
+      withDeadlockRetry(
+        async () => {
+          calls++;
+          throw pgError("40P01");
+        },
+        { maxAttempts: 1, delayMs: NO_DELAY },
+      ),
+    ).rejects.toThrow("SQLSTATE 40P01");
+    expect(calls).toBe(1);
+  });
+
+  it("invokes onRetry with the error and the failed attempt number", async () => {
+    const seen: Array<{ err: unknown; attempt: number }> = [];
+    let calls = 0;
+    await withDeadlockRetry(
+      async () => {
+        calls++;
+        if (calls < 3) throw pgError("40P01", `failure ${calls}`);
+        return "ok";
+      },
+      {
+        delayMs: NO_DELAY,
+        onRetry: (err, attempt) => seen.push({ err, attempt }),
+      },
+    );
+    expect(seen).toHaveLength(2);
+    expect(seen[0]?.attempt).toBe(1);
+    expect(seen[1]?.attempt).toBe(2);
+    expect((seen[0]?.err as Error).message).toBe("failure 1");
+    expect((seen[1]?.err as Error).message).toBe("failure 2");
+  });
+
+  it("does not invoke onRetry for a non-retryable error", async () => {
+    let retries = 0;
+    await expect(
+      withDeadlockRetry(
+        async () => {
+          throw new Error("plain");
+        },
+        { delayMs: NO_DELAY, onRetry: () => retries++ },
+      ),
+    ).rejects.toThrow("plain");
+    expect(retries).toBe(0);
+  });
+
+  it("rejects a non-positive or non-integer maxAttempts", async () => {
+    await expect(withDeadlockRetry(async () => "x", { maxAttempts: 0 })).rejects.toThrow(
+      RangeError,
+    );
+    await expect(withDeadlockRetry(async () => "x", { maxAttempts: 1.5 })).rejects.toThrow(
+      RangeError,
+    );
+  });
+
+  it("waits between attempts using the injected delay", async () => {
+    const delays: number[] = [];
+    let calls = 0;
+    const start = Date.now();
+    await withDeadlockRetry(
+      async () => {
+        calls++;
+        if (calls < 2) throw pgError("40P01");
+        return "ok";
+      },
+      {
+        delayMs: (attempt) => {
+          delays.push(attempt);
+          return 10;
+        },
+      },
+    );
+    expect(delays).toEqual([2]); // delay computed for the 2nd attempt
+    expect(Date.now() - start).toBeGreaterThanOrEqual(9);
+  });
+});


### PR DESCRIPTION
Closes #883.

## Problem

Full-suite runs occasionally fail with exactly one red test — a different one each run — with the same signature: SQLSTATE `40P01` (`deadlock_detected`) inside `truncateAll()`, landing at ~1005ms (Postgres's default `deadlock_timeout` of 1s).

The mechanism (detailed in #883): `truncateAll()`'s single `DO $$ ... $$` block deletes ~26 tables children→parents in one implicit transaction, while a previous test's **unawaited fire-and-forget work** (`executeAgentInBackground`, `ensureDefaultProfile`, …) is still writing. The background transaction's INSERT takes a `KEY SHARE` lock on its parent `organizations` row (FK enforcement); the truncate wants to delete that row and already holds the child rows the background transaction touches next. Lock cycle → Postgres aborts one side → whichever test was cleaning up goes red.

## Fix

Option (2) from the issue — retry the deadlock class in the test helper. The race is a harness artifact, not production behavior, so retrying the aborted cleanup is honest: the winning background transaction commits, and the retry runs against a quiesced database.

- **`apps/api/test/helpers/deadlock-retry.ts`** (new, dependency-free):
  - `isTransientLockError()` — SQLSTATE match (`40P01`, `40001`, `55P03`) walking the `cause` chain (Drizzle wraps the driver error in `DrizzleQueryError`), same pattern as `isInvalidTextRepresentation` in `lib/db-helpers.ts`. Bounded depth, cycle-safe.
  - `withDeadlockRetry()` — up to 3 attempts, linear backoff (50ms/100ms, injectable), rethrows anything non-transient unchanged.
- **`truncateAll()`** wraps its DO block in `withDeadlockRetry` and warns on each retry (`[truncateAll] transient lock conflict …: deadlock detected`) — the `40P01` count stays greppable in suite output instead of hiding behind a green run, per the issue's "honest signal" point.

Option (1) (quiescing in-flight work) alone would be incomplete — middleware fire-and-forget queries like `ensureDefaultProfile` aren't tracked by `run-tracker.ts` — so the retry backstop is needed regardless; it can still be layered on later.

## Tests

- **Unit** (`test/unit/deadlock-retry.test.ts`, 18 tests, no DB): SQLSTATE detection through wrapped/deep/cyclic cause chains, non-retryable codes rejected, retry loop semantics (attempt counting, immediate rethrow of non-transient errors, exhaustion rethrows the last error, `onRetry` callbacks, delay injection, `maxAttempts` validation).
- **Integration** (`test/integration/services/truncate-deadlock.test.ts`, Postgres-only via `describeRequiresPostgres` — PGlite is single-connection so the deadlock can't exist at tier0): manufactures the real lock cycle **deterministically** instead of hoping for load — a background transaction takes `FOR UPDATE` on an `organizations` row, then touches an `applications` row the concurrent `truncateAll()` has already deleted uncommitted. The cycle is structural; the only exit is the deadlock detector. Asserts `truncateAll()` resolves whichever side is the victim, that the deadlock actually occurred, and that the DB ends up clean.

## Verification

- `bun test apps/api/test` (Tier 3, real Postgres): **2801 pass / 0 fail** — the new integration test exercised the retry live (`[truncateAll] transient lock conflict (attempt 1), retrying: deadlock detected`).
- Tier 0 (`TEST_TIER=0`): unit tests pass, integration test correctly skips.
- `tsc --noEmit`, ESLint, Prettier clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)