### PR TITLE
fix(ui): make collapsed sidebar group labels click-through

### DIFF
--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -408,7 +408,7 @@ const SidebarGroupLabel = React.forwardRef<
       data-sidebar="group-label"
       className={cn(
         "text-sidebar-foreground/70 ring-sidebar-ring flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium transition-[margin,opacity] duration-200 ease-linear outline-none focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
-        "group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
+        "group-data-[collapsible=icon]:pointer-events-none group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Problem

When the main sidebar is collapsed to icon mode, `SidebarGroupLabel` elements get `-mt-8` and `opacity-0` but stay in the stacking context. The invisible labels overlap the menu items above them and intercept clicks and hovers (tooltips, menu buttons).

## Fix

Add `group-data-[collapsible=icon]:pointer-events-none` to `SidebarGroupLabel` so pointer events pass through to the underlying menu items. The margin/opacity transition is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)