### PR TITLE
fix(web): restore agent timeout field via generic MetadataSection children slot

### DIFF
--- a/apps/web/src/components/agent-editor/metadata-section.tsx
+++ b/apps/web/src/components/agent-editor/metadata-section.tsx
@@ -18,16 +18,22 @@ export interface MetadataState {
   description: string;
   author: string;
   keywords: string[];
-  timeout?: number;
 }
 
 interface MetadataSectionProps {
   value: MetadataState;
   onChange: (value: MetadataState) => void;
   isEdit: boolean;
+  /**
+   * Editor-specific metadata fields (e.g. the agent editor's `timeout`),
+   * rendered between the common version and description fields. Each editor
+   * binds its own fields to its manifest state — MetadataSection only owns
+   * the fields every package type shares.
+   */
+  children?: React.ReactNode;
 }
 
-export function MetadataSection({ value, onChange, isEdit }: MetadataSectionProps) {
+export function MetadataSection({ value, onChange, isEdit, children }: MetadataSectionProps) {
   const { t } = useTranslation(["agents", "common"]);
   const update = (patch: Partial<MetadataState>) => onChange({ ...value, ...patch });
   const [nameEdited, setNameEdited] = useState(isEdit);
@@ -96,16 +102,7 @@ export function MetadataSection({ value, onChange, isEdit }: MetadataSectionProp
         placeholder="1.0.0"
         description={t("editor.metaVersionDesc")}
       />
-      {value.timeout !== undefined && (
-        <FormField
-          id="meta-timeout"
-          label={t("editor.execTimeout")}
-          type="number"
-          value={String(value.timeout)}
-          onChange={(v) => update({ timeout: parseInt(v) || 300 })}
-          description={t("editor.execTimeoutDesc")}
-        />
-      )}
+      {children}
       <div className="space-y-2">
         <Label htmlFor="meta-description">{t("editor.metaDescription")}</Label>
         <Textarea

--- a/apps/web/src/components/agent-editor/utils.ts
+++ b/apps/web/src/components/agent-editor/utils.ts
@@ -161,7 +161,10 @@ export function getManifestName(m: Record<string, unknown>): { scope: string; id
   return match ? { scope: match[1]!, id: match[2]! } : { scope: "", id: raw };
 }
 
-/** Extract MetadataState from a manifest object. Includes timeout if present (agents only).
+/** Extract MetadataState from a manifest object — the fields common to every
+ * package type. Editor-specific manifest fields (e.g. the agent `timeout`)
+ * are bound directly to manifest state by their editor and rendered through
+ * MetadataSection's children slot.
  *
  * `author` accepts both the AFPS §3.1 bare-string form and the structured
  * `{ name, email?, url? }` object form: the editor's metadata UI is a single
@@ -186,7 +189,6 @@ export function manifestToMetadata(m: Record<string, unknown>): MetadataState {
     description: (m.description as string) ?? "",
     author: authorText,
     keywords: Array.isArray(m.keywords) ? (m.keywords as string[]) : [],
-    ...(typeof m.timeout === "number" ? { timeout: m.timeout } : {}),
   };
 }
 
@@ -202,7 +204,6 @@ export function metadataToManifestPatch(m: MetadataState): Record<string, unknow
     description: m.description,
     author: m.author,
     keywords: m.keywords,
-    ...(m.timeout !== undefined ? { timeout: m.timeout } : {}),
   };
 }
 

--- a/apps/web/src/pages/package-editor.tsx
+++ b/apps/web/src/pages/package-editor.tsx
@@ -12,6 +12,7 @@ import { packageDetailPath, packageListPath } from "../lib/package-paths";
 import { primaryDisplayFile } from "../lib/package-files";
 import { useEditorState, type EditorStateBase } from "../hooks/use-editor-state";
 import { UnsavedChangesModal } from "../components/unsaved-changes-modal";
+import { FormField } from "../components/form-field";
 
 // Agent editor components
 import { MetadataSection } from "../components/agent-editor/metadata-section";
@@ -186,7 +187,23 @@ function AgentEditorInner({
       hideSubmitBar={activeTab === "json"}
     >
       {activeTab === "general" && (
-        <MetadataSection value={metadata} onChange={onMetadataChange} isEdit={isEdit} />
+        <MetadataSection value={metadata} onChange={onMetadataChange} isEdit={isEdit}>
+          <FormField
+            id="meta-timeout"
+            label={t("editor.execTimeout")}
+            type="number"
+            min={1}
+            value={typeof state.manifest.timeout === "number" ? String(state.manifest.timeout) : ""}
+            onChange={(v) => {
+              const n = parseInt(v, 10);
+              // `undefined` clears the key through the shallow manifest merge
+              // (JSON serialization drops it on save → server default, 300s).
+              updateManifest({ timeout: Number.isNaN(n) ? undefined : n });
+            }}
+            placeholder="300"
+            description={t("editor.execTimeoutDesc")}
+          />
+        </MetadataSection>
       )}
       {activeTab === "prompt" && (
         <PromptEditor


### PR DESCRIPTION
## Problem

The `timeout` field in the agent manifest editor only rendered when the manifest already contained a `timeout` value (`value.timeout !== undefined`). Agents created without one — import, fork, chat-created, minimal manifests — never showed the field, so it could not be set from the UI at all. From the user's perspective the field had disappeared.

## Changes

- **`MetadataSection`** now owns only the metadata fields every package type shares (name, scope, version, description, keywords, …) and exposes a `children` slot, rendered between the version and description fields, for editor-specific fields. `timeout` is removed from `MetadataState`.
- **`manifestToMetadata` / `metadataToManifestPatch`** no longer know about `timeout`.
- **Agent editor** (`package-editor.tsx`) composes its timeout `FormField` through the slot, bound directly to `state.manifest.timeout` via `updateManifest`:
  - always visible for agents,
  - empty input shows the server default as placeholder (300s),
  - clearing the input removes the key from the manifest (JSON serialization drops the `undefined`).

Future type-specific metadata fields are just another child — no `MetadataSection` change needed.

## Verification

`tsc --noEmit`, `eslint`, `prettier --check` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)