### PR TITLE
fix(runtime-pi): api_upload conversion — derive X-Upload-Content-Type from source MIME, not target

### DIFF
--- a/runtime-pi/mcp/api-upload-extension.ts
+++ b/runtime-pi/mcp/api-upload-extension.ts
@@ -111,6 +111,7 @@ function makeExtension(
             fromFile: { type: "string" },
             uploadProtocol: { type: "string", enum: protocols },
             metadata: { type: "object", additionalProperties: true },
+            sourceMimeType: { type: "string" },
             partSizeBytes: { type: "integer", minimum: 1 },
           },
         },
@@ -121,6 +122,7 @@ function makeExtension(
           fromFile?: string;
           uploadProtocol?: string;
           metadata?: Record<string, unknown>;
+          sourceMimeType?: string;
           partSizeBytes?: number;
         };
 
@@ -171,6 +173,7 @@ function makeExtension(
             fromFile: args.fromFile,
             uploadProtocol: protocol as UploadProtocol,
             metadata: args.metadata,
+            ...(args.sourceMimeType !== undefined ? { sourceMimeType: args.sourceMimeType } : {}),
             ...(args.partSizeBytes !== undefined ? { partSizeBytes: args.partSizeBytes } : {}),
           },
           {

--- a/runtime-pi/mcp/api-upload-resolver.ts
+++ b/runtime-pi/mcp/api-upload-resolver.ts
@@ -89,6 +89,9 @@ export interface IntegrationUploadRequest {
   fromFile: string;
   uploadProtocol: UploadProtocol;
   metadata?: Record<string, unknown>;
+  /** MIME type of the source bytes (→ `X-Upload-Content-Type`). Distinct
+   *  from `metadata.mimeType`, which is the desired/target file type. */
+  sourceMimeType?: string;
   partSizeBytes?: number;
 }
 
@@ -227,6 +230,7 @@ export class McpApiUploadResolver {
       target: req.target,
       totalBytes,
       metadata: req.metadata ?? {},
+      sourceMimeType: req.sourceMimeType,
       partSizeBytes,
       apiCall: this.makeApiCall(ctx.signal),
       signal: ctx.signal,

--- a/runtime-pi/mcp/upload-adapters/google-resumable.ts
+++ b/runtime-pi/mcp/upload-adapters/google-resumable.ts
@@ -87,11 +87,21 @@ export const googleResumableAdapter: UploadAdapter = {
       "Content-Type": "application/json; charset=UTF-8",
       "X-Upload-Content-Length": String(ctx.totalBytes),
     };
-    // Optional declared upstream MIME — Drive ranks this above the
-    // metadata-derived MIME for sniffing.
-    const upstreamMime = ctx.metadata?.["mimeType"];
-    if (typeof upstreamMime === "string" && upstreamMime.length > 0) {
-      headers["X-Upload-Content-Type"] = upstreamMime;
+    // `X-Upload-Content-Type` declares the MIME of the BYTES being uploaded
+    // (the source). For a conversion this differs from the desired file type
+    // in `metadata.mimeType` (the target — e.g. a Google-native
+    // `application/vnd.google-apps.*` type). Prefer the explicit source type;
+    // otherwise fall back to `metadata.mimeType` ONLY when it is not a
+    // Google-native type, since uploading native-type bytes is impossible and
+    // Drive rejects the chunk with a 400.
+    const targetMime = ctx.metadata?.["mimeType"];
+    const sourceMime =
+      ctx.sourceMimeType ??
+      (typeof targetMime === "string" && !targetMime.startsWith("application/vnd.google-apps.")
+        ? targetMime
+        : undefined);
+    if (typeof sourceMime === "string" && sourceMime.length > 0) {
+      headers["X-Upload-Content-Type"] = sourceMime;
     }
     const res = await ctx.apiCall({
       apiCallToolName: ctx.apiCallToolName,

--- a/runtime-pi/mcp/upload-adapters/types.ts
+++ b/runtime-pi/mcp/upload-adapters/types.ts
@@ -94,6 +94,12 @@ export interface AdapterContext {
   totalBytes: number;
   /** Caller-supplied metadata (Drive file name, MIME type, …). */
   metadata: Record<string, unknown>;
+  /** MIME type of the SOURCE bytes being uploaded → `X-Upload-Content-Type`.
+   *  Distinct from `metadata.mimeType`, which is the DESIRED (target) file
+   *  type — e.g. a Google-native `application/vnd.google-apps.*` type that
+   *  triggers server-side conversion. When absent, adapters fall back to a
+   *  safe default and never declare a native type as the source. */
+  sourceMimeType?: string;
   /** Suggested chunk size; the adapter may clamp to its own protocol-
    *  level minimum/alignment requirements. */
   partSizeBytes: number;

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -970,6 +970,16 @@ function buildSidecarTools(options: MountMcpOptions): {
                 "tus: free-form key/value (encoded as `Upload-Metadata`). " +
                 "MS Graph: `{ item: { ... } }` envelope.",
             },
+            sourceMimeType: {
+              type: "string",
+              description:
+                "MIME type of the SOURCE bytes being uploaded — sent as `X-Upload-Content-Type`. " +
+                "Distinct from `metadata.mimeType`, which is the DESIRED (target) file type. " +
+                "For a Google Drive conversion, set `sourceMimeType` to the upload's real type " +
+                "(e.g. `text/markdown`, `text/html`, `text/csv`) AND `metadata.mimeType` to the " +
+                "Google-native target (e.g. `application/vnd.google-apps.document`); Drive then " +
+                "converts. Omit it to upload the bytes verbatim (no conversion).",
+            },
             partSizeBytes: {
               type: "integer",
               minimum: 1,

--- a/runtime-pi/test/google-resumable-source-mime.test.ts
+++ b/runtime-pi/test/google-resumable-source-mime.test.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Appstrate
+
+/**
+ * Regression: the `X-Upload-Content-Type` header on the resumable init MUST
+ * describe the SOURCE bytes, not the DESIRED (target) file type in
+ * `metadata.mimeType`. Declaring a Google-native target type as the source
+ * makes Drive reject the FIRST chunk with a 400 (validated against the live
+ * Drive API), which broke every Markdown/HTML/CSV → Google-Doc conversion.
+ */
+import { describe, it, expect } from "bun:test";
+import { googleResumableAdapter } from "../mcp/upload-adapters/google-resumable.ts";
+import type { AdapterContext } from "../mcp/upload-adapters/types.ts";
+
+function initWith(over: Partial<AdapterContext>): Promise<Record<string, string> | undefined> {
+  let seen: Record<string, string> | undefined;
+  const ctx = {
+    apiCallToolName: "x__api_call",
+    target: "https://www.googleapis.com/upload/drive/v3/files?uploadType=resumable",
+    totalBytes: 40,
+    metadata: {},
+    partSizeBytes: 256 * 1024,
+    apiCall: async (req: { headers: Record<string, string> }) => {
+      seen = req.headers;
+      return { status: 200, headers: { location: "https://sess.example/upload/s1" }, body: "{}" };
+    },
+    signal: new AbortController().signal,
+    hashUpdate: () => {},
+    ...over,
+  } as AdapterContext;
+  return googleResumableAdapter.initSession(ctx).then(() => seen);
+}
+
+describe("google-resumable X-Upload-Content-Type (source vs target MIME)", () => {
+  it("uses the explicit sourceMimeType (enables Drive conversion)", async () => {
+    const h = await initWith({
+      sourceMimeType: "text/markdown",
+      metadata: { name: "x", mimeType: "application/vnd.google-apps.document" },
+    });
+    expect(h?.["X-Upload-Content-Type"]).toBe("text/markdown");
+  });
+
+  it("does NOT declare a Google-native target type as the source (the 400 bug)", async () => {
+    const h = await initWith({
+      metadata: { name: "x", mimeType: "application/vnd.google-apps.document" },
+    });
+    expect(h?.["X-Upload-Content-Type"]).toBeUndefined();
+  });
+
+  it("falls back to metadata.mimeType when it is a real (non-native) source type", async () => {
+    const h = await initWith({ metadata: { name: "x", mimeType: "text/plain" } });
+    expect(h?.["X-Upload-Content-Type"]).toBe("text/plain");
+  });
+
+  it("sets no source type when none is available", async () => {
+    const h = await initWith({ metadata: { name: "x" } });
+    expect(h?.["X-Upload-Content-Type"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

`api_upload` over `google-resumable` cannot convert an uploaded file to a Google-native type (Markdown/HTML/CSV → Google Doc/Sheet). The resumable init succeeds but Drive rejects the **first chunk** with a `400 Bad Request`, so no file is created.

Follow-up to #881 (which exposed `api_upload` in the tool catalog). This is a **separate** bug — the conversion path — that surfaced once the tool became usable.

## Root cause

`google-resumable.ts` sets `X-Upload-Content-Type` — which declares the MIME of the **bytes being uploaded** (the source) — from `metadata.mimeType`. But for a conversion, `metadata.mimeType` is the **target** type (e.g. `application/vnd.google-apps.document`). Declaring a Google-native type as the source is nonsensical (you can't upload native-type bytes), so Drive accepts the init but rejects the chunk.

## Validation (live Drive API)

Full resumable flow (init + chunk) against the real Drive API, varying only `X-Upload-Content-Type`:

| `X-Upload-Content-Type` | body `mimeType` | init | chunk | result |
|---|---|---|---|---|
| `application/vnd.google-apps.document` (target) | `…document` | 200 | **400** | fails (current behavior) |
| `text/markdown` (source) | `…document` | 200 | **200** | ✅ converted Google Doc created |

## Fix

Introduce an explicit **`sourceMimeType`** on `api_upload`, threaded through to the adapter:

- `sidecar/mcp.ts` — authoritative `api_upload` input schema (what the agent sees) + a description spelling out source-vs-target
- `api-upload-extension.ts`, `api-upload-resolver.ts`, `upload-adapters/types.ts` — plumb `sourceMimeType` from tool args → `IntegrationUploadRequest` → `AdapterContext`
- `google-resumable.ts` — `X-Upload-Content-Type` now prefers `ctx.sourceMimeType`; falls back to `metadata.mimeType` **only when it is not a `application/vnd.google-apps.*` native type** (so the 400 can no longer happen and plain uploads are unchanged)

Usage for conversion becomes:

```jsonc
{
  "target": "https://www.googleapis.com/upload/drive/v3/files?uploadType=resumable",
  "fromFile": "report.md",
  "uploadProtocol": "google-resumable",
  "sourceMimeType": "text/markdown",
  "metadata": { "name": "Report", "parents": ["…"], "mimeType": "application/vnd.google-apps.document" }
}
```

## Backward compatibility

- No `sourceMimeType`, `metadata.mimeType` a real (non-native) type → unchanged (still used as the source declaration).
- No `sourceMimeType`, `metadata.mimeType` a Google-native type → header now **omitted** instead of sent (previously guaranteed a 400).
- Plain uploads (no `mimeType`) → unchanged.

## Tests

- New `runtime-pi/test/google-resumable-source-mime.test.ts` — 4 cases (explicit source; native-target skipped; non-native fallback; none). **4/4 pass.**
- Existing `api-upload-extension.test.ts` (5/5) and `mcp-api-upload-resolver.test.ts` (20/20) green.
- `runtime-pi` typecheck clean.

Based on latest `main` (`af4fd939`), which is ahead of `v1.0.0-beta.39`.

cc @pierrecabriere

🤖 Generated with [Claude Code](https://claude.com/claude-code)
