### PR TITLE
fix(chat): route connect URLs through a typed connectOffer field (#906)

### DIFF
--- a/packages/module-chat/src/connect-offer.ts
+++ b/packages/module-chat/src/connect-offer.ts
@@ -187,10 +187,11 @@ export function redactConnectLinks(output: unknown): unknown {
 /**
  * Split a tool `execute` result for the UI/persistence channel: redact every
  * connect link in place and attach the captured offer as a typed top-level
- * `connectOffer` field. Handles the envelopes an execute result arrives in —
- * MCP `CallToolResult` `{content:[…], structuredContent?}`, the AI SDK bridge
- * `{type:"content"|"json", value}`, or a plain payload object. Returns the
- * original reference when nothing changed.
+ * `connectOffer` field. Handles the two shapes `@ai-sdk/mcp` `execute` returns —
+ * the raw MCP `CallToolResult` `{content:[…], structuredContent?}` (also on
+ * `isError`), or a bare `structuredContent` payload object when an
+ * `outputSchema` is configured. Returns the original reference when nothing
+ * changed.
  */
 export function splitToolResult(result: unknown): unknown {
   if (result == null || typeof result !== "object") return result;
@@ -224,29 +225,6 @@ export function splitToolResult(result: unknown): unknown {
       ...(o.structuredContent !== undefined ? { structuredContent } : {}),
       ...(offer ? { connectOffer: offer } : {}),
     };
-  }
-
-  if (o.type === "json" && "value" in o) {
-    const r = splitConnectPayload(o.value);
-    if (r.redacted === o.value) return result;
-    return { ...o, value: r.redacted, ...(r.offer ? { connectOffer: r.offer } : {}) };
-  }
-
-  if (o.type === "content" && Array.isArray(o.value)) {
-    let changed = false;
-    let offer: ConnectOffer | null = null;
-    const nextValue = o.value.map((part) => {
-      if (part == null || typeof part !== "object") return part;
-      const p = part as Record<string, unknown>;
-      if (p.type !== "text" || typeof p.text !== "string") return part;
-      const r = splitJsonText(p.text);
-      offer ??= r.offer;
-      if (r.text === p.text) return part;
-      changed = true;
-      return { ...p, text: r.text };
-    });
-    if (!changed) return result;
-    return { ...o, value: nextValue, ...(offer ? { connectOffer: offer } : {}) };
   }
 
   const r = splitConnectPayload(result);

--- a/packages/module-chat/src/connect-offer.ts
+++ b/packages/module-chat/src/connect-offer.ts
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Connect-offer redaction + extraction — the single walk both chat engines use
+ * on tool results that may carry a connect/authorize URL.
+ *
+ * A connect URL must exist in exactly one place per channel:
+ *
+ *  - MODEL channel — never. Every `connect_url`/`auth_url` string is replaced
+ *    by {@link REDACTED_CONNECT_LINK} so the model cannot paste a link it never
+ *    receives.
+ *  - UI channel — only in the typed `connectOffer` field the splitters attach
+ *    to the tool output. The connect card reads that field; it never scrapes
+ *    the payload (issue #906: the scraper used to grab the placeholder from the
+ *    model channel and render it as a relative URL).
+ *
+ * Redaction and extraction are the SAME pass (`splitValue`): whatever gets
+ * scrubbed from the payload is what surfaces as the offer, so the two can never
+ * drift apart.
+ *
+ * Dependency-free on purpose: `ui/auth-offer.ts` (bundled into the SPA) imports
+ * the {@link ConnectOffer} type and {@link readConnectOffer} from here, so this
+ * module must not pull in server-only imports (MCP client, logger).
+ */
+
+/**
+ * Placeholder that replaces a connect/authorize URL in the MODEL-visible tool
+ * output. The model can't paste a link it never receives; the UI renders the
+ * native connect card from the typed `connectOffer` field instead.
+ */
+export const REDACTED_CONNECT_LINK = "[connect link hidden — the chat renders the connect card]";
+
+/** Field names carrying a connect/authorize URL (snake + camel). */
+const CONNECT_URL_KEYS = new Set(["connect_url", "auth_url", "connectUrl", "authUrl"]);
+
+/** Depth bound for the redaction walk — MCP payloads are shallow. */
+const MAX_REDACT_DEPTH = 16;
+
+/**
+ * Typed connect offer captured while redacting. Keys are wire-shaped
+ * (snake_case, straight off the platform payload) — deliberately so: the inner
+ * `connect_url` key is itself in {@link CONNECT_URL_KEYS}, so if an offer
+ * object ever strays through the redactor again it gets scrubbed rather than
+ * leaked.
+ */
+export interface ConnectOffer {
+  /** Absolute http(s) URL — validated at capture time. */
+  connect_url: string;
+  /** Legacy OAuth flows pair `auth_url` with a correlation `state`. */
+  state?: string;
+  expires_at?: number;
+}
+
+interface SplitResult {
+  /** Redacted value; the ORIGINAL reference when nothing changed (prompt-cache friendly). */
+  value: unknown;
+  changed: boolean;
+  /** First valid offer found, in walk order. */
+  offer: ConnectOffer | null;
+}
+
+/** Build an offer from the node whose connect key just got redacted. */
+function offerFromNode(obj: Record<string, unknown>, url: string): ConnectOffer {
+  const state = typeof obj.state === "string" ? obj.state : undefined;
+  const expiresAt =
+    typeof obj.expires_at === "number"
+      ? obj.expires_at
+      : typeof obj.expiresAt === "number"
+        ? obj.expiresAt
+        : undefined;
+  return {
+    connect_url: url,
+    ...(state !== undefined ? { state } : {}),
+    ...(expiresAt !== undefined ? { expires_at: expiresAt } : {}),
+  };
+}
+
+/**
+ * Deep-walk `value`, replacing any `connect_url`/`auth_url`/`connectUrl`/`authUrl`
+ * string with the placeholder and capturing the first absolute-URL offer. When
+ * nothing changed the original reference is returned so callers can keep text
+ * byte-identical (prompt caching).
+ */
+function splitValue(value: unknown, depth: number): SplitResult {
+  if (depth > MAX_REDACT_DEPTH || value == null || typeof value !== "object") {
+    return { value, changed: false, offer: null };
+  }
+
+  if (Array.isArray(value)) {
+    let changed = false;
+    let offer: ConnectOffer | null = null;
+    const out = value.map((item) => {
+      const r = splitValue(item, depth + 1);
+      if (r.changed) changed = true;
+      offer ??= r.offer;
+      return r.value;
+    });
+    return changed ? { value: out, changed: true, offer } : { value, changed: false, offer };
+  }
+
+  const obj = value as Record<string, unknown>;
+  let changed = false;
+  let offer: ConnectOffer | null = null;
+  const out: Record<string, unknown> = {};
+  for (const [key, v] of Object.entries(obj)) {
+    if (CONNECT_URL_KEYS.has(key) && typeof v === "string") {
+      out[key] = REDACTED_CONNECT_LINK;
+      changed = true;
+      // Capture only real absolute URLs — an already-redacted placeholder (or
+      // any other prose under a connect key) is scrubbed but never offered.
+      if (!offer && /^https?:\/\//.test(v)) offer = offerFromNode(obj, v);
+      continue;
+    }
+    const r = splitValue(v, depth + 1);
+    if (r.changed) changed = true;
+    offer ??= r.offer;
+    out[key] = r.value;
+  }
+  return changed ? { value: out, changed: true, offer } : { value, changed: false, offer };
+}
+
+/**
+ * Split an arbitrary (already parsed) payload: redacted copy + first offer.
+ * `redacted` is the same reference when nothing changed.
+ */
+export function splitConnectPayload(payload: unknown): {
+  redacted: unknown;
+  offer: ConnectOffer | null;
+} {
+  const r = splitValue(payload, 0);
+  return { redacted: r.value, offer: r.offer };
+}
+
+/** Redact-only view of {@link splitConnectPayload} (model-channel scrubbing). */
+export function redactConnectPayload(payload: unknown): unknown {
+  return splitValue(payload, 0).value;
+}
+
+/**
+ * Split a text block that may hold a JSON payload: parses, redacts, and
+ * re-stringifies ONLY when something changed — non-JSON text passes through
+ * byte-identical, never regex-mangled.
+ */
+export function splitJsonText(text: string): { text: string; offer: ConnectOffer | null } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return { text, offer: null };
+  }
+  const r = splitValue(parsed, 0);
+  return { text: r.changed ? JSON.stringify(r.value) : text, offer: r.offer };
+}
+
+/**
+ * Redact connect links from a `toModelOutput` result ({type:"json"|"content"}).
+ * Pure, redact-only — the model channel never gets a `connectOffer` field. For
+ * `content` text parts we only touch valid JSON (re-stringified only when
+ * something changed); anything else is returned as-is.
+ */
+export function redactConnectLinks(output: unknown): unknown {
+  if (output == null || typeof output !== "object") return output;
+  const o = output as Record<string, unknown>;
+
+  if (o.type === "json") {
+    const r = splitValue(o.value, 0);
+    return r.changed ? { ...o, value: r.value } : output;
+  }
+
+  if (o.type === "content" && Array.isArray(o.value)) {
+    let changed = false;
+    const nextValue = o.value.map((part) => {
+      if (part == null || typeof part !== "object") return part;
+      const p = part as Record<string, unknown>;
+      if (p.type !== "text" || typeof p.text !== "string") return part;
+      const r = splitJsonText(p.text);
+      if (r.text === p.text) return part;
+      changed = true;
+      return { ...p, text: r.text };
+    });
+    return changed ? { ...o, value: nextValue } : output;
+  }
+
+  return output;
+}
+
+/**
+ * Split a tool `execute` result for the UI/persistence channel: redact every
+ * connect link in place and attach the captured offer as a typed top-level
+ * `connectOffer` field. Handles the envelopes an execute result arrives in —
+ * MCP `CallToolResult` `{content:[…], structuredContent?}`, the AI SDK bridge
+ * `{type:"content"|"json", value}`, or a plain payload object. Returns the
+ * original reference when nothing changed.
+ */
+export function splitToolResult(result: unknown): unknown {
+  if (result == null || typeof result !== "object") return result;
+  const o = result as Record<string, unknown>;
+
+  if (Array.isArray(o.content)) {
+    let changed = false;
+    let offer: ConnectOffer | null = null;
+    const content = o.content.map((part) => {
+      if (part == null || typeof part !== "object") return part;
+      const p = part as Record<string, unknown>;
+      if (p.type !== "text" || typeof p.text !== "string") return part;
+      const r = splitJsonText(p.text);
+      offer ??= r.offer;
+      if (r.text === p.text) return part;
+      changed = true;
+      return { ...p, text: r.text };
+    });
+    let structuredContent = o.structuredContent;
+    if (structuredContent !== undefined) {
+      const sc = splitConnectPayload(structuredContent);
+      if (sc.redacted !== structuredContent) changed = true;
+      // structuredContent is the canonical payload — its offer wins.
+      if (sc.offer) offer = sc.offer;
+      structuredContent = sc.redacted;
+    }
+    if (!changed) return result;
+    return {
+      ...o,
+      content,
+      ...(o.structuredContent !== undefined ? { structuredContent } : {}),
+      ...(offer ? { connectOffer: offer } : {}),
+    };
+  }
+
+  if (o.type === "json" && "value" in o) {
+    const r = splitConnectPayload(o.value);
+    if (r.redacted === o.value) return result;
+    return { ...o, value: r.redacted, ...(r.offer ? { connectOffer: r.offer } : {}) };
+  }
+
+  if (o.type === "content" && Array.isArray(o.value)) {
+    let changed = false;
+    let offer: ConnectOffer | null = null;
+    const nextValue = o.value.map((part) => {
+      if (part == null || typeof part !== "object") return part;
+      const p = part as Record<string, unknown>;
+      if (p.type !== "text" || typeof p.text !== "string") return part;
+      const r = splitJsonText(p.text);
+      offer ??= r.offer;
+      if (r.text === p.text) return part;
+      changed = true;
+      return { ...p, text: r.text };
+    });
+    if (!changed) return result;
+    return { ...o, value: nextValue, ...(offer ? { connectOffer: offer } : {}) };
+  }
+
+  const r = splitConnectPayload(result);
+  if (r.redacted === result) return result;
+  return {
+    ...(r.redacted as Record<string, unknown>),
+    ...(r.offer ? { connectOffer: r.offer } : {}),
+  };
+}
+
+/**
+ * Read the typed `connectOffer` off a persisted tool output (top level, or one
+ * `output` level down for bridges that nest the result). Shape-checked — this
+ * is the ONLY sanctioned way for the UI to obtain a connect URL from a tool
+ * result produced after the typed channel shipped.
+ */
+export function readConnectOffer(result: unknown): ConnectOffer | null {
+  if (result == null || typeof result !== "object") return null;
+  const o = result as Record<string, unknown>;
+  const direct = asConnectOffer(o.connectOffer);
+  if (direct) return direct;
+  if (o.output != null && typeof o.output === "object") {
+    return asConnectOffer((o.output as Record<string, unknown>).connectOffer);
+  }
+  return null;
+}
+
+function asConnectOffer(value: unknown): ConnectOffer | null {
+  if (value == null || typeof value !== "object") return null;
+  const o = value as Record<string, unknown>;
+  if (typeof o.connect_url !== "string" || !/^https?:\/\//.test(o.connect_url)) return null;
+  return {
+    connect_url: o.connect_url,
+    ...(typeof o.state === "string" ? { state: o.state } : {}),
+    ...(typeof o.expires_at === "number" ? { expires_at: o.expires_at } : {}),
+  };
+}

--- a/packages/module-chat/src/pi-chat/mcp-tools.ts
+++ b/packages/module-chat/src/pi-chat/mcp-tools.ts
@@ -35,7 +35,14 @@ const RUN_AND_WAIT_TOOL = "run_and_wait";
 interface PiToolResult {
   content: Array<{ type: "text"; text: string }>;
   details: unknown;
-  /** Typed connect offer for the UI card; pi-ai never serializes it upstream. */
+  /**
+   * Typed connect offer for the UI card; pi-ai never serializes it upstream.
+   * CONTRACT: pi-agent-core forwards the execute return REFERENCE into
+   * `tool_execution_end` only while no `afterToolCall` hook is configured —
+   * that hook rebuilds the result as `{content, details, terminate}` and would
+   * silently strip this field (and `details` is redacted, so nothing would
+   * fall back). If a hook is ever added, it must carry `connectOffer` through.
+   */
   connectOffer?: ConnectOffer;
 }
 

--- a/packages/module-chat/src/pi-chat/mcp-tools.ts
+++ b/packages/module-chat/src/pi-chat/mcp-tools.ts
@@ -21,7 +21,12 @@ import { createMcpHttpClient, type AppstrateMcpClient } from "@appstrate/mcp-tra
 import { Type, type ExtensionAPI, type ExtensionFactory } from "@appstrate/runner-pi";
 import type { UIMessageChunk } from "ai";
 import { stripMcpToolPrefix } from "./ui-stream-mapper.ts";
-import { redactConnectPayload } from "../platform-mcp.ts";
+import {
+  redactConnectPayload,
+  splitConnectPayload,
+  splitJsonText,
+  type ConnectOffer,
+} from "../connect-offer.ts";
 import { logger } from "../logger.ts";
 
 const RUN_AND_WAIT_TOOL = "run_and_wait";
@@ -30,19 +35,24 @@ const RUN_AND_WAIT_TOOL = "run_and_wait";
 interface PiToolResult {
   content: Array<{ type: "text"; text: string }>;
   details: unknown;
+  /** Typed connect offer for the UI card; pi-ai never serializes it upstream. */
+  connectOffer?: ConnectOffer;
 }
 
 /**
  * Wrap an arbitrary payload as a Pi tool result. Channel split mirrors the
- * ai-sdk path's `wrapToolModelOutputs`: `content` is what pi-ai serializes to
- * the MODEL, so connect links are redacted there; `details` never reaches the
- * model (pi-ai sends only `content` upstream) and carries the FULL payload for
- * the UI, whose connect-card extractor walks the whole tool output.
+ * ai-sdk path's `wrapToolConnectOffers`: `content` is what pi-ai serializes to
+ * the MODEL, so connect links are redacted there; the connect URL surfaces
+ * ONLY through the typed `connectOffer` field the connect card reads. `details`
+ * (UI JSON view) carries the redacted payload — the live URL lives in exactly
+ * one place.
  */
 export function toPiToolResult(payload: unknown): PiToolResult {
+  const { redacted, offer } = splitConnectPayload(payload);
   return {
-    content: [{ type: "text", text: JSON.stringify(redactConnectPayload(payload)) }],
-    details: payload,
+    content: [{ type: "text", text: JSON.stringify(redacted) }],
+    details: redacted,
+    ...(offer ? { connectOffer: offer } : {}),
   };
 }
 
@@ -51,13 +61,17 @@ export function mcpResultToPi(result: {
   content: Array<Record<string, unknown>>;
   structuredContent?: unknown;
 }): PiToolResult {
+  let offer: ConnectOffer | null = null;
   const content = result.content.map((c) => {
-    // MODEL-visible channel — scrub connect links from JSON text (same
-    // semantics as the ai-sdk path's redaction: valid JSON is redacted and
-    // re-stringified only when something changed; non-JSON text passes
-    // through byte-identical).
-    if (c.type === "text")
-      return { type: "text" as const, text: redactJsonText(String(c.text ?? "")) };
+    // MODEL-visible channel — scrub connect links from JSON text (valid JSON is
+    // redacted and re-stringified only when something changed; non-JSON text
+    // passes through byte-identical). The scrubbed URL is captured as the
+    // typed offer instead.
+    if (c.type === "text") {
+      const split = splitJsonText(String(c.text ?? ""));
+      offer ??= split.offer;
+      return { type: "text" as const, text: split.text };
+    }
     // Pi tool results the LLM reads are text/image; render anything else as a
     // text pointer so the model still sees it (parity with the runtime forwarder).
     if (c.type === "image") {
@@ -65,21 +79,18 @@ export function mcpResultToPi(result: {
     }
     return { type: "text" as const, text: JSON.stringify(redactConnectPayload(c)) };
   });
-  // `details` is UI-only (never serialized to the model): keep the FULL result
-  // so the connect card can extract the unredacted connect_url.
-  return { content, details: result.structuredContent ?? result };
-}
-
-/** Redact connect links inside a JSON text block; non-JSON text is untouched. */
-function redactJsonText(text: string): string {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(text);
-  } catch {
-    return text; // Non-JSON text: leave byte-identical, never regex-mangle.
+  // `details` is UI-only (never serialized to the model) but persisted — so it
+  // is redacted too; the connect card reads the typed `connectOffer` field.
+  let details: unknown;
+  if (result.structuredContent !== undefined) {
+    const sc = splitConnectPayload(result.structuredContent);
+    // structuredContent is the canonical payload — its offer wins.
+    if (sc.offer) offer = sc.offer;
+    details = sc.redacted;
+  } else {
+    details = { ...result, content };
   }
-  const redacted = redactConnectPayload(parsed);
-  return redacted === parsed ? text : JSON.stringify(redacted);
+  return { content, details, ...(offer ? { connectOffer: offer } : {}) };
 }
 
 export interface PlatformMcpTools {

--- a/packages/module-chat/src/platform-mcp.ts
+++ b/packages/module-chat/src/platform-mcp.ts
@@ -17,6 +17,7 @@
 
 import { createMCPClient, type MCPClient } from "@ai-sdk/mcp";
 import { runAndWaitSteps } from "@appstrate/core/run-and-wait-client";
+import { redactConnectLinks, splitConnectPayload, splitToolResult } from "./connect-offer.ts";
 import { logger } from "./logger.ts";
 
 type ToolSet = Awaited<ReturnType<MCPClient["tools"]>>;
@@ -70,6 +71,7 @@ export async function openPlatformMcp(args: {
   let tools: ToolSet;
   try {
     tools = await client.tools();
+    tools = wrapToolConnectOffers(tools);
     tools = wrapRunAndWaitTool(tools, {
       origin: args.origin,
       headers,
@@ -96,8 +98,12 @@ export async function openPlatformMcp(args: {
 }
 
 function callToolResult(payload: unknown, isError = false): unknown {
+  // Split at the source: the model channel (content text) is redacted, the UI
+  // gets the connect URL only through the typed `connectOffer` field.
+  const { redacted, offer } = splitConnectPayload(payload);
   return {
-    content: [{ type: "text", text: JSON.stringify(payload) }],
+    content: [{ type: "text", text: JSON.stringify(redacted) }],
+    ...(offer ? { connectOffer: offer } : {}),
     ...(isError ? { isError: true } : {}),
   };
 }
@@ -133,109 +139,41 @@ export function wrapRunAndWaitTool(
 }
 
 /**
- * Placeholder that replaces a connect/authorize URL in the MODEL-visible tool
- * output. The model can't paste a link it never receives; the UI still gets the
- * full `execute` result (untouched) and renders the native connect card from it.
+ * Wrap every tool's `execute` so its result — what the AI SDK persists and the
+ * UI renders — has connect links redacted at the source, with the captured URL
+ * attached as the typed `connectOffer` field the connect card reads
+ * ({@link ./connect-offer.ts}). Tools without an `execute` are left as-is;
+ * `run_and_wait` is replaced wholesale by {@link wrapRunAndWaitTool} afterwards
+ * (its streamed steps split inside `callToolResult`).
  */
-const REDACTED_CONNECT_LINK = "[connect link hidden — the chat renders the connect card]";
-
-/** Field names carrying a connect/authorize URL (snake + camel). */
-const CONNECT_URL_KEYS = new Set(["connect_url", "auth_url", "connectUrl", "authUrl"]);
-
-/** Depth bound for the redaction walk — MCP payloads are shallow. */
-const MAX_REDACT_DEPTH = 16;
-
-/**
- * Deep-walk `value`, replacing any `connect_url`/`auth_url`/`connectUrl`/`authUrl`
- * string with the placeholder. Returns the (possibly new) value plus whether
- * anything changed — when nothing changed the original reference is returned so
- * callers can keep text byte-identical (prompt caching).
- */
-function redactValue(value: unknown, depth: number): { value: unknown; changed: boolean } {
-  if (depth > MAX_REDACT_DEPTH || value == null || typeof value !== "object") {
-    return { value, changed: false };
+export function wrapToolConnectOffers(tools: ToolSet): ToolSet {
+  const next = { ...tools } as Record<string, unknown>;
+  for (const [name, tool] of Object.entries(next)) {
+    const t = tool as
+      | (Record<string, unknown> & {
+          execute?: (args: unknown, options: unknown) => unknown;
+        })
+      | undefined;
+    if (typeof t?.execute !== "function") continue;
+    const original = t.execute.bind(t);
+    next[name] = {
+      ...t,
+      async execute(args: unknown, options: unknown) {
+        return splitToolResult(await original(args, options));
+      },
+    };
   }
-
-  if (Array.isArray(value)) {
-    let changed = false;
-    const out = value.map((item) => {
-      const r = redactValue(item, depth + 1);
-      if (r.changed) changed = true;
-      return r.value;
-    });
-    return changed ? { value: out, changed: true } : { value, changed: false };
-  }
-
-  const obj = value as Record<string, unknown>;
-  let changed = false;
-  const out: Record<string, unknown> = {};
-  for (const [key, v] of Object.entries(obj)) {
-    if (CONNECT_URL_KEYS.has(key) && typeof v === "string") {
-      out[key] = REDACTED_CONNECT_LINK;
-      changed = true;
-      continue;
-    }
-    const r = redactValue(v, depth + 1);
-    if (r.changed) changed = true;
-    out[key] = r.value;
-  }
-  return changed ? { value: out, changed: true } : { value, changed: false };
-}
-
-/**
- * Deep-redact connect links from an arbitrary payload object. Returns the same
- * reference when nothing changed (prompt-cache friendly). Used by the Pi chat
- * engine's tool forwarder ({@link ../pi-chat/mcp-tools.ts}) to scrub the
- * MODEL-visible text channel — the same guarantee `wrapToolModelOutputs` gives
- * the ai-sdk path.
- */
-export function redactConnectPayload(payload: unknown): unknown {
-  return redactValue(payload, 0).value;
-}
-
-/**
- * Redact connect links from a `toModelOutput` result ({type:"json"|"content"}).
- * Pure. For `content` text parts we only touch valid JSON (re-stringified only
- * when something changed) — non-JSON text is passed through untouched. Anything
- * else is returned as-is.
- */
-export function redactConnectLinks(output: unknown): unknown {
-  if (output == null || typeof output !== "object") return output;
-  const o = output as Record<string, unknown>;
-
-  if (o.type === "json") {
-    const r = redactValue(o.value, 0);
-    return r.changed ? { ...o, value: r.value } : output;
-  }
-
-  if (o.type === "content" && Array.isArray(o.value)) {
-    let changed = false;
-    const nextValue = o.value.map((part) => {
-      if (part == null || typeof part !== "object") return part;
-      const p = part as Record<string, unknown>;
-      if (p.type !== "text" || typeof p.text !== "string") return part;
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(p.text);
-      } catch {
-        return part; // Non-JSON text: leave byte-identical, never regex-mangle.
-      }
-      const r = redactValue(parsed, 0);
-      if (!r.changed) return part;
-      changed = true;
-      return { ...p, text: JSON.stringify(r.value) };
-    });
-    return changed ? { ...o, value: nextValue } : output;
-  }
-
-  return output;
+  return next as unknown as ToolSet;
 }
 
 /**
  * Wrap every tool's `toModelOutput` so the MODEL-visible channel has connect
- * links redacted. `execute` results (what the UI renders) are untouched. Tools
- * without a `toModelOutput` are left as-is; tool object identity is otherwise
- * preserved via spread.
+ * links redacted. Belt-and-braces on top of {@link wrapToolConnectOffers}
+ * (execute results are already split at the source): it also covers a
+ * `toModelOutput` that re-serializes the whole output — the offer's inner key
+ * is `connect_url`, so the redactor scrubs it too. Tools without a
+ * `toModelOutput` are left as-is; tool object identity is otherwise preserved
+ * via spread.
  */
 export function wrapToolModelOutputs(tools: ToolSet): ToolSet {
   const next = { ...tools } as Record<string, unknown>;

--- a/packages/module-chat/src/ui/auth-offer.ts
+++ b/packages/module-chat/src/ui/auth-offer.ts
@@ -3,14 +3,20 @@
 /**
  * Pure helper (no React) that pulls a connect offer (`{ connect_url }` for the
  * unified hosted-connect-portal op, or the legacy `{ auth_url, state }` OAuth
- * op) out of an `invoke_operation` tool result. The result arrives in many envelopes
- * depending on the runtime path (raw MCP CallToolResult `{content:[{text}]}`,
- * the AI SDK bridge `{type:"content",value:[{text}]}`, `{type:"json",value}`,
- * a bare content array, a JSON string, …), so rather than enumerate shapes we
- * walk the whole structure and grab the first node that carries an auth URL.
+ * op) out of an `invoke_operation` tool result.
+ *
+ * Primary channel: the typed `connectOffer` field both engines attach to the
+ * tool output ({@link ../connect-offer.ts}) — the only place the live URL
+ * exists in a persisted result. The deep-walk below is a LEGACY fallback for
+ * sessions persisted before that field shipped, where the URL still sits raw
+ * somewhere in the payload (raw MCP CallToolResult `{content:[{text}]}`, the
+ * AI SDK bridge `{type:"content",value:[{text}]}`, `{type:"json",value}`, a
+ * bare content array, a JSON string, …).
  *
  * Kept React-free so it can be unit-tested without a DOM.
  */
+
+import { readConnectOffer } from "../connect-offer.ts";
 
 export interface AuthOffer {
   authUrl: string;
@@ -121,7 +127,11 @@ export function parseResume(text: string): ResumeMeta | null {
   return { packageId: "" };
 }
 
-/** Find an `{ auth_url|authUrl }` bearing object anywhere in `value`. */
+/**
+ * LEGACY deep search — pre-`connectOffer` sessions only. Finds an
+ * `{ auth_url|authUrl|connect_url|connectUrl }` bearing object anywhere in
+ * `value`.
+ */
 function deepFind(value: unknown, depth: number): AuthOffer | null {
   if (depth > 8 || value == null) return null;
 
@@ -150,8 +160,11 @@ function deepFind(value: unknown, depth: number): AuthOffer | null {
   // Direct hit on this node (snake or camel). `connect_url` is the unified
   // hosted-connect-portal offer (issue #769); `auth_url` is the legacy
   // OAuth-only offer. Both open the same way and resume via the same signal.
+  // Absolute-URL guard: pre-`connectOffer` results carry the redaction
+  // placeholder under these same keys in the model channel — accepting it
+  // rendered the placeholder as a relative href (issue #906).
   const url = obj.connect_url ?? obj.connectUrl ?? obj.auth_url ?? obj.authUrl;
-  if (typeof url === "string" && url) {
+  if (typeof url === "string" && /^https?:\/\//.test(url)) {
     const state = obj.state;
     return { authUrl: url, state: typeof state === "string" ? state : undefined };
   }
@@ -165,5 +178,9 @@ function deepFind(value: unknown, depth: number): AuthOffer | null {
 }
 
 export function extractAuthOffer(result: unknown): AuthOffer | null {
+  // Typed channel first — the only place a post-split result carries the URL.
+  const offer = readConnectOffer(result);
+  if (offer) return { authUrl: offer.connect_url, ...(offer.state ? { state: offer.state } : {}) };
+  // Legacy sessions persisted before the typed field existed.
   return deepFind(result, 0);
 }

--- a/packages/module-chat/test/connect-offer.test.ts
+++ b/packages/module-chat/test/connect-offer.test.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Single-pass connect-offer split: redaction and extraction are the same walk,
+ * so whatever leaves the payload surfaces as the typed offer — and ONLY there.
+ * Regression coverage for issue #906 (the UI scraper used to pick the redaction
+ * placeholder out of the model channel and render it as a relative URL).
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  REDACTED_CONNECT_LINK,
+  readConnectOffer,
+  splitConnectPayload,
+  splitJsonText,
+  splitToolResult,
+} from "../src/connect-offer.ts";
+import { wrapToolConnectOffers } from "../src/platform-mcp.ts";
+
+const URL_ = "https://app.example.com/api/integrations/connect/start?token=SECRET";
+
+describe("splitConnectPayload", () => {
+  it("redacts and captures in one pass, with sibling state/expires_at", () => {
+    const payload = {
+      status: 200,
+      body: { connect_url: URL_, state: "st-1", expires_at: 1784142529000 },
+    };
+    const { redacted, offer } = splitConnectPayload(payload);
+    expect(JSON.stringify(redacted)).not.toContain("token=SECRET");
+    expect((redacted as { body: { connect_url: string } }).body.connect_url).toBe(
+      REDACTED_CONNECT_LINK,
+    );
+    expect(offer).toEqual({ connect_url: URL_, state: "st-1", expires_at: 1784142529000 });
+  });
+
+  it("redacts a non-URL string under a connect key but never offers it", () => {
+    const { redacted, offer } = splitConnectPayload({ connect_url: REDACTED_CONNECT_LINK });
+    expect((redacted as { connect_url: string }).connect_url).toBe(REDACTED_CONNECT_LINK);
+    expect(offer).toBeNull();
+  });
+
+  it("returns the same reference and no offer when nothing matches", () => {
+    const payload = { ok: true, nested: { a: [1, 2] } };
+    const { redacted, offer } = splitConnectPayload(payload);
+    expect(redacted).toBe(payload);
+    expect(offer).toBeNull();
+  });
+
+  it("captures the first offer when several are present, redacting all", () => {
+    const payload = {
+      first: { auth_url: "https://a.example/one" },
+      second: { auth_url: "https://a.example/two" },
+    };
+    const { redacted, offer } = splitConnectPayload(payload);
+    expect(offer).toEqual({ connect_url: "https://a.example/one" });
+    expect(JSON.stringify(redacted)).not.toContain("a.example/two");
+  });
+});
+
+describe("splitJsonText", () => {
+  it("splits a JSON text block, leaving non-JSON byte-identical", () => {
+    const json = JSON.stringify({ connect_url: URL_ });
+    const split = splitJsonText(json);
+    expect(split.text).not.toContain("token=SECRET");
+    expect(split.offer).toEqual({ connect_url: URL_ });
+
+    const prose = "plain prose, no JSON";
+    expect(splitJsonText(prose)).toEqual({ text: prose, offer: null });
+  });
+});
+
+describe("splitToolResult", () => {
+  it("splits an MCP CallToolResult and attaches the typed offer", () => {
+    const result = {
+      content: [
+        { type: "text", text: JSON.stringify({ status: 200, body: { connect_url: URL_ } }) },
+      ],
+      isError: false,
+    };
+    const out = splitToolResult(result) as Record<string, unknown>;
+    expect((out.content as Array<{ text: string }>)[0]!.text).not.toContain("token=SECRET");
+    expect(out.connectOffer).toEqual({ connect_url: URL_ });
+    expect(out.isError).toBe(false);
+  });
+
+  it("prefers the structuredContent offer and redacts it too", () => {
+    const result = {
+      content: [{ type: "text", text: JSON.stringify({ connect_url: "https://x/from-text" }) }],
+      structuredContent: { connect_url: URL_ },
+    };
+    const out = splitToolResult(result) as { structuredContent: { connect_url: string } } & {
+      connectOffer: unknown;
+    };
+    expect(out.structuredContent.connect_url).toBe(REDACTED_CONNECT_LINK);
+    expect(out.connectOffer).toEqual({ connect_url: URL_ });
+  });
+
+  it("handles the AI SDK bridge envelopes ({type:'content'|'json'})", () => {
+    const contentEnv = {
+      type: "content",
+      value: [{ type: "text", text: JSON.stringify({ auth_url: URL_, state: "s" }) }],
+    };
+    const outContent = splitToolResult(contentEnv) as Record<string, unknown>;
+    expect(JSON.stringify(outContent.value)).not.toContain("token=SECRET");
+    expect(outContent.connectOffer).toEqual({ connect_url: URL_, state: "s" });
+
+    const jsonEnv = { type: "json", value: { connect_url: URL_ } };
+    const outJson = splitToolResult(jsonEnv) as Record<string, unknown>;
+    expect((outJson.value as { connect_url: string }).connect_url).toBe(REDACTED_CONNECT_LINK);
+    expect(outJson.connectOffer).toEqual({ connect_url: URL_ });
+  });
+
+  it("returns the original reference for a result without connect links", () => {
+    const result = { content: [{ type: "text", text: JSON.stringify({ ok: true }) }] };
+    expect(splitToolResult(result)).toBe(result);
+  });
+});
+
+describe("readConnectOffer", () => {
+  it("reads the typed field at the top level and one output level down", () => {
+    const offer = { connect_url: URL_, state: "s" };
+    expect(readConnectOffer({ content: [], connectOffer: offer })).toEqual(offer);
+    expect(readConnectOffer({ output: { connectOffer: offer } })).toEqual(offer);
+  });
+
+  it("rejects malformed or placeholder-bearing offers", () => {
+    expect(readConnectOffer({ connectOffer: { connect_url: REDACTED_CONNECT_LINK } })).toBeNull();
+    expect(readConnectOffer({ connectOffer: { connect_url: 42 } })).toBeNull();
+    expect(readConnectOffer({ connectOffer: "https://x/y" })).toBeNull();
+    expect(readConnectOffer(null)).toBeNull();
+  });
+});
+
+describe("wrapToolConnectOffers (ai-sdk execute wrapper)", () => {
+  it("splits every tool's execute result and leaves execute-less tools untouched", async () => {
+    const noExecute = { description: "schema only" };
+    const withExecute = {
+      description: "connect kickoff",
+      execute: async () => ({
+        content: [{ type: "text", text: JSON.stringify({ body: { connect_url: URL_ } }) }],
+      }),
+    };
+    const wrapped = wrapToolConnectOffers({ noExecute, withExecute } as never) as unknown as {
+      noExecute: unknown;
+      withExecute: { execute: (a: unknown, o: unknown) => Promise<Record<string, unknown>> };
+    };
+
+    expect(wrapped.noExecute).toBe(noExecute as never);
+
+    const out = await wrapped.withExecute.execute({}, {});
+    expect(JSON.stringify(out.content)).not.toContain("token=SECRET");
+    expect(out.connectOffer).toEqual({ connect_url: URL_ });
+  });
+});

--- a/packages/module-chat/test/connect-offer.test.ts
+++ b/packages/module-chat/test/connect-offer.test.ts
@@ -95,19 +95,10 @@ describe("splitToolResult", () => {
     expect(out.connectOffer).toEqual({ connect_url: URL_ });
   });
 
-  it("handles the AI SDK bridge envelopes ({type:'content'|'json'})", () => {
-    const contentEnv = {
-      type: "content",
-      value: [{ type: "text", text: JSON.stringify({ auth_url: URL_, state: "s" }) }],
-    };
-    const outContent = splitToolResult(contentEnv) as Record<string, unknown>;
-    expect(JSON.stringify(outContent.value)).not.toContain("token=SECRET");
-    expect(outContent.connectOffer).toEqual({ connect_url: URL_, state: "s" });
-
-    const jsonEnv = { type: "json", value: { connect_url: URL_ } };
-    const outJson = splitToolResult(jsonEnv) as Record<string, unknown>;
-    expect((outJson.value as { connect_url: string }).connect_url).toBe(REDACTED_CONNECT_LINK);
-    expect(outJson.connectOffer).toEqual({ connect_url: URL_ });
+  it("handles a bare structuredContent payload (outputSchema-configured tools)", () => {
+    const out = splitToolResult({ connect_url: URL_, state: "s" }) as Record<string, unknown>;
+    expect(out.connect_url).toBe(REDACTED_CONNECT_LINK);
+    expect(out.connectOffer).toEqual({ connect_url: URL_, state: "s" });
   });
 
   it("returns the original reference for a result without connect links", () => {

--- a/packages/module-chat/test/extract-auth-offer.test.ts
+++ b/packages/module-chat/test/extract-auth-offer.test.ts
@@ -95,4 +95,56 @@ describe("extractAuthOffer", () => {
     expect(extractAuthOffer({ content: [{ type: "text", text: "an error happened" }] })).toBeNull();
     expect(extractAuthOffer({ type: "content", value: [{ type: "text", text: "{}" }] })).toBeNull();
   });
+
+  it("prefers the typed connectOffer channel over anything in the payload", () => {
+    const result = {
+      content: [{ type: "text", text: JSON.stringify({ connect_url: "https://stale/other" }) }],
+      connectOffer: { connect_url: "https://app/connect/start?token=t", state: "st" },
+    };
+    expect(extractAuthOffer(result)).toEqual({
+      authUrl: "https://app/connect/start?token=t",
+      state: "st",
+    });
+  });
+
+  it("never renders the redaction placeholder as a URL (issue #906)", () => {
+    // Exact persisted shape from the bug report: the model channel (`content`)
+    // carries the placeholder, the legacy UI channel (`details`) the real URL.
+    const placeholder = "[connect link hidden — the chat renders the connect card]";
+    const stored = {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({
+            status: 200,
+            body: { connect_url: placeholder, expires_at: 1784142529000 },
+          }),
+        },
+      ],
+      details: {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({
+              status: 200,
+              body: {
+                connect_url: "http://localhost:3001/api/integrations/connect/start?token=eyJREAL",
+                expires_at: 1784142529000,
+              },
+            }),
+          },
+        ],
+        isError: false,
+      },
+    };
+    expect(extractAuthOffer(stored)).toEqual({
+      authUrl: "http://localhost:3001/api/integrations/connect/start?token=eyJREAL",
+      state: undefined,
+    });
+  });
+
+  it("rejects a relative or non-http string under a connect key (legacy walk)", () => {
+    expect(extractAuthOffer({ connect_url: "/api/integrations/connect/start" })).toBeNull();
+    expect(extractAuthOffer({ auth_url: "javascript:alert(1)" })).toBeNull();
+  });
 });

--- a/packages/module-chat/test/pi-chat-mcp-redaction.test.ts
+++ b/packages/module-chat/test/pi-chat-mcp-redaction.test.ts
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Connect-link redaction on the Pi chat path — parity with the ai-sdk path's
- * `wrapToolModelOutputs`. The MODEL-visible channel of a Pi tool result is its
- * `content` text blocks (pi-ai serializes only `content` upstream); the UI
- * reads the full tool output (including `details`) to render the connect card.
- * So: `content` must have `connect_url`/`auth_url` scrubbed, `details` must
- * keep the original payload intact.
+ * Connect-link handling on the Pi chat path — parity with the ai-sdk path's
+ * `wrapToolConnectOffers`. The MODEL-visible channel of a Pi tool result is its
+ * `content` text blocks (pi-ai serializes only `content` upstream) and must
+ * have `connect_url`/`auth_url` scrubbed. The UI reads the typed `connectOffer`
+ * field to render the connect card — the live URL exists nowhere else in the
+ * persisted output (`details` is redacted too, issue #906).
  */
 
 import { describe, expect, it } from "bun:test";
@@ -19,56 +19,71 @@ const OFFER = {
 };
 
 describe("toPiToolResult (run_and_wait payloads)", () => {
-  it("redacts connect_url from the model-visible text, keeps details intact", () => {
+  it("redacts connect_url everywhere, surfaces it only through connectOffer", () => {
     const result = toPiToolResult(OFFER);
     const modelText = result.content[0]!.text;
     expect(modelText).not.toContain("token=SECRET");
     expect(modelText).toContain("connect link hidden");
-    expect(result.details).toEqual(OFFER);
+    // The persisted payload channels carry the placeholder, never the URL.
+    expect(JSON.stringify(result.details)).not.toContain("token=SECRET");
+    // The typed offer is the single place the live URL survives.
+    expect(result.connectOffer).toEqual({ connect_url: OFFER.connect_url });
   });
 
-  it("leaves payloads without connect links byte-identical", () => {
+  it("leaves payloads without connect links byte-identical, with no offer", () => {
     const payload = { status: "success", output: { ok: true } };
     const result = toPiToolResult(payload);
     expect(result.content[0]!.text).toBe(JSON.stringify(payload));
     expect(result.details).toBe(payload);
+    expect(result.connectOffer).toBeUndefined();
   });
 });
 
 describe("mcpResultToPi (forwarded MCP tool results)", () => {
-  it("redacts connect links inside JSON text blocks, preserves the full result in details", () => {
+  it("redacts connect links inside JSON text blocks and captures the typed offer", () => {
     const mcp = {
       content: [{ type: "text", text: JSON.stringify(OFFER) }],
     };
     const result = mcpResultToPi(mcp as never);
     expect(result.content[0]!.text).not.toContain("token=SECRET");
     expect(result.content[0]!.text).toContain("connect link hidden");
-    // UI channel: the original result (with the live URL) survives untouched.
-    expect(JSON.stringify(result.details)).toContain("token=SECRET");
+    // Details are redacted too — the URL lives only in the typed offer.
+    expect(JSON.stringify(result.details)).not.toContain("token=SECRET");
+    expect(result.connectOffer).toEqual({ connect_url: OFFER.connect_url });
   });
 
-  it("also redacts the legacy auth_url field", () => {
+  it("also redacts the legacy auth_url field and keeps its state in the offer", () => {
     const mcp = {
       content: [
-        { type: "text", text: JSON.stringify({ auth_url: "https://x/authorize?s=SECRET" }) },
+        {
+          type: "text",
+          text: JSON.stringify({ auth_url: "https://x/authorize?s=SECRET", state: "st-1" }),
+        },
       ],
     };
     const result = mcpResultToPi(mcp as never);
     expect(result.content[0]!.text).not.toContain("s=SECRET");
+    expect(result.connectOffer).toEqual({
+      connect_url: "https://x/authorize?s=SECRET",
+      state: "st-1",
+    });
   });
 
   it("passes non-JSON text through byte-identical", () => {
     const mcp = { content: [{ type: "text", text: "plain prose, no JSON" }] };
     const result = mcpResultToPi(mcp as never);
     expect(result.content[0]!.text).toBe("plain prose, no JSON");
+    expect(result.connectOffer).toBeUndefined();
   });
 
-  it("prefers structuredContent for details when present", () => {
+  it("prefers structuredContent for details (redacted) and for the offer", () => {
     const mcp = {
       content: [{ type: "text", text: JSON.stringify(OFFER) }],
       structuredContent: OFFER,
     };
     const result = mcpResultToPi(mcp as never);
-    expect(result.details).toBe(OFFER);
+    expect(result.details).toEqual({ ...OFFER, connect_url: expect.stringContaining("hidden") });
+    expect(JSON.stringify(result.details)).not.toContain("token=SECRET");
+    expect(result.connectOffer).toEqual({ connect_url: OFFER.connect_url });
   });
 });

--- a/packages/module-chat/test/platform-mcp.test.ts
+++ b/packages/module-chat/test/platform-mcp.test.ts
@@ -123,6 +123,62 @@ describe("platform MCP run_and_wait wrapper", () => {
     expect(calls).toHaveLength(1);
   });
 
+  test("splits connect links out of streamed step payloads (typed connectOffer)", async () => {
+    const url = "https://test.local/api/integrations/connect/start?token=SECRET";
+    const responses = [
+      jsonResponse({ id: "run_1", packageId: "@acme/writer", status: "pending" }),
+      jsonResponse({
+        id: "run_1",
+        packageId: "@acme/writer",
+        status: "success",
+        result: { status: "auth_required", connect_url: url },
+      }),
+    ];
+    const fetchImpl: typeof fetch = async () => {
+      const res = responses.shift();
+      if (!res) throw new Error("unexpected fetch");
+      return res;
+    };
+
+    let originalCalled = false;
+    const tools = wrapRunAndWaitTool(
+      {
+        run_and_wait: {
+          inputSchema: { type: "object", properties: {} },
+          execute: () => {
+            originalCalled = true;
+            return { content: [{ type: "text", text: "{}" }] };
+          },
+        },
+      } as never,
+      { origin: "https://test.local", headers: {}, fetch: fetchImpl },
+    ) as {
+      run_and_wait: {
+        execute: (
+          rawArgs: unknown,
+          options: { abortSignal?: AbortSignal },
+        ) => AsyncIterable<unknown>;
+      };
+    };
+
+    const outputs: Array<Record<string, unknown>> = [];
+    for await (const output of tools.run_and_wait.execute(
+      { kind: "agent", scope: "@acme", name: "writer" },
+      {},
+    )) {
+      outputs.push(output as Record<string, unknown>);
+    }
+
+    expect(originalCalled).toBe(false);
+    const terminal = outputs.at(-1)!;
+    // Model channel (content text) never carries the URL…
+    const text = (terminal.content as Array<{ text: string }>)[0]!.text;
+    expect(text).not.toContain("token=SECRET");
+    expect(text).toContain("connect link hidden");
+    // …the typed offer does.
+    expect(terminal.connectOffer).toEqual({ connect_url: url });
+  });
+
   test("validates arguments before dispatching", async () => {
     const fetchImpl: typeof fetch = async () => {
       throw new Error("should not fetch");

--- a/packages/module-chat/test/redact-connect-links.test.ts
+++ b/packages/module-chat/test/redact-connect-links.test.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from "bun:test";
-import { redactConnectLinks, wrapToolModelOutputs } from "../src/platform-mcp.ts";
+import { redactConnectLinks } from "../src/connect-offer.ts";
+import { wrapToolModelOutputs } from "../src/platform-mcp.ts";
 
 const PLACEHOLDER = "[connect link hidden — the chat renders the connect card]";
 


### PR DESCRIPTION
## Problem

#906: in the pi-chat path, the connect card rendered the redaction placeholder (`[connect link hidden — …]`) as its href — the browser resolved it relative to `/chat/…` and the button led to a blank page.

Root cause is structural, not a one-off: the card's extractor (`deepFind` in `ui/auth-offer.ts`) deep-scraped the whole persisted tool output for the first `connect_url`-bearing node. The pi envelope enumerates the model channel (`content`, redacted) before the UI channel (`details`, raw), so the placeholder — a non-empty string — won.

## Fix

Instead of teaching the scraper to skip the placeholder, redaction and extraction become **the same single pass**, server-side, on the raw payload — the bug class disappears by construction.

New `src/connect-offer.ts` (dependency-free, importable by the SPA bundle):

- `splitConnectPayload` / `splitJsonText` / `splitToolResult` — deep-walk that redacts every `connect_url`/`auth_url` (snake + camel) **and** captures the first absolute http(s) URL as a typed `ConnectOffer { connect_url, state?, expires_at? }`. One walk, so redaction and extraction can never drift. `splitToolResult` covers exactly the shapes `@ai-sdk/mcp`'s `execute` returns (raw `CallToolResult`, or a bare `structuredContent` payload) — verified against the dist, no speculative envelope handling.
- `readConnectOffer` — the shape-checked reader the UI uses.

Both engines attach the offer to the tool output:

- **pi-chat** (`toPiToolResult` / `mcpResultToPi`): `content` stays redacted as before; `details` is now redacted too — the live URL no longer sits duplicated in the persisted JSONB, it exists only in `connectOffer`. pi-agent-core forwards the execute return reference untouched into `tool_execution_end` (no `afterToolCall` hook configured — contract documented on the field, since that hook would rebuild the result and strip it).
- **ai-sdk** (`wrapToolConnectOffers`, new; `callToolResult` for streamed `run_and_wait` steps): execute results are split at the source, so the persisted output is redacted with the typed offer attached. `wrapToolModelOutputs` stays as belt-and-braces — the offer's inner key is deliberately `connect_url`, so even a `toModelOutput` that re-serializes the whole output (the `{type:"json"}` fallback in `mcpToModelOutput`) gets scrubbed.

UI (`extractAuthOffer`): reads the typed field first. The legacy deep walk survives only as a fallback for sessions persisted before this change, now guarded to absolute http(s) URLs (the fix suggested in #906) so a placeholder can never render as a link again.

## Tests

- New `test/connect-offer.test.ts`: single-pass split (capture + redact, sibling `state`/`expires_at`, byte-identical passthrough, first-offer-wins), both execute result shapes, typed reader rejection cases, ai-sdk execute wrapper.
- `extract-auth-offer.test.ts`: exact persisted payload from #906 as a regression case, typed-channel precedence, relative/`javascript:` URL rejection.
- `pi-chat-mcp-redaction.test.ts`: updated invariant — the live URL exists **nowhere** in `content`/`details`, only in `connectOffer`.
- `platform-mcp.test.ts`: `run_and_wait` streamed step carrying a connect URL → redacted text + typed offer.

`bun test packages/module-chat/test`: 188 pass. `turbo check` (module-chat + web + deps): green.

## Compatibility

No DB migration, no wire/schema change — the field rides inside the existing persisted tool output. Old sessions keep rendering via the guarded legacy fallback.

Closes #906

🤖 Generated with [Claude Code](https://claude.com/claude-code)