### PR TITLE
fix(packages): stop publish from corrupting stored artifacts, make integrity errors deterministic

### DIFF
--- a/apps/api/src/openapi/paths/packages.ts
+++ b/apps/api/src/openapi/paths/packages.ts
@@ -646,6 +646,15 @@ export const packagesPaths = {
         "400": { $ref: "#/components/responses/ValidationError" },
         "401": { $ref: "#/components/responses/Unauthorized" },
         "403": { $ref: "#/components/responses/Forbidden" },
+        "409": {
+          description:
+            "No changes to snapshot, or version already published (immutable — bump the version). RFC 9457 problem+json with `code` one of `no_changes`, `version_exists`, `agent_in_use`, or `conflict`.",
+          content: {
+            "application/problem+json": {
+              schema: { $ref: "#/components/schemas/ProblemDetail" },
+            },
+          },
+        },
       },
     },
   },
@@ -1199,7 +1208,7 @@ export const packagesPaths = {
         "403": { $ref: "#/components/responses/Forbidden" },
         "409": {
           description:
-            "Agent in use (runs in progress) or no changes to snapshot. RFC 9457 problem+json with `code` one of `agent_in_use`, `no_changes`, or `conflict`.",
+            "Agent in use (runs in progress), no changes to snapshot, or version already published (immutable — bump the version). RFC 9457 problem+json with `code` one of `agent_in_use`, `no_changes`, `version_exists`, or `conflict`.",
           content: {
             "application/problem+json": {
               schema: { $ref: "#/components/schemas/ProblemDetail" },
@@ -1864,6 +1873,15 @@ export const packagesPaths = {
         "400": { $ref: "#/components/responses/ValidationError" },
         "401": { $ref: "#/components/responses/Unauthorized" },
         "403": { $ref: "#/components/responses/Forbidden" },
+        "409": {
+          description:
+            "No changes to snapshot, or version already published (immutable — bump the version). RFC 9457 problem+json with `code` one of `no_changes`, `version_exists`, `agent_in_use`, or `conflict`.",
+          content: {
+            "application/problem+json": {
+              schema: { $ref: "#/components/schemas/ProblemDetail" },
+            },
+          },
+        },
       },
     },
   },
@@ -2453,6 +2471,15 @@ export const packagesPaths = {
         "400": { $ref: "#/components/responses/ValidationError" },
         "401": { $ref: "#/components/responses/Unauthorized" },
         "403": { $ref: "#/components/responses/Forbidden" },
+        "409": {
+          description:
+            "No changes to snapshot, or version already published (immutable — bump the version). RFC 9457 problem+json with `code` one of `no_changes`, `version_exists`, `agent_in_use`, or `conflict`.",
+          content: {
+            "application/problem+json": {
+              schema: { $ref: "#/components/schemas/ProblemDetail" },
+            },
+          },
+        },
       },
     },
   },

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -538,8 +538,9 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
         });
       }
 
+      let createdItem;
       try {
-        await createOrgItem(
+        createdItem = await createOrgItem(
           orgId,
           { id: packageId, content, createdBy: user.id },
           rcfg.cfg,
@@ -574,12 +575,18 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
       }
       await uploadPackageFiles(rcfg.cfg.storageFolder, orgId, packageId, normalizedFiles);
 
-      // Create initial version (non-fatal)
+      // Create initial version (non-fatal). Snapshot the STORED draft
+      // manifest (not the pre-normalization request body): `createOrgItem`
+      // injects `$schema`/`type`/… and the jsonb round-trip reorders keys, so
+      // snapshotting `validatedManifest` produced a version whose bytes could
+      // never match a later rebuild from the draft. That byte drift defeated
+      // the publish dedup and, before #896, made every create-then-republish
+      // silently overwrite the artifact while keeping the stale integrity row.
       await createVersionSafe({
         packageId,
         orgId,
         userId: user.id,
-        manifest: validatedManifest,
+        manifest: asRecord(createdItem.draftManifest),
         normalizedFiles,
       });
 
@@ -1150,6 +1157,12 @@ function makeCreateVersionHandler(rcfg: PackageRouteConfig) {
     if ("error" in result) {
       if (result.error === "no_changes") {
         throw conflict("no_changes", "No changes since the last version");
+      }
+      if (result.error === "version_exists") {
+        throw conflict(
+          "version_exists",
+          "This version is already published and immutable — bump the version to publish the changed content",
+        );
       }
       throw invalidRequest("Failed to create version (invalid or duplicate)");
     }

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -538,15 +538,12 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
         });
       }
 
-      let createdItem;
-      try {
-        createdItem = await createOrgItem(
-          orgId,
-          { id: packageId, content, createdBy: user.id },
-          rcfg.cfg,
-          validatedManifest as Record<string, unknown>,
-        );
-      } catch (err) {
+      const createdItem = await createOrgItem(
+        orgId,
+        { id: packageId, content, createdBy: user.id },
+        rcfg.cfg,
+        validatedManifest as Record<string, unknown>,
+      ).catch((err: unknown) => {
         // The pre-check above narrows the common case, but a concurrent create
         // can still lose the race — map the persistence-layer collision to 409
         // instead of a 500 (mirrors the ZIP/skill create path below).
@@ -554,7 +551,7 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
           throw conflict("name_collision", err.message);
         }
         throw err;
-      }
+      });
 
       // After-create hook (optional per-type post-create side-effect)
       if (rcfg.afterCreate) {

--- a/apps/api/src/services/package-versions.ts
+++ b/apps/api/src/services/package-versions.ts
@@ -48,6 +48,17 @@ interface CreateVersionParams {
    * partial index.
    */
   deps?: DepEntry[];
+  /**
+   * Artifact upload, invoked INSIDE the transaction and ONLY when the outcome
+   * is `created` — i.e. strictly after the forward-only/exists decision, while
+   * the per-package advisory lock is held. This ordering is the #896 fix:
+   * uploading before the decision let an `exists` republish overwrite the
+   * published bytes while the row kept the old integrity hash (a permanent
+   * `bundle_integrity_mismatch` at run time), and let a `rejected` republish
+   * clobber-then-delete a perfectly good artifact. An upload failure rolls the
+   * version row back, so a committed row always had a successful upload.
+   */
+  uploadZip?: () => Promise<void>;
 }
 
 /**
@@ -57,15 +68,17 @@ interface CreateVersionParams {
  * Returns `null` ONLY for the legitimate no-op cases — an invalid semver, a
  * version that already exists (with no row to return), or a forward-only
  * rejection. A genuine DB failure THROWS so callers can distinguish a real
- * error from a benign skip (e.g. so the ZIP-cleanup path in
- * {@link createVersionAndUpload} fires and the import doesn't commit an
- * orphaned packages row without a version).
+ * error from a benign skip. A returned row carries `outcome` so callers can
+ * tell a fresh publish (`created`) from an already-existing version
+ * (`exists`) — the latter never touches the stored artifact.
  */
 export async function createPackageVersion(params: CreateVersionParams): Promise<{
   id: number;
   version: string;
+  outcome: "created" | "exists";
 } | null> {
-  const { packageId, version, integrity, artifactSize, manifest, createdBy, deps } = params;
+  const { packageId, version, integrity, artifactSize, manifest, createdBy, deps, uploadZip } =
+    params;
 
   if (!isValidVersion(version)) {
     logger.error("Invalid semver version", { packageId, version });
@@ -95,13 +108,16 @@ export async function createPackageVersion(params: CreateVersionParams): Promise
     );
 
     if (outcome.action === "exists") {
+      // Published versions are immutable: return the existing row WITHOUT
+      // touching the stored artifact. Overwriting the bytes here while keeping
+      // the row's integrity hash is exactly the corruption reported in #896.
       logger.warn("Version already exists", { packageId, version });
       const [existingRow] = await tx
         .select({ id: packageVersions.id, version: packageVersions.version })
         .from(packageVersions)
         .where(and(eq(packageVersions.packageId, packageId), eq(packageVersions.version, version)))
         .limit(1);
-      return existingRow ?? null;
+      return existingRow ? { ...existingRow, outcome: "exists" as const } : null;
     }
     if (outcome.action === "rejected") {
       logger.warn("Version rejected", {
@@ -135,7 +151,17 @@ export async function createPackageVersion(params: CreateVersionParams): Promise
         });
     }
 
-    return { id: row!.id, version: row!.version };
+    // Upload the artifact only now that the outcome is decided as `created`,
+    // still inside the transaction: an upload failure rolls the row back, so
+    // a committed row is never left pointing at absent bytes, and a rejected
+    // or already-existing version never has its published bytes overwritten
+    // (#896). Holding the per-package advisory lock across the upload is the
+    // accepted cost — it only serializes publishes of the SAME package.
+    if (uploadZip) {
+      await uploadZip();
+    }
+
+    return { id: row!.id, version: row!.version, outcome: "created" as const };
   });
 }
 
@@ -506,12 +532,15 @@ export async function getLatestVersionIntegrity(packageId: string): Promise<stri
   return row?.integrity ?? null;
 }
 
-type CreateVersionError = "invalid_version" | "no_changes";
+type CreateVersionError = "invalid_version" | "no_changes" | "version_exists";
 type CreateVersionResult = { id: number; version: string } | { error: CreateVersionError };
 
 /** Create an immutable version snapshot from the current draft (packages table).
  *  Uses manifest.version as-is — no auto-bump. Returns an error object if version is missing,
- *  invalid, fails forward-only validation, or content is identical to the latest version. */
+ *  invalid, fails forward-only validation, or content is identical to the latest version.
+ *  A draft whose content changed but whose version was not bumped yields `version_exists`
+ *  (published versions are immutable — the old silent-success path overwrote the stored
+ *  bytes while keeping the stale integrity row, #896). */
 export async function createVersionFromDraft(params: {
   packageId: string;
   orgId: string;
@@ -606,7 +635,12 @@ export async function createVersionFromDraft(params: {
     zipBuffer,
     manifest: finalManifest,
   });
-  return result ?? { error: "invalid_version" };
+  if (!result) return { error: "invalid_version" };
+  // Same version, different content (the identical-content case returned
+  // `no_changes` above): refuse loudly instead of silently keeping the old
+  // artifact — the caller must bump the version to publish the new content.
+  if (result.outcome === "exists") return { error: "version_exists" };
+  return { id: result.id, version: result.version };
 }
 
 // ─────────────────────────────────────────────
@@ -680,6 +714,19 @@ export async function replaceVersionContent(params: {
   const deps = extractDependencies(manifest);
   await assertNoCycle(packageId, deps);
 
+  // Bail before touching storage when the version row doesn't exist: the old
+  // order uploaded first, so a bad `version` overwrote the artifact of... a
+  // version nobody had, or worse raced a concurrent publish (#896-adjacent).
+  const [existingRow] = await db
+    .select({ id: packageVersions.id })
+    .from(packageVersions)
+    .where(and(eq(packageVersions.packageId, packageId), eq(packageVersions.version, version)))
+    .limit(1);
+  if (!existingRow) {
+    logger.warn("replaceVersionContent: version row not found", { packageId, version });
+    return;
+  }
+
   // Upload ZIP first to avoid integrity mismatch if upload fails after DB update
   await uploadPackageZip(packageId, version, zipBuffer);
 
@@ -714,14 +761,21 @@ export async function replaceVersionContent(params: {
 // Convenience: create version + upload ZIP
 // ─────────────────────────────────────────────
 
-/** Create a version snapshot and upload the ZIP to Storage in one call. */
+/** Create a version snapshot and upload the ZIP to Storage in one call.
+ *
+ *  The upload happens INSIDE `createPackageVersion`'s transaction, strictly
+ *  after the forward-only/exists decision (#896): an `exists` or `rejected`
+ *  outcome never touches storage, so a republish of an existing version can
+ *  no longer overwrite published bytes (leaving the row's stale integrity
+ *  hash to fail every subsequent run) or delete a good artifact via the old
+ *  upload-then-clean-up sequence. */
 export async function createVersionAndUpload(params: {
   packageId: string;
   version: string;
   createdBy: string | null;
   zipBuffer: Buffer;
   manifest: Record<string, unknown>;
-}): Promise<{ id: number; version: string } | null> {
+}): Promise<{ id: number; version: string; outcome: "created" | "exists" } | null> {
   const { packageId, version, createdBy, zipBuffer, manifest } = params;
 
   const integrity = computeIntegrity(new Uint8Array(zipBuffer));
@@ -734,13 +788,11 @@ export async function createVersionAndUpload(params: {
   const deps = extractDependencies(manifest);
   await assertNoCycle(packageId, deps);
 
-  // Upload ZIP first — a ZIP without a DB row is safer than a DB row without a ZIP
-  await uploadPackageZip(packageId, version, zipBuffer);
-
   try {
     // The version row + its derived dependency index commit atomically inside
-    // createPackageVersion's transaction (deps passed through here).
-    const result = await createPackageVersion({
+    // createPackageVersion's transaction; the artifact upload runs in there
+    // too, only on a `created` outcome, so row and bytes commit together.
+    return await createPackageVersion({
       packageId,
       version,
       integrity,
@@ -748,26 +800,25 @@ export async function createVersionAndUpload(params: {
       manifest,
       createdBy,
       deps,
+      uploadZip: () => uploadPackageZip(packageId, version, zipBuffer),
     });
-
-    // `null` = no row created (invalid semver / forward-only rejection — NOT
-    // the "exists" case, which returns the existing row). The ZIP was already
-    // uploaded above, so clean it up rather than leave it orphaned in storage.
-    if (!result) {
-      try {
-        await deleteVersionZip(packageId, version);
-      } catch {
-        logger.warn("Failed to clean up ZIP after no-op version create", { packageId, version });
-      }
-    }
-
-    return result;
   } catch (err) {
-    // Clean up uploaded ZIP on DB failure (best-effort — don't mask original error)
+    // The transaction rolled back. If the upload itself went through (or
+    // partially) before a later step failed, the bytes sit at a path no
+    // version row references. Best-effort cleanup — but ONLY when no row
+    // exists for this version: if one does, the artifact at that path is the
+    // published one from an earlier publish and must not be deleted.
     try {
-      await deleteVersionZip(packageId, version);
+      const [existingRow] = await db
+        .select({ id: packageVersions.id })
+        .from(packageVersions)
+        .where(and(eq(packageVersions.packageId, packageId), eq(packageVersions.version, version)))
+        .limit(1);
+      if (!existingRow) {
+        await deleteVersionZip(packageId, version);
+      }
     } catch {
-      logger.warn("Failed to clean up ZIP after DB error", { packageId, version });
+      logger.warn("Failed to clean up ZIP after version create error", { packageId, version });
     }
     throw err;
   }

--- a/apps/api/test/integration/routes/packages.test.ts
+++ b/apps/api/test/integration/routes/packages.test.ts
@@ -1763,12 +1763,16 @@ describe("Packages API", () => {
         }),
       });
       expect(create.status).toBe(201);
+      // Create already auto-published 0.1.0 with byte-identical content, so an
+      // explicit republish of the same version is a detected no-op (#896 made
+      // this deterministic — it used to silently overwrite the artifact).
       const pub = await app.request("/api/packages/agents/@forksrc/forkable-agent/versions", {
         method: "POST",
         headers: authHeaders(srcCtx, { "Content-Type": "application/json" }),
         body: JSON.stringify({ version: "0.1.0" }),
       });
-      expect(pub.status).toBe(201);
+      expect(pub.status).toBe(409);
+      expect(((await pub.json()) as any).code).toBe("no_changes");
 
       const res = await app.request("/api/packages/@forksrc/forkable-agent/fork", {
         method: "POST",
@@ -1806,12 +1810,15 @@ describe("Packages API", () => {
         }),
       });
       expect(create.status).toBe(201);
+      // Same as the agent arm: create auto-published 0.1.0, the republish is a
+      // detected no-op instead of a silent artifact overwrite (#896).
       const pub = await app.request("/api/packages/skills/@forksrc2/forkable-skill/versions", {
         method: "POST",
         headers: authHeaders(srcCtx, { "Content-Type": "application/json" }),
         body: JSON.stringify({ version: "0.1.0" }),
       });
-      expect(pub.status).toBe(201);
+      expect(pub.status).toBe(409);
+      expect(((await pub.json()) as any).code).toBe("no_changes");
 
       const res = await app.request("/api/packages/@forksrc2/forkable-skill/fork", {
         method: "POST",

--- a/apps/api/test/integration/services/package-versions.test.ts
+++ b/apps/api/test/integration/services/package-versions.test.ts
@@ -3,7 +3,7 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 import { and, eq } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
-import { packageVersions, packageVersionDependencies } from "@appstrate/db/schema";
+import { packages, packageVersions, packageVersionDependencies } from "@appstrate/db/schema";
 import type { DepEntry } from "@appstrate/core/dependencies";
 import { truncateAll } from "../../helpers/db.ts";
 import { createTestUser } from "../../helpers/auth.ts";
@@ -20,7 +20,7 @@ import {
   getVersionInfo,
   getLatestVersionCreatedAt,
 } from "../../../src/services/package-versions.ts";
-import { buildMinimalZip } from "../../../src/services/package-storage.ts";
+import { buildMinimalZip, downloadVersionZip } from "../../../src/services/package-storage.ts";
 describe("package-versions service", () => {
   let userId: string;
   let orgId: string;
@@ -519,6 +519,119 @@ describe("package-versions service", () => {
 
       // No version row created.
       expect(await getVersionCount(pkg.id)).toBe(0);
+    });
+  });
+
+  // ── #896 — published-artifact immutability at the publish gate ─────
+  //
+  // The old sequence uploaded the ZIP BEFORE deciding the version outcome, so
+  // a republish of an existing version overwrote the stored bytes while the
+  // row kept the integrity hash of the original publish — every subsequent
+  // run then failed `bundle_integrity_mismatch`, and republishing (201) never
+  // converged. These tests pin the invariant: whatever the publish outcome,
+  // the stored bytes for an existing version keep matching its recorded hash.
+  describe("createVersionAndUpload — published-artifact immutability (#896)", () => {
+    it("republishing an existing version with different bytes returns 'exists' and leaves the artifact untouched", async () => {
+      const pkg = await seedPackage({ orgId, id: `@${orgSlug}/immutable` });
+      const manifest: Record<string, unknown> = { name: pkg.id, version: "1.0.0", type: "agent" };
+      const zipV1 = Buffer.from(buildMinimalZip(manifest, "original prompt"));
+
+      const first = await createVersionAndUpload({
+        packageId: pkg.id,
+        version: "1.0.0",
+        createdBy: userId,
+        zipBuffer: zipV1,
+        manifest,
+      });
+      expect(first!.outcome).toBe("created");
+
+      const zipChanged = Buffer.from(buildMinimalZip(manifest, "CHANGED prompt"));
+      const second = await createVersionAndUpload({
+        packageId: pkg.id,
+        version: "1.0.0",
+        createdBy: userId,
+        zipBuffer: zipChanged,
+        manifest,
+      });
+      expect(second!.outcome).toBe("exists");
+      expect(second!.id).toBe(first!.id);
+
+      // Stored bytes must still hash to the integrity recorded at first
+      // publish — downloadVersionZip re-verifies and throws on mismatch.
+      const [row] = await db
+        .select({ integrity: packageVersions.integrity })
+        .from(packageVersions)
+        .where(and(eq(packageVersions.packageId, pkg.id), eq(packageVersions.version, "1.0.0")))
+        .limit(1);
+      const stored = await downloadVersionZip(pkg.id, "1.0.0", row!.integrity);
+      expect(stored).not.toBeNull();
+      expect(Buffer.compare(stored!, zipV1)).toBe(0);
+    });
+
+    it("a forward-only-rejected publish never touches storage", async () => {
+      const pkg = await seedPackage({ orgId, id: `@${orgSlug}/forward-only` });
+      const m2: Record<string, unknown> = { name: pkg.id, version: "2.0.0", type: "agent" };
+      const created = await createVersionAndUpload({
+        packageId: pkg.id,
+        version: "2.0.0",
+        createdBy: userId,
+        zipBuffer: Buffer.from(buildMinimalZip(m2, "v2")),
+        manifest: m2,
+      });
+      expect(created!.outcome).toBe("created");
+
+      const m1: Record<string, unknown> = { name: pkg.id, version: "1.0.0", type: "agent" };
+      const rejected = await createVersionAndUpload({
+        packageId: pkg.id,
+        version: "1.0.0",
+        createdBy: userId,
+        zipBuffer: Buffer.from(buildMinimalZip(m1, "v1")),
+        manifest: m1,
+      });
+      expect(rejected).toBeNull();
+
+      // No orphan artifact for the rejected version, and 2.0.0 still verifies.
+      expect(await downloadVersionZip(pkg.id, "1.0.0")).toBeNull();
+      const [row] = await db
+        .select({ integrity: packageVersions.integrity })
+        .from(packageVersions)
+        .where(and(eq(packageVersions.packageId, pkg.id), eq(packageVersions.version, "2.0.0")))
+        .limit(1);
+      expect(await downloadVersionZip(pkg.id, "2.0.0", row!.integrity)).not.toBeNull();
+    });
+
+    it("createVersionFromDraft answers version_exists when content changed without a version bump", async () => {
+      const id = `@${orgSlug}/needs-bump`;
+      const pkg = await seedPackage({
+        orgId,
+        id,
+        draftManifest: { name: id, version: "1.0.0", type: "agent" },
+        draftContent: "v1 prompt",
+      });
+
+      const first = await createVersionFromDraft({ packageId: pkg.id, orgId, userId });
+      expect("error" in first).toBe(false);
+
+      // Unchanged draft → still the dedup answer.
+      const unchanged = await createVersionFromDraft({ packageId: pkg.id, orgId, userId });
+      expect(unchanged).toEqual({ error: "no_changes" });
+
+      // Changed content, same version → refuse loudly instead of the old
+      // silent 201 that corrupted the stored artifact.
+      await db
+        .update(packages)
+        .set({ draftContent: "v2 prompt — changed" })
+        .where(eq(packages.id, pkg.id));
+      const republished = await createVersionFromDraft({ packageId: pkg.id, orgId, userId });
+      expect(republished).toEqual({ error: "version_exists" });
+
+      // Published artifact still matches its recorded integrity.
+      const [row] = await db
+        .select({ integrity: packageVersions.integrity })
+        .from(packageVersions)
+        .where(and(eq(packageVersions.packageId, pkg.id), eq(packageVersions.version, "1.0.0")))
+        .limit(1);
+      expect(await downloadVersionZip(pkg.id, "1.0.0", row!.integrity)).not.toBeNull();
     });
   });
 });

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -14619,7 +14619,7 @@ export interface operations {
             400: components["responses"]["ValidationError"];
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
-            /** @description Agent in use (runs in progress) or no changes to snapshot. RFC 9457 problem+json with `code` one of `agent_in_use`, `no_changes`, or `conflict`. */
+            /** @description Agent in use (runs in progress), no changes to snapshot, or version already published (immutable — bump the version). RFC 9457 problem+json with `code` one of `agent_in_use`, `no_changes`, `version_exists`, or `conflict`. */
             409: {
                 headers: {
                     [name: string]: unknown;
@@ -15403,6 +15403,15 @@ export interface operations {
             400: components["responses"]["ValidationError"];
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+            /** @description No changes to snapshot, or version already published (immutable — bump the version). RFC 9457 problem+json with `code` one of `no_changes`, `version_exists`, `agent_in_use`, or `conflict`. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetail"];
+                };
+            };
         };
     };
     getIntegrationPackageVersionInfo: {
@@ -15967,6 +15976,15 @@ export interface operations {
             400: components["responses"]["ValidationError"];
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+            /** @description No changes to snapshot, or version already published (immutable — bump the version). RFC 9457 problem+json with `code` one of `no_changes`, `version_exists`, `agent_in_use`, or `conflict`. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetail"];
+                };
+            };
         };
     };
     getMcpServerPackageVersionInfo: {
@@ -16538,6 +16556,15 @@ export interface operations {
             400: components["responses"]["ValidationError"];
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+            /** @description No changes to snapshot, or version already published (immutable — bump the version). RFC 9457 problem+json with `code` one of `no_changes`, `version_exists`, `agent_in_use`, or `conflict`. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetail"];
+                };
+            };
         };
     };
     getSkillVersionInfo: {

--- a/packages/afps-runtime/src/bundle/build.ts
+++ b/packages/afps-runtime/src/bundle/build.ts
@@ -136,7 +136,14 @@ export async function buildBundleFromCatalog(
     // Fetch the deduped level in parallel — fetch is read-only against the
     // catalog; all shared-state mutation (packages/visiting/missing) stays
     // in the sequential sections of this frame.
-    const fetched = await Promise.all(
+    //
+    // Settle ALL fetches instead of racing on the first rejection: with
+    // several broken deps, `Promise.all` surfaced whichever rejection lost
+    // the I/O race, so the package named in the error changed run to run —
+    // read as "the corruption moves around" by operators (#896). Failures
+    // are folded back in declaration order, and integrity failures are
+    // aggregated so one error names every corrupted package at once.
+    const settled = await Promise.allSettled(
       toFetch.map(async (resolved) => {
         const depPkg = await catalog.fetch(resolved.identity);
         if (depPkg.identity !== resolved.identity) {
@@ -149,6 +156,31 @@ export async function buildBundleFromCatalog(
         return depPkg;
       }),
     );
+
+    const failures: Array<{ identity: PackageIdentity; reason: unknown }> = [];
+    const fetched: BundlePackage[] = [];
+    for (let i = 0; i < settled.length; i++) {
+      const outcome = settled[i]!;
+      if (outcome.status === "fulfilled") {
+        fetched.push(outcome.value);
+      } else {
+        failures.push({ identity: toFetch[i]!.identity, reason: outcome.reason });
+      }
+    }
+    if (failures.length > 0) {
+      const mismatches = failures.filter(
+        (f) => f.reason instanceof BundleError && f.reason.code === "INTEGRITY_MISMATCH",
+      );
+      if (mismatches.length > 0) {
+        const identities = mismatches.map((f) => f.identity);
+        throw new BundleError(
+          "INTEGRITY_MISMATCH",
+          `Integrity check failed for ${identities.join(", ")}`,
+          { packages: identities },
+        );
+      }
+      throw failures[0]!.reason;
+    }
 
     // Recurse sequentially (DFS) — child walks mutate the shared maps, so
     // they must not interleave. A deeper walk may have loaded a sibling's

--- a/packages/afps-runtime/test/bundle/build.test.ts
+++ b/packages/afps-runtime/test/bundle/build.test.ts
@@ -358,6 +358,74 @@ describe("buildBundleFromCatalog", () => {
     expect((err as BundleError).message).toMatch(/catalog\.fetch returned identity/);
   });
 
+  it("aggregates every INTEGRITY_MISMATCH fetch failure into one deterministic error (#896)", async () => {
+    // With several corrupted deps, the old `Promise.all` surfaced whichever
+    // rejection lost the I/O race — the package named in the error changed
+    // run to run, which operators read as corruption "moving around". The
+    // builder must settle all fetches and name every failing package, in
+    // declaration order, on every run.
+    const root = makePkg(
+      "@me/root@1.0.0" as PackageIdentity,
+      { ...ROOT, dependencies: { skills: { "@me/a": "^1", "@me/b": "^1", "@me/ok": "^1" } } },
+      { "prompt.md": enc("p") },
+    );
+    const ok = makePkg(
+      "@me/ok@1.0.0" as PackageIdentity,
+      { name: "@me/ok", version: "1.0.0", type: "skill", schema_version: "0.1" },
+      { "SKILL.md": enc("fine") },
+    );
+    const corruptCatalog = {
+      resolve: async (name: string) => ({ identity: `${name}@1.0.0` as PackageIdentity }),
+      fetch: async (identity: PackageIdentity) => {
+        if (identity === ok.identity) return ok;
+        // Vary the rejection latency so a racing implementation would name
+        // @me/b (fastest failure) — the settled implementation must not.
+        await new Promise((r) => setTimeout(r, identity.startsWith("@me/a") ? 20 : 0));
+        throw new BundleError("INTEGRITY_MISMATCH", `Integrity check failed for ${identity}`);
+      },
+    };
+
+    for (let run = 0; run < 3; run++) {
+      const err = await buildBundleFromCatalog(root, corruptCatalog).then(
+        () => null,
+        (e: unknown) => e,
+      );
+      expect(err).toBeInstanceOf(BundleError);
+      expect((err as BundleError).code).toBe("INTEGRITY_MISMATCH");
+      expect((err as BundleError).message).toBe(
+        "Integrity check failed for @me/a@1.0.0, @me/b@1.0.0",
+      );
+      expect((err as BundleError).details).toEqual({
+        packages: ["@me/a@1.0.0", "@me/b@1.0.0"],
+      });
+    }
+  });
+
+  it("surfaces the first-declared failure when no fetch failure is an integrity mismatch", async () => {
+    const root = makePkg(
+      "@me/root@1.0.0" as PackageIdentity,
+      { ...ROOT, dependencies: { skills: { "@me/a": "^1", "@me/b": "^1" } } },
+      { "prompt.md": enc("p") },
+    );
+    const failingCatalog = {
+      resolve: async (name: string) => ({ identity: `${name}@1.0.0` as PackageIdentity }),
+      fetch: async (identity: PackageIdentity) => {
+        // @me/b fails instantly, @me/a after a delay: declaration order must
+        // still win over completion order.
+        await new Promise((r) => setTimeout(r, identity.startsWith("@me/a") ? 20 : 0));
+        throw new BundleError("ARCHIVE_INVALID", `broken archive for ${identity}`);
+      },
+    };
+
+    const err = await buildBundleFromCatalog(root, failingCatalog).then(
+      () => null,
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(BundleError);
+    expect((err as BundleError).code).toBe("ARCHIVE_INVALID");
+    expect((err as BundleError).message).toBe("broken archive for @me/a@1.0.0");
+  });
+
   it("composes in-memory + fallback for inline-run-style ingestion", async () => {
     // Simulates a user posting a root manifest that references an
     // already-registered skill. Posted payload (in-memory) takes


### PR DESCRIPTION
Fixes #896.

## Diagnosis

The reporter's read — "artifact corruption at rest" — was right about the layer (server-side) but the corruption was **created by the publish pipeline itself**, and the "oscillation" was an error-reporting race, not corruption moving around. Three defects chained:

### 1. Publish uploaded bytes before deciding the version outcome

`createVersionAndUpload` ran `uploadPackageZip` **before** `createPackageVersion` evaluated forward-only/exists. On an `exists` outcome (republish of an already-published version) it overwrote the stored ZIP with the freshly-built bytes and returned the existing row — whose `integrity` hash still described the *original* bytes. Result: a permanent `bundle_integrity_mismatch` for that version, and a 201 response that looked like a successful republish. That is exactly why republishing "never stuck" in the report.

**Fix:** the upload now runs *inside* `createPackageVersion`'s transaction, strictly after the outcome is decided as `created`, under the per-package advisory lock. `exists`/`rejected` outcomes never touch storage; an upload failure rolls the row back, so a committed row always has matching bytes. The old catch-path cleanup (which could delete a published artifact after a DB error on an exists republish) is now guarded on "no version row references this path".

### 2. The corruption seed: create-time snapshot never byte-matched the draft

The create route snapshotted the **pre-normalization request manifest** into the auto-published initial version, while the stored draft gets `$schema` injected and jsonb key reordering. So a later "publish" of the *unchanged* draft produced different bytes, the `no_changes` dedup never fired, and the flow fell straight into the overwrite above. **Every create-then-republish corrupted the artifact.** This matches the report: skills that "publish cleanly (201)" then fail integrity at run time.

**Fix:** the initial version now snapshots the stored draft manifest (`createdItem.draftManifest`), making unchanged republishes byte-identical → deterministic `409 no_changes`.

### 3. The "oscillation": a Promise.all race in bundle assembly

`buildBundleFromCatalog` fetched dependencies with `Promise.all`; with several corrupted skills the error named whichever rejection lost the I/O race — a different package on every run (the reporter's runs 1–6 whack-a-mole, including re-failures of "fixed" skills). Draft mode was affected too because a draft *agent* still resolves its *skills* to published versions.

**Fix:** fetches settle (`Promise.allSettled`); all `INTEGRITY_MISMATCH` failures aggregate into **one deterministic error naming every corrupted package** in declaration order. Non-integrity failures surface first-by-declaration instead of first-by-race.

## Behavior changes

- `POST .../versions` with a changed draft and an unbumped version now answers **`409 version_exists`** ("bump the version") instead of a silent 201 that corrupted the artifact. Documented on the four create-version OpenAPI operations.
- Unchanged republish of the auto-published initial version now answers `409 no_changes` (previously it silently corrupted).
- `bundle_integrity_mismatch` detail now lists **all** corrupted packages at once, deterministically.

## Answers to the issue's questions

1. *Force rebuild?* Not needed once this lands: republishing with a **bumped version** always produces a consistent row+artifact, and `^` pins pick it up. Already-corrupted versions can be repaired by publishing a bumped version (the error now names all of them in one shot).
2. *Hash normalization asymmetry?* None — SRI sha256 over raw ZIP bytes on both sides, and the ZIP build is deterministic. The mismatch came from the write path above, not hashing or CDN caches.

## Tests

- `package-versions.test.ts`: exists-republish leaves stored bytes matching the recorded hash; forward-only rejection never touches storage; changed-content/unbumped-version → `version_exists` with artifact intact.
- `build.test.ts`: multi-corruption aggregates deterministically across repeated runs (with adversarial latency skew); non-integrity failures surface in declaration order.
- Fork tests updated: explicit republish after create is now a detected no-op (`409 no_changes`) — pinning the dedup alignment.
- Full runs green: `apps/api` (2803 pass), modules (947 pass), `afps-runtime` (600 pass), `bun run check` (33/33 tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)