### PR TITLE
fix(chat): mobile sidebar conversation selection

### DIFF
--- a/packages/module-chat/src/ui/index.tsx
+++ b/packages/module-chat/src/ui/index.tsx
@@ -138,7 +138,12 @@ export function ChatPage({
               />
               <aside
                 className="bg-background absolute inset-y-0 left-0 flex w-72 max-w-[85%] flex-col border-r shadow-xl"
-                onClickCapture={(e) => {
+                // Bubble phase, NOT capture: a capture handler would flush
+                // `setMobileOpen(false)` synchronously (discrete event) and
+                // unmount this subtree BEFORE the bubble dispatch, swallowing
+                // the row button's own onClick (select/navigate). In bubble
+                // order the child's handler runs first, then this closes.
+                onClick={(e) => {
                   if ((e.target as HTMLElement).closest("button")) setMobileOpen(false);
                 }}
               >

--- a/packages/module-chat/src/ui/thread-list.tsx
+++ b/packages/module-chat/src/ui/thread-list.tsx
@@ -164,7 +164,10 @@ function ConversationRow({
             {relativeTime(session.updatedAt)}
           </span>
         )}
-        <div className="bg-background absolute right-0 flex items-center gap-0.5 rounded-md p-0.5 opacity-0 shadow-sm transition-opacity group-hover:opacity-100">
+        {/* pointer-events must track visibility: opacity-0 alone keeps the
+            invisible buttons tappable — on touch devices (no hover) a tap on
+            the timestamp area would hit the hidden Delete. */}
+        <div className="bg-background pointer-events-none absolute right-0 flex items-center gap-0.5 rounded-md p-0.5 opacity-0 shadow-sm transition-opacity group-hover:pointer-events-auto group-hover:opacity-100">
           <button
             type="button"
             aria-label="Renommer"


### PR DESCRIPTION
## Bug

On mobile, tapping a conversation in the chat drawer closed the drawer but never navigated to the conversation.

## Root cause

The drawer's auto-close handler ran in the **capture** phase (`onClickCapture` on the `<aside>`). React attaches separate root listeners for the capture and bubble phases of a discrete event, with a synchronous flush after each dispatch. So `setMobileOpen(false)` re-rendered and **unmounted the drawer subtree before the bubble dispatch** — the row button's own `onClick` (`select → navigate("/chat/:id")`) belonged to an unmounted tree and never fired. Classic capture-unmounts-child footgun. The drawer's "+" (new conversation) and delete buttons were swallowed the same way. Desktop was unaffected (no capture handler on the desktop aside).

**Fix**: move the handler to the bubble phase. Bubble order is child → ancestor: the row's navigate runs first, then the drawer closes. Same `closest("button")` logic, both updates batched in one dispatch.

## Adjacent defect (same component, touch-specific)

The hover-revealed row actions (rename/delete) were `opacity-0` without `pointer-events-none` — invisible but still tappable. On touch devices (no hover), a tap on the right zone of a row (timestamp/unread dot area) could hit the **invisible Delete** and drop a conversation with no confirmation. Now `pointer-events-none` while hidden, `group-hover:pointer-events-auto` when revealed.

## Verification

- `bun run check` — 33/33 (tsc, eslint react-hooks recommended-latest, prettier, verify:openapi).
- Manual: mobile viewport → open drawer → tap conversation → drawer closes AND URL/conversation switches; "+" starts a new chat; tap on a row's timestamp area is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)