### PR TITLE
fix(cli): guard runner uninstall against rm -rf of root + staged-download hygiene

### DIFF
--- a/apps/cli/src/commands/runner.ts
+++ b/apps/cli/src/commands/runner.ts
@@ -18,7 +18,7 @@
  */
 
 import * as clack from "@clack/prompts";
-import { dirname } from "node:path";
+import { dirname, isAbsolute, normalize } from "node:path";
 import { intro, outro, askText, confirm, exitWithError } from "../lib/ui.ts";
 import { CLI_VERSION, DEV_CLI_VERSION } from "../lib/version.ts";
 import {
@@ -360,6 +360,21 @@ function parsePort(raw: string | undefined): number {
   return n;
 }
 
+/**
+ * Promote the verified staged daemon onto `RUNNER_BIN_PATH`. On a failed
+ * promotion (chmod/rename), the staged file is removed — otherwise the ~70 MB
+ * verified binary would be left behind as a hidden orphan in the bin dir.
+ * Exported for tests; both `install` and `update` route through it.
+ */
+export async function promoteStagedDaemon(d: { fs: RunnerFs }, stagedPath: string): Promise<void> {
+  try {
+    await d.fs.promoteFile(stagedPath, RUNNER_BIN_PATH, 0o755);
+  } catch (err) {
+    await d.fs.remove(stagedPath).catch(() => {});
+    throw err;
+  }
+}
+
 async function downloadAndInstallBinaries(
   config: RunnerConfig,
   version: string,
@@ -381,7 +396,7 @@ async function downloadAndInstallBinaries(
     destPath: RUNNER_BIN_PATH,
     onProgress: (p) => daemonSpin.message(`${daemonLabel} — ${formatProgress(p)}`),
   });
-  await d.fs.promoteFile(stagedPath, RUNNER_BIN_PATH, 0o755);
+  await promoteStagedDaemon(d, stagedPath);
   daemonSpin.stop(`Installed daemon → ${RUNNER_BIN_PATH}`);
 
   const fcSpin = clack.spinner();
@@ -757,7 +772,7 @@ export async function runnerUpdateCommand(opts: RunnerUpdateOptions = {}): Promi
     });
     // Atomic swap over the live binary — rename(2) keeps the running
     // process's fd valid; the restart below picks up the new inode.
-    await d.fs.promoteFile(stagedPath, RUNNER_BIN_PATH, 0o755);
+    await promoteStagedDaemon(d, stagedPath);
     spin.stop(`Installed daemon → ${RUNNER_BIN_PATH}`);
 
     // Re-pin the guest artifacts to the new daemon version BEFORE the restart:
@@ -827,22 +842,43 @@ export interface RunnerUninstallOptions {
 }
 
 /**
+ * Refuse any data dir a recursive root `rm -rf` must never target: relative
+ * paths (cwd-dependent) and anything shallower than two path segments. Guards
+ * `uninstall` against a corrupted env file (`FIRECRACKER_KERNEL_PATH=/vmlinux`
+ * → `dirname` = `/`) or a typo'd `--data-dir /` recursing the filesystem root
+ * as root. Every resolution branch below flows through it. Exported for tests.
+ */
+export function assertSaneDataDir(dir: string): string {
+  const normalized = normalize(dir);
+  const segments = normalized.split("/").filter(Boolean);
+  if (!isAbsolute(normalized) || segments.length < 2) {
+    throw new Error(
+      `Refusing to use "${dir}" as the runner data dir: expected an absolute path at ` +
+        `least two segments deep (e.g. ${RUNNER_DATA_DIR}). A shallower target would let ` +
+        `uninstall recursively delete far beyond the runner's state.`,
+    );
+  }
+  return normalized;
+}
+
+/**
  * Recover the install's state root: an explicit `--data-dir` wins, else the
  * `FIRECRACKER_KERNEL_PATH` pin in the env file (`<dataDir>/vmlinux`), else the
  * compiled default. This makes `uninstall` remove the SAME dir a non-default
- * `install --data-dir` created.
+ * `install --data-dir` created. Every branch is gated by `assertSaneDataDir`
+ * — the result feeds a recursive root `rm`. Exported for tests.
  */
-async function resolveUninstallDataDir(
+export async function resolveUninstallDataDir(
   explicit: string | undefined,
-  d: ResolvedDeps,
+  d: { fs: RunnerFs },
 ): Promise<string> {
-  if (explicit) return explicit;
+  if (explicit) return assertSaneDataDir(explicit);
   const envText = await d.fs.readFile(RUNNER_ENV_PATH);
   if (envText) {
     const kernel = parseRunnerEnvFile(envText).FIRECRACKER_KERNEL_PATH;
-    if (kernel && kernel.endsWith("/vmlinux")) return dirname(kernel);
+    if (kernel && kernel.endsWith("/vmlinux")) return assertSaneDataDir(dirname(kernel));
   }
-  return RUNNER_DATA_DIR;
+  return assertSaneDataDir(RUNNER_DATA_DIR);
 }
 
 /**

--- a/apps/cli/src/lib/runner/download.ts
+++ b/apps/cli/src/lib/runner/download.ts
@@ -98,7 +98,11 @@ export async function downloadDaemon(opts: {
 }): Promise<{ stagedPath: string }> {
   const urls = daemonUrls(opts.version, opts.arch);
   const asset = daemonAssetName(opts.arch);
-  const stagedPath = join(dirname(opts.destPath), `.${asset}.download-${process.pid}`);
+  // Fixed staged name (no pid suffix): a retry after a crash/SIGKILL simply
+  // overwrites the previous partial file instead of accumulating hidden ~70 MB
+  // orphans next to the binary. The SHA-256 gate below fails closed if two
+  // concurrent installs ever interleave writes.
+  const stagedPath = join(dirname(opts.destPath), `.${asset}.download`);
 
   // 1. Fetch + verify the small signed manifest BEFORE the large binary
   //    stream: it fails fast on a bad/missing signature without pulling the

--- a/apps/cli/src/lib/self-update.ts
+++ b/apps/cli/src/lib/self-update.ts
@@ -459,8 +459,11 @@ export async function performCurlUpdate(
   const workDir = await deps.makeWorkDir();
   // Stage the (large) binary in the SAME directory as `dest` so the final
   // promotion is an atomic same-filesystem rename over the running binary.
-  // The small checksums + signature live in the throwaway work dir.
-  const staged = join(dirname(dest), `.appstrate.download.${process.pid}`);
+  // The small checksums + signature live in the throwaway work dir. Fixed
+  // staged name (no pid suffix): a retry after a crash/SIGKILL overwrites the
+  // previous partial file instead of accumulating hidden ~113 MB orphans;
+  // the SHA-256 gate fails closed on interleaved writes.
+  const staged = join(dirname(dest), ".appstrate.download");
   try {
     const urls = releaseUrls(target, opts.platform);
     const asset = assetName(opts.platform);

--- a/apps/cli/test/runner.test.ts
+++ b/apps/cli/test/runner.test.ts
@@ -48,6 +48,9 @@ import {
   runnerDoctor,
   pollHealth,
   enableService,
+  assertSaneDataDir,
+  resolveUninstallDataDir,
+  promoteStagedDaemon,
 } from "../src/commands/runner.ts";
 import type { RunnerExec, RunnerFs, RunnerHttp } from "../src/lib/runner/exec.ts";
 
@@ -522,9 +525,10 @@ describe("downloadDaemon", () => {
       arch: "x86_64",
       destPath: TEST_DAEMON_DEST,
     });
-    // Staged next to the destination (same dir → atomic promote).
-    expect(out.stagedPath.startsWith("/usr/local/bin/")).toBe(true);
-    expect(out.stagedPath).toContain("appstrate-runner-x86_64");
+    // Staged next to the destination (same dir → atomic promote), under a
+    // FIXED hidden name — no pid suffix, so a retry after a crash overwrites
+    // the previous partial file instead of accumulating hidden orphans.
+    expect(out.stagedPath).toBe("/usr/local/bin/.appstrate-runner-x86_64.download");
   });
 
   it("throws on a sha256 mismatch and removes the staged file", async () => {
@@ -1027,5 +1031,88 @@ describe("runnerUninstallCommand", () => {
     await runnerUninstallCommand({ yes: true, deps: { getuid: () => 0, fs, exec } });
     // Still targets the canonical paths (remove is rm -rf → no-op on missing).
     expect(removed).toContain(RUNNER_BIN_PATH);
+  });
+});
+
+// ─── uninstall data-dir guard ───────────────────────────────────────────────
+
+describe("assertSaneDataDir", () => {
+  it("accepts absolute paths at least two segments deep", () => {
+    expect(assertSaneDataDir("/var/lib/appstrate-runner")).toBe("/var/lib/appstrate-runner");
+    expect(assertSaneDataDir("/srv/runner")).toBe("/srv/runner");
+    expect(assertSaneDataDir(RUNNER_DATA_DIR)).toBe(RUNNER_DATA_DIR);
+    // Dot segments normalize before the depth check (trailing slash is kept).
+    expect(assertSaneDataDir("/srv/./runner/")).toBe("/srv/runner/");
+  });
+
+  it("refuses relative paths", () => {
+    expect(() => assertSaneDataDir("srv/runner")).toThrow(/Refusing to use/);
+    expect(() => assertSaneDataDir("./data")).toThrow(/Refusing to use/);
+  });
+
+  it("refuses the filesystem root", () => {
+    expect(() => assertSaneDataDir("/")).toThrow(/Refusing to use/);
+    // `..` climbing must not sneak past the depth check either.
+    expect(() => assertSaneDataDir("/srv/runner/../..")).toThrow(/Refusing to use/);
+  });
+
+  it("refuses single-segment paths", () => {
+    expect(() => assertSaneDataDir("/srv")).toThrow(/Refusing to use/);
+    expect(() => assertSaneDataDir("/vmlinux")).toThrow(/Refusing to use/);
+  });
+});
+
+describe("resolveUninstallDataDir", () => {
+  it("refuses an explicit --data-dir / (would rm -rf the filesystem root)", async () => {
+    const { fs } = fakeFs();
+    await expect(resolveUninstallDataDir("/", { fs })).rejects.toThrow(/Refusing to use/);
+  });
+
+  it("refuses a kernel pin at the root (FIRECRACKER_KERNEL_PATH=/vmlinux → dirname /)", async () => {
+    const { fs } = fakeFs({ [RUNNER_ENV_PATH]: "FIRECRACKER_KERNEL_PATH=/vmlinux\n" });
+    await expect(resolveUninstallDataDir(undefined, { fs })).rejects.toThrow(/Refusing to use/);
+  });
+
+  it("accepts a sane kernel pin and returns its directory", async () => {
+    const { fs } = fakeFs({ [RUNNER_ENV_PATH]: "FIRECRACKER_KERNEL_PATH=/srv/runner/vmlinux\n" });
+    expect(await resolveUninstallDataDir(undefined, { fs })).toBe("/srv/runner");
+  });
+
+  it("falls back to the compiled default (itself guard-checked)", async () => {
+    const { fs } = fakeFs();
+    expect(await resolveUninstallDataDir(undefined, { fs })).toBe(RUNNER_DATA_DIR);
+  });
+});
+
+// ─── staged daemon promotion ────────────────────────────────────────────────
+
+describe("promoteStagedDaemon", () => {
+  const staged = "/usr/local/bin/.appstrate-runner-x86_64.download";
+
+  it("promotes the staged binary onto the daemon path", async () => {
+    const { fs, installed, removed } = fakeFs({ [staged]: "<staged>" });
+    await promoteStagedDaemon({ fs }, staged);
+    expect(installed).toEqual([{ dest: RUNNER_BIN_PATH, bytes: new Uint8Array(), mode: 0o755 }]);
+    expect(removed).toEqual([]);
+  });
+
+  it("removes the staged file when promotion fails (no ~70 MB orphan)", async () => {
+    const { fs, removed } = fakeFs({ [staged]: "<staged>" });
+    fs.promoteFile = async () => {
+      throw new Error("EACCES: chmod failed");
+    };
+    await expect(promoteStagedDaemon({ fs }, staged)).rejects.toThrow(/EACCES/);
+    expect(removed).toEqual([staged]);
+  });
+
+  it("rethrows the promotion error even if the staged cleanup itself fails", async () => {
+    const { fs } = fakeFs({ [staged]: "<staged>" });
+    fs.promoteFile = async () => {
+      throw new Error("rename failed");
+    };
+    fs.remove = async () => {
+      throw new Error("rm failed");
+    };
+    await expect(promoteStagedDaemon({ fs }, staged)).rejects.toThrow(/rename failed/);
   });
 });

--- a/apps/cli/test/self-update.test.ts
+++ b/apps/cli/test/self-update.test.ts
@@ -370,6 +370,29 @@ describe("runSelfUpdate — curl flow", () => {
     expect(state.replaced).toEqual([{ dest: "/home/user/.local/bin/appstrate" }]);
   });
 
+  it("stages the download under a fixed hidden name (retry overwrites a crashed partial)", async () => {
+    const state = freshState();
+    const deps = makeFakeDeps(state);
+    let stagedSeen: string | undefined;
+    const basePromote = deps.promoteFile;
+    deps.promoteFile = async (staged, dest) => {
+      stagedSeen = staged;
+      await basePromote(staged, dest);
+    };
+    const out = await runSelfUpdate({
+      source: "curl",
+      platform: { platform: "linux", arch: "x64" },
+      log: () => {},
+      version: "1.2.3",
+      currentVersion: "1.0.0",
+      deps,
+    });
+    expect(out.exitCode).toBe(SELF_UPDATE_EXIT.OK);
+    // No pid suffix: a retry after crash/SIGKILL overwrites the previous
+    // partial file instead of accumulating hidden ~113 MB orphans.
+    expect(stagedSeen).toBe("/home/user/.local/bin/.appstrate.download");
+  });
+
   it("reports already-up-to-date and skips replace when versions match", async () => {
     const state = freshState();
     const out = await runSelfUpdate({


### PR DESCRIPTION
## What / why

Re-implements the hardening commit from the deleted local-only branch `fix/pr845-review` (commit `40dd4e3d0`, verified absent from main) — review follow-ups on #845 that never shipped. Content adapted to what main looks like today (re-implementation, not a cherry-pick).

## The three gaps

**1. P1 — `runner uninstall` could `rm -rf` the filesystem root**
`resolveUninstallDataDir` fed its output straight into the recursive root `rm`. A corrupted env file (`FIRECRACKER_KERNEL_PATH=/vmlinux` → `dirname` = `/`) or a typo'd `--data-dir /` would recurse the FS root as root.
- New `assertSaneDataDir(dir)`: refuses relative paths and anything shallower than two path segments (dot segments normalized first, so `..` climbing can't sneak past the depth check).
- Every resolution branch — explicit `--data-dir`, kernel-pin derivation, compiled default — now flows through it.

**2. Staged daemon promotion left a ~70 MB orphan on failure**
A failed `promoteFile` (chmod/rename) left the verified staged binary behind in the bin dir.
- New `promoteStagedDaemon(d, stagedPath)` removes the staged file on failure (and still rethrows the original promotion error even if the cleanup itself fails); both `install` and `update` route through it.

**3. Staged download names accumulated hidden files**
Staged names carried a `process.pid` suffix, so a retry after crash/SIGKILL accumulated hidden ~70–113 MB files next to the binary.
- Fixed staged names: `.<asset>.download` (`apps/cli/src/lib/runner/download.ts`) and `.appstrate.download` (`apps/cli/src/lib/self-update.ts`). A retry overwrites the previous partial; the SHA-256 gate fails closed on interleaved writes.

## Tests

New bun:test coverage in `apps/cli/test/runner.test.ts` + `apps/cli/test/self-update.test.ts`:
- `assertSaneDataDir` accept/refuse matrix (relative, `/`, single-segment, `..` climbing, valid deep paths)
- `resolveUninstallDataDir`: explicit `--data-dir /` refusal, `FIRECRACKER_KERNEL_PATH=/vmlinux` kernel-pin refusal, sane pin + default acceptance
- `promoteStagedDaemon`: staged cleanup on promotion failure, error precedence when cleanup also fails
- Fixed staged-name assertions for both the daemon download and CLI self-update

## Verification

- `bun run check` (turbo, full monorepo): 33/33 tasks pass
- `cd apps/cli && bun test`: 1259 pass, 0 fail

Closes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)