### PR TITLE
feat(web): notify when a newer platform release is available

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -299,6 +299,14 @@ CONNECTION_ENCRYPTION_KEY=jChGxOEG1YjCtrkrTYhO7FFdIKaHpe/j1PBY/LqID6s=
 # would otherwise outlive their refresh_token upstream.
 # OAUTH_REFRESH_WORKER_ENABLED=false
 
+# ─── Optional: Platform update-availability check ────────────
+# The API polls the GitHub Releases API (server-side cache, at most a few
+# requests per day) so the web UI can show an "update available" badge.
+# Notification only — upgrading stays a host-side operation. Set to false
+# for zero outbound calls (air-gapped deployments). The check is also
+# inactive when APP_VERSION is not stamped (source/dev runs).
+# UPDATE_CHECK_ENABLED=true
+
 # ─── Optional: Integration refresh-failure escalation ────────
 # When an integration's OAuth token refresh fails *transiently* (network
 # / 5xx — NOT invalid_grant, which flips needs_reconnection at once) this

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -43,6 +43,7 @@ import meRouter from "./routes/me.ts";
 import profileRouter from "./routes/profile.ts";
 import invitationsRouter from "./routes/invitations.ts";
 import welcomeRouter from "./routes/welcome.ts";
+import { createVersionRouter } from "./routes/version.ts";
 import { swaggerUI } from "@hono/swagger-ui";
 import { buildOpenApiSpec } from "./openapi/index.ts";
 import {
@@ -343,6 +344,9 @@ app.route("/invite", invitationsRouter);
 
 // Welcome route (authenticated, cookie-based — org context not required)
 app.route("/api", welcomeRouter);
+
+// Version + update availability (authenticated — org context not required)
+app.route("/api", createVersionRouter());
 
 // Internal routes (container-to-host, auth via run token — no JWT)
 const internalRouter = createInternalRouter();

--- a/apps/api/src/openapi/index.ts
+++ b/apps/api/src/openapi/index.ts
@@ -37,6 +37,7 @@ import { invitationsPaths } from "./paths/invitations.ts";
 import { internalPaths } from "./paths/internal.ts";
 import { welcomePaths } from "./paths/welcome.ts";
 import { metaPaths } from "./paths/meta.ts";
+import { versionPaths } from "./paths/version.ts";
 import { notificationsPaths } from "./paths/notifications.ts";
 import { packagesPaths } from "./paths/packages.ts";
 import { applicationsPaths } from "./paths/applications.ts";
@@ -66,6 +67,7 @@ const corePaths = {
   ...internalPaths,
   ...welcomePaths,
   ...metaPaths,
+  ...versionPaths,
   ...notificationsPaths,
   ...packagesPaths,
   ...applicationsPaths,

--- a/apps/api/src/openapi/paths/version.ts
+++ b/apps/api/src/openapi/paths/version.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export const versionPaths = {
+  "/api/version": {
+    get: {
+      operationId: "getVersion",
+      tags: ["Meta"],
+      summary: "Running version and update availability",
+      description:
+        "Returns the running platform build identity (release version + git commit, stamped into the image at build time) and whether a newer release is published on GitHub. The GitHub check is cached server-side (hours-long TTL, rate-limit safe) and can be disabled entirely with `UPDATE_CHECK_ENABLED=false`; it is also inactive on source/dev runs where no release version is stamped. Notification only — upgrading is a host-side operation.",
+      responses: {
+        "200": {
+          description: "Running version and update-check status",
+          headers: {
+            "Request-Id": { $ref: "#/components/headers/RequestId" },
+            "Appstrate-Version": { $ref: "#/components/headers/AppstrateVersion" },
+          },
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  version: {
+                    type: "object",
+                    description: "Deployed build identity ('dev' on source runs).",
+                    properties: {
+                      app: { type: "string" },
+                      commit: { type: "string" },
+                    },
+                    required: ["app"],
+                  },
+                  update: {
+                    type: "object",
+                    description: "Update availability, from the cached GitHub release check.",
+                    properties: {
+                      check_enabled: {
+                        type: "boolean",
+                        description:
+                          "False when opted out via UPDATE_CHECK_ENABLED=false or when the running version is unknown (dev).",
+                      },
+                      update_available: { type: "boolean" },
+                      latest_version: {
+                        type: ["string", "null"],
+                        description:
+                          "Latest published release (no 'v' prefix). Null until a check succeeds.",
+                      },
+                      checked_at: {
+                        type: ["string", "null"],
+                        format: "date-time",
+                        description:
+                          "Timestamp of the last successful GitHub check. Null until one succeeds.",
+                      },
+                    },
+                    required: ["check_enabled", "update_available", "latest_version", "checked_at"],
+                  },
+                },
+                required: ["version", "update"],
+              },
+              example: {
+                version: { app: "1.0.0-beta.38", commit: "5bbe1d9" },
+                update: {
+                  check_enabled: true,
+                  update_available: true,
+                  latest_version: "1.0.0-beta.40",
+                  checked_at: "2026-07-19T08:00:00.000Z",
+                },
+              },
+            },
+          },
+        },
+        "401": { $ref: "#/components/responses/Unauthorized" },
+      },
+    },
+  },
+} as const;

--- a/apps/api/src/routes/version.ts
+++ b/apps/api/src/routes/version.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { Hono } from "hono";
+import type { AppEnv } from "../types/index.ts";
+import { unauthorized } from "../lib/errors.ts";
+import { getVersionInfo } from "../lib/version.ts";
+import { getUpdateChecker } from "../services/update-check.ts";
+
+/**
+ * GET /api/version — running build identity + update availability (#694).
+ *
+ * Session-gated (any authenticated caller — session or API key): the running
+ * version is already visible to operators via /health, but the update-check
+ * result stays behind auth so anonymous crawlers can neither fingerprint
+ * outdated instances nor burn the server-side GitHub check cache.
+ */
+export function createVersionRouter(): Hono<AppEnv> {
+  const router = new Hono<AppEnv>();
+
+  router.get("/version", async (c) => {
+    if (!c.get("user")?.id) {
+      throw unauthorized("Not authenticated");
+    }
+    const update = await getUpdateChecker().getStatus();
+    return c.json({ version: getVersionInfo(), update });
+  });
+
+  return router;
+}

--- a/apps/api/src/services/update-check.ts
+++ b/apps/api/src/services/update-check.ts
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Platform update availability check (issue #694).
+ *
+ * Polls the GitHub Releases API for the latest published release and compares
+ * it with the running build (`APP_VERSION`, stamped into the image at build
+ * time). Notification only — upgrades stay host-orchestrated
+ * (`docker compose pull && docker compose up -d`).
+ *
+ * Rate-limit safety: GitHub's unauthenticated API caps at 60 req/h per IP, so
+ * the result is cached in memory (success TTL 6 h, failure TTL 30 min) and
+ * concurrent callers share one in-flight request. The SPA can therefore poll
+ * `GET /api/version` freely — at most one outbound call per TTL window.
+ *
+ * Opt-out: `UPDATE_CHECK_ENABLED=false` disables the outbound call entirely
+ * (some operators want zero egress). Source/dev runs (no `APP_VERSION`) also
+ * skip the check — there is no meaningful version to compare.
+ */
+
+import semver from "semver";
+import { getEnv } from "@appstrate/env";
+import { normalizeVersion } from "@appstrate/core/semver";
+import { logger } from "../lib/logger.ts";
+import { getVersionInfo } from "../lib/version.ts";
+
+const LATEST_RELEASE_URL = "https://api.github.com/repos/appstrate/appstrate/releases/latest";
+const SUCCESS_TTL_MS = 6 * 60 * 60 * 1000; // 6 h — a few checks per day is plenty
+const FAILURE_TTL_MS = 30 * 60 * 1000; // 30 min — retry soon, but never hammer on errors
+const FETCH_TIMEOUT_MS = 10_000;
+
+/** Wire shape of the `update` block returned by `GET /api/version` (snake_case). */
+export interface UpdateStatus {
+  /** False when opted out via env or when the running version is unknown (dev). */
+  check_enabled: boolean;
+  update_available: boolean;
+  /** Latest published release (normalized, no `v` prefix). Null until a check succeeds. */
+  latest_version: string | null;
+  /** ISO timestamp of the last successful GitHub check. Null until one succeeds. */
+  checked_at: string | null;
+}
+
+/**
+ * True when `latest` is strictly newer than `current` per SemVer 2.0
+ * precedence (prerelease identifiers included — `1.0.0-beta.39 > 1.0.0-beta.38`,
+ * `1.0.0 > 1.0.0-beta.38`). Invalid input on either side → false (never
+ * nag on garbage).
+ */
+export function isNewerVersion(current: string, latest: string): boolean {
+  const c = semver.valid(normalizeVersion(current));
+  const l = semver.valid(normalizeVersion(latest));
+  if (!c || !l) return false;
+  return semver.gt(l, c);
+}
+
+/**
+ * Fetch the latest release tag from the GitHub Releases API and normalize it
+ * (`v1.2.3` → `1.2.3`). Same endpoint/pattern as the CLI's `self-update`
+ * (`apps/cli/src/lib/self-update.ts`). Throws on network errors, non-2xx, or
+ * a malformed payload — the caller caches the failure.
+ */
+export async function fetchLatestReleaseVersion(): Promise<string> {
+  const res = await fetch(LATEST_RELEASE_URL, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "appstrate-platform-update-check",
+    },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub Releases API responded ${res.status} ${res.statusText}`);
+  }
+  const parsed: unknown = await res.json();
+  if (
+    !parsed ||
+    typeof parsed !== "object" ||
+    typeof (parsed as { tag_name?: unknown }).tag_name !== "string"
+  ) {
+    throw new Error("GitHub Releases API response missing tag_name");
+  }
+  return normalizeVersion((parsed as { tag_name: string }).tag_name);
+}
+
+interface UpdateCheckerOptions {
+  /** Running release version (normalized or tag form). Null = unknown/dev → check disabled. */
+  currentVersion: string | null;
+  /** Env opt-out (`UPDATE_CHECK_ENABLED`). */
+  enabled: boolean;
+  /** Injectable for tests — defaults to the real GitHub fetch. */
+  fetchLatest?: () => Promise<string>;
+  /** Injectable clock for tests. */
+  now?: () => number;
+  successTtlMs?: number;
+  failureTtlMs?: number;
+}
+
+interface CacheEntry {
+  /** Null when the last attempt failed (negative cache). */
+  latestVersion: string | null;
+  /** Epoch ms of the last SUCCESSFUL check (0 = never). */
+  checkedAt: number;
+  expiresAt: number;
+}
+
+/**
+ * TTL-cached, single-flight wrapper around the GitHub latest-release lookup.
+ * Instantiated once per process via {@link getUpdateChecker}; tests construct
+ * their own instances with injected deps.
+ */
+export class UpdateChecker {
+  private readonly currentVersion: string | null;
+  private readonly enabled: boolean;
+  private readonly fetchLatest: () => Promise<string>;
+  private readonly now: () => number;
+  private readonly successTtlMs: number;
+  private readonly failureTtlMs: number;
+
+  private cache: CacheEntry | null = null;
+  private inFlight: Promise<CacheEntry> | null = null;
+
+  constructor(opts: UpdateCheckerOptions) {
+    this.currentVersion = opts.currentVersion;
+    this.enabled = opts.enabled;
+    this.fetchLatest = opts.fetchLatest ?? fetchLatestReleaseVersion;
+    this.now = opts.now ?? Date.now;
+    this.successTtlMs = opts.successTtlMs ?? SUCCESS_TTL_MS;
+    this.failureTtlMs = opts.failureTtlMs ?? FAILURE_TTL_MS;
+  }
+
+  async getStatus(): Promise<UpdateStatus> {
+    // Opt-out or unknown running version → never call out, report disabled.
+    if (!this.enabled || !this.currentVersion) {
+      return {
+        check_enabled: false,
+        update_available: false,
+        latest_version: null,
+        checked_at: null,
+      };
+    }
+
+    const entry = await this.getCacheEntry();
+    const latest = entry.latestVersion;
+    return {
+      check_enabled: true,
+      update_available: latest !== null && isNewerVersion(this.currentVersion, latest),
+      latest_version: latest,
+      checked_at: entry.checkedAt > 0 ? new Date(entry.checkedAt).toISOString() : null,
+    };
+  }
+
+  private async getCacheEntry(): Promise<CacheEntry> {
+    if (this.cache && this.cache.expiresAt > this.now()) return this.cache;
+    // Single-flight: concurrent callers during a refresh share one request.
+    this.inFlight ??= this.refresh();
+    try {
+      return await this.inFlight;
+    } finally {
+      this.inFlight = null;
+    }
+  }
+
+  private async refresh(): Promise<CacheEntry> {
+    try {
+      const latestVersion = await this.fetchLatest();
+      const checkedAt = this.now();
+      this.cache = { latestVersion, checkedAt, expiresAt: checkedAt + this.successTtlMs };
+    } catch (err) {
+      // Negative cache — keep the previous successful result visible (a
+      // transient GitHub outage should not clear an already-known update),
+      // but retry sooner than the success TTL.
+      logger.warn("Update check failed — retrying later", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      this.cache = {
+        latestVersion: this.cache?.latestVersion ?? null,
+        checkedAt: this.cache?.checkedAt ?? 0,
+        expiresAt: this.now() + this.failureTtlMs,
+      };
+    }
+    return this.cache;
+  }
+}
+
+let _checker: UpdateChecker | null = null;
+
+/** Process-wide singleton, lazily built from env + the stamped build version. */
+export function getUpdateChecker(): UpdateChecker {
+  if (!_checker) {
+    const env = getEnv();
+    const running = getVersionInfo().app;
+    _checker = new UpdateChecker({
+      currentVersion: running === "dev" ? null : running,
+      enabled: env.UPDATE_CHECK_ENABLED,
+    });
+  }
+  return _checker;
+}
+
+/** Test hook — drop the singleton so env changes are picked up. */
+export function _resetUpdateCheckerForTesting(): void {
+  _checker = null;
+}

--- a/apps/api/test/unit/update-check.test.ts
+++ b/apps/api/test/unit/update-check.test.ts
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Pure-logic tests for the update-availability check (#694): semver
+// comparison and the TTL/single-flight cache. No network, no DB — the
+// GitHub fetch and the clock are injected.
+
+import { describe, it, expect } from "bun:test";
+import { isNewerVersion, UpdateChecker } from "../../src/services/update-check.ts";
+
+describe("isNewerVersion", () => {
+  it("detects a newer patch release", () => {
+    expect(isNewerVersion("1.0.0", "1.0.1")).toBe(true);
+  });
+
+  it("returns false for equal versions", () => {
+    expect(isNewerVersion("1.2.3", "1.2.3")).toBe(false);
+  });
+
+  it("returns false when latest is older", () => {
+    expect(isNewerVersion("1.2.3", "1.2.2")).toBe(false);
+  });
+
+  it("orders prerelease identifiers numerically (beta.38 < beta.39)", () => {
+    expect(isNewerVersion("1.0.0-beta.38", "1.0.0-beta.39")).toBe(true);
+    expect(isNewerVersion("1.0.0-beta.39", "1.0.0-beta.38")).toBe(false);
+    // Not lexicographic: beta.9 < beta.10
+    expect(isNewerVersion("1.0.0-beta.9", "1.0.0-beta.10")).toBe(true);
+  });
+
+  it("ranks a stable release above its prereleases", () => {
+    expect(isNewerVersion("1.0.0-beta.38", "1.0.0")).toBe(true);
+    expect(isNewerVersion("1.0.0", "1.0.1-beta.1")).toBe(true);
+  });
+
+  it("tolerates v prefixes and build metadata", () => {
+    expect(isNewerVersion("v1.0.0", "v1.1.0")).toBe(true);
+    expect(isNewerVersion("1.0.0+build.1", "1.0.0+build.2")).toBe(false);
+  });
+
+  it("returns false on invalid input (never nags on garbage)", () => {
+    expect(isNewerVersion("dev", "1.0.0")).toBe(false);
+    expect(isNewerVersion("1.0.0", "not-a-version")).toBe(false);
+    expect(isNewerVersion("", "")).toBe(false);
+  });
+});
+
+function makeChecker(opts: {
+  currentVersion?: string | null;
+  enabled?: boolean;
+  results: Array<string | Error>;
+  now?: () => number;
+  successTtlMs?: number;
+  failureTtlMs?: number;
+}) {
+  let calls = 0;
+  const checker = new UpdateChecker({
+    currentVersion: opts.currentVersion === undefined ? "1.0.0" : opts.currentVersion,
+    enabled: opts.enabled ?? true,
+    now: opts.now,
+    successTtlMs: opts.successTtlMs,
+    failureTtlMs: opts.failureTtlMs,
+    fetchLatest: () => {
+      const result = opts.results[Math.min(calls, opts.results.length - 1)]!;
+      calls++;
+      return result instanceof Error ? Promise.reject(result) : Promise.resolve(result);
+    },
+  });
+  return { checker, fetchCalls: () => calls };
+}
+
+describe("UpdateChecker", () => {
+  it("reports an available update when GitHub has a newer release", async () => {
+    const { checker } = makeChecker({
+      currentVersion: "1.0.0-beta.38",
+      results: ["1.0.0-beta.40"],
+    });
+    const status = await checker.getStatus();
+    expect(status).toEqual({
+      check_enabled: true,
+      update_available: true,
+      latest_version: "1.0.0-beta.40",
+      checked_at: expect.any(String) as unknown as string,
+    });
+  });
+
+  it("reports no update when already on the latest release", async () => {
+    const { checker } = makeChecker({ currentVersion: "1.0.0", results: ["1.0.0"] });
+    const status = await checker.getStatus();
+    expect(status.update_available).toBe(false);
+    expect(status.latest_version).toBe("1.0.0");
+  });
+
+  it("never fetches when disabled via env", async () => {
+    const { checker, fetchCalls } = makeChecker({ enabled: false, results: ["9.9.9"] });
+    const status = await checker.getStatus();
+    expect(status).toEqual({
+      check_enabled: false,
+      update_available: false,
+      latest_version: null,
+      checked_at: null,
+    });
+    expect(fetchCalls()).toBe(0);
+  });
+
+  it("never fetches when the running version is unknown (dev)", async () => {
+    const { checker, fetchCalls } = makeChecker({ currentVersion: null, results: ["9.9.9"] });
+    const status = await checker.getStatus();
+    expect(status.check_enabled).toBe(false);
+    expect(fetchCalls()).toBe(0);
+  });
+
+  it("caches the result within the success TTL", async () => {
+    let t = 1_000_000;
+    const { checker, fetchCalls } = makeChecker({
+      results: ["2.0.0"],
+      now: () => t,
+      successTtlMs: 10_000,
+    });
+    await checker.getStatus();
+    t += 5_000; // still inside TTL
+    await checker.getStatus();
+    expect(fetchCalls()).toBe(1);
+    t += 6_000; // past TTL
+    await checker.getStatus();
+    expect(fetchCalls()).toBe(2);
+  });
+
+  it("deduplicates concurrent callers into one fetch (single-flight)", async () => {
+    const { checker, fetchCalls } = makeChecker({ results: ["2.0.0"] });
+    const [a, b, c] = await Promise.all([
+      checker.getStatus(),
+      checker.getStatus(),
+      checker.getStatus(),
+    ]);
+    expect(fetchCalls()).toBe(1);
+    expect(a.latest_version).toBe("2.0.0");
+    expect(b.latest_version).toBe("2.0.0");
+    expect(c.latest_version).toBe("2.0.0");
+  });
+
+  it("negative-caches failures with the shorter TTL, then retries", async () => {
+    let t = 1_000_000;
+    const { checker, fetchCalls } = makeChecker({
+      results: [new Error("github down"), "2.0.0"],
+      now: () => t,
+      successTtlMs: 100_000,
+      failureTtlMs: 10_000,
+    });
+    const failed = await checker.getStatus();
+    expect(failed.update_available).toBe(false);
+    expect(failed.latest_version).toBeNull();
+    expect(failed.checked_at).toBeNull();
+
+    t += 5_000; // inside failure TTL — no refetch
+    await checker.getStatus();
+    expect(fetchCalls()).toBe(1);
+
+    t += 6_000; // past failure TTL — retry succeeds
+    const ok = await checker.getStatus();
+    expect(fetchCalls()).toBe(2);
+    expect(ok.update_available).toBe(true);
+    expect(ok.latest_version).toBe("2.0.0");
+  });
+
+  it("keeps the last known result visible through a transient failure", async () => {
+    let t = 1_000_000;
+    const { checker } = makeChecker({
+      results: ["2.0.0", new Error("github down")],
+      now: () => t,
+      successTtlMs: 10_000,
+      failureTtlMs: 10_000,
+    });
+    const first = await checker.getStatus();
+    expect(first.update_available).toBe(true);
+
+    t += 11_000; // success expired → refresh fails
+    const second = await checker.getStatus();
+    expect(second.update_available).toBe(true);
+    expect(second.latest_version).toBe("2.0.0");
+    expect(second.checked_at).toBe(first.checked_at);
+  });
+});

--- a/apps/cli/src/lib/compose-defaults.ts
+++ b/apps/cli/src/lib/compose-defaults.ts
@@ -57,6 +57,7 @@ export const CODE_DEFAULTS: Record<string, string> = {
   OTEL_TRUST_INCOMING_TRACE: "false",
   MODULES: "oidc,webhooks,mcp,core-providers,@appstrate/module-chat",
   OAUTH_REFRESH_WORKER_ENABLED: "false",
+  UPDATE_CHECK_ENABLED: "true",
   INTEGRATION_REFRESH_MAX_FAILURES: "5",
   INTEGRATION_REFRESH_GRACE_SECONDS: "3600",
   REMOTE_RUN_SINK_DEFAULT_TTL_SECONDS: "7200",

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -4099,6 +4099,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/version": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Running version and update availability
+         * @description Returns the running platform build identity (release version + git commit, stamped into the image at build time) and whether a newer release is published on GitHub. The GitHub check is cached server-side (hours-long TTL, rate-limit safe) and can be disabled entirely with `UPDATE_CHECK_ENABLED=false`; it is also inactive on source/dev runs where no release version is stamped. Notification only — upgrading is a host-side operation.
+         */
+        get: operations["getVersion"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/webhooks": {
         parameters: {
             query?: never;
@@ -18807,6 +18827,62 @@ export interface operations {
                 };
             };
             429: components["responses"]["RateLimited"];
+        };
+    };
+    getVersion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Running version and update-check status */
+            200: {
+                headers: {
+                    "Request-Id": components["headers"]["RequestId"];
+                    "Appstrate-Version": components["headers"]["AppstrateVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "version": {
+                     *         "app": "1.0.0-beta.38",
+                     *         "commit": "5bbe1d9"
+                     *       },
+                     *       "update": {
+                     *         "check_enabled": true,
+                     *         "update_available": true,
+                     *         "latest_version": "1.0.0-beta.40",
+                     *         "checked_at": "2026-07-19T08:00:00.000Z"
+                     *       }
+                     *     }
+                     */
+                    "application/json": {
+                        /** @description Deployed build identity ('dev' on source runs). */
+                        version: {
+                            app: string;
+                            commit?: string;
+                        };
+                        /** @description Update availability, from the cached GitHub release check. */
+                        update: {
+                            /** @description False when opted out via UPDATE_CHECK_ENABLED=false or when the running version is unknown (dev). */
+                            check_enabled: boolean;
+                            update_available: boolean;
+                            /** @description Latest published release (no 'v' prefix). Null until a check succeeds. */
+                            latest_version: string | null;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp of the last successful GitHub check. Null until one succeeds.
+                             */
+                            checked_at: string | null;
+                        };
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
         };
     };
     listWebhooks: {

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -5,6 +5,7 @@ import { Link } from "react-router-dom";
 import { OrgSwitcher } from "@/components/org-switcher";
 import { NavOrg } from "@/components/nav-org";
 import { SidebarBilling } from "@/components/sidebar-billing";
+import { UpdateBadge } from "@/components/update-badge";
 import { useTheme } from "@/stores/theme-store";
 import {
   Sidebar,
@@ -57,6 +58,7 @@ export function AppSidebar(props: ComponentProps<typeof Sidebar>) {
         <SidebarBilling />
       </SidebarContent>
       <SidebarFooter>
+        <UpdateBadge />
         <OrgSwitcher />
       </SidebarFooter>
     </Sidebar>

--- a/apps/web/src/components/update-badge.tsx
+++ b/apps/web/src/components/update-badge.tsx
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTranslation } from "react-i18next";
+import { ArrowUpCircle } from "lucide-react";
+import { useUpdateCheck } from "../hooks/use-update-check";
+import {
+  SidebarGroup,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+} from "@appstrate/ui/components/sidebar";
+
+/**
+ * "Update available" badge (#694) — shown in the sidebar footer when the
+ * platform is behind the latest published release. Notification only: it
+ * links to the self-hosting upgrade guide, the upgrade itself is a host-side
+ * operation (`docker compose pull && docker compose up -d`). Renders nothing
+ * when up to date, when the check is disabled (`UPDATE_CHECK_ENABLED=false`),
+ * or on source/dev runs.
+ */
+const UPGRADE_GUIDE_URL =
+  "https://github.com/appstrate/appstrate/blob/main/examples/self-hosting/README.md#upgrading";
+
+export function UpdateBadge() {
+  const { t } = useTranslation();
+  const { data } = useUpdateCheck();
+
+  const update = data?.update;
+  if (!update?.update_available || !update.latest_version) return null;
+
+  const label = t("nav.updateAvailable", { version: `v${update.latest_version}` });
+
+  return (
+    <SidebarGroup className="py-0">
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            asChild
+            tooltip={t("nav.updateAvailableTooltip")}
+            className="text-primary hover:text-primary"
+          >
+            <a href={UPGRADE_GUIDE_URL} target="_blank" rel="noreferrer" title={label}>
+              <ArrowUpCircle size={16} />
+              <span className="truncate">{label}</span>
+            </a>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarGroup>
+  );
+}

--- a/apps/web/src/hooks/use-update-check.ts
+++ b/apps/web/src/hooks/use-update-check.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { $api } from "../api/client";
+
+/**
+ * Running platform version + update availability (`GET /api/version`, #694).
+ *
+ * The expensive part (GitHub Releases lookup) is cached server-side with an
+ * hours-long TTL, so this query is cheap — but there is still no reason to
+ * refetch on every focus/mount. One fetch per session + a slow background
+ * refresh keeps the badge current on long-lived dashboard tabs.
+ */
+export function useUpdateCheck() {
+  return $api.useQuery(
+    "get",
+    "/api/version",
+    {},
+    {
+      staleTime: 60 * 60 * 1000, // 1 h
+      refetchInterval: 6 * 60 * 60 * 1000, // pick up new releases on long-lived tabs
+      refetchOnWindowFocus: false,
+      retry: false,
+    },
+  );
+}

--- a/apps/web/src/locales/en/common.json
+++ b/apps/web/src/locales/en/common.json
@@ -31,6 +31,8 @@
   "nav.library": "Library",
   "nav.appSettings": "App Settings",
   "nav.credits": "Credits",
+  "nav.updateAvailable": "Update available: {{version}}",
+  "nav.updateAvailableTooltip": "A newer Appstrate release is available — open the upgrade guide",
   "btn.cancel": "Cancel",
   "btn.save": "Save",
   "btn.delete": "Delete",

--- a/apps/web/src/locales/fr/common.json
+++ b/apps/web/src/locales/fr/common.json
@@ -31,6 +31,8 @@
   "nav.library": "Bibliothèque",
   "nav.appSettings": "Paramètres app",
   "nav.credits": "Crédits",
+  "nav.updateAvailable": "Mise à jour disponible : {{version}}",
+  "nav.updateAvailableTooltip": "Une nouvelle version d'Appstrate est disponible — ouvrir le guide de mise à jour",
   "btn.cancel": "Annuler",
   "btn.save": "Enregistrer",
   "btn.delete": "Supprimer",

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -326,6 +326,14 @@ const envSchema = z
     // wiring from a running instance.
     OAUTH_REFRESH_WORKER_ENABLED: boolEnv("false"),
 
+    // Platform update-availability check (#694) — the API polls the GitHub
+    // Releases API (cached server-side, a few requests per day at most) so
+    // the SPA can show a "update available" badge. Notification only; the
+    // upgrade itself stays host-orchestrated. Set to false for zero outbound
+    // calls (air-gapped / privacy-sensitive deployments). Also implicitly
+    // inactive when APP_VERSION is absent (source/dev runs).
+    UPDATE_CHECK_ENABLED: boolEnv("true"),
+
     // Integration connection refresh-failure escalation. When an OAuth token
     // refresh fails *transiently* (not `invalid_grant`) this many times in a
     // row AND the token is already expired past the grace window below, the

--- a/scripts/verify-openapi.ts
+++ b/scripts/verify-openapi.ts
@@ -292,6 +292,7 @@ const expectedEndpoints = [
   // Meta
   "GET /api/openapi.json",
   "GET /api/docs",
+  "GET /api/version",
 
   // Notifications
   "GET /api/notifications",
@@ -657,8 +658,7 @@ function getOpenApiRequestBodySchema(
   if (!operation?.requestBody) return undefined;
 
   let schema = operation.requestBody?.content?.["application/json"]?.schema as
-    | Record<string, unknown>
-    | undefined;
+    Record<string, unknown> | undefined;
 
   // Resolve top-level $ref
   if (schema && typeof schema.$ref === "string") {


### PR DESCRIPTION
## What / Why

Self-hosters currently have no in-app signal that they are running an outdated release — upgrades are host-orchestrated and easily forgotten. This adds a passive "update available" notification in the web UI. **Notification only** — no one-click upgrade, no new host privileges, Docker socket stays read-only (per the issue's out-of-scope list).

Closes #694

## Endpoint

`GET /api/version` (session- or API-key-gated) returns:

```json
{
  "version": { "app": "1.0.0-beta.38", "commit": "5bbe1d9" },
  "update": {
    "check_enabled": true,
    "update_available": true,
    "latest_version": "1.0.0-beta.40",
    "checked_at": "2026-07-19T08:00:00.000Z"
  }
}
```

- Running version comes from the existing `APP_VERSION` / `GIT_SHA` build stamps (`getVersionInfo()` — same source as `/health` and the SPA footer). No new injection plumbing needed: the release workflow already stamps the image.
- Gated behind auth so anonymous crawlers can neither fingerprint outdated instances nor burn the check cache.
- OpenAPI path added (`openapi/paths/version.ts`), registered in the verify-openapi expected-endpoint list, SPA typed client regenerated (`bun run generate:api`).

## Caching & rate-limit safety

`services/update-check.ts` polls `GET https://api.github.com/repos/appstrate/appstrate/releases/latest` (same pattern as the CLI's `self-update`) behind an in-memory cache:

- **6 h success TTL / 30 min failure TTL** — at most a handful of outbound calls per day, far under GitHub's 60 req/h unauthenticated limit; never per page-load.
- **Single-flight**: concurrent callers share one in-flight request.
- **Failure-tolerant**: a transient GitHub outage keeps the last known result visible (negative cache never clears an already-known update).
- **SemVer 2.0 comparison** via the `semver` package with `normalizeVersion` from `@appstrate/core/semver` — prerelease-aware (`1.0.0-beta.38 < 1.0.0-beta.39 < 1.0.0`), invalid input never nags.

## Opt-out

- `UPDATE_CHECK_ENABLED=false` (new optional var in `@appstrate/env`, default `true`) → zero outbound calls, endpoint reports `check_enabled: false`. Mirrored in `CODE_DEFAULTS` (compose-drift guard) and documented in `.env.example`.
- Source/dev runs (no stamped `APP_VERSION`) also skip the check automatically.

## Web UI

- `UpdateBadge` in the app sidebar footer (above the org switcher, tooltip-aware when collapsed): **"Mise à jour disponible : vX.Y.Z"**, linking to the self-hosting upgrade guide (`examples/self-hosting/README.md#upgrading`). Renders nothing when up to date, opted out, or on dev runs.
- French-first i18n via i18next with flat dotted keys (`nav.updateAvailable`, `nav.updateAvailableTooltip`) in `fr` + `en` `common.json`.
- Data via the typed client (`$api.useQuery("get", "/api/version")`) in `use-update-check.ts` — 1 h staleTime, slow background refetch, no focus refetch (server cache does the heavy lifting anyway).

## Tests / verification

- `apps/api/test/unit/update-check.test.ts` — 15 bun:test unit tests (no network/DB, injected fetch + clock): SemVer prerelease ordering, opt-out and dev-run short-circuits, success/failure TTLs, single-flight dedupe, last-known-result retention through transient failures. **15 pass.**
- `bun run check` — **33/33 tasks green** (tsc, eslint, prettier, verify-openapi incl. Code ⊆ Spec, verify:api-types, type-coverage).
- `bun run test:unit` — **1069 pass, 0 fail.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)