### PR TITLE
fix(web): align settings layouts scroll model with app shell

### DIFF
--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -189,7 +189,7 @@ function MainLayout() {
   return (
     <SidebarProvider open={sidebarOpen} onOpenChange={setSidebarOpen}>
       <AppSidebar />
-      <SidebarInset>
+      <SidebarInset className="h-svh">
         <header className="flex h-16 shrink-0 items-center gap-2 border-b transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
           {/* Mobile-only trigger — desktop collapse lives in the sidebar header */}
           <SidebarTrigger className="ml-2 md:hidden" />
@@ -199,7 +199,7 @@ function MainLayout() {
             <NavUser />
           </div>
         </header>
-        <div className="flex flex-1 flex-col">
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
           <Outlet />
         </div>
       </SidebarInset>

--- a/apps/web/src/components/settings-layout.tsx
+++ b/apps/web/src/components/settings-layout.tsx
@@ -71,7 +71,7 @@ export function SettingsLayout({ sections, title, emoji, breadcrumbs }: Settings
     <SidebarProvider
       disableKeyboardShortcut
       defaultOpen
-      className="min-h-0! w-auto flex-1"
+      className="min-h-0! w-auto flex-1 overflow-hidden"
       style={{ "--sidebar-width": "14rem" } as React.CSSProperties}
     >
       {/* Desktop: real sidebar flush against the global AppSidebar */}
@@ -110,7 +110,7 @@ export function SettingsLayout({ sections, title, emoji, breadcrumbs }: Settings
         </SidebarContent>
       </Sidebar>
 
-      <SidebarInset className="bg-background min-w-0 p-6">
+      <SidebarInset className="bg-background min-w-0 overflow-y-auto p-6">
         <PageHeader title={title} emoji={emoji} breadcrumbs={breadcrumbs} />
 
         {/* Mobile: dropdown selector (sidebar hidden) */}

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -152,6 +152,7 @@
   "schedules.emptyHint": "Add a schedule to run an agent automatically.",
   "schedules.agentLabel": "Agent",
   "preferences.title": "Preferences",
+  "preferences.sectionAccount": "Account",
   "preferences.tabGeneral": "General",
   "preferences.tabSecurity": "Security",
   "preferences.tabConnections": "My connections",

--- a/apps/web/src/locales/fr/settings.json
+++ b/apps/web/src/locales/fr/settings.json
@@ -152,6 +152,7 @@
   "schedules.emptyHint": "Ajoutez une planification pour exécuter un agent automatiquement.",
   "schedules.agentLabel": "Agent",
   "preferences.title": "Préférences",
+  "preferences.sectionAccount": "Compte",
   "preferences.tabGeneral": "Général",
   "preferences.tabSecurity": "Sécurité",
   "preferences.tabConnections": "Mes connexions",

--- a/apps/web/src/pages/preferences/layout.tsx
+++ b/apps/web/src/pages/preferences/layout.tsx
@@ -17,6 +17,7 @@ export function PreferencesLayout() {
       ]}
       sections={[
         {
+          label: t("preferences.sectionAccount"),
           items: [
             { to: "/preferences/general", icon: User, label: t("preferences.tabGeneral") },
             {


### PR DESCRIPTION
## Problème

- Layout global : `AppSidebar` est `fixed h-svh` → pleine hauteur, contenu droit scrollable.
- Layouts paramètres org / préférences : la sous-sidebar (`collapsible="none"`) est un simple enfant flex `h-full` — sur une page longue elle grandit avec le contenu et défile avec la page (l'`AppVersion` en bas sort de l'écran).

## Changements

- **`app.tsx` (MainLayout)** : shell verrouillé au viewport — `SidebarInset` passe en `h-svh`, le wrapper de contenu devient l'unique conteneur scrollable (`min-h-0 overflow-y-auto`). Effet voulu : le header h-16 reste visible au scroll, cohérent avec la sidebar pinnée.
- **`settings-layout.tsx`** : provider imbriqué en `overflow-hidden` (hauteur bornée par le shell) + `SidebarInset` interne en `overflow-y-auto`. La sous-sidebar reste pleine hauteur (son `SidebarContent` a déjà `overflow-auto`), seul le contenu défile.
- **Préférences** : la sidebar affiche désormais une section titrée « Compte » (`SidebarGroupLabel`), comme les sections « Organisation » / « Application » des paramètres org. Clé i18n plate `preferences.sectionAccount` (fr/en).

## Vérifications

- chat-page (`h-[calc(100dvh-4rem)]`) = exactement la hauteur du nouveau wrapper, inchangé.
- log-viewer a son propre conteneur de scroll ; aucun code web ne dépend du scroll fenêtre.
- Prettier OK sur les fichiers touchés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)