### PR TITLE
fix(module-chat): run progress card overlaps chat composer on scroll

### DIFF
--- a/packages/module-chat/src/ui/chat-run-progress-card.tsx
+++ b/packages/module-chat/src/ui/chat-run-progress-card.tsx
@@ -119,8 +119,11 @@ export function ChatRunProgressCard({
   const line = terminal ? { id: -1, text: terminalRunLineText(effectiveStatus) } : current;
   const effectiveRunHref = runHref ?? (runId ? buildRunPageHref(packageId, runId) : undefined);
 
+  // `isolate` scopes the internal z-0/z-10 layering to this card — without it
+  // the z-10 content escapes into the thread's stacking context and paints
+  // over the sticky composer when the card scrolls behind it.
   return (
-    <div className="bg-card text-card-foreground relative my-3 w-full rounded-lg border">
+    <div className="bg-card text-card-foreground relative isolate my-3 w-full rounded-lg border">
       {/* Full-card click target (opens the detail modal). Behind the content so
           the run-page link can re-enable pointer events for itself — avoids
           nesting interactive elements. */}


### PR DESCRIPTION
## Problème

Dans le chat, la carte de progression d'un run (`ChatRunProgressCard`) passait par-dessus le champ de saisie (composer sticky) lors du scroll.

## Cause

La carte superpose un bouton plein-cadre (`z-0`, ouvre la modale de détail) et son contenu (`relative z-10`). Le root de la carte (`relative` sans z-index) ne crée pas de stacking context, donc le `z-10` interne s'échappe dans le stacking context du thread et peint au-dessus du `ViewportFooter` sticky (z auto).

## Fix

`isolate` sur le div root de la carte — le layering interne z-0/z-10 reste confiné à la carte. Le footer, positionné et plus tard dans le DOM, repasse au-dessus.

## Validation

- `prettier --check` ✅
- `tsc --noEmit` (module-chat) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)