### PR TITLE
feat(core,api): expose optional getOrgName module init helper

### DIFF
--- a/apps/api/src/lib/modules/registry.ts
+++ b/apps/api/src/lib/modules/registry.ts
@@ -10,7 +10,7 @@
  */
 
 import { db } from "@appstrate/db/client";
-import { organizationMembers, user } from "@appstrate/db/schema";
+import { organizationMembers, organizations, user } from "@appstrate/db/schema";
 import { eq, and, inArray } from "drizzle-orm";
 import type { MiddlewareHandler } from "hono";
 import type { ModuleInitContext, PlatformServices } from "@appstrate/core/module";
@@ -131,6 +131,7 @@ export function buildModuleInitContext(): ModuleInitContext {
       return sendMail;
     },
     getOrgAdminEmails,
+    getOrgName,
     services: buildPlatformServices(),
   };
   return ctx;
@@ -153,4 +154,18 @@ async function getOrgAdminEmails(orgId: string): Promise<string[]> {
     );
 
   return admins.map((a) => a.email);
+}
+
+// ---------------------------------------------------------------------------
+// DI: org display-name query
+// ---------------------------------------------------------------------------
+
+async function getOrgName(orgId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ name: organizations.name })
+    .from(organizations)
+    .where(eq(organizations.id, orgId))
+    .limit(1);
+
+  return row?.name ?? null;
 }

--- a/apps/api/test/integration/services/module-init-context-org-name.test.ts
+++ b/apps/api/test/integration/services/module-init-context-org-name.test.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { buildModuleInitContext } from "../../../src/lib/modules/registry.ts";
+import { truncateAll } from "../../helpers/db.ts";
+import { createTestContext } from "../../helpers/auth.ts";
+
+/**
+ * `ctx.getOrgName` is the DI seam modules (e.g. @appstrate/cloud) use to label
+ * org-scoped emails with the organization concerned. It must resolve the real
+ * display name and return null — never a placeholder — for a missing org.
+ */
+describe("ModuleInitContext.getOrgName", () => {
+  beforeEach(async () => {
+    await truncateAll();
+  });
+
+  it("resolves the organization display name", async () => {
+    const { orgId } = await createTestContext({ orgName: "Acme Corp" });
+
+    const ctx = buildModuleInitContext();
+    expect(await ctx.getOrgName!(orgId)).toBe("Acme Corp");
+  });
+
+  it("returns null for an unknown org id", async () => {
+    const ctx = buildModuleInitContext();
+    expect(await ctx.getOrgName!(crypto.randomUUID())).toBeNull();
+  });
+});

--- a/apps/api/test/unit/modules/platform-services.test.ts
+++ b/apps/api/test/unit/modules/platform-services.test.ts
@@ -44,4 +44,9 @@ describe("ModuleInitContext.services — platform service wiring", () => {
     expect(typeof services.resolveSubscriptionChatModel).toBe("function");
     expect(typeof services.recordChatUsage).toBe("function");
   });
+
+  it("wires the org query helpers (getOrgAdminEmails + getOrgName)", () => {
+    expect(typeof ctx.getOrgAdminEmails).toBe("function");
+    expect(typeof ctx.getOrgName).toBe("function");
+  });
 });

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -22,6 +22,12 @@ of a provider-neutral bearer-swap.
 
 ### Added
 
+- **`ModuleInitContext.getOrgName?`** — optional query helper resolving an
+  organization's display name (`(orgId) => Promise<string | null>`, null when
+  the org no longer exists). Lets modules label org-scoped outbound messages
+  (e.g. transactional emails) with the organization concerned. Optional so
+  modules degrade gracefully on older platforms that don't inject it.
+
 - **`api_upload` is a first-class catalog member (#881)** —
   `resolveIntegrationToolCatalog` now appends the `api_upload` companion after
   each `api_call` whose auth declares `_meta["dev.appstrate/api"].auths.<key>

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -942,6 +942,12 @@ export interface ModuleInitContext {
   /** Query helper: get org admin emails. */
   getOrgAdminEmails: (orgId: string) => Promise<string[]>;
   /**
+   * Query helper: resolve an organization's display name, or null when the
+   * org no longer exists. Optional — older platforms don't provide it, so
+   * modules must degrade gracefully when absent.
+   */
+  getOrgName?: (orgId: string) => Promise<string | null>;
+  /**
    * Typed platform capabilities injected at init. Modules capture this
    * reference and consume services through it without importing
    * apps/api internals.


### PR DESCRIPTION
## Summary

Companion to appstrate/cloud#33 (billing emails must display the organization concerned — a user in several orgs can't tell which org a billing email is about).

Modules that send org-scoped outbound messages have no platform DB access. This adds the DI seam they need:

- **`ModuleInitContext.getOrgName?`** (`@appstrate/core/module`) — `(orgId) => Promise<string | null>`, null when the org no longer exists. **Optional** so modules degrade gracefully on platforms predating the field (cloud sends its emails without the label instead of crashing).
- Wired in `apps/api/src/lib/modules/registry.ts` next to `getOrgAdminEmails`, same direct-query DI pattern. Returns `null` for a missing org — never a placeholder.
- CHANGELOG entry under Unreleased (ships with the next `core@` tag; until then cloud reads the field structurally).

No billing vocabulary in core — the helper is a neutral org-name resolver.

## Tests

- `platform-services.test.ts`: shape assertion that both org query helpers are wired on the built context.
- New `module-init-context-org-name.test.ts` (integration): resolves the real display name; returns null for a valid-but-absent uuid. (A malformed uuid throws like the sibling `getOrgAdminEmails` — callers treat resolution as best-effort.)
- `bun run check` green (turbo + OpenAPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)