### PR TITLE
fix(oidc): restart expired login links in place instead of dead-ending

### DIFF
--- a/apps/api/src/modules/oidc/index.ts
+++ b/apps/api/src/modules/oidc/index.ts
@@ -158,6 +158,7 @@ const oidcModule: AppstrateModule = {
     "/api/oauth/forgot-password",
     "/api/oauth/reset-password",
     "/api/oauth/assets/social-sign-in.js",
+    "/api/oauth/assets/login-expiry.js",
     // Device-flow verification pages. `GET /activate` must be publicly
     // reachable so an unauthenticated user lands on the entry form and
     // gets redirected to `/auth/login?returnTo=...` with the user_code

--- a/apps/api/src/modules/oidc/pages/login-expiry-script.ts
+++ b/apps/api/src/modules/oidc/pages/login-expiry-script.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Client-side expiry detection for the OIDC login page.
+ *
+ * ROLE: UX polish only. Better Auth signs each login link with an `exp`
+ * (Unix seconds); when it lapses the SERVER already restarts the flow in
+ * place (`isLoginLinkExpired` → 302 through `/api/auth/oauth2/authorize` →
+ * fresh signed link + banner). This script detects the *approaching* `exp`
+ * BEFORE the user submits, so a link that went stale while the tab sat in
+ * the background is refreshed (or flagged) without a failed round-trip.
+ *
+ * ZERO SECURITY VALUE: the server expiry check stays authoritative. This
+ * script never gates anything — it only refreshes early or shows a hint.
+ * Client clock skew is safe both ways: a skewed-fast clock refreshes a
+ * still-valid link (harmless — a fresh link is minted), a skewed-slow clock
+ * lets a stale link through to the server, which catches it and restarts.
+ *
+ * CSP: login/register pages target a strict `script-src 'self'`, so the
+ * behavior ships as an EXTERNAL asset (served verbatim by
+ * `GET /api/oauth/assets/login-expiry.js`) — never inlined, no nonce.
+ * The source is a module-level string constant with zero user-controlled
+ * values, matching `social-sign-in-script.ts`.
+ *
+ * Contract with the page markup (owned by `login.ts`):
+ *   - The `<form>` MUST carry `data-login-exp="<unix-seconds>"` and
+ *     `data-refresh-url="<authorize-restart-url>"`.
+ *   - A hidden warning element (`[data-expiry-warning]` with the `hidden`
+ *     attribute) MUST exist for the DIRTY-form path to un-hide.
+ */
+
+import { html, raw, type RawHtml } from "./html.ts";
+
+/**
+ * Renders the (hidden by default) "this login page is about to expire"
+ * banner. Un-hidden by `LOGIN_EXPIRY_SCRIPT` only when the user has already
+ * typed into the form at the deadline — otherwise the script silently
+ * refreshes instead. Reuses the layout's `.error` look (no dedicated
+ * `.warning` class exists and the shared layout has no per-page style slot,
+ * so this is the least-invasive fit).
+ *
+ * Markup is the contract consumed by `LOGIN_EXPIRY_SCRIPT`: the
+ * `[data-expiry-warning]` attribute + the `hidden` attribute must match the
+ * selector/toggle the script relies on.
+ */
+export function renderExpiryWarning(refreshUrl: string): RawHtml {
+  return html`<div class="error" data-expiry-warning hidden>
+    Cette page de connexion va expirer. <a href="${refreshUrl}">Rafraîchir la page</a>
+  </div>`;
+}
+
+/** Public URL for the externalized expiry-detection script. */
+export const LOGIN_EXPIRY_SCRIPT_PATH = "/api/oauth/assets/login-expiry.js";
+
+/**
+ * Source of the externalized expiry-detection helper, served verbatim by
+ * `GET /api/oauth/assets/login-expiry.js`. Module-level constant (zero build
+ * step, long-cacheable — only changes on deploy).
+ *
+ * Behavior:
+ *   - Reads `data-login-exp` (Unix seconds) + `data-refresh-url` off the
+ *     `form[data-login-exp]`. Bails silently if absent or non-finite.
+ *   - Deadline = `exp - 30s`. A one-time `input` listener marks the form
+ *     DIRTY the moment the user types.
+ *   - At the deadline: PRISTINE → `location.replace(refreshUrl)` (silent —
+ *     no cookie is set so the fresh page shows no banner); DIRTY → un-hide
+ *     the warning banner once, never navigate under the user's fingers.
+ *   - Triggers: a `setTimeout` (clamped >= 0) AND re-checks wall-clock on
+ *     `visibilitychange` (tab becomes visible) + `pageshow` (bfcache
+ *     restore). Background-tab timers are throttled by the browser, so the
+ *     dominant real case — "user returns to the tab 20 minutes later" — is
+ *     caught by the visibility re-check, not the timer.
+ *   - A `done` flag disarms every listener/timer after firing either action.
+ */
+export const LOGIN_EXPIRY_SCRIPT = `(function () {
+  var form = document.querySelector("form[data-login-exp]");
+  if (!form) return;
+  var exp = Number(form.getAttribute("data-login-exp"));
+  var refreshUrl = form.getAttribute("data-refresh-url");
+  if (!isFinite(exp) || !refreshUrl) return;
+
+  // Refresh 30s before the server-side exp so the fresh link is ready
+  // before the old one is actually rejected. Client clock skew is safe both
+  // ways: early refresh of a valid link is harmless (a new link is minted),
+  // late is caught by the authoritative server check.
+  var deadlineMs = (exp - 30) * 1000;
+  var dirty = false;
+  var done = false;
+  var timer = null;
+
+  function disarm() {
+    done = true;
+    if (timer !== null) clearTimeout(timer);
+    document.removeEventListener("visibilitychange", onVisible);
+    window.removeEventListener("pageshow", check);
+    form.removeEventListener("input", onInput);
+  }
+
+  function fire() {
+    if (done) return;
+    if (dirty) {
+      // Never yank the page from under a user who is mid-typing — surface a
+      // non-blocking banner with a manual refresh link instead.
+      var banner = document.querySelector("[data-expiry-warning]");
+      if (banner) banner.removeAttribute("hidden");
+      disarm();
+    } else {
+      // Pristine form: silently swap to a fresh link. No notice cookie is
+      // set on this path, so the fresh page renders with no banner — the
+      // user never notices.
+      disarm();
+      location.replace(refreshUrl);
+    }
+  }
+
+  function check() {
+    if (done) return;
+    if (Date.now() >= deadlineMs) fire();
+  }
+
+  function onVisible() {
+    // Background-tab setTimeout is throttled, so re-check wall-clock against
+    // the deadline whenever the tab becomes visible again.
+    if (document.visibilityState === "visible") check();
+  }
+
+  function onInput() {
+    dirty = true;
+    form.removeEventListener("input", onInput);
+  }
+
+  form.addEventListener("input", onInput);
+  document.addEventListener("visibilitychange", onVisible);
+  window.addEventListener("pageshow", check);
+  timer = setTimeout(fire, Math.max(0, deadlineMs - Date.now()));
+})();
+`;
+
+/**
+ * `<script>` tag referencing the externalized helper. CSP-safe: loaded from
+ * the same origin, no inline code.
+ */
+export function renderLoginExpiryScript(): RawHtml {
+  return raw(`<script src="${LOGIN_EXPIRY_SCRIPT_PATH}" defer></script>`);
+}

--- a/apps/api/src/modules/oidc/pages/login-expiry-script.ts
+++ b/apps/api/src/modules/oidc/pages/login-expiry-script.ts
@@ -12,9 +12,16 @@
  *
  * ZERO SECURITY VALUE: the server expiry check stays authoritative. This
  * script never gates anything — it only refreshes early or shows a hint.
- * Client clock skew is safe both ways: a skewed-fast clock refreshes a
- * still-valid link (harmless — a fresh link is minted), a skewed-slow clock
- * lets a stale link through to the server, which catches it and restarts.
+ * Client clock skew is safe both ways: a skewed-slow clock lets a stale link
+ * through to the server, which catches it and restarts; a skewed-fast clock
+ * refreshes a still-valid link, which is harmless once — but a clock fast by
+ * more than the link TTL would see EVERY fresh link as already past deadline
+ * and silently refresh in a tight loop the server cannot detect (each bounce
+ * mints a genuinely fresh link, so the server-side loop guard never engages).
+ * A per-tab `sessionStorage` counter therefore caps consecutive silent
+ * refreshes; past the cap the script degrades to the DIRTY behavior (banner
+ * with a manual refresh link). This also stops an abandoned pristine tab
+ * from re-refreshing forever every ~TTL.
  *
  * CSP: login/register pages target a strict `script-src 'self'`, so the
  * behavior ships as an EXTERNAL asset (served verbatim by
@@ -79,6 +86,28 @@ export const LOGIN_EXPIRY_SCRIPT = `(function () {
   var refreshUrl = form.getAttribute("data-refresh-url");
   if (!isFinite(exp) || !refreshUrl) return;
 
+  // Per-tab cap on consecutive silent refreshes (see file header). Wrapped in
+  // try/catch: sessionStorage can throw in some privacy modes, in which case
+  // the guard degrades to "always at cap" via null (banner instead of loop).
+  var REFRESH_CAP = 3;
+  var REFRESH_KEY = "oidcLoginExpiryRefreshes";
+  function readRefreshCount() {
+    try {
+      var n = Number(sessionStorage.getItem(REFRESH_KEY));
+      return isFinite(n) && n >= 0 ? n : 0;
+    } catch (_e) {
+      return null;
+    }
+  }
+  function bumpRefreshCount(n) {
+    try {
+      sessionStorage.setItem(REFRESH_KEY, String(n + 1));
+      return true;
+    } catch (_e) {
+      return false;
+    }
+  }
+
   // Refresh 30s before the server-side exp so the fresh link is ready
   // before the old one is actually rejected. Client clock skew is safe both
   // ways: early refresh of a valid link is harmless (a new link is minted),
@@ -96,21 +125,31 @@ export const LOGIN_EXPIRY_SCRIPT = `(function () {
     form.removeEventListener("input", onInput);
   }
 
+  function showBanner() {
+    var banner = document.querySelector("[data-expiry-warning]");
+    if (banner) banner.removeAttribute("hidden");
+    disarm();
+  }
+
   function fire() {
     if (done) return;
     if (dirty) {
       // Never yank the page from under a user who is mid-typing — surface a
       // non-blocking banner with a manual refresh link instead.
-      var banner = document.querySelector("[data-expiry-warning]");
-      if (banner) banner.removeAttribute("hidden");
-      disarm();
-    } else {
-      // Pristine form: silently swap to a fresh link. No notice cookie is
-      // set on this path, so the fresh page renders with no banner — the
-      // user never notices.
-      disarm();
-      location.replace(refreshUrl);
+      showBanner();
+      return;
     }
+    // Pristine form: silently swap to a fresh link. No notice cookie is set
+    // on this path, so the fresh page renders with no banner — the user
+    // never notices. Bounded by the per-tab refresh cap; at (or without a
+    // readable) counter, fall back to the banner.
+    var count = readRefreshCount();
+    if (count === null || count >= REFRESH_CAP || !bumpRefreshCount(count)) {
+      showBanner();
+      return;
+    }
+    disarm();
+    location.replace(refreshUrl);
   }
 
   function check() {

--- a/apps/api/src/modules/oidc/pages/login.ts
+++ b/apps/api/src/modules/oidc/pages/login.ts
@@ -14,6 +14,7 @@
 import { html, type RawHtml } from "./html.ts";
 import { renderLayout } from "./layout.ts";
 import { renderSocialButtons, renderSocialSignInScript } from "./social-sign-in-script.ts";
+import { renderExpiryWarning, renderLoginExpiryScript } from "./login-expiry-script.ts";
 import type { ResolvedAppBranding } from "../services/branding.ts";
 
 export interface LoginPageProps {
@@ -49,6 +50,20 @@ export interface LoginPageProps {
    * session email server-side.
    */
   lockEmail?: boolean;
+  /**
+   * Unix seconds `exp` this login link was signed with (Better Auth). When
+   * paired with `refreshUrl`, arms the client-side expiry-detection script
+   * (`login-expiry-script.ts`) which silently refreshes a stale-while-idle
+   * link (or, if the user has typed, shows a non-blocking warning). UX only
+   * — the server expiry check stays authoritative.
+   */
+  expUnix?: number;
+  /**
+   * Restart URL the expiry script navigates to (pristine form) or links to
+   * (dirty form) — the same `/api/auth/oauth2/authorize` + query replay the
+   * server uses to re-mint a fresh link. Required alongside `expUnix`.
+   */
+  refreshUrl?: string;
 }
 
 export function renderLoginPage(props: LoginPageProps): RawHtml {
@@ -74,11 +89,25 @@ export function renderLoginPage(props: LoginPageProps): RawHtml {
   const magicLinkUrl = `/api/oauth/magic-link${props.queryString}`;
   const forgotPasswordUrl = `/api/oauth/forgot-password${props.queryString}`;
 
+  // Client-side expiry detection (UX only) is armed when the caller passes
+  // both the signed `exp` and the restart URL. The `<form>` carries them as
+  // data attributes the external script reads; the hidden banner + script
+  // tag are emitted only in that case. See `login-expiry-script.ts`.
+  const expiryEnabled =
+    props.expUnix !== undefined && Number.isFinite(props.expUnix) && !!props.refreshUrl;
+  const refreshUrl = props.refreshUrl ?? "";
+
   const bodyHtml = html`
     <h1>Connexion</h1>
     <p>Connectez-vous pour continuer.</p>
     ${props.error ? html`<div class="error">${props.error}</div>` : null}
-    <form method="POST" action="${action}" autocomplete="on">
+    ${expiryEnabled ? renderExpiryWarning(refreshUrl) : null}
+    <form
+      method="POST"
+      action="${action}"
+      autocomplete="on"
+      ${expiryEnabled ? html`data-login-exp="${String(props.expUnix)}" data-refresh-url="${refreshUrl}"` : null}
+    >
       <input type="hidden" name="_csrf" value="${props.csrfToken}" />
       <input
         type="email"
@@ -113,6 +142,7 @@ export function renderLoginPage(props: LoginPageProps): RawHtml {
       }
     </div>
     ${google || github ? renderSocialSignInScript() : null}
+    ${expiryEnabled ? renderLoginExpiryScript() : null}
   `;
   return renderLayout({ branding: props.branding, title, maxWidth: 400, bodyHtml });
 }

--- a/apps/api/src/modules/oidc/routes.ts
+++ b/apps/api/src/modules/oidc/routes.ts
@@ -106,6 +106,7 @@ import {
   renderActivateResultPage,
 } from "./pages/activate.ts";
 import { SOCIAL_SIGN_IN_SCRIPT } from "./pages/social-sign-in-script.ts";
+import { LOGIN_EXPIRY_SCRIPT } from "./pages/login-expiry-script.ts";
 import { getAuth } from "@appstrate/db/auth";
 import { oauthClient, deviceCode } from "@appstrate/db/schema";
 
@@ -780,6 +781,20 @@ export function createOidcRouter() {
     });
   });
 
+  // Client-side expiry-detection helper for the login page. Same static-asset
+  // treatment as social-sign-in.js — external (CSP `script-src 'self'`), zero
+  // user-controlled values, long-cacheable. Source: `pages/login-expiry-script.ts`.
+  router.get("/api/oauth/assets/login-expiry.js", rateLimitByIp(120), () => {
+    return new Response(LOGIN_EXPIRY_SCRIPT, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/javascript; charset=utf-8",
+        "Cache-Control": "public, max-age=3600, must-revalidate",
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  });
+
   // ── Public polymorphic login/consent pages ─────────────────────────────────
 
   router.get("/api/oauth/login", rateLimitByIp(60), async (c) => {
@@ -851,6 +866,16 @@ export function createOidcRouter() {
         : undefined;
     // OIDC `login_hint` pins the email (invitation flow) — pre-fill + lock it.
     const loginHint = url.searchParams.get("login_hint")?.toLowerCase().trim() || undefined;
+    // Client-side expiry detection (UX polish, no security value — the server
+    // check above is authoritative). We only reach here when the link is NOT
+    // expired (the expiry branch returned earlier), but still guard
+    // `Number.isFinite` before arming the script. The refresh URL replays the
+    // raw `url.search` through authorize — byte-identical to the server-side
+    // restart redirect (authorize whitelists params, so keeping the raw query
+    // including any `error` is fine and simplest).
+    const expParam = url.searchParams.get("exp");
+    const expUnix = expParam !== null ? Number(expParam) : undefined;
+    const expiryArmed = expUnix !== undefined && Number.isFinite(expUnix);
     // Email prefill precedence: `login_hint` wins and locks the field; else
     // the email the expired link carried (via the notice) pre-fills it but is
     // NOT locked — the user may correct it.
@@ -864,6 +889,7 @@ export function createOidcRouter() {
       error: errorMessage,
       email: loginHint ?? notice?.email,
       lockEmail: !!loginHint,
+      ...(expiryArmed ? { expUnix, refreshUrl: `/api/auth/oauth2/authorize${url.search}` } : {}),
     });
     return c.html(body.value);
   });

--- a/apps/api/src/modules/oidc/routes.ts
+++ b/apps/api/src/modules/oidc/routes.ts
@@ -56,6 +56,10 @@ import {
   clearPendingClientCookie,
   headersWithAuthoritativePendingClient,
 } from "./services/pending-client-cookie.ts";
+import {
+  issueLoginNoticeCookie,
+  readAndClearLoginNoticeCookie,
+} from "./services/login-notice-cookie.ts";
 import { isValidRedirectUri } from "./services/redirect-uri.ts";
 import { resolveBrandingForClient, PLATFORM_DEFAULT_BRANDING } from "./services/branding.ts";
 import { issueCsrfToken, verifyCsrfToken } from "./services/csrf.ts";
@@ -788,20 +792,45 @@ export function createOidcRouter() {
     });
     if (page instanceof Response) return page;
     const { url, ctx } = page;
-    // Better Auth signs the redirect with `exp` (Unix seconds). Reject
-    // expired login URLs so stale links cannot create upstream sessions.
+    // Read the one-shot login-notice cookie ONCE for the whole request path.
+    // `readAndClear` has one-shot semantics (it clears on every call), so we
+    // must not call it twice — the loop-guard branch below and the normal
+    // render both consume this single local. A present notice here means the
+    // prior request bounced through `authorize` to mint a fresh link.
+    const notice = readAndClearLoginNoticeCookie(c);
+    // Better Auth signs the redirect with `exp` (Unix seconds). When the login
+    // URL has expired we don't dead-end the user on a useless form — we set a
+    // notice cookie and bounce back through `/api/auth/oauth2/authorize` with
+    // the SAME query string. BA's authorize GET whitelists only OAuth params
+    // (its Zod schema drops the stale `exp`/`sig`/`ba_iat`) and re-redirects to
+    // the login page with a FRESH signed link. This mirrors Keycloak's
+    // auth-session restart. Security is unchanged: the bounce re-runs full
+    // authorize validation and the original `state`/`code_challenge` ride
+    // along byte-identical (required — the SPA's PKCE verifier in
+    // sessionStorage must keep matching).
     if (isLoginLinkExpired(url.searchParams.get("exp"))) {
-      const body = renderLoginPage({
-        queryString: url.search,
-        branding: ctx.branding,
-        csrfToken: "",
-        socialProviders: ctx.socialProviders,
-        smtpEnabled: ctx.features.smtp,
-        allowSignup: allowSignupForClient(ctx.client),
-        error:
-          "Ce lien de connexion a expiré. Veuillez relancer la connexion depuis l'application.",
-      });
-      return c.html(body.value, 400);
+      // Loop guard: a notice cookie still present here means we already
+      // restarted once and the fresh link came back expired — pathological
+      // (the same host mints `exp = now + 600`), so fail visibly instead of
+      // redirect-looping. The `readAndClear` above already evicted the cookie
+      // so a later legitimate visit starts clean.
+      if (notice) {
+        return c.html(
+          renderErrorPage({
+            title: "Connexion impossible",
+            message:
+              "La page de connexion n'a pas pu être rafraîchie. Veuillez relancer la connexion depuis l'application.",
+            branding: ctx.branding,
+          }).value,
+          400,
+        );
+      }
+      issueLoginNoticeCookie(c, { code: "login_link_expired" });
+      // Same resume shape as the post-login redirect below: replay the query
+      // byte-identical (see the byte-for-byte comment above `stripError…`) —
+      // do NOT round-trip through `URLSearchParams`. BA strips the stale
+      // `exp`/`sig` and mints a fresh link.
+      return c.redirect(`/api/auth/oauth2/authorize${url.search}`, 302);
     }
     // Pin the pending client_id in a signed cookie so the BA `beforeSignup`
     // hook can enforce the signup policy on social / magic-link flows that
@@ -812,9 +841,19 @@ export function createOidcRouter() {
     // `signup_disabled` for a closed org-level client. Surface a friendly
     // banner instead of silently rendering a blank login page.
     const errorCode = url.searchParams.get("error");
-    const errorMessage = errorCode ? mapLoginErrorCode(errorCode) : undefined;
+    // Banner precedence: an explicit `?error=` code (social-callback failure)
+    // always wins; otherwise, if we arrived here via an expiry restart, show
+    // the notice banner. `notice` was read once at the top of the handler.
+    const errorMessage = errorCode
+      ? mapLoginErrorCode(errorCode)
+      : notice
+        ? "Ce lien de connexion avait expiré. Veuillez vous reconnecter pour continuer."
+        : undefined;
     // OIDC `login_hint` pins the email (invitation flow) — pre-fill + lock it.
     const loginHint = url.searchParams.get("login_hint")?.toLowerCase().trim() || undefined;
+    // Email prefill precedence: `login_hint` wins and locks the field; else
+    // the email the expired link carried (via the notice) pre-fills it but is
+    // NOT locked — the user may correct it.
     const body = renderLoginPage({
       queryString: stripErrorFromQueryString(url.search),
       branding: ctx.branding,
@@ -823,7 +862,7 @@ export function createOidcRouter() {
       smtpEnabled: ctx.features.smtp,
       allowSignup: allowSignupForClient(ctx.client),
       error: errorMessage,
-      email: loginHint,
+      email: loginHint ?? notice?.email,
       lockEmail: !!loginHint,
     });
     return c.html(body.value);
@@ -840,25 +879,27 @@ export function createOidcRouter() {
     if (page instanceof Response) return page;
     const { url, ctx } = page;
     const allowSignup = allowSignupForClient(ctx.client);
-    // Reject form submissions for expired login URLs — prevents creating a
-    // Better Auth session from a stale link. Render the login page with an
-    // inline error (same as the GET handler) instead of returning JSON —
-    // the browser submitted a form, not an API call.
+    // Parse the body up-front (before the expiry check) so we can capture the
+    // typed email for prefill on the restart bounce. Nothing between the old
+    // positions depended on ordering — the expiry block was the first thing in
+    // the handler — so hoisting `parseBody` here is safe.
+    const form = await c.req.parseBody();
+    // On an expired login URL, mirror the GET handler: set a notice cookie and
+    // bounce back through `/api/auth/oauth2/authorize` with the SAME query
+    // string so BA mints a fresh link, instead of dead-ending on a useless
+    // form. Carry the typed email forward for prefill. No loop guard on POST:
+    // the restart always lands on the GET handler, which owns the guard. The
+    // 302 answers a POST but browsers follow it with GET — correct, the target
+    // is a navigation.
     if (isLoginLinkExpired(url.searchParams.get("exp"))) {
-      const body = renderLoginPage({
-        queryString: url.search,
-        branding: ctx.branding,
-        csrfToken: "",
-        socialProviders: ctx.socialProviders,
-        smtpEnabled: ctx.features.smtp,
-        allowSignup,
-        error:
-          "Ce lien de connexion a expiré. Veuillez relancer la connexion depuis l'application.",
+      const email = readFormString(form, "email")?.toLowerCase().trim();
+      issueLoginNoticeCookie(c, {
+        code: "login_link_expired",
+        ...(email ? { email } : {}),
       });
-      return c.html(body.value, 400);
+      return c.redirect(`/api/auth/oauth2/authorize${url.search}`, 302);
     }
 
-    const form = await c.req.parseBody();
     if (!verifyCsrfToken(c, readFormString(form, "_csrf"))) {
       const page = renderLoginPage({
         queryString: url.search,

--- a/apps/api/src/modules/oidc/routes.ts
+++ b/apps/api/src/modules/oidc/routes.ts
@@ -889,6 +889,11 @@ export function createOidcRouter() {
     // Email prefill precedence: `login_hint` wins and locks the field; else
     // the email the expired link carried (via the notice) pre-fills it but is
     // NOT locked — the user may correct it.
+    // Known degradation: `login_hint` is not in Better Auth's authorize query
+    // whitelist, so it cannot survive an expiry restart — a locked-email flow
+    // that expires comes back with the email prefilled (via the notice
+    // cookie) but unlocked. Cosmetic only: the field is never an access
+    // control (membership is enforced server-side at sign-in/token mint).
     const body = renderLoginPage({
       queryString: stripErrorFromQueryString(url.search),
       branding: ctx.branding,

--- a/apps/api/src/modules/oidc/routes.ts
+++ b/apps/api/src/modules/oidc/routes.ts
@@ -824,12 +824,19 @@ export function createOidcRouter() {
     // along byte-identical (required — the SPA's PKCE verifier in
     // sessionStorage must keep matching).
     if (isLoginLinkExpired(url.searchParams.get("exp"))) {
-      // Loop guard: a notice cookie still present here means we already
-      // restarted once and the fresh link came back expired — pathological
-      // (the same host mints `exp = now + 600`), so fail visibly instead of
-      // redirect-looping. The `readAndClear` above already evicted the cookie
-      // so a later legitimate visit starts clean.
-      if (notice) {
+      const state = url.searchParams.get("state") ?? undefined;
+      // Loop guard — PER TRANSACTION, keyed to the OAuth `state`. A genuine
+      // loop (restart bounced through `authorize` and the fresh link came
+      // back expired — pathological, the same host mints `exp = now + 600`)
+      // replays the SAME `state`; only then do we fail visibly instead of
+      // redirect-looping. A notice whose `state` differs is a DIFFERENT
+      // transaction — e.g. a second tab also sitting on an expired link —
+      // and restarts normally. Both-undefined counts as a match: a state-less
+      // transaction has no discriminator, and a working loop guard beats
+      // tab-friendliness there (our SPA always sends `state`). The
+      // `readAndClear` above already evicted the cookie so a later
+      // legitimate visit starts clean.
+      if (notice && notice.state === state) {
         return c.html(
           renderErrorPage({
             title: "Connexion impossible",
@@ -840,7 +847,10 @@ export function createOidcRouter() {
           400,
         );
       }
-      issueLoginNoticeCookie(c, { code: "login_link_expired" });
+      issueLoginNoticeCookie(c, {
+        code: "login_link_expired",
+        ...(state !== undefined ? { state } : {}),
+      });
       // Same resume shape as the post-login redirect below: replay the query
       // byte-identical (see the byte-for-byte comment above `stripError…`) —
       // do NOT round-trip through `URLSearchParams`. BA strips the stale
@@ -905,6 +915,13 @@ export function createOidcRouter() {
     if (page instanceof Response) return page;
     const { url, ctx } = page;
     const allowSignup = allowSignupForClient(ctx.client);
+    // Consume any lingering notice cookie — POST never renders the banner, and
+    // discarding here prevents a stale one (from a prior bounce, within its
+    // 60s TTL) from wrongly re-showing on a later GET after a successful
+    // login. The expiry branch below may then issue a fresh cookie: the
+    // delete + set land on the same response in call order, and browsers let
+    // the later same-name cookie win — intentional and safe.
+    readAndClearLoginNoticeCookie(c);
     // Parse the body up-front (before the expiry check) so we can capture the
     // typed email for prefill on the restart bounce. Nothing between the old
     // positions depended on ordering — the expiry block was the first thing in
@@ -913,15 +930,18 @@ export function createOidcRouter() {
     // On an expired login URL, mirror the GET handler: set a notice cookie and
     // bounce back through `/api/auth/oauth2/authorize` with the SAME query
     // string so BA mints a fresh link, instead of dead-ending on a useless
-    // form. Carry the typed email forward for prefill. No loop guard on POST:
-    // the restart always lands on the GET handler, which owns the guard. The
-    // 302 answers a POST but browsers follow it with GET — correct, the target
-    // is a navigation.
+    // form. Carry the typed email forward for prefill, and the transaction
+    // `state` so the GET-side loop guard can discriminate this transaction
+    // from an unrelated tab's. No loop guard on POST: the restart always
+    // lands on the GET handler, which owns the guard. The 302 answers a POST
+    // but browsers follow it with GET — correct, the target is a navigation.
     if (isLoginLinkExpired(url.searchParams.get("exp"))) {
       const email = readFormString(form, "email")?.toLowerCase().trim();
+      const state = url.searchParams.get("state") ?? undefined;
       issueLoginNoticeCookie(c, {
         code: "login_link_expired",
         ...(email ? { email } : {}),
+        ...(state !== undefined ? { state } : {}),
       });
       return c.redirect(`/api/auth/oauth2/authorize${url.search}`, 302);
     }

--- a/apps/api/src/modules/oidc/services/login-notice-cookie.ts
+++ b/apps/api/src/modules/oidc/services/login-notice-cookie.ts
@@ -11,8 +11,13 @@
  * reads + clears the cookie to:
  *   1. show an error banner ("link expired, please sign in again"), and
  *   2. optionally prefill the email the expired link carried, and
- *   3. act as an anti-redirect-loop marker — a login page that already sees a
- *      notice cookie must NOT bounce a second time.
+ *   3. act as an anti-redirect-loop marker — but PER OAUTH TRANSACTION, keyed
+ *      to the `state` param. A genuine loop replays the SAME `state` (the SPA
+ *      mints a unique state per login), so the loop guard only fires when an
+ *      expired login page sees a notice cookie whose `state` matches the
+ *      request's. This avoids a false trip when two independent tabs are each
+ *      on an expired link: tab B's distinct `state` (or absent state) is a
+ *      different transaction, so it restarts normally instead of dead-ending.
  *
  * Why a cookie and not a query param: Better Auth's `authorize` endpoint
  * re-serializes its query string through a Zod whitelist and DROPS any
@@ -49,8 +54,21 @@ const COOKIE_PATH = "/api/oauth";
 const COOKIE_MAX_AGE = 60; // 60 seconds — the authorize→login round-trip is
 // sub-second; 60s absorbs slow redirects without leaving a stale banner.
 
-/** The known, closed set of notice payloads this cookie can carry. */
-export type LoginNotice = { code: "login_link_expired"; email?: string };
+/**
+ * The known, closed set of notice payloads this cookie can carry.
+ *
+ * `state` is the OAuth `state` of the transaction that bounced — the loop
+ * guard compares it against the restarted request's `state` so only a genuine
+ * same-transaction loop (not two independent tabs) trips the terminal page.
+ */
+export type LoginNotice = { code: "login_link_expired"; email?: string; state?: string };
+
+/**
+ * Max stored length of `state`. It exists solely as a loop discriminator, so a
+ * generous cap suffices; an over-long value (never produced by our SPA) is
+ * dropped rather than stored (see `buildSignedLoginNoticeValue`).
+ */
+const MAX_STATE_LENGTH = 256;
 
 /**
  * Serialize + sign `notice` and set the cookie. Safe to call multiple times on
@@ -95,9 +113,18 @@ export function readAndClearLoginNoticeCookie(c: Context<AppEnv>): LoginNotice |
  */
 export function buildSignedLoginNoticeValue(notice: LoginNotice): string {
   const exp = Math.floor(Date.now() / 1000) + COOKIE_MAX_AGE;
+  // Cookie-size guard: drop an abnormally long `state` rather than store it.
+  // Losing it only degrades the loop guard to the pre-`state` behavior (first
+  // expired GET carrying a notice cookie is treated as a loop) — still safe,
+  // just slightly less tab-friendly for the pathological input.
+  const state =
+    notice.state !== undefined && notice.state.length <= MAX_STATE_LENGTH
+      ? notice.state
+      : undefined;
   const json = JSON.stringify({
     code: notice.code,
     ...(notice.email !== undefined ? { email: notice.email } : {}),
+    ...(state !== undefined ? { state } : {}),
   });
   const encoded = Buffer.from(json, "utf8").toString("base64url");
   const signed = `${encoded}.${exp}`;
@@ -134,14 +161,16 @@ function parseAndVerify(raw: string): LoginNotice | null {
 
 /**
  * Validate the parsed shape without a raw `as` cast on untrusted data. `code`
- * must be the known literal; `email`, if present, must be a string.
+ * must be the known literal; `email` and `state`, if present, must be strings.
  */
 function narrowNotice(value: unknown): LoginNotice | null {
   if (typeof value !== "object" || value === null) return null;
   const obj = value as Record<string, unknown>;
   if (obj.code !== "login_link_expired") return null;
   if (obj.email !== undefined && typeof obj.email !== "string") return null;
-  return obj.email !== undefined
-    ? { code: "login_link_expired", email: obj.email }
-    : { code: "login_link_expired" };
+  if (obj.state !== undefined && typeof obj.state !== "string") return null;
+  const notice: LoginNotice = { code: "login_link_expired" };
+  if (obj.email !== undefined) notice.email = obj.email;
+  if (obj.state !== undefined) notice.state = obj.state;
+  return notice;
 }

--- a/apps/api/src/modules/oidc/services/login-notice-cookie.ts
+++ b/apps/api/src/modules/oidc/services/login-notice-cookie.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Login-notice signed cookie — the UX notice + anti-loop marker for the
+ * login-link-expiry "restart-in-place" flow.
+ *
+ * ROLE: when a Better Auth-signed login link reaches `/api/oauth/login` after
+ * its `exp` has passed, the handler cannot render the (now useless) form. It
+ * instead sets THIS cookie and bounces the browser through
+ * `/api/auth/oauth2/authorize` to mint a fresh link. The fresh login page then
+ * reads + clears the cookie to:
+ *   1. show an error banner ("link expired, please sign in again"), and
+ *   2. optionally prefill the email the expired link carried, and
+ *   3. act as an anti-redirect-loop marker — a login page that already sees a
+ *      notice cookie must NOT bounce a second time.
+ *
+ * Why a cookie and not a query param: Better Auth's `authorize` endpoint
+ * re-serializes its query string through a Zod whitelist and DROPS any
+ * unknown params, so a `?notice=…` marker cannot survive the
+ * authorize → loginPage round-trip. A cookie rides alongside the redirect
+ * chain untouched.
+ *
+ * The cookie carries NO authority: it is purely display state + a loop guard.
+ * Forging it at worst shows a banner (and suppresses one restart bounce) — it
+ * grants no access, pins no realm, and is never trusted for any security
+ * decision. We still HMAC-sign it (with `BETTER_AUTH_SECRET`) so a malformed /
+ * tampered value is cleanly rejected rather than parsed, but unlike the
+ * pending-client cookie there is nothing to protect, so we skip the
+ * production insecure-`Secure`-flag warning: an unencrypted notice cookie
+ * leaks nothing worth warning about.
+ *
+ * The email is embedded in the payload, which (because emails contain dots)
+ * we serialize as JSON and base64url-encode BEFORE signing. The cookie value
+ * is `<base64urlPayload>.<exp>.<sig>` — base64url and the `<kid>$<hmac>` sig
+ * contain no dots, so splitting on `.` still yields exactly 3 parts (same
+ * 3-part shape as `pending-client-cookie.ts`).
+ *
+ * Scoped to `Path=/api/oauth` — the only routes that issue and read it.
+ */
+
+import { setCookie, deleteCookie, getCookie } from "hono/cookie";
+import type { Context } from "hono";
+import { getEnv } from "@appstrate/env";
+import { signAuthHmac, verifyAuthHmac } from "../../../lib/auth-secrets.ts";
+import type { AppEnv } from "../../../types/index.ts";
+
+const COOKIE_NAME = "oidc_login_notice";
+const COOKIE_PATH = "/api/oauth";
+const COOKIE_MAX_AGE = 60; // 60 seconds — the authorize→login round-trip is
+// sub-second; 60s absorbs slow redirects without leaving a stale banner.
+
+/** The known, closed set of notice payloads this cookie can carry. */
+export type LoginNotice = { code: "login_link_expired"; email?: string };
+
+/**
+ * Serialize + sign `notice` and set the cookie. Safe to call multiple times on
+ * the same request — the latest call wins (browsers overwrite by
+ * (name, path, domain)).
+ */
+export function issueLoginNoticeCookie(c: Context<AppEnv>, notice: LoginNotice): void {
+  const value = buildSignedLoginNoticeValue(notice);
+  const secure = getEnv().APP_URL.startsWith("https://");
+  setCookie(c, COOKIE_NAME, value, {
+    httpOnly: true,
+    sameSite: "Lax",
+    secure,
+    path: COOKIE_PATH,
+    maxAge: COOKIE_MAX_AGE,
+  });
+}
+
+/**
+ * Read + verify the notice cookie, then DELETE it — one-shot semantics. The
+ * cookie is cleared on every call regardless of validity: a garbage or
+ * tampered value must not linger and re-trigger the banner on the next render.
+ * Returns the decoded notice on success, `null` on any failure (missing,
+ * expired, bad sig, malformed payload).
+ */
+export function readAndClearLoginNoticeCookie(c: Context<AppEnv>): LoginNotice | null {
+  const raw = getCookie(c, COOKIE_NAME);
+  // Clear first, unconditionally — even an invalid cookie should be evicted.
+  deleteCookie(c, COOKIE_NAME, { path: COOKIE_PATH });
+  return raw ? parseAndVerify(raw) : null;
+}
+
+// ─── Internals ────────────────────────────────────────────────────────────────
+
+/**
+ * Build the signed cookie value: `<base64urlPayload>.<exp>.<sig>` where
+ * `sig = signAuthHmac(`${base64urlPayload}.${exp}`)`. Exported for unit tests
+ * that need to construct raw values (e.g. an expired `exp`).
+ */
+export function buildSignedLoginNoticeValue(notice: LoginNotice): string {
+  const exp = Math.floor(Date.now() / 1000) + COOKIE_MAX_AGE;
+  const json = JSON.stringify({
+    code: notice.code,
+    ...(notice.email !== undefined ? { email: notice.email } : {}),
+  });
+  const encoded = Buffer.from(json, "utf8").toString("base64url");
+  const signed = `${encoded}.${exp}`;
+  const sig = signAuthHmac(signed);
+  return `${signed}.${sig}`;
+}
+
+function parseAndVerify(raw: string): LoginNotice | null {
+  // Format: `<base64urlPayload>.<exp>.<sig>`. base64url contains no dot and
+  // the `<kid>$<hmac>` sig contains no dot, so a well-formed value splits into
+  // exactly 3 parts.
+  const parts = raw.split(".");
+  if (parts.length !== 3) return null;
+  const [encoded, expStr, sig] = parts as [string, string, string];
+  if (!verifyAuthHmac(`${encoded}.${expStr}`, sig)) return null;
+  const exp = Number.parseInt(expStr, 10);
+  if (!Number.isFinite(exp) || exp < Math.floor(Date.now() / 1000)) return null;
+
+  // Defensive decode + parse — a bad payload yields null, never a throw.
+  let decoded: string;
+  try {
+    decoded = Buffer.from(encoded, "base64url").toString("utf8");
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(decoded);
+  } catch {
+    return null;
+  }
+  return narrowNotice(parsed);
+}
+
+/**
+ * Validate the parsed shape without a raw `as` cast on untrusted data. `code`
+ * must be the known literal; `email`, if present, must be a string.
+ */
+function narrowNotice(value: unknown): LoginNotice | null {
+  if (typeof value !== "object" || value === null) return null;
+  const obj = value as Record<string, unknown>;
+  if (obj.code !== "login_link_expired") return null;
+  if (obj.email !== undefined && typeof obj.email !== "string") return null;
+  return obj.email !== undefined
+    ? { code: "login_link_expired", email: obj.email }
+    : { code: "login_link_expired" };
+}

--- a/apps/api/src/modules/oidc/services/login-notice-cookie.ts
+++ b/apps/api/src/modules/oidc/services/login-notice-cookie.ts
@@ -71,6 +71,14 @@ export type LoginNotice = { code: "login_link_expired"; email?: string; state?: 
 const MAX_STATE_LENGTH = 256;
 
 /**
+ * Max stored length of `email` — RFC 5321's 254-octet address ceiling. The
+ * email is a prefill convenience only; an over-long value (hostile or typo'd
+ * form input) is dropped rather than allowed to bloat the signed cookie past
+ * the ~4KB browser limit, where the whole cookie would be silently discarded.
+ */
+const MAX_EMAIL_LENGTH = 254;
+
+/**
  * Serialize + sign `notice` and set the cookie. Safe to call multiple times on
  * the same request — the latest call wins (browsers overwrite by
  * (name, path, domain)).
@@ -121,9 +129,13 @@ export function buildSignedLoginNoticeValue(notice: LoginNotice): string {
     notice.state !== undefined && notice.state.length <= MAX_STATE_LENGTH
       ? notice.state
       : undefined;
+  const email =
+    notice.email !== undefined && notice.email.length <= MAX_EMAIL_LENGTH
+      ? notice.email
+      : undefined;
   const json = JSON.stringify({
     code: notice.code,
-    ...(notice.email !== undefined ? { email: notice.email } : {}),
+    ...(email !== undefined ? { email } : {}),
     ...(state !== undefined ? { state } : {}),
   });
   const encoded = Buffer.from(json, "utf8").toString("base64url");

--- a/apps/api/src/modules/oidc/services/login-notice-cookie.ts
+++ b/apps/api/src/modules/oidc/services/login-notice-cookie.ts
@@ -70,17 +70,20 @@ export function issueLoginNoticeCookie(c: Context<AppEnv>, notice: LoginNotice):
 }
 
 /**
- * Read + verify the notice cookie, then DELETE it — one-shot semantics. The
- * cookie is cleared on every call regardless of validity: a garbage or
- * tampered value must not linger and re-trigger the banner on the next render.
- * Returns the decoded notice on success, `null` on any failure (missing,
- * expired, bad sig, malformed payload).
+ * Read + verify the notice cookie, then DELETE it — one-shot semantics. Any
+ * PRESENT cookie is cleared regardless of validity: a garbage or tampered
+ * value must not linger and re-trigger the banner on the next render. When no
+ * cookie is present, no clearing header is emitted — this keeps the common
+ * login render free of `Set-Cookie` noise and, on the restart bounce, avoids
+ * stacking a delete + set of the same cookie in one response. Returns the
+ * decoded notice on success, `null` on any failure (missing, expired, bad
+ * sig, malformed payload).
  */
 export function readAndClearLoginNoticeCookie(c: Context<AppEnv>): LoginNotice | null {
   const raw = getCookie(c, COOKIE_NAME);
-  // Clear first, unconditionally — even an invalid cookie should be evicted.
+  if (raw === undefined) return null;
   deleteCookie(c, COOKIE_NAME, { path: COOKIE_PATH });
-  return raw ? parseAndVerify(raw) : null;
+  return parseAndVerify(raw);
 }
 
 // ─── Internals ────────────────────────────────────────────────────────────────

--- a/apps/api/src/modules/oidc/test/integration/routes/oauth-enduser-pages.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/routes/oauth-enduser-pages.test.ts
@@ -488,6 +488,49 @@ describe("Public end-user pages — /api/oauth/*", () => {
       const html = await res.text();
       expect(html).toContain('method="POST"');
     });
+
+    // ── Client-side expiry detection (UX polish, Phase 3) ──────────────────
+    // A valid (future) `exp` arms the external expiry-detection script: the
+    // form carries the signed `exp` + a restart URL through authorize, a
+    // hidden warning banner is rendered, and the script tag is emitted. All
+    // UX only — the server-side expiry restart above stays authoritative.
+
+    it("GET /login with a future exp arms the client-side expiry script", async () => {
+      const { clientId } = await registerClient(ctx);
+      const futureExp = Math.floor(Date.now() / 1000) + 600; // 10 minutes from now
+      const qs = `?client_id=${encodeURIComponent(clientId)}&state=fresh&exp=${futureExp}&sig=test`;
+      const res = await app.request(`/api/oauth/login${qs}`);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      // The form carries the signed exp for the client script to read.
+      expect(html).toContain(`data-login-exp="${futureExp}"`);
+      // The refresh URL replays through authorize (same restart target as the
+      // server-side bounce).
+      expect(html).toMatch(/data-refresh-url="\/api\/auth\/oauth2\/authorize/);
+      // The (hidden) warning banner exists for the dirty-form path to un-hide.
+      expect(html).toContain("data-expiry-warning");
+      // The external script tag is emitted (CSP-safe, not inline).
+      expect(html).toContain('<script src="/api/oauth/assets/login-expiry.js"');
+    });
+
+    it("GET /login without an exp does NOT arm the client-side expiry script", async () => {
+      const { clientId } = await registerClient(ctx);
+      const qs = `?client_id=${encodeURIComponent(clientId)}&state=fresh`;
+      const res = await app.request(`/api/oauth/login${qs}`);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).not.toContain("data-login-exp");
+      expect(html).not.toContain("/api/oauth/assets/login-expiry.js");
+    });
+
+    it("GET /api/oauth/assets/login-expiry.js serves the expiry script as JS", async () => {
+      const res = await app.request("/api/oauth/assets/login-expiry.js");
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/javascript");
+      const body = await res.text();
+      // Sanity: it is the expiry script (reads the form's data attribute).
+      expect(body).toContain("data-login-exp");
+    });
   });
 
   describe("OAuth login session TTL", () => {

--- a/apps/api/src/modules/oidc/test/integration/routes/oauth-enduser-pages.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/routes/oauth-enduser-pages.test.ts
@@ -24,6 +24,7 @@ import {
 import oidcModule from "../../../index.ts";
 import { resetOidcGuardsLimiters } from "../../../auth/guards.ts";
 import { prefixedId } from "../../../../../lib/ids.ts";
+import { buildSignedLoginNoticeValue } from "../../../services/login-notice-cookie.ts";
 
 const app = getTestApp({ modules: [oidcModule] });
 
@@ -321,23 +322,155 @@ describe("Public end-user pages — /api/oauth/*", () => {
     expect(out).toContain("Email ou mot de passe incorrect");
   });
 
-  // ── Stale login URL protections ────────────────────────────────────────
-  // When a user clicks a stale/bookmarked OAuth login link, the login
-  // endpoint must not create a persistent BA session that would let any
-  // downstream OIDC client silently auto-grant on the next visit.
+  // ── Stale login URL "restart-in-place" flow ─────────────────────────────
+  // When a user clicks a stale/bookmarked OAuth login link we no longer
+  // dead-end them on a useless 400 form. Instead we set a one-shot notice
+  // cookie and 302 back through `/api/auth/oauth2/authorize` with the SAME
+  // query string; Better Auth strips the stale `exp`/`sig` and re-mints a
+  // fresh signed link. The fresh login page reads + clears the cookie to
+  // show an "expired, sign in again" banner (and prefill the email the
+  // expired link carried). A notice cookie already present on an expired GET
+  // is the anti-loop marker → fail visibly instead of redirect-looping.
+  // Crucially the stale link never creates a BA session.
 
-  describe("expired login URL protection (exp param)", () => {
-    it("GET /login with an expired exp param returns 400 with error message", async () => {
+  describe("expired login URL restart-in-place (exp param)", () => {
+    // A full authorize-shaped query string — what a real BA login link
+    // carries (every OAuth param) so it can be replayed to authorize
+    // verbatim. `code_challenge` is the RFC 7636 §4.2 example value (a valid
+    // 43-char S256 challenge) so authorize accepts the PKCE request. Built by
+    // hand (not URLSearchParams) so the byte-identical assertions below hold —
+    // spaces stay `%20`, never `+`.
+    function buildLoginQs(clientId: string, exp: number): string {
+      return (
+        `?response_type=code` +
+        `&client_id=${encodeURIComponent(clientId)}` +
+        `&redirect_uri=${encodeURIComponent("https://acme.example.com/oauth/callback")}` +
+        `&scope=openid` +
+        `&state=stale` +
+        `&code_challenge=E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM` +
+        `&code_challenge_method=S256` +
+        `&exp=${exp}` +
+        `&sig=fakesig`
+      );
+    }
+
+    // Read individual Set-Cookie headers (never split on `,` — cookies carry
+    // RFC-1123 `Expires` dates that contain commas).
+    function readSetCookies(res: Response): string[] {
+      const getSetCookie = (res.headers as unknown as { getSetCookie?: () => string[] })
+        .getSetCookie;
+      return typeof getSetCookie === "function" ? getSetCookie.call(res.headers) : [];
+    }
+
+    function findNoticeCookie(res: Response): string | undefined {
+      return readSetCookies(res).find((c) => c.startsWith("oidc_login_notice="));
+    }
+
+    it("GET /login with an expired exp bounces to authorize (byte-identical query) + sets a notice cookie", async () => {
       const { clientId } = await registerClient(ctx);
       const pastExp = Math.floor(Date.now() / 1000) - 60; // 1 minute ago
-      const qs = `?client_id=${encodeURIComponent(clientId)}&state=stale&exp=${pastExp}&sig=fakesig`;
-      const res = await app.request(`/api/oauth/login${qs}`);
-      expect(res.status).toBe(400);
-      const html = await res.text();
-      expect(html).toContain("expiré");
+      const qs = buildLoginQs(clientId, pastExp);
+      const res = await app.request(`/api/oauth/login${qs}`, { redirect: "manual" });
+      expect(res.status).toBe(302);
+      // Byte-identical replay — the query string is forwarded untouched so the
+      // SPA's PKCE `state`/`code_challenge` keep matching.
+      expect(res.headers.get("location")).toBe(`/api/auth/oauth2/authorize${qs}`);
+      // One-shot notice cookie set for the fresh login page to read.
+      expect(findNoticeCookie(res)).toBeDefined();
+      // The stale link never authenticated the user.
+      expect(res.headers.get("set-cookie") ?? "").not.toContain("better-auth.session_token");
     });
 
-    it("GET /login without exp param still renders normally (BA handles its own signing)", async () => {
+    it("the authorize bounce re-mints a FRESH login link whose page shows the banner + clears the cookie", async () => {
+      const { clientId } = await registerClient(ctx);
+      const pastExp = Math.floor(Date.now() / 1000) - 60;
+      const qs = buildLoginQs(clientId, pastExp);
+
+      // Step 1 — expired GET → 302 to authorize + notice cookie.
+      const bounceRes = await app.request(`/api/oauth/login${qs}`, { redirect: "manual" });
+      expect(bounceRes.status).toBe(302);
+      const authorizeLocation = bounceRes.headers.get("location")!;
+      const noticeCookie = findNoticeCookie(bounceRes)!.split(";")[0]!;
+
+      // Step 2 — follow the bounce to BA authorize with NO session. BA drops
+      // the stale exp/sig and 302s back to /api/oauth/login with a FRESH link.
+      const authorizeRes = await app.request(authorizeLocation, {
+        headers: { accept: "text/html" },
+        redirect: "manual",
+      });
+      expect(authorizeRes.status).toBe(302);
+      const freshLogin = new URL(authorizeRes.headers.get("location")!, "http://localhost");
+      expect(freshLogin.pathname).toBe("/api/oauth/login");
+      const freshExp = Number(freshLogin.searchParams.get("exp"));
+      expect(Number.isFinite(freshExp)).toBe(true);
+      expect(freshExp).toBeGreaterThan(Math.floor(Date.now() / 1000));
+
+      // Step 3 — GET the fresh login page WITH the notice cookie → 200 normal
+      // render carrying the expiry banner, a live CSRF token, and a Set-Cookie
+      // that clears the one-shot notice.
+      const freshRes = await app.request(freshLogin.pathname + freshLogin.search, {
+        headers: { cookie: noticeCookie },
+      });
+      expect(freshRes.status).toBe(200);
+      const html = await freshRes.text();
+      expect(html).toContain("avait expiré");
+      const csrf = html.match(/name="_csrf" value="([^"]+)"/);
+      expect(csrf).not.toBeNull();
+      expect(csrf![1]!.length).toBeGreaterThan(0);
+      const cleared = readSetCookies(freshRes).find((c) => c.startsWith("oidc_login_notice="));
+      expect(cleared).toBeDefined();
+      expect(cleared!.toLowerCase()).toContain("max-age=0");
+    });
+
+    it("POST /login with an expired exp bounces to authorize with the typed email captured for prefill", async () => {
+      const { clientId } = await registerClient(ctx);
+      const pastExp = Math.floor(Date.now() / 1000) - 60;
+      const qs = buildLoginQs(clientId, pastExp);
+
+      // The expiry check now runs BEFORE the CSRF check — a stale form
+      // submission (even with a garbage `_csrf`) restarts rather than 403s.
+      const postRes = await app.request(`/api/oauth/login${qs}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: "email=someone@example.com&password=x&_csrf=whatever",
+        redirect: "manual",
+      });
+      expect(postRes.status).toBe(302);
+      expect(postRes.headers.get("location")).toBe(`/api/auth/oauth2/authorize${qs}`);
+      // No BA session created from the stale link.
+      expect(postRes.headers.get("set-cookie") ?? "").not.toContain("better-auth.session_token");
+      const noticeCookie = findNoticeCookie(postRes)!.split(";")[0]!;
+
+      // A subsequent (fresh) login page prefills the typed email + banner. The
+      // email came from the notice, NOT `login_hint`, so it stays editable.
+      const freshRes = await app.request(
+        `/api/oauth/login?client_id=${encodeURIComponent(clientId)}&state=x`,
+        { headers: { cookie: noticeCookie } },
+      );
+      expect(freshRes.status).toBe(200);
+      const html = await freshRes.text();
+      expect(html).toContain("avait expiré");
+      expect(html).toContain('value="someone@example.com"');
+      expect(html).not.toContain("readonly");
+    });
+
+    it("GET /login with an expired exp AND an existing notice cookie fails visibly (loop guard, no redirect)", async () => {
+      const { clientId } = await registerClient(ctx);
+      const pastExp = Math.floor(Date.now() / 1000) - 60;
+      const qs = buildLoginQs(clientId, pastExp);
+      // A valid, non-expired notice cookie already present → we already
+      // bounced once; refuse to redirect-loop and render the terminal page.
+      const notice = buildSignedLoginNoticeValue({ code: "login_link_expired" });
+      const res = await app.request(`/api/oauth/login${qs}`, {
+        headers: { cookie: `oidc_login_notice=${notice}` },
+        redirect: "manual",
+      });
+      expect(res.status).toBe(400);
+      const html = await res.text();
+      expect(html).toContain("Connexion impossible");
+    });
+
+    it("GET /login without an exp param still renders normally (BA handles its own signing)", async () => {
       const { clientId } = await registerClient(ctx);
       const qs = `?client_id=${encodeURIComponent(clientId)}&state=fresh`;
       const res = await app.request(`/api/oauth/login${qs}`);
@@ -354,21 +487,6 @@ describe("Public end-user pages — /api/oauth/*", () => {
       expect(res.status).toBe(200);
       const html = await res.text();
       expect(html).toContain('method="POST"');
-    });
-
-    it("POST /login with an expired exp param rejects before authenticating", async () => {
-      const { clientId } = await registerClient(ctx);
-      const pastExp = Math.floor(Date.now() / 1000) - 60;
-      const qs = `?client_id=${encodeURIComponent(clientId)}&state=stale&exp=${pastExp}&sig=fake`;
-      const res = await app.request(`/api/oauth/login${qs}`, {
-        method: "POST",
-        headers: { "Content-Type": "application/x-www-form-urlencoded" },
-        body: "email=a@b.com&password=hunter2",
-      });
-      expect(res.status).toBe(400);
-      // No Set-Cookie with a session token — the user was never authenticated.
-      const cookies = res.headers.get("set-cookie") ?? "";
-      expect(cookies).not.toContain("better-auth.session_token");
     });
   });
 

--- a/apps/api/src/modules/oidc/test/integration/routes/oauth-enduser-pages.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/routes/oauth-enduser-pages.test.ts
@@ -454,13 +454,14 @@ describe("Public end-user pages — /api/oauth/*", () => {
       expect(html).not.toContain("readonly");
     });
 
-    it("GET /login with an expired exp AND an existing notice cookie fails visibly (loop guard, no redirect)", async () => {
+    it("GET /login with an expired exp AND a SAME-state notice cookie fails visibly (loop guard, no redirect)", async () => {
       const { clientId } = await registerClient(ctx);
       const pastExp = Math.floor(Date.now() / 1000) - 60;
+      // buildLoginQs sets `state=stale` — a notice carrying the SAME state
+      // means THIS transaction already bounced once; refuse to redirect-loop
+      // and render the terminal page.
       const qs = buildLoginQs(clientId, pastExp);
-      // A valid, non-expired notice cookie already present → we already
-      // bounced once; refuse to redirect-loop and render the terminal page.
-      const notice = buildSignedLoginNoticeValue({ code: "login_link_expired" });
+      const notice = buildSignedLoginNoticeValue({ code: "login_link_expired", state: "stale" });
       const res = await app.request(`/api/oauth/login${qs}`, {
         headers: { cookie: `oidc_login_notice=${notice}` },
         redirect: "manual",
@@ -468,6 +469,54 @@ describe("Public end-user pages — /api/oauth/*", () => {
       expect(res.status).toBe(400);
       const html = await res.text();
       expect(html).toContain("Connexion impossible");
+    });
+
+    it("GET /login with an expired exp and a DIFFERENT-state notice cookie restarts normally (two-tab case)", async () => {
+      const { clientId } = await registerClient(ctx);
+      const pastExp = Math.floor(Date.now() / 1000) - 60;
+      const qs = buildLoginQs(clientId, pastExp); // state=stale
+      // The cookie belongs to ANOTHER tab's transaction (different state) —
+      // this is not a loop, so this tab must bounce like a first restart and
+      // re-key the notice cookie to its own state.
+      const otherTabNotice = buildSignedLoginNoticeValue({
+        code: "login_link_expired",
+        state: "other-tab-state",
+      });
+      const res = await app.request(`/api/oauth/login${qs}`, {
+        headers: { cookie: `oidc_login_notice=${otherTabNotice}` },
+        redirect: "manual",
+      });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe(`/api/auth/oauth2/authorize${qs}`);
+      expect(findNoticeCookie(res)).toBeDefined();
+    });
+
+    it("GET /login with a non-numeric exp bounces like an expired link (NaN-bypass guard, end-to-end)", async () => {
+      const { clientId } = await registerClient(ctx);
+      // `Number("garbage") < now` is always false — isLoginLinkExpired must
+      // treat non-numeric as expired, and the handler must restart, not 500.
+      const qs =
+        `?client_id=${encodeURIComponent(clientId)}` + `&state=stale&exp=garbage&sig=fakesig`;
+      const res = await app.request(`/api/oauth/login${qs}`, { redirect: "manual" });
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe(`/api/auth/oauth2/authorize${qs}`);
+      expect(findNoticeCookie(res)).toBeDefined();
+    });
+
+    it("HTML-escapes a hostile email carried by the notice cookie (prefill XSS)", async () => {
+      const { clientId } = await registerClient(ctx);
+      // The prefill value is the only sink for the cookie's email — assert
+      // the `html` helper escaping actually neutralizes an injection attempt.
+      const hostile = '"><script>alert(1)</script>';
+      const notice = buildSignedLoginNoticeValue({ code: "login_link_expired", email: hostile });
+      const res = await app.request(
+        `/api/oauth/login?client_id=${encodeURIComponent(clientId)}&state=x`,
+        { headers: { cookie: `oidc_login_notice=${notice}` } },
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).not.toContain("<script>alert");
+      expect(html).toContain("&quot;&gt;&lt;script&gt;");
     });
 
     it("GET /login without an exp param still renders normally (BA handles its own signing)", async () => {

--- a/apps/api/src/modules/oidc/test/integration/routes/oauth-enduser-pages.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/routes/oauth-enduser-pages.test.ts
@@ -404,6 +404,10 @@ describe("Public end-user pages — /api/oauth/*", () => {
       const freshExp = Number(freshLogin.searchParams.get("exp"));
       expect(Number.isFinite(freshExp)).toBe(true);
       expect(freshExp).toBeGreaterThan(Math.floor(Date.now() / 1000));
+      // `state` MUST survive the authorize → login round-trip: it is what the
+      // notice cookie's loop guard keys on, and what the SPA's PKCE resume
+      // relies on. Pin it so a BA upgrade dropping it fails loudly here.
+      expect(freshLogin.searchParams.get("state")).toBe("stale");
 
       // Step 3 — GET the fresh login page WITH the notice cookie → 200 normal
       // render carrying the expiry banner, a live CSRF token, and a Set-Cookie

--- a/apps/api/src/modules/oidc/test/unit/login-notice-cookie.test.ts
+++ b/apps/api/src/modules/oidc/test/unit/login-notice-cookie.test.ts
@@ -173,6 +173,17 @@ describe("login-notice-cookie", () => {
     expect(notice).toEqual({ code: "login_link_expired" });
   });
 
+  it("drops an over-long email (cookie-size guard) instead of storing it", async () => {
+    const app = makeApp();
+    const raw = buildSignedLoginNoticeValue({
+      code: "login_link_expired",
+      email: `${"x".repeat(250)}@a.com`, // 256 chars > RFC 5321's 254 cap
+      state: "abc-123",
+    });
+    const { notice } = await readWithCookie(app, `${COOKIE_NAME}=${raw}`);
+    expect(notice).toEqual({ code: "login_link_expired", state: "abc-123" });
+  });
+
   it("returns null when no cookie is present", async () => {
     const app = makeApp();
     const res = await app.request("/read");

--- a/apps/api/src/modules/oidc/test/unit/login-notice-cookie.test.ts
+++ b/apps/api/src/modules/oidc/test/unit/login-notice-cookie.test.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the `oidc_login_notice` one-shot signed cookie — the UX
+ * banner + anti-loop marker for the login-link-expiry restart flow.
+ *
+ * The cookie helpers need a Hono `Context`, so we drive them through a minimal
+ * in-process Hono app (`app.request()`, no port/DB) and inspect the emitted
+ * `Set-Cookie` headers. Tamper / expiry / garbage cases build the raw cookie
+ * value from the same signing building blocks (`signAuthHmac`) the service
+ * uses, then send it back on the `Cookie` header.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { Hono } from "hono";
+import {
+  issueLoginNoticeCookie,
+  readAndClearLoginNoticeCookie,
+  buildSignedLoginNoticeValue,
+  type LoginNotice,
+} from "../../services/login-notice-cookie.ts";
+import { signAuthHmac } from "../../../../lib/auth-secrets.ts";
+import type { AppEnv } from "../../../../types/index.ts";
+
+const COOKIE_NAME = "oidc_login_notice";
+
+function makeApp() {
+  const app = new Hono<AppEnv>();
+  app.post("/issue", async (c) => {
+    const body = (await c.req.json()) as { email?: string };
+    const notice: LoginNotice =
+      body.email !== undefined
+        ? { code: "login_link_expired", email: body.email }
+        : { code: "login_link_expired" };
+    issueLoginNoticeCookie(c, notice);
+    return c.text("ok");
+  });
+  app.get("/read", (c) => {
+    const notice = readAndClearLoginNoticeCookie(c);
+    return c.json({ notice });
+  });
+  return app;
+}
+
+/** Extract the `name=value` first segment from a `Set-Cookie` header. */
+function cookiePairFrom(res: Response): string {
+  const setCookie = res.headers.get("set-cookie");
+  expect(setCookie).toBeTruthy();
+  return setCookie!.split(";")[0]!;
+}
+
+/** Issue a notice, returning the `Cookie`-header pair the browser would send back. */
+async function issueAndCapture(app: Hono<AppEnv>, body: { email?: string }): Promise<string> {
+  const res = await app.request("/issue", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  expect(res.status).toBe(200);
+  return cookiePairFrom(res);
+}
+
+/** Read the notice back given a raw cookie value; returns the parsed notice + the read Response. */
+async function readWithCookie(
+  app: Hono<AppEnv>,
+  cookieHeader: string,
+): Promise<{ notice: LoginNotice | null; res: Response }> {
+  const res = await app.request("/read", { headers: { cookie: cookieHeader } });
+  const body = (await res.json()) as { notice: LoginNotice | null };
+  return { notice: body.notice, res };
+}
+
+describe("login-notice-cookie", () => {
+  it("issue → read round-trips the payload without email", async () => {
+    const app = makeApp();
+    const pair = await issueAndCapture(app, {});
+    const { notice } = await readWithCookie(app, pair);
+    expect(notice).toEqual({ code: "login_link_expired" });
+  });
+
+  it("issue → read round-trips the payload with email", async () => {
+    const app = makeApp();
+    const pair = await issueAndCapture(app, { email: "user@example.com" });
+    const { notice } = await readWithCookie(app, pair);
+    expect(notice).toEqual({ code: "login_link_expired", email: "user@example.com" });
+  });
+
+  it("preserves emails with dots, plus signs, and unicode across the round-trip", async () => {
+    const app = makeApp();
+    const emails = ["first.last+tag@sub.example.co.uk", "üñïçødé@exämple.com", "a.b.c+d.e@x.y.z"];
+    for (const email of emails) {
+      const pair = await issueAndCapture(app, { email });
+      const { notice } = await readWithCookie(app, pair);
+      expect(notice).toEqual({ code: "login_link_expired", email });
+    }
+  });
+
+  it("returns null for a tampered signature", async () => {
+    const app = makeApp();
+    const raw = buildSignedLoginNoticeValue({ code: "login_link_expired", email: "a@b.com" });
+    // Flip the final char of the signature.
+    const last = raw.at(-1) === "A" ? "B" : "A";
+    const tampered = raw.slice(0, -1) + last;
+    const { notice } = await readWithCookie(app, `${COOKIE_NAME}=${tampered}`);
+    expect(notice).toBeNull();
+  });
+
+  it("returns null for an expired exp (verified sig, past timestamp)", async () => {
+    const app = makeApp();
+    const encoded = Buffer.from(JSON.stringify({ code: "login_link_expired" }), "utf8").toString(
+      "base64url",
+    );
+    const exp = Math.floor(Date.now() / 1000) - 5;
+    const sig = signAuthHmac(`${encoded}.${exp}`);
+    const raw = `${encoded}.${exp}.${sig}`;
+    const { notice } = await readWithCookie(app, `${COOKIE_NAME}=${raw}`);
+    expect(notice).toBeNull();
+  });
+
+  it("returns null for garbage / wrong part count", async () => {
+    const app = makeApp();
+    for (const raw of ["garbage", "a.b", "a.b.c.d", ""]) {
+      const { notice } = await readWithCookie(app, `${COOKIE_NAME}=${raw}`);
+      expect(notice).toBeNull();
+    }
+  });
+
+  it("returns null when the payload decodes but has the wrong shape", async () => {
+    const app = makeApp();
+    // Valid sig + exp, but the JSON payload uses an unknown code.
+    const encoded = Buffer.from(JSON.stringify({ code: "something_else" }), "utf8").toString(
+      "base64url",
+    );
+    const exp = Math.floor(Date.now() / 1000) + 60;
+    const sig = signAuthHmac(`${encoded}.${exp}`);
+    const { notice } = await readWithCookie(app, `${COOKIE_NAME}=${encoded}.${exp}.${sig}`);
+    expect(notice).toBeNull();
+  });
+
+  it("clears the cookie on read even when the value is invalid", async () => {
+    const app = makeApp();
+    const { notice, res } = await readWithCookie(app, `${COOKIE_NAME}=garbage`);
+    expect(notice).toBeNull();
+    const setCookie = res.headers.get("set-cookie");
+    expect(setCookie).toContain(`${COOKIE_NAME}=`);
+    expect(setCookie).toContain("Max-Age=0");
+  });
+
+  it("clears the cookie on read of a valid value (one-shot)", async () => {
+    const app = makeApp();
+    const pair = await issueAndCapture(app, { email: "one@shot.com" });
+    const { notice, res } = await readWithCookie(app, pair);
+    expect(notice).toEqual({ code: "login_link_expired", email: "one@shot.com" });
+    const setCookie = res.headers.get("set-cookie");
+    expect(setCookie).toContain(`${COOKIE_NAME}=`);
+    expect(setCookie).toContain("Max-Age=0");
+  });
+
+  it("returns null when no cookie is present", async () => {
+    const app = makeApp();
+    const res = await app.request("/read");
+    const body = (await res.json()) as { notice: LoginNotice | null };
+    expect(body.notice).toBeNull();
+  });
+});

--- a/apps/api/src/modules/oidc/test/unit/login-notice-cookie.test.ts
+++ b/apps/api/src/modules/oidc/test/unit/login-notice-cookie.test.ts
@@ -156,6 +156,23 @@ describe("login-notice-cookie", () => {
     expect(setCookie).toContain("Max-Age=0");
   });
 
+  it("round-trips the transaction state via the raw builder", async () => {
+    const app = makeApp();
+    const raw = buildSignedLoginNoticeValue({ code: "login_link_expired", state: "abc-123" });
+    const { notice } = await readWithCookie(app, `${COOKIE_NAME}=${raw}`);
+    expect(notice).toEqual({ code: "login_link_expired", state: "abc-123" });
+  });
+
+  it("drops an over-long state (cookie-size guard) instead of storing it", async () => {
+    const app = makeApp();
+    const raw = buildSignedLoginNoticeValue({
+      code: "login_link_expired",
+      state: "x".repeat(257),
+    });
+    const { notice } = await readWithCookie(app, `${COOKIE_NAME}=${raw}`);
+    expect(notice).toEqual({ code: "login_link_expired" });
+  });
+
   it("returns null when no cookie is present", async () => {
     const app = makeApp();
     const res = await app.request("/read");

--- a/scripts/verify-openapi.ts
+++ b/scripts/verify-openapi.ts
@@ -1568,6 +1568,7 @@ const CODE_TO_SPEC_ALLOWLIST = new Set<string>([
   // documented in the spec (oidc/openapi/paths.ts), so it is not an orphan, and
   // there is no POST route. An allowlist entry for either verb would be dead.
   "GET /api/oauth/assets/social-sign-in.js",
+  "GET /api/oauth/assets/login-expiry.js",
   // OIDC device-flow activation pages — server-rendered HTML.
   "GET /activate",
   "POST /activate",


### PR DESCRIPTION
## Problème

Un end-user qui ouvre la page de login OIDC depuis un lien expiré (param `exp` signé par Better Auth, TTL 600s couplé à `codeExpiresIn`) tombait sur un 400 terminal « Ce lien de connexion a expiré » — sans bouton retry, et avec `csrfToken: ""` donc un formulaire mort. L'utilisateur restait bloqué tant qu'il ne retournait pas manuellement sur l'application d'origine pour régénérer un lien.

## Solution — restart-in-place (modèle Keycloak)

Sur expiry, le serveur pose un cookie one-shot signé (`oidc_login_notice`, 60s, aucune autorité) et 302 à travers `/api/auth/oauth2/authorize` avec la query rejouée **byte-identique**. Better Auth ignore les `exp`/`sig`/`ba_iat` périmés (whitelist Zod), re-valide client_id/redirect_uri/PKCE et re-mint un lien frais. La page de login fraîche lit+efface le cookie : **bannière d'erreur visible + formulaire vivant** (CSRF valide, email prérempli sur le chemin POST). Après login, le flow OAuth d'origine reprend — `state`/`code_challenge` inchangés, le verifier PKCE du SPA matche toujours.

Pourquoi un cookie et pas un param : l'endpoint authorize de BA re-sérialise la query via une whitelist Zod — un marqueur query ne survit pas au round-trip.

## Contenu

- **Cookie one-shot signé** `oidc_login_notice` (HMAC `BETTER_AUTH_SECRET`, httpOnly, Lax, `Path=/api/oauth`) — bannière + prefill email + marqueur anti-boucle **par transaction** (clé `state` : deux onglets sur des liens expirés = transactions distinctes, seul un vrai loop même-`state` affiche la page d'erreur terminale)
- **Restart serveur** GET+POST `/api/oauth/login` — supprime les deux rendus `csrfToken: ""`
- **Détection frontend** (`login-expiry.js`, asset externe CSP `script-src 'self'`) : refresh silencieux à `exp-30s` si formulaire vierge, bannière non bloquante si formulaire touché ; re-check sur `visibilitychange`/`pageshow` (timers throttlés en onglet background). UX pure — le check serveur reste autoritaire.

## Sécurité

- Le rebond repasse la validation authorize complète ; le restart ne porte aucune autorité propre
- Un lien expiré ne crée toujours jamais de session BA
- Review adversariale passée : open-redirect (impossible — path same-origin fixe), XSS prefill (escaping `html` testé avec payload hostile), CSRF (branche expiry sans mutation d'état), forge cookie (signé, cosmétique au pire), rate-limit (bucket dédié sur l'asset)

## Tests

495 tests module oidc verts (dont : bounce byte-identique, follow-through BA re-mint réel, loop guard même-state vs deux-onglets, `exp` non-numérique end-to-end, XSS email échappé, cap 256 du state, round-trips cookie). Suite complète : 8545 pass / 0 fail. `bun run check` vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)