### PR TITLE
fix(runs): read the pinned manifest, not the draft, on post-kickoff surfaces

### DIFF
--- a/apps/api/src/routes/internal.ts
+++ b/apps/api/src/routes/internal.ts
@@ -29,7 +29,7 @@ import {
   MAX_MEMORY_CONTENT,
 } from "../services/state/package-persistence.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
-import { getPackage } from "../services/package-catalog.ts";
+import { getRunEffectiveAgent } from "../services/run-effective-agent.ts";
 import {
   ApiError,
   unauthorized,
@@ -67,6 +67,13 @@ async function verifyRunToken(c: Context): Promise<{
     status: string;
     modelCredentialId: string | null;
     runOrigin: "platform" | "remote";
+    /**
+     * The agent definition the run executes — `"draft"` or a concrete semver
+     * stamped at kickoff (#636). The dependency guards read the manifest AT
+     * this ref so a post-kickoff draft edit cannot retroactively change a
+     * pinned run's authorization set.
+     */
+    versionRef: string | null;
     /**
      * Snapshot of the connection resolver output frozen at run kickoff
      * (#199). The credentials resolver uses it to honour admin pins and
@@ -111,6 +118,7 @@ async function verifyRunToken(c: Context): Promise<{
       status: runs.status,
       modelCredentialId: runs.modelCredentialId,
       runOrigin: runs.runOrigin,
+      versionRef: runs.versionRef,
       resolvedConnections: runs.resolvedConnections,
       resolvedIntegrationVersions: runs.resolvedIntegrationVersions,
     })
@@ -138,6 +146,7 @@ async function verifyRunToken(c: Context): Promise<{
       status: run.status,
       modelCredentialId: run.modelCredentialId ?? null,
       runOrigin: run.runOrigin,
+      versionRef: run.versionRef ?? null,
       resolvedConnections: run.resolvedConnections ?? null,
       resolvedIntegrationVersions: run.resolvedIntegrationVersions ?? null,
     },
@@ -299,13 +308,22 @@ export function createInternalRouter() {
    * application. Same guard used by /mcp-server-bundle and the
    * /integration-credentials endpoints to keep a leaked run token from
    * enumerating integration secrets across the org.
+   *
+   * "The running agent" means the definition the run EXECUTES —
+   * `getRunEffectiveAgent` reads the `package_versions` snapshot when
+   * `runs.version_ref` pins one, the draft otherwise. Reading the mutable
+   * draft here let a post-kickoff draft edit change a pinned run's
+   * authorization set in both directions: a dep removed from the draft
+   * 404'd the boot credential fetch of a scheduled run pinned to a version
+   * that still declares it, and a dep newly added to the draft widened what
+   * a leaked run token of an old pinned run could enumerate.
    */
   async function assertAgentDeclaresIntegration(
     packageId: string,
-    run: { packageId: string; orgId: string; applicationId: string },
+    run: { packageId: string; orgId: string; applicationId: string; versionRef: string | null },
     runId: string,
   ): Promise<void> {
-    const agent = await getPackage(run.packageId, run.orgId, { includeEphemeral: true });
+    const agent = await getRunEffectiveAgent(run);
     if (!agent) throw notFound("Agent not found");
     const deps = asRecord(asRecord(agent.manifest).dependencies);
     const integrations = asRecord(deps.integrations);
@@ -491,6 +509,7 @@ export function createInternalRouter() {
       packageId: string;
       orgId: string;
       applicationId: string;
+      versionRef: string | null;
       resolvedIntegrationVersions: Record<
         string,
         { version: string | null; source: "version" | "draft" | "system" }
@@ -498,7 +517,10 @@ export function createInternalRouter() {
     },
     runId: string,
   ): Promise<void> {
-    const agent = await getPackage(run.packageId, run.orgId, { includeEphemeral: true });
+    // Enumerate the deps of the definition the run EXECUTES (pinned snapshot
+    // when `version_ref` is a concrete semver) — same rationale as
+    // `assertAgentDeclaresIntegration` above.
+    const agent = await getRunEffectiveAgent(run);
     if (!agent) throw notFound("Agent not found");
     const deps = asRecord(asRecord(agent.manifest).dependencies);
     const integrations = asRecord(deps.integrations);

--- a/apps/api/src/services/package-versions.ts
+++ b/apps/api/src/services/package-versions.ts
@@ -227,6 +227,25 @@ export async function getLatestVersionInfo(
   };
 }
 
+/**
+ * Exact-version manifest lookup — the light read for run-scoped consumers
+ * that need a published manifest WITHOUT the artifact bytes. The run's
+ * `version_ref` is a concrete semver stamped at kickoff, so no spec
+ * resolution (dist-tag / range) applies here. Returns null when the version
+ * row is absent (never published, or deleted after kickoff).
+ */
+export async function getExactVersionManifest(
+  packageId: string,
+  version: string,
+): Promise<Record<string, unknown> | null> {
+  const [row] = await db
+    .select({ manifest: packageVersions.manifest })
+    .from(packageVersions)
+    .where(and(eq(packageVersions.packageId, packageId), eq(packageVersions.version, version)))
+    .limit(1);
+  return asRecordOrNull(row?.manifest);
+}
+
 /** 3-step version resolution: exact → dist-tag → semver range. */
 export async function resolveVersion(packageId: string, query: string): Promise<number | null> {
   const allVersions: CatalogVersion[] = await db

--- a/apps/api/src/services/run-effective-agent.ts
+++ b/apps/api/src/services/run-effective-agent.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Effective agent manifest for an ACTIVE run — the single post-kickoff read
+ * path for "what does the running agent's definition say?".
+ *
+ * At kickoff, `resolveAgentRunVersion` (#636) pins the run's definition to a
+ * published `package_versions` snapshot and stamps the concrete semver on
+ * `runs.version_ref` (`"draft"` when the working copy runs). Every runtime
+ * surface that consults the agent manifest AFTER kickoff — the sidecar
+ * credential guards, the mcp-server bundle guard, finalize's output-schema
+ * validation — must read that SAME definition. Re-reading the mutable draft
+ * lets a post-publish draft edit retroactively change a pinned run's
+ * authorization set or output contract: a dependency removed from the draft
+ * 404'd the credential fetch of a scheduled run pinned to a version that
+ * still declares it (the `@tractr/fathom-glenn` incident), and a dependency
+ * newly added to the draft would widen what a leaked run token of an old
+ * pinned run may enumerate.
+ */
+
+import { logger } from "../lib/logger.ts";
+import { getPackage } from "./package-catalog.ts";
+import { getExactVersionManifest } from "./package-versions.ts";
+import type { AgentManifest } from "../types/index.ts";
+
+export interface RunEffectiveAgent {
+  /** Package id — stable across draft and pinned reads. */
+  id: string;
+  /** The manifest of the definition the run executes (pinned snapshot or live draft). */
+  manifest: AgentManifest;
+  /** Which definition backed `manifest` — `"version"` iff the pinned snapshot loaded. */
+  manifestSource: "version" | "draft";
+}
+
+/**
+ * Load the manifest of the definition a run executes.
+ *
+ * - `version_ref = "draft"` (editor runs, system agents, inline shadow
+ *   packages, legacy rows) → the live draft.
+ * - concrete semver → the `package_versions` snapshot for that exact
+ *   version. When the row is gone (version deleted after kickoff) the draft
+ *   is served as a last resort with a warning — the pre-helper behavior.
+ *
+ * Returns null when the package row itself is gone (agent deleted mid-run;
+ * `package_versions` rows cascade with it).
+ */
+export async function getRunEffectiveAgent(run: {
+  packageId: string;
+  orgId: string;
+  versionRef: string | null;
+}): Promise<RunEffectiveAgent | null> {
+  // `includeEphemeral` keeps inline-run shadow packages addressable.
+  const agent = await getPackage(run.packageId, run.orgId, { includeEphemeral: true });
+  if (!agent) return null;
+
+  const versionRef = run.versionRef ?? "draft";
+  // System agents ship their definition with the platform and have no
+  // published versions — the draft row IS the effective definition.
+  if (versionRef === "draft" || agent.source === "system") {
+    return { id: agent.id, manifest: agent.manifest, manifestSource: "draft" };
+  }
+
+  const pinned = await getExactVersionManifest(run.packageId, versionRef);
+  if (!pinned) {
+    logger.warn("run's pinned version manifest is missing — falling back to draft", {
+      packageId: run.packageId,
+      versionRef,
+    });
+    return { id: agent.id, manifest: agent.manifest, manifestSource: "draft" };
+  }
+  return { id: agent.id, manifest: pinned as unknown as AgentManifest, manifestSource: "version" };
+}

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -43,7 +43,7 @@ import {
   CHECKPOINT_KEY,
 } from "./state/package-persistence.ts";
 import { actorFromIds } from "../lib/actor.ts";
-import { getPackage } from "./package-catalog.ts";
+import { getRunEffectiveAgent } from "./run-effective-agent.ts";
 import { validateOutput } from "./schema.ts";
 import { asJSONSchemaObject } from "@appstrate/core/form";
 import { callHook, emitEvent } from "../lib/modules/module-loader.ts";
@@ -130,6 +130,7 @@ export async function getRunSinkContext(runId: string): Promise<RunSinkContext |
       sinkClosedAt: runs.sinkClosedAt,
       lastEventSequence: runs.lastEventSequence,
       startedAt: runs.startedAt,
+      versionRef: runs.versionRef,
       modelSource: runs.modelSource,
     })
     .from(runs)
@@ -143,7 +144,7 @@ export async function getRunSinkContext(runId: string): Promise<RunSinkContext |
   // source agent mid-run nulls the column while the run survives for
   // observability/billing. `RunSinkContext.packageId` is typed as a non-null
   // string, so a raw `row as RunSinkContext` cast would smuggle a runtime null
-  // past every finalize consumer (getPackage, memory/pinned persistence,
+  // past every finalize consumer (getRunEffectiveAgent, memory/pinned persistence,
   // afterRun / onRunStatusChange hook params) — silently skipping finalization
   // side-effects for a deleted-agent run. Recover the agent's `@scope/name`
   // from the INSERT-time snapshot (stamped precisely for this deleted-agent
@@ -316,9 +317,12 @@ async function finalizeRunImpl(input: FinalizeRunInput): Promise<void> {
   // 1. Flush any buffered events before we close the sink.
   await drainBufferedEvents(run, { allowGaps: true });
 
-  // 2. Load manifest for output-schema validation. `includeEphemeral: true`
-  //    keeps inline-run shadow packages addressable here.
-  const agent = await getPackage(run.packageId, run.orgId, { includeEphemeral: true });
+  // 2. Load the manifest of the definition the run EXECUTED for output-schema
+  //    validation — the pinned `package_versions` snapshot when `version_ref`
+  //    names one, the draft otherwise. Validating against the mutable draft
+  //    let a post-kickoff schema edit flip a pinned run's outcome (false
+  //    failure on a tightened draft schema, false success on a loosened one).
+  const agent = await getRunEffectiveAgent(run);
 
   // 3. Derive final status + error message. Pure computation — no DB writes
   //    before the CAS so concurrent synthesis + container-posted finalize

--- a/apps/api/src/types/run-sink.ts
+++ b/apps/api/src/types/run-sink.ts
@@ -28,6 +28,13 @@ export interface RunSinkContext {
   lastEventSequence: number;
   startedAt: Date;
   /**
+   * The agent definition the run executes — `"draft"` or a concrete semver
+   * stamped at kickoff (#636). Finalize reads the output schema from the
+   * manifest AT this ref (`getRunEffectiveAgent`) so a post-kickoff draft
+   * edit cannot change a pinned run's output contract.
+   */
+  versionRef: string;
+  /**
    * Model source resolved at run creation time (`"system"` for platform-paid
    * models, `"org"` for BYOK). Forwarded to the `afterRun` hook so module
    * billing handlers can distinguish billable from non-billable runs.

--- a/apps/api/test/integration/routes/internal-integration-credentials.test.ts
+++ b/apps/api/test/integration/routes/internal-integration-credentials.test.ts
@@ -24,7 +24,7 @@ import { describe, it, expect, beforeEach } from "bun:test";
 import { getTestApp } from "../../helpers/app.ts";
 import { db, truncateAll } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
-import { seedAgent, seedRun, seedPackage } from "../../helpers/seed.ts";
+import { seedAgent, seedRun, seedPackage, seedPackageVersion } from "../../helpers/seed.ts";
 import { signRunToken } from "../../../src/lib/run-token.ts";
 import { installPackage } from "../../../src/services/application-packages.ts";
 import {
@@ -353,5 +353,132 @@ describe("POST /internal/integration-credentials/:scope/:name/refresh", () => {
     const [runRow] = await db.select().from(runs).where(eq(runs.id, runId));
     const meta = runRow!.metadata as { degraded_integrations?: string[] } | null;
     expect(meta?.degraded_integrations).toContain(INTEGRATION);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Version-pinned runs — the dep guard reads the EFFECTIVE manifest.
+//
+// `assertAgentDeclaresIntegration` must authorize against the definition the
+// run EXECUTES (`runs.version_ref` → `package_versions` snapshot), never the
+// mutable draft. Regression for the @tractr/fathom-glenn incident: a dep
+// removed from the draft after publish 404'd the boot credential fetch of a
+// scheduled run pinned to a version that still declares it. The reverse
+// direction is the security half: a dep newly added to the draft must stay
+// out of reach of a run pinned to a version that doesn't declare it.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("GET /internal/integration-credentials — version-pinned runs", () => {
+  let ctx: TestContext;
+
+  async function seedIntegration(id: string) {
+    await seedPackage({
+      id,
+      orgId: ctx.orgId,
+      type: "integration",
+      source: "local",
+      draftManifest: buildIntegrationManifest(id),
+    });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, id);
+    const ciphertext = encryptCredentialEnvelope({ outputs: { api_key: "live-secret-value" } });
+    await db.insert(integrationConnections).values({
+      integrationId: id,
+      authKey: "primary",
+      accountId: "acct-test",
+      applicationId: ctx.defaultAppId,
+      userId: ctx.user.id,
+      endUserId: null,
+      credentialsEncrypted: ciphertext,
+      scopesGranted: [],
+    });
+  }
+
+  async function seedPinnedRun(versionRef: string): Promise<string> {
+    const run = await seedRun({
+      packageId: AGENT,
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      userId: ctx.user.id,
+      status: "running",
+      versionRef,
+    });
+    return signRunToken(run.id);
+  }
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "pinnedcreds" });
+  });
+
+  it("ALLOW: a dep removed from the draft stays fetchable for a run pinned to a version declaring it", async () => {
+    // Draft no longer declares INTEGRATION; published 1.0.0 does.
+    await seedAgent({
+      id: AGENT,
+      orgId: ctx.orgId,
+      createdBy: ctx.user.id,
+      draftManifest: buildAgentManifest([]),
+    });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, AGENT);
+    await seedPackageVersion({
+      packageId: AGENT,
+      version: "1.0.0",
+      manifest: buildAgentManifest([INTEGRATION]),
+    });
+    await seedIntegration(INTEGRATION);
+    const token = await seedPinnedRun("1.0.0");
+
+    const res = await app.request(`/internal/integration-credentials/${INTEGRATION}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { auths: Array<{ fields: Record<string, string> }> };
+    expect(body.auths[0]!.fields.api_key).toBe("live-secret-value");
+  });
+
+  it("DENY: a dep newly added to the draft is NOT reachable by a run pinned to a version without it", async () => {
+    // Draft declares INTEGRATION; published 1.0.0 declares nothing. A leaked
+    // run token of the pinned run must not widen to the draft's dep set.
+    await seedAgent({
+      id: AGENT,
+      orgId: ctx.orgId,
+      createdBy: ctx.user.id,
+      draftManifest: buildAgentManifest([INTEGRATION]),
+    });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, AGENT);
+    await seedPackageVersion({
+      packageId: AGENT,
+      version: "1.0.0",
+      manifest: buildAgentManifest([]),
+    });
+    await seedIntegration(INTEGRATION);
+    const token = await seedPinnedRun("1.0.0");
+
+    const res = await app.request(`/internal/integration-credentials/${INTEGRATION}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(404);
+    expect(JSON.stringify(await res.json())).toMatch(/not a dependency/i);
+  });
+
+  it("FALLBACK: a version_ref whose snapshot is gone degrades to the draft dep set", async () => {
+    // The pinned version row was deleted after kickoff — the guard falls back
+    // to the draft (which declares INTEGRATION), preserving pre-fix behavior.
+    await seedAgent({
+      id: AGENT,
+      orgId: ctx.orgId,
+      createdBy: ctx.user.id,
+      draftManifest: buildAgentManifest([INTEGRATION]),
+    });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, AGENT);
+    await seedIntegration(INTEGRATION);
+    const token = await seedPinnedRun("9.9.9");
+
+    const res = await app.request(`/internal/integration-credentials/${INTEGRATION}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    expect(res.status).toBe(200);
   });
 });

--- a/apps/api/test/integration/routes/internal-mcp-server-bundle.test.ts
+++ b/apps/api/test/integration/routes/internal-mcp-server-bundle.test.ts
@@ -21,7 +21,9 @@
 
 import { describe, it, expect, beforeEach } from "bun:test";
 import { getTestApp } from "../../helpers/app.ts";
-import { truncateAll } from "../../helpers/db.ts";
+import { db, truncateAll } from "../../helpers/db.ts";
+import { eq } from "drizzle-orm";
+import { packages } from "@appstrate/db/schema";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
 import { seedAgent, seedRun, seedPackage, seedPackageVersion } from "../../helpers/seed.ts";
 import { signRunToken } from "../../../src/lib/run-token.ts";
@@ -240,5 +242,64 @@ describe("GET /internal/mcp-server-bundle/:scope/:name", () => {
     });
 
     expect(res.status).toBe(404);
+  });
+
+  it("ALLOW: a version-pinned run keeps bundle access when the draft dropped the integration dep", async () => {
+    // Regression (@tractr/fathom-glenn class): the guard must enumerate the
+    // deps of the manifest the run EXECUTES. Published agent 2.0.0 declares
+    // the integration referencing MCP_SERVER; the draft no longer does. A run
+    // pinned to 2.0.0 must still fetch the server bundle at boot.
+    await seedLocalIntegration(true);
+    await seedMcpServerWithBundle(MCP_SERVER, SERVER_BUNDLE_BYTES);
+
+    const pinnedManifest = {
+      name: AGENT,
+      version: "2.0.0",
+      type: "agent",
+      schema_version: "0.2",
+      display_name: "Test Agent",
+      dependencies: { integrations: { [INTEGRATION]: "^1.0.0" } },
+      integrations_configuration: { [INTEGRATION]: { tools: ["search"] } },
+    };
+    await seedPackageVersion({ packageId: AGENT, version: "2.0.0", manifest: pinnedManifest });
+    await db
+      .update(packages)
+      .set({
+        draftManifest: {
+          name: AGENT,
+          version: "2.0.1",
+          type: "agent",
+          schema_version: "0.2",
+          display_name: "Test Agent",
+          dependencies: { integrations: {} },
+          integrations_configuration: {},
+        },
+      })
+      .where(eq(packages.id, AGENT));
+
+    const pinnedRun = await seedRun({
+      packageId: AGENT,
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      userId: ctx.user.id,
+      status: "running",
+      versionRef: "2.0.0",
+    });
+    const pinnedToken = signRunToken(pinnedRun.id);
+
+    // The pinned run reads the 2.0.0 dep set → ALLOW.
+    const res = await app.request(`/internal/mcp-server-bundle/${MCP_SERVER}`, {
+      headers: { Authorization: `Bearer ${pinnedToken}` },
+    });
+    expect(res.status).toBe(200);
+    expect(Array.from(new Uint8Array(await res.arrayBuffer()))).toEqual(
+      Array.from(SERVER_BUNDLE_BYTES),
+    );
+
+    // The original draft-ref run (beforeEach) now sees an empty draft dep set → DENY.
+    const draftRes = await app.request(`/internal/mcp-server-bundle/${MCP_SERVER}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(draftRes.status).toBe(404);
   });
 });

--- a/apps/api/test/integration/routes/runs-events-ingestion.test.ts
+++ b/apps/api/test/integration/routes/runs-events-ingestion.test.ts
@@ -30,14 +30,14 @@
 import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { eq, sql } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
-import { runs, runLogs, llmUsage } from "@appstrate/db/schema";
+import { runs, runLogs, llmUsage, packages } from "@appstrate/db/schema";
 import { and } from "drizzle-orm";
 import { encrypt } from "@appstrate/connect";
 import { sign } from "@appstrate/afps-runtime/events";
 import { getTestApp } from "../../helpers/app.ts";
 import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
-import { seedPackage } from "../../helpers/seed.ts";
+import { seedPackage, seedPackageVersion } from "../../helpers/seed.ts";
 import { loadModulesFromInstances, resetModules } from "../../../src/lib/modules/module-loader.ts";
 import {
   capUtf8Text,
@@ -78,6 +78,8 @@ async function seedRunWithSink(
     tokenUsage?: Record<string, number> | null;
     /** Persisted on `runs.modelSource` — forwarded to the `afterRun` hook. */
     modelSource?: string | null;
+    /** Persisted on `runs.versionRef` — pins the manifest finalize validates against. */
+    versionRef?: string;
   } = {},
 ): Promise<string> {
   const runId = `run_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
@@ -87,6 +89,7 @@ async function seedRunWithSink(
     orgId: ctx.orgId,
     applicationId: ctx.defaultAppId,
     status: overrides.status ?? "running",
+    ...(overrides.versionRef !== undefined ? { versionRef: overrides.versionRef } : {}),
     runOrigin: "platform",
     sinkSecretEncrypted: encrypt(RUN_SECRET),
     sinkExpiresAt: new Date(Date.now() + 3600_000),
@@ -1899,6 +1902,107 @@ describe("POST /api/runs/:runId/events/finalize — output-schema validation per
       status: "success",
       durationMs: 100,
     });
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    expect(row?.error).toMatch(/without calling the required `output` tool/);
+  });
+
+  // ── Version-pinned runs: finalize validates against the manifest the run
+  //    EXECUTED (`runs.version_ref` → `package_versions` snapshot), never the
+  //    mutable draft. A post-kickoff draft edit must not flip a pinned run's
+  //    outcome in either direction.
+
+  it("pinned run: a draft schema tightened AFTER publish does not fail a run valid per its pinned manifest", async () => {
+    // Published 1.0.0 has NO output schema; the draft (seeded in beforeEach)
+    // requires `answer`. A run pinned to 1.0.0 finishing without output must
+    // stay success — validating against the draft would flip it to failed.
+    await seedPackageVersion({
+      packageId: "@test/schema-agent",
+      version: "1.0.0",
+      manifest: {
+        name: "@test/schema-agent",
+        version: "1.0.0",
+        type: "agent",
+        runtime_tools: ["report"],
+      },
+    });
+    const runId = await seedRunWithSink(ctx, "@test/schema-agent", { versionRef: "1.0.0" });
+
+    const res = await postFinalize(runId, {
+      status: "success",
+      report: "No structured output — the pinned version declares no schema.",
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("success");
+    expect(row?.error).toBeNull();
+  });
+
+  it("pinned run: the pinned manifest's schema IS enforced even when the draft dropped it", async () => {
+    // Published 2.0.0 requires `answer`; replace the draft with one declaring
+    // NO output schema. A run pinned to 2.0.0 finishing without output must
+    // fail — validating against the draft would let it pass.
+    await seedPackageVersion({
+      packageId: "@test/schema-agent",
+      version: "2.0.0",
+      manifest: {
+        name: "@test/schema-agent",
+        version: "2.0.0",
+        type: "agent",
+        runtime_tools: ["output", "report"],
+        output: {
+          schema: {
+            type: "object",
+            required: ["answer"],
+            additionalProperties: false,
+            properties: { answer: { type: "string" } },
+          },
+        },
+      },
+    });
+    await db
+      .update(packages)
+      .set({
+        draftManifest: {
+          name: "@test/schema-agent",
+          version: "2.0.1",
+          type: "agent",
+          runtime_tools: ["report"],
+        },
+      })
+      .where(eq(packages.id, "@test/schema-agent"));
+    const runId = await seedRunWithSink(ctx, "@test/schema-agent", { versionRef: "2.0.0" });
+
+    const res = await postFinalize(runId, {
+      status: "success",
+      report: "Forgot to call output.",
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(res.status).toBe(200);
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    expect(row?.error).toMatch(/without calling the required `output` tool/);
+  });
+
+  it("pinned run whose version row is gone falls back to the draft schema", async () => {
+    // `version_ref` names a version that was deleted after kickoff — the
+    // helper degrades to the draft (which requires `answer`), preserving the
+    // pre-fix behavior instead of skipping validation entirely.
+    const runId = await seedRunWithSink(ctx, "@test/schema-agent", { versionRef: "9.9.9" });
+
+    const res = await postFinalize(runId, {
+      status: "success",
+      report: "No output.",
+      durationMs: 100,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    });
+    expect(res.status).toBe(200);
 
     const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
     expect(row?.status).toBe("failed");

--- a/apps/api/test/unit/services/run-event-ingestion.test.ts
+++ b/apps/api/test/unit/services/run-event-ingestion.test.ts
@@ -42,6 +42,7 @@ function makeRun(overrides: Partial<RunSinkContext> = {}): RunSinkContext {
     sinkClosedAt: null,
     lastEventSequence: 0,
     startedAt: new Date(),
+    versionRef: "draft",
     modelSource: null,
     ...overrides,
   };


### PR DESCRIPTION
## Incident

Prod run `run_b92ea2e8-f571-4b69-858c-6d66e6381f74` (`@tractr/fathom-to-repo-prompt-only`, scheduled, pinned to `1.12.3`) failed at boot:

> Integration boot failed — 1 of 5 integration(s) did not start: @tractr/fathom-glenn (Integration '@tractr/fathom-glenn' is not a dependency of the running agent)

The pinned 1.12.3 manifest declares `@tractr/fathom-glenn`, but the **draft** manifest dropped it on 2026-07-22. The sidecar credential guard re-read the draft, so every subsequent scheduled run of that pin fails.

## Root cause — a class, not a one-off

Kickoff correctly pins the definition (`resolveAgentRunVersion` #636 → `runs.version_ref`), but three **post-kickoff** surfaces still re-read the mutable draft via `getPackage`:

| Surface | Symptom |
|---|---|
| `assertAgentDeclaresIntegration` (internal.ts) | Dep removed from draft → boot 404 for a pinned run that declares it (the incident). Dep **added** to draft → a leaked run token of an old pinned run could enumerate credentials the pinned version never declared. |
| `assertAgentReferencesMcpServer` (internal.ts) | Same draft dep enumeration → same boot-failure class for local-source integrations' bundle fetch. |
| `finalizeRun` output-schema validation (run-event-ingestion.ts) | Draft schema tightened after publish → valid pinned run flipped to `failed`; loosened → invalid run passes. |

Verified safe (already pinned): `resolveLiveIntegrationCredentials` + spawn resolver read **integration** manifests at the frozen version (#686); kickoff pins the agent via `substituteVersion`; admin/kickoff paths (readiness, pins, registry resolver) read the draft by design.

## Fix

New `services/run-effective-agent.ts` → `getRunEffectiveAgent({packageId, orgId, versionRef})` — the single post-kickoff read path for "what does the running agent's definition say":

- concrete `version_ref` → `package_versions` snapshot (new `getExactVersionManifest`, manifest-only lookup, no artifact download)
- `"draft"` / system agents / inline shadow packages → the draft
- version row deleted after kickoff → draft fallback + warning (pre-fix behavior)

All three surfaces now use it; `verifyRunToken` and `RunSinkContext` expose `versionRef`.

Considered and rejected: membership on `runs.resolved_integration_versions` — soft-resolved integrations (`not_found`/`wrong_type`/`invalid` at freeze) get no frozen entry yet still spawn from the draft, so the effective manifest is the only necessary-and-sufficient authorization set.

## Tests

7 new regression tests:
- credentials guard: ALLOW dep removed from draft (incident), DENY dep added to draft only (security tightening), draft fallback on missing version row
- mcp-server bundle guard: pinned run keeps access when the draft dropped the dep (+ draft run correctly loses it)
- finalize: pinned schema absent → draft tightening doesn't fail the run; pinned schema enforced when draft dropped it; missing version row falls back to draft schema

`bun test apps/api/test` → 2927 pass / 0 fail; `bun run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)