### PR TITLE
fix: harden built-in model metering

### DIFF
--- a/apps/api/src/lib/boot.ts
+++ b/apps/api/src/lib/boot.ts
@@ -40,6 +40,7 @@ import { initScheduleWorker } from "../services/scheduler.ts";
 import { initInlineCompactionWorker } from "../services/inline-compaction.ts";
 import { initOAuthModelRefreshWorker } from "../services/model-providers/refresh-worker.ts";
 import { initPairingCleanupWorker } from "../services/model-providers/pairing-cleanup-worker.ts";
+import { initLlmUsageRetryWorker } from "../services/llm-usage-retry.ts";
 import { initCancelSubscriber } from "../services/run-tracker.ts";
 import { startRunWatchdog } from "../services/run-watchdog.ts";
 import { getOrchestrator } from "../services/orchestrator/index.ts";
@@ -261,6 +262,11 @@ export async function boot(): Promise<void> {
 
   // Parallel init: orchestrator, scheduler, and DB cleanups are all independent
   const parallelInits: Promise<void>[] = [
+    // Billing correctness barrier: unlike ancillary workers, this init is not
+    // caught/degraded. Boot must fail if the durable metering recovery channel
+    // is unavailable; otherwise a transient ledger write failure after
+    // provider spend could be lost permanently.
+    initLlmUsageRetryWorker(),
     orchestrator.initialize().catch((err) => {
       logger.warn("Could not initialize container orchestrator", {
         error: getErrorMessage(err),

--- a/apps/api/src/lib/shutdown.ts
+++ b/apps/api/src/lib/shutdown.ts
@@ -14,6 +14,7 @@ import { shutdownScheduleWorker } from "../services/scheduler.ts";
 import { shutdownInlineCompactionWorker } from "../services/inline-compaction.ts";
 import { shutdownOAuthModelRefreshWorker } from "../services/model-providers/refresh-worker.ts";
 import { shutdownPairingCleanupWorker } from "../services/model-providers/pairing-cleanup-worker.ts";
+import { shutdownLlmUsageRetryWorker } from "../services/llm-usage-retry.ts";
 import { stopRunWatchdog } from "../services/run-watchdog.ts";
 import { getOrchestrator } from "../services/orchestrator/index.ts";
 import { stopUploadGc } from "../services/uploads.ts";
@@ -67,6 +68,9 @@ export function createShutdownHandler(setShuttingDown: () => void): () => Promis
 
     logger.info("Shutting down OAuth model pairing cleanup worker...");
     await shutdownPairingCleanupWorker();
+
+    logger.info("Shutting down LLM usage retry worker...");
+    await shutdownLlmUsageRetryWorker();
 
     logger.info("Shutting down modules...");
     await shutdownModules();

--- a/apps/api/src/routes/llm-proxy.ts
+++ b/apps/api/src/routes/llm-proxy.ts
@@ -56,6 +56,7 @@ import { requirePermission } from "../middleware/require-permission.ts";
 import { invalidRequest, forbidden, notFound } from "../lib/errors.ts";
 import { assertBearerOnly } from "../lib/bearer-only.ts";
 import { getRunAttribution } from "../services/state/runs.ts";
+import { enforceSystemProxyAdmission } from "../services/system-proxy-admission.ts";
 import { recordLlmLatency } from "@appstrate/core/telemetry";
 import {
   proxyLlmCall,
@@ -70,6 +71,7 @@ import type { LlmProxyAdapter, LlmProxyPrincipal } from "../services/llm-proxy/t
 import { buildLlmProxyPrincipal } from "../services/llm-proxy/types.ts";
 import { getLlmProxyLimits, type LlmProxyLimits } from "../services/proxy-limits.ts";
 import type { AppEnv } from "../types/index.ts";
+import { ACTIVE_RUN_STATUSES } from "@appstrate/db/schema";
 
 export function createLlmProxyRouter() {
   const router = new Hono<AppEnv>();
@@ -145,12 +147,14 @@ export function createLlmProxyRouter() {
  *      API-key principals are app-scoped infrastructure identities (the run
  *      may legitimately carry a user/end-user actor or a sibling key), so the
  *      org + application boundary is their enforcement line.
+ *   4. The run is still active. A terminal run id must not become a reusable
+ *      billing context for arbitrary post-run system-model calls.
  */
 async function assertRunAttributable(
   c: Context<AppEnv>,
   runId: string,
   principal: LlmProxyPrincipal,
-): Promise<void> {
+): Promise<NonNullable<Awaited<ReturnType<typeof getRunAttribution>>>> {
   const run = await getRunAttribution(principal.orgId, runId);
   if (!run) {
     throw notFound(`run ${runId} not found`);
@@ -162,6 +166,10 @@ async function assertRunAttributable(
   if (principal.kind === "jwt_user" && run.userId !== principal.userId) {
     throw forbidden("X-Run-Id does not reference a run owned by the calling user");
   }
+  if (!ACTIVE_RUN_STATUSES.has(run.status)) {
+    throw invalidRequest(`run ${runId} is no longer active`);
+  }
+  return run;
 }
 
 async function handleProxy(
@@ -192,9 +200,15 @@ async function handleProxy(
   // `llm_usage.run_id` → `computeRunCost` → `runs.cost`. Validate it against
   // the principal BEFORE the upstream call so a caller with `llm-proxy:call`
   // cannot bill LLM cost onto an arbitrary (even cross-tenant) run.
-  if (runId) {
-    await assertRunAttributable(c, runId, principal);
+  const runAttribution = runId ? await assertRunAttributable(c, runId, principal) : null;
+  if (runAttribution && !runAttribution.packageId) {
+    throw invalidRequest(`run ${runAttribution.id} has no agent package attribution`);
   }
+  const usageContext = runAttribution
+    ? ({ context: "run", packageId: runAttribution.packageId! } as const)
+    : c.get("firstPartyLoopback")
+      ? ({ context: "chat", sessionId: chatSessionId } as const)
+      : null;
 
   const buf = await c.req.arrayBuffer();
   if (buf.byteLength === 0) {
@@ -213,6 +227,8 @@ async function handleProxy(
       incomingHeaders: c.req.raw.headers,
       rawBody,
       maxRequestBytes: limits.max_request_bytes,
+      beforeSystemUpstream: (resolved) =>
+        enforceSystemProxyAdmission({ orgId, resolved, usageContext }),
     });
 
     const durationMs = Date.now() - started;

--- a/apps/api/src/services/chat-subscription.ts
+++ b/apps/api/src/services/chat-subscription.ts
@@ -24,7 +24,7 @@ import type { ChatUsageRecord, SubscriptionChatResolution } from "@appstrate/cor
 import type { UsageRejection } from "@appstrate/core/module";
 import { getErrorMessage } from "@appstrate/core/errors";
 import { computeTokenCost } from "@appstrate/afps-runtime/runner";
-import { recordLlmUsage } from "./llm-usage-ledger.ts";
+import { recordLlmUsageReliably } from "./llm-usage-retry.ts";
 import { loadModel, modelNeedsReconnection } from "./org-models.ts";
 import { isSystemModel } from "./model-registry.ts";
 import { getModelProvider } from "./model-providers/registry.ts";
@@ -124,33 +124,36 @@ export async function resolveSubscriptionChatModel(
  */
 export async function recordChatUsage(record: ChatUsageRecord): Promise<void> {
   try {
-    await recordLlmUsage({
-      source: "proxy",
-      orgId: record.orgId,
-      userId: record.userId,
-      chatSessionId: record.chatSessionId,
-      model: record.presetId,
-      realModel: record.modelId,
-      api: record.apiShape,
-      credentialSource: "org",
-      inputTokens: record.inputTokens,
-      outputTokens: record.outputTokens,
-      cacheReadTokens: record.cacheReadTokens ?? null,
-      cacheWriteTokens: record.cacheWriteTokens ?? null,
-      costUsd: computeTokenCost(
-        {
-          input_tokens: record.inputTokens,
-          output_tokens: record.outputTokens,
-          cache_read_input_tokens: record.cacheReadTokens ?? 0,
-          cache_creation_input_tokens: record.cacheWriteTokens ?? 0,
-        },
-        record.cost,
-      ),
-      durationMs: record.durationMs,
-      // Chat turns aren't retried at the CLI layer, but proxy-source rows carry
-      // a request_id by the ledger check constraint — mint a fresh one.
-      requestId: crypto.randomUUID(),
-    });
+    await recordLlmUsageReliably(
+      {
+        source: "proxy",
+        orgId: record.orgId,
+        userId: record.userId,
+        chatSessionId: record.chatSessionId,
+        model: record.presetId,
+        realModel: record.modelId,
+        api: record.apiShape,
+        credentialSource: "org",
+        inputTokens: record.inputTokens,
+        outputTokens: record.outputTokens,
+        cacheReadTokens: record.cacheReadTokens ?? null,
+        cacheWriteTokens: record.cacheWriteTokens ?? null,
+        costUsd: computeTokenCost(
+          {
+            input_tokens: record.inputTokens,
+            output_tokens: record.outputTokens,
+            cache_read_input_tokens: record.cacheReadTokens ?? 0,
+            cache_creation_input_tokens: record.cacheWriteTokens ?? 0,
+          },
+          record.cost,
+        ),
+        durationMs: record.durationMs,
+        // Stable across durable retries; the partial unique index makes an
+        // uncertain post-commit acknowledgement idempotent.
+        requestId: crypto.randomUUID(),
+      },
+      { onConflict: "proxy-idempotent" },
+    );
   } catch (err) {
     logger.error("chat: failed to record llm usage", {
       orgId: record.orgId,

--- a/apps/api/src/services/llm-proxy/core.ts
+++ b/apps/api/src/services/llm-proxy/core.ts
@@ -60,6 +60,13 @@ export interface ProxyCallInputs {
   fetchImpl?: typeof fetch;
   /** Override the request-body cap. Defaults to 10 MiB. */
   maxRequestBytes?: number;
+  /**
+   * Admission seam invoked after a system preset is resolved and after a
+   * response-cache miss, but before any upstream request. The route wires this
+   * to the module `beforeUsage` hook with its validated chat/run context.
+   * Org-owned presets never invoke it.
+   */
+  beforeSystemUpstream?: (resolved: ResolvedModel, presetId: string) => Promise<void>;
 }
 
 export class LlmProxyUnsupportedModelError extends Error {
@@ -133,7 +140,15 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
     throw new LlmProxyUnsupportedSubscriptionError(resolved.providerId);
   }
 
-  const rewrittenBody = request.rewriteModel(resolved.modelId);
+  // OpenAI-compatible streaming usage is opt-in. Force it server-side for
+  // system presets even when a remote/third-party client forgot the flag:
+  // billing must not depend on the caller SDK doing the right thing. Org-owned
+  // custom endpoints are left untouched for compatibility.
+  const includeStreamUsage =
+    resolved.isSystemModel &&
+    (inputs.adapter.apiShape === "openai-completions" ||
+      inputs.adapter.apiShape === "mistral-conversations");
+  const rewrittenBody = request.rewriteModel(resolved.modelId, { includeStreamUsage });
 
   // Model-alias swap (issue #727). When the resolved preset is an alias, the
   // upstream echoes the REAL id in its response `model` field (and may name it
@@ -171,6 +186,14 @@ export async function proxyLlmCall(inputs: ProxyCallInputs): Promise<Response> {
       return probe.response;
     }
     cacheKeyForWrite = probe.cacheKey;
+  }
+
+  // Cached responses spend no provider tokens. On a cache miss, gate every
+  // platform-paid proxy call immediately before the upstream request. This
+  // closes the remote-run path where run creation cannot know whether the
+  // remote runner will later select a system preset.
+  if (resolved.isSystemModel) {
+    await inputs.beforeSystemUpstream?.(resolved, presetId);
   }
 
   const upstreamUrl = joinUpstreamUrl(resolved.baseUrl, inputs.upstreamPath);

--- a/apps/api/src/services/llm-proxy/helpers.ts
+++ b/apps/api/src/services/llm-proxy/helpers.ts
@@ -39,9 +39,11 @@ export interface ParsedProxyRequest {
   stream: boolean;
   /**
    * Produce a fresh body byte sequence with `model` swapped for
-   * `upstreamModelId`. The rest of the payload is preserved verbatim.
+   * `upstreamModelId`. When `includeStreamUsage` is set, a streaming
+   * OpenAI-compatible request is also forced to ask for the terminal usage
+   * frame. The rest of the payload is preserved.
    */
-  rewriteModel(upstreamModelId: string): Uint8Array;
+  rewriteModel(upstreamModelId: string, opts?: { includeStreamUsage?: boolean }): Uint8Array;
 }
 
 /**
@@ -68,8 +70,15 @@ export function parseProxyRequest(rawBody: Uint8Array): ParsedProxyRequest {
   return {
     presetId: model,
     stream: obj["stream"] === true,
-    rewriteModel(upstreamModelId: string): Uint8Array {
+    rewriteModel(upstreamModelId: string, opts?: { includeStreamUsage?: boolean }): Uint8Array {
       obj["model"] = upstreamModelId;
+      if (opts?.includeStreamUsage && obj["stream"] === true) {
+        const current = obj["stream_options"];
+        obj["stream_options"] =
+          current && typeof current === "object" && !Array.isArray(current)
+            ? { ...(current as Record<string, unknown>), include_usage: true }
+            : { include_usage: true };
+      }
       return new TextEncoder().encode(JSON.stringify(obj));
     },
   };

--- a/apps/api/src/services/llm-proxy/metering.ts
+++ b/apps/api/src/services/llm-proxy/metering.ts
@@ -9,14 +9,14 @@
  *     encoding would make the caller re-decode plaintext → ZlibError);
  *   - tap the teed SSE stream to extract usage WITHOUT buffering the whole
  *     response;
- *   - insert a usage row whose cost is Σ(tokens × cost/1e6), swallowing DB
- *     errors so a metering failure never breaks a successful LLM call.
+ *   - insert a usage row whose cost is Σ(tokens × cost/1e6), handing transient
+ *     DB failures to the durable usage-retry queue.
  */
 
 import { logger } from "../../lib/logger.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
 import { computeTokenCost } from "@appstrate/afps-runtime/runner";
-import { recordLlmUsage } from "../llm-usage-ledger.ts";
+import { recordLlmUsageReliably } from "../llm-usage-retry.ts";
 import type { ModelCost } from "@appstrate/core/module";
 import type { ModelSwap } from "@appstrate/core/sidecar-types";
 import {
@@ -163,14 +163,22 @@ export interface RecordUsageInputs {
 
 /**
  * Insert one `llm_usage` row (source="proxy") via the single ledger writer.
- * Metering failures MUST NOT break a successful LLM call — the caller already
- * consumed the response bytes — so DB errors are logged and swallowed (ops
- * reconcile from upstream invoices).
+ * A transient DB failure is durably queued with the same request id; if BOTH
+ * Postgres and the retry queue are unavailable, the error propagates instead of
+ * silently losing billable usage.
  */
 export async function recordProxyUsage(inputs: RecordUsageInputs): Promise<void> {
-  if (!inputs.usage) return;
-  try {
-    await recordLlmUsage({
+  if (!inputs.usage) {
+    logger.error("llm-proxy: successful response contained no parseable usage", {
+      orgId: inputs.principal.orgId,
+      presetId: inputs.presetId,
+      credentialSource: inputs.resolved.isSystemModel ? "system" : "org",
+    });
+    return;
+  }
+
+  await recordLlmUsageReliably(
+    {
       source: "proxy",
       orgId: inputs.principal.orgId,
       apiKeyId: inputs.principal.kind === "api_key" ? inputs.principal.apiKeyId : null,
@@ -196,17 +204,12 @@ export async function recordProxyUsage(inputs: RecordUsageInputs): Promise<void>
       cacheWriteTokens: inputs.usage.cacheWriteTokens ?? null,
       costUsd: computeCostUsd(inputs.usage, inputs.resolved.cost ?? null),
       durationMs: inputs.durationMs,
-      // Fresh UUID per upstream call — satisfies the partial-unique index on
-      // (source='proxy', request_id). CLI-level retries land as new rows.
+      // Stable across durable retries. `proxy-idempotent` maps an uncertain
+      // post-commit acknowledgement to a no-op on replay.
       requestId: crypto.randomUUID(),
-    });
-  } catch (err) {
-    logger.error("llm-proxy: failed to record usage", {
-      orgId: inputs.principal.orgId,
-      presetId: inputs.presetId,
-      error: getErrorMessage(err),
-    });
-  }
+    },
+    { onConflict: "proxy-idempotent" },
+  );
 }
 
 export function computeCostUsd(usage: UpstreamUsage, cost: ModelCost | null): number {
@@ -396,9 +399,10 @@ export async function forwardMeteredResponse(
     void tapSseUsage(tapStream, adapter)
       .then(meter)
       .catch((err: unknown) => {
-        // Metering tap is best-effort and out-of-band of the client stream; a
-        // parse/insert failure must surface in logs, not vanish into an
-        // unhandled rejection (silent usage under-counting otherwise).
+        // The tap is out-of-band of the client stream. Direct DB failures are
+        // normally recovered by the durable retry queue; reaching this catch
+        // means parsing failed or both persistence channels failed, and must
+        // surface loudly rather than become an unhandled rejection.
         logger.error(`${logLabel}: SSE usage metering failed`, {
           runId: ctx.runId,
           presetId: ctx.presetId,
@@ -452,9 +456,9 @@ export async function forwardMeteredResponse(
     });
   }
 
-  // The upstream body is fully buffered, so awaiting the insert costs ~1ms and
-  // removes the observable race (recordProxyUsage swallows its own DB errors, and
-  // no-ops on null usage). Streaming uses `void` deliberately — already on wire.
+  // The upstream body is fully buffered, so awaiting the insert (or durable
+  // retry enqueue) removes the observable race. Streaming uses `void`
+  // deliberately — its bytes are already on the wire.
   await meter(adapter.parseJsonUsage(parsed));
 
   const headers = buildClientHeaders(upstream.headers, swap);

--- a/apps/api/src/services/llm-usage-ledger.ts
+++ b/apps/api/src/services/llm-usage-ledger.ts
@@ -19,9 +19,10 @@
  *      row whose transaction later rolls back from firing a phantom event.
  *
  * It is intentionally a thin insert+emit seam, not a framework: cost is already
- * computed by each caller (they own the token→USD arithmetic and their own
- * best-effort try/catch), and the runner's monotonic upsert is expressed as one
- * opt-in flag rather than a second code path.
+ * computed by each caller (they own the token→USD arithmetic and persistence
+ * policy), and the runner's monotonic upsert is expressed as one opt-in flag
+ * rather than a second code path. Billable producers wrap this with
+ * `llm-usage-retry.ts` for durable recovery.
  */
 
 import { db, type Db } from "@appstrate/db/client";
@@ -75,7 +76,7 @@ export interface RecordLlmUsageOptions {
    * unique index `uq_llm_usage_runner_run_id` (at most one runner row per run;
    * the highest cumulative cost wins). The plain insert (proxy / chat) omits it.
    */
-  onConflict?: "runner-monotonic";
+  onConflict?: "runner-monotonic" | "proxy-idempotent";
   /**
    * Deferred-emit collector for a caller that records INSIDE its own
    * transaction. When provided, {@link recordLlmUsage} does NOT broadcast
@@ -107,7 +108,7 @@ function resolveContext(
  * columns (`real_model` / `api`). When {@link RecordLlmUsageOptions.deferEmit}
  * is supplied the event is collected instead of broadcast — see that option's
  * doc for the post-commit contract. DB errors are NOT swallowed here — each
- * caller owns its best-effort try/catch and its own log line.
+ * caller decides whether to fail, retry, or durably enqueue.
  */
 export async function recordLlmUsage(
   entry: LlmUsageEntry,
@@ -177,7 +178,20 @@ export async function recordLlmUsage(
             `,
           })
           .returning({ id: llmUsage.id })
-      : await executor.insert(llmUsage).values(values).returning({ id: llmUsage.id });
+      : opts.onConflict === "proxy-idempotent"
+        ? await executor
+            .insert(llmUsage)
+            .values(values)
+            // A DB client can lose the INSERT acknowledgement after Postgres
+            // committed it. Durable retry replays the exact same request_id;
+            // the partial unique index turns that uncertain outcome into a
+            // clean no-op instead of a duplicate ledger row.
+            .onConflictDoNothing({
+              target: llmUsage.requestId,
+              where: sql`source = 'proxy' AND request_id IS NOT NULL`,
+            })
+            .returning({ id: llmUsage.id })
+        : await executor.insert(llmUsage).values(values).returning({ id: llmUsage.id });
 
   const llmUsageId = inserted[0]?.id ?? null;
   if (llmUsageId === null) return null;

--- a/apps/api/src/services/llm-usage-retry.ts
+++ b/apps/api/src/services/llm-usage-retry.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Durable retry path for `llm_usage` writes.
+ *
+ * Provider bytes may already be consumed when metering runs (especially SSE),
+ * so a transient Postgres failure cannot be repaired by retrying the LLM call.
+ * Failed ledger writes are therefore handed to the platform queue: Redis-backed
+ * in production, local in-memory in embedded single-instance mode. Proxy jobs
+ * replay a stable request_id and runner jobs use their monotonic run upsert, so
+ * every retry is idempotent.
+ */
+
+import { createQueue, type JobQueue } from "../infra/queue/index.ts";
+import { logger } from "../lib/logger.ts";
+import { getErrorMessage } from "@appstrate/core/errors";
+import {
+  recordLlmUsage,
+  type LlmUsageEntry,
+  type RecordLlmUsageOptions,
+} from "./llm-usage-ledger.ts";
+
+const QUEUE_NAME = "llm-usage-retry";
+const RETRY_ATTEMPTS = 288; // five-minute cap => roughly 24 hours of retries
+const MAX_BACKOFF_MS = 5 * 60_000;
+
+type RetryConflictMode = NonNullable<RecordLlmUsageOptions["onConflict"]>;
+
+interface LlmUsageRetryJob {
+  entry: LlmUsageEntry;
+  onConflict: RetryConflictMode;
+}
+
+let usageRetryQueue: JobQueue<LlmUsageRetryJob> | null = null;
+
+async function getQueue(): Promise<JobQueue<LlmUsageRetryJob>> {
+  if (!usageRetryQueue) {
+    usageRetryQueue = await createQueue<LlmUsageRetryJob>(QUEUE_NAME, {
+      attempts: RETRY_ATTEMPTS,
+      backoff: { type: "custom" },
+      removeOnComplete: 1000,
+      // Keep terminal failures for operator inspection/replay. The queue-level
+      // retention remains bounded while a 24h outage does not silently erase
+      // the evidence.
+      removeOnFail: 5000,
+    });
+  }
+  return usageRetryQueue;
+}
+
+function retryBackoff(attempt: number): number {
+  return Math.min(MAX_BACKOFF_MS, 500 * 2 ** Math.min(attempt - 1, 10));
+}
+
+/**
+ * Start the retry consumer and verify that its backing queue is reachable.
+ * Boot awaits this: accepting billable traffic with no recovery channel would
+ * recreate the silent-loss window this worker exists to close.
+ */
+export async function initLlmUsageRetryWorker(): Promise<void> {
+  const queue = await getQueue();
+  queue.process(
+    async (job) => {
+      await recordLlmUsage(job.data.entry, { onConflict: job.data.onConflict });
+    },
+    { concurrency: 4, backoffStrategy: retryBackoff },
+  );
+  await queue.count();
+}
+
+/**
+ * Persist a ledger entry, durably enqueueing it when the direct write fails.
+ *
+ * `required` is used by run finalization: the terminal runner snapshot must be
+ * visible in Postgres before the run becomes settled, otherwise Cloud could
+ * claim an older cumulative row and never revisit its serial id. In that one
+ * path we propagate the DB error so finalize is retried and the run remains
+ * unsettled. Every other path may safely enqueue because its context is still
+ * active or the proxy row will receive a fresh serial id when replayed.
+ */
+export async function recordLlmUsageReliably(
+  entry: LlmUsageEntry,
+  opts: RecordLlmUsageOptions & { required?: boolean } = {},
+): Promise<void> {
+  try {
+    await recordLlmUsage(entry, opts);
+    return;
+  } catch (directError) {
+    if (opts.required) throw directError;
+
+    const onConflict: RetryConflictMode =
+      opts.onConflict ?? (entry.source === "runner" ? "runner-monotonic" : "proxy-idempotent");
+    try {
+      await (
+        await getQueue()
+      ).add(
+        "persist-usage",
+        { entry, onConflict },
+        { attempts: RETRY_ATTEMPTS, backoff: { type: "custom" } },
+      );
+      logger.warn("Queued llm_usage write after direct persistence failure", {
+        source: entry.source,
+        orgId: entry.orgId,
+        runId: entry.runId ?? null,
+        requestId: entry.requestId ?? null,
+        error: getErrorMessage(directError),
+      });
+    } catch (queueError) {
+      logger.error("Failed to persist or enqueue llm_usage", {
+        source: entry.source,
+        orgId: entry.orgId,
+        runId: entry.runId ?? null,
+        requestId: entry.requestId ?? null,
+        directError: getErrorMessage(directError),
+        queueError: getErrorMessage(queueError),
+      });
+      throw new AggregateError(
+        [directError, queueError],
+        "llm_usage persistence and durable retry enqueue both failed",
+      );
+    }
+  }
+}
+
+export async function shutdownLlmUsageRetryWorker(): Promise<void> {
+  await usageRetryQueue?.shutdown();
+  usageRetryQueue = null;
+}
+
+/** Test-only reset for files that create the queue lifecycle explicitly. */
+export async function _resetLlmUsageRetryWorkerForTests(): Promise<void> {
+  await shutdownLlmUsageRetryWorker();
+}

--- a/apps/api/src/services/model-registry.ts
+++ b/apps/api/src/services/model-registry.ts
@@ -125,6 +125,20 @@ const rawModelProviderCredentialSchema = z.object({
 type RawModelProviderCredential = z.infer<typeof rawModelProviderCredentialSchema>;
 
 /**
+ * Provider-declared compatibility aliases that are no longer safe to send as
+ * system-model backings. Keep the public preset id stable while routing the
+ * upstream call to the supported successor. This is intentionally limited to
+ * platform-owned env configuration: BYOK/custom model ids remain operator
+ * controlled and are never rewritten behind their back.
+ */
+const SYSTEM_MODEL_UPSTREAM_MIGRATIONS: Readonly<Record<string, Readonly<Record<string, string>>>> =
+  {
+    deepseek: {
+      "deepseek-chat": "deepseek-v4-flash",
+    },
+  };
+
+/**
  * Initialize system model provider keys and models from the SYSTEM_PROVIDER_KEYS env var.
  * Call once at boot AFTER `registerModelProviders()` — the env entries
  * resolve their `apiShape` + `baseUrl` from the registry by `providerId`.
@@ -261,6 +275,18 @@ export function initSystemModelProviderKeys(rawOverride?: unknown[]): void {
           }
 
           const modelId = validM.id ?? `${validCredential.id}:${validM.modelId}`;
+          const upstreamModelId =
+            SYSTEM_MODEL_UPSTREAM_MIGRATIONS[validCredential.providerId]?.[validM.modelId] ??
+            validM.modelId;
+          if (upstreamModelId !== validM.modelId) {
+            logger.warn("[model-registry] migrated deprecated system model backing", {
+              modelProviderCredentialId: validCredential.id,
+              presetId: modelId,
+              providerId: validCredential.providerId,
+              fromModelId: validM.modelId,
+              toModelId: upstreamModelId,
+            });
+          }
           mdlMap.set(modelId, {
             id: modelId,
             // Pass through env-supplied label; read path falls back to the
@@ -269,7 +295,7 @@ export function initSystemModelProviderKeys(rawOverride?: unknown[]): void {
             providerId: validCredential.providerId,
             apiShape,
             baseUrl,
-            modelId: validM.modelId,
+            modelId: upstreamModelId,
             apiKey: validCredential.apiKey,
             credentialId: validCredential.id,
             input: validM.input ?? null,

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -448,11 +448,19 @@ async function finalizeRunImpl(input: FinalizeRunInput): Promise<void> {
   //     row, the other is a no-op via ON CONFLICT DO NOTHING — no
   //     pre-check needed.
   if (typeof result.cost === "number" && result.cost > 0) {
-    await writeRunnerLedgerRow({ orgId: run.orgId, applicationId: run.applicationId }, run.id, {
-      cost: result.cost,
-      usage: validatedUsage,
-      modelSource: run.modelSource,
-    });
+    await writeRunnerLedgerRow(
+      { orgId: run.orgId, applicationId: run.applicationId },
+      run.id,
+      {
+        cost: result.cost,
+        usage: validatedUsage,
+        modelSource: run.modelSource,
+      },
+      // Do not settle the run until its authoritative cumulative snapshot is
+      // directly visible. The Cloud cursor claims a runner row once by serial
+      // id and cannot safely observe a later asynchronous update to that id.
+      { required: true },
+    );
   }
 
   const cost = await computeRunCost(run.id, run.orgId);

--- a/apps/api/src/services/run-launcher/appstrate-event-sink.ts
+++ b/apps/api/src/services/run-launcher/appstrate-event-sink.ts
@@ -56,7 +56,8 @@ import type { RunResult } from "@appstrate/afps-runtime/runner";
 import { isPlainObject } from "@appstrate/core/safe-json";
 import { db, type Db } from "@appstrate/db/client";
 import type { UsageRecordedParams } from "@appstrate/core/module";
-import { recordLlmUsage, type CredentialSource } from "../llm-usage-ledger.ts";
+import { type CredentialSource } from "../llm-usage-ledger.ts";
+import { recordLlmUsageReliably } from "../llm-usage-retry.ts";
 import type { AppScope } from "../../lib/scope.ts";
 import { appendRunLog, updateRun } from "../state/runs.ts";
 import { logger } from "../../lib/logger.ts";
@@ -257,8 +258,9 @@ export async function persistRunEvent(
       // cumulative running totals on each metric event, so concurrent
       // writers (a later metric event, the finalize-time fallback)
       // UPSERT the row with monotonic-max semantics. The ledger write
-      // is best-effort by its own contract (see writeRunnerLedgerRow's
-      // try/catch) so it never aborts the surrounding transaction.
+      // falls back to the durable usage-retry queue. The surrounding
+      // transaction aborts only if both Postgres and that queue are
+      // unavailable, so billable usage is never silently discarded.
       if (opts.writeLedger) {
         await writeRunnerLedgerRow(
           scope,
@@ -375,8 +377,8 @@ function resolveLogLevel(value: unknown): "debug" | "info" | "warn" | "error" | 
  *   - reorder is safe — the highest-seen total wins regardless of arrival
  *     order
  *
- * Best-effort: metric persistence MUST NOT fail the ingestion path.
- * Errors are logged.
+ * A failed direct metric write is handed to the durable usage-retry queue. The
+ * ingestion path only fails when both persistence channels are unavailable.
  *
  * `opts.executor` writes inside the ingestion transaction; `opts.deferEmit`
  * (paired with it) collects the `onUsageRecorded` event so the ingestion layer
@@ -401,6 +403,13 @@ export async function writeRunnerLedgerRow(
      * by the transactional metric path so the broadcast happens post-commit.
      */
     deferEmit?: (event: UsageRecordedParams) => void;
+    /**
+     * Finalization barrier: require the terminal cumulative snapshot to be in
+     * Postgres before the run becomes settled. Cloud claims a runner row by its
+     * existing serial id, so asynchronously updating it after settlement could
+     * otherwise strand the final delta.
+     */
+    required?: boolean;
   } = {},
 ): Promise<void> {
   // Skip degenerate events with neither usage nor cost — nothing to bill
@@ -411,9 +420,7 @@ export async function writeRunnerLedgerRow(
     // The single ledger writer performs the monotonic upsert against the
     // partial unique index (highest cumulative total wins) and broadcasts
     // `onUsageRecorded` (deferred to post-commit when `deferEmit` is set).
-    // Best-effort by contract: metric persistence MUST NOT fail the ingestion
-    // path, so errors are logged, never rethrown.
-    await recordLlmUsage(
+    await recordLlmUsageReliably(
       {
         source: "runner",
         orgId: scope.orgId,
@@ -425,13 +432,19 @@ export async function writeRunnerLedgerRow(
         cacheWriteTokens: row.usage?.cache_creation_input_tokens ?? null,
         costUsd: row.cost ?? 0,
       },
-      { executor: opts.executor, onConflict: "runner-monotonic", deferEmit: opts.deferEmit },
+      {
+        executor: opts.executor,
+        onConflict: "runner-monotonic",
+        deferEmit: opts.deferEmit,
+        required: opts.required,
+      },
     );
   } catch (err) {
     logger.error("Failed to write runner ledger row", {
       runId,
       error: getErrorMessage(err),
     });
+    throw err;
   }
 }
 

--- a/apps/api/src/services/run-preflight-gates.ts
+++ b/apps/api/src/services/run-preflight-gates.ts
@@ -170,7 +170,10 @@ export async function runPreflightGates(input: PreflightGatesInput): Promise<Pre
       orgId,
       context: "run",
       packageId: agent.id,
-      runningCount,
+      // The DB count is observed before this run is inserted. Admission needs
+      // the projected in-flight count INCLUDING the run being considered;
+      // otherwise the first run of an org is checked with a zero-cost estimate.
+      runningCount: runningCount + 1,
     });
     beforeUsageHookMs = Date.now() - hookStart;
     if (rejection) {

--- a/apps/api/src/services/state/runs.ts
+++ b/apps/api/src/services/state/runs.ts
@@ -749,6 +749,8 @@ export async function getRunAttribution(
   runId: string,
 ): Promise<{
   id: string;
+  packageId: string | null;
+  status: RunStatus;
   applicationId: string;
   userId: string | null;
   endUserId: string | null;
@@ -757,6 +759,8 @@ export async function getRunAttribution(
   const [row] = await db
     .select({
       id: runs.id,
+      packageId: runs.packageId,
+      status: runs.status,
       applicationId: runs.applicationId,
       userId: runs.userId,
       endUserId: runs.endUserId,

--- a/apps/api/src/services/system-proxy-admission.ts
+++ b/apps/api/src/services/system-proxy-admission.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Admission gate for platform-paid calls that enter through `/api/llm-proxy`.
+ *
+ * Platform-origin runs and chat turns are gated before launch, but a remote run
+ * chooses its model later on its own host. The proxy is therefore the first
+ * place that can know the remote call resolved to a system preset. This seam
+ * applies the module `beforeUsage` hook immediately before the upstream
+ * request, using only server-validated context. First-party chat already owns
+ * that hook at turn admission; its signed loopback context is validated here
+ * without dispatching the hook a second time.
+ */
+
+import type { ResolvedModel } from "./org-models.ts";
+import { getRunningRunCountForOrg } from "./state/runs.ts";
+import { callHook, hasHook } from "../lib/modules/module-loader.ts";
+import { ApiError } from "../lib/errors.ts";
+
+export type SystemProxyUsageContext =
+  { context: "run"; packageId: string } | { context: "chat"; sessionId: string | null } | null;
+
+export async function enforceSystemProxyAdmission(args: {
+  orgId: string;
+  resolved: ResolvedModel;
+  usageContext: SystemProxyUsageContext;
+}): Promise<void> {
+  // BYOK/API-key presets spend the org's own credential, and OSS deployments
+  // may intentionally expose system presets without a billing module.
+  if (!args.resolved.isSystemModel || !hasHook("beforeUsage")) return;
+
+  // A platform-paid raw proxy call must belong to a validated product surface:
+  // X-Run-Id for an agent, or the signed first-party loopback identity for
+  // chat. Refusing an unattributed system call prevents a headless API key from
+  // bypassing the run/chat quota gates while still allowing BYOK proxy calls.
+  if (!args.usageContext) {
+    throw new ApiError({
+      status: 400,
+      code: "usage_context_required",
+      title: "Usage Context Required",
+      detail:
+        "Platform-provided model calls must include a valid X-Run-Id or originate from the first-party chat loopback.",
+    });
+  }
+
+  // `gateChatUsage` already called `beforeUsage` once for this exact turn
+  // before minting the inference loopback token. Calling it again here would
+  // duplicate hook side effects and quota reads. The signed loopback identity
+  // is still load-bearing: it is what distinguishes chat from an unattributed
+  // raw proxy call.
+  if (args.usageContext.context === "chat") return;
+
+  const params = {
+    orgId: args.orgId,
+    context: "run" as const,
+    packageId: args.usageContext.packageId,
+    // The referenced run already exists and the route verified that it is
+    // active, so the DB count normally includes it. Keep a floor of one
+    // against a status/count race.
+    runningCount: Math.max(1, await getRunningRunCountForOrg({ orgId: args.orgId })),
+  };
+
+  const rejection = await callHook("beforeUsage", params);
+  if (!rejection) return;
+
+  throw new ApiError({
+    status: rejection.status ?? 403,
+    code: rejection.code,
+    title: rejection.status === 402 ? "Payment Required" : "Usage Rejected",
+    detail: rejection.message,
+  });
+}

--- a/apps/api/test/integration/routes/llm-proxy-system-admission.test.ts
+++ b/apps/api/test/integration/routes/llm-proxy-system-admission.test.ts
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * System-model proxy path: remote runs only discover their model at inference
+ * time, so `/api/llm-proxy` must gate the resolved system preset before
+ * upstream spend. The same path also forces OpenAI-compatible streaming usage
+ * on the wire and stamps the resulting ledger row as platform-paid.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@appstrate/db/client";
+import { llmUsage } from "@appstrate/db/schema";
+import type {
+  AppstrateModule,
+  BeforeUsageParams,
+  ModuleInitContext,
+  UsageRejection,
+} from "@appstrate/core/module";
+import { getTestApp } from "../../helpers/app.ts";
+import { truncateAll } from "../../helpers/db.ts";
+import { flushRedis } from "../../helpers/redis.ts";
+import { createTestContext, type TestContext } from "../../helpers/auth.ts";
+import { seedApiKey, seedPackage, seedRun } from "../../helpers/seed.ts";
+import { updateRun } from "../../../src/services/state/runs.ts";
+import {
+  getSystemModels,
+  initSystemModelProviderKeys,
+} from "../../../src/services/model-registry.ts";
+import { seedTestModelProviders } from "../../helpers/model-providers.ts";
+import { loadModulesFromInstances, resetModules } from "../../../src/lib/modules/module-loader.ts";
+
+const app = getTestApp();
+const SYSTEM_PRESET = "system-proxy-test";
+
+function fakeInitCtx(): ModuleInitContext {
+  return {
+    redisUrl: null,
+    appUrl: "http://localhost:3000",
+    getSendMail: async () => () => {},
+    getOrgAdminEmails: async () => [],
+    services: {} as ModuleInitContext["services"],
+  };
+}
+
+function gateModule(result: UsageRejection | null, calls: BeforeUsageParams[]): AppstrateModule {
+  return {
+    manifest: { id: "system-proxy-gate", name: "System Proxy Gate", version: "0.0.0" },
+    async init() {},
+    hooks: {
+      beforeUsage: async (params) => {
+        calls.push(params);
+        return result;
+      },
+    },
+  };
+}
+
+interface Harness {
+  ctx: TestContext;
+  apiKey: string;
+  runId: string;
+}
+
+async function buildHarness(): Promise<Harness> {
+  const ctx = await createTestContext({ orgSlug: "system-proxy-admission" });
+  const key = await seedApiKey({
+    orgId: ctx.orgId,
+    applicationId: ctx.defaultAppId,
+    createdBy: ctx.user.id,
+    scopes: ["llm-proxy:call"],
+  });
+  const pkg = await seedPackage({
+    id: "@system/proxy-agent",
+    orgId: ctx.orgId,
+    type: "agent",
+  });
+  const run = await seedRun({
+    packageId: pkg.id,
+    orgId: ctx.orgId,
+    applicationId: ctx.defaultAppId,
+    status: "running",
+  });
+  return { ctx, apiKey: key.rawKey, runId: run.id };
+}
+
+function headers(h: Harness, withRun = true): Record<string, string> {
+  return {
+    authorization: `Bearer ${h.apiKey}`,
+    "x-org-id": h.ctx.orgId,
+    "x-application-id": h.ctx.defaultAppId,
+    "content-type": "application/json",
+    ...(withRun ? { "x-run-id": h.runId } : {}),
+  };
+}
+
+let originalFetch: typeof fetch;
+
+describe("POST /api/llm-proxy — system admission and streaming usage", () => {
+  beforeEach(async () => {
+    await truncateAll();
+    await flushRedis();
+    resetModules();
+    seedTestModelProviders();
+    initSystemModelProviderKeys([
+      {
+        id: "system-proxy-key",
+        providerId: "test-apikey",
+        baseUrlOverride: "https://api.openai.test/v1",
+        apiKey: "sk-system-test",
+        models: [
+          {
+            id: SYSTEM_PRESET,
+            modelId: "upstream-system-model",
+            cost: { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 },
+          },
+        ],
+      },
+    ]);
+    expect(getSystemModels().has(SYSTEM_PRESET)).toBe(true);
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    resetModules();
+    initSystemModelProviderKeys([]);
+    seedTestModelProviders();
+  });
+
+  it("returns the module's 402 for a remote run before any upstream request", async () => {
+    const h = await buildHarness();
+    const calls: BeforeUsageParams[] = [];
+    await loadModulesFromInstances(
+      [
+        gateModule(
+          { code: "quota_exceeded", message: "Credit quota exceeded", status: 402 },
+          calls,
+        ),
+      ],
+      fakeInitCtx(),
+    );
+
+    let upstreamHit = false;
+    globalThis.fetch = (async () => {
+      upstreamHit = true;
+      return new Response("must not be called", { status: 599 });
+    }) as unknown as typeof fetch;
+
+    const res = await app.request("/api/llm-proxy/openai-completions/v1/chat/completions", {
+      method: "POST",
+      headers: headers(h),
+      body: JSON.stringify({
+        model: SYSTEM_PRESET,
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+
+    expect(res.status).toBe(402);
+    expect(upstreamHit).toBe(false);
+    expect(calls).toEqual([
+      {
+        orgId: h.ctx.orgId,
+        context: "run",
+        packageId: "@system/proxy-agent",
+        runningCount: 1,
+      },
+    ]);
+  });
+
+  it("refuses an unattributed raw system call while leaving BYOK semantics untouched", async () => {
+    const h = await buildHarness();
+    await loadModulesFromInstances([gateModule(null, [])], fakeInitCtx());
+
+    let upstreamHit = false;
+    globalThis.fetch = (async () => {
+      upstreamHit = true;
+      return new Response("must not be called", { status: 599 });
+    }) as unknown as typeof fetch;
+
+    const res = await app.request("/api/llm-proxy/openai-completions/v1/chat/completions", {
+      method: "POST",
+      headers: headers(h, false),
+      body: JSON.stringify({
+        model: SYSTEM_PRESET,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect((await res.json()) as { code: string }).toMatchObject({
+      code: "usage_context_required",
+    });
+    expect(upstreamHit).toBe(false);
+  });
+
+  it("refuses to reuse a terminal run as a system-model billing context", async () => {
+    const h = await buildHarness();
+    await loadModulesFromInstances([gateModule(null, [])], fakeInitCtx());
+    await updateRun({ orgId: h.ctx.orgId, applicationId: h.ctx.defaultAppId }, h.runId, {
+      status: "success",
+    });
+
+    let upstreamHit = false;
+    globalThis.fetch = (async () => {
+      upstreamHit = true;
+      return new Response("must not be called", { status: 599 });
+    }) as unknown as typeof fetch;
+
+    const res = await app.request("/api/llm-proxy/openai-completions/v1/chat/completions", {
+      method: "POST",
+      headers: headers(h),
+      body: JSON.stringify({
+        model: SYSTEM_PRESET,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(upstreamHit).toBe(false);
+  });
+
+  it("forces include_usage and records an allowed remote system stream", async () => {
+    const h = await buildHarness();
+    const calls: BeforeUsageParams[] = [];
+    await loadModulesFromInstances([gateModule(null, calls)], fakeInitCtx());
+
+    let forwardedBody: Record<string, unknown> | null = null;
+    globalThis.fetch = (async (_input, init) => {
+      forwardedBody = JSON.parse(new TextDecoder().decode(init?.body as Uint8Array)) as Record<
+        string,
+        unknown
+      >;
+      const sse =
+        `data: {"id":"c1","object":"chat.completion.chunk","model":"upstream-system-model","choices":[{"index":0,"delta":{"content":"ok"},"finish_reason":null}]}\n\n` +
+        `data: {"id":"c1","object":"chat.completion.chunk","model":"upstream-system-model","choices":[],"usage":{"prompt_tokens":12,"completion_tokens":4,"total_tokens":16}}\n\n` +
+        `data: [DONE]\n\n`;
+      return new Response(sse, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    }) as typeof fetch;
+
+    const res = await app.request("/api/llm-proxy/openai-completions/v1/chat/completions", {
+      method: "POST",
+      headers: headers(h),
+      body: JSON.stringify({
+        model: SYSTEM_PRESET,
+        stream: true,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    await res.text();
+    expect(forwardedBody).toMatchObject({
+      model: "upstream-system-model",
+      stream_options: { include_usage: true },
+    });
+    expect(calls).toHaveLength(1);
+
+    const deadline = Date.now() + 1_000;
+    let row: typeof llmUsage.$inferSelect | undefined;
+    while (Date.now() < deadline) {
+      [row] = await db.select().from(llmUsage).where(eq(llmUsage.runId, h.runId)).limit(1);
+      if (row) break;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    expect(row).toBeDefined();
+    expect(row!.credentialSource).toBe("system");
+    expect(row!.inputTokens).toBe(12);
+    expect(row!.outputTokens).toBe(4);
+  });
+});

--- a/apps/api/test/integration/services/llm-usage-ledger.test.ts
+++ b/apps/api/test/integration/services/llm-usage-ledger.test.ts
@@ -121,6 +121,30 @@ describe("recordLlmUsage — plain insert (proxy / chat)", () => {
     expect(row!.runId).toBeNull();
   });
 
+  it("replays a proxy retry idempotently when request_id already committed", async () => {
+    const entry = {
+      source: "proxy" as const,
+      orgId: ctx.orgId,
+      userId: ctx.user.id,
+      credentialSource: "system" as const,
+      inputTokens: 12,
+      outputTokens: 4,
+      costUsd: 0.002,
+      requestId: "req_durable_retry",
+    };
+
+    const first = await recordLlmUsage(entry, { onConflict: "proxy-idempotent" });
+    const replay = await recordLlmUsage(entry, { onConflict: "proxy-idempotent" });
+
+    expect(typeof first).toBe("number");
+    expect(replay).toBeNull();
+    const rows = await db
+      .select()
+      .from(llmUsage)
+      .where(eq(llmUsage.requestId, "req_durable_retry"));
+    expect(rows).toHaveLength(1);
+  });
+
   it("rejects a row attributed to BOTH a run and a chat session (llm_usage_context_single)", async () => {
     await seedAgent({ id: "@ledgerwriter/agent", orgId: ctx.orgId, createdBy: ctx.user.id });
     const run = await seedRun({

--- a/apps/api/test/integration/services/run-preflight-gates.test.ts
+++ b/apps/api/test/integration/services/run-preflight-gates.test.ts
@@ -157,7 +157,14 @@ describe("runPreflightGates — beforeUsage model-source gating", () => {
     }
     // Dispatched with the run discriminant (not the chat shape).
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toMatchObject({ orgId: ctx.orgId, context: "run", packageId: "@gates/agent" });
+    expect(calls[0]).toMatchObject({
+      orgId: ctx.orgId,
+      context: "run",
+      packageId: "@gates/agent",
+      // No run existed in the DB, but the hook receives the projected count
+      // including the run currently being admitted.
+      runningCount: 1,
+    });
   });
 
   it("does NOT dispatch the hook for an org-owned (BYOK) model", async () => {

--- a/apps/api/test/unit/services/model-registry-upstream-migration.test.ts
+++ b/apps/api/test/unit/services/model-registry-upstream-migration.test.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterAll, describe, expect, it } from "bun:test";
+import {
+  getSystemModels,
+  initSystemModelProviderKeys,
+} from "../../../src/services/model-registry.ts";
+import { seedTestModelProviders } from "../../helpers/model-providers.ts";
+
+describe("initSystemModelProviderKeys — deprecated upstream migration", () => {
+  afterAll(() => {
+    initSystemModelProviderKeys([]);
+    seedTestModelProviders();
+  });
+
+  it("keeps the public preset stable while routing DeepSeek chat to v4 flash", () => {
+    seedTestModelProviders();
+    initSystemModelProviderKeys([
+      {
+        id: "deepseek-system",
+        providerId: "deepseek",
+        apiKey: "sk-system",
+        models: [
+          {
+            id: "appstrate-medium",
+            modelId: "deepseek-chat",
+            label: "Appstrate Medium",
+            aliased: true,
+          },
+        ],
+      },
+    ]);
+
+    const model = getSystemModels().get("appstrate-medium");
+    expect(model).toBeDefined();
+    expect(model!.id).toBe("appstrate-medium");
+    expect(model!.modelId).toBe("deepseek-v4-flash");
+    expect(model!.aliased).toBe(true);
+  });
+
+  it("does not rewrite the same model id for a custom/BYOK-compatible provider", () => {
+    seedTestModelProviders();
+    initSystemModelProviderKeys([
+      {
+        id: "custom-system",
+        providerId: "test-apikey",
+        apiKey: "sk-system",
+        models: [{ id: "legacy-compatible", modelId: "deepseek-chat" }],
+      },
+    ]);
+
+    expect(getSystemModels().get("legacy-compatible")!.modelId).toBe("deepseek-chat");
+  });
+});

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -893,9 +893,11 @@ export interface AuthStrategy {
 
 /**
  * Parameters passed to the `beforeUsage` hook — a discriminated union over the
- * usage surface. `run` carries the agent package id and the org's current
- * running-run count (so a module can apply concurrency-aware admission); `chat`
- * carries the session id (null for an ephemeral turn with no persisted session).
+ * usage surface. `run` carries the agent package id and the projected in-flight
+ * count INCLUDING the run being admitted (so a module can apply
+ * concurrency-aware admission without treating the first run as zero cost);
+ * `chat` carries the session id (null for an ephemeral turn with no persisted
+ * session).
  */
 export type BeforeUsageParams =
   | { orgId: string; context: "run"; packageId: string; runningCount: number }

--- a/packages/module-chat/src/llm.ts
+++ b/packages/module-chat/src/llm.ts
@@ -149,6 +149,11 @@ export function modelFromFamily(
         apiKey: "proxy",
         headers,
         fetch: fetchImpl,
+        // OpenAI-compatible providers only include token counters in the
+        // terminal SSE frame when explicitly requested. Without this flag a
+        // successful built-in chat turn can stream normally while the proxy
+        // has no usage object to persist or bill.
+        includeUsage: true,
       })(model.id);
   }
 }

--- a/packages/module-chat/test/chat-stream-handler.test.ts
+++ b/packages/module-chat/test/chat-stream-handler.test.ts
@@ -160,7 +160,10 @@ function openAiSse(): Response {
 }
 
 interface DispatchCapture {
-  inferenceBody: { messages?: Array<{ role: string; content: unknown }> } | null;
+  inferenceBody: {
+    messages?: Array<{ role: string; content: unknown }>;
+    stream_options?: { include_usage?: boolean };
+  } | null;
   inferenceUrl: string | null;
 }
 
@@ -280,6 +283,10 @@ describe("handleChatStream (ai-sdk path)", () => {
     expect(res.capture.inferenceUrl).toContain(
       "/api/llm-proxy/openai-completions/v1/chat/completions",
     );
+    // Streaming usage is opt-in on OpenAI-compatible APIs. This field is
+    // load-bearing for the built-in-model billing path: the proxy can only
+    // write the chat's llm_usage row when the terminal SSE frame has usage.
+    expect(body?.stream_options).toEqual({ include_usage: true });
     expect(body?.messages?.[0]?.role).toBe("system");
     const systemContent = String(body?.messages?.[0]?.content ?? "");
     expect(systemContent).toContain(SYSTEM_PROMPT.slice(0, 64));


### PR DESCRIPTION
## Summary
- force streaming usage collection for built-in chat and proxy calls
- gate remote system-model calls and reject missing or terminal run attribution
- make llm_usage persistence durable and idempotent, with a final-run persistence barrier
- include the admitted run in quota estimates
- keep DeepSeek system presets working through the supported upstream model

## Validation
- bun run check: 33/33 tasks
- focused chat, proxy, admission, ledger and run-finalization suites pass
- Cloud-compatible system/BYOK attribution behavior covered
- git diff --check