### PR TITLE
test: align MCP E2E tool list

### DIFF
--- a/e2e/tests/mcp/mcp.api.spec.ts
+++ b/e2e/tests/mcp/mcp.api.spec.ts
@@ -133,6 +133,7 @@ test.describe("MCP over an API key (full stack)", () => {
       "describe_operation",
       "get_me",
       "invoke_operation",
+      "list_documents",
       "run_and_wait",
       "search_operations",
     ]);


### PR DESCRIPTION
## Summary
- include the existing list_documents MCP tool in the full-stack tools/list expectation
- fixes the deterministic post-merge E2E failure on main

## Validation
- targeted MCP Playwright test: 1 pass
- bun run check: 33/33 tasks

The e2e label is applied so the previously failing full suite runs before merge.