### PR TITLE
fix(agents): validate model id in agent model setter

### DIFF
--- a/apps/api/src/openapi/paths/agents.ts
+++ b/apps/api/src/openapi/paths/agents.ts
@@ -524,7 +524,7 @@ export const agentsPaths = {
       tags: ["Agents"],
       summary: "Set agent model override",
       description:
-        "Set a model override for this agent. Pass a model ID or null to revert to org default.",
+        "Set a model override for this agent. Pass a model ID or null to revert to org default. The model ID must name a system model preset or an org model owned by the organization — unknown or cross-org IDs are rejected with 404.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -225,10 +225,7 @@ export function createAgentsRouter() {
       const scope = getAppScope(c);
       const data = await readJsonBody(c, modelIdSchema);
 
-      // Reject unknown or cross-org model ids up front (#960) — same contract
-      // as explicit run/schedule overrides. `null` stays valid to clear the
-      // override; the resolveModel() fallback remains only for references
-      // that go stale after being written.
+      // Reject unknown/cross-org ids like run and schedule overrides do (#960); null clears.
       await assertExplicitModelExists(scope.orgId, data.modelId);
 
       await updateInstalledPackage(scope, agent.id, { modelId: data.modelId });

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -35,6 +35,7 @@ import { readJsonBody } from "../lib/request-body.ts";
 import { asJSONSchemaObject, mergeWithDefaults } from "@appstrate/core/form";
 import { getAppScope } from "../lib/scope.ts";
 import { resolveAgentConnectionReadiness } from "../services/integration-pins-service.ts";
+import { assertExplicitModelExists } from "../services/org-models.ts";
 import {
   buildBundleForAgentExport,
   buildBundleFromAgentDraft,
@@ -223,6 +224,12 @@ export function createAgentsRouter() {
       const agent = c.get("package");
       const scope = getAppScope(c);
       const data = await readJsonBody(c, modelIdSchema);
+
+      // Reject unknown or cross-org model ids up front (#960) — same contract
+      // as explicit run/schedule overrides. `null` stays valid to clear the
+      // override; the resolveModel() fallback remains only for references
+      // that go stale after being written.
+      await assertExplicitModelExists(scope.orgId, data.modelId);
 
       await updateInstalledPackage(scope, agent.id, { modelId: data.modelId });
 

--- a/apps/api/test/integration/routes/agents.test.ts
+++ b/apps/api/test/integration/routes/agents.test.ts
@@ -1,11 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, beforeEach } from "bun:test";
+import { describe, it, expect, beforeEach, beforeAll, afterAll } from "bun:test";
 import { and, eq } from "drizzle-orm";
 import { getTestApp } from "../../helpers/app.ts";
 import { db, truncateAll } from "../../helpers/db.ts";
 import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
-import { seedAgent, seedRun, seedApplication } from "../../helpers/seed.ts";
+import {
+  seedAgent,
+  seedRun,
+  seedApplication,
+  seedOrgModel,
+  seedOrgModelProviderKey,
+} from "../../helpers/seed.ts";
+import {
+  getSystemModels,
+  initSystemModelProviderKeys,
+} from "../../../src/services/model-registry.ts";
 import { installPackage } from "../../../src/services/application-packages.ts";
 import { createVersionFromDraft } from "../../../src/services/package-versions.ts";
 import { assertDbCount } from "../../helpers/assertions.ts";
@@ -760,33 +770,101 @@ describe("Agents API", () => {
   });
 
   describe("PUT /api/agents/:scope/:name/model", () => {
-    it("returns the bare model-setting resource (same shape as GET)", async () => {
+    const SYSTEM_PRESET = "system-agent-model-test";
+
+    beforeAll(() => {
+      initSystemModelProviderKeys([
+        {
+          id: "system-agent-model-key",
+          providerId: "test-apikey",
+          baseUrlOverride: "https://api.openai.test/v1",
+          apiKey: "sk-system-test",
+          models: [{ id: SYSTEM_PRESET, modelId: "upstream-system-model" }],
+        },
+      ]);
+      expect(getSystemModels().has(SYSTEM_PRESET)).toBe(true);
+    });
+
+    afterAll(() => {
+      // Restore the env-derived (empty) baseline for the rest of the run.
+      initSystemModelProviderKeys();
+    });
+
+    async function seedModelAgent() {
       await seedInstalledAgent({
         id: "@myorg/model-agent",
         orgId: ctx.orgId,
         createdBy: ctx.user.id,
         applicationId: ctx.defaultAppId,
       });
+    }
 
-      const res = await app.request("/api/agents/@myorg/model-agent/model", {
+    function putModel(modelId: string | null, headers = authHeaders(ctx)) {
+      return app.request("/api/agents/@myorg/model-agent/model", {
         method: "PUT",
-        headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ modelId: "model-123" }),
+        headers: { ...headers, "Content-Type": "application/json" },
+        body: JSON.stringify({ modelId }),
       });
+    }
+
+    it("returns the bare model-setting resource (same shape as GET)", async () => {
+      await seedModelAgent();
+      const key = await seedOrgModelProviderKey({ orgId: ctx.orgId });
+      const model = await seedOrgModel({ orgId: ctx.orgId, credentialId: key.id });
+
+      const res = await putModel(model.id);
       expect(res.status).toBe(200);
       const body = (await res.json()) as { modelId: string | null } & Record<string, unknown>;
       // Bare model-setting resource — no `success` scrap (#657).
-      expect(body.modelId).toBe("model-123");
+      expect(body.modelId).toBe(model.id);
       expect("success" in body).toBe(false);
 
       // Reverting to org default returns the null resource, not a stub.
-      const revert = await app.request("/api/agents/@myorg/model-agent/model", {
-        method: "PUT",
-        headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
-        body: JSON.stringify({ modelId: null }),
-      });
+      const revert = await putModel(null);
+      expect(revert.status).toBe(200);
       const revertBody = (await revert.json()) as { modelId: string | null };
       expect(revertBody.modelId).toBeNull();
+    });
+
+    it("accepts a system model preset id", async () => {
+      await seedModelAgent();
+
+      const res = await putModel(SYSTEM_PRESET);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { modelId: string | null };
+      expect(body.modelId).toBe(SYSTEM_PRESET);
+    });
+
+    it("rejects an unknown model id with 404 and does not persist it (#960)", async () => {
+      await seedModelAgent();
+
+      const res = await putModel("raw-upstream-model-name");
+      expect(res.status).toBe(404);
+
+      const get = await app.request("/api/agents/@myorg/model-agent/model", {
+        headers: authHeaders(ctx),
+      });
+      const body = (await get.json()) as { modelId: string | null };
+      expect(body.modelId).toBeNull();
+    });
+
+    it("rejects a model UUID owned by another org (#960)", async () => {
+      await seedModelAgent();
+      const otherCtx = await createTestContext({ orgSlug: "otherorg" });
+      const otherKey = await seedOrgModelProviderKey({ orgId: otherCtx.orgId });
+      const otherModel = await seedOrgModel({
+        orgId: otherCtx.orgId,
+        credentialId: otherKey.id,
+      });
+
+      const res = await putModel(otherModel.id);
+      expect(res.status).toBe(404);
+
+      const get = await app.request("/api/agents/@myorg/model-agent/model", {
+        headers: authHeaders(ctx),
+      });
+      const body = (await get.json()) as { modelId: string | null };
+      expect(body.modelId).toBeNull();
     });
   });
 });

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -253,7 +253,7 @@ export interface paths {
         get: operations["getAgentModel"];
         /**
          * Set agent model override
-         * @description Set a model override for this agent. Pass a model ID or null to revert to org default.
+         * @description Set a model override for this agent. Pass a model ID or null to revert to org default. The model ID must name a system model preset or an org model owned by the organization — unknown or cross-org IDs are rejected with 404.
          */
         put: operations["setAgentModel"];
         post?: never;


### PR DESCRIPTION
## Summary

`PUT /api/agents/{scope}/{name}/model` accepted and persisted any non-empty string as the agent model override. At run time, `resolveModel()` treated the unknown stored id as stale and silently fell back to the org default (then the system default), so the agent could execute a different model — and credential source — than the one its configuration endpoint reported.

This PR calls `assertExplicitModelExists(orgId, modelId)` in the setter before persisting, the same contract already enforced for explicit run overrides (`routes/runs.ts`, `runs-remote.ts`, `inline-run.ts`) and schedule overrides (`routes/schedules.ts`). The agent model setter was the only override surface without this validation.

## Behavior

- Unknown/raw upstream model id → `404` (nothing persisted)
- Model UUID owned by another org → `404` (nothing persisted; `loadModel` filters by `orgId`)
- Valid system model preset id → accepted
- Valid enabled org-model UUID → accepted
- `null` → still valid, clears the override
- The run-time `resolveModel()` fallback is unchanged — it remains as resilience for references that become stale *after* configuration (e.g. a model row deleted later)

## Changes

- `apps/api/src/routes/agents.ts` — validate before `updateInstalledPackage()`
- `apps/api/test/integration/routes/agents.test.ts` — route-level tests for the five cases above (existing happy-path test now seeds a real org model instead of a raw string)
- `apps/api/src/openapi/paths/agents.ts` — description documents the 404 contract (response was already declared)
- `apps/web/src/api/schema.d.ts` — regenerated

## Testing

- `bun test apps/api/test/integration/routes/agents.test.ts` — 32 pass
- `bun run check` — green (only pre-existing module-chat fast-refresh warnings)

Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)