### PR TITLE
feat(admission): quote-based usage admission for zero-cost BYOK and future compute accounting (deploy cloud module first)

### DIFF
--- a/apps/api/src/modules/README.md
+++ b/apps/api/src/modules/README.md
@@ -206,10 +206,22 @@ Full design: `docs/architecture/OBSERVABILITY.md`.
 
 ## Hooks and events
 
-- **Hooks** (`callHook`, first-match-wins): `beforeUsage`, `afterRun`, `beforeSignup`. The first module that provides a hook is called, subsequent modules are skipped. `beforeUsage` gates metered LLM usage on a surface — a discriminated union over `run` (agent run) and `chat` (chat turn); `afterRun` returns a metadata patch persisted on the final run record, `beforeSignup` gates signup.
+- **Hooks** (`callHook`, first-match-wins): `beforeUsage`, `afterRun`, `beforeSignup`. The first module that provides a hook is called, subsequent modules are skipped. `beforeUsage` is the admission gate over LLM usage — a discriminated union over `run` (agent run) and `chat` (chat turn), detailed below; `afterRun` returns a metadata patch persisted on the final run record, `beforeSignup` gates signup.
 - **Events** (`emitEvent`, broadcast-to-all): `onRunStatusChange`, `onOrgCreate`, `onOrgDelete`. Handlers run for side effects only; errors in one handler are isolated and do not block others.
 
 Names are defined in `packages/core/src/module.ts` (`ModuleHooks`, `ModuleEvents`). To add a new hook or event, update that file first so both platform and modules see the same contract.
+
+### `beforeUsage` — admission (core 4.1.0+)
+
+The hook is dispatched for **every** run and **every** chat turn, not for a subset the platform pre-selected. Each dispatch carries neutral execution facts, and the module turns them into a decision:
+
+- **`credentialSource`** — whose credential is spent on inference: `"system"` (platform-supplied credential or system model preset), `"org"` (the organization's own BYOK key or OAuth subscription), or — `run` only — `null` when a remote-origin run resolves its model later on its own host (any inference it then routes through the system model proxy is admitted at that seam instead).
+- **`executionPlane`** — whose compute runs the work: `"platform"` (a sandbox the platform operates, or its own chat process — always the case for `chat`) or `"remote"` (caller-supplied host).
+- **`timeoutSeconds`** (`run` only) — the effective post-ceiling upper bound on platform compute occupancy, or `null` at a seam that does not own the run's compute and must therefore contribute nothing for it (NOT "unknown, assume the worst" — that double-counts).
+
+**Deciding that an operation consumes nothing is the module's job**, not the platform's. The platform used to skip the hook whenever the organization brought its own credential; that assumption breaks as soon as platform compute is accounted for, since a BYOK run still occupies a platform-operated sandbox. A module that only cares about platform-supplied inference reproduces the old outcome by returning `null` when `credentialSource !== "system"`.
+
+An operation the organization supplies entirely by itself — `credentialSource !== "system"` **and** `executionPlane !== "platform"`, i.e. a remote BYOK run — should be short-circuited with `null` before the handler reads any of its own state (no DB round-trip, no account lookup): there is nothing for the platform to account for.
 
 ## Auth strategies
 

--- a/apps/api/src/routes/llm-proxy.ts
+++ b/apps/api/src/routes/llm-proxy.ts
@@ -209,7 +209,11 @@ async function handleProxy(
         context: "run",
         packageId: runAttribution.packageId!,
         runOrigin: runAttribution.runOrigin,
-        modelSource: runAttribution.modelSource,
+        // Persisted `runs.model_source` — the run's credential source under its
+        // older column name. The admission seam reads it to tell a run whose
+        // model component was already quoted at preflight from one that was
+        // quoted at zero (and could otherwise launder system inference).
+        credentialSource: runAttribution.modelSource,
       } as const)
     : c.get("firstPartyLoopback")
       ? ({ context: "chat", sessionId: chatSessionId } as const)

--- a/apps/api/src/services/chat-subscription.ts
+++ b/apps/api/src/services/chat-subscription.ts
@@ -167,11 +167,20 @@ export async function recordChatUsage(record: ChatUsageRecord): Promise<void> {
  * Chat admission gate — the chat-surface entry into the `beforeUsage` hook.
  *
  * The chat module calls this for its non-subscription (built-in / API-key)
- * branch before starting a turn. The gate decides system-provided vs. org-owned
- * SERVER-SIDE (`isSystemModel` on the chosen preset) so the module stays dumb:
- *   - org's own API-key model → never gated (returns null immediately);
- *   - system-provided model → dispatch `beforeUsage` (chat context). A rejection
- *     flows back for the module to surface as an RFC 9457 problem response.
+ * branch before starting a turn. The gate resolves system-provided vs. org-owned
+ * SERVER-SIDE (`isSystemModel` on the chosen preset) so the chat module stays
+ * dumb — it has no model-registry access — but that resolution is REPORTED as
+ * the `credentialSource` fact, not used to pre-filter:
+ *
+ *   - every turn dispatches `beforeUsage` (chat context) with
+ *     `credentialSource` + `executionPlane`; a rejection flows back for the
+ *     module to surface as an RFC 9457 problem response.
+ *   - a turn on the org's own credential reports `credentialSource: "org"`. The
+ *     platform no longer declares it free and skips the hook: a chat turn always
+ *     runs inside the platform's own process, so the platform funds its compute
+ *     even when it funds no inference. A module that meters only
+ *     platform-supplied inference quotes that turn at zero and admits it — same
+ *     outcome as the old early return, but decided by the module.
  *
  * Returns null when no module provides the hook (OSS mode allows everything).
  */
@@ -180,13 +189,18 @@ export async function checkUsageAllowed(args: {
   presetId: string;
   sessionId: string | null;
 }): Promise<UsageRejection | null> {
-  // An org's own model spends the org's own credential — never platform-metered.
-  if (!isSystemModel(args.presetId)) return null;
   if (!hasHook("beforeUsage")) return null;
   const rejection = await callHook("beforeUsage", {
     orgId: args.orgId,
     context: "chat",
     sessionId: args.sessionId,
+    // A chat turn resolves its model on the platform before admission, so the
+    // credential source is always determinable here (never `null`, unlike a
+    // remote-origin run).
+    credentialSource: isSystemModel(args.presetId) ? "system" : "org",
+    // A turn executes in the platform's own process — never on a
+    // caller-supplied host.
+    executionPlane: "platform",
   });
   return rejection ?? null;
 }

--- a/apps/api/src/services/run-creation.ts
+++ b/apps/api/src/services/run-creation.ts
@@ -139,19 +139,29 @@ export async function createRun(input: CreateRunInput): Promise<CreateRunResult>
   // --- Shared preflight: rate, concurrency, timeout cap, beforeUsage hook.
   //     Single source of truth across platform / remote / scheduled origins.
   //
-  //     `modelSource: null` — a remote-origin run resolves NO platform model at
-  //     creation (the runner executes on its own host with its own model +
-  //     credentials; `runs.model_source` stays NULL — see the createRunRow
-  //     comment below). So the run-surface `beforeUsage` hook is skipped: it is
-  //     not cheaply determinable here whether the run will route inference
-  //     through the system proxy, and any inference that does is metered
-  //     per-call on the proxy rows (`credential_source:"system"`), which carry
-  //     the platform attribution. Gating a remote run's OWN-credential
-  //     inference here would be the spurious-402 bug on the remote path.
+  //     The hook is NOT skipped on this path — it is dispatched with the facts
+  //     that describe a remote run, and the module decides:
+  //
+  //     `credentialSource: null` — a remote-origin run resolves NO platform
+  //     model at creation (the runner executes on its own host with its own
+  //     model + credentials; `runs.model_source` stays NULL — see the
+  //     createRunRow comment below), so the credential that will pay for
+  //     inference is genuinely unknown here and the model component is
+  //     unquotable. Any inference the run DOES route through the platform's
+  //     system proxy is admitted at that seam (`system-proxy-admission.ts`),
+  //     where the source is known, and metered per-call on the proxy rows
+  //     (`credential_source:"system"`).
+  //
+  //     `executionPlane: "remote"` — the caller supplies the host, so the
+  //     platform funds no compute and the compute component is zero. Together
+  //     the two facts describe a fully self-funded operation, which is what a
+  //     module short-circuits instead of the platform pre-classifying it as
+  //     free (that pre-classification was the old spurious-402 workaround).
   const gates = await runPreflightGates({
     orgId,
     agent: input.agent,
-    modelSource: null,
+    credentialSource: null,
+    executionPlane: "remote",
   });
   if (!gates.ok) return { ok: false, error: gates.error };
   const { agent } = gates;

--- a/apps/api/src/services/run-pipeline.ts
+++ b/apps/api/src/services/run-pipeline.ts
@@ -322,21 +322,21 @@ export async function prepareAndExecuteRun(params: RunPipelineParams): Promise<R
   // the ~1.75 s pre-createRun pipeline is decomposable in prod without a tracer.
   const pipelineStart = Date.now();
   const spanAttributes = { "appstrate.run.id": runId, "appstrate.org.id": orgId };
-  // --- Step 0: Resolve the model source for the admission gate ---
+  // --- Step 0: Resolve the credential source reported to the admission gate ---
   //
-  // The `beforeUsage` gate must fire ONLY for platform-provided models — an org
-  // running its own credential (BYOK / OAuth subscription) spends no platform
-  // credit and must not be blocked by a cloud credit cap (the spurious-402
-  // bug). Resolve the same model `buildRunContext` will (Step 3) — cheap: system
-  // models are in-memory and DB rows are short-TTL cached, so the later
-  // resolution is a cache hit. `modelId` is the effective preset (per-run
+  // The `beforeUsage` gate fires for EVERY run; this resolution does not decide
+  // whether it fires, it supplies the fact the module quotes the MODEL
+  // component against (platform-supplied credential vs. the org's own BYOK /
+  // OAuth credential). Resolve the same model `buildRunContext` will (Step 3) —
+  // cheap: system models are in-memory and DB rows are short-TTL cached, so the
+  // later resolution is a cache hit. `modelId` is the effective preset (per-run
   // override folded in by the route/scheduler/inline callers), matching the
   // `params.modelId ?? config.modelId` cascade buildRunContext applies. A run
-  // with no resolvable model (`null`) fails downstream with
-  // `ModelNotConfiguredError`; treating it as non-system here just skips a gate
-  // that would never matter.
+  // with no resolvable model reports `null` and then fails downstream with
+  // `ModelNotConfiguredError` — it never reaches inference, so an unquotable
+  // model component costs nothing.
   const gateModel = await resolveModel(orgId, params.agent.id, modelId ?? null);
-  const modelSourceForGate: "system" | "org" | null = gateModel
+  const credentialSourceForGate: "system" | "org" | null = gateModel
     ? gateModel.isSystemModel
       ? "system"
       : "org"
@@ -350,7 +350,11 @@ export async function prepareAndExecuteRun(params: RunPipelineParams): Promise<R
     runPreflightGates({
       orgId,
       agent: params.agent,
-      modelSource: modelSourceForGate,
+      credentialSource: credentialSourceForGate,
+      // This pipeline launches the run inside platform-operated isolation (a
+      // sandbox container / microVM), so the platform funds its compute
+      // whatever credential the model uses.
+      executionPlane: "platform",
     }),
   );
   const gatesMs = Date.now() - gatesStart;

--- a/apps/api/src/services/run-preflight-gates.ts
+++ b/apps/api/src/services/run-preflight-gates.ts
@@ -6,11 +6,12 @@
  *
  *   1. Per-org rate limit (Redis token bucket).
  *   2. Per-org concurrency cap.
- *   3. `beforeUsage` module hook (admission policies — usage caps, feature
- *      gates) — run surface.
- *   4. Timeout ceiling — agent manifest's `timeout` capped to the platform
+ *   3. Timeout ceiling — agent manifest's `timeout` capped to the platform
  *      limit. Returns a cloned agent when a cap is applied so callers pass
  *      the capped value into the container env without mutating the DB.
+ *   4. `beforeUsage` module hook (admission policies — usage caps, feature
+ *      gates) — run surface. Runs last of the four so it is told the EFFECTIVE
+ *      (post-ceiling) timeout and the observed in-flight count.
  *
  * Why a dedicated module: platform (`run-pipeline.prepareAndExecuteRun`)
  * and remote (`run-creation.createRun`) used to duplicate all the
@@ -30,27 +31,45 @@ export interface PreflightGatesInput {
   orgId: string;
   agent: LoadedPackage;
   /**
-   * Where the run's resolved model comes from, decided SERVER-SIDE by the
-   * caller (platform pipeline: `resolveModel(...).isSystemModel`; remote: never
-   * resolves a platform model → `null`). Governs the `beforeUsage` admission
-   * hook: it fires ONLY for a platform-provided (`"system"`) model — the same
-   * rule the chat surface applies (`checkUsageAllowed` → `isSystemModel`).
+   * Whose credential pays for the inference this run performs, decided
+   * SERVER-SIDE by the caller (platform pipeline: `resolveModel(...)
+   * .isSystemModel`; remote: never resolves a platform model → `null`).
    *
-   *   - `"system"` → platform credential is spent → dispatch `beforeUsage` so a
-   *     metering module (cloud) can enforce credit caps.
-   *   - `"org"` → the org spends its OWN credential (BYOK / OAuth subscription)
-   *     → never platform-metered → skip the hook (spending a run gate here is
-   *     the spurious-402 bug this guards against).
+   * This is a FACT reported to `beforeUsage`, NOT a decision about whether the
+   * hook fires — the hook fires on every run. A module reads it to quote the
+   * MODEL component of the operation:
+   *
+   *   - `"system"` → a platform-supplied credential is spent (a
+   *     `SYSTEM_PROVIDER_KEYS` entry / system preset). The platform funds the
+   *     model component.
+   *   - `"org"` → the org spends its OWN credential (BYOK API key or OAuth
+   *     subscription). The platform funds no model component — a module that
+   *     only meters platform-supplied inference quotes zero here, which is what
+   *     keeps a BYOK run from taking a spurious 402.
    *   - `null` → a remote-origin run resolves no platform model at creation
    *     (the runner executes on its own host with its own model + credentials),
-   *     so it is not cheaply determinable whether it will route inference
-   *     through the system proxy. We skip the run-surface hook; any system-proxy
-   *     inference a remote run does make is metered per-call on the proxy rows
-   *     (`credential_source:"system"`), which carry the attribution.
-   *   - `undefined` → unresolved (no caller currently omits it) → treated as
-   *     non-system → skip.
+   *     so the fact is genuinely not determinable here. Not a coverage gap: any
+   *     inference such a run later routes through the platform's system proxy
+   *     is admitted at the proxy seam (`system-proxy-admission.ts`), where the
+   *     credential source IS known, and metered per-call on the proxy ledger
+   *     rows (`credential_source:"system"`).
+   *
+   * Naming: matches the `llm_usage.credential_source` ledger column a metering
+   * module reconciles against. The `runs.model_source` DB column is the same
+   * concept under an older, persisted name — deliberately not renamed.
    */
-  modelSource?: "system" | "org" | null;
+  credentialSource: "system" | "org" | null;
+  /**
+   * Whose compute runs the work — the other neutral fact `beforeUsage` quotes
+   * against. `"platform"` for a run executing in platform-operated isolation (a
+   * sandbox container / microVM), `"remote"` when the caller supplies the host
+   * and the platform contributes no compute.
+   *
+   * Reported separately from {@link credentialSource} because the two are
+   * independent: a BYOK run can still occupy platform compute, and a
+   * platform-credential run can execute on a caller-supplied host.
+   */
+  executionPlane: "platform" | "remote";
 }
 
 /** Per-sub-gate wall-clock timings (ms), surfaced for the pipeline timing log. */
@@ -147,9 +166,13 @@ export async function runPreflightGates(input: PreflightGatesInput): Promise<Pre
     };
   }
 
-  // 3. Timeout ceiling — applied before `beforeUsage` so module code sees
-  //    the effective timeout (e.g. for pre-charging cost estimation).
+  // 3. Timeout ceiling — applied BEFORE `beforeUsage` (and computed here, not
+  //    after) so the hook is told the run's EFFECTIVE compute bound, not the
+  //    manifest's wish. An agent declaring a timeout above the platform ceiling
+  //    can never occupy compute for longer than the ceiling, so quoting it on
+  //    the declared value would over-charge.
   const declaredTimeout = typeof agent.manifest.timeout === "number" ? agent.manifest.timeout : 300;
+  const effectiveTimeoutSeconds = Math.min(declaredTimeout, platformLimits.timeout_ceiling_seconds);
   if (declaredTimeout > platformLimits.timeout_ceiling_seconds) {
     agent = {
       ...agent,
@@ -157,14 +180,26 @@ export async function runPreflightGates(input: PreflightGatesInput): Promise<Pre
     };
   }
 
-  // 4. `beforeUsage` module hook (run surface) — ONLY for platform-provided
-  //    ("system") models. A run on the org's OWN model (BYOK / OAuth
-  //    subscription) or a remote-origin run (own host + credentials) spends no
-  //    platform credit, so gating it here is the spurious-402 the model-source
-  //    check prevents. Mirrors the chat surface (`checkUsageAllowed`). See
-  //    `PreflightGatesInput.modelSource` for the full per-value rationale.
+  // 4. `beforeUsage` module hook (run surface) — dispatched for EVERY run,
+  //    whatever its credential source or execution plane.
+  //
+  //    The platform used to decide here that a non-`"system"` model was free
+  //    and skip the hook entirely. That hard-coded "BYOK ⇒ free", which is only
+  //    true while platform compute is unbilled: a BYOK run on the platform
+  //    plane still occupies a sandbox the platform pays for. So the platform
+  //    now reports neutral FACTS — who funds the credential
+  //    (`credentialSource`), who funds the compute (`executionPlane`), and the
+  //    upper bound on that compute (`timeoutSeconds`) — and the module quotes
+  //    the operation and decides. A module that only meters platform-supplied
+  //    inference simply quotes zero for a BYOK run, which is what keeps the
+  //    spurious-402 fixed without the platform pre-classifying anything.
+  //
+  //    Cost of dispatching unconditionally: a module now sees runs it may quote
+  //    at zero. That is deliberate — it is the module's job to short-circuit a
+  //    fully self-funded operation (neither platform credential nor platform
+  //    compute) before it reads any billing state.
   let beforeUsageHookMs = 0;
-  if (input.modelSource === "system" && hasHook("beforeUsage")) {
+  if (hasHook("beforeUsage")) {
     const hookStart = Date.now();
     const rejection = await callHook("beforeUsage", {
       orgId,
@@ -174,6 +209,12 @@ export async function runPreflightGates(input: PreflightGatesInput): Promise<Pre
       // the projected in-flight count INCLUDING the run being considered;
       // otherwise the first run of an org is checked with a zero-cost estimate.
       runningCount: runningCount + 1,
+      credentialSource: input.credentialSource,
+      executionPlane: input.executionPlane,
+      // Post-ceiling: the real upper bound on platform compute time. A run
+      // admitted here always owns its compute quote — the proxy seam passes
+      // `null` precisely so it does not quote this same run's compute twice.
+      timeoutSeconds: effectiveTimeoutSeconds,
     });
     beforeUsageHookMs = Date.now() - hookStart;
     if (rejection) {

--- a/apps/api/src/services/system-proxy-admission.ts
+++ b/apps/api/src/services/system-proxy-admission.ts
@@ -3,13 +3,15 @@
 /**
  * Admission gate for platform-paid calls that enter through `/api/llm-proxy`.
  *
- * Platform-origin runs using a system model and chat turns are gated before
- * launch, but a remote run chooses its model later on its own host. The proxy
- * is therefore the first place that can know the remote call resolved to a
- * system preset. This seam applies the module `beforeUsage` hook immediately
- * before the upstream request, using only server-validated context. First-party
- * chat already owns that hook at turn admission; its signed loopback context
- * is validated here without dispatching the hook a second time.
+ * Runs and chat turns are admitted before launch, but only a call whose MODEL
+ * component was quoted there is covered: a remote run chooses its model later
+ * on its own host, and a platform BYOK run was quoted with no model component
+ * at all. The proxy is the first place that can know either of those resolved
+ * to a platform-supplied system preset, so this seam applies the module
+ * `beforeUsage` hook immediately before the upstream request, using only
+ * server-validated context. First-party chat already owns that hook at turn
+ * admission; its signed loopback context is validated here without dispatching
+ * the hook a second time.
  */
 
 import type { ResolvedModel } from "./org-models.ts";
@@ -22,7 +24,13 @@ export type SystemProxyUsageContext =
       context: "run";
       packageId: string;
       runOrigin: "platform" | "remote";
-      modelSource: string | null;
+      /**
+       * The referenced run's persisted credential source — the raw
+       * `runs.model_source` column value (same concept, older persisted name;
+       * the column is deliberately not renamed). Used ONLY to decide whether
+       * this run's MODEL component was already quoted at preflight.
+       */
+      credentialSource: string | null;
     }
   | { context: "chat"; sessionId: string | null }
   | null;
@@ -57,19 +65,27 @@ export async function enforceSystemProxyAdmission(args: {
   // raw proxy call.
   if (args.usageContext.context === "chat") return;
 
-  // A platform-origin run on a SYSTEM model was already admitted once at
-  // preflight (run-preflight-gates.ts). Its per-call proxy usage stays
-  // attributed, but re-dispatching the hook here would gate the same run twice
-  // and duplicate quota reads on every LLM call.
+  // Was this run's MODEL component already quoted when the run was admitted?
   //
-  // `runOrigin === "platform"` alone is NOT proof of prior admission: BYOK
-  // platform runs (`modelSource === "org"`) and legacy/unresolved rows
-  // (`modelSource === null`) deliberately skipped the system-usage hook. If one
-  // of those run ids is later attached to a raw system-preset proxy request, it
-  // must be admitted here just like a remote run. Otherwise an llm-proxy caller
-  // could use an active BYOK run as a billing context to bypass a quota rejection.
+  // Every platform run is now admitted at preflight (run-preflight-gates.ts) —
+  // the hook fires whatever the run's credential source. But it is admitted
+  // with THAT run's facts, and only a `"system"` run reported a
+  // platform-supplied credential, i.e. only a `"system"` run had a MODEL
+  // component quoted. Re-dispatching for it here would gate the same
+  // platform-supplied inference twice and duplicate quota reads on every LLM
+  // call, so it returns early.
+  //
+  // A platform BYOK run (`credentialSource === "org"`) or a legacy/unresolved
+  // row (`null`) was quoted with a ZERO model component — correctly, since its
+  // own inference spends the org's credential. That makes it a bypass vector:
+  // an llm-proxy caller can attach such a run id to a raw SYSTEM-preset request
+  // and launder platform-funded inference through a run that was quoted at
+  // zero, defeating a quota rejection. Those runs must therefore be admitted
+  // here, exactly like a remote run. The expression is unchanged from when the
+  // platform skipped the hook for non-system runs — but it now means "was the
+  // model component already quoted", not "did the hook already run".
   const admittedAtPreflight =
-    args.usageContext.runOrigin === "platform" && args.usageContext.modelSource === "system";
+    args.usageContext.runOrigin === "platform" && args.usageContext.credentialSource === "system";
   if (admittedAtPreflight) return;
 
   const params = {
@@ -80,6 +96,19 @@ export async function enforceSystemProxyAdmission(args: {
     // active, so the DB count normally includes it. Keep a floor of one
     // against a status/count race.
     runningCount: Math.max(1, await getRunningRunCountForOrg({ orgId: args.orgId })),
+    // This seam only runs for a resolved SYSTEM preset (`resolved.isSystemModel`
+    // is checked above), so the call being admitted is platform-funded
+    // inference by construction — whatever credential the RUN itself declared.
+    credentialSource: "system" as const,
+    executionPlane:
+      args.usageContext.runOrigin === "platform" ? ("platform" as const) : ("remote" as const),
+    // Not determinable at this seam — the proxy holds no agent manifest — and
+    // deliberately not faked. `null` means "contribute no compute component
+    // here": this seam admits the inference of an ALREADY-RUNNING run whose
+    // compute was either quoted at its own preflight (platform plane) or is not
+    // platform-funded at all (remote plane). Passing a guessed duration, or `0`
+    // as a sentinel, would double-count that same run's compute.
+    timeoutSeconds: null,
   };
 
   const rejection = await callHook("beforeUsage", params);

--- a/apps/api/test/integration/routes/llm-proxy-system-admission.test.ts
+++ b/apps/api/test/integration/routes/llm-proxy-system-admission.test.ts
@@ -29,6 +29,7 @@ import {
 } from "../../../src/services/model-registry.ts";
 import { seedTestModelProviders } from "../../helpers/model-providers.ts";
 import { loadModulesFromInstances, resetModules } from "../../../src/lib/modules/module-loader.ts";
+import { mintLoopbackToken } from "../../../../../packages/module-chat/src/loopback-auth.ts";
 
 const app = getTestApp();
 const SYSTEM_PRESET = "system-proxy-test";
@@ -171,14 +172,24 @@ describe("POST /api/llm-proxy — system admission and streaming usage", () => {
         context: "run",
         packageId: "@system/proxy-agent",
         runningCount: 1,
+        // The seam only runs for a resolved system preset, so the call being
+        // admitted is platform-funded inference whatever the run declared.
+        credentialSource: "system",
+        // Remote origin — the platform funds no compute for this run.
+        executionPlane: "remote",
+        // The proxy holds no manifest: "contribute no compute component here",
+        // never a guessed duration (which would double-count).
+        timeoutSeconds: null,
       },
     ]);
   });
 
-  it("does not re-dispatch beforeUsage for a platform-origin run (already gated at preflight)", async () => {
+  it("does not re-dispatch beforeUsage for a platform-origin SYSTEM run (model component already quoted at preflight)", async () => {
     // Same rejecting module as the remote-run 402 test — but the run is
-    // platform-origin, so the proxy admission must NOT gate it a second time:
-    // the call reaches upstream and the hook records zero dispatches.
+    // platform-origin AND system-credential, so its MODEL component was already
+    // quoted when the run was admitted. Re-dispatching would gate the same
+    // platform-supplied inference twice: the call reaches upstream and the hook
+    // records zero dispatches.
     const h = await buildHarness();
     const platformRun = await seedRun({
       packageId: "@system/proxy-agent",
@@ -228,7 +239,15 @@ describe("POST /api/llm-proxy — system admission and streaming usage", () => {
     expect(calls).toHaveLength(0);
   });
 
-  it("dispatches beforeUsage for platform runs that were not system-admitted at preflight", async () => {
+  it("dispatches beforeUsage for platform runs whose model component was quoted at zero (BYOK-run-as-billing-context bypass)", async () => {
+    // THE bypass this seam defends against: a platform BYOK run (or a
+    // legacy/unresolved row) was admitted at preflight with a ZERO model
+    // component — correct, since its own inference spends the org's credential.
+    // Attaching that active run id to a raw SYSTEM-preset proxy request would
+    // otherwise launder platform-funded inference through a run quoted at zero
+    // and defeat a quota rejection. Both must be admitted here, like a remote
+    // run. (The `admittedAtPreflight` expression is unchanged by the
+    // fact-reporting refactor, but its justification is now this one.)
     const h = await buildHarness();
     const byokRun = await seedRun({
       packageId: "@system/proxy-agent",
@@ -276,20 +295,82 @@ describe("POST /api/llm-proxy — system admission and streaming usage", () => {
     }
 
     expect(upstreamHits).toBe(0);
-    expect(calls).toEqual([
+    // Platform origin → `executionPlane: "platform"`, but `timeoutSeconds: null`
+    // so the module quotes NO compute component here: that run's compute was
+    // already quoted at its own preflight.
+    const expectedCall: BeforeUsageParams = {
+      orgId: h.ctx.orgId,
+      context: "run",
+      packageId: "@system/proxy-agent",
+      runningCount: 3,
+      credentialSource: "system",
+      executionPlane: "platform",
+      timeoutSeconds: null,
+    };
+    expect(calls).toEqual([expectedCall, expectedCall]);
+  });
+
+  it("does not re-dispatch beforeUsage for a first-party chat loopback call (already admitted at turn start)", async () => {
+    // The chat surface owns the hook at turn admission (`checkUsageAllowed`),
+    // which now fires for every turn — system or org credential. The signed
+    // loopback identity is still load-bearing here (it is what distinguishes
+    // chat from an unattributed raw proxy call), but dispatching again would
+    // gate the same turn twice.
+    const h = await buildHarness();
+    const calls: BeforeUsageParams[] = [];
+    await loadModulesFromInstances(
+      [
+        gateModule(
+          { code: "quota_exceeded", message: "Credit quota exceeded", status: 402 },
+          calls,
+        ),
+      ],
+      fakeInitCtx(),
+    );
+
+    let upstreamHit = false;
+    globalThis.fetch = (async () => {
+      upstreamHit = true;
+      return new Response(
+        JSON.stringify({
+          id: "c1",
+          object: "chat.completion",
+          model: "upstream-system-model",
+          choices: [{ index: 0, message: { role: "assistant", content: "ok" } }],
+          usage: { prompt_tokens: 3, completion_tokens: 1, total_tokens: 4 },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as unknown as typeof fetch;
+
+    const loopback = mintLoopbackToken(
       {
+        userId: h.ctx.user.id,
+        email: h.ctx.user.email ?? "u@test",
+        name: h.ctx.user.name ?? "U",
         orgId: h.ctx.orgId,
-        context: "run",
-        packageId: "@system/proxy-agent",
-        runningCount: 3,
+        orgRole: "owner",
       },
-      {
-        orgId: h.ctx.orgId,
-        context: "run",
-        packageId: "@system/proxy-agent",
-        runningCount: 3,
+      { chatSessionId: "chs_loopback" },
+    );
+
+    const res = await app.request("/api/llm-proxy/openai-completions/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${loopback}`,
+        "x-org-id": h.ctx.orgId,
+        "x-application-id": h.ctx.defaultAppId,
+        "content-type": "application/json",
       },
-    ]);
+      body: JSON.stringify({
+        model: SYSTEM_PRESET,
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(upstreamHit).toBe(true);
+    expect(calls).toHaveLength(0);
   });
 
   it("refuses an unattributed raw system call while leaving BYOK semantics untouched", async () => {

--- a/apps/api/test/integration/services/run-preflight-gates.test.ts
+++ b/apps/api/test/integration/services/run-preflight-gates.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect, beforeEach, afterAll } from "bun:test";
 import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
-import { seedPackage } from "../../helpers/seed.ts";
+import { seedPackage, seedRun } from "../../helpers/seed.ts";
 import { runPreflightGates } from "../../../src/services/run-preflight-gates.ts";
 import { getPlatformRunLimits } from "../../../src/services/run-limits.ts";
 import { loadModulesFromInstances, resetModules } from "../../../src/lib/modules/module-loader.ts";
@@ -44,8 +44,16 @@ describe("runPreflightGates", () => {
 
   beforeEach(async () => {
     await truncateAll();
+    // No module → no `beforeUsage` hook. These cases assert the non-hook gates,
+    // and the hook now fires for every run, so a module leaked in by an earlier
+    // file would otherwise perturb `beforeUsageHookMs`.
+    resetModules();
     ctx = await createTestContext({ email: "gates@test.dev", orgSlug: "gates" });
     await seedPackage({ orgId: ctx.orgId, id: "@gates/agent", type: "agent" });
+  });
+
+  afterAll(() => {
+    resetModules();
   });
 
   it("returns ok with an untouched agent when the manifest timeout is below the ceiling", async () => {
@@ -53,6 +61,8 @@ describe("runPreflightGates", () => {
     const res = await runPreflightGates({
       orgId: ctx.orgId,
       agent,
+      credentialSource: "system",
+      executionPlane: "platform",
     });
     expect(res.ok).toBe(true);
     if (res.ok) expect(res.agent.manifest.timeout).toBe(60);
@@ -63,6 +73,8 @@ describe("runPreflightGates", () => {
     const res = await runPreflightGates({
       orgId: ctx.orgId,
       agent,
+      credentialSource: "system",
+      executionPlane: "platform",
     });
     expect(res.ok).toBe(true);
     if (res.ok) {
@@ -81,6 +93,8 @@ describe("runPreflightGates", () => {
     const res = await runPreflightGates({
       orgId: ctx.orgId,
       agent,
+      credentialSource: "system",
+      executionPlane: "platform",
     });
     expect(res.ok).toBe(true);
     if (res.ok) {
@@ -93,12 +107,16 @@ describe("runPreflightGates", () => {
 });
 
 /**
- * `beforeUsage` model-source gating (fix: BYOK/OAuth/remote runs must NOT hit
- * the credit-cap gate). The hook fires ONLY for a platform-provided (`"system"`)
- * model — the same rule the chat surface applies. A metering module (cloud)
- * relies on these branches, so a regression that gated an org's own model — or
- * failed to gate a system one — surfaces here rather than as a billing/402
- * incident.
+ * `beforeUsage` execution-fact reporting. The hook fires for EVERY run — the
+ * platform stopped deciding that a non-system model is free and skipping it
+ * (that hard-coded "BYOK ⇒ free", which stops being true the moment platform
+ * compute is billed). It now reports neutral facts — `credentialSource`,
+ * `executionPlane`, and the EFFECTIVE post-ceiling `timeoutSeconds` — and a
+ * metering module (cloud) quotes them.
+ *
+ * These assertions pin the facts a module quotes against: dropping one, or
+ * reporting a pre-ceiling timeout, would silently over- or under-charge rather
+ * than fail loudly.
  */
 function fakeInitCtx(): ModuleInitContext {
   return {
@@ -124,7 +142,7 @@ function gateModule(result: UsageRejection | null, calls: BeforeUsageParams[]): 
   };
 }
 
-describe("runPreflightGates — beforeUsage model-source gating", () => {
+describe("runPreflightGates — beforeUsage execution facts", () => {
   let ctx: TestContext;
 
   beforeEach(async () => {
@@ -148,7 +166,8 @@ describe("runPreflightGates — beforeUsage model-source gating", () => {
     const res = await runPreflightGates({
       orgId: ctx.orgId,
       agent: loadedPackage("@gates/agent", 60),
-      modelSource: "system",
+      credentialSource: "system",
+      executionPlane: "platform",
     });
 
     expect(res.ok).toBe(false);
@@ -157,58 +176,144 @@ describe("runPreflightGates — beforeUsage model-source gating", () => {
     }
     // Dispatched with the run discriminant (not the chat shape).
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toMatchObject({
+    expect(calls[0]).toEqual({
       orgId: ctx.orgId,
       context: "run",
       packageId: "@gates/agent",
       // No run existed in the DB, but the hook receives the projected count
       // including the run currently being admitted.
       runningCount: 1,
+      credentialSource: "system",
+      executionPlane: "platform",
+      timeoutSeconds: 60,
     });
   });
 
-  it("does NOT dispatch the hook for an org-owned (BYOK) model", async () => {
+  it("dispatches the hook for an org-owned (BYOK) platform run with credentialSource 'org'", async () => {
+    // Reversal of the old topology: a BYOK run is no longer declared free by
+    // the platform. It occupies platform compute, so the module is told the
+    // facts and quotes it (a model-only meter quotes zero and admits).
     const calls: BeforeUsageParams[] = [];
-    await loadModulesFromInstances(
-      // Even a rejecting metering module must not block an org's own credential.
-      [gateModule({ code: "over_cap", message: "blocked", status: 402 }, calls)],
-      fakeInitCtx(),
-    );
+    await loadModulesFromInstances([gateModule(null, calls)], fakeInitCtx());
 
     const res = await runPreflightGates({
       orgId: ctx.orgId,
       agent: loadedPackage("@gates/agent", 60),
-      modelSource: "org",
+      credentialSource: "org",
+      executionPlane: "platform",
     });
 
     expect(res.ok).toBe(true);
-    if (res.ok) expect(res.timings.beforeUsageHookMs).toBe(0);
-    expect(calls).toHaveLength(0);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      orgId: ctx.orgId,
+      context: "run",
+      packageId: "@gates/agent",
+      runningCount: 1,
+      credentialSource: "org",
+      executionPlane: "platform",
+      timeoutSeconds: 60,
+    });
   });
 
-  it("does NOT dispatch the hook for a remote-origin run (modelSource null)", async () => {
+  it("dispatches the hook for a remote-origin run (credentialSource null, remote plane)", async () => {
     const calls: BeforeUsageParams[] = [];
-    await loadModulesFromInstances(
-      [gateModule({ code: "over_cap", message: "blocked", status: 402 }, calls)],
-      fakeInitCtx(),
-    );
+    await loadModulesFromInstances([gateModule(null, calls)], fakeInitCtx());
 
     const res = await runPreflightGates({
       orgId: ctx.orgId,
       agent: loadedPackage("@gates/agent", 60),
-      modelSource: null,
+      credentialSource: null,
+      executionPlane: "remote",
     });
 
     expect(res.ok).toBe(true);
-    expect(calls).toHaveLength(0);
+    expect(calls).toHaveLength(1);
+    // Neither platform credential nor platform compute — the two facts that let
+    // a module short-circuit a fully self-funded run before any billing read.
+    expect(calls[0]).toEqual({
+      orgId: ctx.orgId,
+      context: "run",
+      packageId: "@gates/agent",
+      runningCount: 1,
+      credentialSource: null,
+      executionPlane: "remote",
+      timeoutSeconds: 60,
+    });
+  });
+
+  it("reports the POST-ceiling timeout when the manifest declares more than the platform allows", async () => {
+    // The cap is applied before the hook: quoting compute on the declared value
+    // would charge for time the run can never occupy.
+    const limits = getPlatformRunLimits();
+    const calls: BeforeUsageParams[] = [];
+    await loadModulesFromInstances([gateModule(null, calls)], fakeInitCtx());
+
+    const res = await runPreflightGates({
+      orgId: ctx.orgId,
+      agent: loadedPackage("@gates/agent", limits.timeout_ceiling_seconds + 600),
+      credentialSource: "system",
+      executionPlane: "platform",
+    });
+
+    expect(res.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect((calls[0] as { timeoutSeconds: number | null }).timeoutSeconds).toBe(
+      limits.timeout_ceiling_seconds,
+    );
+  });
+
+  it("reports the default timeout when the manifest declares none", async () => {
+    const calls: BeforeUsageParams[] = [];
+    await loadModulesFromInstances([gateModule(null, calls)], fakeInitCtx());
+
+    const res = await runPreflightGates({
+      orgId: ctx.orgId,
+      agent: loadedPackage("@gates/agent"),
+      credentialSource: "system",
+      executionPlane: "platform",
+    });
+
+    expect(res.ok).toBe(true);
+    expect((calls[0] as { timeoutSeconds: number | null }).timeoutSeconds).toBe(300);
+  });
+
+  it("reports runningCount as the projected count INCLUDING the run being admitted", async () => {
+    const calls: BeforeUsageParams[] = [];
+    await loadModulesFromInstances([gateModule(null, calls)], fakeInitCtx());
+    // Two runs already in flight → the hook must see 3, not the observed 2.
+    await seedRun({
+      packageId: "@gates/agent",
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      status: "running",
+    });
+    await seedRun({
+      packageId: "@gates/agent",
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      status: "running",
+    });
+
+    const res = await runPreflightGates({
+      orgId: ctx.orgId,
+      agent: loadedPackage("@gates/agent", 60),
+      credentialSource: "system",
+      executionPlane: "platform",
+    });
+
+    expect(res.ok).toBe(true);
+    expect((calls[0] as { runningCount: number }).runningCount).toBe(3);
   });
 
   it("returns ok for a system model when no metering module provides the hook (OSS mode)", async () => {
     const res = await runPreflightGates({
       orgId: ctx.orgId,
       agent: loadedPackage("@gates/agent", 60),
-      modelSource: "system",
+      credentialSource: "system",
+      executionPlane: "platform",
     });
     expect(res.ok).toBe(true);
+    if (res.ok) expect(res.timings.beforeUsageHookMs).toBe(0);
   });
 });

--- a/apps/api/test/unit/modules/module-loader.test.ts
+++ b/apps/api/test/unit/modules/module-loader.test.ts
@@ -206,6 +206,9 @@ describe("module-loader", () => {
         context: "run",
         packageId: "a",
         runningCount: 0,
+        credentialSource: "system",
+        executionPlane: "platform",
+        timeoutSeconds: 300,
       });
       expect(result).toBeUndefined();
     });
@@ -222,6 +225,9 @@ describe("module-loader", () => {
         context: "run",
         packageId: "a",
         runningCount: 0,
+        credentialSource: "system",
+        executionPlane: "platform",
+        timeoutSeconds: 300,
       });
       expect(result).toEqual({ code: "blocked", message: "no" });
       expect(hookA).toHaveBeenCalledTimes(1);

--- a/apps/api/test/unit/services/check-usage-allowed.test.ts
+++ b/apps/api/test/unit/services/check-usage-allowed.test.ts
@@ -4,18 +4,22 @@
  * `checkUsageAllowed` — the chat-surface entry into the unified `beforeUsage`
  * admission hook (`services/chat-subscription.ts`). The chat module calls it for
  * its non-subscription (built-in / API-key) branch before starting a turn. The
- * gate decides system-provided vs. org-owned SERVER-SIDE so the module stays
- * dumb:
+ * gate resolves system-provided vs. org-owned SERVER-SIDE so the chat module
+ * stays dumb, but that resolution is REPORTED, not used to pre-filter:
  *
- *   - an org's own model is never platform-metered → null WITHOUT dispatching
- *     the hook (an org spends its own credential, no gate to run);
- *   - a system-provided model with no metering module → null (OSS allows all);
- *   - a system-provided model with a metering module → the module's rejection
- *     flows straight back (a 402 the route turns into problem+json).
+ *   - every turn dispatches the hook, carrying `credentialSource`
+ *     (`"system"` | `"org"`) and `executionPlane: "platform"` (a chat turn
+ *     always runs in the platform's own process);
+ *   - an org-credential turn is dispatched too — the platform no longer
+ *     declares it free, the module quotes it (typically at zero) and decides;
+ *   - no metering module → null (OSS allows all);
+ *   - a metering module's rejection flows straight back (a 402 the route turns
+ *     into problem+json).
  *
- * These are the exact branches a metering module (cloud) depends on, so a
- * regression that gated an org's own model — or failed to gate a system one —
- * would surface here rather than as a billing incident.
+ * These are the exact facts a metering module (cloud) quotes against, so a
+ * regression that stopped reporting one — or resurrected the old "skip the hook
+ * for an org model" short-circuit — surfaces here rather than as a billing
+ * incident.
  */
 
 import { describe, it, expect, afterAll, beforeEach } from "bun:test";
@@ -81,10 +85,38 @@ describe("checkUsageAllowed", () => {
     seedTestModelProviders();
   });
 
-  it("returns null for an org-owned model WITHOUT dispatching the hook", async () => {
+  it("dispatches the hook for an org-owned model with credentialSource 'org'", async () => {
     // Sanity: the org preset is genuinely not a system model.
     expect(getSystemModels().has("org-preset-123")).toBe(false);
 
+    const calls: BeforeUsageParams[] = [];
+    await loadModulesFromInstances([gateModule(null, calls)], fakeInitCtx());
+
+    const result = await checkUsageAllowed({
+      orgId: "org_1",
+      presetId: "org-preset-123",
+      sessionId: "chs_1",
+    });
+
+    // The platform no longer short-circuits an org-credential turn: it reports
+    // the fact and lets the module quote it. (A metering module that only
+    // meters platform-supplied inference quotes zero and returns null here —
+    // same outcome as the old early return, decided by the module.)
+    expect(result).toBeNull();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      orgId: "org_1",
+      context: "chat",
+      sessionId: "chs_1",
+      credentialSource: "org",
+      executionPlane: "platform",
+    });
+  });
+
+  it("lets a metering module reject an org-owned model turn (platform compute is still platform-funded)", async () => {
+    // The reversal that matters: a rejecting module CAN now block a BYOK chat
+    // turn, because a chat turn always occupies platform compute. Whether it
+    // does is the module's policy — the platform no longer forces "allowed".
     const calls: BeforeUsageParams[] = [];
     await loadModulesFromInstances(
       [gateModule({ code: "over_cap", message: "blocked", status: 402 }, calls)],
@@ -97,10 +129,8 @@ describe("checkUsageAllowed", () => {
       sessionId: "chs_1",
     });
 
-    // Org's own credential is never platform-metered — short-circuits BEFORE the
-    // hook (so even a rejecting metering module can't block it).
-    expect(result).toBeNull();
-    expect(calls).toHaveLength(0);
+    expect(result).toEqual({ code: "over_cap", message: "blocked", status: 402 });
+    expect(calls).toHaveLength(1);
   });
 
   it("returns null for a system model when no metering module provides the hook", async () => {
@@ -127,9 +157,16 @@ describe("checkUsageAllowed", () => {
     });
 
     expect(result).toEqual({ code: "over_cap", message: "Soft cap reached", status: 402 });
-    // Dispatched with the chat discriminant + the session id (not the run shape).
+    // Dispatched with the chat discriminant + the session id (not the run
+    // shape), plus the two execution facts the module quotes against.
     expect(calls).toHaveLength(1);
-    expect(calls[0]).toEqual({ orgId: "org_1", context: "chat", sessionId: "chs_42" });
+    expect(calls[0]).toEqual({
+      orgId: "org_1",
+      context: "chat",
+      sessionId: "chs_42",
+      credentialSource: "system",
+      executionPlane: "platform",
+    });
   });
 
   it("returns null for a system model when the metering module allows the turn", async () => {

--- a/bun.lock
+++ b/bun.lock
@@ -251,7 +251,7 @@
     },
     "packages/core": {
       "name": "@appstrate/core",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dependencies": {
         "@afps-spec/schema": "^0.6.1",
         "@appstrate/afps-shared": "^0.3.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,87 @@ All notable changes to `@appstrate/core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] — 2026-07-25
+
+`beforeUsage` reports neutral execution facts instead of being pre-filtered by
+the platform. Additive — no removals, no breaking changes.
+
+> **Minor, not major.** `BeforeUsageParams` is **widened**: a hook that only
+> READS its params keeps compiling and keeps behaving identically on the
+> operations it already handled. Code that **constructs** the params — module
+> test fakes, essentially — must supply the new fields or it no longer
+> type-checks. The behavioural half of the change (see Changed) reaches every
+> module all the same: a handler is now called for operations the platform used
+> to filter out on its behalf, and must return `null` for the ones it does not
+> account for.
+
+### Added
+
+- **`BeforeUsageParams` carries the operation's execution facts.** Both members
+  of the union gain `credentialSource` and `executionPlane`; the `run` member
+  also gains `timeoutSeconds`. They are FACTS, not verdicts — the module turns
+  them into a policy decision.
+  - **`credentialSource`** — whose credential is spent on inference.
+    `"system"` (a platform-supplied credential: a `SYSTEM_PROVIDER_KEYS` entry
+    or a system model preset), `"org"` (the organization spends its OWN
+    credential — a BYOK API key or a provider subscription it authorized over
+    OAuth), or, on `run` only, `null` when a remote-origin run resolves its
+    model later on its own host. `null` is not a coverage gap: if such a run
+    routes inference through the platform's system model proxy, that seam
+    dispatches its own `beforeUsage` with a `credentialSource` that IS known
+    there. The name matches the `llm_usage.credential_source` ledger column a
+    metering module reconciles against; the `runs.model_source` database column
+    is the same concept under an older, persisted name — deliberately not
+    renamed.
+  - **`executionPlane`** — whose compute runs the work. `"platform"` (a
+    sandboxed container or microVM the platform operates, or the platform's own
+    chat process) or `"remote"` (the caller supplies the host). Always
+    `"platform"` on `chat`, and present rather than omitted there so a module
+    can read the field off either member without first narrowing on `context`.
+    Reported as an axis independent of `credentialSource` on purpose: an
+    organization can spend its own credential and still occupy platform
+    compute, or supply its own host while spending a platform-supplied
+    credential. A module that collapses the two into a single signal mis-admits
+    one of those combinations.
+  - **`timeoutSeconds`** (`run` only) — the run's EFFECTIVE timeout in seconds,
+    i.e. the agent's declared timeout after the platform ceiling has been
+    applied. It is the upper bound on how long the run may occupy platform
+    compute, NOT a prediction of its actual duration. `null` means "contribute
+    nothing for compute here", and is deliberate rather than unknown: the
+    system-proxy seam admits the inference of an ALREADY-RUNNING run whose
+    compute was accounted for when the run itself was admitted (platform
+    plane), or is not platform-supplied at all (remote plane). A consumer must
+    NOT read `null` as "unknown, assume the worst" — that would account for the
+    same run's compute twice. A module that does not account for duration can
+    ignore the field entirely.
+
+### Changed
+
+- **`beforeUsage` is dispatched for EVERY run and EVERY chat turn.** It
+  previously fired only for an operation the platform had already classified as
+  metered — in practice, only when the resolved model came from a
+  platform-supplied credential; an operation on the organization's own
+  credential never reached the hook at all. That classification hard-coded "the
+  organization brings its own credential ⇒ nothing is consumed", which stops
+  holding the moment platform compute is accounted for: such a run still
+  occupies a sandbox the platform operates. The platform now reports the facts
+  and the module applies its own policy — **including the decision that an
+  operation consumes nothing**, which is no longer made on the module's behalf.
+  A module that accounts only for platform-supplied inference reaches the same
+  outcome as before by returning `null` when `credentialSource !== "system"`;
+  one that also accounts for platform compute reads `executionPlane` and
+  `timeoutSeconds`, with no change to this type and no change to where the hook
+  fires. An operation that consumes neither a platform-supplied credential nor
+  platform compute — `credentialSource !== "system"` and
+  `executionPlane !== "platform"` — is the case to short-circuit first.
+- **`PlatformServices.checkUsageAllowed`** — same signature, no pre-filter. The
+  platform still resolves system-provided vs. organization-owned server-side
+  (that is what keeps the chat module dumb — it has no model-registry access),
+  but it now REPORTS the resolution as `credentialSource` instead of using it to
+  decide whether to dispatch. A turn on the organization's own credential is
+  dispatched all the same, because a chat turn always executes in the platform's
+  own process. Subscription turns still never call this.
+
 ## [4.0.0] — 2026-07-21
 
 > **Release ordering.** This release bumps `@appstrate/afps-shared` to
@@ -53,7 +134,9 @@ accessToken)`, the sidecar `/llm` oauth branch's only header policy. Forces the
     union: `{ context: "run"; packageId; runningCount }` and
     `{ context: "chat"; sessionId }` (both carry `orgId`). Same return contract
     as the old gate: `UsageRejection { code, message, status? }` to block, or
-    null to allow. `RunRejection` is renamed to `UsageRejection`.
+    null to allow. `RunRejection` is renamed to `UsageRejection`. _(Params
+    widened in 4.1.0 with `credentialSource` / `executionPlane` /
+    `timeoutSeconds`.)_
   - **`ModuleEvents.onUsageRecorded`** (`UsageRecordedParams`) — broadcast after
     each `llm_usage` ledger row is appended, carrying per-row attribution
     (source, principal, context, credential source, token counts, `costUsd`).
@@ -69,7 +152,10 @@ accessToken)`, the sidecar `/llm` oauth branch's only header policy. Forces the
     Removed). Never projects `real_model` / `api`.
   - **`PlatformServices.checkUsageAllowed`** — chat-surface entry into
     `beforeUsage`; the platform decides system-provided vs. org-owned and only
-    dispatches the hook for a system-provided model.
+    dispatches the hook for a system-provided model. _(Superseded in 4.1.0: the
+    hook is dispatched for every turn and the resolution is reported as the
+    `credentialSource` fact — this describes 4.0.0 behaviour, not current
+    behaviour.)_
   - **`ChatUsageRecord.cost`** — the model's catalog per-token rates; the
     platform seam computes the equivalent USD via the shared `computeTokenCost`
     formula so the chat / proxy / runner producers can't drift.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -898,10 +898,112 @@ export interface AuthStrategy {
  * concurrency-aware admission without treating the first run as zero cost);
  * `chat` carries the session id (null for an ephemeral turn with no persisted
  * session).
+ *
+ * Both surfaces additionally report two neutral execution facts —
+ * `credentialSource` (whose credential is spent on inference) and
+ * `executionPlane` (whose compute runs the work) — and a run also reports the
+ * upper bound on how long it may occupy that compute (`timeoutSeconds`).
+ *
+ * These are FACTS, not verdicts. The platform never classifies an operation as
+ * exempt and skips the hook on its behalf: it dispatches on every metered usage
+ * attempt and lets the module apply its own policy to the reported facts. That
+ * separation is what keeps the contract stable — a module that only cares about
+ * platform-supplied inference simply ignores operations where
+ * `credentialSource !== "system"`, while a module that also accounts for
+ * platform compute reads `executionPlane` and `timeoutSeconds`, with no change
+ * to this type and no change to where the hook fires.
  */
 export type BeforeUsageParams =
-  | { orgId: string; context: "run"; packageId: string; runningCount: number }
-  | { orgId: string; context: "chat"; sessionId: string | null };
+  | {
+      orgId: string;
+      context: "run";
+      packageId: string;
+      runningCount: number;
+      /**
+       * Whose credential is spent on the inference this run performs.
+       *
+       * - `"system"` — a platform-supplied credential is used (a
+       *   `SYSTEM_PROVIDER_KEYS` entry, or a system model preset). The
+       *   organization consumes a resource it does not own.
+       * - `"org"` — the organization spends its OWN credential: a BYOK API key
+       *   it configured, or a provider subscription it authorized over OAuth.
+       *   No platform-supplied credential is consumed for inference.
+       * - `null` — not determinable at admission time. A remote-origin run
+       *   resolves its model later, on its own host, so the platform cannot
+       *   know here which credential it will end up using. This is not a
+       *   coverage gap: if such a run later routes inference through the
+       *   platform's system model proxy, that seam dispatches its own
+       *   `beforeUsage` with a `credentialSource` that IS known there.
+       *
+       * Naming note: this matches the `llm_usage.credential_source` ledger
+       * column, which is what a metering module reconciles a run against after
+       * the fact. The `runs.model_source` database column is the same concept
+       * under an older, persisted name — deliberately not renamed.
+       */
+      credentialSource: "system" | "org" | null;
+      /**
+       * Whose compute runs the work.
+       *
+       * - `"platform"` — the run executes on infrastructure the platform
+       *   operates and is responsible for (a sandboxed container or microVM).
+       * - `"remote"` — the caller supplies the host. The platform orchestrates
+       *   and records the run but contributes no compute of its own.
+       *
+       * Reported separately from `credentialSource` because the two are
+       * genuinely independent: an organization can bring its own credential and
+       * still occupy platform compute, or supply its own host while using a
+       * platform-supplied credential. A module that collapses them into a
+       * single signal will mis-admit one of those combinations.
+       */
+      executionPlane: "platform" | "remote";
+      /**
+       * The upper bound on how long this run may occupy platform compute.
+       *
+       * - a number — the run's EFFECTIVE timeout in seconds: the agent's
+       *   declared timeout after the platform ceiling has been applied. It is a
+       *   ceiling, NOT a prediction of the actual duration; most runs finish
+       *   well before it.
+       * - `null` — not determinable at this admission point, and deliberately
+       *   so: the seam admitting the operation is not the seam that owns its
+       *   compute. Concretely, the system-proxy seam admits the inference of an
+       *   ALREADY-RUNNING run; that run's compute was already accounted for
+       *   when the run itself was admitted (platform plane), or is not
+       *   platform-supplied at all (remote plane). A consumer must therefore
+       *   read `null` as "contribute no compute component here", NOT as
+       *   "unknown, assume the worst" — assuming the worst would account for
+       *   the same run's compute twice.
+       *
+       * Present so a module that accounts for compute duration can derive its
+       * estimate from a fact already known at admission time, instead of
+       * needing a later widening of this contract. A module that does not
+       * account for duration can ignore the field entirely.
+       */
+      timeoutSeconds: number | null;
+    }
+  | {
+      orgId: string;
+      context: "chat";
+      sessionId: string | null;
+      /**
+       * Whose credential is spent on the inference for this chat turn.
+       *
+       * - `"system"` — the turn resolves to a platform-supplied model preset.
+       * - `"org"` — the turn resolves to a model the organization configured
+       *   with its own credential.
+       *
+       * Never `null` here: a chat turn resolves its model on the platform,
+       * before admission, so the fact is always determinable — unlike a
+       * remote-origin run, which resolves its model elsewhere.
+       */
+      credentialSource: "system" | "org";
+      /**
+       * Always `"platform"` for chat: a turn runs inside the platform's own
+       * process, never on a caller-supplied host. Present rather than omitted
+       * so a module can read `executionPlane` off either union member without
+       * first narrowing on `context`.
+       */
+      executionPlane: "platform";
+    };
 
 /** Structured rejection returned by `beforeUsage` when a module blocks usage. */
 export interface UsageRejection {
@@ -1225,14 +1327,28 @@ export interface PlatformServices {
   /**
    * Chat admission gate — the chat-surface entry point into the `beforeUsage`
    * hook. The chat module calls this for its non-subscription (built-in /
-   * API-key) branch before starting a turn; the platform decides whether the
-   * chosen model is system-provided and only then dispatches the hook (an org's
-   * own API-key model is never gated). Returns a {@link UsageRejection} to block
-   * the turn (the module surfaces it as an RFC 9457 problem response with the
-   * hook's status — 402 flows through), or null to allow. Subscription turns
-   * never call this (they spend the user's own credential, `credentialSource`
-   * `org`). Keeping the system-provided decision server-side keeps the chat
-   * module dumb — it has no model-registry access.
+   * API-key) branch before starting a turn, and the platform dispatches the
+   * hook for EVERY such turn. Returns a {@link UsageRejection} to block the
+   * turn (the module surfaces it as an RFC 9457 problem response with the
+   * hook's status — 402 flows through), or null to allow.
+   *
+   * The platform still resolves whether the chosen model is system-provided or
+   * organization-owned — keeping that resolution server-side is what keeps the
+   * chat module dumb, since it has no model-registry access — but it now
+   * REPORTS that resolution as the `credentialSource` fact instead of using it
+   * to pre-filter. A turn on the organization's own credential reports
+   * `credentialSource: "org"` and is dispatched all the same, because a chat
+   * turn always executes in the platform's own process: the platform supplies
+   * the compute even when it supplies no credential. `executionPlane` is
+   * consequently always `"platform"` on this surface.
+   *
+   * A module that only accounts for platform-supplied inference treats such a
+   * turn as contributing nothing and admits it — the same outcome the platform
+   * used to assume on the module's behalf, now decided by the module that owns
+   * the policy.
+   *
+   * Subscription turns never call this (they spend the user's own credential,
+   * `credentialSource` `org`).
    */
   checkUsageAllowed(args: {
     orgId: string;

--- a/packages/module-chat/src/chat-stream.ts
+++ b/packages/module-chat/src/chat-stream.ts
@@ -349,11 +349,12 @@ export async function handleChatStream(
 
   // Admission gate — non-subscription (built-in / API-key) turns only. A
   // subscription turn spends the user's OWN credential (`credentialSource`
-  // `org`) and is never gated. The platform decides system-provided vs.
-  // org-owned server-side and dispatches `beforeUsage` (chat context) only for a
-  // system-provided model — an org's own API-key model is never blocked. Gated
-  // BEFORE the phase-B preamble so a rejected turn opens no MCP session and
-  // persists no user message.
+  // `org`) and is never gated. For the turns that do reach it, the platform
+  // resolves system-provided vs. org-owned server-side and dispatches
+  // `beforeUsage` (chat context) with that fact — every turn, not only the
+  // system-provided ones; a metering module quotes it and decides. Gated BEFORE
+  // the phase-B preamble so a rejected turn opens no MCP session and persists no
+  // user message.
   if (!isSubscription) {
     const rejection = await deps.checkUsageAllowed({
       orgId,

--- a/packages/module-chat/src/platform-services.ts
+++ b/packages/module-chat/src/platform-services.ts
@@ -77,11 +77,12 @@ export interface ChatPlatformDeps {
   cleanupSessionDocuments(chatSessionId: string, tx?: ChatDbTx): Promise<void>;
   /**
    * Admission gate for a non-subscription (built-in / API-key) turn. The
-   * platform decides whether the chosen preset is system-provided and, if so,
-   * dispatches the `beforeUsage` hook; an org's own model is never gated.
-   * Returns a {@link UsageRejection} to block the turn (surfaced as an RFC 9457
-   * problem response with the hook's status — 402 flows through), or null to
-   * allow.
+   * platform resolves whether the chosen preset is system-provided and reports
+   * it as a fact to the `beforeUsage` hook, which it dispatches for every such
+   * turn — a metering module decides what an org-credential turn costs, the
+   * platform no longer decides it is free. Returns a {@link UsageRejection} to
+   * block the turn (surfaced as an RFC 9457 problem response with the hook's
+   * status — 402 flows through), or null to allow.
    */
   checkUsageAllowed(args: {
     orgId: string;


### PR DESCRIPTION
## What

Usage admission stops being a boolean and becomes a quote.

Today the `beforeUsage` module hook is dispatched only when the platform has already concluded the operation is billable — in practice, only when the resolved model comes from a platform-supplied credential:

```ts
if (input.modelSource === "system" && hasHook("beforeUsage")) { … }   // run preflight
if (!isSystemModel(args.presetId)) return null;                       // chat
```

That hard-codes **"the org brings its own key ⇒ nothing is consumed"**. It is true today only because platform compute is not accounted for. The moment it is, a platform-hosted BYOK run has `model = 0`, `compute > 0`, `total > 0` — and the platform would be skipping admission for it entirely. Fixing that later would mean changing the admission topology again, in exactly the place where a mistake means either spurious 402s or unmetered usage.

So the platform stops classifying and starts reporting. The hook now fires for **every** run and **every** chat turn, carrying neutral execution facts; the module quotes them and decides.

Closes #961. Follows #951 (which fixed the spurious-402 tactically by skipping the hook for non-system models) and #944 (the report that surfaced the zero-quota/BYOK interaction).

## The contract (`@appstrate/core` 4.0.0 → 4.1.0)

`BeforeUsageParams` gains three facts:

| Fact | Values | Meaning |
|---|---|---|
| `credentialSource` | `"system"` / `"org"` / `null` (runs) | Whose credential is spent on inference. `null` = a remote-origin run resolves its model off-platform. |
| `executionPlane` | `"platform"` / `"remote"` | Whose compute runs the work. |
| `timeoutSeconds` | `number` / `null` (runs) | Effective **post-ceiling** upper bound on platform compute occupancy. `null` = "this seam does not own the run's compute, contribute nothing for it". |

Two properties this shape is chosen for:

- **The two facts are independent axes.** An org can bring its own credential and still occupy a platform sandbox; a platform credential can be used on a caller-supplied host. Anything that collapses them into one signal mis-admits one of those combinations — which is precisely the shape of the pre-filter being removed.
- **No billing vocabulary enters core.** Apache-2.0 core reports what is *consumed*, never what it is *worth*. Turning facts into a policy decision stays entirely in the private module. `timeoutSeconds` is a ceiling the platform already computes, not a price input.

`timeoutSeconds` is nullable rather than using `0` as a sentinel: on a published type, a legitimate value that silently doubles as "ignore me" is a footgun, and widening `number` → `number | null` later would be breaking.

**Minor, not major:** an implementor that only *reads* the params is unaffected. Code that *constructs* `BeforeUsageParams` (module test fakes) must supply the new fields.

## Where the facts come from

| Seam | Reports |
|---|---|
| run preflight (platform origin) | resolved `credentialSource`, `platform`, effective post-ceiling timeout |
| run creation (remote origin) | `null`, `remote` |
| chat admission | resolved preset source, `platform` — a turn always runs in our own process |
| system-proxy seam | `"system"` (it only runs for a resolved system preset), plane from run origin, `timeoutSeconds: null` |

The timeout is now computed **before** the ceiling clone so the hook sees the effective bound. An agent declaring a timeout above the platform ceiling can never occupy compute for longer than the ceiling, so quoting the declared value would over-state it.

## The bypass this preserves

`system-proxy-admission.ts` keeps `runOrigin === "platform" && credentialSource === "system"` as its short-circuit — the same expression, a different meaning: from *"did the hook already run"* to *"was the MODEL component already accounted for"*.

It defends a real attack. A platform BYOK run is now admitted reporting no platform credential, so it is waved through. Attaching that active run id to a raw system-preset `/api/llm-proxy` request would launder platform-funded inference through an operation that was quoted at zero, defeating a rejection. Pinned by a regression test named for the bypass, plus a new test asserting the first-party chat loopback is *not* double-dispatched.

## Observable behaviour changes

Dispatching unconditionally is not free, and both consequences are intended rather than incidental:

- **One extra admission read on previously-skipped paths.** A BYOK platform run and a BYOK chat turn now reach the module, which reads one indexed billing-account row before admitting. Previously they did nothing at all. A *remote* BYOK run still costs nothing — the module short-circuits on the facts before touching its store.
- **A suspended account can no longer run BYOK work on platform compute.** The entitlement gate is independent of the quote, so a blocked subscription is rejected even when the operation quotes zero. That is the point of separating the two gates: a suspended org occupying platform sandboxes for free was the gap. Remote BYOK is unaffected (see the cloud PR for the deliberate divergence there).

## Verification

- `bun run check` — 33/33 tasks green (the 4 lint warnings are pre-existing `module-chat` UI `react-refresh` noise).
- Full tier-0 suite — **8726 pass, 89 skip, 0 fail** across 675 files.
- Tests updated where they asserted the old topology (that reversal is intentional, not a regression), plus new coverage: dispatch for `credentialSource: "org"` and `null`, post-ceiling timeout reported, `runningCount` still projected-inclusive, the proxy bypass, and the chat-loopback non-dispatch.

## Deploy lockstep (read before releasing)

The private billing module must land **first**. Ordering:

1. publish `@appstrate/core` **4.1.0**;
2. deploy the cloud module version that reads the quote;
3. deploy this platform change.

Deploying this platform change against an *older* cloud module would re-introduce #944: the platform stops pre-filtering, and a module still gating on a flat estimate would 402 every BYOK run. In OSS mode nothing changes — with no module loaded the hook is a no-op regardless.

## Prior art / SOTA checks

The design was checked against primary sources rather than assumed:

- Admitting a zero quote instead of gating it has direct precedent — RFC 4006 result code **4011** ("credit control not applicable, e.g. the service is free of charge"), and LiteLLM short-circuits its budget gate on a non-positive reservation. The *opposite* behaviour is filed as a bug against LiteLLM.
- Reporting execution facts at the boundary and keeping plan/price conversion in the metering layer is the RFC 8506 / OpenMeter shape.
- Using a declared ceiling as an *admission* bound while settling on measured actuals is the AWS Bedrock pattern (reserve `max_tokens`, refund the unused remainder, bill actual usage).

**Known divergence, carried deliberately:** the per-run estimate is multiplied by the in-flight count, which has no primary-source precedent — the SOTA answer to concurrent overshoot is an atomic reserve-on-admit / release-on-terminate counter (Bedrock, LiteLLM, RFC 8506). That multiplication is pre-existing behaviour, reserve/settle is explicitly out of scope for this ticket, and it remains a lossy stand-in for a reservation: an orphaned run inflates the count until the platform's orphan sweep reclaims it.

Follow-up worth filing: bound the model estimate by `max_tokens` / the model's output ceiling instead of a flat per-operation figure (also closes a `max_tokens: 10^9` estimate-inflation surface).

## Out of scope

No migration, no schema change, no DTO change. `runs.model_source` keeps its name — it is the same concept under an older persisted name, and the mapping is documented at the seam that reads it. Compute is still not charged. Reserve/settle hard caps remain deferred.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
