### PR TITLE
perf: implement the 2026-07 performance audit

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,6 +27,19 @@
 **/test/
 **/tests/
 **/coverage/
+**/test-results/
+**/playwright-report/
+.playwright/
+conformance-snapshot/
+
+# Build/tool scratch state. `**/` because .dockerignore patterns are anchored
+# at the context root (see the note at the top of this file): the Python
+# runners under runtime-pi/runners/* build their venv IN-TREE, so a
+# root-anchored `.venv` would miss every one of them.
+**/.venv/
+**/__pycache__/
+**/*.tsbuildinfo
+**/.cache/
 
 # Logs
 *.log

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,18 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/bun-setup
 
+      # Bun's global download cache. Keyed on the lockfile so a dependency bump
+      # re-downloads; `restore-keys` lets an unchanged-majority install still
+      # hit warm tarballs. Deliberately NOT added to the shared bun-setup
+      # composite action — release/publish workflows must keep installing from a
+      # cold, unmediated registry.
+      - name: Cache Bun download cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4.4.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-cache-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-cache-${{ runner.os }}-
+
       - name: Install dependencies
         run: bun install
 
@@ -32,14 +44,56 @@ jobs:
       - name: Verify lockfile is up to date
         run: git diff --exit-code bun.lock
 
+      # Incremental state for `bun run check`: the turbo task cache plus the
+      # ESLint and Prettier file caches. Both file caches use the `content`
+      # strategy (see the root package.json scripts), which is what makes them
+      # survive a fresh checkout — the default `metadata` strategy keys on mtime
+      # and would miss every file after `actions/checkout`.
+      #
+      # Explicit restore/save split (NOT the monolithic actions/cache): the
+      # monolithic post-step only saves on job SUCCESS, and the run that most
+      # needs a warm lint cache is the push that FIXES a red check.
+      #
+      # The key carries the toolchain + config hash, so a dependency or rule
+      # change starts a fresh lineage instead of trusting stale verdicts.
+      - name: Restore check caches
+        id: check-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4.4.0
+        with:
+          path: |
+            .turbo/cache
+            .eslintcache
+            node_modules/.cache/prettier
+          key: >-
+            check-${{ runner.os }}-${{ hashFiles('bun.lock', 'eslint.config.mjs',
+            '.prettierrc', 'turbo.json') }}-${{ github.sha }}
+          restore-keys: >-
+            check-${{ runner.os }}-${{ hashFiles('bun.lock', 'eslint.config.mjs',
+            '.prettierrc', 'turbo.json') }}-
+
       - name: Run checks
         run: bun run check
         env:
+          # Keep the turbo cache out of node_modules so the cache path above is
+          # stable across `bun install`.
+          TURBO_CACHE_DIR: .turbo/cache
           BETTER_AUTH_SECRET: ci-dummy-secret
           CONNECTION_ENCRYPTION_KEY: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
           UPLOAD_SIGNING_SECRET: ci-dummy-upload-signing-secret
           RUN_TOKEN_SECRET: ci-dummy-run-token-secret
           CONNECT_SESSION_SECRET: ci-dummy-connect-session-secret
+
+      - name: Save check caches
+        if: always()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4.4.0
+        with:
+          path: |
+            .turbo/cache
+            .eslintcache
+            node_modules/.cache/prettier
+          key: >-
+            check-${{ runner.os }}-${{ hashFiles('bun.lock', 'eslint.config.mjs',
+            '.prettierrc', 'turbo.json') }}-${{ github.sha }}
 
   # `bun run check` above CANNOT catch a missing dependency in a source-only
   # package: the root devDependencies hoist type packages into the shared

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,16 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/bun-setup
 
+      # Bun's global download cache, keyed on the lockfile. Kept out of the
+      # shared bun-setup composite action on purpose: release/publish workflows
+      # must keep installing from a cold, unmediated registry.
+      - name: Cache Bun download cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4.4.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-cache-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-cache-${{ runner.os }}-
+
       - name: Install dependencies
         run: bun install
 
@@ -124,6 +134,16 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/bun-setup
 
+      # Bun's global download cache, keyed on the lockfile. Kept out of the
+      # shared bun-setup composite action on purpose: release/publish workflows
+      # must keep installing from a cold, unmediated registry.
+      - name: Cache Bun download cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4.4.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-cache-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-cache-${{ runner.os }}-
+
       - name: Install dependencies
         run: bun install
 
@@ -164,6 +184,16 @@ jobs:
       - name: Setup Bun
         uses: ./.github/actions/bun-setup
 
+      # Bun's global download cache, keyed on the lockfile. Kept out of the
+      # shared bun-setup composite action on purpose: release/publish workflows
+      # must keep installing from a cold, unmediated registry.
+      - name: Cache Bun download cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4.4.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-cache-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-cache-${{ runner.os }}-
+
       - name: Install dependencies
         run: bun install
 
@@ -193,6 +223,16 @@ jobs:
 
       - name: Setup Bun
         uses: ./.github/actions/bun-setup
+
+      # Bun's global download cache, keyed on the lockfile. Kept out of the
+      # shared bun-setup composite action on purpose: release/publish workflows
+      # must keep installing from a cold, unmediated registry.
+      - name: Cache Bun download cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v4.4.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-cache-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-cache-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,8 @@
 # Requires BuildKit (Docker 23+, or DOCKER_BUILDKIT=1). The `COPY --parents`
 # directives below are BuildKit-only — the classic builder (DOCKER_BUILDKIT=0)
 # cannot build this image.
-# ── Stage 1: Install dependencies ──────────────────────────────────
-FROM oven/bun:1.3.14-alpine AS deps
-
-LABEL org.opencontainers.image.source="https://github.com/appstrate/appstrate"
-LABEL org.opencontainers.image.description="Appstrate — Open-source platform for running autonomous AI agents in sandboxed Docker containers"
-LABEL org.opencontainers.image.licenses="Apache-2.0"
+# ── Stage 1: Workspace manifests (shared by both install stages) ───
+FROM oven/bun:1.3.14-alpine AS manifests
 
 WORKDIR /app
 
@@ -27,10 +23,40 @@ COPY package.json bun.lock turbo.json ./
 COPY --parents */package.json */*/package.json ./
 COPY patches/ patches/
 
-# rationale: see .github/actions/bun-setup/action.yml
-RUN bun install
+# ── Stage 2a: Full install (build toolchain) ──────────────────────
+# Everything the BUILD needs: Vite/Rolldown, TypeScript, Turbo, the SPA's
+# dependency tree. This tree is ~1.0 GB and never reaches the final image.
+FROM manifests AS deps
 
-# ── Stage 2: Build ────────────────────────────────────────────────
+# rationale: see .github/actions/bun-setup/action.yml
+RUN --mount=type=cache,target=/root/.bun/install/cache,sharing=locked \
+    bun install
+
+# ── Stage 2b: Runtime install (shipped workspace members only) ────
+# The final image ships exactly three node_modules trees — root (the shared
+# `.bun` store), apps/api, and packages/* — so the runtime install is filtered
+# to that subgraph. This drops apps/web (monaco-editor, react-icons,
+# lucide-react …), apps/cli, e2e (playwright) and the root dev toolchain
+# (turbo, typescript, prettier, eslint, redocly) from the store the final
+# stage copies: measured 1.0 GB → 642 MB.
+#
+# NOT `--production`: several packages value-import at runtime a dependency
+# that is declared as a `devDependency` — most importantly
+# `packages/core/src/storage-s3.ts` imports `@aws-sdk/client-s3`, which core
+# does not declare and apps/api declares as a devDependency. `--production`
+# therefore deletes the S3 storage backend from the image, and because the
+# backend is source-only (Bun executes `.ts` directly, no build step) the
+# build stays GREEN and the failure only appears at runtime. Fix the manifests
+# first if `--production` is ever wanted; it is worth only ~26 MB more.
+#
+# `--filter` is safe against that class of bug: it selects whole workspace
+# members and keeps each selected member's devDependencies intact.
+FROM manifests AS deps-runtime
+
+RUN --mount=type=cache,target=/root/.bun/install/cache,sharing=locked \
+    bun install --filter '@appstrate/api' --filter './packages/*'
+
+# ── Stage 3: Build ────────────────────────────────────────────────
 FROM oven/bun:1.3.14-alpine AS build
 
 WORKDIR /app
@@ -53,13 +79,22 @@ RUN bun install
 
 RUN bun run build
 
-# ── Stage 3: Production image ─────────────────────────────────────
+# ── Stage 4: Production image ─────────────────────────────────────
 FROM oven/bun:1.3.14-alpine
+
+# On the FINAL stage on purpose: a LABEL set on an intermediate stage never
+# reaches the published image (it was on `deps` before, so the image shipped
+# only Bun's upstream OCI labels).
+LABEL org.opencontainers.image.source="https://github.com/appstrate/appstrate"
+LABEL org.opencontainers.image.description="Appstrate — Open-source platform for running autonomous AI agents in sandboxed Docker containers"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 
 WORKDIR /app
 
-# Runtime dependencies (root hoisted + every workspace member's isolated
-# node_modules), graph-derived via `COPY --parents` like the build stage.
+# Runtime dependencies (root `.bun` store + every workspace member's isolated
+# node_modules), graph-derived via `COPY --parents` like the build stage —
+# but from `deps-runtime`, NOT `deps`: the build tree carries the SPA and dev
+# toolchain the runtime never loads.
 # Bun isolated installs keep each package's deps OUT of the root hoist
 # (e.g. zod under module-chat) as symlink farms into the root .bun store
 # — cheap to ship,
@@ -67,8 +102,8 @@ WORKDIR /app
 # caused exactly that three times (afps-shared/semver, module-claude-code,
 # module-chat); the glob can't miss a member and skips absent dirs instead
 # of failing the build.
-COPY --from=deps /app/node_modules ./node_modules
-COPY --from=deps --parents /app/./apps/api/node_modules /app/./packages/*/node_modules ./
+COPY --from=deps-runtime /app/node_modules ./node_modules
+COPY --from=deps-runtime --parents /app/./apps/api/node_modules /app/./packages/*/node_modules ./
 
 # ── Workspace package sources (Bun runs TypeScript directly — no build step) ──
 # Graph-derived via `COPY --parents`: apps/api source + every packages/*/src

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,7 +6,7 @@ import { serveStatic } from "hono/bun";
 import { getEnv } from "@appstrate/env";
 import { recordProcessAnomaly } from "@appstrate/core/telemetry";
 import { logger } from "./lib/logger.ts";
-import { boot } from "./lib/boot.ts";
+import { bootCritical, bootBackground } from "./lib/boot.ts";
 import { createShutdownHandler } from "./lib/shutdown.ts";
 import { requireAppContext } from "./middleware/app-context.ts";
 import { requestId } from "./middleware/request-id.ts";
@@ -34,7 +34,7 @@ import { createEndUsersRouter } from "./routes/end-users.ts";
 import { createUploadsRouter, createUploadContentRouter } from "./routes/uploads.ts";
 import { createDocumentsRouter, createDocumentPreviewRouter } from "./routes/documents.ts";
 import { createAdminStorageDeletionRouter } from "./routes/admin-storage-deletion.ts";
-import healthRouter from "./routes/health.ts";
+import healthRouter, { bootGate, markServerReady } from "./routes/health.ts";
 import { createIntegrationsRouter } from "./routes/integrations.ts";
 import { createCredentialProxyRouter } from "./routes/credential-proxy.ts";
 import { createLlmProxyRouter } from "./routes/llm-proxy.ts";
@@ -106,6 +106,12 @@ app.use("*", async (c, next) => {
   if (c.req.method === "POST" && RUN_DOCUMENT_UPLOAD_PATH.test(c.req.path)) return next();
   return globalBodyLimit(c, next);
 });
+
+// Boot gate — 503 on every route until `bootBackground()` (kicked off after
+// the export at the bottom of this file) resolves. Registered BEFORE
+// `healthRouter` so the probe is answered by the gate while starting.
+// Definition + rationale: `routes/health.ts`.
+app.use("*", bootGate());
 
 // Health check — before auth middleware (no auth required)
 app.route("/", healthRouter);
@@ -239,8 +245,10 @@ app.use("*", async (c, next) => {
   return apiVersionMiddleware(c, next);
 });
 
-// Boot: load system resources, init services, clean up orphans
-await boot();
+// Boot phase 1 — migrations, modules, auth, fail-fast config validation.
+// Everything the route table's shape depends on. Phase 2 is kicked off after
+// the export below, so the port binds without waiting for it.
+await bootCritical();
 
 // Initialize app config (async — modules may contribute structured data like OIDC client ID)
 await initAppConfig();
@@ -406,7 +414,30 @@ export default {
   idleTimeout: 255,
 };
 
-logger.info("Server started", { port: env.PORT });
+logger.info("Server listening (starting up)", { port: env.PORT });
+
+// Boot phase 2 — orphan cleanup, system-package DB sync, workers. Deliberately
+// NOT awaited: Bun binds the port once this module finishes evaluating, so
+// awaiting here would keep the socket closed for the whole of it (worst case
+// the per-orphan container stops, which is exactly the restart-after-incident
+// path where the API should come back fastest). Until it resolves, the boot
+// gate above answers 503 on every route.
+//
+// A rejection is fatal, matching the previous blocking `await boot()`: the
+// metering retry worker's init is deliberately uncaught upstream because a
+// missing durable recovery channel can lose billable spend permanently.
+const bootStartedAt = Date.now();
+void bootBackground()
+  .then(() => {
+    markServerReady();
+    logger.info("Server ready", { port: env.PORT, startupMs: Date.now() - bootStartedAt });
+  })
+  .catch((err: unknown) => {
+    logger.error("Boot failed — exiting", {
+      error: err instanceof Error ? (err.stack ?? err.message) : String(err),
+    });
+    process.exit(1);
+  });
 
 // Proxy-upload diagnosability (issue #829): with S3 storage and no
 // S3_PUBLIC_ENDPOINT, upload URLs are signed against APP_URL and the browser

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -46,6 +46,7 @@ import profileRouter from "./routes/profile.ts";
 import invitationsRouter from "./routes/invitations.ts";
 import welcomeRouter from "./routes/welcome.ts";
 import { swaggerUI } from "@hono/swagger-ui";
+import { createOpenApiSpecRouter } from "./routes/openapi-spec.ts";
 import { buildOpenApiSpec } from "./openapi/index.ts";
 import {
   getModulePublicPaths,
@@ -121,7 +122,8 @@ function getOpenApiSpec() {
     );
   return _openApiSpec;
 }
-app.get("/api/openapi.json", (c) => c.json(getOpenApiSpec()));
+// Serialized once + ETag/304 revalidation — see routes/openapi-spec.ts.
+app.route("/", createOpenApiSpecRouter(getOpenApiSpec));
 app.get("/api/docs", swaggerUI({ url: "/api/openapi.json" }));
 
 // Public llms.txt — points AI coding agents at the CLI + OpenAPI entry

--- a/apps/api/src/infra/event-buffer/redis-event-buffer.ts
+++ b/apps/api/src/infra/event-buffer/redis-event-buffer.ts
@@ -40,12 +40,38 @@ export class RedisEventBuffer implements EventBuffer {
     // already unique by construction, so prefix the JSON with it (and a
     // separator that JSON can't produce at column 0) to make the member
     // identity sequence-keyed regardless of payload content.
-    await redis.zadd(key, sequence, `${sequence}|${JSON.stringify(event)}`);
-    // Trim from the lowest-scored end if we overflow MAX_BUFFER_ENTRIES.
-    // `0` is the lowest rank; `-(MAX_BUFFER_ENTRIES + 1)` keeps the
-    // top-N most recent. Returns the number of removed members — non-zero
-    // means we dropped events, which is a real anomaly worth surfacing.
-    const trimmed = await redis.zremrangebyrank(key, 0, -(MAX_BUFFER_ENTRIES + 1));
+    //
+    // The three commands are ONE round trip via MULTI. They were three
+    // sequential awaits, so every ingested event of every remote run paid
+    // three network RTTs where one suffices — and the window between the
+    // ZADD and the EXPIRE meant a crash in between left a key with no TTL.
+    // MULTI also makes the trim atomic with the insert, so a concurrent
+    // reader can never observe the set above its cap.
+    //
+    // ZREMRANGEBYRANK trims from the lowest-scored end on overflow: `0` is
+    // the lowest rank, `-(MAX_BUFFER_ENTRIES + 1)` keeps the top-N most
+    // recent. Its reply is the number of removed members — non-zero means we
+    // dropped events, which is a real anomaly worth surfacing.
+    const replies = await redis
+      .multi()
+      .zadd(key, sequence, `${sequence}|${JSON.stringify(event)}`)
+      .zremrangebyrank(key, 0, -(MAX_BUFFER_ENTRIES + 1))
+      .expire(key, ttlSeconds)
+      .exec();
+
+    // `exec()` resolves to null when the transaction was discarded (e.g. the
+    // connection dropped mid-MULTI) and otherwise to one `[error, reply]`
+    // tuple per queued command. Surface either as a throw so the caller's
+    // existing failure handling is unchanged from the sequential-await
+    // version, where any command rejecting propagated.
+    if (replies === null) {
+      throw new Error("event buffer MULTI discarded");
+    }
+    for (const [err] of replies) {
+      if (err) throw err;
+    }
+
+    const trimmed = Number(replies[1]?.[1] ?? 0);
     if (trimmed > 0) {
       logger.warn("event buffer overflowed — dropped oldest entries", {
         runId,
@@ -53,7 +79,6 @@ export class RedisEventBuffer implements EventBuffer {
         cap: MAX_BUFFER_ENTRIES,
       });
     }
-    await redis.expire(key, ttlSeconds);
   }
 
   async peekLowest(runId: string): Promise<BufferedEvent | null> {

--- a/apps/api/src/infra/queue/bullmq-queue.ts
+++ b/apps/api/src/infra/queue/bullmq-queue.ts
@@ -6,7 +6,7 @@
 
 import { Queue, Worker, UnrecoverableError } from "bullmq";
 import type { ConnectionOptions } from "bullmq";
-import { getRedisConnection } from "../../lib/redis.ts";
+import { getRedisQueueConnection } from "../../lib/redis.ts";
 import { logger } from "../../lib/logger.ts";
 import type {
   JobQueue,
@@ -27,7 +27,7 @@ export class BullMQQueue<T> implements JobQueue<T> {
     defaultJobOptions?: JobAddOptions,
   ) {
     this.queue = new Queue<Record<string, unknown>, unknown, string>(name, {
-      connection: getRedisConnection() as unknown as ConnectionOptions,
+      connection: getRedisQueueConnection() as unknown as ConnectionOptions,
       defaultJobOptions: {
         // Bounded retention by default — without it BullMQ keeps every
         // completed/failed job forever and the Redis footprint grows
@@ -100,7 +100,7 @@ export class BullMQQueue<T> implements JobQueue<T> {
         }
       },
       {
-        connection: getRedisConnection() as unknown as ConnectionOptions,
+        connection: getRedisQueueConnection() as unknown as ConnectionOptions,
         ...(opts?.concurrency ? { concurrency: opts.concurrency } : {}),
         ...(opts?.limiter ? { limiter: opts.limiter } : {}),
         ...(opts?.backoffStrategy

--- a/apps/api/src/lib/boot.ts
+++ b/apps/api/src/lib/boot.ts
@@ -49,7 +49,48 @@ import { ensureBucket } from "@appstrate/db/storage";
 import { logInfraMode } from "../infra/index.ts";
 import { installPermissionAuditLogger } from "./permission-audit.ts";
 
-export async function boot(): Promise<void> {
+/**
+ * Max concurrent orphan stop+finalize pairs at boot. See the call site — kept
+ * well under the postgres.js pool (`max: 20`).
+ */
+const ORPHAN_CLEANUP_CONCURRENCY = 6;
+
+/**
+ * `Promise.all`-shaped map with a bounded worker pool. Local by design: this
+ * file and `services/system-packages.ts` each keep their own tiny pool rather
+ * than sharing a new util module.
+ */
+async function mapBounded<T>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (cursor < items.length) {
+      const item = items[cursor++]!;
+      await fn(item);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+}
+
+/**
+ * Phase 1 — everything the HTTP surface's *shape* depends on, plus every
+ * fail-fast validation. Must finish before the port is bound.
+ *
+ * Hono throws `Can not add a route since the matcher is already built` the
+ * moment a route is registered after the first request has been matched, so
+ * module routes (`registerModuleRoutes`) can never be deferred past the bind —
+ * which makes module loading, and the core migrations it sits on, strictly
+ * pre-bind work. The cheap synchronous validators (`initRunLimits`,
+ * `initProxyLimits`, …) stay here too: they exist to abort boot on a bad
+ * config, and aborting is only meaningful before anything is listening.
+ *
+ * Everything that is merely *state the handlers read* moves to
+ * {@link bootBackground}, behind the readiness gate in `index.ts`.
+ */
+export async function bootCritical(): Promise<void> {
   // Register RBAC denial audit handler BEFORE modules load. Every guard
   // created from this point on — core routes via `requirePermission`,
   // module routes via `requireModulePermission`/`requireCorePermission` —
@@ -173,9 +214,31 @@ export async function boot(): Promise<void> {
   // the SYSTEM_INTEGRATIONS env var
   initSystemIntegrations();
 
-  // Load system packages from ZIPs, sync to DB + S3
-  await loadAndSyncSystemPackages().catch((err) => {
-    logger.warn("Could not load/sync system packages", {
+  // Read the `.afps` archives off disk into the in-memory registry. Cheap
+  // (~45 ms) and consulted by request-path helpers (`isSystemPackage`), so it
+  // stays pre-bind; the DB + S3 reconciliation it used to be bundled with is
+  // the slow half and runs in `bootBackground`.
+  await initSystemPackages().catch((err) => {
+    logger.warn("Could not load system packages", {
+      error: getErrorMessage(err),
+    });
+  });
+}
+
+/**
+ * Phase 2 — state, workers and cleanup. Runs AFTER the port is bound, behind
+ * the readiness gate in `index.ts`, which answers 503 on every route until
+ * this resolves. Nothing here changes the route table.
+ *
+ * A rejection here is fatal exactly as it was when this code lived in a
+ * blocking `await boot()`: the caller in `index.ts` exits the process.
+ */
+export async function bootBackground(): Promise<void> {
+  const env = (await import("@appstrate/env")).getEnv();
+
+  // Reconcile the loaded system packages into the DB + S3.
+  await syncSystemPackagesToDb().catch((err) => {
+    logger.warn("Could not sync system packages", {
       error: getErrorMessage(err),
     });
   });
@@ -209,7 +272,17 @@ export async function boot(): Promise<void> {
     const orphanIds = await listOrphanRunIds();
     if (orphanIds.length > 0) {
       let finalized = 0;
-      for (const runId of orphanIds) {
+      // Bounded parallelism, NOT a serial loop. Each orphan costs a Docker
+      // `POST /containers/{id}/stop?t=5`, which blocks for up to the full
+      // grace period when the container ignores SIGTERM — serially that is
+      // 5 s × orphan count added to boot, at exactly the moment (restart
+      // after an incident) the API should come back fastest. The grace
+      // period itself is deliberately left alone: it is what lets a still
+      // running sidecar flush its final events before the SIGKILL.
+      //
+      // Concurrency is capped well under the postgres.js pool (`max: 20`)
+      // because `synthesiseFinalize` writes.
+      await mapBounded(orphanIds, ORPHAN_CLEANUP_CONCURRENCY, async (runId) => {
         try {
           // An orphaned run may still have a live remote workload — a
           // firecracker microVM on the runner host keeps executing (and
@@ -238,7 +311,7 @@ export async function boot(): Promise<void> {
             error: getErrorMessage(err),
           });
         }
-      }
+      });
       logger.info("Finalized orphaned runs", { count: finalized, runIds: orphanIds });
     }
   } catch (err) {
@@ -360,16 +433,6 @@ export async function boot(): Promise<void> {
   // immediately, then polls for due jobs. Purges S3/FS objects whose DB rows
   // were deleted (documents, uploads, run workspaces, org/app/end-user cascades).
   startStorageDeletionWorker();
-}
-
-/**
- * Load system packages from ZIPs on disk, then sync to DB + S3.
- * Upserts packages rows (source: "system"), uploads files to global _system/ namespace,
- * and creates packageVersions with SHA256 SRI integrity.
- */
-async function loadAndSyncSystemPackages(): Promise<void> {
-  await initSystemPackages();
-  await syncSystemPackagesToDb();
 }
 
 /**

--- a/apps/api/src/lib/redis.ts
+++ b/apps/api/src/lib/redis.ts
@@ -7,12 +7,29 @@ import { getErrorMessage } from "@appstrate/core/errors";
 
 let publisher: Redis | null = null;
 let subscriber: Redis | null = null;
+let queueConnection: Redis | null = null;
 
-function createRedisClient(): Redis {
+/**
+ * Retries ioredis attempts per command before rejecting, on the connections
+ * that serve HTTP requests.
+ *
+ * `null` means "retry forever", which is what BullMQ requires and what every
+ * client here used to get. On a request path that is the wrong contract: while
+ * Redis is unreachable, a rate-limit or cache command HANGS instead of
+ * failing, so the request hangs with it and the caller sees a timeout rather
+ * than an error. A finite count turns a Redis outage into a fast, handleable
+ * rejection.
+ */
+const HTTP_MAX_RETRIES_PER_REQUEST = 3;
+
+function createRedisClient(opts?: { forQueue?: boolean }): Redis {
   const url = getEnv().REDIS_URL;
   if (!url) throw new Error("REDIS_URL is required when using Redis-backed adapters");
   const client = new Redis(url, {
-    maxRetriesPerRequest: null, // required by BullMQ
+    // BullMQ mandates `null` on its own connections: its blocking reads
+    // (BRPOPLPUSH) legitimately outlive any finite retry budget, and Worker
+    // throws at construction otherwise. Everything else gets a finite budget.
+    maxRetriesPerRequest: opts?.forQueue ? null : HTTP_MAX_RETRIES_PER_REQUEST,
     enableReadyCheck: false,
     connectTimeout: 10_000,
     retryStrategy(times) {
@@ -30,11 +47,34 @@ function createRedisClient(): Redis {
   return client;
 }
 
+/**
+ * Shared client for request-path work: rate limiting, cache, event buffer,
+ * distributed locks, pub/sub publishes. Fails commands fast when Redis is
+ * down — see {@link HTTP_MAX_RETRIES_PER_REQUEST}.
+ *
+ * NOT for BullMQ: use {@link getRedisQueueConnection}.
+ */
 export function getRedisConnection(): Redis {
   if (!publisher) {
     publisher = createRedisClient();
   }
   return publisher;
+}
+
+/**
+ * Dedicated client for BullMQ, which requires `maxRetriesPerRequest: null`.
+ *
+ * Separate from {@link getRedisConnection} so the queue's "retry forever"
+ * contract cannot leak onto the request path. BullMQ additionally calls
+ * `.duplicate()` internally for its blocking client, and duplicates inherit
+ * these options — which is exactly why the finite budget must not be set
+ * here.
+ */
+export function getRedisQueueConnection(): Redis {
+  if (!queueConnection) {
+    queueConnection = createRedisClient({ forQueue: true });
+  }
+  return queueConnection;
 }
 
 export function getRedisSubscriber(): Redis {
@@ -49,6 +89,7 @@ export async function closeRedis(): Promise<void> {
   try {
     await publisher?.quit();
     await subscriber?.quit();
+    await queueConnection?.quit();
   } catch (err) {
     logger.warn("Error closing Redis connections", {
       error: getErrorMessage(err),
@@ -56,4 +97,5 @@ export async function closeRedis(): Promise<void> {
   }
   publisher = null;
   subscriber = null;
+  queueConnection = null;
 }

--- a/apps/api/src/lib/shutdown.ts
+++ b/apps/api/src/lib/shutdown.ts
@@ -24,6 +24,24 @@ import { shutdownTelemetry } from "@appstrate/core/telemetry";
 
 const SHUTDOWN_TIMEOUT_MS = 30_000;
 
+/**
+ * Hard ceiling on the WHOLE shutdown sequence, not just the in-flight drain.
+ *
+ * Every step below is an unbounded `await` (BullMQ `close()` without `force`
+ * waits for the job it is processing; `shutdownModules()` runs third-party
+ * code; `shutdownTelemetry()` flushes over the network). Without a deadline a
+ * single hung step means the connection teardown and `process.exit(0)` never
+ * run, and the supervisor's SIGKILL is what actually ends the process.
+ *
+ * Must stay BELOW the supervisor's stop grace period, otherwise it can never
+ * fire. `docker-compose.yml` sets `stop_grace_period: 45s` on the `appstrate`
+ * service for exactly this reason — Docker's default is 10s, which is shorter
+ * than the drain above and is what made the teardown unreachable. Operators
+ * running outside that compose file (k8s `terminationGracePeriodSeconds`,
+ * systemd `TimeoutStopSec`) need the same alignment.
+ */
+const SHUTDOWN_DEADLINE_MS = 40_000;
+
 export function createShutdownHandler(setShuttingDown: () => void): () => Promise<void> {
   let called = false;
 
@@ -31,6 +49,19 @@ export function createShutdownHandler(setShuttingDown: () => void): () => Promis
     if (called) return;
     called = true;
     setShuttingDown();
+
+    const deadline = setTimeout(() => {
+      logger.error("Shutdown deadline exceeded — forcing exit", {
+        deadlineMs: SHUTDOWN_DEADLINE_MS,
+        inFlight: getInFlightCount(),
+      });
+      process.exit(1);
+    }, SHUTDOWN_DEADLINE_MS);
+    // Never hold the event loop open on the timer itself: if every step
+    // completes the process exits below anyway. `unref` only stops the timer
+    // from KEEPING an idle loop alive — a loop hung on a pending await is not
+    // idle, so the deadline still fires in the case it exists to cover.
+    deadline.unref();
 
     logger.info("Shutdown initiated, stopping container orchestrator...");
     stopUploadGc();
@@ -96,6 +127,7 @@ export function createShutdownHandler(setShuttingDown: () => void): () => Promis
     }
     await Promise.all(closeOps);
 
+    clearTimeout(deadline);
     logger.info("Shutdown complete");
     process.exit(0);
   };

--- a/apps/api/src/openapi/parameters.ts
+++ b/apps/api/src/openapi/parameters.ts
@@ -27,6 +27,16 @@ export const parameters = {
       "When true, include full payload with `result` and `data` fields. Default (false) strips large user-content fields for safer consumption by external agents.",
     schema: { type: "boolean", default: false },
   },
+  SseChannels: {
+    name: "channels",
+    in: "query" as const,
+    required: false,
+    description:
+      "Comma-separated list of SSE channels to subscribe to (`run_update`, `run_log`, `run_metric`, `connection_update`, `chat_session_update`). " +
+      "Omit to receive every channel (default, unchanged behaviour). Unknown names are ignored; if nothing is recognised the stream falls back to every channel. " +
+      "Declaring only the channels you consume avoids fanning the `run_log` firehose out to a stream that discards it.",
+    schema: { type: "string", example: "run_update,connection_update" },
+  },
   AppstrateUser: {
     name: "Appstrate-User",
     in: "header" as const,

--- a/apps/api/src/openapi/paths/meta.ts
+++ b/apps/api/src/openapi/paths/meta.ts
@@ -6,11 +6,29 @@ export const metaPaths = {
       operationId: "getOpenApiSpec",
       tags: ["Meta"],
       summary: "OpenAPI specification",
-      description: "Returns the OpenAPI 3.1 specification as JSON.",
+      description:
+        "Returns the OpenAPI 3.1 specification as JSON. The response carries a strong `ETag` " +
+        "that is stable for the lifetime of the deployment — send it back as `If-None-Match` " +
+        "to revalidate a cached copy and get a `304 Not Modified` instead of the full document.",
       security: [],
+      parameters: [
+        {
+          name: "If-None-Match",
+          in: "header",
+          required: false,
+          description: "Entity-tag of a cached copy. A match yields `304 Not Modified`.",
+          schema: { type: "string" },
+        },
+      ],
       responses: {
         "200": {
           description: "OpenAPI spec",
+          headers: {
+            ETag: {
+              description: "Strong entity-tag of the served specification.",
+              schema: { type: "string" },
+            },
+          },
           content: {
             "application/json": {
               schema: { type: "object" },
@@ -18,6 +36,15 @@ export const metaPaths = {
                 openapi: "3.1.0",
                 info: { title: "Appstrate API", version: "2026-03-21" },
               },
+            },
+          },
+        },
+        "304": {
+          description: "Cached copy is still current (`If-None-Match` matched). No body.",
+          headers: {
+            ETag: {
+              description: "Strong entity-tag of the served specification.",
+              schema: { type: "string" },
             },
           },
         },

--- a/apps/api/src/openapi/paths/realtime.ts
+++ b/apps/api/src/openapi/paths/realtime.ts
@@ -16,6 +16,18 @@ const SSE_ID_FIELD_DESCRIPTION =
   "Client-side dedup on `id` is safe. Server-side replay via `Last-Event-ID` is NOT implemented — " +
   "reconnect lands on the live tail; missed events are not replayed.";
 
+/**
+ * Shared documentation snippet for the optional `channels` subscription
+ * filter. Server-side filtering: a stream that does not declare a channel
+ * never has those frames serialized for it. Omitting the parameter keeps the
+ * historical "everything" behaviour so existing clients are unaffected.
+ */
+const SSE_CHANNELS_DESCRIPTION =
+  "\n\nChannel selection: pass `channels=` with a comma-separated subset " +
+  "(e.g. `channels=run_update,connection_update`) to receive only those frames. " +
+  "The filter is applied server-side before serialization. Omit it to receive every channel. " +
+  "Note that dropping `run_log` is what keeps a dashboard-wide stream off the per-log firehose.";
+
 export const realtimePaths = {
   "/api/realtime/runs": {
     get: {
@@ -24,12 +36,14 @@ export const realtimePaths = {
       summary: "SSE: all run status changes",
       description:
         'Server-Sent Events stream for all run status changes in the org. Supports cookie auth and API key auth via ?token=ask_... query parameter. API keys must carry the `runs:read` scope — a valid key without it is rejected with 403.\n\nEvent format: `event: run_update\\ndata: {"id":"run_...","status":"running","packageId":"@scope/name",...}\\n\\n`\n\nEvent types: `run_update` (status change), `run_log` (log entry), `run_metric` (running cumulative cost + token usage), `connection_update` (INSERT/UPDATE/DELETE on integration_connections, actor-scoped to the caller\'s own rows). Heartbeat: a named SSE `event: ping` frame (empty data) sent immediately on connect and every 30s thereafter.\n\n' +
-        SSE_ID_FIELD_DESCRIPTION,
+        SSE_ID_FIELD_DESCRIPTION +
+        SSE_CHANNELS_DESCRIPTION,
       parameters: [
         { $ref: "#/components/parameters/SseOrgId" },
         { $ref: "#/components/parameters/SseAppId" },
         { $ref: "#/components/parameters/SseToken" },
         { $ref: "#/components/parameters/Verbose" },
+        { $ref: "#/components/parameters/SseChannels" },
       ],
       responses: {
         "200": {
@@ -48,13 +62,15 @@ export const realtimePaths = {
       summary: "SSE: single run events",
       description:
         "Server-Sent Events stream for run status + log events. Supports cookie auth and API key auth via ?token=ask_... query parameter. API keys must carry the `runs:read` scope — a valid key without it is rejected with 403.\n\nEvent types: `run_update` (status change), `run_log` (log entry), `run_metric` (running cumulative cost + token usage), `connection_update` (INSERT/UPDATE/DELETE on integration_connections, actor-scoped to the caller's own rows). Heartbeat: a named SSE `event: ping` frame (empty data) sent immediately on connect and every 30s thereafter.\n\n" +
-        SSE_ID_FIELD_DESCRIPTION,
+        SSE_ID_FIELD_DESCRIPTION +
+        SSE_CHANNELS_DESCRIPTION,
       parameters: [
         { name: "id", in: "path", required: true, schema: { type: "string" } },
         { $ref: "#/components/parameters/SseOrgId" },
         { $ref: "#/components/parameters/SseAppId" },
         { $ref: "#/components/parameters/SseToken" },
         { $ref: "#/components/parameters/Verbose" },
+        { $ref: "#/components/parameters/SseChannels" },
       ],
       responses: {
         "200": {
@@ -73,7 +89,8 @@ export const realtimePaths = {
       summary: "SSE: agent run changes",
       description:
         "Server-Sent Events stream for run changes for a specific agent. Supports cookie auth and API key auth via ?token=ask_... query parameter. API keys must carry the `runs:read` scope — a valid key without it is rejected with 403.\n\nEvent types: `run_update` (status change), `run_log` (log entry), `run_metric` (running cumulative cost + token usage), `connection_update` (INSERT/UPDATE/DELETE on integration_connections, actor-scoped to the caller's own rows). Heartbeat: a named SSE `event: ping` frame (empty data) sent immediately on connect and every 30s thereafter.\n\n" +
-        SSE_ID_FIELD_DESCRIPTION,
+        SSE_ID_FIELD_DESCRIPTION +
+        SSE_CHANNELS_DESCRIPTION,
       parameters: [
         {
           name: "packageId",
@@ -86,6 +103,7 @@ export const realtimePaths = {
         { $ref: "#/components/parameters/SseAppId" },
         { $ref: "#/components/parameters/SseToken" },
         { $ref: "#/components/parameters/Verbose" },
+        { $ref: "#/components/parameters/SseChannels" },
       ],
       responses: {
         "200": {

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,12 +1,65 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { Hono } from "hono";
+import { Hono, type MiddlewareHandler } from "hono";
 import { sql } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
 import { getSystemPackagesByType } from "../services/system-packages.ts";
 import { getVersionInfo } from "../lib/version.ts";
+import { ApiError } from "../lib/errors.ts";
 
 const startedAt = Date.now();
+
+// ─── Readiness ───
+
+let serverReady = false;
+
+/**
+ * Flip the process to "ready". Called once from `index.ts` when
+ * `bootBackground()` resolves — i.e. when orphan cleanup, the system-package
+ * DB sync and every worker are done. The port is already bound well before
+ * this; see {@link bootGate}.
+ */
+export function markServerReady(): void {
+  serverReady = true;
+}
+
+/** Test-only reset of the module-level readiness flag. */
+export function _resetServerReadyForTesting(): void {
+  serverReady = false;
+}
+
+/**
+ * Boot gate — the mirror image of the shutdown gate. Between the port bind and
+ * the end of `bootBackground()` the process is listening but not ready, so
+ * rather than run a request against half-initialized state (or leave the socket
+ * closed and hand clients a bare CONNREFUSED) it answers an explicit 503 that
+ * says which state we are in.
+ *
+ * `/health` is answered from HERE while starting, not by the router below: the
+ * real checks would otherwise report on state that is still being built. Every
+ * other path gets an RFC 9457 `starting` problem document.
+ *
+ * INVARIANT: this gate does NOT make deferring route registration safe. Hono
+ * throws `Can not add a route since the matcher is already built` on any route
+ * added after the first request is matched, so the whole route table — core and
+ * module — is still registered before the bind. See `lib/boot.ts`.
+ */
+export function bootGate(): MiddlewareHandler {
+  return async (c, next) => {
+    if (serverReady) return next();
+    if (c.req.path === "/health") {
+      return c.json({ status: "starting", version: getVersionInfo() }, 503, {
+        "Retry-After": "1",
+      });
+    }
+    throw new ApiError({
+      status: 503,
+      code: "starting",
+      title: "Service Unavailable",
+      detail: "Server is still starting up",
+    });
+  };
+}
 
 const healthRouter = new Hono();
 

--- a/apps/api/src/routes/openapi-spec.ts
+++ b/apps/api/src/routes/openapi-spec.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `GET /api/openapi.json` — the live OpenAPI 3.1 document.
+ *
+ * Public and pre-auth by design (the CLI and Swagger UI both fetch it before
+ * any credential exists), which is exactly why it must be cheap: the spec is
+ * ~470 KiB of JSON and the endpoint is not rate-limited. Two properties make
+ * it so:
+ *
+ *  - the serialization is computed ONCE per process (the spec is immutable
+ *    once modules are initialized at boot), instead of re-running
+ *    `JSON.stringify` over the whole document on every request;
+ *  - the response carries a strong `ETag`, so a client that already has the
+ *    document revalidates with `If-None-Match` and gets an empty `304`.
+ *    `apps/cli` already sends the header — before this it could never hit.
+ */
+
+import { Hono } from "hono";
+import type { AppEnv } from "../types/index.ts";
+
+/** RFC 9110 §13.1.2 — `*`, or any entity-tag in the comma-separated list (weak comparison). */
+export function ifNoneMatchSatisfied(header: string | undefined, etag: string): boolean {
+  if (!header) return false;
+  const candidates = header.split(",").map((v) => v.trim());
+  if (candidates.includes("*")) return true;
+  const strip = (v: string) => (v.startsWith("W/") ? v.slice(2) : v);
+  return candidates.some((v) => strip(v) === strip(etag));
+}
+
+/**
+ * @param buildSpec - Assembles the spec. Called at most once per router
+ *   instance, lazily on the first request (module OpenAPI paths are only
+ *   available after boot).
+ */
+export function createOpenApiSpecRouter(buildSpec: () => unknown) {
+  const router = new Hono<AppEnv>();
+
+  let payload: { body: string; etag: string } | null = null;
+  const getPayload = () => {
+    if (!payload) {
+      const body = JSON.stringify(buildSpec());
+      const digest = new Bun.CryptoHasher("sha256").update(body).digest("hex").slice(0, 32);
+      payload = { body, etag: `"${digest}"` };
+    }
+    return payload;
+  };
+
+  router.get("/api/openapi.json", (c) => {
+    const { body, etag } = getPayload();
+    c.header("ETag", etag);
+    // Always revalidate: the document changes across deployments, and the
+    // ETag makes that check free for both sides.
+    c.header("Cache-Control", "public, max-age=0, must-revalidate");
+    if (ifNoneMatchSatisfied(c.req.header("If-None-Match"), etag)) return c.body(null, 304);
+    c.header("Content-Type", "application/json; charset=UTF-8");
+    return c.body(body);
+  });
+
+  return router;
+}

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -7,14 +7,31 @@ import { db } from "@appstrate/db/client";
 import { getAuth } from "@appstrate/db/auth";
 import { organizationMembers, runs } from "@appstrate/db/schema";
 import { scopedWhere } from "../lib/db-helpers.ts";
-import { addSubscriber, removeSubscriber } from "../services/realtime.ts";
-import type { RealtimeEvent } from "../services/realtime.ts";
+import { addSubscriber, removeSubscriber, REALTIME_CHANNELS } from "../services/realtime.ts";
+import type { RealtimeEvent, RealtimeChannel } from "../services/realtime.ts";
 import { forbidden, unauthorized } from "../lib/errors.ts";
 import { validateApiKey } from "../services/api-keys.ts";
 import { resolveApiKeyPermissions } from "../lib/permissions.ts";
 import { validateApplicationInOrg } from "../middleware/app-context.ts";
 import { logger } from "../lib/logger.ts";
 import type { OrgRole } from "../types/index.ts";
+
+/**
+ * Hard cap on frames queued for one subscriber before we give up on it.
+ *
+ * Sized well above any legitimate burst: the loudest producer is `run_log`
+ * on a verbose single-run stream, and a run that emits 2 000 unread log
+ * frames faster than the socket accepts them is a consumer that has stopped
+ * reading, not a fast run.
+ */
+const MAX_PENDING_EVENTS = 2_000;
+
+/**
+ * How long a single frame write may stay unsettled before the connection is
+ * treated as dead. Generous on purpose — frames are small and the keep-alive
+ * period is 30 s, so exceeding this means the peer is not draining at all.
+ */
+const WRITE_DEADLINE_MS = 60_000;
 
 /** Strip large user-content fields from SSE payloads for non-verbose consumers. */
 function stripPayload(evt: RealtimeEvent): Record<string, unknown> {
@@ -26,6 +43,31 @@ function stripPayload(evt: RealtimeEvent): Record<string, unknown> {
   // `result`); `run_metric` is bounded numerics + four ids; `connection_update`
   // is identifiers + flags — all pass through unmodified.
   return evt.data;
+}
+
+/**
+ * Parse the optional `?channels=` subscription filter.
+ *
+ * Contract (deliberately fail-open):
+ *   • parameter absent            → `undefined` = subscribe to every channel.
+ *     This is what every pre-existing client (CLI, SDKs, integrators) sends,
+ *     so their stream is byte-identical to before.
+ *   • parameter present           → the intersection with the known channel
+ *     names. Unknown tokens are ignored rather than rejected so adding a
+ *     channel later can't 400 an older client that hardcoded a list.
+ *   • nothing recognised          → `undefined` (every channel) rather than an
+ *     empty subscription. A typo must degrade to "too much data", never to a
+ *     silently dead stream.
+ */
+function parseChannels(raw: string | undefined): ReadonlySet<RealtimeChannel> | undefined {
+  if (raw === undefined) return undefined;
+  const requested = new Set<RealtimeChannel>();
+  for (const token of raw.split(",")) {
+    const name = token.trim();
+    const known = REALTIME_CHANNELS.find((c) => c === name);
+    if (known) requested.add(known);
+  }
+  return requested.size > 0 ? requested : undefined;
 }
 
 interface SSEAuthResult {
@@ -147,6 +189,7 @@ function openRealtimeStream(
      */
     userId?: string;
     endUserId?: string;
+    channels?: ReadonlySet<RealtimeChannel>;
   },
   verbose: boolean,
   onSubscribe?: (send: (evt: RealtimeEvent) => void) => void | Promise<void>,
@@ -156,8 +199,40 @@ function openRealtimeStream(
     // immediately via the stream's own async context (avoids Bun buffering).
     const pending: { event: string; data: string }[] = [];
     let wake: (() => void) | null = null;
+    /** Set when this subscriber was dropped for being unable to keep up. */
+    let droppedForBackpressure = false;
 
     const send = (evt: RealtimeEvent) => {
+      if (droppedForBackpressure) return;
+      // Backpressure policy — DROP THE SUBSCRIBER, don't grow the server.
+      //
+      // `pending` is filled synchronously from PG LISTEN callbacks and drained
+      // by the stream's own async loop. A consumer that stops reading (dead
+      // TCP peer, suspended tab, a client whose socket has a full send buffer)
+      // stalls the drain while the producer keeps pushing, so an unbounded
+      // queue turns one wedged client into unbounded API-process memory —
+      // multiplied by every open stream.
+      //
+      // Trade-off, stated plainly: a dropped subscriber LOSES EVENTS. There is
+      // no `Last-Event-ID` replay (see the resume note below), so the client's
+      // reconnect lands on the live tail and the gap is permanent. That is
+      // accepted deliberately: a client this far behind is already showing
+      // stale state, the browser hooks reconnect automatically, and the
+      // alternative (unbounded growth) degrades every other tenant on the
+      // process. The cap is sized so only a genuinely stuck consumer trips it.
+      if (pending.length >= MAX_PENDING_EVENTS) {
+        droppedForBackpressure = true;
+        pending.length = 0;
+        removeSubscriber(subId);
+        logger.warn("SSE subscriber dropped — outbound queue overflowed", {
+          subId,
+          cap: MAX_PENDING_EVENTS,
+          runId: filter.runId,
+          packageId: filter.packageId,
+        });
+        wake?.();
+        return;
+      }
       const payload = verbose ? evt.data : stripPayload(evt);
       pending.push({ event: evt.event, data: JSON.stringify(payload) });
       wake?.();
@@ -168,6 +243,14 @@ function openRealtimeStream(
       removeSubscriber(subId);
       wake?.();
     });
+    // Belt-and-braces teardown for half-open connections. Hono only wires its
+    // `c.req.raw.signal` listener on Bun < 1.2 (`isOldBunVersion` in
+    // hono/helper/streaming/sse), so on current Bun the ONLY abort path is
+    // `responseReadable.cancel()` — which covers a clean disconnect but not a
+    // peer that vanished without a FIN. When the runtime does abort the
+    // request signal we tear down immediately instead of waiting for the
+    // write deadline below. `stream.abort()` is idempotent.
+    c.req.raw.signal.addEventListener("abort", () => stream.abort(), { once: true });
     void Promise.resolve(onSubscribe?.(send)).catch((err: unknown) => {
       logger.warn("SSE initial snapshot failed", {
         subId,
@@ -202,38 +285,87 @@ function openRealtimeStream(
     let nextEventId = 0;
     const allocateId = (): string => `${subId}:${++nextEventId}`;
 
-    // Immediate ping confirms the connection is alive.
-    await stream.writeSSE({ event: "ping", data: "", id: allocateId() });
-
-    const PING_INTERVAL = 30_000;
-    let lastWrite = Date.now();
-
-    while (!stream.aborted) {
-      // Drain any queued events
-      while (pending.length > 0) {
-        const msg = pending.shift()!;
-        await stream.writeSSE({ ...msg, id: allocateId() });
-        lastWrite = Date.now();
-      }
-
-      // Wait for next event or ping timeout, whichever comes first
-      const elapsed = Date.now() - lastWrite;
-      const timeout = Math.max(0, PING_INTERVAL - elapsed);
-
-      await new Promise<void>((resolve) => {
-        const timer = setTimeout(resolve, timeout);
-        wake = () => {
-          clearTimeout(timer);
-          resolve();
-        };
+    /**
+     * Write one frame with a deadline.
+     *
+     * Hono's `StreamingApi.write` swallows writer errors and never flips
+     * `stream.aborted`, so a half-open peer surfaces here as a write that
+     * simply never settles (the TransformStream stops being pulled once the
+     * runtime's socket buffer fills). Racing a timer converts that silent
+     * wedge into a normal teardown. Returns false when the deadline expired.
+     */
+    const writeFrame = async (msg: {
+      event: string;
+      data: string;
+      id: string;
+    }): Promise<boolean> => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const deadline = new Promise<false>((resolve) => {
+        timer = setTimeout(() => resolve(false), WRITE_DEADLINE_MS);
       });
-      wake = null;
-
-      // If no events were queued during the wait, send a keep-alive ping
-      if (pending.length === 0) {
-        await stream.writeSSE({ event: "ping", data: "", id: allocateId() });
-        lastWrite = Date.now();
+      try {
+        return await Promise.race([stream.writeSSE(msg).then(() => true), deadline]);
+      } finally {
+        clearTimeout(timer);
       }
+    };
+
+    try {
+      // Immediate ping confirms the connection is alive.
+      await writeFrame({ event: "ping", data: "", id: allocateId() });
+
+      const PING_INTERVAL = 30_000;
+      let lastWrite = Date.now();
+
+      while (!stream.aborted && !droppedForBackpressure) {
+        // Drain any queued events
+        while (pending.length > 0) {
+          const msg = pending.shift()!;
+          if (!(await writeFrame({ ...msg, id: allocateId() }))) {
+            logger.warn("SSE write deadline exceeded — closing stalled stream", {
+              subId,
+              deadlineMs: WRITE_DEADLINE_MS,
+            });
+            stream.abort();
+            return;
+          }
+          lastWrite = Date.now();
+        }
+        if (droppedForBackpressure) break;
+
+        // Wait for next event or ping timeout, whichever comes first
+        const elapsed = Date.now() - lastWrite;
+        const timeout = Math.max(0, PING_INTERVAL - elapsed);
+
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, timeout);
+          wake = () => {
+            clearTimeout(timer);
+            resolve();
+          };
+        });
+        wake = null;
+
+        // If no events were queued during the wait, send a keep-alive ping
+        if (pending.length === 0 && !droppedForBackpressure) {
+          if (!(await writeFrame({ event: "ping", data: "", id: allocateId() }))) {
+            logger.warn("SSE keep-alive deadline exceeded — closing stalled stream", {
+              subId,
+              deadlineMs: WRITE_DEADLINE_MS,
+            });
+            stream.abort();
+            return;
+          }
+          lastWrite = Date.now();
+        }
+      }
+    } finally {
+      // Single guaranteed unsubscribe point. `onAbort` covers clean
+      // disconnects, but the loop can also exit via the backpressure drop or
+      // the write deadline — leaving the subscriber registered would keep the
+      // fan-out pushing into a queue nobody drains. `removeSubscriber` is a
+      // `Map.delete`, so calling it twice is harmless.
+      removeSubscriber(subId);
     }
   });
 }
@@ -310,6 +442,7 @@ export function createRealtimeRouter() {
         applicationId: validated.applicationId,
         isAdmin: validated.isAdmin,
         userId: validated.userId,
+        channels: parseChannels(c.req.query("channels")),
       },
       verbose,
       (send) =>
@@ -339,6 +472,7 @@ export function createRealtimeRouter() {
         applicationId: validated.applicationId,
         isAdmin: validated.isAdmin,
         userId: validated.userId,
+        channels: parseChannels(c.req.query("channels")),
       },
       verbose,
     );
@@ -360,6 +494,7 @@ export function createRealtimeRouter() {
         applicationId: validated.applicationId,
         isAdmin: validated.isAdmin,
         userId: validated.userId,
+        channels: parseChannels(c.req.query("channels")),
       },
       verbose,
     );

--- a/apps/api/src/services/integration-service.ts
+++ b/apps/api/src/services/integration-service.ts
@@ -202,13 +202,16 @@ async function resolvePublishedManifest(
   if (!pkgRow) return { ok: false, reason: "not_found" };
   if (pkgRow.type !== expectedType) return { ok: false, reason: "wrong_type" };
 
+  // Projection is deliberately metadata-only: `pickVersion` reads nothing but
+  // (version, integrity, yanked), and this list is UNBOUNDED — a package with
+  // N published versions would otherwise pull N manifest jsonb blobs to keep
+  // exactly one. The winner's manifest is fetched by itself below.
   const [versionRows, tagRows] = await Promise.all([
     db
       .select({
         version: packageVersions.version,
         integrity: packageVersions.integrity,
         yanked: packageVersions.yanked,
-        manifest: packageVersions.manifest,
       })
       .from(packageVersions)
       // Same tenant boundary on the version lookup itself (not just the
@@ -233,15 +236,27 @@ async function resolvePublishedManifest(
   // exact → dist-tag → range resolution and the yanked-visibility rule shared
   // with `DbPackageCatalog`.
   const spec = pin && pin.trim().length > 0 ? pin.trim() : "latest";
-  const picked = pickVersion(
-    spec,
-    versionRows.map((v) => ({ version: v.version, integrity: v.integrity, yanked: v.yanked })),
-    tagRows,
-  );
+  const picked = pickVersion(spec, versionRows, tagRows);
   if (!picked) return { ok: false, reason: "unsatisfiable_pin" };
 
-  const row = versionRows.find((v) => v.version === picked.version);
-  return { ok: true, rawManifest: row?.manifest, version: picked.version, source: "version" };
+  // Manifest of the WINNING version only — same tenant boundary as the list
+  // read above, so the two reads cannot skew across a concurrent
+  // delete/recreate of the package id.
+  const [manifestRow] = await db
+    .select({ manifest: packageVersions.manifest })
+    .from(packageVersions)
+    .innerJoin(packages, and(eq(packages.id, packageVersions.packageId), orgOrSystemFilter(orgId)))
+    .where(
+      and(eq(packageVersions.packageId, packageId), eq(packageVersions.version, picked.version)),
+    )
+    .limit(1);
+
+  return {
+    ok: true,
+    rawManifest: manifestRow?.manifest,
+    version: picked.version,
+    source: "version",
+  };
 }
 
 /**

--- a/apps/api/src/services/package-items/crud.ts
+++ b/apps/api/src/services/package-items/crud.ts
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { eq, and, or, desc, sql, isNotNull } from "drizzle-orm";
+import { eq, and, or, ne, desc, sql, isNotNull } from "drizzle-orm";
+import { unionAll } from "drizzle-orm/pg-core";
 import { db } from "@appstrate/db/client";
 import { applicationPackages, packages } from "@appstrate/db/schema";
 import type { Package } from "@appstrate/db/schema";
-import { extractDependencies } from "@appstrate/core/dependencies";
-import { buildPackageId } from "@appstrate/core/naming";
 import { AFPS_SCHEMA_URLS } from "@appstrate/core/validation";
 import { type PackageTypeConfig } from "./config.ts";
 import { enqueueStorageDeletion } from "../storage-deletion.ts";
@@ -44,30 +43,95 @@ export async function getPackageById(id: string): Promise<Package | null> {
 // Helpers (private)
 // ─────────────────────────────────────────────
 
-/** Fetch package display names from a list of package IDs. */
-/** Find packages that depend on the target package (via manifest dependencies). */
+/**
+ * The three AFPS §4.1 dependency maps on a manifest. Compile-time constants —
+ * they are interpolated as SQL literals below, never user input.
+ */
+const DEPENDENCY_MAPS = ["skills", "mcp_servers", "integrations"] as const;
+type DependencyMap = (typeof DEPENDENCY_MAPS)[number];
+
+/**
+ * SQL for one dependency map of `packages.draft_manifest`, normalized to an
+ * empty object when it is absent or not an object. Both `jsonb_object_keys`
+ * and `jsonb_exists` reject non-object input, and a hand-edited manifest whose
+ * `dependencies.skills` is a string must not take down the catalog read.
+ */
+function dependencyMapSql(map: DependencyMap) {
+  const expr = sql`${packages.draftManifest} -> 'dependencies' -> ${map}::text`;
+  return sql`(case when jsonb_typeof(${expr}) = 'object' then ${expr} else '{}'::jsonb end)`;
+}
+
+/** SQL mirroring {@link getPackageDisplayName}: manifest `display_name` when it is a string, else the id. */
+const displayNameSql = sql<string>`(case
+  when jsonb_typeof(${packages.draftManifest} -> 'display_name') = 'string'
+  then ${packages.draftManifest} ->> 'display_name'
+  else ${packages.id}
+end)`;
+
+/**
+ * Find packages that depend on the target package (via manifest dependencies).
+ *
+ * Evaluated in SQL: the previous implementation pulled EVERY org package's
+ * `draft_manifest` jsonb into the process to answer a boolean question, on
+ * both the item-detail read and the delete pre-check.
+ */
 async function findDependentPackages(
   orgId: string,
   targetPackageId: string,
 ): Promise<{ id: string; display_name: string }[]> {
-  const orgPkgs = await db
-    .select({ id: packages.id, draftManifest: packages.draftManifest })
-    .from(packages)
-    .where(and(scopedWhere(packages, { orgId }), notEphemeralFilter()));
+  const declaresTarget = or(
+    ...DEPENDENCY_MAPS.map(
+      (map) => sql`jsonb_exists(${dependencyMapSql(map)}, ${targetPackageId})`,
+    ),
+  )!;
 
-  const dependents: { id: string; display_name: string }[] = [];
-  for (const pkg of orgPkgs) {
-    if (!pkg.draftManifest || pkg.id === targetPackageId) continue;
-    const m = parseDraftManifest(pkg.draftManifest);
-    const deps = extractDependencies(m);
-    for (const dep of deps) {
-      if (buildPackageId(dep.depScope, dep.depName) === targetPackageId) {
-        dependents.push({ id: pkg.id, display_name: getPackageDisplayName(pkg) });
-        break;
-      }
-    }
+  return db
+    .select({ id: packages.id, display_name: displayNameSql })
+    .from(packages)
+    .where(
+      and(
+        scopedWhere(packages, { orgId }),
+        notEphemeralFilter(),
+        ne(packages.id, targetPackageId),
+        declaresTarget,
+      ),
+    )
+    .orderBy(packages.id);
+}
+
+/**
+ * `used_by_agents` for every package of the org, computed in SQL.
+ *
+ * One row per declared dependency edge (a short package id string) instead of
+ * one full `draft_manifest` jsonb per org package — the counting loop only
+ * ever needed the KEYS of the three dependency maps. Semantics are preserved
+ * edge-for-edge, including a package that declares the same id under two maps
+ * counting twice, and a package counting itself.
+ *
+ * The one behavioral difference is a strict improvement: a malformed manifest
+ * (invalid scoped name, non-string version range) used to make
+ * `extractDependencies` throw and 500 the whole catalog read. Here such a key
+ * is simply counted under an id no package can have, so it matches nothing.
+ */
+async function countDependencyEdges(orgId: string): Promise<Map<string, number>> {
+  const branches = DEPENDENCY_MAPS.map((map) =>
+    db
+      .select({
+        depId: sql<string>`jsonb_object_keys(${dependencyMapSql(map)})`.as("dep_id"),
+      })
+      .from(packages)
+      // Ephemeral shadow packages are transient and never referenced by other
+      // packages, so filtering them out also skips their (empty) dependencies.
+      .where(and(scopedWhere(packages, { orgId }), notEphemeralFilter())),
+  );
+
+  const rows = await unionAll(branches[0]!, branches[1]!, ...branches.slice(2));
+
+  const countMap = new Map<string, number>();
+  for (const row of rows) {
+    countMap.set(row.depId, (countMap.get(row.depId) ?? 0) + 1);
   }
-  return dependents;
+  return countMap;
 }
 
 // ─────────────────────────────────────────────
@@ -221,14 +285,16 @@ export async function listOrgItems(
   const installFilter = opts?.activeOnly
     ? and(isNotNull(applicationPackages.packageId), eq(applicationPackages.enabled, true))
     : or(eq(packages.source, "system"), isNotNull(applicationPackages.packageId));
-  const data = await db
+  // `draftContent` (the whole SKILL.md / prompt.md body) is deliberately NOT
+  // projected: the list mapper never reads it, and it is by far the largest
+  // column on the row.
+  const dataQuery = db
     .select({
       id: packages.id,
       orgId: packages.orgId,
       type: packages.type,
       source: packages.source,
       draftManifest: packages.draftManifest,
-      draftContent: packages.draftContent,
       createdBy: packages.createdBy,
       createdAt: packages.createdAt,
       updatedAt: packages.updatedAt,
@@ -257,22 +323,9 @@ export async function listOrgItems(
       desc(packages.createdAt),
     );
 
-  // Count usage by scanning all org packages' manifests. Ephemeral shadow
-  // packages are transient and never referenced by other packages, so
-  // filtering them out also skips their (empty) dependencies.
-  const countMap = new Map<string, number>();
-  const allOrgPkgs = await db
-    .select({ id: packages.id, draftManifest: packages.draftManifest })
-    .from(packages)
-    .where(and(scopedWhere(packages, { orgId }), notEphemeralFilter()));
-  for (const pkg of allOrgPkgs) {
-    if (!pkg.draftManifest) continue;
-    const deps = extractDependencies(parseDraftManifest(pkg.draftManifest));
-    for (const dep of deps) {
-      const depId = buildPackageId(dep.depScope, dep.depName);
-      countMap.set(depId, (countMap.get(depId) ?? 0) + 1);
-    }
-  }
+  // The catalog page and the usage counts are independent reads over the same
+  // tenant — issued concurrently rather than one after the other.
+  const [data, countMap] = await Promise.all([dataQuery, countDependencyEdges(orgId)]);
 
   return data.map((row) => {
     const m = parseDraftManifest(row.draftManifest);

--- a/apps/api/src/services/realtime.ts
+++ b/apps/api/src/services/realtime.ts
@@ -14,6 +14,17 @@ import {
 
 export type { RealtimeEvent };
 
+/** Every channel name the fan-out can emit (`ping` is transport-level, not a channel). */
+export type RealtimeChannel = RealtimeEvent["event"];
+
+export const REALTIME_CHANNELS: readonly RealtimeChannel[] = [
+  "run_update",
+  "run_log",
+  "run_metric",
+  "connection_update",
+  "chat_session_update",
+];
+
 type Subscriber = {
   id: string;
   filter: {
@@ -22,6 +33,15 @@ type Subscriber = {
     orgId: string;
     applicationId: string;
     isAdmin?: boolean;
+    /**
+     * Channels the subscriber declared interest in. `undefined` means "every
+     * channel" — the historical behaviour, preserved so an existing client
+     * (CLI, SDK, integrator) that never learned about the parameter keeps
+     * receiving the full stream. A declared set only ever REMOVES frames the
+     * subscriber would have thrown away client-side, so no consumer can lose
+     * data it was actually reading.
+     */
+    channels?: ReadonlySet<RealtimeChannel>;
     /**
      * Actor identity for the `connection_update` channel. The trigger
      * fires for every connection on the application; the subscriber
@@ -38,6 +58,36 @@ type Subscriber = {
 
 const subscribers = new Map<string, Subscriber>();
 let initialized = false;
+
+/**
+ * Channel gate — the cheapest possible check, so it runs FIRST in every
+ * fan-out loop (before the org/app/run comparisons and, critically, before
+ * `JSON.stringify` in the subscriber's `send`).
+ *
+ * A subscriber with no declared channel set accepts everything.
+ */
+function accepts(sub: Subscriber, channel: RealtimeChannel): boolean {
+  return sub.filter.channels === undefined || sub.filter.channels.has(channel);
+}
+
+/**
+ * Cheap pre-gate: is ANY connected subscriber interested in this channel?
+ *
+ * When nobody is, we skip `JSON.parse` + Zod validation of the payload
+ * entirely — which is the whole point for `run_log`, whose NOTIFY payload
+ * carries up to 6 KB of log `data` per row and used to be parsed and
+ * validated on every insert even when every open stream discarded it.
+ *
+ * This can only skip work that would have produced zero `send()` calls:
+ * the per-subscriber loop below re-checks `accepts()` for each subscriber,
+ * so a `true` here never widens fan-out.
+ */
+function anyAccepts(channel: RealtimeChannel): boolean {
+  for (const sub of subscribers.values()) {
+    if (accepts(sub, channel)) return true;
+  }
+  return false;
+}
 
 /** Convert snake_case keys from PG NOTIFY to camelCase for API consistency. */
 function snakeToCamel(obj: Record<string, unknown>): Record<string, unknown> {
@@ -59,6 +109,7 @@ export async function initRealtime(): Promise<void> {
 
   await listenClient.listen("run_update", (payload) => {
     try {
+      if (!anyAccepts("run_update")) return;
       const raw = JSON.parse(payload) as Record<string, unknown>;
       const parsed = runUpdateEventSchema.safeParse(snakeToCamel(raw));
       if (!parsed.success) {
@@ -68,6 +119,7 @@ export async function initRealtime(): Promise<void> {
         return;
       }
       for (const sub of subscribers.values()) {
+        if (!accepts(sub, "run_update")) continue;
         if (sub.filter.orgId !== raw.org_id) continue;
         if (sub.filter.applicationId !== raw.application_id) continue;
         if (sub.filter.runId && sub.filter.runId !== raw.id) continue;
@@ -93,6 +145,9 @@ export async function initRealtime(): Promise<void> {
 
   await listenClient.listen("run_log_insert", (payload) => {
     try {
+      // The firehose. Every `run_logs` INSERT lands here; when no open stream
+      // declared the `run_log` channel we drop it before paying for the parse.
+      if (!anyAccepts("run_log")) return;
       const raw = JSON.parse(payload) as Record<string, unknown>;
       const parsed = runLogEventSchema.safeParse(snakeToCamel(raw));
       if (!parsed.success) {
@@ -102,6 +157,7 @@ export async function initRealtime(): Promise<void> {
         return;
       }
       for (const sub of subscribers.values()) {
+        if (!accepts(sub, "run_log")) continue;
         if (sub.filter.orgId !== raw.org_id) continue;
         if (sub.filter.applicationId !== raw.application_id) continue;
         if (sub.filter.runId && sub.filter.runId !== raw.run_id) continue;
@@ -133,6 +189,7 @@ export async function initRealtime(): Promise<void> {
   // broadcaster payload contract.
   await listenClient.listen("run_metric", (payload) => {
     try {
+      if (!anyAccepts("run_metric")) return;
       const raw = JSON.parse(payload) as Record<string, unknown>;
       const parsed = runMetricEventSchema.safeParse(snakeToCamel(raw));
       if (!parsed.success) {
@@ -142,6 +199,7 @@ export async function initRealtime(): Promise<void> {
         return;
       }
       for (const sub of subscribers.values()) {
+        if (!accepts(sub, "run_metric")) continue;
         if (sub.filter.orgId !== raw.org_id) continue;
         if (sub.filter.applicationId !== raw.application_id) continue;
         if (sub.filter.runId && sub.filter.runId !== raw.run_id) continue;
@@ -176,6 +234,7 @@ export async function initRealtime(): Promise<void> {
   // `applicationId ∈ orgId`.
   await listenClient.listen("connection_update", (payload) => {
     try {
+      if (!anyAccepts("connection_update")) return;
       const raw = JSON.parse(payload) as Record<string, unknown>;
       const parsed = connectionUpdateEventSchema.safeParse(snakeToCamel(raw));
       if (!parsed.success) {
@@ -186,6 +245,7 @@ export async function initRealtime(): Promise<void> {
       }
       const data = parsed.data;
       for (const sub of subscribers.values()) {
+        if (!accepts(sub, "connection_update")) continue;
         if (sub.filter.applicationId !== raw.application_id) continue;
         // Actor filter: only fan out rows the subscriber owns. Without
         // this, every member of an app would receive every other
@@ -216,6 +276,7 @@ export async function initRealtime(): Promise<void> {
   // subscriptions without an actor are skipped rather than leaked to.
   await listenClient.listen("chat_session_update", (payload) => {
     try {
+      if (!anyAccepts("chat_session_update")) return;
       const raw = JSON.parse(payload) as Record<string, unknown>;
       const parsed = chatSessionUpdateEventSchema.safeParse(snakeToCamel(raw));
       if (!parsed.success) {
@@ -226,6 +287,7 @@ export async function initRealtime(): Promise<void> {
         return;
       }
       for (const sub of subscribers.values()) {
+        if (!accepts(sub, "chat_session_update")) continue;
         if (sub.filter.orgId !== raw.org_id) continue;
         if (sub.filter.userId === undefined || sub.filter.userId !== raw.user_id) continue;
         sub.send({ event: "chat_session_update", data: parsed.data });
@@ -246,4 +308,16 @@ export function addSubscriber(sub: Subscriber): void {
 
 export function removeSubscriber(id: string): void {
   subscribers.delete(id);
+}
+
+/**
+ * Test-only introspection — number of registered subscribers.
+ *
+ * Used to assert that a stream dropped for backpressure actually
+ * unregisters (the drop happens inside the route's stream closure, whose
+ * subscriber id is generated internally). Compare a delta, not an absolute:
+ * the whole test process shares this map.
+ */
+export function activeSubscriberCount(): number {
+  return subscribers.size;
 }

--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -296,11 +296,26 @@ export async function finalizeRun(input: FinalizeRunInput): Promise<void> {
   // Finalize span — the single CAS-guarded convergence for every run
   // termination path. Nests under the active request/run span when present.
   // A true no-op when observability is disabled.
-  await runWithSpan(
-    "appstrate.run.finalize",
-    { attributes: { "appstrate.run.id": input.run.id } },
-    () => finalizeRunImpl(input),
-  );
+  try {
+    await runWithSpan(
+      "appstrate.run.finalize",
+      { attributes: { "appstrate.run.id": input.run.id } },
+      () => finalizeRunImpl(input),
+    );
+  } finally {
+    // Single, unconditional release point for the run's in-memory metric
+    // throttle entry. `finalizeRunImpl` has many exits (idempotent no-op when
+    // the sink is already closed, the CAS-winner path, and any throw from the
+    // post-CAS side effects); dropping the entry here covers all of them,
+    // including the throwing ones that previously leaked it for the lifetime
+    // of the process. Also runs AFTER the post-CAS side effects, so a metric
+    // event racing them cannot re-create an entry that nothing then clears.
+    //
+    // Local-only by construction: the entry lives on whichever replica
+    // ingested the metric event, which is not necessarily the one handling
+    // `/finalize`. The broadcaster's own idle sweep is what bounds that case.
+    clearRunMetricBroadcastState(input.run.id);
+  }
 }
 
 async function finalizeRunImpl(input: FinalizeRunInput): Promise<void> {
@@ -553,16 +568,11 @@ async function finalizeRunImpl(input: FinalizeRunInput): Promise<void> {
 
   if (rowsAffected.length === 0) {
     logger.debug("finalizeRun idempotent — sink already closed", { runId: run.id });
-    // Even on the no-op branch, clear any lingering throttle state so
-    // a long-running API process doesn't leak entries for retry-storm
-    // runs that all collapse onto the same id.
-    clearRunMetricBroadcastState(run.id);
     return;
   }
 
-  // Drop the per-run throttle state — the run is terminal, no further
-  // metric events will arrive. Bounds the broadcaster's in-memory map.
-  clearRunMetricBroadcastState(run.id);
+  // NOTE: the per-run metric throttle entry is released in `finalizeRun`'s
+  // `finally` — one release point covering every exit of this function.
 
   // SLI emission — exactly-once on the CAS winner. Run-duration histogram +
   // terminal-status counter (the failure-rate source). No-op when disabled.

--- a/apps/api/src/services/run-metric-broadcaster.ts
+++ b/apps/api/src/services/run-metric-broadcaster.ts
@@ -62,12 +62,59 @@ interface ThrottleState {
 const throttleByRunId = new Map<string, ThrottleState>();
 
 /**
+ * Idle age after which an entry is swept even though no `finalizeRun` ever
+ * cleared it. Comfortably above the longest plausible gap between two metric
+ * events of a live run, so a sweep never resets the throttle of a run that is
+ * actually streaming (and if it did, the only consequence is one extra
+ * leading-edge broadcast).
+ */
+const ENTRY_MAX_IDLE_MS = 15 * 60_000;
+
+/** Minimum interval between sweeps — the sweep is O(map size), so rate-limit it. */
+const SWEEP_INTERVAL_MS = 60_000;
+
+let lastSweptAt = 0;
+
+/**
+ * Drop entries whose last broadcast is older than {@link ENTRY_MAX_IDLE_MS}.
+ *
+ * Why a time-based sweep exists at all: the entry is created on the replica
+ * that INGESTS the metric event, and only `finalizeRun` removes it — on the
+ * replica that receives `/finalize`. Single-container today, so the two are
+ * the same process and the explicit clear always lands; the sweep is what
+ * keeps that from silently becoming an unbounded map the day the API runs
+ * more than one replica. Deliberately piggy-backed on `scheduleRunMetricBroadcast`
+ * rather than a `setInterval` — no timer to own, unref, or tear down in tests.
+ *
+ * Cannot lose a broadcast: an entry with a pending trailing timer is never
+ * swept, and sweeping an idle entry only means the run's next metric event
+ * fires on the leading edge instead of being coalesced.
+ */
+function sweepIdleEntries(now: number): void {
+  if (now - lastSweptAt < SWEEP_INTERVAL_MS) return;
+  lastSweptAt = now;
+  for (const [runId, state] of throttleByRunId) {
+    if (state.trailingTimer !== null) continue;
+    if (now - state.lastFiredAt < ENTRY_MAX_IDLE_MS) continue;
+    throttleByRunId.delete(runId);
+  }
+}
+
+/** Test-only introspection — number of live throttle entries. */
+export function activeRunMetricThrottleCount(): number {
+  return throttleByRunId.size;
+}
+
+/**
  * Schedule a `run_metric` broadcast for the given run. Safe to call on
  * every metric event — the per-run throttle handles coalescing.
  */
 export function scheduleRunMetricBroadcast(runId: string): void {
-  const state = throttleByRunId.get(runId);
   const now = Date.now();
+  // Sweep BEFORE reading the entry, so we never mutate a state object the
+  // sweep just detached from the map.
+  sweepIdleEntries(now);
+  const state = throttleByRunId.get(runId);
 
   if (!state) {
     // First emit ever for this run — fire on the leading edge so the
@@ -121,6 +168,7 @@ export function _resetRunMetricBroadcasterForTests(): void {
     if (state.trailingTimer) clearTimeout(state.trailingTimer);
   }
   throttleByRunId.clear();
+  lastSweptAt = 0;
 }
 
 async function fireBroadcast(runId: string): Promise<void> {

--- a/apps/api/src/services/run-wait.ts
+++ b/apps/api/src/services/run-wait.ts
@@ -12,8 +12,10 @@
  *
  * Wakeup mechanism (in priority order):
  *
- *  1. **PG NOTIFY** — the `runs_notify_trigger` fires `run_update` on every
- *     `runs` UPDATE; `services/realtime.ts` LISTENs once per process and
+ *  1. **PG NOTIFY** — `runs_notify_update_trigger` fires `run_update` on any
+ *     `runs` UPDATE that changes a payload-visible column (`status` among
+ *     them, which is all this module reads); `services/realtime.ts` LISTENs
+ *     once per process and
  *     fans out to in-process subscribers. This works across multi-instance
  *     deployments (each instance holds its own LISTEN connection to the
  *     shared PostgreSQL) AND in Tier-0 (PGlite implements LISTEN/NOTIFY
@@ -284,6 +286,10 @@ export async function waitForRunTerminal(opts: {
         orgId: scope.orgId,
         applicationId: scope.applicationId,
         isAdmin: true,
+        // This in-process subscriber only ever acts on `run_update` (see the
+        // `send` handler below); declaring it keeps the run's log and metric
+        // frames from being serialized for a consumer that discards them.
+        channels: new Set(["run_update"]),
       },
       send: (evt) => {
         if (evt.event !== "run_update") return;

--- a/apps/api/src/services/state/runs.ts
+++ b/apps/api/src/services/state/runs.ts
@@ -42,6 +42,7 @@ import { getEnv } from "@appstrate/env";
 import { logger } from "../../lib/logger.ts";
 import { listResponse } from "../../lib/list-response.ts";
 import { scopedWhere } from "../../lib/db-helpers.ts";
+import { orgOrSystemFilter } from "../../lib/package-helpers.ts";
 import { type Actor, actorFilter } from "../../lib/actor.ts";
 import {
   runMetadataSchema,
@@ -1203,20 +1204,25 @@ export async function listRunsWithFilter(
   offset = 0,
   actor: Actor | null = null,
 ): Promise<RunListPage> {
-  const [countRow] = await db.select({ count: count() }).from(runs).where(filter);
-
-  const rows = await db
-    .select(enrichedRunSelect(actor))
-    .from(runs)
-    .leftJoin(profiles, eq(runs.userId, profiles.id))
-    .leftJoin(endUsers, eq(runs.endUserId, endUsers.id))
-    .leftJoin(apiKeys, eq(runs.apiKeyId, apiKeys.id))
-    .leftJoin(schedules, eq(runs.scheduleId, schedules.id))
-    .leftJoin(packages, eq(packages.id, runs.packageId))
-    .where(filter)
-    .orderBy(desc(runs.startedAt))
-    .limit(limit)
-    .offset(offset);
+  // The `total` count and the page share the same filter but are independent
+  // reads — issued concurrently so the endpoint costs one round trip instead
+  // of two serialized ones. Both are tenant-indexed; neither is a seq scan.
+  const [countRows, rows] = await Promise.all([
+    db.select({ count: count() }).from(runs).where(filter),
+    db
+      .select(enrichedRunSelect(actor))
+      .from(runs)
+      .leftJoin(profiles, eq(runs.userId, profiles.id))
+      .leftJoin(endUsers, eq(runs.endUserId, endUsers.id))
+      .leftJoin(apiKeys, eq(runs.apiKeyId, apiKeys.id))
+      .leftJoin(schedules, eq(runs.scheduleId, schedules.id))
+      .leftJoin(packages, eq(packages.id, runs.packageId))
+      .where(filter)
+      .orderBy(desc(runs.startedAt))
+      .limit(limit)
+      .offset(offset),
+  ]);
+  const [countRow] = countRows;
 
   const data = rows.map(mapEnrichedRun);
   const total = countRow?.count ?? 0;
@@ -1307,24 +1313,28 @@ export async function listGlobalRuns(
 
   const filter = and(...conditions)!;
 
-  const [countRow] = await db
-    .select({ count: count() })
-    .from(runs)
-    .leftJoin(packages, eq(packages.id, runs.packageId))
-    .where(filter);
-
-  const rows = await db
-    .select(enrichedRunSelect(actor))
-    .from(runs)
-    .leftJoin(packages, eq(packages.id, runs.packageId))
-    .leftJoin(profiles, eq(runs.userId, profiles.id))
-    .leftJoin(endUsers, eq(runs.endUserId, endUsers.id))
-    .leftJoin(apiKeys, eq(runs.apiKeyId, apiKeys.id))
-    .leftJoin(schedules, eq(runs.scheduleId, schedules.id))
-    .where(filter)
-    .orderBy(desc(runs.startedAt))
-    .limit(limit)
-    .offset(offset);
+  // Same rationale as `listRunsWithFilter`: count and page are independent
+  // reads over one filter, so they go out concurrently.
+  const [countRows, rows] = await Promise.all([
+    db
+      .select({ count: count() })
+      .from(runs)
+      .leftJoin(packages, eq(packages.id, runs.packageId))
+      .where(filter),
+    db
+      .select(enrichedRunSelect(actor))
+      .from(runs)
+      .leftJoin(packages, eq(packages.id, runs.packageId))
+      .leftJoin(profiles, eq(runs.userId, profiles.id))
+      .leftJoin(endUsers, eq(runs.endUserId, endUsers.id))
+      .leftJoin(apiKeys, eq(runs.apiKeyId, apiKeys.id))
+      .leftJoin(schedules, eq(runs.scheduleId, schedules.id))
+      .where(filter)
+      .orderBy(desc(runs.startedAt))
+      .limit(limit)
+      .offset(offset),
+  ]);
+  const [countRow] = countRows;
 
   const data = rows.map(mapEnrichedRun);
   const total = countRow?.count ?? 0;
@@ -1359,12 +1369,13 @@ export async function getRunFull(scope: AppScope, id: string, actor: Actor | nul
     eq(runs.applicationId, scope.applicationId),
   ];
 
+  // `packages.draftManifest` + `draftContent` (the agent's full prompt) are
+  // consumed ONLY by the inline branch below, so they are deliberately NOT in
+  // this projection: every non-inline detail read — and the `?wait` long-poll,
+  // which calls this twice — would otherwise drag the whole manifest jsonb and
+  // the prompt text over the wire for nothing.
   const [row] = await db
-    .select({
-      ...enrichedRunSelect(actor),
-      packageManifest: packages.draftManifest,
-      packagePrompt: packages.draftContent,
-    })
+    .select(enrichedRunSelect(actor))
     .from(runs)
     .leftJoin(profiles, eq(runs.userId, profiles.id))
     .leftJoin(endUsers, eq(runs.endUserId, endUsers.id))
@@ -1381,9 +1392,21 @@ export async function getRunFull(scope: AppScope, id: string, actor: Actor | nul
   // After compaction, draftManifest is `{}` and draftContent is `""` — we
   // normalize both to null so the frontend can show "Details expired".
   const isInline = row.packageEphemeral === true;
-  const manifest = row.packageManifest as Record<string, unknown> | null;
-  const inlineManifest = isInline && manifest && Object.keys(manifest).length > 0 ? manifest : null;
-  const inlinePrompt = isInline && row.packagePrompt ? row.packagePrompt : null;
+  let inlineManifest: Record<string, unknown> | null = null;
+  let inlinePrompt: string | null = null;
+  if (isInline && row.run.packageId) {
+    // Same reachability as the LEFT JOIN this replaces (the run is already
+    // org+app scoped), with the tenant predicate restated on the package read
+    // itself — org-owned shadow row or system package, never another tenant's.
+    const [pkg] = await db
+      .select({ manifest: packages.draftManifest, content: packages.draftContent })
+      .from(packages)
+      .where(and(eq(packages.id, row.run.packageId), orgOrSystemFilter(scope.orgId)))
+      .limit(1);
+    const manifest = pkg?.manifest as Record<string, unknown> | null | undefined;
+    inlineManifest = manifest && Object.keys(manifest).length > 0 ? manifest : null;
+    inlinePrompt = pkg?.content ? pkg.content : null;
+  }
 
   return {
     ...mapEnrichedRun(row),

--- a/apps/api/src/services/system-packages.ts
+++ b/apps/api/src/services/system-packages.ts
@@ -202,6 +202,16 @@ export async function syncSystemPackagesToDb(
     // drifted `type` / `source` / `orgId` still heals in place. Without this,
     // every boot re-ran 66 UPSERTs (plus an S3 re-upload) to write back
     // byte-identical values.
+    //
+    // CONSEQUENCE, and it is the price of content-addressing: the archive
+    // bytes become the ONLY thing that can invalidate the persisted row. A
+    // change to how this package DERIVES `manifest` / `content` / `files`
+    // from unchanged bytes (a loader or normalization fix in
+    // `@appstrate/core/system-packages`) is therefore NOT picked up by a
+    // redeploy — the hash still matches and the stale derivation survives.
+    // Shipping such a change means bumping the affected system packages'
+    // versions, exactly as issue #928 concluded. Do not "fix" this by
+    // dropping the guard; every boot would go back to 594 no-op round trips.
     if (
       existingVersion &&
       existingVersion.integrity === freshIntegrity &&

--- a/apps/api/src/services/system-packages.ts
+++ b/apps/api/src/services/system-packages.ts
@@ -16,6 +16,18 @@ import { storageFolderForType } from "./package-items/config.ts";
 
 export type { SystemPackageEntry };
 
+/** What one `syncSystemPackagesToDb` pass actually wrote. */
+export interface SystemPackageSyncReport {
+  /** `packages` rows inserted or updated. */
+  syncedPackages: number;
+  /** `package_versions` rows created. */
+  syncedVersions: number;
+  /** Canonical packages already persisted from byte-identical archives. */
+  unchangedPackages: number;
+  /** Versions already registered from byte-identical archives. */
+  unchangedVersions: number;
+}
+
 /** System packages dir: AFPS packages live alongside the API source. */
 const SYSTEM_PACKAGES_DIR = join(import.meta.dir, "../../../../system-packages");
 
@@ -26,6 +38,34 @@ let systemPackages: ReadonlyMap<string, SystemPackageEntry> = new Map();
 // to register each version in `package_versions` so semver ranges like `^1.0.0`
 // resolve correctly even when a newer major has shipped.
 let systemPackageVersions: readonly SystemPackageEntry[] = [];
+
+/**
+ * Max concurrent DB round-trips issued by the boot sync. The postgres.js pool
+ * is `max: 20` and boot is not the only thing holding connections, so an
+ * unbounded `Promise.all` over ~66 packages × 2 passes would queue every
+ * caller behind the pool. Kept well under the pool size on purpose.
+ */
+const SYNC_CONCURRENCY = 6;
+
+/**
+ * `Promise.all`-shaped map with a bounded worker pool. Local by design: this
+ * file and `lib/boot.ts` each keep their own tiny pool rather than sharing a
+ * new util module.
+ */
+async function mapBounded<T>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (cursor < items.length) {
+      const item = items[cursor++]!;
+      await fn(item);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+}
 
 /** Load system packages from AFPS archives. Call once at boot. */
 export async function initSystemPackages(): Promise<void> {
@@ -89,33 +129,89 @@ export function getSystemPackagesByType(type: PackageType): SystemPackageEntry[]
  * - UPSERT one `packages` row per packageId at the canonical (highest semver) version
  * - Register every loaded version in `package_versions` (idempotent)
  * - Refuse-overwrite on integrity drift without a version bump (the safety gate)
+ *
+ * Returns what it did. A boot over an unchanged package set must report zero
+ * writes — that is the contract the content-addressed skip guards below exist
+ * to keep, and what the sync test asserts.
  */
 export async function syncSystemPackagesToDb(
   canonical?: ReadonlyMap<string, SystemPackageEntry>,
   versions?: readonly SystemPackageEntry[],
-): Promise<void> {
+): Promise<SystemPackageSyncReport> {
   const canonicalPackages = canonical ?? getSystemPackages();
   const allVersions = versions ?? getAllSystemPackageVersions();
-  if (canonicalPackages.size === 0) return;
+  if (canonicalPackages.size === 0) {
+    return { syncedPackages: 0, syncedVersions: 0, unchangedPackages: 0, unchangedVersions: 0 };
+  }
 
   let syncedPackages = 0;
   let syncedVersions = 0;
+  let unchangedPackages = 0;
+  let unchangedVersions = 0;
+
+  // One SHA-256 per loaded archive, shared by both passes below (the canonical
+  // pass and the version pass hash the same `zipBuffer` for the canonical
+  // entry). Keyed by entry identity — the canonical map holds the very same
+  // objects as `allVersions`.
+  const integrityCache = new Map<SystemPackageEntry, string>();
+  const integrityOf = (entry: SystemPackageEntry): string => {
+    let value = integrityCache.get(entry);
+    if (value === undefined) {
+      value = computeIntegrity(new Uint8Array(entry.zipBuffer));
+      integrityCache.set(entry, value);
+    }
+    return value;
+  };
 
   // Step 1 — UPSERT one `packages` row per packageId, using the canonical
   // (highest semver) version. This drives `draftManifest`/`draftContent`,
   // file uploads, and the public package-list UI.
   const syncCanonical = async (id: string, entry: SystemPackageEntry) => {
     const { manifest, type, version } = entry;
+    const freshIntegrity = integrityOf(entry);
+
+    // Single read that answers both questions the write below depends on:
+    // is this canonical version already registered (drives `updatedAt`), and
+    // is the `packages` row already in the shape we would write?
+    //
+    // INNER JOIN on purpose: `package_versions.package_id` is ON DELETE
+    // CASCADE, so a missing `packages` row means its version rows are gone
+    // too — no match, and the branch falls through to the full UPSERT.
+    const [existingVersion] = await db
+      .select({
+        integrity: packageVersions.integrity,
+        packageType: packages.type,
+        packageSource: packages.source,
+        packageOrgId: packages.orgId,
+      })
+      .from(packageVersions)
+      .innerJoin(packages, eq(packages.id, packageVersions.packageId))
+      .where(and(eq(packageVersions.packageId, id), eq(packageVersions.version, version)))
+      .limit(1);
 
     // `updatedAt` is bumped only when this canonical version is genuinely
     // new — re-boots over an unchanged set must remain side-effect-free
     // for downstream consumers that watch `updatedAt`.
-    const [existingVersion] = await db
-      .select({ id: packageVersions.id })
-      .from(packageVersions)
-      .where(and(eq(packageVersions.packageId, id), eq(packageVersions.version, version)))
-      .limit(1);
     const isNewVersion = !existingVersion;
+
+    // Skip guard. `.afps` archives are content-addressed by `integrity`
+    // (SHA-256 over the archive bytes), so a matching hash means
+    // `draftManifest` / `draftContent` / `files` were all derived from the
+    // exact same bytes already persisted — there is nothing to write, and
+    // nothing to re-upload. The row's identity columns are compared too so a
+    // drifted `type` / `source` / `orgId` still heals in place. Without this,
+    // every boot re-ran 66 UPSERTs (plus an S3 re-upload) to write back
+    // byte-identical values.
+    if (
+      existingVersion &&
+      existingVersion.integrity === freshIntegrity &&
+      existingVersion.packageType === type &&
+      existingVersion.packageSource === "system" &&
+      existingVersion.packageOrgId === null
+    ) {
+      unchangedPackages++;
+      return;
+    }
 
     await db
       .insert(packages)
@@ -167,7 +263,7 @@ export async function syncSystemPackagesToDb(
   // instead; the previously-loaded version stays authoritative until the
   // version is bumped.
   const syncVersion = async (entry: SystemPackageEntry) => {
-    const freshIntegrity = computeIntegrity(new Uint8Array(entry.zipBuffer));
+    const freshIntegrity = integrityOf(entry);
 
     const [existing] = await db
       .select({ integrity: packageVersions.integrity })
@@ -180,7 +276,17 @@ export async function syncSystemPackagesToDb(
       )
       .limit(1);
 
-    if (existing && existing.integrity !== freshIntegrity) {
+    // Already registered with byte-identical content: nothing to do. Calling
+    // `createVersionAndUpload` here would walk the dependency graph (a read per
+    // dep) and open a transaction that takes a per-package advisory lock only
+    // to discover the version exists and log "Version already exists" — 66
+    // no-op transactions per boot.
+    if (existing && existing.integrity === freshIntegrity) {
+      unchangedVersions++;
+      return;
+    }
+
+    if (existing) {
       logger.error(
         "System package content changed without a version bump — refusing to " +
           "overwrite a published, immutable version. Bump the version in the " +
@@ -205,30 +311,30 @@ export async function syncSystemPackagesToDb(
     syncedVersions++;
   };
 
-  await Promise.all(
-    Array.from(canonicalPackages).map(([id, entry]) =>
-      syncCanonical(id, entry).catch((err) => {
-        logger.warn("Failed to sync canonical system package", {
-          packageId: id,
-          error: getErrorMessage(err),
-        });
-      }),
-    ),
+  await mapBounded(Array.from(canonicalPackages), SYNC_CONCURRENCY, ([id, entry]) =>
+    syncCanonical(id, entry).catch((err) => {
+      logger.warn("Failed to sync canonical system package", {
+        packageId: id,
+        error: getErrorMessage(err),
+      });
+    }),
   );
-  await Promise.all(
-    allVersions.map((entry) =>
-      syncVersion(entry).catch((err) => {
-        logger.warn("Failed to register system package version", {
-          packageId: entry.packageId,
-          version: entry.version,
-          error: getErrorMessage(err),
-        });
-      }),
-    ),
+  await mapBounded(allVersions, SYNC_CONCURRENCY, (entry) =>
+    syncVersion(entry).catch((err) => {
+      logger.warn("Failed to register system package version", {
+        packageId: entry.packageId,
+        version: entry.version,
+        error: getErrorMessage(err),
+      });
+    }),
   );
 
   logger.info("System packages synced", {
     packages: syncedPackages,
     versions: syncedVersions,
+    unchangedPackages,
+    unchangedVersions,
   });
+
+  return { syncedPackages, syncedVersions, unchangedPackages, unchangedVersions };
 }

--- a/apps/api/test/integration/middleware/boot-gate.test.ts
+++ b/apps/api/test/integration/middleware/boot-gate.test.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Boot gate — the readiness half of the start/stop pair (`routes/health.ts`).
+ *
+ * `apps/api/src/index.ts` binds the port as soon as `bootCritical()` (core
+ * migrations, module load, auth, fail-fast config validation) is done, then
+ * runs `bootBackground()` — orphan cleanup, the system-package DB sync, every
+ * worker — without blocking the bind. That window used to be a closed socket:
+ * clients got CONNREFUSED with nothing to distinguish "starting" from "dead".
+ *
+ * The gate turns that window into an explicit answer:
+ *
+ *   - `/health` reports `status: "starting"` with 503 + `Retry-After`, so a
+ *     readiness probe never routes traffic to a half-built process.
+ *   - Every other path gets an RFC 9457 `starting` problem document, NOT the
+ *     handler — routes must never run before their dependencies exist.
+ *   - Once `markServerReady()` fires, the gate is transparent: requests reach
+ *     the real handlers, `/health` runs its real checks.
+ *
+ * The gate is mounted before EVERY other middleware except request-id /
+ * telemetry / client-ip / CORS / body-limit, so this test mounts it the same
+ * way over a stand-in route table.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Hono } from "hono";
+import healthRouter, {
+  bootGate,
+  markServerReady,
+  _resetServerReadyForTesting,
+} from "../../../src/routes/health.ts";
+import { errorHandler } from "../../../src/middleware/error-handler.ts";
+import type { AppEnv } from "../../../src/types/index.ts";
+
+/** Production-shaped mount: error handler → boot gate → health → app routes. */
+function buildGatedApp(): Hono<AppEnv> {
+  const app = new Hono<AppEnv>();
+  app.onError(errorHandler);
+  app.use("*", bootGate());
+  app.route("/", healthRouter);
+  app.get("/api/agents", (c) => c.json({ data: [] }));
+  app.get("/", (c) => c.html("<html>spa</html>"));
+  return app;
+}
+
+describe("boot gate", () => {
+  beforeEach(() => {
+    _resetServerReadyForTesting();
+  });
+
+  afterEach(() => {
+    // Never leave the module-level flag flipped for other suites.
+    _resetServerReadyForTesting();
+  });
+
+  // ─── While starting ────────────────────────────────────
+
+  it("answers /health with an explicit `starting` 503 instead of the real checks", async () => {
+    const app = buildGatedApp();
+
+    const res = await app.request("/health");
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("1");
+    const body = (await res.json()) as { status: string; checks?: unknown };
+    expect(body.status).toBe("starting");
+    // The real health handler was NOT reached — it would have run the DB probe
+    // and emitted `checks`.
+    expect(body.checks).toBeUndefined();
+  });
+
+  it("refuses application routes with an RFC 9457 `starting` problem document", async () => {
+    const app = buildGatedApp();
+
+    const res = await app.request("/api/agents");
+
+    expect(res.status).toBe(503);
+    expect(res.headers.get("content-type")).toContain("application/problem+json");
+    const body = (await res.json()) as { code?: string; title?: string; detail?: string };
+    expect(body.code).toBe("starting");
+    expect(body.detail).toContain("starting up");
+  });
+
+  it("refuses the SPA fallback too — a boot window serves no page", async () => {
+    const app = buildGatedApp();
+
+    const res = await app.request("/");
+
+    expect(res.status).toBe(503);
+    expect(await res.text()).not.toContain("<html>");
+  });
+
+  it("gates every method, not just reads", async () => {
+    const app = buildGatedApp();
+
+    for (const method of ["GET", "POST", "PUT", "PATCH", "DELETE"]) {
+      const res = await app.request("/api/agents", { method });
+      expect(res.status).toBe(503);
+    }
+  });
+
+  // ─── After boot completes ──────────────────────────────
+
+  it("becomes transparent once the server is marked ready", async () => {
+    const app = buildGatedApp();
+
+    // Same app instance across the transition — Hono's matcher is already
+    // built by the requests above, which is exactly why no route may be
+    // registered after the bind.
+    expect((await app.request("/api/agents")).status).toBe(503);
+
+    markServerReady();
+
+    const res = await app.request("/api/agents");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ data: [] });
+
+    const spa = await app.request("/");
+    expect(spa.status).toBe(200);
+    expect(await spa.text()).toContain("<html>");
+  });
+
+  it("hands /health back to the real handler once ready", async () => {
+    const app = buildGatedApp();
+    markServerReady();
+
+    const res = await app.request("/health");
+
+    // The real handler ran: it reports uptime + per-dependency checks, and no
+    // longer carries the `starting` marker.
+    const body = (await res.json()) as {
+      status: string;
+      uptime_ms?: number;
+      checks?: Record<string, unknown>;
+    };
+    expect(body.status).not.toBe("starting");
+    expect(body.checks).toBeDefined();
+    expect(typeof body.uptime_ms).toBe("number");
+  });
+});

--- a/apps/api/test/integration/routes/openapi-spec.test.ts
+++ b/apps/api/test/integration/routes/openapi-spec.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `GET /api/openapi.json` — caching contract.
+ *
+ * The endpoint is public, pre-auth and un-rate-limited, so the ~470 KiB
+ * document must be serialized once and revalidatable. `apps/cli` already
+ * sends `If-None-Match` and handles 304; these tests lock the server side of
+ * that exchange, plus the fact that the spec is not re-serialized per hit.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { Hono } from "hono";
+import { createOpenApiSpecRouter, ifNoneMatchSatisfied } from "../../../src/routes/openapi-spec.ts";
+
+const spec = { openapi: "3.1.0", info: { title: "Appstrate API", version: "2026-03-21" } };
+
+function makeApp() {
+  let builds = 0;
+  const app = new Hono();
+  app.route(
+    "/",
+    createOpenApiSpecRouter(() => {
+      builds += 1;
+      return spec;
+    }),
+  );
+  return { app, buildCount: () => builds };
+}
+
+describe("GET /api/openapi.json", () => {
+  it("serves the spec with a strong ETag", async () => {
+    const { app } = makeApp();
+    const res = await app.request("/api/openapi.json");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toContain("application/json");
+    expect(res.headers.get("ETag")).toMatch(/^"[0-9a-f]{32}"$/);
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=0, must-revalidate");
+    expect(await res.json()).toEqual(spec);
+  });
+
+  it("returns 304 with an empty body when If-None-Match matches", async () => {
+    const { app } = makeApp();
+    const first = await app.request("/api/openapi.json");
+    const etag = first.headers.get("ETag")!;
+
+    const res = await app.request("/api/openapi.json", { headers: { "If-None-Match": etag } });
+
+    expect(res.status).toBe(304);
+    expect(res.headers.get("ETag")).toBe(etag);
+    expect(await res.text()).toBe("");
+  });
+
+  it("returns 200 when If-None-Match carries a stale tag", async () => {
+    const { app } = makeApp();
+    const res = await app.request("/api/openapi.json", {
+      headers: { "If-None-Match": '"0000000000000000000000000000dead"' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(spec);
+  });
+
+  it("honours a weak tag and a multi-value If-None-Match list", async () => {
+    const { app } = makeApp();
+    const etag = (await app.request("/api/openapi.json")).headers.get("ETag")!;
+
+    const weak = await app.request("/api/openapi.json", {
+      headers: { "If-None-Match": `W/${etag}` },
+    });
+    expect(weak.status).toBe(304);
+
+    const list = await app.request("/api/openapi.json", {
+      headers: { "If-None-Match": `"stale", ${etag}` },
+    });
+    expect(list.status).toBe(304);
+
+    const wildcard = await app.request("/api/openapi.json", { headers: { "If-None-Match": "*" } });
+    expect(wildcard.status).toBe(304);
+  });
+
+  it("is a stable ETag and builds the spec only once across requests", async () => {
+    const { app, buildCount } = makeApp();
+
+    const a = await app.request("/api/openapi.json");
+    const b = await app.request("/api/openapi.json");
+
+    expect(a.headers.get("ETag")).toBe(b.headers.get("ETag"));
+    expect(buildCount()).toBe(1);
+  });
+});
+
+describe("ifNoneMatchSatisfied", () => {
+  it("rejects a missing or empty header", () => {
+    expect(ifNoneMatchSatisfied(undefined, '"abc"')).toBe(false);
+    expect(ifNoneMatchSatisfied("", '"abc"')).toBe(false);
+  });
+
+  it("does not treat a substring as a match", () => {
+    expect(ifNoneMatchSatisfied('"ab"', '"abc"')).toBe(false);
+  });
+});

--- a/apps/api/test/integration/routes/realtime-sse.test.ts
+++ b/apps/api/test/integration/routes/realtime-sse.test.ts
@@ -23,7 +23,7 @@ import {
 } from "../../helpers/auth.ts";
 import { seedAgent, seedRun, seedApplication, seedApiKey } from "../../helpers/seed.ts";
 import { sql } from "drizzle-orm";
-import { initRealtime } from "../../../src/services/realtime.ts";
+import { initRealtime, activeSubscriberCount } from "../../../src/services/realtime.ts";
 import { collectSSEEvents } from "../../helpers/sse.ts";
 
 const app = getTestApp();
@@ -773,6 +773,198 @@ describe("realtime SSE routes (integration)", () => {
       expect(events).toHaveLength(1);
       expect(events[0]!.event).toBe("run_log");
       expect(JSON.parse(events[0]!.data).message).toBe("debug-for-admin");
+    });
+  });
+
+  // ── ?channels= subscription filter ──────────────────────────
+
+  describe("?channels= subscription filter", () => {
+    it("a stream declaring only run_update never receives run_log", async () => {
+      const res = await sseRequest("/api/realtime/runs?channels=run_update", ctx);
+      expect(res.status).toBe(200);
+      expect(res.body).not.toBeNull();
+
+      await wait();
+      // Fire the undeclared channel FIRST: if it were delivered it would be
+      // the first collected frame and the assertion below would catch it.
+      await pgNotify("run_log_insert", {
+        org_id: ctx.orgId,
+        application_id: ctx.defaultAppId,
+        run_id: run.id,
+        level: "info",
+        message: "filtered-out",
+      });
+      await wait();
+      await pgNotify("run_update", {
+        org_id: ctx.orgId,
+        application_id: ctx.defaultAppId,
+        id: run.id,
+        status: "success",
+        package_id: agentPkg.id,
+      });
+
+      const events = await collectSSEEvents(res.body!, 1, {
+        timeoutMs: 3000,
+        ignoreEvents: ["ping"],
+      });
+      expect(events).toHaveLength(1);
+      expect(events[0]!.event).toBe("run_update");
+    });
+
+    it("declaring no channels still delivers every channel (backward compatible)", async () => {
+      // The existing CLI/SDK/integrator clients send no `channels` param —
+      // their stream must be unchanged.
+      const res = await sseRequest("/api/realtime/runs", ctx);
+      expect(res.body).not.toBeNull();
+
+      await wait();
+      await pgNotify("run_log_insert", {
+        org_id: ctx.orgId,
+        application_id: ctx.defaultAppId,
+        run_id: run.id,
+        level: "info",
+        message: "still-delivered",
+      });
+
+      const events = await collectSSEEvents(res.body!, 1, {
+        timeoutMs: 3000,
+        ignoreEvents: ["ping"],
+      });
+      expect(events).toHaveLength(1);
+      expect(events[0]!.event).toBe("run_log");
+    });
+
+    it("an unrecognised channel name falls back to every channel (never a dead stream)", async () => {
+      const res = await sseRequest("/api/realtime/runs?channels=not_a_channel", ctx);
+      expect(res.body).not.toBeNull();
+
+      await wait();
+      await pgNotify("run_log_insert", {
+        org_id: ctx.orgId,
+        application_id: ctx.defaultAppId,
+        run_id: run.id,
+        level: "info",
+        message: "fallback-delivered",
+      });
+
+      const events = await collectSSEEvents(res.body!, 1, {
+        timeoutMs: 3000,
+        ignoreEvents: ["ping"],
+      });
+      expect(events).toHaveLength(1);
+      expect(events[0]!.event).toBe("run_log");
+    });
+
+    it("a multi-channel declaration keeps every declared channel", async () => {
+      const res = await sseRequest(
+        `/api/realtime/runs/${run.id}?verbose=true&channels=run_update,run_log`,
+        ctx,
+      );
+      expect(res.body).not.toBeNull();
+
+      await wait();
+      await pgNotify("run_log_insert", {
+        org_id: ctx.orgId,
+        application_id: ctx.defaultAppId,
+        run_id: run.id,
+        level: "info",
+        message: "declared",
+      });
+
+      // Frame 1 is the initial run_update snapshot, frame 2 the run_log.
+      const events = await collectSSEEvents(res.body!, 2, {
+        timeoutMs: 3000,
+        ignoreEvents: ["ping"],
+      });
+      const names = events.map((e) => e.event);
+      expect(names).toContain("run_update");
+      expect(names).toContain("run_log");
+    });
+  });
+
+  // ── Backpressure ────────────────────────────────────────────
+
+  describe("outbound queue backpressure", () => {
+    it("drops (unsubscribes) a stream whose consumer stopped reading", async () => {
+      // Open a stream and NEVER read its body: hono's TransformStream stops
+      // being pulled after the first chunk, so the drain loop wedges on its
+      // first write while PG NOTIFY keeps filling `pending`. Before the cap,
+      // that queue grew without bound — one stuck client could exhaust the
+      // API process's memory.
+      const before = activeSubscriberCount();
+      const res = await sseRequest("/api/realtime/runs", ctx);
+      expect(res.status).toBe(200);
+      expect(res.body).not.toBeNull();
+
+      await wait();
+      expect(activeSubscriberCount()).toBe(before + 1);
+
+      // 3 000 distinct notifications in one statement. Distinct `id` values
+      // are load-bearing: Postgres collapses byte-identical NOTIFYs issued in
+      // the same transaction into a single delivery.
+      await db.execute(sql`
+        SELECT pg_notify('run_update', json_build_object(
+          'operation', 'UPDATE',
+          'id', 'ovf-' || g,
+          'package_id', ${agentPkg.id}::text,
+          'status', 'running',
+          'user_id', NULL,
+          'end_user_id', NULL,
+          'org_id', ${ctx.orgId}::text,
+          'application_id', ${ctx.defaultAppId}::text,
+          'schedule_id', NULL,
+          'error', NULL,
+          'started_at', NULL,
+          'completed_at', NULL,
+          'duration', NULL
+        )::text)
+        FROM generate_series(1, 3000) g
+      `);
+
+      // Poll rather than sleep a fixed amount — delivery of 3 000 NOTIFYs
+      // through the LISTEN connection is not instantaneous.
+      for (let i = 0; i < 60 && activeSubscriberCount() > before; i++) {
+        await wait(100);
+      }
+      expect(activeSubscriberCount()).toBe(before);
+
+      // Release the wedged writer so the stream's loop can exit (otherwise it
+      // sits on the 60 s write deadline for the rest of the file).
+      await res.body!.cancel();
+    });
+
+    it("keeps a stream whose backlog stays under the cap", async () => {
+      // Same wedged-consumer setup, two orders of magnitude below the cap.
+      // Proves the drop above is the cap firing, not merely "an unread stream
+      // gets torn down" — a slow-but-recoverable consumer keeps its stream
+      // (and its queued events) instead of losing them.
+      const before = activeSubscriberCount();
+      const res = await sseRequest("/api/realtime/runs", ctx);
+      expect(res.body).not.toBeNull();
+
+      await wait();
+      await db.execute(sql`
+        SELECT pg_notify('run_update', json_build_object(
+          'operation', 'UPDATE',
+          'id', 'small-' || g,
+          'package_id', ${agentPkg.id}::text,
+          'status', 'running',
+          'user_id', NULL,
+          'end_user_id', NULL,
+          'org_id', ${ctx.orgId}::text,
+          'application_id', ${ctx.defaultAppId}::text,
+          'schedule_id', NULL,
+          'error', NULL,
+          'started_at', NULL,
+          'completed_at', NULL,
+          'duration', NULL
+        )::text)
+        FROM generate_series(1, 50) g
+      `);
+      await wait(500);
+
+      expect(activeSubscriberCount()).toBe(before + 1);
+      await res.body!.cancel();
     });
   });
 

--- a/apps/api/test/integration/routes/runs-events-ingestion.test.ts
+++ b/apps/api/test/integration/routes/runs-events-ingestion.test.ts
@@ -45,6 +45,10 @@ import {
   synthesiseFinalize,
 } from "../../../src/services/run-event-ingestion.ts";
 import { emptyRunResult } from "@appstrate/afps-runtime/runner";
+import {
+  scheduleRunMetricBroadcast,
+  activeRunMetricThrottleCount,
+} from "../../../src/services/run-metric-broadcaster.ts";
 import { getRunFull } from "../../../src/services/state/runs.ts";
 import type { RunArtifactsSummary } from "@appstrate/db/schema";
 import type { AppstrateModule, RunStatusChangeParams } from "@appstrate/core/module";
@@ -851,6 +855,35 @@ describe("POST /api/runs/:runId/events/finalize — complete result persistence"
     expect(row?.status).toBe("failed");
     expect(row?.error).toMatch(/could not reach the LLM API/);
     expect(row?.tokenUsage).toMatchObject({ input_tokens: 0, output_tokens: 0 });
+  });
+
+  // The metric broadcaster keeps a per-run throttle entry in module memory.
+  // It used to be released from inside `finalizeRunImpl`, so any throw in the
+  // post-CAS side effects leaked the entry for the lifetime of the process.
+  // The release now lives in `finalizeRun`'s `finally`, which covers every
+  // exit — including the idempotent "sink already closed" early return.
+  it("releases the metric throttle entry on every finalize exit", async () => {
+    const runId = await seedRunWithSink(ctx, "@test/final-agent", {
+      tokenUsage: { input_tokens: 10, output_tokens: 5 },
+    });
+    const baseline = activeRunMetricThrottleCount();
+
+    scheduleRunMetricBroadcast(runId);
+    expect(activeRunMetricThrottleCount()).toBe(baseline + 1);
+
+    const run = await getRunSinkContext(runId);
+    const result = emptyRunResult();
+    result.status = "success";
+    await finalizeRun({ run: run!, result });
+    expect(activeRunMetricThrottleCount()).toBe(baseline);
+
+    // Second finalize takes the idempotent branch (sink already closed) and
+    // must still release an entry created in between.
+    scheduleRunMetricBroadcast(runId);
+    expect(activeRunMetricThrottleCount()).toBe(baseline + 1);
+    const reread = await getRunSinkContext(runId);
+    await finalizeRun({ run: reread!, result });
+    expect(activeRunMetricThrottleCount()).toBe(baseline);
   });
 
   it("strips unknown keys from finalize usage before the runs.tokenUsage write", async () => {

--- a/apps/api/test/integration/services/notify-triggers.test.ts
+++ b/apps/api/test/integration/services/notify-triggers.test.ts
@@ -48,7 +48,11 @@ describe("NOTIFY triggers (regression)", () => {
   // sensitive (Bun's per-file ordering is not strict alphabetical) which is
   // why CI flaked while local runs sometimes passed.
   afterAll(async () => {
-    await db.execute(sql`DROP TRIGGER IF EXISTS runs_notify_trigger ON runs`);
+    // The runs trigger is split in two — INSERT (unconditional) and UPDATE
+    // (guarded by a WHEN clause). `createNotifyTriggers` already dropped the
+    // pre-split `runs_notify_trigger` name when it installed these.
+    await db.execute(sql`DROP TRIGGER IF EXISTS runs_notify_insert_trigger ON runs`);
+    await db.execute(sql`DROP TRIGGER IF EXISTS runs_notify_update_trigger ON runs`);
     await db.execute(sql`DROP TRIGGER IF EXISTS run_logs_notify_trigger ON run_logs`);
     // Connection trigger drives the connectors-page live badge; drop it too
     // so it does not leak into other suites that fire integration_connections
@@ -91,6 +95,56 @@ describe("NOTIFY triggers (regression)", () => {
     await db.execute(
       (await import("drizzle-orm")).sql`UPDATE runs SET status = 'running' WHERE id = ${run.id}`,
     );
+  });
+
+  // The run-event ingestion CAS UPDATEs `runs` once per ingested event, and
+  // the runner heartbeats every 30 s — both write ONLY `last_event_sequence` /
+  // `last_heartbeat_at`, neither of which appears in the NOTIFY payload. Every
+  // one of those used to broadcast a payload identical to the previous one to
+  // every SSE subscriber in the org. The UPDATE trigger's WHEN clause drops
+  // exactly those, and nothing else.
+  it("notify_run_change skips UPDATEs whose payload would be unchanged, keeps the rest", async () => {
+    const run = await seedRun({
+      packageId: "@notifyorg/trigger-agent",
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      userId: ctx.user.id,
+      status: "pending",
+    });
+
+    const received: Array<{ id: string; status: string }> = [];
+    await listenClient.listen("run_update", (raw) => {
+      try {
+        const payload = JSON.parse(raw) as { id: string; status: string };
+        if (payload.id !== run.id) return;
+        received.push({ id: payload.id, status: payload.status });
+      } catch {
+        /* ignore */
+      }
+    });
+
+    // Ingestion-bookkeeping shape: sequence + heartbeat only. Must be silent.
+    for (let i = 1; i <= 5; i++) {
+      await db.execute(
+        sql`UPDATE runs SET last_event_sequence = ${i}, last_heartbeat_at = now() WHERE id = ${run.id}`,
+      );
+    }
+    for (let i = 0; i < 8 && received.length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(received).toHaveLength(0);
+
+    // Any payload-visible column must still fire — one notification per
+    // distinct payload, no loss.
+    await db.execute(sql`UPDATE runs SET status = 'running' WHERE id = ${run.id}`);
+    await db.execute(sql`UPDATE runs SET error = 'boom' WHERE id = ${run.id}`);
+    await db.execute(sql`UPDATE runs SET duration = 42 WHERE id = ${run.id}`);
+    await db.execute(sql`UPDATE runs SET completed_at = now() WHERE id = ${run.id}`);
+    for (let i = 0; i < 40 && received.length < 4; i++) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(received).toHaveLength(4);
+    expect(received.every((r) => r.status === "running")).toBe(true);
   });
 
   it("notify_run_log_insert fires on run_logs INSERT", async () => {

--- a/apps/api/test/integration/services/notify-triggers.test.ts
+++ b/apps/api/test/integration/services/notify-triggers.test.ts
@@ -115,8 +115,20 @@ describe("NOTIFY triggers (regression)", () => {
     const received: Array<{ id: string; status: string }> = [];
     await listenClient.listen("run_update", (raw) => {
       try {
-        const payload = JSON.parse(raw) as { id: string; status: string };
+        const payload = JSON.parse(raw) as {
+          id: string;
+          status: string;
+          operation: "INSERT" | "UPDATE";
+        };
         if (payload.id !== run.id) return;
+        // This test is about the UPDATE trigger's WHEN clause. The INSERT
+        // trigger is unconditional, and `listenClient` is shared: once any
+        // other test file has registered `run_update`, the connection is
+        // already LISTENing, so the notification `seedRun` above emitted can
+        // be delivered AFTER this handler attaches and be miscounted. Run
+        // alone the channel is fresh and it never arrives — which is exactly
+        // the kind of green that hides an order-dependent test.
+        if (payload.operation === "INSERT") return;
         received.push({ id: payload.id, status: payload.status });
       } catch {
         /* ignore */

--- a/apps/api/test/integration/services/package-items-dependency-counts.test.ts
+++ b/apps/api/test/integration/services/package-items-dependency-counts.test.ts
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Non-regression lock for the dependency-graph reads of
+ * `services/package-items/crud.ts`.
+ *
+ * `used_by_agents` (list) and `agents` (detail / delete pre-check) used to be
+ * computed in JS after loading EVERY org package's `draft_manifest` jsonb.
+ * They are now SQL aggregates over the same rows. These tests pin the observable
+ * semantics — tenant scoping, ephemeral exclusion, self-reference, multi-map
+ * counting — so the two implementations cannot drift apart silently.
+ *
+ * The list test additionally compares the service output against a JS oracle
+ * that reproduces the previous algorithm on the same fixture.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { and } from "drizzle-orm";
+import { db, truncateAll } from "../../helpers/db.ts";
+import { createTestContext, type TestContext } from "../../helpers/auth.ts";
+import { seedPackage, seedInstalledPackage } from "../../helpers/seed.ts";
+import { packages } from "@appstrate/db/schema";
+import { extractDependencies } from "@appstrate/core/dependencies";
+import { buildPackageId } from "@appstrate/core/naming";
+import { scopedWhere } from "../../../src/lib/db-helpers.ts";
+import { notEphemeralFilter } from "../../../src/lib/package-helpers.ts";
+import { parseDraftManifest } from "../../../src/lib/manifest-utils.ts";
+import {
+  listOrgItems,
+  getOrgItem,
+  deleteOrgItem,
+} from "../../../src/services/package-items/crud.ts";
+import { CONFIG_BY_TYPE } from "../../../src/services/package-items/config.ts";
+
+/**
+ * The pre-SQL implementation, verbatim: load every non-ephemeral org package's
+ * manifest and count dependency edges in JS. Used as the oracle the SQL
+ * aggregate must agree with.
+ */
+async function legacyCountMap(orgId: string): Promise<Map<string, number>> {
+  const countMap = new Map<string, number>();
+  const allOrgPkgs = await db
+    .select({ id: packages.id, draftManifest: packages.draftManifest })
+    .from(packages)
+    .where(and(scopedWhere(packages, { orgId }), notEphemeralFilter()));
+  for (const pkg of allOrgPkgs) {
+    if (!pkg.draftManifest) continue;
+    const deps = extractDependencies(parseDraftManifest(pkg.draftManifest));
+    for (const dep of deps) {
+      const depId = buildPackageId(dep.depScope, dep.depName);
+      countMap.set(depId, (countMap.get(depId) ?? 0) + 1);
+    }
+  }
+  return countMap;
+}
+
+function agentManifest(id: string, dependencies: Record<string, unknown>) {
+  return {
+    name: id,
+    version: "0.1.0",
+    type: "agent",
+    description: "Test agent",
+    dependencies,
+  };
+}
+
+describe("package-items dependency counts", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "depcount" });
+  });
+
+  describe("used_by_agents (listOrgItems)", () => {
+    beforeEach(async () => {
+      // Three skills: one used twice, one used once, one unused.
+      for (const name of ["shared-skill", "solo-skill", "unused-skill"]) {
+        await seedPackage({
+          id: `@depcount/${name}`,
+          orgId: ctx.orgId,
+          type: "skill",
+          createdBy: ctx.user.id,
+        });
+        await seedInstalledPackage(ctx.defaultAppId, `@depcount/${name}`);
+      }
+
+      await seedPackage({
+        id: "@depcount/agent-a",
+        orgId: ctx.orgId,
+        createdBy: ctx.user.id,
+        draftManifest: agentManifest("@depcount/agent-a", {
+          skills: { "@depcount/shared-skill": "^0.1.0", "@depcount/solo-skill": "^0.1.0" },
+        }),
+      });
+      await seedPackage({
+        id: "@depcount/agent-b",
+        orgId: ctx.orgId,
+        createdBy: ctx.user.id,
+        draftManifest: agentManifest("@depcount/agent-b", {
+          skills: { "@depcount/shared-skill": "^0.1.0" },
+        }),
+      });
+    });
+
+    it("matches the legacy JS count for every listed item", async () => {
+      const items = await listOrgItems(ctx.orgId, CONFIG_BY_TYPE.skill, ctx.defaultAppId);
+      const oracle = await legacyCountMap(ctx.orgId);
+
+      expect(items.length).toBe(3);
+      for (const item of items) {
+        expect(item.used_by_agents).toBe(oracle.get(item.id) ?? 0);
+      }
+
+      const byId = new Map(items.map((i) => [i.id, i.used_by_agents]));
+      expect(byId.get("@depcount/shared-skill")).toBe(2);
+      expect(byId.get("@depcount/solo-skill")).toBe(1);
+      expect(byId.get("@depcount/unused-skill")).toBe(0);
+    });
+
+    it("ignores ephemeral shadow packages and other orgs' manifests", async () => {
+      await seedPackage({
+        id: "@inline/shadow-run",
+        orgId: ctx.orgId,
+        ephemeral: true,
+        createdBy: ctx.user.id,
+        draftManifest: agentManifest("@inline/shadow-run", {
+          skills: { "@depcount/unused-skill": "^0.1.0" },
+        }),
+      });
+
+      const other = await createTestContext({ orgSlug: "otherorg" });
+      await seedPackage({
+        id: "@otherorg/agent",
+        orgId: other.orgId,
+        createdBy: other.user.id,
+        draftManifest: agentManifest("@otherorg/agent", {
+          skills: { "@depcount/unused-skill": "^0.1.0" },
+        }),
+      });
+
+      const items = await listOrgItems(ctx.orgId, CONFIG_BY_TYPE.skill, ctx.defaultAppId);
+      const byId = new Map(items.map((i) => [i.id, i.used_by_agents]));
+      expect(byId.get("@depcount/unused-skill")).toBe(0);
+      expect(byId.get("@depcount/shared-skill")).toBe(2);
+    });
+
+    it("counts every dependency map, including a self-reference", async () => {
+      await seedPackage({
+        id: "@depcount/mcp-one",
+        orgId: ctx.orgId,
+        type: "mcp-server",
+        createdBy: ctx.user.id,
+        // Self-reference: the legacy loop counted it, so the SQL must too.
+        draftManifest: agentManifest("@depcount/mcp-one", {
+          mcp_servers: { "@depcount/mcp-one": "^0.1.0" },
+        }),
+      });
+      await seedInstalledPackage(ctx.defaultAppId, "@depcount/mcp-one");
+      await seedPackage({
+        id: "@depcount/agent-c",
+        orgId: ctx.orgId,
+        createdBy: ctx.user.id,
+        draftManifest: agentManifest("@depcount/agent-c", {
+          mcp_servers: { "@depcount/mcp-one": "^0.1.0" },
+          integrations: { "@depcount/mcp-one": "^0.1.0" },
+        }),
+      });
+
+      const items = await listOrgItems(ctx.orgId, CONFIG_BY_TYPE["mcp-server"], ctx.defaultAppId);
+      const oracle = await legacyCountMap(ctx.orgId);
+      const row = items.find((i) => i.id === "@depcount/mcp-one");
+      expect(row?.used_by_agents).toBe(oracle.get("@depcount/mcp-one") ?? 0);
+      // self + agent-c's mcp_servers entry + agent-c's integrations entry
+      expect(row?.used_by_agents).toBe(3);
+    });
+
+    it("survives a manifest whose dependency map is not an object", async () => {
+      await seedPackage({
+        id: "@depcount/broken-agent",
+        orgId: ctx.orgId,
+        createdBy: ctx.user.id,
+        draftManifest: { name: "@depcount/broken-agent", dependencies: { skills: "nonsense" } },
+      });
+      await seedPackage({
+        id: "@depcount/no-manifest",
+        orgId: ctx.orgId,
+        createdBy: ctx.user.id,
+        draftManifest: null,
+      });
+
+      const items = await listOrgItems(ctx.orgId, CONFIG_BY_TYPE.skill, ctx.defaultAppId);
+      const byId = new Map(items.map((i) => [i.id, i.used_by_agents]));
+      expect(byId.get("@depcount/shared-skill")).toBe(2);
+    });
+  });
+
+  describe("dependent packages (getOrgItem / deleteOrgItem)", () => {
+    beforeEach(async () => {
+      await seedPackage({
+        id: "@depcount/used-skill",
+        orgId: ctx.orgId,
+        type: "skill",
+        createdBy: ctx.user.id,
+      });
+      await seedPackage({
+        id: "@depcount/free-skill",
+        orgId: ctx.orgId,
+        type: "skill",
+        createdBy: ctx.user.id,
+      });
+      await seedPackage({
+        id: "@depcount/consumer",
+        orgId: ctx.orgId,
+        createdBy: ctx.user.id,
+        draftManifest: {
+          ...agentManifest("@depcount/consumer", {
+            skills: { "@depcount/used-skill": "^0.1.0" },
+          }),
+          display_name: "Consumer Agent",
+        },
+      });
+    });
+
+    it("reports the dependent with its manifest display_name", async () => {
+      const item = await getOrgItem(ctx.orgId, "@depcount/used-skill", CONFIG_BY_TYPE.skill);
+      expect(item?.agents).toEqual([{ id: "@depcount/consumer", display_name: "Consumer Agent" }]);
+    });
+
+    it("falls back to the package id when display_name is not a string", async () => {
+      await seedPackage({
+        id: "@depcount/unnamed",
+        orgId: ctx.orgId,
+        createdBy: ctx.user.id,
+        draftManifest: {
+          ...agentManifest("@depcount/unnamed", {
+            skills: { "@depcount/free-skill": "^0.1.0" },
+          }),
+          display_name: 42,
+        },
+      });
+
+      const item = await getOrgItem(ctx.orgId, "@depcount/free-skill", CONFIG_BY_TYPE.skill);
+      expect(item?.agents).toEqual([
+        { id: "@depcount/unnamed", display_name: "@depcount/unnamed" },
+      ]);
+    });
+
+    it("blocks deletion while referenced and allows it once free", async () => {
+      const blocked = await deleteOrgItem(ctx.orgId, "@depcount/used-skill", CONFIG_BY_TYPE.skill);
+      expect(blocked.ok).toBe(false);
+      expect(blocked.error).toBe("IN_USE");
+      expect(blocked.dependents?.map((d) => d.id)).toEqual(["@depcount/consumer"]);
+
+      const free = await deleteOrgItem(ctx.orgId, "@depcount/free-skill", CONFIG_BY_TYPE.skill);
+      expect(free.ok).toBe(true);
+    });
+
+    it("never reports a self-reference or another org's package as a dependent", async () => {
+      await seedPackage({
+        id: "@depcount/self-ref",
+        orgId: ctx.orgId,
+        type: "skill",
+        createdBy: ctx.user.id,
+        draftManifest: agentManifest("@depcount/self-ref", {
+          skills: { "@depcount/self-ref": "^0.1.0" },
+        }),
+      });
+      const other = await createTestContext({ orgSlug: "otherorg2" });
+      await seedPackage({
+        id: "@otherorg2/agent",
+        orgId: other.orgId,
+        createdBy: other.user.id,
+        draftManifest: agentManifest("@otherorg2/agent", {
+          skills: { "@depcount/self-ref": "^0.1.0" },
+        }),
+      });
+
+      const item = await getOrgItem(ctx.orgId, "@depcount/self-ref", CONFIG_BY_TYPE.skill);
+      expect(item?.agents).toEqual([]);
+    });
+  });
+});

--- a/apps/api/test/integration/services/realtime-connection-update.test.ts
+++ b/apps/api/test/integration/services/realtime-connection-update.test.ts
@@ -98,7 +98,11 @@ describe("realtime — connection_update channel (actor + tenant filter)", () =>
   // their `toHaveBeenCalledTimes(N)` assertions by one. Mirrors the teardown in
   // `notify-triggers.test.ts` (see its comment for the CI-flake history).
   afterAll(async () => {
-    await db.execute(sql`DROP TRIGGER IF EXISTS runs_notify_trigger ON runs`);
+    // The runs trigger is split in two — INSERT (unconditional) and UPDATE
+    // (guarded by a WHEN clause). `createNotifyTriggers` already dropped the
+    // pre-split `runs_notify_trigger` name when it installed these.
+    await db.execute(sql`DROP TRIGGER IF EXISTS runs_notify_insert_trigger ON runs`);
+    await db.execute(sql`DROP TRIGGER IF EXISTS runs_notify_update_trigger ON runs`);
     await db.execute(sql`DROP TRIGGER IF EXISTS run_logs_notify_trigger ON run_logs`);
     await db.execute(
       sql`DROP TRIGGER IF EXISTS integration_connections_notify_trigger ON integration_connections`,

--- a/apps/api/test/integration/services/realtime.test.ts
+++ b/apps/api/test/integration/services/realtime.test.ts
@@ -557,6 +557,129 @@ describe("realtime service (integration)", () => {
     });
   });
 
+  // ── channel subscription filter ─────────────────────────────
+  //
+  // A subscriber may declare the channels it consumes. The global dashboard
+  // stream reads three of the five, so without this the server serialized the
+  // entire `run_log` firehose into a stream that threw every frame away.
+  // Declaring nothing must keep the historical "receive everything" behaviour
+  // so no existing client (CLI, SDK, integrator) loses frames.
+
+  describe("channel filter", () => {
+    it("a subscriber declaring only run_update receives no run_log frames", async () => {
+      const send = mock((_e: RealtimeEvent) => {});
+      const id = "sub-channels-runupdate";
+      trackSubscriber(id);
+
+      addSubscriber({
+        id,
+        filter: {
+          orgId: "org-ch",
+          applicationId: "app-ch",
+          isAdmin: true,
+          channels: new Set(["run_update"]),
+        },
+        send,
+      });
+
+      await pgNotify("run_log_insert", {
+        org_id: "org-ch",
+        application_id: "app-ch",
+        run_id: "exec-ch",
+        level: "info",
+        message: "should not be delivered",
+      });
+      await wait();
+      expect(send).not.toHaveBeenCalled();
+
+      // The declared channel still flows — this is a filter, not a mute.
+      await pgNotify("run_update", {
+        org_id: "org-ch",
+        application_id: "app-ch",
+        id: "exec-ch",
+        status: "running",
+      });
+      await wait();
+      expect(send).toHaveBeenCalledTimes(1);
+      expect(send.mock.calls[0]![0]!.event).toBe("run_update");
+    });
+
+    it("a subscriber declaring NO channels receives every channel (backward compatible)", async () => {
+      const send = mock((_e: RealtimeEvent) => {});
+      const id = "sub-channels-none-declared";
+      trackSubscriber(id);
+
+      addSubscriber({
+        id,
+        filter: { orgId: "org-ch2", applicationId: "app-ch2", isAdmin: true },
+        send,
+      });
+
+      await pgNotify("run_update", {
+        org_id: "org-ch2",
+        application_id: "app-ch2",
+        id: "exec-ch2",
+        status: "running",
+      });
+      await wait();
+      await pgNotify("run_log_insert", {
+        org_id: "org-ch2",
+        application_id: "app-ch2",
+        run_id: "exec-ch2",
+        level: "info",
+        message: "still delivered",
+      });
+      await wait();
+      await pgNotify("run_metric", {
+        org_id: "org-ch2",
+        application_id: "app-ch2",
+        run_id: "exec-ch2",
+        package_id: "pkg-ch2",
+      });
+      await wait();
+
+      const received = send.mock.calls.map((c) => c[0]!.event);
+      expect(received).toContain("run_update");
+      expect(received).toContain("run_log");
+      expect(received).toContain("run_metric");
+    });
+
+    it("filtering one subscriber does not starve another on the same channel", async () => {
+      const filtered = mock((_e: RealtimeEvent) => {});
+      const unfiltered = mock((_e: RealtimeEvent) => {});
+      trackSubscriber("sub-ch-filtered");
+      trackSubscriber("sub-ch-unfiltered");
+
+      addSubscriber({
+        id: "sub-ch-filtered",
+        filter: {
+          orgId: "org-ch3",
+          applicationId: "app-ch3",
+          isAdmin: true,
+          channels: new Set(["run_update"]),
+        },
+        send: filtered,
+      });
+      addSubscriber({
+        id: "sub-ch-unfiltered",
+        filter: { orgId: "org-ch3", applicationId: "app-ch3", isAdmin: true },
+        send: unfiltered,
+      });
+
+      await pgNotify("run_log_insert", {
+        org_id: "org-ch3",
+        application_id: "app-ch3",
+        run_id: "exec-ch3",
+        level: "info",
+        message: "one wants it, one does not",
+      });
+      await wait();
+
+      expect(filtered).not.toHaveBeenCalled();
+      expect(unfiltered).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // ── initRealtime idempotency ────────────────────────────────
 
   describe("initRealtime idempotency", () => {

--- a/apps/api/test/integration/services/system-packages-sync.test.ts
+++ b/apps/api/test/integration/services/system-packages-sync.test.ts
@@ -192,6 +192,99 @@ describe("syncSystemPackagesToDb", () => {
     expect(versionRows).toHaveLength(1);
   });
 
+  it("second boot over an unchanged set performs ZERO writes", async () => {
+    // `.afps` archives are content-addressed by `integrity` (SHA-256 over the
+    // archive bytes), so a boot that loads the same bytes it already persisted
+    // has nothing to do. Before the skip guards, every boot re-ran an UPSERT
+    // per canonical package AND opened one advisory-locked transaction per
+    // version just to rediscover that the version existed — ~594 round trips
+    // and 66 "Version already exists" log lines on a no-op boot.
+    const a = makeFixtureEntry({ id: "@sys-test/skip-a", version: "1.0.0" });
+    const b = makeFixtureEntry({ id: "@sys-test/skip-b", version: "2.3.4", type: "integration" });
+    const { canonical, versions } = buildRegistry([a, b]);
+
+    const first = await syncSystemPackagesToDb(canonical, versions);
+    expect(first).toEqual({
+      syncedPackages: 2,
+      syncedVersions: 2,
+      unchangedPackages: 0,
+      unchangedVersions: 0,
+    });
+
+    // Same registry, same bytes — the second pass must write nothing at all.
+    const second = await syncSystemPackagesToDb(canonical, versions);
+    expect(second).toEqual({
+      syncedPackages: 0,
+      syncedVersions: 0,
+      unchangedPackages: 2,
+      unchangedVersions: 2,
+    });
+
+    // ...and the persisted state is intact, not merely untouched-because-broken.
+    const rows = await db
+      .select({ id: packages.id, source: packages.source, type: packages.type })
+      .from(packages)
+      .where(eq(packages.source, "system"));
+    expect(rows.map((r) => r.id).sort()).toEqual(["@sys-test/skip-a", "@sys-test/skip-b"]);
+    expect(rows.find((r) => r.id === "@sys-test/skip-b")!.type).toBe("integration");
+  });
+
+  it("still heals a `packages` row whose type drifted, even at unchanged bytes", async () => {
+    // The skip guard keys on integrity AND the row's identity columns, so a
+    // packageId that changed type across versions (or a row corrupted out of
+    // band) is not skipped into staying wrong.
+    const entry = makeFixtureEntry({
+      id: "@sys-test/heal-type",
+      version: "1.0.0",
+      type: "skill",
+    });
+    const { canonical, versions } = buildRegistry([entry]);
+    await syncSystemPackagesToDb(canonical, versions);
+
+    await db.update(packages).set({ type: "agent" }).where(eq(packages.id, "@sys-test/heal-type"));
+
+    const report = await syncSystemPackagesToDb(canonical, versions);
+
+    // The canonical pass ran (did not skip); the version pass still skipped.
+    expect(report.syncedPackages).toBe(1);
+    expect(report.unchangedPackages).toBe(0);
+    expect(report.unchangedVersions).toBe(1);
+
+    const [healed] = await db
+      .select({ type: packages.type })
+      .from(packages)
+      .where(eq(packages.id, "@sys-test/heal-type"))
+      .limit(1);
+    expect(healed!.type).toBe("skill");
+  });
+
+  it("fully re-creates a package deleted between boots", async () => {
+    // `package_versions.package_id` is ON DELETE CASCADE, so a dropped
+    // `packages` row takes its versions with it — the skip guard's INNER JOIN
+    // can never match a half-present package, and the next sync rebuilds both.
+    const entry = makeFixtureEntry({ id: "@sys-test/resurrect", version: "1.0.0" });
+    const { canonical, versions } = buildRegistry([entry]);
+    await syncSystemPackagesToDb(canonical, versions);
+
+    await db.delete(packages).where(eq(packages.id, "@sys-test/resurrect"));
+
+    const report = await syncSystemPackagesToDb(canonical, versions);
+    expect(report).toEqual({
+      syncedPackages: 1,
+      syncedVersions: 1,
+      unchangedPackages: 0,
+      unchangedVersions: 0,
+    });
+
+    const [row] = await db
+      .select({ id: packages.id, source: packages.source })
+      .from(packages)
+      .where(eq(packages.id, "@sys-test/resurrect"))
+      .limit(1);
+    expect(row).toBeDefined();
+    expect(row!.source).toBe("system");
+  });
+
   // ─── Integrity drift safety gate ───────────────────────
 
   it("REFUSES to overwrite a published version whose bytes changed without a version bump", async () => {

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -12,8 +12,11 @@
       document.documentElement.classList.add(t);
     })();
   </script>
+  <!-- Raster only, on purpose: public/favicon.svg is a 358 kB wrapper around two
+       base64 PNGs (light/dark variants), and every browser that supports SVG icons
+       preferred it over the 2 kB PNG — it was the single largest asset the page
+       requested. Do not re-add it without shrinking it to real vector art. -->
   <link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
-  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="shortcut icon" href="/favicon.ico" />
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
   <meta name="apple-mobile-web-app-title" content="Appstrate" />

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -2634,7 +2634,7 @@ export interface paths {
         };
         /**
          * OpenAPI specification
-         * @description Returns the OpenAPI 3.1 specification as JSON.
+         * @description Returns the OpenAPI 3.1 specification as JSON. The response carries a strong `ETag` that is stable for the lifetime of the deployment — send it back as `If-None-Match` to revalidate a cached copy and get a `304 Not Modified` instead of the full document.
          */
         get: operations["getOpenApiSpec"];
         put?: never;
@@ -3769,6 +3769,8 @@ export interface paths {
          *     Event types: `run_update` (status change), `run_log` (log entry), `run_metric` (running cumulative cost + token usage), `connection_update` (INSERT/UPDATE/DELETE on integration_connections, actor-scoped to the caller's own rows). Heartbeat: a named SSE `event: ping` frame (empty data) sent immediately on connect and every 30s thereafter.
          *
          *     Each SSE frame carries an `id:` field of the form `${subscriberId}:${monotonic}`. Ids are globally unique across reconnects (each new EventSource gets a fresh subscriberId). Client-side dedup on `id` is safe. Server-side replay via `Last-Event-ID` is NOT implemented — reconnect lands on the live tail; missed events are not replayed.
+         *
+         *     Channel selection: pass `channels=` with a comma-separated subset (e.g. `channels=run_update,connection_update`) to receive only those frames. The filter is applied server-side before serialization. Omit it to receive every channel. Note that dropping `run_log` is what keeps a dashboard-wide stream off the per-log firehose.
          */
         get: operations["streamAgentRuns"];
         put?: never;
@@ -3795,6 +3797,8 @@ export interface paths {
          *     Event types: `run_update` (status change), `run_log` (log entry), `run_metric` (running cumulative cost + token usage), `connection_update` (INSERT/UPDATE/DELETE on integration_connections, actor-scoped to the caller's own rows). Heartbeat: a named SSE `event: ping` frame (empty data) sent immediately on connect and every 30s thereafter.
          *
          *     Each SSE frame carries an `id:` field of the form `${subscriberId}:${monotonic}`. Ids are globally unique across reconnects (each new EventSource gets a fresh subscriberId). Client-side dedup on `id` is safe. Server-side replay via `Last-Event-ID` is NOT implemented — reconnect lands on the live tail; missed events are not replayed.
+         *
+         *     Channel selection: pass `channels=` with a comma-separated subset (e.g. `channels=run_update,connection_update`) to receive only those frames. The filter is applied server-side before serialization. Omit it to receive every channel. Note that dropping `run_log` is what keeps a dashboard-wide stream off the per-log firehose.
          */
         get: operations["streamAllRuns"];
         put?: never;
@@ -3819,6 +3823,8 @@ export interface paths {
          *     Event types: `run_update` (status change), `run_log` (log entry), `run_metric` (running cumulative cost + token usage), `connection_update` (INSERT/UPDATE/DELETE on integration_connections, actor-scoped to the caller's own rows). Heartbeat: a named SSE `event: ping` frame (empty data) sent immediately on connect and every 30s thereafter.
          *
          *     Each SSE frame carries an `id:` field of the form `${subscriberId}:${monotonic}`. Ids are globally unique across reconnects (each new EventSource gets a fresh subscriberId). Client-side dedup on `id` is safe. Server-side replay via `Last-Event-ID` is NOT implemented — reconnect lands on the live tail; missed events are not replayed.
+         *
+         *     Channel selection: pass `channels=` with a comma-separated subset (e.g. `channels=run_update,connection_update`) to receive only those frames. The filter is applied server-side before serialization. Omit it to receive every channel. Note that dropping `run_log` is what keeps a dashboard-wide stream off the per-log firehose.
          */
         get: operations["streamRun"];
         put?: never;
@@ -5864,6 +5870,8 @@ export interface components {
         SseOrgId: string;
         /** @description When true, include full payload with `result` and `data` fields. Default (false) strips large user-content fields for safer consumption by external agents. */
         Verbose: boolean;
+        /** @description Comma-separated list of SSE channels to subscribe to (`run_update`, `run_log`, `run_metric`, `connection_update`, `chat_session_update`). Omit to receive every channel (default, unchanged behaviour). Unknown names are ignored; if nothing is recognised the stream falls back to every channel. Declaring only the channels you consume avoids fanning the `run_log` firehose out to a stream that discards it. */
+        SseChannels: string;
         /** @description End-user ID (eu_ prefix) to execute the request on behalf of. API key auth only — rejected with 400 on cookie auth. */
         AppstrateUser: string;
         /** @description API version override (format: YYYY-MM-DD). Defaults to the org's pinned version or the current platform version. */
@@ -14299,7 +14307,10 @@ export interface operations {
     getOpenApiSpec: {
         parameters: {
             query?: never;
-            header?: never;
+            header?: {
+                /** @description Entity-tag of a cached copy. A match yields `304 Not Modified`. */
+                "If-None-Match"?: string;
+            };
             path?: never;
             cookie?: never;
         };
@@ -14308,6 +14319,8 @@ export interface operations {
             /** @description OpenAPI spec */
             200: {
                 headers: {
+                    /** @description Strong entity-tag of the served specification. */
+                    ETag?: string;
                     [name: string]: unknown;
                 };
                 content: {
@@ -14322,6 +14335,15 @@ export interface operations {
                      */
                     "application/json": Record<string, never>;
                 };
+            };
+            /** @description Cached copy is still current (`If-None-Match` matched). No body. */
+            304: {
+                headers: {
+                    /** @description Strong entity-tag of the served specification. */
+                    ETag?: string;
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };
@@ -17967,6 +17989,8 @@ export interface operations {
                 token?: components["parameters"]["SseToken"];
                 /** @description When true, include full payload with `result` and `data` fields. Default (false) strips large user-content fields for safer consumption by external agents. */
                 verbose?: components["parameters"]["Verbose"];
+                /** @description Comma-separated list of SSE channels to subscribe to (`run_update`, `run_log`, `run_metric`, `connection_update`, `chat_session_update`). Omit to receive every channel (default, unchanged behaviour). Unknown names are ignored; if nothing is recognised the stream falls back to every channel. Declaring only the channels you consume avoids fanning the `run_log` firehose out to a stream that discards it. */
+                channels?: components["parameters"]["SseChannels"];
             };
             header?: never;
             path: {
@@ -18001,6 +18025,8 @@ export interface operations {
                 token?: components["parameters"]["SseToken"];
                 /** @description When true, include full payload with `result` and `data` fields. Default (false) strips large user-content fields for safer consumption by external agents. */
                 verbose?: components["parameters"]["Verbose"];
+                /** @description Comma-separated list of SSE channels to subscribe to (`run_update`, `run_log`, `run_metric`, `connection_update`, `chat_session_update`). Omit to receive every channel (default, unchanged behaviour). Unknown names are ignored; if nothing is recognised the stream falls back to every channel. Declaring only the channels you consume avoids fanning the `run_log` firehose out to a stream that discards it. */
+                channels?: components["parameters"]["SseChannels"];
             };
             header?: never;
             path?: never;
@@ -18032,6 +18058,8 @@ export interface operations {
                 token?: components["parameters"]["SseToken"];
                 /** @description When true, include full payload with `result` and `data` fields. Default (false) strips large user-content fields for safer consumption by external agents. */
                 verbose?: components["parameters"]["Verbose"];
+                /** @description Comma-separated list of SSE channels to subscribe to (`run_update`, `run_log`, `run_metric`, `connection_update`, `chat_session_update`). Omit to receive every channel (default, unchanged behaviour). Unknown names are ignored; if nothing is recognised the stream falls back to every channel. Declaring only the channels you consume avoids fanning the `run_log` firehose out to a stream that discards it. */
+                channels?: components["parameters"]["SseChannels"];
             };
             header?: never;
             path: {

--- a/apps/web/src/app.tsx
+++ b/apps/web/src/app.tsx
@@ -185,6 +185,23 @@ function LazyRoute({ children }: { children: React.ReactNode }) {
   return <Suspense fallback={<LoadingState />}>{children}</Suspense>;
 }
 
+/**
+ * The one boot placeholder. Every gate below renders it, so a visitor sees a
+ * single uninterrupted spinner while the boot reads settle, never a sequence
+ * of visually identical ones handed off between gates.
+ *
+ * The boot reads themselves are started in `main.tsx`, in parallel: by the
+ * time `useAuth()` reports a user the org list is usually already cached, so
+ * `OrgGate` normally resolves without ever painting this.
+ */
+function BootScreen() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <Spinner />
+    </div>
+  );
+}
+
 function MainLayout() {
   const { open: sidebarOpen, setOpen: setSidebarOpen } = useSidebarStore();
   useApplicationResolver();
@@ -261,11 +278,7 @@ function OrgGate({ children }: { children: React.ReactNode }) {
   }
 
   if (loading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
+    return <BootScreen />;
   }
 
   // No orgs at all -- redirect to onboarding (or to "waiting for invitation"
@@ -281,11 +294,7 @@ function OrgGate({ children }: { children: React.ReactNode }) {
 
   // Orgs exist but none selected yet (auto-select happening)
   if (!currentOrg) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
+    return <BootScreen />;
   }
 
   return <>{children}</>;
@@ -321,11 +330,7 @@ export function App() {
   useExternalRedirect(!!user);
 
   if (loading) {
-    return (
-      <div className="flex min-h-screen items-center justify-center">
-        <Spinner />
-      </div>
-    );
+    return <BootScreen />;
   }
 
   // Hosted connect portal (issue #769) — standalone, auth-agnostic. Rendered
@@ -409,13 +414,7 @@ export function App() {
             <Route
               path="/auth/callback"
               element={
-                <Suspense
-                  fallback={
-                    <div className="flex min-h-screen items-center justify-center">
-                      <Spinner />
-                    </div>
-                  }
-                >
+                <Suspense fallback={<BootScreen />}>
                   <AuthCallbackPage />
                 </Suspense>
               }
@@ -502,13 +501,7 @@ export function App() {
             <Route
               path="/auth/callback"
               element={
-                <Suspense
-                  fallback={
-                    <div className="flex min-h-screen items-center justify-center">
-                      <Spinner />
-                    </div>
-                  }
-                >
+                <Suspense fallback={<BootScreen />}>
                   <AuthCallbackPage />
                 </Suspense>
               }

--- a/apps/web/src/components/run-agent-button.tsx
+++ b/apps/web/src/components/run-agent-button.tsx
@@ -1,21 +1,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Play } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@appstrate/ui/components/button";
 import { Spinner } from "./spinner";
+import { Modal } from "./modal";
+import { LoadingState } from "./page-states";
 import { RunModal } from "./run-modal";
-import {
-  MissingConnectionsModal,
-  type MissingIntegrationFieldError,
-} from "./missing-connections-modal";
+import type { MissingIntegrationFieldError } from "./missing-connections-modal";
 import { useRunAgent } from "../hooks/use-mutations";
 import { usePackageDetail } from "../hooks/use-packages";
 import { usePermissions } from "../hooks/use-permissions";
 import { ApiError } from "../api/errors";
 import type { AgentDetail } from "@appstrate/shared-types";
+
+/**
+ * 412 recovery surface — lazy because it is a modal that only ever opens on a
+ * failed run kickoff, while this button sits in the eager entry graph (agent
+ * list → card → button). Its subtree reaches `IntegrationConnectionPicker` →
+ * `@appstrate/core/integration` → `@afps-spec/schema`, which instantiates AJV
+ * at module scope; a static edge shipped AJV + semver (~144 kB raw) to every
+ * visitor. Keep this import dynamic.
+ */
+const MissingConnectionsModal = lazy(() =>
+  import("./missing-connections-modal").then((m) => ({ default: m.MissingConnectionsModal })),
+);
 
 interface RunAgentButtonProps {
   packageId: string;
@@ -130,6 +141,11 @@ export function RunAgentButton({
     });
   };
 
+  const closeMissingModal = () => {
+    setMissingErrors(null);
+    runAgent.reset();
+  };
+
   const isPending = isFetching || runAgent.isPending;
   const isDisabled = disabled || isPending;
 
@@ -186,31 +202,41 @@ export function RunAgentButton({
         />
       )}
 
-      <MissingConnectionsModal
-        open={missingErrors !== null}
-        onClose={() => {
-          setMissingErrors(null);
-          runAgent.reset();
-        }}
-        errors={missingErrors ?? []}
-        agentPackageId={packageId}
-        {...(detail?.dependencies.integrations
-          ? { integrationEntries: detail.dependencies.integrations }
-          : {})}
-        retrying={runAgent.isPending}
-        onRetryWithOverrides={(overrides) => {
-          // Re-fire the run with the user's picks. Keep the modal open
-          // until the response lands so the picker stays visible if the
-          // server returns a fresh 412 (e.g. picks disappeared mid-flight).
-          runAgent.mutate(
-            { version: runVersion, connectionOverrides: overrides },
-            {
-              onSuccess: () => setMissingErrors(null),
-              onError: onRunError,
-            },
-          );
-        }}
-      />
+      {missingErrors !== null && (
+        // Mounted only while the 412 modal is open — that mount is what
+        // triggers the dynamic import. The fallback keeps the same modal
+        // frame so the dialog appears immediately and only its body swaps.
+        <Suspense
+          fallback={
+            <Modal open onClose={closeMissingModal} title={t("missingConnections.title")}>
+              <LoadingState />
+            </Modal>
+          }
+        >
+          <MissingConnectionsModal
+            open
+            onClose={closeMissingModal}
+            errors={missingErrors}
+            agentPackageId={packageId}
+            {...(detail?.dependencies.integrations
+              ? { integrationEntries: detail.dependencies.integrations }
+              : {})}
+            retrying={runAgent.isPending}
+            onRetryWithOverrides={(overrides) => {
+              // Re-fire the run with the user's picks. Keep the modal open
+              // until the response lands so the picker stays visible if the
+              // server returns a fresh 412 (e.g. picks disappeared mid-flight).
+              runAgent.mutate(
+                { version: runVersion, connectionOverrides: overrides },
+                {
+                  onSuccess: () => setMissingErrors(null),
+                  onError: onRunError,
+                },
+              );
+            }}
+          />
+        </Suspense>
+      )}
     </>
   );
 }

--- a/apps/web/src/hooks/use-auth.ts
+++ b/apps/web/src/hooks/use-auth.ts
@@ -54,9 +54,19 @@ function setAuthenticatedUser(
 }
 
 async function syncAuth() {
-  const result = await authClient.getSession();
+  // `fetchProfile()` takes no argument from the session — `GET /api/profile`
+  // authenticates on the very same cookie `getSession()` reads — so the two
+  // requests are issued together instead of one behind the other. Ordering is
+  // still enforced *after* the fact: `getSession()` stays the sole authority
+  // on whether a user exists, and a profile that failed to load is treated
+  // exactly as before.
+  //
+  // For a visitor with no session both now fail instead of only the first.
+  // That is deliberate and silent: `fetchProfile()` swallows its own failure
+  // and returns null, so nothing reaches an error boundary or a toast, and
+  // the `else` branch below still lands on the login screen.
+  const [result, profile] = await Promise.all([authClient.getSession(), fetchProfile()]);
   if (result.data?.user) {
-    const profile = await fetchProfile();
     if (!profile) {
       await authClient.signOut().catch(() => {});
       clearSession();
@@ -93,6 +103,17 @@ function initAuth() {
   syncAuth().catch(() => {
     clearSession();
   });
+}
+
+/**
+ * Start the session resync at boot rather than on the first `useAuth()`
+ * render. Called from `main.tsx` before `createRoot`, so the session/profile
+ * round-trip overlaps the locale fetch and the first render instead of
+ * queueing behind them. Idempotent — `useAuth()` still calls the same
+ * initializer, which no-ops once this has run.
+ */
+export function startAuthBootstrap(): void {
+  initAuth();
 }
 
 /**

--- a/apps/web/src/hooks/use-global-run-sync.ts
+++ b/apps/web/src/hooks/use-global-run-sync.ts
@@ -224,7 +224,13 @@ export function useGlobalRunSync() {
     // only for a non-OK response (handled by the reconnect loop).
     const connectOnce = async () => {
       const res = await fetch(
-        `/api/realtime/runs?orgId=${encodeURIComponent(orgId)}&applicationId=${encodeURIComponent(applicationId)}&verbose=true`,
+        // Declare the three channels this hook actually dispatches on. Without
+        // it the server fans the whole `run_log` firehose (every log line of
+        // every run in the application) into this stream just for the reader
+        // loop to drop it — and admins/owners got the `debug` level too.
+        // `verbose` is deliberately absent: it only affects `run_log`, which
+        // we no longer subscribe to.
+        `/api/realtime/runs?orgId=${encodeURIComponent(orgId)}&applicationId=${encodeURIComponent(applicationId)}&channels=run_update,connection_update,chat_session_update`,
         {
           credentials: "include",
           signal: controller.signal,

--- a/apps/web/src/hooks/use-org.ts
+++ b/apps/web/src/hooks/use-org.ts
@@ -14,6 +14,45 @@ export function useCurrentOrgId(): string | null {
   return useStore(orgStore, (s) => s.id);
 }
 
+async function fetchOrgs() {
+  const { data } = await client.GET("/api/orgs");
+  return data?.data ?? [];
+}
+
+/**
+ * In-flight org list started by `primeOrgList()` at boot, waiting to be
+ * adopted by the first `useOrg()` that mounts. One-shot: it is handed over
+ * exactly once, and every later fetch goes through `fetchOrgs()` normally.
+ */
+let primedOrgs: ReturnType<typeof fetchOrgs> | null = null;
+
+/**
+ * Start the org list immediately, without waiting for React to mount the org
+ * gate. `GET /api/orgs` authenticates on the session cookie alone — it needs
+ * nothing from the session or profile reads — so at boot it belongs beside
+ * them rather than behind them (see `main.tsx`).
+ *
+ * The promise is handed to React Query as the query function's own result, so
+ * the query still owns the whole state machine (pending → success/error,
+ * retries, gate spinner). A failure is dropped instead of being cached: the
+ * common failure is "no session yet", and a poisoned `["orgs"]` entry would
+ * read as an *empty* org list to `OrgGate` and bounce a legitimate user into
+ * onboarding after they log in.
+ */
+export function primeOrgList(): void {
+  const request = fetchOrgs();
+  primedOrgs = request;
+  request.catch(() => {
+    if (primedOrgs === request) primedOrgs = null;
+  });
+}
+
+function orgListQueryFn() {
+  const primed = primedOrgs;
+  primedOrgs = null;
+  return primed ?? fetchOrgs();
+}
+
 export function useOrg() {
   const queryClient = useQueryClient();
   const currentOrgId = useStore(orgStore, (s) => s.id);
@@ -24,10 +63,7 @@ export function useOrg() {
     // (see the removeQueries predicate below) and other call sites invalidate
     // ["orgs"] directly. Only the fetch itself goes through the typed client.
     queryKey: orgKeys.all,
-    queryFn: async () => {
-      const { data } = await client.GET("/api/orgs");
-      return data?.data ?? [];
-    },
+    queryFn: orgListQueryFn,
   });
 
   const setOrgId = useCallback((id: string) => orgStore.getState().setId(id), []);

--- a/apps/web/src/hooks/use-realtime.ts
+++ b/apps/web/src/hooks/use-realtime.ts
@@ -49,8 +49,13 @@ export function useRunRealtime(runId: string | null | undefined, handlers: RunRe
     const applicationId = getCurrentApplicationId();
     if (!orgId || !applicationId) return;
 
+    // Only the three run channels are dispatched below, so declare them: the
+    // per-run stream would otherwise also carry `connection_update` (every
+    // connection row the caller owns) and `chat_session_update` for a page
+    // that listens to neither. `verbose=true` is still required — it is what
+    // keeps `run_log.data` in the payload.
     const es = new EventSource(
-      `/api/realtime/runs/${runId}?orgId=${encodeURIComponent(orgId)}&applicationId=${encodeURIComponent(applicationId)}&verbose=true`,
+      `/api/realtime/runs/${runId}?orgId=${encodeURIComponent(orgId)}&applicationId=${encodeURIComponent(applicationId)}&verbose=true&channels=run_update,run_log,run_metric`,
       { withCredentials: true },
     );
 

--- a/apps/web/src/i18n-config.ts
+++ b/apps/web/src/i18n-config.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * i18n constants shared by the runtime (`i18n.ts`) and the build
+ * (`vite.config.ts`, which emits `modulepreload` hints for the boot locale
+ * chunks).
+ *
+ * **This module MUST stay import-free.** `vite.config.ts` loads it in the Node
+ * build context, where pulling in i18next — or anything reaching for `window`
+ * — would break config evaluation.
+ *
+ * These values used to be written out twice, once here and once in the Vite
+ * plugin, under a "keep in sync" comment. A drifted namespace list is
+ * invisible: the preload hint simply stops matching, the RTT comes back, and
+ * nothing fails. Deriving both sides from this file makes that impossible.
+ */
+
+/** Language used when nothing is stored and nothing matches. */
+export const I18N_FALLBACK_LANGUAGE = "fr";
+
+/** Languages with a complete locale directory. */
+export const I18N_SUPPORTED_LANGUAGES = ["fr", "en"] as const;
+
+/** localStorage key i18next persists the active language under. */
+export const I18N_LANGUAGE_STORAGE_KEY = "i18nextLng";
+
+/**
+ * Namespaces preloaded for every user, and therefore on the critical path to
+ * first paint: `main.tsx` gates `createRoot()` on `i18nReady`, which resolves
+ * once these have loaded.
+ *
+ * A MODULE's namespace is deliberately absent (e.g. `chat`):
+ * `useTranslation("chat")` loads it on demand inside the module route's
+ * Suspense boundary, so a disabled module costs nothing — same rule as its
+ * code chunk.
+ */
+export const I18N_BOOT_NAMESPACES = ["common", "agents", "settings", "documents"] as const;

--- a/apps/web/src/i18n.ts
+++ b/apps/web/src/i18n.ts
@@ -3,13 +3,19 @@
 import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import resourcesToBackend from "i18next-resources-to-backend";
+import {
+  I18N_BOOT_NAMESPACES,
+  I18N_FALLBACK_LANGUAGE,
+  I18N_LANGUAGE_STORAGE_KEY,
+  I18N_SUPPORTED_LANGUAGES,
+} from "./i18n-config.ts";
 
 // Accessing localStorage throws when storage is blocked (sandboxed iframe,
 // Safari private mode, cookies-disabled). Guard it so a blocked store can
 // never crash the SPA bootstrap — we just fall back to the default language.
 function readSavedLng(): string | null {
   try {
-    return localStorage.getItem("i18nextLng");
+    return localStorage.getItem(I18N_LANGUAGE_STORAGE_KEY);
   } catch {
     return null;
   }
@@ -30,15 +36,13 @@ export const i18nReady = i18n
   .use(initReactI18next)
   .init({
     lng: savedLng || undefined,
-    fallbackLng: "fr",
-    supportedLngs: ["fr", "en"],
+    fallbackLng: I18N_FALLBACK_LANGUAGE,
+    supportedLngs: [...I18N_SUPPORTED_LANGUAGES],
     defaultNS: "common",
     fallbackNS: "common",
-    // Core namespaces, preloaded for every user. A MODULE's namespace is
-    // deliberately absent (e.g. `chat`): `useTranslation("chat")` loads it on
-    // demand inside the module route's Suspense boundary, so a disabled module
-    // costs nothing — same rule as its code chunk.
-    ns: ["common", "agents", "settings", "documents"],
+    // Shared with `vite.config.ts`, which preloads exactly these chunks — see
+    // `i18n-config.ts` for why the list lives there rather than inline.
+    ns: [...I18N_BOOT_NAMESPACES],
     interpolation: { escapeValue: false },
   });
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,6 +6,8 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { App } from "./app";
+import { startAuthBootstrap } from "./hooks/use-auth";
+import { primeOrgList } from "./hooks/use-org";
 import { clearChunkReloadFlag, reloadOnceForChunkError } from "./lib/chunk-reload";
 import "./stores/theme-store";
 import "./styles.css";
@@ -31,6 +33,21 @@ const queryClient = new QueryClient({
     },
   },
 });
+
+// The first screen needs three server reads that share no data with each
+// other: the Better Auth session, `GET /api/profile` and `GET /api/orgs`. All
+// three authenticate on the session cookie alone, so none of them has to wait
+// for another. They used to run strictly one after the next — the session
+// gated the profile, the profile gated the first render, and the first render
+// was what mounted the org gate that issued the org list.
+//
+// Kicking them here, before `i18nReady` resolves and before React mounts,
+// collapses those three round-trips into one and takes them off the locale
+// fetch's tail. `GET /api/applications` is the only first-screen read with a
+// real data dependency (it needs the selected org id), so what is left is two
+// network levels, not four.
+startAuthBootstrap();
+primeOrgList();
 
 // Wait for the active language's namespaces to load before the first render
 // so the UI never flashes raw translation keys. Render anyway on failure —

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,12 +1,83 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import path from "path";
+import {
+  I18N_BOOT_NAMESPACES,
+  I18N_FALLBACK_LANGUAGE,
+  I18N_LANGUAGE_STORAGE_KEY,
+} from "./src/i18n-config.ts";
+
+/** `…/src/locales/<language>/<namespace>.json` */
+const LOCALE_MODULE_RE = /[/\\]src[/\\]locales[/\\]([^/\\]+)[/\\]([^/\\]+)\.json$/;
+
+/**
+ * Emit `modulepreload` hints for the boot locale chunks.
+ *
+ * i18next fetches them through a dynamic import (`i18n.ts` →
+ * `resourcesToBackend`), so the browser only discovers those URLs once the
+ * whole entry graph has downloaded AND executed — a fully serialized
+ * round-trip in front of the first render. Vite's own preload injection is
+ * driven by the static import graph and therefore never sees them.
+ *
+ * This walks the emitted bundle for locale modules, groups their chunk URLs
+ * by language, and injects a small inline script that appends the hints for
+ * the language the visitor actually has. It runs while the head is still
+ * parsing, so the locale chunks download alongside the entry chunk instead of
+ * after it. Language resolution mirrors `i18n.ts`: the `i18nextLng`
+ * localStorage key, falling back to `fr`. An unknown language, a blocked
+ * localStorage, or a missing map entry simply skips the hint — the runtime
+ * import still works, it is just not preloaded.
+ */
+function i18nBootPreload(): Plugin {
+  let base = "/";
+  const bootNamespaces = new Set<string>(I18N_BOOT_NAMESPACES);
+  return {
+    name: "appstrate:i18n-boot-preload",
+    apply: "build",
+    configResolved(config) {
+      base = config.base;
+    },
+    transformIndexHtml: {
+      order: "post",
+      handler(_html, ctx) {
+        if (!ctx.bundle) return;
+
+        const byLanguage: Record<string, string[]> = {};
+        for (const output of Object.values(ctx.bundle)) {
+          if (output.type !== "chunk") continue;
+          const moduleIds: string[] = output.moduleIds ?? Object.keys(output.modules ?? {});
+          for (const moduleId of moduleIds) {
+            const match = LOCALE_MODULE_RE.exec(moduleId);
+            if (!match) continue;
+            const [, language, namespace] = match;
+            if (!bootNamespaces.has(namespace)) continue;
+            (byLanguage[language] ??= []).push(`${base}${output.fileName}`);
+            break;
+          }
+        }
+        if (Object.keys(byLanguage).length === 0) return;
+
+        // `</` is escaped so a filename can never close the script element.
+        const map = JSON.stringify(byLanguage).replace(/</g, "\\u003c");
+        const fallback = JSON.stringify(I18N_FALLBACK_LANGUAGE);
+        const storageKey = JSON.stringify(I18N_LANGUAGE_STORAGE_KEY);
+        return [
+          {
+            tag: "script",
+            injectTo: "head",
+            children: `(function(){var m=${map},f=${fallback},l=f;try{var s=localStorage.getItem(${storageKey});if(s)l=s.split("-")[0]}catch(e){}var u=m[l]||m[f];if(!u)return;for(var i=0;i<u.length;i++){var k=document.createElement("link");k.rel="modulepreload";k.crossOrigin="anonymous";k.href=u[i];document.head.appendChild(k)}})();`,
+          },
+        ];
+      },
+    },
+  };
+}
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), i18nBootPreload()],
   envDir: "../../",
   resolve: {
     alias: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -249,6 +249,12 @@ services:
     ports:
       - "${PORT:-3000}:3000"
     restart: unless-stopped
+    # Docker's default stop grace is 10s — SHORTER than the platform's 30s
+    # in-flight run drain, so SIGKILL landed mid-drain and the teardown that
+    # follows it (BullMQ/worker close, telemetry flush, DB + Redis close,
+    # exit 0) never ran. 45s covers the drain plus the 40s hard deadline in
+    # `apps/api/src/lib/shutdown.ts`. Keep the two aligned if either moves.
+    stop_grace_period: 45s
     mem_limit: 8g
     environment:
       # ── Core ──

--- a/package.json
+++ b/package.json
@@ -62,10 +62,10 @@
     "test:e2e": "cd e2e && npx playwright test",
     "test:e2e:api": "cd e2e && npx playwright test --project=api",
     "test:e2e:ui": "cd e2e && npx playwright test --project=ui",
-    "lint": "eslint .",
+    "lint": "eslint . --cache --cache-strategy content",
     "lint:fix": "eslint . --fix && prettier --write \"apps/*/src/**\" \"packages/*/src/**\"",
     "format": "prettier --write \"apps/*/src/**\" \"packages/*/src/**\"",
-    "format:check": "prettier --check \"apps/*/src/**\" \"packages/*/src/**\"",
+    "format:check": "prettier --check --cache --cache-strategy content \"apps/*/src/**\" \"packages/*/src/**\"",
     "detect:breaking": "bun scripts/detect-breaking-changes.ts",
     "generate:api": "bun scripts/generate-api-types.ts",
     "verify:api-types": "bun scripts/generate-api-types.ts --check",
@@ -114,7 +114,7 @@
     "verify:compose-defaults": "bun scripts/verify-compose-defaults.ts",
     "openapi:baseline": "bun scripts/detect-breaking-changes.ts --update-baseline",
     "openapi:diff": "bun scripts/detect-breaking-changes.ts",
-    "clean": "rm -rf node_modules/.cache .turbo apps/*/dist apps/web/.vite packages/*/dist coverage",
+    "clean": "rm -rf node_modules/.cache .turbo .eslintcache apps/*/dist apps/web/.vite packages/*/dist coverage",
     "prepare": "husky"
   },
   "workspaces": [

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "exports": {
     "./schema": "./src/schema/index.ts",
+    "./run-status": "./src/run-status.ts",
     "./client": "./src/client.ts",
     "./auth": "./src/auth.ts",
     "./auth-policy": "./src/auth-policy.ts",

--- a/packages/db/src/notify.ts
+++ b/packages/db/src/notify.ts
@@ -117,14 +117,68 @@ export async function createNotifyTriggers(db: Db): Promise<void> {
   // Create triggers idempotently. Use DO blocks with explicit existence
   // checks instead of DROP TRIGGER IF EXISTS to avoid NOTICE logs on first
   // boot (when the triggers don't exist yet).
+  //
+  // The runs trigger is SPLIT in two — INSERT (unconditional) and UPDATE
+  // (guarded by a WHEN clause) — because a trigger declared for INSERT cannot
+  // reference OLD in its WHEN condition; Postgres rejects such a combined
+  // trigger at CREATE time.
+  //
+  // Why the UPDATE guard exists: the run-event ingestion CAS
+  // (`persistEventAndAdvance`) UPDATEs `runs` once PER INGESTED EVENT, setting
+  // only `last_event_sequence` + `last_heartbeat_at`. Neither appears in the
+  // NOTIFY payload, so every one of those writes broadcast a payload BYTE-FOR-
+  // BYTE identical to the previous one, to every SSE subscriber in the org.
+  // The 30 s runner heartbeat has the same shape.
+  //
+  // The WHEN condition below lists EXACTLY the columns `notify_run_change`
+  // interpolates into the payload, compared with `IS DISTINCT FROM` so a
+  // NULL↔value transition counts as a change. An UPDATE is therefore
+  // suppressed only when the notification it would emit is identical to the
+  // one the previous write already delivered — the fan-out is unchanged for
+  // every payload-visible transition (status, error, timestamps, duration,
+  // ownership, scheduling). `error` is compared in full even though the
+  // payload truncates it to 2 000 chars: comparing the untruncated value can
+  // only make the guard fire MORE often, never less.
+  //
+  // Columns deliberately NOT in the list (a write touching only these no
+  // longer notifies `run_update`): `last_event_sequence`, `last_heartbeat_at`,
+  // `cost`, `token_usage`, `result`, `checkpoint`, `artifacts`,
+  // `sink_closed_at`. None of them is readable from a `run_update` frame —
+  // live cost/usage reach the UI on the dedicated `run_metric` channel, and
+  // the terminal values ride the finalize UPDATE, which also writes `status`
+  // + `completed_at` and therefore still fires.
   await db.execute(drizzleSql`
     DO $$ BEGIN
       IF EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'runs_notify_trigger') THEN
         DROP TRIGGER runs_notify_trigger ON runs;
       END IF;
-      CREATE TRIGGER runs_notify_trigger
-        AFTER INSERT OR UPDATE ON runs
+      IF EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'runs_notify_insert_trigger') THEN
+        DROP TRIGGER runs_notify_insert_trigger ON runs;
+      END IF;
+      IF EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'runs_notify_update_trigger') THEN
+        DROP TRIGGER runs_notify_update_trigger ON runs;
+      END IF;
+      CREATE TRIGGER runs_notify_insert_trigger
+        AFTER INSERT ON runs
         FOR EACH ROW EXECUTE FUNCTION notify_run_change();
+      CREATE TRIGGER runs_notify_update_trigger
+        AFTER UPDATE ON runs
+        FOR EACH ROW
+        WHEN (
+          OLD.id IS DISTINCT FROM NEW.id
+          OR OLD.package_id IS DISTINCT FROM NEW.package_id
+          OR OLD.status IS DISTINCT FROM NEW.status
+          OR OLD.user_id IS DISTINCT FROM NEW.user_id
+          OR OLD.end_user_id IS DISTINCT FROM NEW.end_user_id
+          OR OLD.org_id IS DISTINCT FROM NEW.org_id
+          OR OLD.application_id IS DISTINCT FROM NEW.application_id
+          OR OLD.schedule_id IS DISTINCT FROM NEW.schedule_id
+          OR OLD.error IS DISTINCT FROM NEW.error
+          OR OLD.started_at IS DISTINCT FROM NEW.started_at
+          OR OLD.completed_at IS DISTINCT FROM NEW.completed_at
+          OR OLD.duration IS DISTINCT FROM NEW.duration
+        )
+        EXECUTE FUNCTION notify_run_change();
     END $$;
   `);
 

--- a/packages/db/src/run-status.ts
+++ b/packages/db/src/run-status.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Run-status literals — the single source of truth for the `run_status`
+ * value set.
+ *
+ * **This module MUST stay import-free.** It is the one piece of the DB
+ * package the browser bundle is allowed to reach: `@appstrate/shared-types`
+ * re-exports these values to the SPA, and any import added here (drizzle-orm,
+ * zod, another schema file) would be dragged into the eager entry graph along
+ * with the rest of the schema barrel — which also leaked table/column names
+ * (`llm_usage`, `oauth_clients`, `end_users`, …) into a public asset.
+ *
+ * The Drizzle `pgEnum` and the Zod validator DERIVE from these tuples
+ * (`schema/enums.ts`), never the other way round: the DB enum, the validator
+ * and the inferred TS union cannot drift from what the client ships.
+ */
+
+export const runStatusValues = [
+  "pending",
+  "running",
+  "success",
+  "failed",
+  "timeout",
+  "cancelled",
+] as const;
+
+export type RunStatus = (typeof runStatusValues)[number];
+
+/**
+ * Terminal run statuses — runs in any of these states are no longer
+ * progressing. Used by event-ingestion ordering, SSE invalidation,
+ * and any caller that needs to short-circuit polling.
+ */
+export const terminalRunStatusValues = ["success", "failed", "timeout", "cancelled"] as const;
+export const TERMINAL_RUN_STATUSES: ReadonlySet<RunStatus> = new Set(terminalRunStatusValues);
+export type TerminalRunStatus = (typeof terminalRunStatusValues)[number];
+
+/**
+ * Active (non-terminal) run statuses — the run is still progressing.
+ * Mirror of {@link TERMINAL_RUN_STATUSES} for callers that need to gate
+ * UI on "in flight" rather than "done". Derived from the same const
+ * tuple pattern so adding a new status to {@link runStatusValues} forces
+ * an explicit decision about which set it belongs to.
+ */
+export const activeRunStatusValues = ["pending", "running"] as const;
+export const ACTIVE_RUN_STATUSES: ReadonlySet<RunStatus> = new Set(activeRunStatusValues);
+
+/**
+ * RunEvent types that mark a run as terminal — `run.success`, `run.failed`,
+ * `run.timeout`, `run.cancelled`. Mirrors `terminalRunStatusValues` but for
+ * the event-stream side of the boundary.
+ */
+export const TERMINAL_RUN_EVENT_TYPES: ReadonlySet<string> = new Set(
+  terminalRunStatusValues.map((status) => `run.${status}`),
+);

--- a/packages/db/src/schema/enums.ts
+++ b/packages/db/src/schema/enums.ts
@@ -13,54 +13,32 @@
 
 import { z } from "zod";
 import { pgEnum } from "drizzle-orm/pg-core";
+import { runStatusValues } from "../run-status.ts";
 
 export const orgRoleValues = ["owner", "admin", "member", "viewer"] as const;
 export const orgRoleEnum = pgEnum("org_role", orgRoleValues);
 export const zOrgRoleEnum = z.enum(orgRoleValues);
 export type OrgRole = z.infer<typeof zOrgRoleEnum>;
 
-export const runStatusValues = [
-  "pending",
-  "running",
-  "success",
-  "failed",
-  "timeout",
-  "cancelled",
-] as const;
+/**
+ * Run statuses are the one enum whose literals live OUTSIDE this file, in the
+ * import-free `../run-status.ts`: the SPA needs the values (not the Drizzle
+ * object), and importing them from here would pull drizzle-orm + the whole
+ * schema barrel into the browser bundle. The `pgEnum` below derives from that
+ * tuple, so the DB enum can never drift from what the client ships.
+ */
+export {
+  runStatusValues,
+  terminalRunStatusValues,
+  TERMINAL_RUN_STATUSES,
+  activeRunStatusValues,
+  ACTIVE_RUN_STATUSES,
+  TERMINAL_RUN_EVENT_TYPES,
+} from "../run-status.ts";
+export type { RunStatus, TerminalRunStatus } from "../run-status.ts";
+
 export const runStatusEnum = pgEnum("run_status", runStatusValues);
 export const zRunStatusEnum = z.enum(runStatusValues);
-export type RunStatus = z.infer<typeof zRunStatusEnum>;
-
-/**
- * Terminal run statuses — runs in any of these states are no longer
- * progressing. Used by event-ingestion ordering, SSE invalidation,
- * and any caller that needs to short-circuit polling.
- */
-export const terminalRunStatusValues = ["success", "failed", "timeout", "cancelled"] as const;
-export const TERMINAL_RUN_STATUSES: ReadonlySet<RunStatus> = new Set(terminalRunStatusValues);
-export type TerminalRunStatus = (typeof terminalRunStatusValues)[number];
-
-/**
- * Active (non-terminal) run statuses — the run is still progressing.
- * Mirror of {@link TERMINAL_RUN_STATUSES} for callers that need to gate
- * UI on "in flight" rather than "done". Derived from the same const
- * tuple pattern so adding a new status to {@link runStatusValues} forces
- * an explicit decision about which set it belongs to.
- */
-export const activeRunStatusValues = ["pending", "running"] as const;
-export const ACTIVE_RUN_STATUSES: ReadonlySet<RunStatus> = new Set(activeRunStatusValues);
-
-/**
- * RunEvent types that mark a run as terminal — `run.success`, `run.failed`,
- * `run.timeout`, `run.cancelled`. Mirrors `terminalRunStatusValues` but for
- * the event-stream side of the boundary.
- */
-export const TERMINAL_RUN_EVENT_TYPES: ReadonlySet<string> = new Set([
-  "run.success",
-  "run.failed",
-  "run.timeout",
-  "run.cancelled",
-]);
 
 export const invitationStatusValues = ["pending", "accepted", "expired", "cancelled"] as const;
 export const invitationStatusEnum = pgEnum("invitation_status", invitationStatusValues);

--- a/packages/module-chat/src/finalize-stream.ts
+++ b/packages/module-chat/src/finalize-stream.ts
@@ -5,10 +5,10 @@
  * engines and extracted here so the guarantees are unit-testable.
  *
  * The engine's UI-message stream (a Response body) is teed:
- *  - one branch is recorded into the resumable store via `context.run(streamId)`,
- *    whose returned consumer is what we hand to the client. Recording is driven
- *    by the producer independently of the client consumer, so a reloaded client
- *    can reconnect to the still-live tail (`GET /sessions/:id/stream`).
+ *  - one branch feeds the resumable producer via `context.run(streamId)` AND the
+ *    client, as two sub-branches of a second tee. Recording is driven by the
+ *    producer independently of the client, so a reloaded client can reconnect to
+ *    the still-live tail (`GET /sessions/:id/stream`).
  *  - the other branch is drained server-side to extract and persist the assistant
  *    turn. This drain runs in an independent task (not tied to the Response), so
  *    it keeps pulling — driving generation to completion — even if the client
@@ -16,11 +16,20 @@
  *    the run. The task is registered in the in-flight registry so graceful
  *    shutdown can await it.
  *
+ * The connected client is served its OWN branch, never the store read-back.
+ * `context.run()` returns a store reader unconditionally — including to the
+ * producer — so handing that reader to the client would make every nominal chat
+ * turn round-trip through the store, and (on Redis) poll `XRANGE` every 100ms
+ * for the whole turn just to read back bytes this process already holds. The
+ * store read path is for RESUME only: a second tab, or a reconnect after a
+ * disconnect, both of which go through `context.resume()` in `routes.ts`.
+ *
  * Data-safety does NOT depend on the resumable store: persistence is the drain
  * branch. Resume is the live-token-reconnect polish on top.
  */
 
 import type { UIMessage } from "ai";
+import type { ResumableStreamContext } from "assistant-stream/resumable";
 import { logger } from "./logger.ts";
 import { extractAssistantMessages } from "./stream-parse.ts";
 import { trackTurn } from "./inflight.ts";
@@ -44,6 +53,8 @@ export interface FinalizeChatStreamOptions {
   parentId?: string | null;
   /** Best-effort teardown after persistence settles (close MCP, unregister stop, clear active stream). */
   onSettled?: () => void;
+  /** Injection seam for tests — defaults to the process-wide resumable context. */
+  resumableContext?: ResumableStreamContext;
 }
 
 export async function finalizeChatStream(opts: FinalizeChatStreamOptions): Promise<Response> {
@@ -55,7 +66,7 @@ export async function finalizeChatStream(opts: FinalizeChatStreamOptions): Promi
     return engineResponse;
   }
 
-  const [forStore, forPersist] = sourceBody.tee();
+  const [forRecord, forPersist] = sourceBody.tee();
 
   // Persist the assistant turn when the stream finalizes. Started BEFORE the
   // Response is returned and not tied to it, so a client disconnect cannot skip
@@ -104,19 +115,29 @@ export async function finalizeChatStream(opts: FinalizeChatStreamOptions): Promi
   })();
   trackTurn(persistTask);
 
-  // Record the turn's bytes for resume; the returned consumer is the client view.
-  // The producer reads `forStore` into the store regardless of this consumer, so
-  // a client disconnect does not stop recording. If the resumable layer fails for
-  // any reason, fall back to the raw client branch — never break the live turn.
-  let clientStream: ReadableStream<Uint8Array> = forStore;
+  // Split the recording branch once more: `forStore` feeds the resumable
+  // producer, `forClient` IS the response body. The connected client therefore
+  // reads the engine bytes directly — no store round-trip, no poll loop — while
+  // the producer keeps recording regardless of whether the client is still
+  // there, which is what makes a mid-turn reload resumable.
+  const [forStore, forClient] = forRecord.tee();
   try {
-    clientStream = await getResumableContext().run(streamId, () => forStore);
+    // `run()` hands back a store reader even to the producer. We already have the
+    // bytes, so cancel it immediately: left unread it would poll the store for the
+    // whole turn. Resume readers get their own via `context.resume()`.
+    const unusedStoreReader = await (opts.resumableContext ?? getResumableContext()).run(
+      streamId,
+      () => forStore,
+    );
+    void unusedStoreReader.cancel().catch(() => {});
   } catch (err) {
     // Resume unavailable this turn; client still streams + persistence still runs.
+    // Release the unread producer branch so the tee stops buffering it.
     void err;
+    void forStore.cancel().catch(() => {});
   }
 
-  return new Response(clientStream, {
+  return new Response(forClient, {
     status: engineResponse.status,
     statusText: engineResponse.statusText,
     headers: engineResponse.headers,

--- a/packages/module-chat/src/resumable.ts
+++ b/packages/module-chat/src/resumable.ts
@@ -37,6 +37,22 @@ import { logger } from "./logger.ts";
 
 let context: ResumableStreamContext | null = null;
 
+/**
+ * Retention for a turn's recorded bytes (both stores default to 24h).
+ *
+ * A day of retention buys nothing: the only window in which anything reads a
+ * recording back is "while the turn is live", and `clearActiveStream` drops the
+ * pointer to it the moment the turn finalizes — nothing can resume a finished
+ * turn. Everything past that point is a day of raw SSE bytes per chat turn held
+ * in Redis (or in the in-memory map on the single-replica tier).
+ *
+ * The TTL is refreshed on every append, so this is an inactivity budget measured
+ * from the last chunk, sized off the same 30min ceiling a turn's engine loopback
+ * token gets (`chat-stream.ts` ENGINE_LOOPBACK_TTL_MS). A turn silent for longer
+ * than that is dead and its bytes are garbage.
+ */
+const STREAM_TTL_MS = 30 * 60_000;
+
 /** Build the store once: Redis if reachable, else in-memory (single replica). */
 function buildStore(): ResumableStreamStore {
   const url = process.env.REDIS_URL;
@@ -69,7 +85,8 @@ function buildStore(): ResumableStreamStore {
 
 /** Lazily-created singleton resumable-stream context. */
 export function getResumableContext(): ResumableStreamContext {
-  if (!context) context = createResumableStreamContext({ store: buildStore() });
+  if (!context)
+    context = createResumableStreamContext({ store: buildStore(), ttlMs: STREAM_TTL_MS });
   return context;
 }
 

--- a/packages/module-chat/src/ui/oauth-connect-card.tsx
+++ b/packages/module-chat/src/ui/oauth-connect-card.tsx
@@ -70,7 +70,11 @@ function watchConnectionSse(
       // `/api/realtime/runs` (the org-wide stream, which also carries
       // `connection_update`) — NOT bare `/api/realtime`, which is not a route
       // (it 404s and isn't auth-skipped), so this backstop never fired.
-      `/api/realtime/runs?orgId=${encodeURIComponent(orgId)}&applicationId=${encodeURIComponent(appId)}`,
+      //
+      // `channels` is declared because this opens one org-wide stream PER
+      // rendered card, and the listener below reads `connection_update` only.
+      // Without it each card would also carry the org's whole run_log traffic.
+      `/api/realtime/runs?orgId=${encodeURIComponent(orgId)}&applicationId=${encodeURIComponent(appId)}&channels=connection_update`,
       { withCredentials: true },
     );
     es.addEventListener("connection_update", (ev) => {

--- a/packages/module-chat/src/ui/run-events.ts
+++ b/packages/module-chat/src/ui/run-events.ts
@@ -12,15 +12,14 @@
  * `chat-run-progress-card.tsx`) stays a thin shell.
  *
  * The schemas here are deliberately a MINIMAL local subset of the canonical
- * `@appstrate/shared-types` realtime schemas: depending on shared-types would
- * pull `@appstrate/db` (it imports `runStatusEnum`/`tokenUsage`) into the chat
- * module, coupling the UI to the database package. We only need a handful of
- * fields, so we redeclare them and stay decoupled. Field names match the wire
- * shape (post-camelize) exactly so a server payload validates unchanged.
+ * `@appstrate/shared-types` realtime schemas: we only need a handful of
+ * fields, so we redeclare them and stay decoupled from the API wire module.
+ * Field names match the wire shape (post-camelize) exactly so a server
+ * payload validates unchanged.
  */
 
 import { z } from "zod";
-import type { RunStatus as DbRunStatus, TerminalRunStatus } from "@appstrate/db/schema";
+import { runStatusValues, TERMINAL_RUN_STATUSES } from "@appstrate/db/run-status";
 import { documentUri, parseDocumentUri } from "@appstrate/core/document-uri";
 import { asRecord, unwrapResult } from "./tool-result.ts";
 
@@ -29,43 +28,15 @@ export const RUN_LAUNCH_OPS = ["runAgent", "runInline", "run_and_wait"] as const
 export type RunLaunchOp = (typeof RUN_LAUNCH_OPS)[number];
 
 /**
- * All run statuses. Kept as a local literal so this browser-bundled UI
- * module never pulls `@appstrate/db` values (drizzle) into the web build —
- * the type-only parity assertions below fail compilation if either side
- * drifts from the canonical enums in `packages/db/src/schema/enums.ts`.
+ * All run statuses — re-exported from the canonical, import-free tuple in
+ * `@appstrate/db/run-status` (which the `run_status` `pgEnum` itself derives
+ * from). That module pulls neither drizzle-orm nor the table schema, so this
+ * browser-bundled UI module stays free of DB code while the list can no
+ * longer drift from the database.
  */
-export const RUN_STATUSES = [
-  "pending",
-  "running",
-  "success",
-  "failed",
-  "timeout",
-  "cancelled",
-] as const;
-export type RunStatus = (typeof RUN_STATUSES)[number];
-
-/** Statuses past which a run never changes again. */
-const terminalRunStatuses = ["success", "failed", "timeout", "cancelled"] as const;
-export const TERMINAL_RUN_STATUSES: ReadonlySet<RunStatus> = new Set<RunStatus>(
-  terminalRunStatuses,
-);
-
-// Compile-time parity checks — fail to compile if either literal drifts
-// from the canonical @appstrate/db enums (type-only import, erased at build).
-type _RunStatusParity = [DbRunStatus] extends [RunStatus]
-  ? [RunStatus] extends [DbRunStatus]
-    ? true
-    : never
-  : never;
-type _TerminalParity = [TerminalRunStatus] extends [(typeof terminalRunStatuses)[number]]
-  ? [(typeof terminalRunStatuses)[number]] extends [TerminalRunStatus]
-    ? true
-    : never
-  : never;
-const _runStatusParity: _RunStatusParity = true;
-const _terminalParity: _TerminalParity = true;
-void _runStatusParity;
-void _terminalParity;
+export { TERMINAL_RUN_STATUSES };
+export const RUN_STATUSES = runStatusValues;
+export type RunStatus = (typeof runStatusValues)[number];
 
 export function isTerminalStatus(status: string | null | undefined): status is RunStatus {
   return typeof status === "string" && TERMINAL_RUN_STATUSES.has(status as RunStatus);

--- a/packages/module-chat/test/resumable.test.ts
+++ b/packages/module-chat/test/resumable.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect } from "bun:test";
 import { createUIMessageStream, createUIMessageStreamResponse } from "ai";
+import type { ResumableStreamContext } from "assistant-stream/resumable";
 import { finalizeChatStream } from "../src/finalize-stream.ts";
 import { getResumableContext } from "../src/resumable.ts";
 import { extractAssistantMessages } from "../src/stream-parse.ts";
@@ -42,5 +43,62 @@ describe("resumable streams", () => {
 
   it("resume() returns null for an unknown stream id", async () => {
     expect(await getResumableContext().resume(crypto.randomUUID())).toBeNull();
+  });
+
+  /**
+   * The nominal path must NOT round-trip through the store: `context.run()` hands
+   * back a store reader even to the producer, and serving that to the connected
+   * client made every chat turn read its own bytes back out of Redis (100ms poll
+   * loop for the whole turn). The client gets its own tee branch; the store reader
+   * is released. Recording is unaffected — that is what resume reads.
+   */
+  it("serves the producer its own bytes and releases the store read-back", async () => {
+    const decoder = new TextDecoder();
+    let readBackCancelled = false;
+    const recorded: string[] = [];
+    let recordingDone!: () => void;
+    const recording = new Promise<void>((r) => (recordingDone = r));
+
+    // Stand-in for the real context: records like the library's producer task,
+    // and returns a read-back stream carrying a sentinel the client must never see.
+    const fakeContext: ResumableStreamContext = {
+      run: async (_streamId, makeStream) => {
+        void (async () => {
+          const reader = makeStream().getReader();
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            recorded.push(decoder.decode(value, { stream: true }));
+          }
+          recordingDone();
+        })();
+        return new ReadableStream<Uint8Array>({
+          start: (controller) => controller.enqueue(new TextEncoder().encode("STORE-READ-BACK")),
+          cancel: () => {
+            readBackCancelled = true;
+          },
+        });
+      },
+      resume: async () => null,
+      requireResume: () => Promise.reject(new Error("unused")),
+      status: async () => "missing",
+      delete: async () => {},
+    };
+
+    const res = await finalizeChatStream({
+      engineResponse: engine("live tokens"),
+      streamId: crypto.randomUUID(),
+      resumableContext: fakeContext,
+    });
+    const body = await new Response(res.body).text();
+
+    // The client read the engine stream directly…
+    expect(body).toContain("live tokens");
+    expect(body).not.toContain("STORE-READ-BACK");
+    // …and the producer's store reader was released instead of left polling.
+    expect(readBackCancelled).toBe(true);
+    // Recording still happened — resume depends on it.
+    await recording;
+    expect(recorded.join("")).toContain("live tokens");
   });
 });

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -51,8 +51,7 @@ export interface ListEnvelope<T> {
   limit?: number;
 }
 
-import { runStatusEnum as _runStatusEnum } from "@appstrate/db/schema";
-type _RunStatus = (typeof _runStatusEnum.enumValues)[number];
+import type { RunStatus as _RunStatus } from "@appstrate/db/run-status";
 
 /**
  * Wire-shape Run DTO returned to API consumers. The Drizzle `Run` row keeps
@@ -272,15 +271,20 @@ export interface ResourceEntry {
 
 // --- Run Types ---
 
-import { runStatusEnum } from "@appstrate/db/schema";
-export type RunStatus = (typeof runStatusEnum.enumValues)[number];
+// Value re-exports come from `@appstrate/db/run-status`, NOT the schema
+// barrel: this module is consumed by the SPA, and a value import from
+// `@appstrate/db/schema` cannot be elided by the bundler — it shipped
+// drizzle-orm plus all 18 schema files (table + column names included) to
+// the browser. `run-status.ts` is import-free and is what `runStatusEnum`
+// itself derives from, so there is still exactly one list of statuses.
 export {
   TERMINAL_RUN_STATUSES,
   TERMINAL_RUN_EVENT_TYPES,
   terminalRunStatusValues,
   ACTIVE_RUN_STATUSES,
-} from "@appstrate/db/schema";
-export type { TerminalRunStatus } from "@appstrate/db/schema";
+  runStatusValues,
+} from "@appstrate/db/run-status";
+export type { RunStatus, TerminalRunStatus } from "@appstrate/db/run-status";
 
 // --- Schedule Types ---
 

--- a/packages/shared-types/src/realtime-events.ts
+++ b/packages/shared-types/src/realtime-events.ts
@@ -18,7 +18,10 @@
  */
 import { z } from "zod";
 import { tokenUsageSchema } from "@appstrate/core/token-usage";
-import { runStatusEnum } from "@appstrate/db/schema";
+// Import-free literal tuple, NOT the Drizzle `pgEnum` — this schema module is
+// bundled into the SPA and a value import from `@appstrate/db/schema` drags
+// drizzle-orm + the whole table schema into the browser.
+import { runStatusValues } from "@appstrate/db/run-status";
 import type { RunWireDto } from "./index.ts";
 
 /** `run_update` — emitted by the `notify_run_change` trigger (13 fields). */
@@ -26,7 +29,7 @@ export const runUpdateEventSchema = z.object({
   operation: z.enum(["INSERT", "UPDATE"]),
   id: z.string(),
   packageId: z.string().nullable(),
-  status: z.enum(runStatusEnum.enumValues),
+  status: z.enum(runStatusValues),
   userId: z.string().nullable(),
   endUserId: z.string().nullable(),
   orgId: z.string(),

--- a/runtime-pi/sidecar/helpers.ts
+++ b/runtime-pi/sidecar/helpers.ts
@@ -142,6 +142,29 @@ export const STREAMING_THRESHOLD = 1 * 1024 * 1024; // 1 MB
 export const MAX_STREAMED_BODY_SIZE = 100 * 1024 * 1024; // 100 MB
 
 /**
+ * Concatenate read chunks into one buffer, dropping each source
+ * reference as it is copied.
+ *
+ * The naive `for (const c of chunks) merged.set(c, …)` keeps the whole
+ * `chunks` array reachable for the entire copy, so peak residency is
+ * 2× the body. Releasing each chunk right after it is copied makes the
+ * already-copied prefix collectable, so the peak trends towards 1×.
+ * `chunks` is consumed (emptied) — callers must not reuse it.
+ */
+export function concatAndRelease(chunks: Uint8Array[], total: number): Uint8Array {
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  // Reverse once so `pop()` yields the chunks in their original order while
+  // shrinking the array — O(1) per chunk, and the reference is gone immediately.
+  chunks.reverse();
+  for (let chunk = chunks.pop(); chunk !== undefined; chunk = chunks.pop()) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return merged;
+}
+
+/**
  * Stream-read a Request body into a Uint8Array, refusing the read if
  * the cumulative size crosses `maxBytes`. Returns `"exceeded"` if the
  * cap was hit, the bytes otherwise. We never materialise an
@@ -174,13 +197,7 @@ export async function readRequestBodyBounded(
   } finally {
     reader.releaseLock();
   }
-  const merged = new Uint8Array(total);
-  let offset = 0;
-  for (const chunk of chunks) {
-    merged.set(chunk, offset);
-    offset += chunk.byteLength;
-  }
-  return merged;
+  return concatAndRelease(chunks, total);
 }
 
 export type {

--- a/runtime-pi/sidecar/integration-mitm-listener.ts
+++ b/runtime-pi/sidecar/integration-mitm-listener.ts
@@ -56,6 +56,7 @@ import { createServer as netCreateServer, connect as netConnect, type Socket } f
 import {
   isBlockedHost,
   isBlockedUrl,
+  readRequestBodyBounded,
   resolveAndCheckHost,
   OUTBOUND_TIMEOUT_MS,
   type HostResolver,
@@ -224,6 +225,7 @@ export function createIntegrationMitmListener(
             serve: (opts: {
               port: number;
               hostname: string;
+              maxRequestBodySize: number;
               tls: { cert: string; key: string };
               fetch: (req: Request) => Promise<Response>;
             }) => BunServerHandle;
@@ -236,6 +238,12 @@ export function createIntegrationMitmListener(
       return bun.serve({
         port: 0,
         hostname: "127.0.0.1",
+        // Bun defaults to 128 MiB, an order of magnitude above the cap this
+        // listener actually enforces — and the sidecar's whole cgroup is
+        // 256 MiB. Pinning it to the business cap makes the runtime itself
+        // drop an over-sized body at the socket, before any of it reaches
+        // `handleInnerRequest`.
+        maxRequestBodySize: maxRequestBytes,
         tls: { cert: leaf.certPem, key: leaf.keyPem },
         fetch: (req) =>
           handleInnerRequest(req, sniHost, options.credentials, fetchFn, maxRequestBytes, emit),
@@ -619,8 +627,7 @@ export function extractSni(buf: Buffer): string | null {
  * placeholder name.
  */
 export type ConnectInputSubstitutionResult =
-  | { url: string; bodyText: string | null; headers: Record<string, string> }
-  | { failed: string };
+  { url: string; bodyText: string | null; headers: Record<string, string> } | { failed: string };
 
 /**
  * Pure, unit-testable helper for connect-login transient-input
@@ -693,7 +700,12 @@ function targetWithinAuthorizedUris(url: string, authorizedUris: readonly string
 // Inner-request handler — Bun.serve fetch callback
 // ─────────────────────────────────────────────
 
-async function handleInnerRequest(
+/**
+ * The per-SNI `Bun.serve` fetch callback. Exported (like {@link extractSni})
+ * so the body-cap and strip/inject behaviour can be exercised directly,
+ * without standing up TLS.
+ */
+export async function handleInnerRequest(
   req: Request,
   sniHost: string,
   credentials: MitmCredentialSource,
@@ -712,13 +724,24 @@ async function handleInnerRequest(
   // so the body read can no longer be deferred past it.
   let body: Buffer = Buffer.alloc(0);
   if (req.body) {
+    // Refuse on the DECLARED length first: the previous `await req.arrayBuffer()`
+    // materialised the entire body and only then compared it to the cap, so a
+    // multi-hundred-MiB POST was fully resident in a 256 MiB cgroup just to be
+    // rejected. A lying/absent Content-Length is caught by the bounded read below,
+    // which cancels the stream the moment the cap is crossed.
+    const declared = Number(req.headers.get("content-length"));
+    if (Number.isFinite(declared) && declared > maxRequestBytes) {
+      emit({ kind: "request-refused", url: targetUrl, reason: "body too large" });
+      return new Response("MITM listener: request body exceeds limit", { status: 413 });
+    }
     try {
-      const ab = await req.arrayBuffer();
-      if (ab.byteLength > maxRequestBytes) {
+      const bytes = await readRequestBodyBounded(req, maxRequestBytes);
+      if (bytes === "exceeded") {
         emit({ kind: "request-refused", url: targetUrl, reason: "body too large" });
         return new Response("MITM listener: request body exceeds limit", { status: 413 });
       }
-      body = Buffer.from(ab);
+      // View over the exact-size buffer — no second copy of the body.
+      body = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
     } catch (err) {
       emit({
         kind: "request-refused",

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -70,6 +70,7 @@ import {
   MAX_MCP_ENVELOPE_SIZE,
   MAX_REQUEST_BODY_SIZE,
   MAX_RESPONSE_SIZE,
+  concatAndRelease,
   readRequestBodyBounded,
   substituteVars,
 } from "./helpers.ts";
@@ -1615,6 +1616,11 @@ async function responseToToolResult(
  * is breached. Returns `"exceeded"` on overflow — for binary spills we
  * never want a partial body that the agent might mistake for the full
  * content.
+ *
+ * The concat releases each chunk as it is copied ({@link concatAndRelease}),
+ * so a body near {@link ABSOLUTE_MAX_RESPONSE_SIZE} does not pin 2× its size
+ * at once — the sidecar's cgroup is 256 MiB and up to
+ * `DEFAULT_API_CALL_CONCURRENCY` of these run in parallel.
  */
 async function readBodyToBuffer(res: Response, maxBytes: number): Promise<Uint8Array | "exceeded"> {
   if (!res.body) return new Uint8Array(0);
@@ -1636,13 +1642,7 @@ async function readBodyToBuffer(res: Response, maxBytes: number): Promise<Uint8A
   } finally {
     reader.releaseLock();
   }
-  const merged = new Uint8Array(total);
-  let offset = 0;
-  for (const c of chunks) {
-    merged.set(c, offset);
-    offset += c.byteLength;
-  }
-  return merged;
+  return concatAndRelease(chunks, total);
 }
 
 /**
@@ -1650,11 +1650,19 @@ async function readBodyToBuffer(res: Response, maxBytes: number): Promise<Uint8A
  * append a single `[truncated]` marker so the agent can tell the read
  * was bounded — silent truncation would let a bad upstream poison the
  * agent's reasoning with a short-but-wrong prefix.
+ *
+ * Decoding is incremental: buffering the raw chunks, merging them, and only
+ * then decoding held the bytes twice plus the decoded string. `{ stream: true }`
+ * carries a multi-byte sequence split across a chunk boundary into the next
+ * call, so byte-level truncation stays UTF-8-correct; the final flush emits the
+ * replacement char for a sequence cut by the cap, exactly as the non-fatal
+ * whole-buffer decode did.
  */
 async function readBodyBounded(res: Response, maxBytes: number): Promise<string> {
   if (!res.body) return "";
   const reader = res.body.getReader();
-  const chunks: Uint8Array[] = [];
+  const decoder = new TextDecoder("utf-8", { fatal: false });
+  let text = "";
   let total = 0;
   let truncated = false;
   try {
@@ -1664,25 +1672,19 @@ async function readBodyBounded(res: Response, maxBytes: number): Promise<string>
       if (!value) continue;
       if (total + value.byteLength > maxBytes) {
         const remaining = maxBytes - total;
-        if (remaining > 0) chunks.push(value.subarray(0, remaining));
+        if (remaining > 0) text += decoder.decode(value.subarray(0, remaining), { stream: true });
         total = maxBytes;
         truncated = true;
         await reader.cancel();
         break;
       }
-      chunks.push(value);
+      text += decoder.decode(value, { stream: true });
       total += value.byteLength;
     }
   } finally {
     reader.releaseLock();
   }
-  const merged = new Uint8Array(total);
-  let offset = 0;
-  for (const c of chunks) {
-    merged.set(c, offset);
-    offset += c.byteLength;
-  }
-  const text = new TextDecoder("utf-8", { fatal: false }).decode(merged);
+  text += decoder.decode(); // flush a trailing partial sequence
   return truncated ? `${text}\n[truncated: response exceeded ${maxBytes} bytes]` : text;
 }
 

--- a/runtime-pi/sidecar/test/helpers.test.ts
+++ b/runtime-pi/sidecar/test/helpers.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect } from "bun:test";
 import {
   ABSOLUTE_BODY_CEILING,
+  concatAndRelease,
   isBlockedHost,
   isBlockedUrl,
   substituteVars,
@@ -601,5 +602,40 @@ describe("readRequestBodyBounded", () => {
     const result = await readRequestBodyBounded(req, 10);
     expect(result).toBe("exceeded");
     expect(cancelled).toBe(true);
+  });
+
+  it("preserves chunk order across many chunks", async () => {
+    // The concat releases chunks as it copies (pop off a reversed array), so
+    // ordering is the thing that could silently regress.
+    const chunkCount = 64;
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (let i = 0; i < chunkCount; i++) controller.enqueue(new Uint8Array([i, i + 1, i + 2]));
+        controller.close();
+      },
+    });
+    const req = new Request("https://x/", { method: "POST", body, duplex: "half" } as RequestInit);
+    const result = await readRequestBodyBounded(req, 1024);
+    expect(result).toBeInstanceOf(Uint8Array);
+    const bytes = result as Uint8Array;
+    expect(bytes.byteLength).toBe(chunkCount * 3);
+    for (let i = 0; i < chunkCount; i++) {
+      expect(Array.from(bytes.subarray(i * 3, i * 3 + 3))).toEqual([i, i + 1, i + 2]);
+    }
+  });
+});
+
+describe("concatAndRelease", () => {
+  it("concatenates in order and empties the source array", () => {
+    const chunks = [new Uint8Array([1, 2]), new Uint8Array([3]), new Uint8Array([4, 5, 6])];
+    const merged = concatAndRelease(chunks, 6);
+    expect(Array.from(merged)).toEqual([1, 2, 3, 4, 5, 6]);
+    // The chunks are released as they are copied — that is the whole point:
+    // the source bytes must not stay pinned alongside the merged buffer.
+    expect(chunks.length).toBe(0);
+  });
+
+  it("returns an empty buffer for no chunks", () => {
+    expect(concatAndRelease([], 0).byteLength).toBe(0);
   });
 });

--- a/runtime-pi/sidecar/test/integration-mitm-body-cap.test.ts
+++ b/runtime-pi/sidecar/test/integration-mitm-body-cap.test.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The MITM listener's inner-request body cap.
+ *
+ * The sidecar runs in a 256 MiB cgroup. `handleInnerRequest` used to call
+ * `await req.arrayBuffer()` and compare the size AFTERWARDS, so an over-cap
+ * body was fully resident before being refused — and the per-SNI `Bun.serve`
+ * carried Bun's 128 MiB default body limit rather than the 10 MiB the listener
+ * enforces. These tests pin the two guarantees that fix implies: refuse on the
+ * declared length without touching the body, and refuse a lying/absent
+ * `Content-Length` without buffering past the cap.
+ *
+ * No TLS here — `handleInnerRequest` is driven directly (function-parameter
+ * injection: credentials, fetch, cap and event sink are all arguments).
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  handleInnerRequest,
+  type MitmCredentialSource,
+  type MitmListenerEvent,
+} from "../integration-mitm-listener.ts";
+
+const CAP = 256 * 1024;
+const CHUNK = 16 * 1024;
+
+const noCredentials: MitmCredentialSource = {
+  current: () => ({ auths: [] }),
+  deliveryPlans: () => ({}),
+};
+
+/** Upstream must never be reached on a refusal path. */
+const forbiddenFetch = (() => {
+  throw new Error("upstream fetch must not be called for a refused request");
+}) as unknown as typeof fetch;
+
+/**
+ * A body that keeps producing until it is cancelled, reporting how much it
+ * actually handed over. `produced` is the memory the sidecar was asked to hold.
+ */
+function endlessBody(): { stream: ReadableStream<Uint8Array>; produced: () => number } {
+  let produced = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      produced += CHUNK;
+      controller.enqueue(new Uint8Array(CHUNK));
+    },
+  });
+  return { stream, produced: () => produced };
+}
+
+describe("MITM listener — inner-request body cap", () => {
+  it("refuses on Content-Length before reading a single byte", async () => {
+    const { stream, produced } = endlessBody();
+    const events: MitmListenerEvent[] = [];
+    const req = new Request("https://127.0.0.1/v1/things", {
+      method: "POST",
+      headers: { "content-length": String(64 * 1024 * 1024) },
+      body: stream,
+      duplex: "half",
+    } as RequestInit);
+
+    const res = await handleInnerRequest(
+      req,
+      "api.test.local",
+      noCredentials,
+      forbiddenFetch,
+      CAP,
+      (e) => events.push(e),
+    );
+
+    expect(res.status).toBe(413);
+    // 64 MiB declared, at most the runtime's own one-chunk prefetch produced:
+    // the handler refused without pulling the body at all.
+    expect(produced()).toBeLessThanOrEqual(CHUNK);
+    expect(events).toEqual([
+      {
+        kind: "request-refused",
+        url: "https://api.test.local/v1/things",
+        reason: "body too large",
+      },
+    ]);
+  });
+
+  it("refuses an undeclared over-cap body without buffering the whole of it", async () => {
+    const { stream, produced } = endlessBody();
+    const events: MitmListenerEvent[] = [];
+    // No Content-Length: chunked upload, the size is only known as it arrives.
+    const req = new Request("https://127.0.0.1/v1/things", {
+      method: "POST",
+      body: stream,
+      duplex: "half",
+    } as RequestInit);
+
+    const res = await handleInnerRequest(
+      req,
+      "api.test.local",
+      noCredentials,
+      forbiddenFetch,
+      CAP,
+      (e) => events.push(e),
+    );
+
+    expect(res.status).toBe(413);
+    // The read is cancelled the moment the cap is crossed. The stream is
+    // infinite, so a full buffer would never terminate — bounding what it
+    // produced to just past the cap is the proof it stopped early.
+    expect(produced()).toBeGreaterThan(0);
+    expect(produced()).toBeLessThanOrEqual(CAP + 2 * CHUNK);
+    expect(events).toEqual([
+      {
+        kind: "request-refused",
+        url: "https://api.test.local/v1/things",
+        reason: "body too large",
+      },
+    ]);
+  });
+
+  it("lets a body at the cap through to the planner", async () => {
+    const events: MitmListenerEvent[] = [];
+    const req = new Request("https://127.0.0.1/v1/things", {
+      method: "POST",
+      body: new Uint8Array(CAP),
+    });
+
+    const res = await handleInnerRequest(
+      req,
+      "api.test.local",
+      noCredentials,
+      forbiddenFetch,
+      CAP,
+      (e) => events.push(e),
+    );
+
+    // Whatever the planner decides for an unauthenticated host, the body itself
+    // was accepted — the cap is inclusive.
+    expect(res.status).not.toBe(413);
+    expect(events.some((e) => e.kind === "request-refused" && e.reason === "body too large")).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
Implements the findings of the performance audit (`claudedocs/perf-audit-2026-07-26.md`), one commit per area.

> **Stacks on `chore/legacy-cleanup`.** Branched from it as requested, so this diff carries its commits until it merges. Review the 10 commits from `perf(web): drop AJV…` onward.

## Where the time actually went

The backend was in better shape than expected: no systemic N+1, indexes consistent with migrations, SSE holding no DB connection, the LLM relay genuinely streaming. What cost real time was **the first screen** — three serial walls no cache hid — plus a set of writes and reads that moved far more bytes than the caller used.

| | before | after |
|---|---|---|
| SPA entry graph | 87 assets · 1 330 250 B raw · 393 278 B gzip | **82 · 1 074 490 · 323 505** (−19,2 % / −17,7 %) |
| Serial depth to first paint | 7 levels (4 API round-trips) | **4 levels (2 API round-trips)** |
| `bun run check`, warm | 16,52 s | **1,58 s** |
| Platform image | 980 MB | **646 MB** |
| System-package sync per boot | 594 round-trips, 66 locked transactions | **skipped when unchanged** (136 ms → 53 ms) |
| Sidecar worst-case peak (cgroup 256 MiB) | 448 MiB | **234 MiB** |
| Port bound after | full `boot()` | **~750 ms, then explicit 503** |

## What each commit does

- **`perf(web)` AJV + schema** — two fully static import chains dragged AJV+semver (144 384 B) and drizzle-orm plus all 18 schema files (76 051 B) into the eager graph. The second also shipped every table and column name — `llm_usage`, `oauth_clients`, `end_users`, `api_keys`, all of `oidc.ts` — into a public asset. Status literals now live in an import-free module the `pgEnum`, the Zod validator and `shared-types` all derive from, so there is still exactly one list.
- **`perf(web)` auth cascade** — `fetchProfile()` takes nothing from the session, so three of the four boot reads only ever needed the cookie. They now start together, before React mounts. `initAuth()` was also only called during render, so `getSession()` did not start until `i18nReady` resolved — a fifth level the audit had missed.
- **`perf(api)` hot-path reads** — `used_by_agents` pulled every org manifest into the process to count keys; now SQL. `getRunFull` read the whole prompt on every call for a branch that rarely runs. `/api/openapi.json` re-serialized 493 KB per request and now carries an ETag, which reactivates the `If-None-Match` the CLI was already sending.
- **`perf(realtime)`** — the dashboard stream took the org's whole `run_log` firehose to discard it; subscribers now declare channels. The ingestion CAS updated `runs` **per ingested event**, each one broadcasting a byte-identical payload; the trigger is split so the UPDATE half carries a `WHEN` over exactly the twelve columns the payload interpolates.
- **`perf(chat,sidecar)`** — `context.run()` returns a store reader even to the producer, so every nominal chat turn round-tripped through Redis and polled it every 100 ms. The producer now relays its own bytes; resume is untouched.
- **`perf(boot)`** — two-phase boot so the port binds early and answers a diagnostic 503 instead of CONNREFUSED.
- **`build`** — ESLint/Prettier caching, and a runtime dependency stage.
- **`fix(redis)`** — every client had `maxRetriesPerRequest: null` because BullMQ requires it, so during a Redis outage request-path commands hung instead of failing.

## Prescriptions that were wrong, and what replaced them

The audit's adversarial pass killed six of eight initial "P0"s. Three more died during implementation, on measurement:

- **`--production` on the Docker image** would have silently deleted the S3 backend: `packages/core/src/storage-s3.ts` imports `@aws-sdk/client-s3`, core does not declare it, and `apps/api` has it as a `devDependency`. Build stays green, fails at runtime. Used `--filter` instead — and it is *smaller* (642 MB vs 803 MB).
- **`--concurrency=auto` on turbo** is slower, measured (19,78 s vs 18,41 s). Not applied.
- **"bind the port first, register routes later"** is impossible: Hono hard-throws `Can not add a route since the matcher is already built` once the first request is matched.
- **Parallelising the sidecar integration boot** was dropped: the iterations mutate ordered state (namespace `_2`/`_3` suffixes), so a `Promise.all` corrupts naming. Needs pre-allocation first, and the gain is nil at the typical N of 1–3.
- The **missing partial index on `runs`** was refuted on a synthetic 300 k-row table — the planner does not even elect it.

## Deliberately out of scope

Firecracker (the daemon has **no** phase instrumentation — optimising blind is what the adversarial pass already punished), table retention (needs production volumetry; `llm_usage` is the billing ledger, so archival not `DELETE`), the 15 redundant indexes (write regression measured at only +3 %), removing notification polling (SSE reconnect does not resync — would lose notifications), `enrichedRunSelect` projection (blocked by `required` in the OpenAPI contract), and the `cloud/` module (separate repo, separate PR).

## Verification

- `bun run check`: **33/33 tasks**, 1 pre-existing warning on an untouched file.
- Full suite: **8927 pass, 46 skip, 0 fail**, stable across repeated runs.
- Docker image **started**, not just built: 200 after 4 s, 211 OpenAPI paths, 30 migrations, real Better Auth signup.
- Boot and SIGTERM verified on a real process.

One test bug was found by running the full suite rather than the file: the trigger regression counted its own INSERT notification. It passed in isolation because `listenClient` is shared — the channel is only already-LISTENing once another file has registered it. Fixed in the last commit.

## Pre-existing issues found on the way (not fixed here)

- `OrgGate` (`app.tsx`) has no error branch: a failing `/api/orgs` reads as "no orgs" and redirects a legitimate user to onboarding. Phase 2 was deliberately shaped not to make this worse.
- `/health` reports `agents: "degraded"` on every healthy instance — the 66 shipped system packages contain no `agent` type, so the check never returns healthy.
- 34 `scripts/*.ts` match no `files` pattern in `eslint.config.mjs` and are never linted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
