### PR TITLE
fix(packages): reject unvalidated manifests on package create (#987)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,34 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`POST /api/packages/mcp-servers` published manifests no schema had ever
+  accepted (#987)** — mcp-server is the only package type whose create reaches
+  the `parsePackageUpload` branch, and that branch skipped validation two ways:
+  a `manifest.json` missing or malformed inside the uploaded archive was
+  swallowed into `undefined` by a non-throwing parser, and `manifest` was
+  optional in the JSON body. Either way `createOrgItem` synthesized a
+  `{version, name, $schema, type}` stub and `createVersionSafe` snapshotted it
+  into `package_versions.manifest` — a published, immutable row failing
+  `mcpServerManifestSchema` on `manifest_version` and `server`. The same
+  corruption was reachable with a perfectly valid manifest of the WRONG type:
+  `validateManifest` dispatches on the manifest's own root `type`, so a `skill`
+  manifest posted to the mcp-server route validated happily and `createOrgItem`
+  then rewrote `type` to the route's type AFTER validation. Manifest validation
+  on create is now unconditional, and one direction-aware gate
+  (`validateManifestForRoute`) rejects a route/manifest type mismatch with a
+  `manifest.type` field error on create and on `PUT` supplying a manifest — the
+  stored direction (`PUT` carry-forward, publishing an existing draft) keeps
+  tolerating drift, because #983 settled that already-persisted artifacts are
+  tolerated on read and a gate there would make a legacy drifted draft
+  permanently un-publishable. The `type` stamping left `createOrgItem` for a
+  pure `buildStoredManifest` that throws on divergence; `forkPackage` — the one
+  caller whose sources can legitimately disagree, reading an immutable
+  published snapshot — keeps the repair, now explicit and logged.
+  **Behavior change for integrators**: an archive without a valid
+  `manifest.json`, or a JSON body without `manifest`, is now a `400` instead of
+  a silently stubbed package, and the JSON body's `version` field is gone (it
+  was only ever read by the fallback that fired when `manifest` was absent).
+
 - **Two contract holes: forks minted un-normalised manifests, stale modules
   booted silently (#974, #973)** — a fork is a READ that MINTS: it copies an
   already-published (immutable, therefore unrepairable) manifest into a brand
@@ -26,9 +54,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   materialises no defaults, leaving publish dedup (#896) untouched. A source
   invalid for any OTHER reason is logged, never rejected: manifests today's
   validator refuses do sit in the catalog — the provider→integration migration
-  (#481) left `type: "provider"` rows behind, and a malformed `manifest.json`
-  uploaded to `POST /api/mcp-servers` still mints an unvalidated stub manifest
-  today — and a gate would make them permanently un-forkable.
+  (#481) left `type: "provider"` rows behind (the write direction that could
+  still mint new ones is closed in #987) — and a gate would make them
+  permanently un-forkable.
 
   The module→platform half of the contract is invisible to `tsc` for an
   out-of-tree module, and it fails silently: core 6.0.0 made

--- a/apps/api/src/lib/manifest-parser.ts
+++ b/apps/api/src/lib/manifest-parser.ts
@@ -16,15 +16,6 @@ export function parseManifestFromFiles(files: Record<string, Uint8Array>): Recor
   return parseManifestBytes(data);
 }
 
-/** Parse manifest.json bytes, returning undefined on failure instead of throwing. */
-export function parseManifestBytesSafe(bytes: Uint8Array): Record<string, unknown> | undefined {
-  try {
-    return parseManifestBytes(bytes);
-  } catch {
-    return undefined;
-  }
-}
-
 /** Parse raw bytes as a JSON object. Throws on invalid JSON or non-object result. */
 function parseManifestBytes(bytes: Uint8Array): Record<string, unknown> {
   const text = new TextDecoder().decode(bytes);

--- a/apps/api/src/openapi/baseline.json
+++ b/apps/api/src/openapi/baseline.json
@@ -2089,6 +2089,13 @@
                     "type": "object",
                     "description": "Per-run config overrides validated against manifest.config.schema (AJV)."
                   },
+                  "context_documents": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "`document://doc_xxx` URIs to mount read-only into the run's `documents/` directory — fan-in by reference, without declaring a file field in the manifest. The platform declares a reserved `_context_documents` input field for them, so they go through the same ACL, byte/count caps and `document_links` chaining as any other document input, and are announced to the agent in its prompt. A manifest (or `input`) that already declares `_context_documents` is rejected with a `400` — the name is reserved."
+                  },
                   "modelId": {
                     "type": ["string", "null"]
                   },
@@ -2330,6 +2337,13 @@
                   },
                   "config": {
                     "type": "object"
+                  },
+                  "context_documents": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Same field as `POST /api/runs/inline` — validated here for shape and for the reserved `_context_documents` name collision, never mounted."
                   },
                   "modelId": {
                     "type": ["string", "null"]
@@ -2954,6 +2968,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
+                "additionalProperties": false,
                 "required": ["source", "applicationId"],
                 "properties": {
                   "source": {
@@ -2961,6 +2976,7 @@
                     "oneOf": [
                       {
                         "type": "object",
+                        "additionalProperties": false,
                         "required": ["kind", "manifest", "prompt"],
                         "properties": {
                           "kind": {
@@ -2981,6 +2997,7 @@
                       },
                       {
                         "type": "object",
+                        "additionalProperties": false,
                         "required": ["kind", "packageId"],
                         "properties": {
                           "kind": {
@@ -4021,7 +4038,7 @@
         "operationId": "streamAllRuns",
         "tags": ["Realtime"],
         "summary": "SSE: all run status changes",
-        "description": "Server-Sent Events stream for all run status changes in the org. Supports cookie auth and API key auth via ?token=ask_... query parameter. API keys must carry the `runs:read` scope — a valid key without it is rejected with 403.\n\nEvent format: `event: run_update\\ndata: {\"id\":\"run_...\",\"status\":\"running\",\"packageId\":\"@scope/name\",...}\\n\\n`\n\nEvent types: `run_update` (status change), `run_log` (log entry), `run_metric` (running cumulative cost + token usage), `connection_update` (INSERT/UPDATE/DELETE on integration_connections, actor-scoped to the caller's own rows). Heartbeat: a named SSE `event: ping` frame (empty data) sent immediately on connect and every 30s thereafter.\n\nEach SSE frame carries an `id:` field of the form `${subscriberId}:${monotonic}`. Ids are globally unique across reconnects (each new EventSource gets a fresh subscriberId). Client-side dedup on `id` is safe. Server-side replay via `Last-Event-ID` is NOT implemented — reconnect lands on the live tail; missed events are not replayed.",
+        "description": "Server-Sent Events stream for all run status changes in the org. Supports cookie auth and API key auth via ?token=ask_... query parameter. API keys must carry the `runs:read` scope — a valid key without it is rejected with 403.\n\nEvent format: `event: run_update\\ndata: {\"id\":\"run_...\",\"status\":\"running\",\"packageId\":\"@scope/name\",...}\\n\\n`\n\nEvent types: `run_update` (status change), `run_log` (log entry), `run_metric` (running cumulative cost + token usage), `connection_update` (INSERT/UPDATE/DELETE on integration_connections, actor-scoped to the caller's own rows). Heartbeat: a named SSE `event: ping` frame (empty data) sent immediately on connect and every 30s thereafter.\n\nEach SSE frame carries an `id:` field of the form `${subscriberId}:${monotonic}`. Ids are globally unique across reconnects (each new EventSource gets a fresh subscriberId). Client-side dedup on `id` is safe. Server-side replay via `Last-Event-ID` is NOT implemented — reconnect lands on the live tail; missed events are not replayed.\n\nChannel selection: pass `channels=` with a comma-separated subset (e.g. `channels=run_update,connection_update`) to receive only those frames. The filter is applied server-side before serialization. Omit it to receive every channel. Note that dropping `run_log` is what keeps a dashboard-wide stream off the per-log firehose.",
         "parameters": [
           {
             "$ref": "#/components/parameters/SseOrgId"
@@ -4034,6 +4051,9 @@
           },
           {
             "$ref": "#/components/parameters/Verbose"
+          },
+          {
+            "$ref": "#/components/parameters/SseChannels"
           }
         ],
         "responses": {
@@ -4061,7 +4081,7 @@
         "operationId": "streamRun",
         "tags": ["Realtime"],
         "summary": "SSE: single run events",
-        "description": "Server-Sent Events stream for run status + log events. Supports cookie auth and API key auth via ?token=ask_... query parameter. API keys must carry the `runs:read` scope — a valid key without it is rejected with 403.\n\nEvent types: `run_update` (status change), `run_log` (log entry), `run_metric` (running cumulative cost + token usage), `connection_update` (INSERT/UPDATE/DELETE on integration_connections, actor-scoped to the caller's own rows). Heartbeat: a named SSE `event: ping` frame (empty data) sent immediately on connect and every 30s thereafter.\n\nEach SSE frame carries an `id:` field of the form `${subscriberId}:${monotonic}`. Ids are globally unique across reconnects (each new EventSource gets a fresh subscriberId). Client-side dedup on `id` is safe. Server-side replay via `Last-Event-ID` is NOT implemented — reconnect lands on the live tail; missed events are not replayed.",
+        "description": "Server-Sent Events stream for run status + log events. Supports cookie auth and API key auth via ?token=ask_... query parameter. API keys must carry the `runs:read` scope — a valid key without it is rejected with 403.\n\nEvent types: `run_update` (status change), `run_log` (log entry), `run_metric` (running cumulative cost + token usage), `connection_update` (INSERT/UPDATE/DELETE on integration_connections, actor-scoped to the caller's own rows). Heartbeat: a named SSE `event: ping` frame (empty data) sent immediately on connect and every 30s thereafter.\n\nEach SSE frame carries an `id:` field of the form `${subscriberId}:${monotonic}`. Ids are globally unique across reconnects (each new EventSource gets a fresh subscriberId). Client-side dedup on `id` is safe. Server-side replay via `Last-Event-ID` is NOT implemented — reconnect lands on the live tail; missed events are not replayed.\n\nChannel selection: pass `channels=` with a comma-separated subset (e.g. `channels=run_update,connection_update`) to receive only those frames. The filter is applied server-side before serialization. Omit it to receive every channel. Note that dropping `run_log` is what keeps a dashboard-wide stream off the per-log firehose.",
         "parameters": [
           {
             "name": "id",
@@ -4082,6 +4102,9 @@
           },
           {
             "$ref": "#/components/parameters/Verbose"
+          },
+          {
+            "$ref": "#/components/parameters/SseChannels"
           }
         ],
         "responses": {
@@ -4109,7 +4132,7 @@
         "operationId": "streamAgentRuns",
         "tags": ["Realtime"],
         "summary": "SSE: agent run changes",
-        "description": "Server-Sent Events stream for run changes for a specific agent. Supports cookie auth and API key auth via ?token=ask_... query parameter. API keys must carry the `runs:read` scope — a valid key without it is rejected with 403.\n\nEvent types: `run_update` (status change), `run_log` (log entry), `run_metric` (running cumulative cost + token usage), `connection_update` (INSERT/UPDATE/DELETE on integration_connections, actor-scoped to the caller's own rows). Heartbeat: a named SSE `event: ping` frame (empty data) sent immediately on connect and every 30s thereafter.\n\nEach SSE frame carries an `id:` field of the form `${subscriberId}:${monotonic}`. Ids are globally unique across reconnects (each new EventSource gets a fresh subscriberId). Client-side dedup on `id` is safe. Server-side replay via `Last-Event-ID` is NOT implemented — reconnect lands on the live tail; missed events are not replayed.",
+        "description": "Server-Sent Events stream for run changes for a specific agent. Supports cookie auth and API key auth via ?token=ask_... query parameter. API keys must carry the `runs:read` scope — a valid key without it is rejected with 403.\n\nEvent types: `run_update` (status change), `run_log` (log entry), `run_metric` (running cumulative cost + token usage), `connection_update` (INSERT/UPDATE/DELETE on integration_connections, actor-scoped to the caller's own rows). Heartbeat: a named SSE `event: ping` frame (empty data) sent immediately on connect and every 30s thereafter.\n\nEach SSE frame carries an `id:` field of the form `${subscriberId}:${monotonic}`. Ids are globally unique across reconnects (each new EventSource gets a fresh subscriberId). Client-side dedup on `id` is safe. Server-side replay via `Last-Event-ID` is NOT implemented — reconnect lands on the live tail; missed events are not replayed.\n\nChannel selection: pass `channels=` with a comma-separated subset (e.g. `channels=run_update,connection_update`) to receive only those frames. The filter is applied server-side before serialization. Omit it to receive every channel. Note that dropping `run_log` is what keeps a dashboard-wide stream off the per-log firehose.",
         "parameters": [
           {
             "name": "packageId",
@@ -4131,6 +4154,9 @@
           },
           {
             "$ref": "#/components/parameters/Verbose"
+          },
+          {
+            "$ref": "#/components/parameters/SseChannels"
           }
         ],
         "responses": {
@@ -12834,11 +12860,30 @@
         "operationId": "getOpenApiSpec",
         "tags": ["Meta"],
         "summary": "OpenAPI specification",
-        "description": "Returns the OpenAPI 3.1 specification as JSON.",
+        "description": "Returns the OpenAPI 3.1 specification as JSON. The response carries a strong `ETag` that is stable for the lifetime of the deployment — send it back as `If-None-Match` to revalidate a cached copy and get a `304 Not Modified` instead of the full document.",
         "security": [],
+        "parameters": [
+          {
+            "name": "If-None-Match",
+            "in": "header",
+            "required": false,
+            "description": "Entity-tag of a cached copy. A match yields `304 Not Modified`.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "OpenAPI spec",
+            "headers": {
+              "ETag": {
+                "description": "Strong entity-tag of the served specification.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -12850,6 +12895,17 @@
                     "title": "Appstrate API",
                     "version": "2026-03-21"
                   }
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Cached copy is still current (`If-None-Match` matched). No body.",
+            "headers": {
+              "ETag": {
+                "description": "Strong entity-tag of the served specification.",
+                "schema": {
+                  "type": "string"
                 }
               }
             }
@@ -16496,7 +16552,7 @@
         ],
         "requestBody": {
           "required": true,
-          "description": "Upload a package ZIP (`multipart/form-data` with a `.afps`/`.zip` file — the package ID is derived from the file name), or post a JSON body. Parsed by `parsePackageUpload`.",
+          "description": "Upload a package ZIP (`multipart/form-data` with a `.afps`/`.zip` file — the package ID is derived from the file name, and the archive must contain a valid `manifest.json`), or post a JSON body carrying the manifest. Parsed by `parsePackageUpload`.",
           "content": {
             "multipart/form-data": {
               "schema": {
@@ -16506,7 +16562,7 @@
                   "file": {
                     "type": "string",
                     "format": "binary",
-                    "description": "Package archive (`.afps` or `.zip`). File name (sans extension) is the kebab-case package id."
+                    "description": "Package archive (`.afps` or `.zip`) containing a valid `manifest.json`. File name (sans extension) is the kebab-case package id."
                   }
                 }
               }
@@ -16514,7 +16570,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["id", "content"],
+                "required": ["id", "content", "manifest"],
                 "properties": {
                   "id": {
                     "type": "string",
@@ -16532,14 +16588,10 @@
                     "type": "string",
                     "description": "Package description. Auto-extracted from the manifest if omitted."
                   },
-                  "version": {
-                    "type": "string",
-                    "description": "Initial semver (optional)."
-                  },
                   "manifest": {
                     "type": "object",
                     "additionalProperties": true,
-                    "description": "Optional manifest object (stored as-is)."
+                    "description": "Manifest object, validated against the AFPS mcp-server schema and stored as-is."
                   }
                 }
               }
@@ -21274,6 +21326,16 @@
         "schema": {
           "type": "boolean",
           "default": false
+        }
+      },
+      "SseChannels": {
+        "name": "channels",
+        "in": "query",
+        "required": false,
+        "description": "Comma-separated list of SSE channels to subscribe to (`run_update`, `run_log`, `run_metric`, `connection_update`, `chat_session_update`). Omit to receive every channel (default, unchanged behaviour). Unknown names are ignored; if nothing is recognised the stream falls back to every channel. Declaring only the channels you consume avoids fanning the `run_log` firehose out to a stream that discards it.",
+        "schema": {
+          "type": "string",
+          "example": "run_update,connection_update"
         }
       },
       "AppstrateUser": {

--- a/apps/api/src/openapi/paths/packages.ts
+++ b/apps/api/src/openapi/paths/packages.ts
@@ -2290,7 +2290,7 @@ export const packagesPaths = {
       requestBody: {
         required: true,
         description:
-          "Upload a package ZIP (`multipart/form-data` with a `.afps`/`.zip` file — the package ID is derived from the file name), or post a JSON body. Parsed by `parsePackageUpload`.",
+          "Upload a package ZIP (`multipart/form-data` with a `.afps`/`.zip` file — the package ID is derived from the file name, and the archive must contain a valid `manifest.json`), or post a JSON body carrying the manifest. Parsed by `parsePackageUpload`.",
         content: {
           "multipart/form-data": {
             schema: {
@@ -2301,7 +2301,7 @@ export const packagesPaths = {
                   type: "string",
                   format: "binary",
                   description:
-                    "Package archive (`.afps` or `.zip`). File name (sans extension) is the kebab-case package id.",
+                    "Package archive (`.afps` or `.zip`) containing a valid `manifest.json`. File name (sans extension) is the kebab-case package id.",
                 },
               },
             },
@@ -2309,7 +2309,7 @@ export const packagesPaths = {
           "application/json": {
             schema: {
               type: "object",
-              required: ["id", "content"],
+              required: ["id", "content", "manifest"],
               properties: {
                 id: { type: "string", description: "Kebab-case package id." },
                 content: { type: "string", description: "Primary package file content." },
@@ -2321,11 +2321,11 @@ export const packagesPaths = {
                   type: "string",
                   description: "Package description. Auto-extracted from the manifest if omitted.",
                 },
-                version: { type: "string", description: "Initial semver (optional)." },
                 manifest: {
                   type: "object",
                   additionalProperties: true,
-                  description: "Optional manifest object (stored as-is).",
+                  description:
+                    "Manifest object, validated against the AFPS mcp-server schema and stored as-is.",
                 },
               },
             },

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -15,7 +15,7 @@ import { handleImportBundle } from "../services/bundle-import.ts";
 import { parsePackageIdentity } from "@appstrate/afps-runtime/bundle";
 import { installPackage, hasPackageAccess } from "../services/application-packages.ts";
 import { resolveIntegrationActivations } from "../services/integration-connections.ts";
-import { parseManifestBytesSafe } from "../lib/manifest-parser.ts";
+import { parseManifestFromFiles } from "../lib/manifest-parser.ts";
 import { getAllPackageIds } from "../services/package-catalog.ts";
 import { isSystemPackage } from "../services/system-packages.ts";
 import { orgOrSystemFilter, notEphemeralFilter } from "../lib/package-helpers.ts";
@@ -167,19 +167,16 @@ interface ParsedUpload {
   content: string;
   normalizedFiles?: Record<string, Uint8Array>;
   /** Full parsed manifest.json from the ZIP — stored as-is (like the registry). */
-  manifest?: Record<string, unknown>;
-  /** User-specified version from JSON body (propagated to manifest default). */
-  version?: string;
+  manifest: Record<string, unknown>;
 }
 
 /** JSON body shape for the non-multipart package upload branch. */
 const jsonUploadSchema = z.object({
   id: z.string().min(1),
   content: z.string().min(1),
-  manifest: z.record(z.string(), z.unknown()).optional(),
+  manifest: z.record(z.string(), z.unknown()),
   name: z.string().optional(),
   description: z.string().optional(),
-  version: z.string().optional(),
 });
 
 /**
@@ -237,21 +234,22 @@ async function parsePackageUpload(
 
     const content = new TextDecoder().decode(normalizedFiles[contentFile!]!);
 
-    let name: string | undefined;
-    let description: string | undefined;
-
-    // Parse manifest.json from ZIP if present — store as-is (like the registry)
-    let manifest: Record<string, unknown> | undefined;
-    const manifestBytes = normalizedFiles["manifest.json"];
-    if (manifestBytes) {
-      manifest = parseManifestBytesSafe(manifestBytes);
-      if (manifest) {
-        // Extract display fields as fallbacks (not for manifest storage)
-        if (!name && typeof manifest.display_name === "string") name = manifest.display_name;
-        if (!description && typeof manifest.description === "string")
-          description = manifest.description;
-      }
+    // manifest.json is mandatory: it is the only part of the archive the AFPS
+    // schema validates, and tolerating its absence let an unvalidated stub
+    // manifest reach the immutable `package_versions` row (issue #987).
+    if (!normalizedFiles["manifest.json"]) {
+      throw invalidRequest("ZIP must contain manifest.json", "file");
     }
+    let manifest: Record<string, unknown>;
+    try {
+      manifest = parseManifestFromFiles(normalizedFiles);
+    } catch (err) {
+      throw invalidRequest(getErrorMessage(err), "file");
+    }
+
+    // Display fields default to the manifest (not stored back into it)
+    let name = typeof manifest.display_name === "string" ? manifest.display_name : undefined;
+    let description = typeof manifest.description === "string" ? manifest.description : undefined;
 
     // Allow overriding name/description from form fields
     const formName = formData.get("name") as string | null;
@@ -284,7 +282,6 @@ async function parsePackageUpload(
     content: body.content,
     normalizedFiles,
     manifest: body.manifest,
-    version: body.version,
   };
 }
 
@@ -613,7 +610,7 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
       return c.json(detail, 201);
     }
 
-    // Skill/Tool create — uses parsePackageUpload (ZIP or JSON body)
+    // Import-only create (mcp-server) — uses parsePackageUpload (ZIP or JSON body)
     const parsed = await parsePackageUpload(c, rcfg.parseOpts);
 
     if (isSystemPackage(parsed.id)) {
@@ -622,17 +619,14 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
       );
     }
 
-    // Validate manifest if present
-    if (parsed.manifest) {
-      const manifestResult = validateManifest(parsed.manifest);
-      if (!manifestResult.valid) {
-        throw validationFailed(manifestErrorsToFieldErrors(manifestResult.errors));
-      }
-      await assertAgentIntegrationScopesValid(
-        manifestResult.manifest as Record<string, unknown>,
-        orgId,
-      );
+    const manifestResult = validateManifest(parsed.manifest);
+    if (!manifestResult.valid) {
+      throw validationFailed(manifestErrorsToFieldErrors(manifestResult.errors));
     }
+    await assertAgentIntegrationScopesValid(
+      manifestResult.manifest as Record<string, unknown>,
+      orgId,
+    );
 
     if (rcfg.validateContent) {
       const validation = rcfg.validateContent(parsed.content);
@@ -648,13 +642,6 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
       }
     }
 
-    // Merge user-specified version into manifest for createOrgItem
-    const effectiveManifest = parsed.manifest
-      ? parsed.manifest
-      : parsed.version
-        ? { version: parsed.version }
-        : undefined;
-
     let item;
     try {
       item = await createOrgItem(
@@ -667,7 +654,7 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
           createdBy: user.id,
         },
         rcfg.cfg,
-        effectiveManifest,
+        parsed.manifest,
       );
     } catch (err) {
       if (err instanceof PackageAlreadyExistsError) {

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -106,6 +106,61 @@ async function assertAgentIntegrationScopesValid(
   }
 }
 
+/**
+ * The manifest gate every package write goes through — schema validation, the
+ * route/manifest `type` agreement check, then the integration-scope subset
+ * check — returning the VALIDATED (normalized) manifest callers persist.
+ *
+ * `direction` says where the manifest came from, and both policies key off it:
+ *
+ * - `"author"` — the manifest is in THIS request (create; a PUT supplying
+ *   `manifest`). The `type` gate applies: the route family fixes the package
+ *   type while `validateManifest` dispatches purely on the manifest's own root
+ *   `type`, so without it a wrong-type manifest validates against ITS OWN
+ *   schema and then has `type` rewritten to the route's downstream —
+ *   persisting a manifest no schema ever accepted (issue #987). Retired
+ *   `runtime_tools` ids reject, so a typo or a removed id is reported instead
+ *   of silently stripped.
+ * - `"stored"` — the manifest is already persisted (PUT content-only
+ *   carry-forward; publishing an existing draft). NO `type` gate: stored
+ *   artifacts are tolerated on read (#983), and gating here would make a
+ *   legacy drifted draft permanently un-publishable. Retired ids drop so such
+ *   a draft stays editable and publishable.
+ */
+async function validateManifestForRoute(
+  manifest: unknown,
+  expectedType: PackageType,
+  orgId: string,
+  direction: "author" | "stored",
+): Promise<Record<string, unknown> & { name: string }> {
+  const result = validateManifest(
+    manifest,
+    direction === "stored" ? { retiredRuntimeTools: "drop" } : undefined,
+  );
+  if (!result.valid) {
+    throw validationFailed(manifestErrorsToFieldErrors(result.errors));
+  }
+  // Every AFPS manifest schema requires `name` as a string, so the validated
+  // shape always carries it — callers use it as the package id.
+  const validated = result.manifest as Record<string, unknown> & { name: string };
+
+  // Checked AFTER validation so a missing/unknown `type` keeps producing the
+  // validator's own typed `type:` error rather than a mismatch message.
+  if (direction === "author" && validated.type !== expectedType) {
+    throw validationFailed([
+      {
+        field: "manifest.type",
+        code: "invalid_manifest",
+        title: "Invalid Manifest",
+        message: `expected "${expectedType}", received "${String(validated.type)}"`,
+      },
+    ]);
+  }
+
+  await assertAgentIntegrationScopesValid(validated, orgId);
+  return validated;
+}
+
 // ═══════════════════════════════════════════════
 // Shared helpers for package CRUD routes
 // ═══════════════════════════════════════════════
@@ -232,7 +287,10 @@ async function parsePackageUpload(
       }
     }
 
-    const content = new TextDecoder().decode(normalizedFiles[contentFile!]!);
+    // No content file is looked up when both `parseOpts` are null (mcp-server,
+    // whose payload is the manifest) — such a package has no primary content.
+    const contentBytes = contentFile ? normalizedFiles[contentFile] : undefined;
+    const content = contentBytes ? new TextDecoder().decode(contentBytes) : "";
 
     // manifest.json is mandatory: it is the only part of the archive the AFPS
     // schema validates, and tolerating its absence let an unvalidated stub
@@ -471,13 +529,12 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
       const content = body.content ?? "";
       const sourceCode = body.source_code ?? "";
 
-      // Validate manifest
-      const manifestResult = validateManifest(manifest);
-      if (!manifestResult.valid) {
-        throw validationFailed(manifestErrorsToFieldErrors(manifestResult.errors));
-      }
-      const validatedManifest = manifestResult.manifest;
-      await assertAgentIntegrationScopesValid(validatedManifest as Record<string, unknown>, orgId);
+      const validatedManifest = await validateManifestForRoute(
+        manifest,
+        rcfg.cfg.type,
+        orgId,
+        "author",
+      );
 
       if (rcfg.requireContent && !content.trim()) {
         throw invalidRequest("Content cannot be empty", "content");
@@ -619,14 +676,7 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
       );
     }
 
-    const manifestResult = validateManifest(parsed.manifest);
-    if (!manifestResult.valid) {
-      throw validationFailed(manifestErrorsToFieldErrors(manifestResult.errors));
-    }
-    await assertAgentIntegrationScopesValid(
-      manifestResult.manifest as Record<string, unknown>,
-      orgId,
-    );
+    await validateManifestForRoute(parsed.manifest, rcfg.cfg.type, orgId, "author");
 
     if (rcfg.validateContent) {
       const validation = rcfg.validateContent(parsed.content);
@@ -826,39 +876,33 @@ function makeUpdateHandler(rcfg: PackageRouteConfig) {
 
     // A PUT that omits `manifest` is a content-only edit: the stored draft is
     // carried forward untouched. That makes this handler directional per
-    // request, and the direction decides how a retired `runtime_tools` id is
-    // treated (see `validateManifest`'s `retiredRuntimeTools`):
-    //   - manifest SUPPLIED → author input → reject, so a typo or an id the
-    //     platform removed is reported instead of silently stripped;
-    //   - manifest OMITTED → the already-stored draft → drop, so a legacy
-    //     agent naming a since-retired tool stays editable (a content-only
-    //     save must not 400 on a field the request never mentioned).
+    // request — `manifest` SUPPLIED is author input, `manifest` OMITTED is the
+    // already-stored draft — and the direction decides both the `type` gate and
+    // how a retired `runtime_tools` id is treated (see
+    // `validateManifestForRoute`). Concretely, a content-only save must not 400
+    // on fields the request never mentioned.
     const authoredManifest = body.manifest;
     const manifest =
       authoredManifest ?? (existing as { manifest?: Record<string, unknown> }).manifest ?? {};
     const content = body.content ?? existing.content ?? "";
     const sourceCode = body.source_code;
 
-    const manifestResult = validateManifest(
-      manifest,
-      authoredManifest ? undefined : { retiredRuntimeTools: "drop" },
-    );
-    if (!manifestResult.valid) {
-      throw validationFailed(manifestErrorsToFieldErrors(manifestResult.errors));
-    }
     // Everything downstream — the persisted row, the after-update hook, the
     // id-immutability check — reads the VALIDATED manifest, never the raw one.
-    // The create path already did (`validatedManifest` in the create handler);
-    // this one persisted the raw shape, so the normalisation validation had
-    // just performed was thrown away on every save. That is what made the
-    // carry-forward case above a permanent no-op instead of a self-healing
-    // write, and let a non-SPA client (CLI, MCP, curl) keep a retired id alive
-    // in the draft indefinitely.
-    const validatedManifest = manifestResult.manifest as Record<string, unknown>;
-    await assertAgentIntegrationScopesValid(validatedManifest, orgId);
+    // The create path already did; this one persisted the raw shape, so the
+    // normalisation validation had just performed was thrown away on every
+    // save. That is what made the carry-forward case above a permanent no-op
+    // instead of a self-healing write, and let a non-SPA client (CLI, MCP,
+    // curl) keep a retired id alive in the draft indefinitely.
+    const validatedManifest = await validateManifestForRoute(
+      manifest,
+      rcfg.cfg.type,
+      orgId,
+      authoredManifest ? "author" : "stored",
+    );
 
     // Ensure ID immutability (all types)
-    const newScopedName = (validatedManifest as { name?: string }).name;
+    const newScopedName = validatedManifest.name;
     if (newScopedName && newScopedName !== itemId) {
       throw invalidRequest("name cannot change", "name");
     }
@@ -1127,21 +1171,14 @@ function makeCreateVersionHandler(rcfg: PackageRouteConfig) {
     // draft that became invalid by any path — this rejects e.g. an
     // `integrations_configuration` entry without a matching declared
     // dependency before it is frozen into an immutable version.
-    // READ direction: the draft is already stored, and a draft written before
-    // a runtime tool was retired must stay publishable. `createVersionFromDraft`
-    // applies the same drop before freezing the snapshot, so the retired id
-    // never reaches the immutable artifact.
-    const manifestResult = validateManifest(item.manifest, { retiredRuntimeTools: "drop" });
-    if (!manifestResult.valid) {
-      throw validationFailed(manifestErrorsToFieldErrors(manifestResult.errors));
-    }
-    // Same integration-scope subset gate the create/update paths apply — a
-    // draft must not be frozen into an immutable version with an
+    // STORED direction: the draft is already persisted, and a draft written
+    // before a runtime tool was retired must stay publishable.
+    // `createVersionFromDraft` applies the same drop before freezing the
+    // snapshot, so the retired id never reaches the immutable artifact. The
+    // integration-scope subset gate the create/update paths apply comes along
+    // with it — a draft must not be frozen into an immutable version with an
     // `integrations_configuration` selection outside the integration catalog.
-    await assertAgentIntegrationScopesValid(
-      manifestResult.manifest as Record<string, unknown>,
-      orgId,
-    );
+    await validateManifestForRoute(item.manifest, rcfg.cfg.type, orgId, "stored");
 
     // Parse optional version override from request body. The body itself is
     // optional (OpenAPI `requestBody.required: false` — the SPA omits it

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -628,7 +628,7 @@ function makeCreateHandler(rcfg: PackageRouteConfig) {
 
       // Create initial version (non-fatal). Snapshot the STORED draft
       // manifest (not the pre-normalization request body): `createOrgItem`
-      // injects `$schema`/`type`/… and the jsonb round-trip reorders keys, so
+      // stamps `$schema`/`name`/… and the jsonb round-trip reorders keys, so
       // snapshotting `validatedManifest` produced a version whose bytes could
       // never match a later rebuild from the draft. That byte drift defeated
       // the publish dedup and, before #896, made every create-then-republish

--- a/apps/api/src/services/package-fork.ts
+++ b/apps/api/src/services/package-fork.ts
@@ -150,15 +150,13 @@ async function forkWithConfig(
   // draft row, version row and ZIP unnoticed. Rejecting is not an option:
   // manifests today's validator refuses DO sit in the catalog, and a gate here
   // would make them permanently un-forkable — the fork is a READ of an
-  // immutable, unrepairable artifact. Two sources, both real:
-  //   - the provider→integration migration (#481, shipped in beta.17) left
-  //     `type: "provider"` manifests behind; they were repaired by a one-off
-  //     backfill script that no longer exists in this repo;
-  //   - `POST /api/mcp-servers` can still MINT one today: a malformed
-  //     `manifest.json` makes `parseManifestBytesSafe` return undefined, so
-  //     `routes/packages.ts` skips its `if (parsed.manifest)` validation
-  //     entirely and `createOrgItem` synthesizes a `{version, name, type}` stub
-  //     that `createVersionSafe` then writes into `package_versions.manifest`.
+  // immutable, unrepairable artifact. One source remains, and it is legacy
+  // only: the provider→integration migration (#481, shipped in beta.17) left
+  // `type: "provider"` manifests behind, repaired at the time by a one-off
+  // backfill script no longer in this repo. #987 closed the write direction —
+  // every create path now validates author input unconditionally and 400s — so
+  // no NEW invalid manifest enters the catalog; this fork is the one path that
+  // still propagates the legacy ones, which is the price of staying forkable.
   // So the operator gets a log line, and the fork proceeds.
   const validation = validateManifest(updatedManifest, { retiredRuntimeTools: "drop" });
   if (!validation.valid) {

--- a/apps/api/src/services/package-fork.ts
+++ b/apps/api/src/services/package-fork.ts
@@ -170,6 +170,24 @@ async function forkWithConfig(
     });
   }
 
+  // Same reason the check above only warns, applied to the identity itself: a
+  // drifted `type` (the `provider` rows #481 left behind, or a snapshot whose
+  // type no longer matches its `packages.type` row) sits in an immutable,
+  // unrepairable artifact, so the fork is the one path allowed to normalize it.
+  // `createOrgItem` used to do this silently for every caller, which is how a
+  // manifest valid for one type became a stored manifest no schema accepts
+  // (issue #987); it now REFUSES divergence, so the repair lives here.
+  if (updatedManifest.type !== cfg.type) {
+    logger.warn("normalizing drifted manifest type on fork", {
+      sourcePackageId,
+      packageId: targetId,
+      version: versionRow.version,
+      manifestType: String(updatedManifest.type),
+      packageType: cfg.type,
+    });
+    updatedManifest.type = cfg.type;
+  }
+
   // Create the fork package (draft)
   const newPkg = await createOrgItem(
     orgId,

--- a/apps/api/src/services/package-items/crud.ts
+++ b/apps/api/src/services/package-items/crud.ts
@@ -5,8 +5,8 @@ import { unionAll } from "drizzle-orm/pg-core";
 import { db } from "@appstrate/db/client";
 import { applicationPackages, packages } from "@appstrate/db/schema";
 import type { Package } from "@appstrate/db/schema";
-import { AFPS_SCHEMA_URLS } from "@appstrate/core/validation";
 import { type PackageTypeConfig } from "./config.ts";
+import { buildStoredManifest } from "./manifest.ts";
 import { enqueueStorageDeletion } from "../storage-deletion.ts";
 import { packageStorageDeletionJobs } from "../package-storage-deletion.ts";
 import { asRecord } from "@appstrate/core/safe-json";
@@ -146,26 +146,30 @@ export interface CreateItemInput {
   createdBy?: string;
 }
 
-/** Insert a new package item. `item.id` must be the fully-scoped packageId (e.g. `@scope/name`). */
+/**
+ * Insert a new package item. `item.id` must be the fully-scoped packageId (e.g. `@scope/name`).
+ *
+ * `manifest` is REQUIRED — every caller has a real one (author input already
+ * validated by the route, a published version snapshot, or the manifest parsed
+ * out of a ZIP/bundle). It used to be optional, and the `{version, name}` stub
+ * synthesized in its absence was persisted as the draft and then snapshotted
+ * verbatim into the immutable `package_versions.manifest` row, where no AFPS
+ * schema had ever accepted it (issue #987).
+ *
+ * `manifest.type` MUST equal `cfg.type` — see {@link buildStoredManifest},
+ * which stamps the stored copy and throws on divergence.
+ */
 export async function createOrgItem(
   orgId: string,
   item: CreateItemInput,
   cfg: PackageTypeConfig,
-  manifest?: Record<string, unknown>,
+  manifest: Record<string, unknown>,
   forkedFrom?: string,
 ): Promise<Package> {
   const now = new Date();
   const packageId = item.id;
 
-  const finalManifest: Record<string, unknown> = manifest
-    ? { ...manifest }
-    : { version: "1.0.0", name: packageId };
-
-  finalManifest.$schema = AFPS_SCHEMA_URLS[cfg.type];
-  finalManifest.type = cfg.type;
-  if (!finalManifest.name) finalManifest.name = packageId;
-  if (item.name) finalManifest.display_name = item.name;
-  if (item.description) finalManifest.description = item.description;
+  const finalManifest = buildStoredManifest(manifest, cfg, item);
 
   try {
     const [row] = await db

--- a/apps/api/src/services/package-items/manifest.ts
+++ b/apps/api/src/services/package-items/manifest.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { AFPS_SCHEMA_URLS } from "@appstrate/core/validation";
+import type { PackageTypeConfig } from "./config.ts";
+
+/**
+ * Build the manifest a newly created package row stores, from the author
+ * manifest. Pure — no DB, no logger — so the canonical-writer contract
+ * (`display_name`, never `displayName`) is testable without the wiring
+ * `createOrgItem` needs.
+ *
+ * `manifest.type` MUST already equal `cfg.type`. It is the manifest's identity
+ * AND the discriminator `validateManifest` dispatches on, so rewriting it after
+ * validation turned a manifest valid for one type into a stored manifest no
+ * schema accepts (issue #987) — hence the invariant instead of a repair.
+ *
+ * `$schema` is still stamped: it is a tooling pointer the platform owns, not
+ * author content, and with `type` guaranteed it is a normalization rather than
+ * an override. `name` defaults to the package id; `item.name` /
+ * `item.description`, when given, override the manifest's `display_name` /
+ * `description`.
+ */
+export function buildStoredManifest(
+  manifest: Record<string, unknown>,
+  cfg: PackageTypeConfig,
+  item: { id: string; name?: string; description?: string },
+): Record<string, unknown> {
+  if (manifest.type !== cfg.type) {
+    // Unreachable over HTTP — every route gates the author manifest's `type`
+    // against its own package type (`validateManifestForRoute`), and the one
+    // caller whose source can legitimately drift (`forkPackage`, reading an
+    // immutable published snapshot) normalizes before calling. So this is a
+    // broken invariant, not client input: a plain Error, never an ApiError.
+    throw new Error(
+      `Manifest type mismatch for '${item.id}': expected "${cfg.type}", received "${String(manifest.type)}"`,
+    );
+  }
+
+  const stored: Record<string, unknown> = { ...manifest };
+  stored.$schema = AFPS_SCHEMA_URLS[cfg.type];
+  if (!stored.name) stored.name = item.id;
+  if (item.name) stored.display_name = item.name;
+  if (item.description) stored.description = item.description;
+  return stored;
+}

--- a/apps/api/test/integration/routes/packages-mcp-server.test.ts
+++ b/apps/api/test/integration/routes/packages-mcp-server.test.ts
@@ -19,6 +19,14 @@
  *   2. LIST — the imported server appears in GET /api/packages/mcp-servers.
  *   3. GET   — the server detail is fetchable by scope/name.
  *   4. Auth boundary on list + get.
+ *   5. CREATE (`POST /api/packages/mcp-servers`) — the manifest gate of issue
+ *      #987. This is the only route family reaching `parsePackageUpload`
+ *      (`jsonBodyCreate: false`), which used to let a manifest through
+ *      unvalidated (absent / malformed `manifest.json`, absent JSON-body
+ *      `manifest`) and then let `createOrgItem` rewrite `type` after
+ *      validation — both landing a manifest no AFPS schema accepts in the
+ *      IMMUTABLE `package_versions.manifest` row.
+ *   6. UPDATE (`PUT`) — the author/stored direction asymmetry that gate rests on.
  */
 
 import { describe, it, expect, beforeEach } from "bun:test";
@@ -28,8 +36,10 @@ import { truncateAll, db } from "../../helpers/db.ts";
 import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
 import { seedPackage } from "../../helpers/seed.ts";
 import { installPackage } from "../../../src/services/application-packages.ts";
+import { uploadPackageFiles } from "../../../src/services/package-items/storage.ts";
 import { mcpServerManifest } from "../../helpers/integration-manifests.ts";
 import { packages, packageVersions } from "@appstrate/db/schema";
+import { validateManifest } from "@appstrate/core/validation";
 import { eq } from "drizzle-orm";
 
 const app = getTestApp();
@@ -223,6 +233,396 @@ describe("mcp-server package routes", () => {
     it("returns 401 without authentication", async () => {
       const res = await app.request(`/api/packages/mcp-servers/${SERVER_ID}`);
       expect(res.status).toBe(401);
+    });
+  });
+
+  // ═══════════════════════════════════════════════
+  // Issue #987 — `POST /api/packages/mcp-servers` is the ONLY create route
+  // reaching `parsePackageUpload` (`jsonBodyCreate: false`). Three doors used
+  // to put a manifest no AFPS schema accepts into the IMMUTABLE
+  // `package_versions.manifest` row:
+  //   - a ZIP with no `manifest.json`      → parsed as `undefined`
+  //   - a ZIP with malformed `manifest.json` → parsed as `undefined`
+  //   - a JSON body with no `manifest`     → optional in the Zod schema
+  // …after which `validateManifest` was skipped (`if (parsed.manifest)`) and
+  // `createOrgItem` synthesized a `{version, name, $schema, type}` stub. A
+  // fourth door needed no absence at all: a VALID manifest of another type
+  // validated against its own schema, then had `type` rewritten to the route's.
+  //
+  // The assertion that matters is therefore never the status code alone: on
+  // every accepted write the stored manifest must PASS `validateManifest`, and
+  // on every rejected one NOTHING may be persisted.
+  // ═══════════════════════════════════════════════
+
+  describe("POST /api/packages/mcp-servers — manifest gate (#987)", () => {
+    const CREATE_PATH = "/api/packages/mcp-servers";
+    /** Multipart derives the package id from the file name; JSON body sends it. */
+    const SLUG = "gate-server";
+    const GATE_ID = `@pkgorg/${SLUG}`;
+
+    function zipOf(entries: Record<string, string>): Uint8Array {
+      const out: Record<string, Uint8Array> = {};
+      for (const [path, text] of Object.entries(entries)) out[path] = enc(text);
+      return zipSync(out as unknown as Parameters<typeof zipSync>[0]);
+    }
+
+    async function postZip(entries: Record<string, string>): Promise<Response> {
+      const form = new FormData();
+      form.append("file", new Blob([zipOf(entries)]), `${SLUG}.afps`);
+      return await app.request(CREATE_PATH, {
+        method: "POST",
+        body: form,
+        headers: authHeaders(ctx),
+      });
+    }
+
+    async function postJson(body: Record<string, unknown>): Promise<Response> {
+      return await app.request(CREATE_PATH, {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify(body),
+      });
+    }
+
+    /** A valid mcp-server manifest for the id this describe block creates. */
+    function validManifest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+      return { ...mcpServerManifest({ name: GATE_ID, version: "1.0.0" }), ...overrides };
+    }
+
+    /**
+     * A VALID manifest of a different package type. `validateManifest`
+     * dispatches on the manifest's own root `type`, so this passes
+     * `skillManifestSchema` — the route's own type is the only thing that can
+     * reject it.
+     */
+    function validSkillManifest(): Record<string, unknown> {
+      return {
+        name: GATE_ID,
+        version: "1.0.0",
+        type: "skill",
+        schema_version: "0.1",
+        display_name: "Impostor Skill",
+        description: "Valid as a skill, invalid as an mcp-server",
+      };
+    }
+
+    /**
+     * A rejected create must leave NO trace: not the `packages` draft row, and
+     * above all not the immutable `package_versions` row the bug published.
+     * `truncateAll()` runs in `beforeEach` and this block seeds nothing, so
+     * "nothing persisted" is exactly "both tables empty".
+     */
+    async function expectNothingPersisted(): Promise<void> {
+      expect(await db.select({ id: packages.id }).from(packages)).toEqual([]);
+      expect(await db.select({ id: packageVersions.id }).from(packageVersions)).toEqual([]);
+    }
+
+    /**
+     * The invariant of #987: the manifest that reached the immutable version
+     * row (and the draft it was snapshotted from) is one an AFPS schema
+     * accepts. `errors` is asserted first so a failure names the offending
+     * field instead of printing `false !== true`.
+     */
+    async function expectStoredManifestsAreSchemaValid(packageId: string): Promise<void> {
+      const [pkg] = await db
+        .select({ type: packages.type, draftManifest: packages.draftManifest })
+        .from(packages)
+        .where(eq(packages.id, packageId))
+        .limit(1);
+      expect(pkg).toBeDefined();
+      expect(pkg!.type).toBe("mcp-server");
+
+      const [ver] = await db
+        .select({ version: packageVersions.version, manifest: packageVersions.manifest })
+        .from(packageVersions)
+        .where(eq(packageVersions.packageId, packageId))
+        .limit(1);
+      expect(ver).toBeDefined();
+
+      const published = validateManifest(ver!.manifest);
+      expect(published.errors ?? []).toEqual([]);
+      expect(published.valid).toBe(true);
+      expect((ver!.manifest as Record<string, unknown>).type).toBe("mcp-server");
+
+      // The draft is what a later `POST …/versions` freezes into the NEXT
+      // immutable row, so it carries the same invariant.
+      const draft = validateManifest(pkg!.draftManifest);
+      expect(draft.errors ?? []).toEqual([]);
+      expect(draft.valid).toBe(true);
+    }
+
+    // ── multipart ZIP ──────────────────────────────
+
+    it("rejects a ZIP with no manifest.json", async () => {
+      const res = await postZip({ "main.js": "// entry stub\n" });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code: string; detail: string; param?: string };
+      expect(body.code).toBe("invalid_request");
+      expect(body.param).toBe("file");
+      expect(body.detail).toContain("manifest.json");
+      await expectNothingPersisted();
+    });
+
+    it("rejects a ZIP whose manifest.json is malformed JSON", async () => {
+      const res = await postZip({
+        "manifest.json": '{ "name": "@pkgorg/gate-server", ',
+        "main.js": "// entry stub\n",
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code: string; param?: string };
+      expect(body.code).toBe("invalid_request");
+      expect(body.param).toBe("file");
+      await expectNothingPersisted();
+    });
+
+    it("rejects a ZIP whose manifest parses but fails the mcp-server schema", async () => {
+      // NOTE: this door was already closed — a manifest that PARSES took the
+      // `if (parsed.manifest)` true branch and got validated. Kept as the
+      // boundary between the two cases above (absent/malformed → `undefined` →
+      // no validation at all) and a real schema rejection.
+      const { server: _dropped, ...noServer } = validManifest();
+      const res = await postZip({
+        "manifest.json": JSON.stringify(noServer),
+        "main.js": "// entry stub\n",
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as {
+        code: string;
+        errors?: { field: string; message: string }[];
+      };
+      expect(body.code).toBe("validation_failed");
+      expect(body.errors?.map((e) => e.field)).toContain("manifest.server");
+      await expectNothingPersisted();
+    });
+
+    it("rejects a ZIP carrying a VALID manifest of another type, naming manifest.type", async () => {
+      const res = await postZip({
+        "manifest.json": JSON.stringify(validSkillManifest()),
+        "main.js": "// entry stub\n",
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as {
+        code: string;
+        detail: string;
+        errors?: { field: string; message: string }[];
+      };
+      expect(body.code).toBe("validation_failed");
+      const typeError = body.errors?.find((e) => e.field === "manifest.type");
+      expect(typeError).toBeDefined();
+      expect(typeError!.message).toContain("mcp-server");
+      expect(typeError!.message).toContain("skill");
+      await expectNothingPersisted();
+    });
+
+    it("accepts a valid ZIP and stores a schema-valid manifest in the version row", async () => {
+      const res = await postZip({
+        "manifest.json": JSON.stringify(validManifest(), null, 2),
+        "main.js": "// entry stub\n",
+      });
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as { id: string };
+      expect(body.id).toBe(GATE_ID);
+      await expectStoredManifestsAreSchemaValid(GATE_ID);
+    });
+
+    // ── JSON body ──────────────────────────────────
+
+    it("rejects a JSON body with no manifest", async () => {
+      const res = await postJson({ id: SLUG, content: "{}" });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as {
+        code: string;
+        errors?: { field: string }[];
+      };
+      expect(body.code).toBe("validation_failed");
+      expect(body.errors?.map((e) => e.field)).toContain("manifest");
+      await expectNothingPersisted();
+    });
+
+    it("rejects a JSON body carrying a VALID manifest of another type", async () => {
+      const manifest = validSkillManifest();
+      const res = await postJson({ id: SLUG, content: JSON.stringify(manifest), manifest });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code: string; errors?: { field: string }[] };
+      expect(body.code).toBe("validation_failed");
+      expect(body.errors?.map((e) => e.field)).toContain("manifest.type");
+      await expectNothingPersisted();
+    });
+
+    it("accepts a valid JSON body and stores a schema-valid manifest in the version row", async () => {
+      const manifest = validManifest();
+      const res = await postJson({
+        id: SLUG,
+        content: JSON.stringify(manifest, null, 2),
+        manifest,
+      });
+
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as { id: string };
+      expect(body.id).toBe(GATE_ID);
+      await expectStoredManifestsAreSchemaValid(GATE_ID);
+    });
+  });
+
+  // ═══════════════════════════════════════════════
+  // Issue #987 — the same gate on `PUT`, which is directional per request:
+  // a body SUPPLYING `manifest` is author input ("author" — type gated), a
+  // content-only body carries the ALREADY-STORED draft forward ("stored" — not
+  // gated, because #983 settled that persisted artifacts are tolerated on read
+  // and a gate here would make a legacy drifted draft permanently un-editable
+  // and un-publishable).
+  // ═══════════════════════════════════════════════
+
+  describe("PUT /api/packages/mcp-servers/:scope/:name — author vs stored direction", () => {
+    const PUT_ID = "@pkgorg/put-server";
+
+    async function currentLockVersion(packageId: string): Promise<number> {
+      const [row] = await db
+        .select({ lockVersion: packages.lockVersion })
+        .from(packages)
+        .where(eq(packages.id, packageId))
+        .limit(1);
+      return row!.lockVersion;
+    }
+
+    async function storedDraftManifest(packageId: string): Promise<Record<string, unknown>> {
+      const [row] = await db
+        .select({ draftManifest: packages.draftManifest })
+        .from(packages)
+        .where(eq(packages.id, packageId))
+        .limit(1);
+      return row!.draftManifest as Record<string, unknown>;
+    }
+
+    async function put(packageId: string, body: Record<string, unknown>): Promise<Response> {
+      return await app.request(`/api/packages/mcp-servers/${packageId}`, {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify(body),
+      });
+    }
+
+    /** A valid manifest of ANOTHER type, keeping `name` so only `type` differs. */
+    function skillManifestFor(packageId: string): Record<string, unknown> {
+      return {
+        name: packageId,
+        version: "1.0.0",
+        type: "skill",
+        schema_version: "0.1",
+        display_name: "Impostor Skill",
+        description: "Valid as a skill, invalid as an mcp-server",
+      };
+    }
+
+    it("rejects an AUTHORED manifest of the wrong type and leaves the draft untouched", async () => {
+      await seedPackage({
+        id: PUT_ID,
+        orgId: ctx.orgId,
+        type: "mcp-server",
+        createdBy: ctx.user.id,
+        draftManifest: mcpServerManifest({ name: PUT_ID, version: "1.0.0" }),
+        draftContent: "{}",
+      });
+      const before = await storedDraftManifest(PUT_ID);
+
+      const res = await put(PUT_ID, {
+        manifest: skillManifestFor(PUT_ID),
+        lock_version: await currentLockVersion(PUT_ID),
+      });
+
+      expect(res.status).toBe(400);
+      const body = (await res.json()) as { code: string; errors?: { field: string }[] };
+      expect(body.code).toBe("validation_failed");
+      expect(body.errors?.map((e) => e.field)).toContain("manifest.type");
+      // The draft a later publish would freeze is unchanged.
+      expect(await storedDraftManifest(PUT_ID)).toEqual(before);
+    });
+
+    it("accepts a content-only save (no manifest in the body)", async () => {
+      await seedPackage({
+        id: PUT_ID,
+        orgId: ctx.orgId,
+        type: "mcp-server",
+        createdBy: ctx.user.id,
+        draftManifest: mcpServerManifest({ name: PUT_ID, version: "1.0.0" }),
+        draftContent: "{}",
+      });
+
+      const res = await put(PUT_ID, {
+        content: '{"edited":true}',
+        lock_version: await currentLockVersion(PUT_ID),
+      });
+
+      expect(res.status).toBe(200);
+      const stored = validateManifest(await storedDraftManifest(PUT_ID));
+      expect(stored.errors ?? []).toEqual([]);
+      expect(stored.valid).toBe(true);
+    });
+
+    it("still accepts a content-only save on a package whose STORED manifest type drifted", async () => {
+      // The legacy state the "stored" direction exists for: a row typed
+      // `mcp-server` whose persisted draft manifest says `skill` (the shape the
+      // #481 migration and the pre-fix create path both left behind). The
+      // content-only save must go through — otherwise the drifted draft is
+      // permanently un-editable — while the authored save on the SAME row is
+      // rejected. That contrast is the whole author/stored split.
+      await seedPackage({
+        id: PUT_ID,
+        orgId: ctx.orgId,
+        type: "mcp-server",
+        createdBy: ctx.user.id,
+        draftManifest: skillManifestFor(PUT_ID),
+        draftContent: "{}",
+      });
+
+      const contentOnly = await put(PUT_ID, {
+        content: '{"edited":true}',
+        lock_version: await currentLockVersion(PUT_ID),
+      });
+      expect(contentOnly.status).toBe(200);
+
+      const authored = await put(PUT_ID, {
+        manifest: skillManifestFor(PUT_ID),
+        lock_version: await currentLockVersion(PUT_ID),
+      });
+      expect(authored.status).toBe(400);
+      const body = (await authored.json()) as { errors?: { field: string }[] };
+      expect(body.errors?.map((e) => e.field)).toContain("manifest.type");
+    });
+
+    it("still publishes a drifted STORED draft (no type gate on the publish path)", async () => {
+      // FORWARD guard, not a regression: publishing was ungated before the fix
+      // too. It pins the deliberate asymmetry — closing the author door must
+      // never close this one, or a legacy drifted draft becomes permanently
+      // un-publishable (#983).
+      const drifted = skillManifestFor(PUT_ID);
+      await seedPackage({
+        id: PUT_ID,
+        orgId: ctx.orgId,
+        type: "mcp-server",
+        createdBy: ctx.user.id,
+        draftManifest: drifted,
+        draftContent: "{}",
+      });
+      // An mcp-server publish zips its STORED draft files, so they must exist.
+      await uploadPackageFiles("mcp-servers", ctx.orgId, PUT_ID, {
+        "manifest.json": enc(JSON.stringify(drifted, null, 2)),
+      });
+
+      const res = await app.request(`/api/packages/mcp-servers/${PUT_ID}/versions`, {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({}),
+      });
+
+      expect(res.status).toBe(201);
     });
   });
 });

--- a/apps/api/test/integration/routes/packages.test.ts
+++ b/apps/api/test/integration/routes/packages.test.ts
@@ -2017,9 +2017,16 @@ describe("Packages API", () => {
       orgId: string,
       manifest: Record<string, unknown>,
       content = "source prompt",
+      /**
+       * The `packages.type` COLUMN, for the case where it deliberately
+       * DISAGREES with `manifest.type` — the drift the #481
+       * provider→integration migration left in the catalog. Defaults to the
+       * manifest's own type (the aligned, ordinary case).
+       */
+      rowType?: "agent" | "skill" | "integration" | "mcp-server",
     ): Promise<void> {
       const version = manifest.version as string;
-      const type = manifest.type as "agent" | "skill";
+      const type = rowType ?? (manifest.type as "agent" | "skill");
       await seedPackage({
         id: packageId,
         orgId,
@@ -2206,6 +2213,60 @@ describe("Packages API", () => {
       // unrelated to this normalisation. What matters here is that nothing the
       // source declared was changed or lost.
       expect(await draftManifest(targetId)).toMatchObject(expected);
+    });
+
+    // Issue #987 made `createOrgItem` REFUSE a manifest whose `type` disagrees
+    // with the package type instead of silently rewriting it. A fork is the one
+    // caller whose two sources can legitimately disagree — the config comes
+    // from the `packages.type` COLUMN, the manifest from an immutable published
+    // snapshot — so it normalizes explicitly before calling. Without that, the
+    // `type: "provider"` rows the #481 migration left in the catalog would fork
+    // into a 500.
+    it("forks a published manifest whose type drifted from its row (#481 legacy)", async () => {
+      const srcCtx = await createTestContext({ orgSlug: "forkdrift" });
+      const sourceId = "@forkdrift/legacy-provider";
+      await seedPublishedSource(
+        sourceId,
+        srcCtx.orgId,
+        {
+          name: sourceId,
+          version: "0.1.0",
+          // The pre-#481 vocabulary: a type no schema accepts today, on a row
+          // the migration retyped to `integration`.
+          type: "provider",
+          schema_version: "0.1",
+          display_name: "Legacy Provider",
+          description: "Left behind by the provider→integration migration",
+        },
+        "",
+        "integration",
+      );
+
+      const res = await app.request(`/api/packages/${sourceId}/fork`, {
+        method: "POST",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({}),
+      });
+
+      // 201, NOT a 500 from the new invariant: the drifted source stays forkable.
+      expect(res.status).toBe(201);
+
+      const targetId = "@pkgorg/legacy-provider";
+      const [row] = await db
+        .select({ type: packages.type })
+        .from(packages)
+        .where(eq(packages.id, targetId))
+        .limit(1);
+      expect(row!.type).toBe("integration");
+      // The fork's draft AND its new immutable version row agree with the row
+      // type — previously only the draft got the rewrite, so the version row
+      // (and the ZIP built from the same object) kept `provider`.
+      expect((await draftManifest(targetId)).type).toBe("integration");
+      expect((await versionManifest(targetId)).type).toBe("integration");
+      const zipped = JSON.parse(await artifactManifestText(targetId, "0.1.0")) as {
+        type?: string;
+      };
+      expect(zipped.type).toBe("integration");
     });
   });
 });

--- a/apps/api/test/unit/build-stored-manifest.test.ts
+++ b/apps/api/test/unit/build-stored-manifest.test.ts
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `buildStoredManifest` — the pure stamping step every package create goes
+ * through (`createOrgItem` → `packages.draft_manifest`, then snapshotted
+ * verbatim into the immutable `package_versions.manifest` row).
+ *
+ * Two contracts live here:
+ *
+ *  1. **The `type` invariant (issue #987)**. The stamping used to REWRITE
+ *     `manifest.type` to the route's package type, after `validateManifest`
+ *     had already dispatched on the manifest's own root `type`. A manifest
+ *     valid for one type therefore became a stored manifest no AFPS schema
+ *     accepts. `buildStoredManifest` now throws instead — a plain `Error`,
+ *     because over HTTP the routes gate the author manifest
+ *     (`validateManifestForRoute`) and `forkPackage` normalizes its published
+ *     snapshot before calling, so reaching this is a broken invariant, never
+ *     client input.
+ *
+ *  2. **The canonical-casing contract** (`display_name`, never `displayName`).
+ *     These assertions used to live in `packages/core/test/writers-canonical.test.ts`
+ *     against a hand-copied `simulateCreateOrgItem`; that copy drifted the
+ *     moment production stopped rewriting `type`. They run against the real
+ *     function here — the API package is the one that can import it.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { buildStoredManifest } from "../../src/services/package-items/manifest.ts";
+import { CONFIG_BY_TYPE } from "../../src/services/package-items/config.ts";
+import { AFPS_SCHEMA_URLS, type PackageType } from "@appstrate/core/validation";
+
+const TYPES = ["agent", "skill", "mcp-server", "integration"] as const;
+
+/** Minimal manifest of `type`, valid enough for a pure stamping test. */
+function manifestOf(type: PackageType, overrides: Record<string, unknown> = {}) {
+  return {
+    name: "@acme/test",
+    version: "1.0.0",
+    type,
+    schema_version: "0.1",
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────
+// The `type` invariant (issue #987)
+// ─────────────────────────────────────────────
+
+describe("buildStoredManifest — manifest/config type agreement", () => {
+  it("throws when the manifest type disagrees with the package type", () => {
+    expect(() =>
+      buildStoredManifest(manifestOf("skill"), CONFIG_BY_TYPE["mcp-server"], {
+        id: "@acme/test",
+      }),
+    ).toThrow(/expected "mcp-server", received "skill"/);
+  });
+
+  it("throws when the manifest carries no type at all", () => {
+    const { type: _dropped, ...typeless } = manifestOf("agent");
+    expect(() => buildStoredManifest(typeless, CONFIG_BY_TYPE.agent, { id: "@acme/test" })).toThrow(
+      /expected "agent", received "undefined"/,
+    );
+  });
+
+  it("names the package id in the error, so the broken row is identifiable", () => {
+    expect(() =>
+      buildStoredManifest(manifestOf("agent"), CONFIG_BY_TYPE.skill, { id: "@acme/mislabelled" }),
+    ).toThrow(/@acme\/mislabelled/);
+  });
+
+  for (const type of TYPES) {
+    it(`accepts a matching ${type} manifest and preserves its type verbatim`, () => {
+      const stored = buildStoredManifest(manifestOf(type), CONFIG_BY_TYPE[type], {
+        id: "@acme/test",
+      });
+      expect(stored.type).toBe(type);
+    });
+  }
+});
+
+// ─────────────────────────────────────────────
+// Stamping
+// ─────────────────────────────────────────────
+
+describe("buildStoredManifest — stamping", () => {
+  for (const type of TYPES) {
+    it(`stamps the ${type} $schema pointer from the package config`, () => {
+      const stored = buildStoredManifest(manifestOf(type), CONFIG_BY_TYPE[type], {
+        id: "@acme/test",
+      });
+      expect(stored.$schema).toBe(AFPS_SCHEMA_URLS[type]);
+    });
+  }
+
+  it("overwrites an author-supplied $schema (the pointer is platform-owned)", () => {
+    const stored = buildStoredManifest(
+      manifestOf("agent", { $schema: "https://evil.example/agent.json" }),
+      CONFIG_BY_TYPE.agent,
+      { id: "@acme/test" },
+    );
+    expect(stored.$schema).toBe(AFPS_SCHEMA_URLS.agent);
+  });
+
+  it("defaults a missing name to the package id", () => {
+    const { name: _dropped, ...nameless } = manifestOf("agent");
+    const stored = buildStoredManifest(nameless, CONFIG_BY_TYPE.agent, { id: "@acme/defaulted" });
+    expect(stored.name).toBe("@acme/defaulted");
+  });
+
+  it("keeps the manifest's own name when it has one", () => {
+    const stored = buildStoredManifest(
+      manifestOf("agent", { name: "@acme/authored" }),
+      CONFIG_BY_TYPE.agent,
+      { id: "@acme/authored" },
+    );
+    expect(stored.name).toBe("@acme/authored");
+  });
+
+  it("writes item.name / item.description as display_name / description", () => {
+    const stored = buildStoredManifest(manifestOf("skill"), CONFIG_BY_TYPE.skill, {
+      id: "@acme/test",
+      name: "Test Item",
+      description: "A test item",
+    });
+    expect(stored.display_name).toBe("Test Item");
+    expect(stored.description).toBe("A test item");
+  });
+
+  it("leaves the manifest's own display_name / description alone when item has none", () => {
+    const stored = buildStoredManifest(
+      manifestOf("skill", { display_name: "Author Label", description: "Author blurb" }),
+      CONFIG_BY_TYPE.skill,
+      { id: "@acme/test" },
+    );
+    expect(stored.display_name).toBe("Author Label");
+    expect(stored.description).toBe("Author blurb");
+  });
+
+  it("does NOT mutate its input — the caller's manifest is reused downstream", () => {
+    const input = manifestOf("agent", { display_name: "Before" }) as Record<string, unknown>;
+    const snapshot = structuredClone(input);
+    buildStoredManifest(input, CONFIG_BY_TYPE.agent, {
+      id: "@acme/other",
+      name: "After",
+      description: "Added",
+    });
+    expect(input).toEqual(snapshot);
+  });
+});
+
+// ─────────────────────────────────────────────
+// Canonical casing — moved off the core copy
+// ─────────────────────────────────────────────
+
+const BANNED_CAMEL_KEYS = [
+  "displayName",
+  "schemaVersion",
+  "fileConstraints",
+  "uiHints",
+  "propertyOrder",
+  "maxSize",
+  "iconUrl",
+  "providersConfiguration",
+  "runtimeTools",
+] as const;
+
+interface Violation {
+  path: string;
+  key: string;
+}
+
+/**
+ * Deep walk for non-canonical camelCase keys. Mirrors the walker in
+ * `packages/core/test/writers-canonical.test.ts` (which still guards
+ * `writeManifestIntegrations`); duplicated rather than shared because that is a
+ * different package's test tree.
+ */
+function findBannedKeysDeep(value: unknown, basePath = "$"): Violation[] {
+  const out: Violation[] = [];
+  if (value === null || typeof value !== "object") return out;
+  if (Array.isArray(value)) {
+    value.forEach((v, i) => out.push(...findBannedKeysDeep(v, `${basePath}[${i}]`)));
+    return out;
+  }
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    const path = `${basePath}.${k}`;
+    if ((BANNED_CAMEL_KEYS as readonly string[]).includes(k)) out.push({ path, key: k });
+    out.push(...findBannedKeysDeep(v, path));
+  }
+  return out;
+}
+
+describe("buildStoredManifest never emits non-canonical camelCase keys", () => {
+  for (const type of TYPES) {
+    it(`stores a ${type} manifest with canonical snake_case keys only`, () => {
+      const stored = buildStoredManifest(manifestOf(type), CONFIG_BY_TYPE[type], {
+        id: "@acme/test",
+        name: "Test Item",
+        description: "A test item",
+      });
+      // display_name MUST be present, displayName MUST NOT.
+      expect(stored.display_name).toBe("Test Item");
+      expect(stored).not.toHaveProperty("displayName");
+      expect(findBannedKeysDeep(stored)).toEqual([]);
+    });
+
+    it(`stores a ${type} manifest without introducing camelCase over snake_case input`, () => {
+      const stored = buildStoredManifest(
+        manifestOf(type, {
+          display_name: "Existing Canonical",
+          icon_url: "https://example.com/icon.png",
+          input: {
+            schema: { properties: { x: { type: "string" } } },
+            file_constraints: { foo: { max_size: 100 } },
+            ui_hints: { x: { placeholder: "x" } },
+            property_order: ["x"],
+          },
+        }),
+        CONFIG_BY_TYPE[type],
+        { id: "@acme/test", name: "Test", description: "Desc" },
+      );
+      expect(findBannedKeysDeep(stored)).toEqual([]);
+    });
+  }
+
+  it("flags a camelCase leak at any depth (walker sanity)", () => {
+    const violations = findBannedKeysDeep({
+      input: { fileConstraints: { foo: { maxSize: 100 } } },
+    });
+    expect(violations.map((v) => v.key).sort()).toEqual(["fileConstraints", "maxSize"]);
+  });
+});

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -16312,13 +16312,13 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        /** @description Upload a package ZIP (`multipart/form-data` with a `.afps`/`.zip` file — the package ID is derived from the file name), or post a JSON body. Parsed by `parsePackageUpload`. */
+        /** @description Upload a package ZIP (`multipart/form-data` with a `.afps`/`.zip` file — the package ID is derived from the file name, and the archive must contain a valid `manifest.json`), or post a JSON body carrying the manifest. Parsed by `parsePackageUpload`. */
         requestBody: {
             content: {
                 "multipart/form-data": {
                     /**
                      * Format: binary
-                     * @description Package archive (`.afps` or `.zip`). File name (sans extension) is the kebab-case package id.
+                     * @description Package archive (`.afps` or `.zip`) containing a valid `manifest.json`. File name (sans extension) is the kebab-case package id.
                      */
                     file: Blob;
                 };
@@ -16331,10 +16331,8 @@ export interface operations {
                     name?: string;
                     /** @description Package description. Auto-extracted from the manifest if omitted. */
                     description?: string;
-                    /** @description Initial semver (optional). */
-                    version?: string;
-                    /** @description Optional manifest object (stored as-is). */
-                    manifest?: {
+                    /** @description Manifest object, validated against the AFPS mcp-server schema and stored as-is. */
+                    manifest: {
                         [key: string]: unknown;
                     };
                 };

--- a/packages/core/test/writers-canonical.test.ts
+++ b/packages/core/test/writers-canonical.test.ts
@@ -3,26 +3,25 @@
 /**
  * Writers MUST NOT emit non-canonical camelCase keys.
  *
- * Umbrella regression test catching the whole class of writer-leak bugs (e.g.
- * `createOrgItem` writing `displayName` instead of `display_name`). Pins the
- * canonical contract so a future writer that accidentally re-introduces
- * camelCase fails CI before merge.
+ * Umbrella regression test catching the whole class of writer-leak bugs (e.g. a
+ * writer emitting `displayName` instead of `display_name`). Pins the canonical
+ * contract so a future writer that accidentally re-introduces camelCase fails
+ * CI before merge.
  *
  * Coverage:
- *  - `createOrgItem` manifest-mutation logic (`apps/api/src/services/package-items/crud.ts`)
- *    is inlined as a pure helper for each of the 4 package types (the DB-bound
- *    function itself requires too much wiring — DB + auth context — to test in
- *    a packages/core unit test). The inlined helper is byte-for-byte identical
- *    to the production manifest-mutation path (`finalManifest.<key> = …`).
  *  - `writeManifestIntegrations` round-trip (the canonical writer for the
  *    `dependencies.integrations.<id>` object form + the top-level
  *    `integrations` block per AFPS §4.1).
+ *  - The package-create writer (`buildStoredManifest`, the pure core of
+ *    `createOrgItem`) is covered in `apps/api/test/unit/build-stored-manifest.test.ts`
+ *    — against the REAL function, in the package that can import it. A
+ *    hand-copied simulation used to stand in for it here and silently drifted
+ *    from production (it still rewrote `manifest.type`, which issue #987 made
+ *    an error).
  *  - `metadataToManifestPatch` is covered by
  *    `apps/web/src/components/agent-editor/test/utils.test.ts` — already
  *    asserts `displayName: undefined` is emitted alongside canonical
- *    `display_name`. Re-tested here at the JSON level since the patch is
- *    shallow-merged into the manifest and the non-canonical key MUST drop on
- *    serialization.
+ *    `display_name`.
  *
  * Banned non-canonical camelCase keys:
  *   displayName, schemaVersion, fileConstraints, uiHints, propertyOrder,
@@ -31,7 +30,6 @@
 
 import { describe, it, expect } from "bun:test";
 import { parseManifestIntegrations, writeManifestIntegrations } from "../src/dependencies.ts";
-import { AFPS_SCHEMA_URLS } from "../src/validation.ts";
 
 // ─────────────────────────────────────────────
 // Banned-key audit
@@ -70,88 +68,6 @@ function findBannedKeysDeep(value: unknown, basePath = "$"): Violation[] {
   }
   return out;
 }
-
-/**
- * Mirrors the manifest-mutation block in
- * `apps/api/src/services/package-items/crud.ts:95-103` (`createOrgItem`).
- * Pure — no DB, no auth context. Pins the canonical contract: `display_name`
- * (not `displayName`).
- */
-function simulateCreateOrgItem(
-  type: "agent" | "skill" | "mcp-server" | "integration",
-  item: { id: string; name?: string; description?: string },
-  manifest?: Record<string, unknown>,
-): Record<string, unknown> {
-  const finalManifest: Record<string, unknown> = manifest
-    ? { ...manifest }
-    : { version: "1.0.0", name: item.id };
-  finalManifest.$schema = AFPS_SCHEMA_URLS[type];
-  finalManifest.type = type;
-  if (!finalManifest.name) finalManifest.name = item.id;
-  if (item.name) finalManifest.display_name = item.name;
-  if (item.description) finalManifest.description = item.description;
-  return finalManifest;
-}
-
-// ─────────────────────────────────────────────
-// createOrgItem simulation per package type
-// ─────────────────────────────────────────────
-
-describe("createOrgItem writer never emits non-canonical camelCase keys", () => {
-  const TYPES = ["agent", "skill", "mcp-server", "integration"] as const;
-
-  for (const type of TYPES) {
-    it(`creates a ${type} manifest with canonical snake_case keys only`, () => {
-      const m = simulateCreateOrgItem(type, {
-        id: "@acme/test",
-        name: "Test Item",
-        description: "A test item",
-      });
-      // display_name MUST be present, displayName MUST NOT.
-      expect(m.display_name).toBe("Test Item");
-      expect(m).not.toHaveProperty("displayName");
-      const violations = findBannedKeysDeep(m);
-      if (violations.length > 0) {
-        // surface a readable failure message
-        throw new Error(
-          `Banned non-canonical camelCase keys leaked from createOrgItem(${type}): ` +
-            violations.map((v) => `${v.path} (${v.key})`).join(", "),
-        );
-      }
-    });
-
-    it(`createOrgItem(${type}) does not introduce camelCase when input has snake_case`, () => {
-      const m = simulateCreateOrgItem(
-        type,
-        { id: "@acme/test", name: "Test", description: "Desc" },
-        {
-          name: "@acme/test",
-          version: "2.0.0",
-          display_name: "Existing Canonical",
-          schema_version: "0.1",
-          icon_url: "https://example.com/icon.png",
-        },
-      );
-      const violations = findBannedKeysDeep(m);
-      expect(violations).toEqual([]);
-    });
-
-    it(`createOrgItem(${type}) emits canonical display_name from item.name`, () => {
-      // item.name MUST be written as the canonical display_name; the writer
-      // MUST NOT introduce a camelCase displayName. NOTE: writers don't
-      // actively strip non-canonical siblings already present on input — that
-      // happens in the editor path. This test pins what the writer DOES emit.
-      const input: Record<string, unknown> = {
-        name: "@acme/test",
-        version: "1.0.0",
-      };
-      const m = simulateCreateOrgItem(type, { id: "@acme/test", name: "Canonical Label" }, input);
-      // The writer emits canonical display_name; displayName never introduced.
-      expect(m.display_name).toBe("Canonical Label");
-      expect(m).not.toHaveProperty("displayName");
-    });
-  }
-});
 
 // ─────────────────────────────────────────────
 // writeManifestIntegrations round-trip


### PR DESCRIPTION
Closes #987.

## The bug

`POST /api/packages/mcp-servers` could write a manifest into `package_versions.manifest` — a published, immutable row — that no schema had ever validated. `mcp-server` is the only package type with `jsonBodyCreate: false`, so it is the only one reaching the `parsePackageUpload` branch, and that branch had two doors:

- **multipart**: `manifest.json` was parsed with `parseManifestBytesSafe`, which swallowed both absence and malformed JSON into `undefined`;
- **JSON body**: `manifest` was `.optional()` in the Zod schema (the issue only described the ZIP half — the JSON half was the same hole).

Either way `validateManifest` was skipped (`if (parsed.manifest)`), `createOrgItem` synthesized a `{version:"1.0.0", name, $schema, type}` stub, and `createVersionSafe` wrote it straight into the version row. Verified empirically — that stub fails `mcpServerManifestSchema`:

```
manifest_version: Invalid input: expected string, received undefined
server: Invalid input: expected object, received undefined
```

**A second door, not in the issue, needed no absence at all.** `validateManifest` dispatches purely on the manifest's own root `type`, and `createOrgItem` rewrote `type` (and `$schema`) to the route's type *after* validation. So a perfectly valid `skill` manifest posted to the mcp-server route validated against `skillManifestSchema` and then landed stored with `type: "mcp-server"` — the exact same failure signature. Reproduced end to end. The mismatch was equally reachable on `PUT`, whose draft a later publish freezes into an immutable version row.

## The fix

**1. The write direction rejects, like `PUT /api/packages/…` already did.** `manifest.json` is required in the archive and parsed with the throwing parser (missing → `ZIP must contain manifest.json`, malformed → the parse error, both 400s on `file`); `manifest` is required in the JSON body; validation is unconditional.

**2. One direction-aware gate.** `validateManifestForRoute` collapses four duplicated `validateManifest → validationFailed → assertAgentIntegrationScopesValid` blocks into one helper, and adds the missing route/manifest `type` agreement check:

- `"author"` (create, `PUT` supplying a manifest) → mismatch is a 400 field error on `manifest.type`; retired `runtime_tools` ids reject.
- `"stored"` (`PUT` content-only carry-forward, publishing an existing draft) → **no** type gate, retired ids drop. #983 settled that already-persisted artifacts are tolerated on read; gating there would make a legacy drifted draft permanently un-publishable.

**3. `createOrgItem` stops rewriting identity.** Its `manifest` parameter is now required (the stub branch died with change 1) and the stamping moved to a pure, db-free `buildStoredManifest` that *throws* on divergence — a plain `Error`, not an `ApiError`, because it is unreachable over HTTP. `$schema` is still stamped: it is a tooling pointer the platform owns, not author content.

`forkPackage` is the one caller whose sources can legitimately disagree — it derives its config from the `packages.type` column while the manifest comes from an immutable published snapshot, and the `type: "provider"` rows the #481 migration left behind are still in the catalog. It keeps the repair, now explicit and logged, next to the "look, warn, NEVER reject" block that documents the policy. **Side effect worth noting**: the fork's draft, its stored `manifest.json`, its rebuilt ZIP and its new version row now all agree on the type — previously only the draft got the rewrite, so a fork of a drifted manifest minted an immutable row that disagreed with its own draft.

Dead code removed: `parseManifestBytesSafe` (no remaining caller) and the JSON body's `version` field (only ever read by the fallback that fired when `manifest` was absent).

## ⚠️ Breaking change

`manifest` is now **required** on the `POST /api/packages/mcp-servers` JSON body, and an archive without a valid `manifest.json` is a 400 instead of a silently-stubbed package. `detect:breaking` flags it; the baseline moves rather than the behaviour, because the rejected inputs are exactly the ones that produced corrupt published rows. Deliberately **not** routed through the date-based `Appstrate-Version` machinery — the "break" is refusing input that produced broken data. Say the word if you want it versioned instead.

The SPA is unaffected: `useCreatePackage` already types `manifest` as required and never sent `version`.

## Tests

Coverage asserts **the invariant, not the status code**: on every accepted write the stored manifest (version row *and* draft) must pass `validateManifest`; on every rejected one both `packages` and `package_versions` must stay empty.

- create: no `manifest.json` / malformed / schema-invalid / valid-but-wrong-type / valid — each in multipart and JSON-body form;
- `PUT`: the sharp case — a row typed `mcp-server` whose persisted draft says `skill` accepts a content-only save and rejects an authored one;
- `buildStoredManifest`: pure unit tests, including non-mutation of the input. The canonical-casing assertions (`display_name`, never `displayName`) moved here from `packages/core/test/writers-canonical.test.ts`, which hand-copied the production block as `simulateCreateOrgItem` and was asserting a contract that stopped existing — they now run against the real function;
- fork: the legacy `type: "provider"` shape still returns 201 (not a 500 from the new invariant).

**7 of the new tests fail on the parent commit**, verified by running them against an extracted copy of it — not reasoned from the diff.

Local: `bun run check` green (33/33), full `bun test` **9134 pass / 0 fail** on a fresh test stack. Labeled `integration` so CI runs the heavy job pre-merge.

## Also in here

- The fork's justification comment cited `POST /api/mcp-servers` minting invalid manifests via a function that no longer exists. Rewritten: one legacy source remains (#481), and this fork is the one path that still propagates it — the price of staying forkable. The #974 changelog entry carried the same stale claim.
- The baseline refresh absorbs four additive diffs already merged on main that never reached the baseline (SSE `channels=`, `context_documents`, `If-None-Match`/`304`). The detector only fails on breaking diffs, so additive drift accumulates silently between refreshes.

## Deliberately out of scope

**`id` derivation diverges inside the same route.** Multipart derives the package id from the **file name** (`@{orgSlug}/{fileName}`) while the JSON body uses `manifest.name`, as does `POST /api/packages/import`. So a multipart upload whose `manifest.name` differs from its file name creates a row whose id disagrees with its own manifest — and `PUT` then rejects every subsequent edit with `name cannot change`. Real, reachable, and a documented public contract (`the package ID is derived from the file name`), so it wants its own decision rather than a drive-by change here. Happy to file the follow-up.

Two things this PR closes *incidentally*, worth knowing: `createVersionSafe`'s silent "missing or invalid version → no version row" skip is now unreachable from create (the AFPS schema enforces semver, and validation is no longer skippable), and `unzipArtifact` already applies a 200 MB / 10 000-file budget on this path, so there was no zip-bomb gap to close.
