### PR TITLE
Add USERCONTENT_URL reachability probe at boot (#1001)

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,7 +6,7 @@ import { serveStatic } from "hono/bun";
 import { getEnv } from "@appstrate/env";
 import { recordProcessAnomaly } from "@appstrate/core/telemetry";
 import { logger } from "./lib/logger.ts";
-import { bootCritical, bootBackground } from "./lib/boot.ts";
+import { bootCritical, bootBackground, probeUsercontentReachability } from "./lib/boot.ts";
 import { createShutdownHandler } from "./lib/shutdown.ts";
 import { requireAppContext } from "./middleware/app-context.ts";
 import { requestId } from "./middleware/request-id.ts";
@@ -431,6 +431,10 @@ void bootBackground()
   .then(() => {
     markServerReady();
     logger.info("Server ready", { port: env.PORT, startupMs: Date.now() - bootStartedAt });
+    // Fire-and-forget reachability probe for USERCONTENT_URL (issue #1001).
+    // Never awaited, never fatal; runs after readiness so it can't race the
+    // boot gate's 503-until-ready window against a hairpin route.
+    void probeUsercontentReachability();
   })
   .catch((err: unknown) => {
     logger.error("Boot failed — exiting", {

--- a/apps/api/src/lib/boot.ts
+++ b/apps/api/src/lib/boot.ts
@@ -613,18 +613,14 @@ export async function probeUsercontentReachability(): Promise<void> {
   let base = env.USERCONTENT_URL;
   while (base.endsWith("/")) base = base.slice(0, -1);
   const url = `${base}/preview/documents/_probe`;
-  let status: number | null = null;
-  try {
-    const res = await fetch(url, {
-      method: "GET",
-      redirect: "manual",
-      signal: AbortSignal.timeout(3000),
-    });
-    status = res.status;
-  } catch {
+  const status: number | null = await fetch(url, {
+    method: "GET",
+    redirect: "manual",
+    signal: AbortSignal.timeout(3000),
+  })
+    .then((res) => res.status)
     // Timeout / connection refused / DNS failure — treated as "not 401".
-    status = null;
-  }
+    .catch(() => null);
   if (status === 401) return; // route reached AND enforcing auth → healthy, stay silent
   logger.error(
     `USERCONTENT_URL preview probe did not return 401 (got ${status ?? "no response"}). ` +

--- a/apps/api/src/lib/boot.ts
+++ b/apps/api/src/lib/boot.ts
@@ -588,3 +588,51 @@ function warnOnTrustProxyMisconfig(trustProxy: string, nodeEnv: string): void {
   if (nodeEnv === "production") logger.error(msg);
   else logger.info(msg);
 }
+
+/**
+ * Boot-time reachability probe for `USERCONTENT_URL` (issue #1001).
+ *
+ * The platform *signs* preview URLs (`services/documents.ts` → `mintPreviewUrl`)
+ * but never fetches them — so if `USERCONTENT_URL` is set to a host the browser
+ * cannot reach, every `preview_url` this instance mints is dead with zero
+ * server-side trace. This probe fires ONE unauthenticated GET at the preview
+ * route on that origin and, unless it gets the expected `401` (route exists and
+ * enforces the preview token — the healthy case), emits a single `error`-level
+ * line naming the URL and observed status.
+ *
+ * Never fatal, never awaited, never blocks readiness: it is kicked off
+ * fire-and-forget from `index.ts` AFTER `markServerReady()` so it can't race the
+ * boot gate (which 503s every route until ready — a mid-boot probe against a
+ * hairpin route would see that 503 instead of the real 401 and false-positive on
+ * every boot). Only runs when `USERCONTENT_URL` is defined.
+ */
+export async function probeUsercontentReachability(): Promise<void> {
+  const env = (await import("@appstrate/env")).getEnv();
+  if (!env.USERCONTENT_URL) return; // only meaningful when the origin is configured
+  // Replicate `mintPreviewUrl`'s slash-trim so we probe the exact base we sign.
+  let base = env.USERCONTENT_URL;
+  while (base.endsWith("/")) base = base.slice(0, -1);
+  const url = `${base}/preview/documents/_probe`;
+  let status: number | null = null;
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      redirect: "manual",
+      signal: AbortSignal.timeout(3000),
+    });
+    status = res.status;
+  } catch {
+    // Timeout / connection refused / DNS failure — treated as "not 401".
+    status = null;
+  }
+  if (status === 401) return; // route reached AND enforcing auth → healthy, stay silent
+  logger.error(
+    `USERCONTENT_URL preview probe did not return 401 (got ${status ?? "no response"}). ` +
+      `Every preview_url this instance signs points at ${base} — if that host is unrouted, all ` +
+      `document previews are dead with no server-side trace. NOTE: this probe reaches the host from ` +
+      `INSIDE the container network; a failure here can be a false positive when hairpin-NAT / ` +
+      `split-horizon DNS prevents the container from reaching its own public hostname while browsers ` +
+      `reach it fine. Verify a preview actually fails before acting.`,
+    { url, status },
+  );
+}

--- a/apps/api/test/unit/usercontent-probe.test.ts
+++ b/apps/api/test/unit/usercontent-probe.test.ts
@@ -84,15 +84,18 @@ describe("probeUsercontentReachability", () => {
   it("stays silent when the probe returns 401 (route reached, auth enforced)", async () => {
     process.env.USERCONTENT_URL = UC;
     _resetCacheForTesting();
-    let probedUrl: string | null = null;
+    // Collected in an array (not a narrowed `let`): it doubles as the
+    // "exactly one request" assertion and keeps the closure write visible to
+    // TypeScript's control-flow analysis.
+    const probed: string[] = [];
     mockFetch(async (input) => {
-      probedUrl = typeof input === "string" ? input : input.toString();
+      probed.push(typeof input === "string" ? input : input.toString());
       return new Response(null, { status: 401 });
     });
 
     await probeUsercontentReachability();
 
-    expect(probedUrl).toBe(PROBE_URL);
+    expect(probed).toEqual([PROBE_URL]);
     expect(errorSpy).toHaveBeenCalledTimes(0);
   });
 

--- a/apps/api/test/unit/usercontent-probe.test.ts
+++ b/apps/api/test/unit/usercontent-probe.test.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `probeUsercontentReachability()` (issue #1001).
+ *
+ * The probe fires ONE unauthenticated GET at
+ * `${USERCONTENT_URL}/preview/documents/_probe` at boot and, unless it observes
+ * the expected `401` (route reached AND enforcing the preview token — healthy),
+ * emits exactly one `logger.error` naming the URL and observed status. It is
+ * never fatal and never runs when `USERCONTENT_URL` is unset.
+ *
+ * Per AGENTS.md ("No `mock.module()`: use dependency injection instead") the
+ * HTTP layer is controlled by swapping `globalThis.fetch` and the env by
+ * rewriting `process.env` + dropping the cached `getEnv()` snapshot via
+ * `_resetCacheForTesting()`. `logger.error` is observed with `spyOn`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, afterAll, spyOn } from "bun:test";
+import { _resetCacheForTesting } from "@appstrate/env";
+import { logger } from "../../src/lib/logger.ts";
+import { probeUsercontentReachability } from "../../src/lib/boot.ts";
+
+// Snapshot the env we mutate so sibling test files in the same process are
+// unaffected.
+const SNAPSHOT = {
+  USERCONTENT_URL: process.env.USERCONTENT_URL,
+};
+
+function restoreEnv(): void {
+  for (const [k, v] of Object.entries(SNAPSHOT)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  _resetCacheForTesting();
+}
+
+// A host distinct from APP_URL (localhost in the test preload) so the env
+// refinement (USERCONTENT_URL host must differ from APP_URL) is satisfied.
+const UC = "http://usercontent.example.test";
+const PROBE_URL = `${UC}/preview/documents/_probe`;
+
+type FetchImpl = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+let originalFetch: typeof fetch;
+function mockFetch(impl: FetchImpl): void {
+  originalFetch = globalThis.fetch;
+  globalThis.fetch = impl as unknown as typeof fetch;
+}
+function restoreFetch(): void {
+  if (originalFetch) globalThis.fetch = originalFetch;
+}
+
+describe("probeUsercontentReachability", () => {
+  let errorSpy: ReturnType<typeof spyOn<typeof logger, "error">>;
+
+  beforeEach(() => {
+    errorSpy = spyOn(logger, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    restoreFetch();
+    restoreEnv();
+  });
+
+  afterAll(() => {
+    restoreEnv();
+  });
+
+  it("no-ops when USERCONTENT_URL is unset — no fetch, no log", async () => {
+    delete process.env.USERCONTENT_URL;
+    _resetCacheForTesting();
+    let fetched = false;
+    mockFetch(async () => {
+      fetched = true;
+      return new Response(null, { status: 200 });
+    });
+
+    await probeUsercontentReachability();
+
+    expect(fetched).toBe(false);
+    expect(errorSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("stays silent when the probe returns 401 (route reached, auth enforced)", async () => {
+    process.env.USERCONTENT_URL = UC;
+    _resetCacheForTesting();
+    let probedUrl: string | null = null;
+    mockFetch(async (input) => {
+      probedUrl = typeof input === "string" ? input : input.toString();
+      return new Response(null, { status: 401 });
+    });
+
+    await probeUsercontentReachability();
+
+    expect(probedUrl).toBe(PROBE_URL);
+    expect(errorSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("warns exactly once with url + status on a non-401 response (503)", async () => {
+    process.env.USERCONTENT_URL = UC;
+    _resetCacheForTesting();
+    mockFetch(async () => new Response(null, { status: 503 }));
+
+    await probeUsercontentReachability();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const [msg, data] = errorSpy.mock.calls[0]!;
+    expect(String(msg)).toContain("did not return 401");
+    expect(data).toEqual({ url: PROBE_URL, status: 503 });
+  });
+
+  it("warns once with status null when the fetch throws (timeout / refused)", async () => {
+    process.env.USERCONTENT_URL = UC;
+    _resetCacheForTesting();
+    mockFetch(async () => {
+      throw new Error("connection refused");
+    });
+
+    await probeUsercontentReachability();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const [, data] = errorSpy.mock.calls[0]!;
+    expect(data).toEqual({ url: PROBE_URL, status: null });
+  });
+});


### PR DESCRIPTION
## Résumé

Ajoute une sonde de démarrage (reachability probe) pour `USERCONTENT_URL` afin de détecter tôt une mauvaise configuration réseau de la couche user-content.

## Comportement

- **Non fatale** : la sonde s'exécute après que l'API a signalé sa readiness ; un échec de la sonde n'empêche jamais le démarrage ni ne fait planter le process.
- **Oracle 401 = silence** : un `HTTP 401` renvoyé par `USERCONTENT_URL` est le signal attendu (l'endpoint est joignable et exige une authentification) → aucun log, la sonde reste silencieuse.
- **Tout autre statut → log level 50** : n'importe quel autre résultat (statut inattendu, timeout, erreur réseau) émet **un seul** log de niveau 50 (error), assorti d'un caveat expliquant qu'un faux négatif est possible en cas de **hairpin-NAT** (une instance qui n'arrive pas à s'atteindre elle-même via son URL publique alors que le service est en réalité joignable de l'extérieur).

## Tests

- Ajout de tests unitaires (`apps/api/test/unit/usercontent-probe.test.ts`) couvrant : le cas 401 silencieux, le cas d'un statut inattendu qui émet exactement un log level 50, et le caractère non fatal de la sonde.

## Fichiers

- `apps/api/src/lib/boot.ts` — implémentation de la sonde.
- `apps/api/src/index.ts` — branchement de la sonde dans la séquence de démarrage, après readiness.
- `apps/api/test/unit/usercontent-probe.test.ts` — tests unitaires.

Closes #1001