### PR TITLE
fix(chat): run cards stuck on "Lancement" — the turn-budget note broke tool-result parsing

### DIFF
--- a/packages/module-chat/src/pi-chat/mcp-tools.ts
+++ b/packages/module-chat/src/pi-chat/mcp-tools.ts
@@ -152,7 +152,12 @@ export interface BuildPlatformMcpToolsOptions {
  * synthetic message would move the breakpoint every step and never hit the cache
  * again. Written into a tool result the note is frozen into the transcript the
  * moment it is produced, so every later request keeps the exact same prefix and
- * the cache still hits. `details` (the UI channel) is left untouched.
+ * the cache still hits.
+ *
+ * The note lands in `content`, which the UI parses too (nothing reads `details`),
+ * so the payload stops being the only text part. `unwrapResult` on the UI side is
+ * deliberately tolerant of trailing non-payload text — do not append here without
+ * checking it still is.
  */
 export function withTurnBudgetNote(result: PiToolResult, budget: PiTurnBudget): PiToolResult {
   const now = (budget.now ?? Date.now)();
@@ -298,8 +303,8 @@ function makeRunAndWaitExtension(
         }
         // The final step is ALSO delivered as the tool result (tool_execution_end
         // re-emits it under the same id — an idempotent update to the same card).
-        // The budget note rides the MODEL channel only, so the UI card (fed from
-        // `details` by the live chunks above) is unchanged.
+        // That last write is the one the card keeps, and it carries the budget
+        // note appended to `content` — the very channel the card parses.
         return withTurnBudgetNote(toPiToolResult(finalPayload), ctx.turnBudget);
       },
     });

--- a/packages/module-chat/src/ui/tool-result.ts
+++ b/packages/module-chat/src/ui/tool-result.ts
@@ -38,12 +38,14 @@ function isTextPart(value: unknown): value is { type: "text"; text: string } {
  *
  * A content array may carry text parts that are NOT part of the payload: the Pi
  * engine appends a model-facing `[turn budget] …` line to every tool result, so
- * the joined text is `{"id":"run_…"}[turn budget] …` — not JSON. Joining first
- * still matters (a payload can arrive split across consecutive chunks), so we
- * join, and only when that fails fall back to the first part that parses on its
- * own. Without this the payload reads as a string, and every consumer built on
- * `asRecord` (run id/status for the run card, the error-shape checks behind
- * `deriveToolPhase`) silently degrades — a failed call would read as a success.
+ * the payload is no longer the only text part and the concatenation
+ * `{"id":"run_…"}[turn budget] …` is not JSON. Hence the rule for an array: the
+ * first text part that parses on its own wins — producers put the payload in
+ * one block, anything after it is prose. When no part parses, the joined text
+ * is returned, so a plain-text result still reads verbatim. Without this the
+ * payload reads as a string, and every consumer built on `asRecord` (run
+ * id/status for the run card, the error-shape checks behind `deriveToolPhase`)
+ * silently degrades — a failed call would read as a success.
  */
 export function unwrapResult(value: unknown, depth = 0): unknown {
   if (depth > 8 || value == null) return value;
@@ -61,18 +63,15 @@ export function unwrapResult(value: unknown, depth = 0): unknown {
   }
 
   if (Array.isArray(value)) {
-    // MCP content array of text parts → concat the text and parse.
+    // MCP content array of text parts → the first part that is a payload on its
+    // own, else the joined text (no payload here, just prose).
     const texts = value.filter(isTextPart).map((p) => p.text);
     if (texts.length > 0) {
-      const joined = unwrapResult(texts.join(""), depth + 1);
-      // A string back means the concatenation isn't JSON — either the payload
-      // sits in one part next to appended prose, or there is no payload at all.
-      if (typeof joined !== "string") return joined;
       for (const text of texts) {
         const part = unwrapResult(text, depth + 1);
         if (typeof part === "object" && part !== null) return part;
       }
-      return joined;
+      return texts.join("");
     }
     if (value.length === 1) return unwrapResult(value[0], depth + 1);
     return value;

--- a/packages/module-chat/src/ui/tool-result.ts
+++ b/packages/module-chat/src/ui/tool-result.ts
@@ -35,6 +35,15 @@ function isTextPart(value: unknown): value is { type: "text"; text: string } {
  * Peel the runtime/bridge envelopes off a tool result, returning the inner
  * payload (parsed when it arrives as a JSON string). Depth-bounded so a
  * pathological structure can't loop.
+ *
+ * A content array may carry text parts that are NOT part of the payload: the Pi
+ * engine appends a model-facing `[turn budget] …` line to every tool result, so
+ * the joined text is `{"id":"run_…"}[turn budget] …` — not JSON. Joining first
+ * still matters (a payload can arrive split across consecutive chunks), so we
+ * join, and only when that fails fall back to the first part that parses on its
+ * own. Without this the payload reads as a string, and every consumer built on
+ * `asRecord` (run id/status for the run card, the error-shape checks behind
+ * `deriveToolPhase`) silently degrades — a failed call would read as a success.
  */
 export function unwrapResult(value: unknown, depth = 0): unknown {
   if (depth > 8 || value == null) return value;
@@ -54,7 +63,17 @@ export function unwrapResult(value: unknown, depth = 0): unknown {
   if (Array.isArray(value)) {
     // MCP content array of text parts → concat the text and parse.
     const texts = value.filter(isTextPart).map((p) => p.text);
-    if (texts.length > 0) return unwrapResult(texts.join(""), depth + 1);
+    if (texts.length > 0) {
+      const joined = unwrapResult(texts.join(""), depth + 1);
+      // A string back means the concatenation isn't JSON — either the payload
+      // sits in one part next to appended prose, or there is no payload at all.
+      if (typeof joined !== "string") return joined;
+      for (const text of texts) {
+        const part = unwrapResult(text, depth + 1);
+        if (typeof part === "object" && part !== null) return part;
+      }
+      return joined;
+    }
     if (value.length === 1) return unwrapResult(value[0], depth + 1);
     return value;
   }

--- a/packages/module-chat/test/chat-turn-budget.test.ts
+++ b/packages/module-chat/test/chat-turn-budget.test.ts
@@ -246,7 +246,7 @@ describe("turn budget shown to the model (A5)", () => {
     expect(formatTurnBudgetNote({ remainingMs: 22_000, stepsUsed: 12 })).toContain("22s left");
   });
 
-  it("rides the Pi engine's tool results, leaving the UI channel untouched", () => {
+  it("appends to the model channel of a Pi tool result, leaving `details` as-is", () => {
     const result = withTurnBudgetNote(
       { content: [{ type: "text", text: '{"id":"run_1"}' }], details: { id: "run_1" } },
       { deadlineAt: NOW + 90_000, stepCount: () => 5, now: () => NOW },
@@ -257,7 +257,9 @@ describe("turn budget shown to the model (A5)", () => {
     expect(result.content[0]).toEqual({ type: "text", text: '{"id":"run_1"}' });
     expect(result.content[1]?.text).toContain("1m30s left");
     expect(result.content[1]?.text).toContain("step 5/16");
-    // `details` is the UI channel — it must not gain agent-facing chatter.
+    // `details` keeps the pre-note payload. That protects no UI: the UI parses
+    // `content` — the very channel the note is appended to — and nothing
+    // currently reads `details`.
     expect(result.details).toEqual({ id: "run_1" });
   });
 });

--- a/packages/module-chat/test/pi-chat-tool-result-boundary.test.ts
+++ b/packages/module-chat/test/pi-chat-tool-result-boundary.test.ts
@@ -12,8 +12,8 @@
  * producer functions and asserts the REAL consumer functions — a change to the
  * result shape on either side fails here.
  *
- * Fixtures are the payloads observed on the wire (chat session
- * `chs_f9d3d9fc39284c9e81543ab5f1903930` and its neighbours), not invented ones.
+ * Fixtures are the payload shapes observed on the wire, not invented ones (the
+ * identifiers themselves are anonymised).
  */
 
 import { describe, expect, it } from "bun:test";
@@ -43,16 +43,15 @@ describe("Pi tool result → chat UI (producer/consumer boundary)", () => {
     const result = withTurnBudgetNote(toPiToolResult({ id: "run_1" }), BUDGET);
 
     // The hazard this whole file guards: the payload is no longer the only text
-    // part, so joining the parts and parsing the concatenation yields a string.
+    // part of the model channel.
     expect(result.content).toHaveLength(2);
     expect(result.content[1]?.text).toStartWith("[turn budget]");
-    expect(() => JSON.parse(result.content.map((p) => p.text).join(""))).toThrow();
   });
 
   it("reads a succeeded run_and_wait result", () => {
     const payload = {
-      id: "run_65305695-9e33-4e69-8e04-b87615e63c09",
-      packageId: "@inline/r-e2f3b9ab-8554-496d-acae-819b420134b1",
+      id: "run_11111111-1111-4111-8111-111111111111",
+      packageId: "@inline/r-11111111-1111-4111-8111-111111111112",
       status: "success",
       done: true,
       result: { output: { done: true } },
@@ -66,8 +65,8 @@ describe("Pi tool result → chat UI (producer/consumer boundary)", () => {
 
   it("reads a cancelled run_and_wait result", () => {
     const payload = {
-      id: "run_eb16d791-9326-4ce3-a415-8e22e168db1e",
-      packageId: "@inline/r-7c2527d3-ad78-4c81-be27-9de36616c047",
+      id: "run_22222222-2222-4222-8222-222222222221",
+      packageId: "@inline/r-22222222-2222-4222-8222-222222222222",
       status: "cancelled",
       done: true,
       error: "Cancelled by user",
@@ -77,8 +76,11 @@ describe("Pi tool result → chat UI (producer/consumer boundary)", () => {
     expect(extractRunId(result)).toBe(payload.id);
     expect(extractRunStatus(result)).toBe("cancelled");
     // A cancellation carries a non-empty `error`, which `isErrorPayload` treats
-    // as a failure — the card renders red. Recorded as the current behaviour,
-    // not endorsed: a user-requested stop is not a tool error.
+    // as a failure. This phase is inert in the card once a run id exists:
+    // `StatusIcon` ignores `phase` whenever the run has a status, and the
+    // destructive styling + error line are gated on `!runId && phase ===
+    // "error"`. The card reads the run's own `cancelled` status and shows the
+    // muted "Annulé" line.
     expect(deriveToolPhase(complete(result))).toBe("error");
   });
 
@@ -88,8 +90,8 @@ describe("Pi tool result → chat UI (producer/consumer boundary)", () => {
     const envelope = {
       status: 201,
       body: {
-        id: "run_4c5ae2f5-ccc5-4238-9066-85df25b739c5",
-        packageId: "@pierre-cabriere/compteur",
+        id: "run_33333333-3333-4333-8333-333333333333",
+        packageId: "@acme/compteur",
         status: "pending",
       },
     };

--- a/packages/module-chat/test/pi-chat-tool-result-boundary.test.ts
+++ b/packages/module-chat/test/pi-chat-tool-result-boundary.test.ts
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Producer ↔ consumer contract for Pi tool results.
+ *
+ * The Pi engine's tool layer (`toPiToolResult` / `mcpResultToPi`, then
+ * `withTurnBudgetNote`) writes the shape the chat UI (`extractRunId`,
+ * `extractRunStatus`, `deriveToolPhase`) reads. Both sides had tests and both
+ * passed while the run card was broken in production: the producer tests
+ * asserted the note's text, the UI tests unwrapped hand-written envelopes, and
+ * nothing fed one into the other. So this file builds the payload with the REAL
+ * producer functions and asserts the REAL consumer functions — a change to the
+ * result shape on either side fails here.
+ *
+ * Fixtures are the payloads observed on the wire (chat session
+ * `chs_f9d3d9fc39284c9e81543ab5f1903930` and its neighbours), not invented ones.
+ */
+
+import { describe, expect, it } from "bun:test";
+import {
+  mcpResultToPi,
+  toPiToolResult,
+  withTurnBudgetNote,
+  type PiTurnBudget,
+} from "../src/pi-chat/mcp-tools.ts";
+import { extractRunId, extractRunStatus } from "../src/ui/run-events.ts";
+import { deriveToolPhase } from "../src/ui/tool-result.ts";
+
+const NOW = 1_800_000_000_000;
+
+/** Fixed clock + step count so the appended note is byte-stable. */
+const BUDGET: PiTurnBudget = {
+  deadlineAt: NOW + 9 * 60_000 + 54_000,
+  stepCount: () => 1,
+  now: () => NOW,
+};
+
+/** What the UI sees for a completed tool call. */
+const complete = (result: unknown) => ({ status: { type: "complete" }, result });
+
+describe("Pi tool result → chat UI (producer/consumer boundary)", () => {
+  it("appends a model-facing note the UI must tolerate", () => {
+    const result = withTurnBudgetNote(toPiToolResult({ id: "run_1" }), BUDGET);
+
+    // The hazard this whole file guards: the payload is no longer the only text
+    // part, so joining the parts and parsing the concatenation yields a string.
+    expect(result.content).toHaveLength(2);
+    expect(result.content[1]?.text).toStartWith("[turn budget]");
+    expect(() => JSON.parse(result.content.map((p) => p.text).join(""))).toThrow();
+  });
+
+  it("reads a succeeded run_and_wait result", () => {
+    const payload = {
+      id: "run_65305695-9e33-4e69-8e04-b87615e63c09",
+      packageId: "@inline/r-e2f3b9ab-8554-496d-acae-819b420134b1",
+      status: "success",
+      done: true,
+      result: { output: { done: true } },
+    };
+    const result = withTurnBudgetNote(toPiToolResult(payload), BUDGET);
+
+    expect(extractRunId(result)).toBe(payload.id);
+    expect(extractRunStatus(result)).toBe("success");
+    expect(deriveToolPhase(complete(result))).toBe("success");
+  });
+
+  it("reads a cancelled run_and_wait result", () => {
+    const payload = {
+      id: "run_eb16d791-9326-4ce3-a415-8e22e168db1e",
+      packageId: "@inline/r-7c2527d3-ad78-4c81-be27-9de36616c047",
+      status: "cancelled",
+      done: true,
+      error: "Cancelled by user",
+    };
+    const result = withTurnBudgetNote(toPiToolResult(payload), BUDGET);
+
+    expect(extractRunId(result)).toBe(payload.id);
+    expect(extractRunStatus(result)).toBe("cancelled");
+    // A cancellation carries a non-empty `error`, which `isErrorPayload` treats
+    // as a failure — the card renders red. Recorded as the current behaviour,
+    // not endorsed: a user-requested stop is not a tool error.
+    expect(deriveToolPhase(complete(result))).toBe("error");
+  });
+
+  it("reads a run launched through the forwarded invoke_operation path", () => {
+    // Forwarded MCP tools return the HTTP envelope verbatim, so the run id sits
+    // under `body`, and the text arrives pretty-printed by the platform.
+    const envelope = {
+      status: 201,
+      body: {
+        id: "run_4c5ae2f5-ccc5-4238-9066-85df25b739c5",
+        packageId: "@pierre-cabriere/compteur",
+        status: "pending",
+      },
+    };
+    const result = withTurnBudgetNote(
+      mcpResultToPi({ content: [{ type: "text", text: JSON.stringify(envelope, null, 2) }] }),
+      BUDGET,
+    );
+
+    expect(extractRunId(result)).toBe(envelope.body.id);
+    expect(extractRunStatus(result)).toBe("pending");
+    expect(deriveToolPhase(complete(result))).toBe("success");
+  });
+
+  it("still surfaces a failed forwarded call as an error", () => {
+    const envelope = {
+      status: 412,
+      body: { title: "Missing Integration Connection", status: 412 },
+    };
+    const result = withTurnBudgetNote(
+      mcpResultToPi({ content: [{ type: "text", text: JSON.stringify(envelope) }] }),
+      BUDGET,
+    );
+
+    expect(extractRunId(result)).toBeUndefined();
+    expect(deriveToolPhase(complete(result))).toBe("error");
+  });
+});

--- a/packages/module-chat/test/tool-result.test.ts
+++ b/packages/module-chat/test/tool-result.test.ts
@@ -42,7 +42,7 @@ describe("unwrapResult — envelope peeling", () => {
   });
 });
 
-describe("unwrapResult — trailing non-JSON text parts", () => {
+describe("unwrapResult — payload among several text parts", () => {
   // The Pi engine appends this model-facing line to every tool result.
   const budgetNote =
     "[turn budget] 7m44s left in this turn, step 1/16. " +
@@ -65,11 +65,12 @@ describe("unwrapResult — trailing non-JSON text parts", () => {
     expect(unwrapResult(mcp)).toEqual(runPayload);
   });
 
-  it("still reassembles a payload split across consecutive chunks", () => {
-    const json = JSON.stringify(runPayload);
+  it("recovers the payload when a prose part precedes it", () => {
+    // `mcpResultToPi` renders non-text MCP blocks as text (`[image …]`), so the
+    // payload is not always the first text part.
     const parts = [
-      { type: "text", text: json.slice(0, 20) },
-      { type: "text", text: json.slice(20) },
+      { type: "text", text: "[image image/png]" },
+      { type: "text", text: JSON.stringify(runPayload) },
     ];
     expect(unwrapResult(parts)).toEqual(runPayload);
   });

--- a/packages/module-chat/test/tool-result.test.ts
+++ b/packages/module-chat/test/tool-result.test.ts
@@ -42,6 +42,65 @@ describe("unwrapResult — envelope peeling", () => {
   });
 });
 
+describe("unwrapResult — trailing non-JSON text parts", () => {
+  // The Pi engine appends this model-facing line to every tool result.
+  const budgetNote =
+    "[turn budget] 7m44s left in this turn, step 1/16. " +
+    "A run_and_wait launch needs at least 2m left or it is refused; " +
+    "anything not written into your reply before the turn ends is lost.";
+  const runPayload = {
+    id: "run_da46b621",
+    packageId: "@appstrate/inbox-triage",
+    status: "success",
+    done: true,
+  };
+
+  it("recovers the payload when a turn-budget note follows it", () => {
+    const mcp = {
+      content: [
+        { type: "text", text: JSON.stringify(runPayload) },
+        { type: "text", text: budgetNote },
+      ],
+    };
+    expect(unwrapResult(mcp)).toEqual(runPayload);
+  });
+
+  it("still reassembles a payload split across consecutive chunks", () => {
+    const json = JSON.stringify(runPayload);
+    const parts = [
+      { type: "text", text: json.slice(0, 20) },
+      { type: "text", text: json.slice(20) },
+    ];
+    expect(unwrapResult(parts)).toEqual(runPayload);
+  });
+
+  it("returns the joined text when no part carries a payload", () => {
+    const parts = [
+      { type: "text", text: "all done. " },
+      { type: "text", text: budgetNote },
+    ];
+    expect(unwrapResult(parts)).toBe(`all done. ${budgetNote}`);
+  });
+
+  it("leaves a content array with no text parts unchanged", () => {
+    const parts = [
+      { type: "image", data: "…" },
+      { type: "image", data: "…" },
+    ];
+    expect(unwrapResult(parts)).toEqual(parts);
+  });
+
+  it("a failing payload followed by the note still reads as an error", () => {
+    const enveloped = {
+      content: [
+        { type: "text", text: JSON.stringify({ status: 502, error: "upstream unavailable" }) },
+        { type: "text", text: budgetNote },
+      ],
+    };
+    expect(deriveToolPhase({ status: { type: "complete" }, result: enveloped })).toBe("error");
+  });
+});
+
 describe("deriveToolPhase", () => {
   it("running status → running", () => {
     expect(deriveToolPhase({ status: { type: "running" }, result: undefined })).toBe("running");


### PR DESCRIPTION
## The symptom

In the chat, run cards stay on the "Lancement" placeholder with a spinner forever — including for runs that finished minutes earlier. Reproduced on production session `chs_f9d3…` (beta.42), where the two runs it shows as "launching" are `success` (46s) and `cancelled` (106s) in the database.

## Root cause

On the Pi engine (`engine: "subscription"`), `withTurnBudgetNote()` appends a second, model-facing text part to **every** tool result's `content` array — the `[turn budget] …` line added in #982:

```ts
return { ...result, content: [...result.content, { type: "text", text }] };
```

The chat UI's `unwrapResult()` joined all text parts and JSON-parsed the concatenation:

```ts
const texts = value.filter(isTextPart).map((p) => p.text);
if (texts.length > 0) return unwrapResult(texts.join(""), depth + 1);
```

`'{"id":"run_…","status":"success"}' + '[turn budget] …'` is not JSON, so the parse failed and the payload came back as a raw **string**. Everything built on `asRecord` then degraded silently:

| Consumer | Effect |
| --- | --- |
| `extractRunId` / `extractRunStatus` / `extractRunPackageId` / `extractRunDocuments` | `undefined` → the card never learns the run id, so it opens no SSE stream and never fetches `/api/runs/:id`. Hence the eternal "Lancement", and no elapsed time, no run-page link, no document chips. |
| `isErrorPayload` → `deriveToolPhase` | A **failed** tool call read as `phase: "success"` — a string can never match an error shape. |
| `extractErrorMessage`, `httpStatusOf` | Nothing extracted. |
| Detail modal "Sortie" | Mangled concatenation instead of the payload, for every tool call on the Pi engine. |

The ai-sdk engine is unaffected: it puts the same note in a system trailer message, not in a tool result.

## The fix

`unwrapResult`'s array branch scans the text parts and returns the first that parses on its own; when none does, the joined text is returned as before, so plain-text results are unchanged. That single change repairs every consumer above at once — no per-consumer patching, no second mechanism.

It is a read-time fix, so **messages already persisted heal on reload**. No migration.

The join-then-parse step is gone rather than kept as a fallback: no producer in this repo splits a payload across text parts (each emits one text block; the one multi-block producer puts the payload in block 0 followed by `resource_link`s), and on the Pi engine a split payload is unrecoverable either way once the note is appended.

## What the branch also corrects

The regression looked safe in review because three labels asserted a contract that does not exist — `withTurnBudgetNote`'s JSDoc and the `run_and_wait` call site both claimed the note "leaves `details`, the UI channel, untouched", and a green turn-budget test was named for it. No UI code reads `details`; the UI parses `content`. All three now say what is true.

## Tests

- `pi-chat-tool-result-boundary.test.ts` (new) — builds the payload with the **real** producers (`toPiToolResult` / `mcpResultToPi` + `withTurnBudgetNote`) and asserts the **real** consumers (`extractRunId` / `extractRunStatus` / `deriveToolPhase`), for both the `run_and_wait` and forwarded `invoke_operation` shapes. This is the gap that let the regression ship: both sides had tests, neither crossed the boundary.
- `tool-result.test.ts` — payload followed by the note, payload preceded by prose (`mcpResultToPi` renders non-text MCP blocks as text), joined-text fallback, and a failing payload + note still classified as an error.

Mutation-checked: reverting the fix fails 7 of the new tests. Fixture identifiers are anonymised.

## Verification

- `bun run check` — 33/33 tasks pass (tsc, eslint, prettier, 191-endpoint OpenAPI validation). The single lint warning is pre-existing on an untouched file.
- `bun test packages/module-chat/test/` — 309 pass, 0 fail.
- An audit of every `content`-array consumer in the repo (chat transcript/replay/persistence, `mcp-transport`, `runtime-pi`, sidecar, `afps-runtime`, platform MCP module, web SPA, the codex and claude-code modules, CLI) found **no other code affected** by the multi-part shape on a path the note reaches.
- Adversarial pass on the diff found no blocker: no throw, loop or unbounded growth on hostile input (2 MB payload, 20k parts, 12-deep nesting, cycles, `__proto__` payloads).

## Deliberately out of scope (pre-existing, filed here for follow-up)

1. **`use-run-log-stream.ts:118` reads fields the REST route does not emit.** `parseRunResource` expects `startedAt`/`completedAt`; `GET /api/runs/:id` emits `started_at`/`completed_at` (`services/state/runs.ts:234`). Bounded: the SSE snapshot is camelCase and arrives on subscribe, and a terminal run gets `duration` from REST — it only bites on an embedded mount with no org/app context, where a running run then shows no elapsed timer.
2. **`deriveToolPhase` classifies a user cancellation as `"error"`** (`isErrorPayload` fires on the non-empty `error: "Cancelled by user"`). Inert in the run card — `phase` is only consulted when no run id exists — but it is a wrong classification a future consumer could trust.
3. **The scan is order-dependent.** The payload wins because producers put it first. Unreachable today, but `mcpResultToPi` stringifies unknown MCP blocks into text parts, so a reordering upstream could make one win the scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
