### PR TITLE
fix(models): a model provider credential could become impossible to delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **A model provider credential could become impossible to delete** —
+  `GET /api/models` dropped every model whose credential could no longer serve
+  inference (a revoked OAuth refresh token, or a stored secret that no longer
+  decrypts). Since `org_models.credential_id` is `ON DELETE RESTRICT`, that
+  produced a deadlock seen in production: the model was invisible in the UI, so
+  it could not be detached, so its credential answered 409 `credential_in_use`
+  forever. Such a model is now LISTED with a new `needs_reconnection` field on
+  `OrgModel`, marked in the models table and in every picker, and still
+  deletable — detaching it is what frees the credential. The write and runtime
+  paths stay fail-closed: it cannot be selected in a picker, cannot become the
+  organization default (409 `model_needs_reconnection`), is refused by the chat
+  model resolver, and still resolves to null for inference. The `metadata_only`
+  query parameter on `GET /api/models` is removed: a row must be decrypted to
+  know its liveness, so the parameter no longer skipped any work.
+
 - **A raw credential starting with a scheme name was silently corrupted before
   it reached the upstream (#988)** — `normalizeAuthScheme` ran on the RESOLVED
   `Authorization` value, after credential injection, so its

--- a/apps/api/src/openapi/baseline.json
+++ b/apps/api/src/openapi/baseline.json
@@ -7805,15 +7805,6 @@
         "parameters": [
           {
             "$ref": "#/components/parameters/XOrgId"
-          },
-          {
-            "name": "metadata_only",
-            "in": "query",
-            "required": false,
-            "description": "When true, resolve each model's protocol family and base URL from the provider registry WITHOUT decrypting its credential. Faster for callers that only need to pick a model (e.g. the chat model picker); a model whose secret is unusable is not filtered and surfaces an error only at inference time.",
-            "schema": {
-              "type": "boolean"
-            }
           }
         ],
         "responses": {
@@ -7864,6 +7855,7 @@
                       "source": "built-in",
                       "enabled": true,
                       "is_default": false,
+                      "needs_reconnection": false,
                       "aliased": false,
                       "credentialId": "pk_abc123",
                       "contextWindow": 128000,
@@ -8062,6 +8054,16 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound"
+          },
+          "409": {
+            "description": "The model's stored credential can no longer be used for inference (`model_needs_reconnection`) — see the `needs_reconnection` field on `OrgModel`. Such a model is listed so it can be inspected or detached, but it cannot become the organization default: every run and chat would fail at inference time.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetail"
+                }
+              }
+            }
           }
         }
       }
@@ -23060,6 +23062,7 @@
           "modelId",
           "enabled",
           "is_default",
+          "needs_reconnection",
           "aliased",
           "iconUrl",
           "source",
@@ -23115,6 +23118,10 @@
           },
           "is_default": {
             "type": "boolean"
+          },
+          "needs_reconnection": {
+            "type": "boolean",
+            "description": "True when the model's stored credential can no longer be used for inference — an OAuth credential flagged as needing reconnection, or (either auth mode) a stored secret that no longer decrypts. The model is listed so it can be inspected, detached or deleted, but it is not usable for inference and cannot be made the organization default. Always false for built-in models, which read their key from the environment."
           },
           "aliased": {
             "type": "boolean",

--- a/apps/api/src/openapi/paths/models.ts
+++ b/apps/api/src/openapi/paths/models.ts
@@ -7,17 +7,7 @@ export const modelsPaths = {
       tags: ["Models"],
       summary: "List organization models",
       description: "Returns all models (built-in + custom) for the current organization.",
-      parameters: [
-        { $ref: "#/components/parameters/XOrgId" },
-        {
-          name: "metadata_only",
-          in: "query",
-          required: false,
-          description:
-            "When true, resolve each model's protocol family and base URL from the provider registry WITHOUT decrypting its credential. Faster for callers that only need to pick a model (e.g. the chat model picker); a model whose secret is unusable is not filtered and surfaces an error only at inference time.",
-          schema: { type: "boolean" },
-        },
-      ],
+      parameters: [{ $ref: "#/components/parameters/XOrgId" }],
       responses: {
         "200": {
           description: "Model list",
@@ -55,6 +45,7 @@ export const modelsPaths = {
                     source: "built-in",
                     enabled: true,
                     is_default: false,
+                    needs_reconnection: false,
                     aliased: false,
                     credentialId: "pk_abc123",
                     contextWindow: 128000,
@@ -205,6 +196,15 @@ export const modelsPaths = {
         // `setDefaultModel` throws `notFound`. The pointer never silently keeps
         // a stale/absent default.
         "404": { $ref: "#/components/responses/NotFound" },
+        "409": {
+          description:
+            "The model's stored credential can no longer be used for inference (`model_needs_reconnection`) — see the `needs_reconnection` field on `OrgModel`. Such a model is listed so it can be inspected or detached, but it cannot become the organization default: every run and chat would fail at inference time.",
+          content: {
+            "application/problem+json": {
+              schema: { $ref: "#/components/schemas/ProblemDetail" },
+            },
+          },
+        },
       },
     },
   },

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -1155,6 +1155,7 @@ export const schemas = {
       "modelId",
       "enabled",
       "is_default",
+      "needs_reconnection",
       "aliased",
       "iconUrl",
       "source",
@@ -1195,6 +1196,11 @@ export const schemas = {
       reasoning: { type: ["boolean", "null"] },
       enabled: { type: "boolean" },
       is_default: { type: "boolean" },
+      needs_reconnection: {
+        type: "boolean",
+        description:
+          "True when the model's stored credential can no longer be used for inference — an OAuth credential flagged as needing reconnection, or (either auth mode) a stored secret that no longer decrypts. The model is listed so it can be inspected, detached or deleted, but it is not usable for inference and cannot be made the organization default. Always false for built-in models, which read their key from the environment.",
+      },
       aliased: {
         type: "boolean",
         description:

--- a/apps/api/src/routes/models.ts
+++ b/apps/api/src/routes/models.ts
@@ -233,11 +233,14 @@ export function createModelsRouter() {
       }
       // Reachability gate — MUST run on both the explicit-label and the
       // derive-label paths, before the insert. `loadInferenceCredentials`
-      // returns null for a dead credential (OAuth in needs_reconnection,
-      // missing row, unresolvable baseUrl); the list serializer filters
-      // models bound to such credentials, so inserting first would 500 on
-      // the bare-resource re-projection below and leave a phantom row the
-      // caller can't see.
+      // returns null for a dead credential (OAuth in needs_reconnection, a
+      // blob that no longer decrypts, missing row, unresolvable baseUrl).
+      // Two things depend on it: everything below reads `creds` (alias
+      // invariants, the catalog defaults the token-budget check is measured
+      // against) and cannot be established without it; and `needs_reconnection`
+      // exists to explain a model that WENT dead, not to license minting one
+      // dead on arrival — such a row could never run, and could not even
+      // become the org default.
       const creds = await loadInferenceCredentials(orgId, credentialId);
       if (!creds) {
         throw invalidRequest(
@@ -595,12 +598,12 @@ export function createModelsRouter() {
         "credentialId",
       );
     }
-    // Reachability gate (same as POST) — re-pointing a model to a dead
-    // credential (needs_reconnection OAuth) would let the UPDATE succeed,
-    // then the bare-resource re-projection below 404s because the list
-    // serializer filters models bound to unreachable credentials — a
-    // misleading "Model not found" after a write that DID land. Reject
-    // before the write instead.
+    // Reachability gate (same as POST) — re-pointing a model AT a credential
+    // that can no longer serve inference is a deliberate move into a broken
+    // state: the row would come back flagged `needs_reconnection`, refuse to
+    // become the org default, and fail every run. Reject before the write.
+    // `newCreds` is also what the alias invariants and the catalog defaults
+    // below are established against.
     let newCreds: Awaited<ReturnType<typeof loadInferenceCredentials>> = null;
     if (data.credentialId) {
       newCreds = await loadInferenceCredentials(orgId, data.credentialId);

--- a/apps/api/src/routes/models.ts
+++ b/apps/api/src/routes/models.ts
@@ -191,13 +191,7 @@ export function createModelsRouter() {
   // GET /api/models — list all models (system + DB)
   router.get("/", requirePermission("models", "read"), async (c) => {
     const orgId = c.get("orgId");
-    // `metadata_only`: resolve protocol family/baseUrl from the registry without
-    // decrypting each model's credential. For callers that only need to pick a
-    // model row (e.g. the chat picker), not to call inference. Rows with a gone
-    // credential/provider are still dropped, but a model whose secret is unusable
-    // (dead OAuth) is NOT filtered here — it surfaces and errors at inference.
-    const metadataOnly = c.req.query("metadata_only") === "true";
-    const models = await listOrgModels(orgId, { metadataOnly });
+    const models = await listOrgModels(orgId);
     // Strip the backing of any model alias before it reaches the dashboard user
     // (Threat A) — see projectAliasedModel. Non-aliased models pass through.
     //

--- a/apps/api/src/services/chat-subscription.ts
+++ b/apps/api/src/services/chat-subscription.ts
@@ -45,10 +45,14 @@ export async function resolveSubscriptionChatModel(
 ): Promise<SubscriptionChatResolution> {
   const resolved = await loadModel(orgId, presetId);
   if (!resolved) {
-    // A model that resolves to nothing because its oauth credential is flagged
-    // needs-reconnection surfaces as a reconnect prompt; anything else (unknown
+    // A model that resolves to nothing because its stored credential is dead —
+    // oauth flagged needs-reconnection, or (either auth mode) a secret that no
+    // longer decrypts — surfaces as a reconnect prompt; anything else (unknown
     // preset, disabled model) falls through to the ai-sdk path, which produces
-    // the appropriate "no such model" error.
+    // the appropriate "no such model" error. Reached only after `loadModel`
+    // already returned null, so nothing is resolvable and no spend can happen
+    // on either branch: this only decides which error the user is shown, and
+    // "reconnect that credential" is the actionable one.
     if (await modelNeedsReconnection(orgId, presetId)) {
       return { subscription: true, needsReconnection: true };
     }

--- a/apps/api/src/services/model-providers/credentials.ts
+++ b/apps/api/src/services/model-providers/credentials.ts
@@ -676,7 +676,13 @@ export async function listOrgModelProviderCredentials(
         authMode: cfg?.authMode ?? "api_key",
         providerId: r.providerId,
         oauth_email: isOauth ? (blob.email ?? null) : null,
-        needs_reconnection: isOauth ? !!blob.needsReconnection : false,
+        // Dead for inference, by either route: an OAuth blob flagged for
+        // re-consent, or (either auth mode) a blob that no longer decrypts —
+        // `blob === null`, which also makes `isOauth` false. The model list
+        // badges its rows on the same two cases and points the user at THIS
+        // tab to fix them; narrowing this flag to the OAuth case would show
+        // the blamed credential as healthy, with no Reconnect button.
+        needs_reconnection: blob === null || (isOauth && !!blob.needsReconnection),
         available_model_ids: r.availableModelIds ?? null,
         created_by: r.createdBy,
         createdAt: toISORequired(r.createdAt),

--- a/apps/api/src/services/org-models.ts
+++ b/apps/api/src/services/org-models.ts
@@ -8,16 +8,12 @@ import { lookupCatalogModel } from "./pricing-catalog.ts";
 import type { CatalogModelEntry } from "@appstrate/shared-types";
 import type { ModelCost } from "@appstrate/core/module";
 import { logger } from "../lib/logger.ts";
-import { notFound } from "../lib/errors.ts";
+import { conflict, notFound } from "../lib/errors.ts";
 import { checkEgressUrl, egressGuardedFetch } from "../lib/egress-host-guard.ts";
 import { SsrfBlockedError } from "@appstrate/core/ssrf";
 import { dedupeLabel } from "@appstrate/core/dedupe-label";
 import type { ModelMetadata, OrgModelInfo, TestResult } from "@appstrate/shared-types";
-import {
-  loadInferenceCredentials,
-  loadCredentialRow,
-  loadCredentialMetadata,
-} from "./model-providers/credentials.ts";
+import { loadInferenceCredentials, loadCredentialMetadata } from "./model-providers/credentials.ts";
 import type { ModelApiShape } from "@appstrate/core/sidecar-types";
 import {
   getResolvedModel,
@@ -114,6 +110,15 @@ export function projectAliasedModel(model: OrgModelInfo): OrgModelInfo {
     label: model.label,
     enabled: model.enabled,
     is_default: model.is_default,
+    // Availability signal, NOT part of the backing — it names no provider,
+    // endpoint or upstream id, so it fingerprints nothing (unlike the
+    // capability/cost fields nulled below). Kept public because an alias can
+    // itself go dead: a DB row may be `aliased` while pointing at a real stored
+    // credential, and hiding the flag would put that alias right back in the
+    // state this projection's caller must be able to act on — listed, unusable,
+    // unexplained. (System/env aliases resolve from `SYSTEM_PROVIDER_KEYS`, a
+    // static key that never goes stale, so for them it is always false.)
+    needs_reconnection: model.needs_reconnection,
     aliased: model.aliased,
     // Deliberate public display icon — chosen on the alias, decoupled from the
     // backing provider, so it carries no fingerprint. Safe to surface.
@@ -141,10 +146,7 @@ export function projectAliasedModel(model: OrgModelInfo): OrgModelInfo {
 
 // --- List (system + DB) ---
 
-export async function listOrgModels(
-  orgId: string,
-  opts?: { metadataOnly?: boolean },
-): Promise<OrgModelInfo[]> {
+export async function listOrgModels(orgId: string): Promise<OrgModelInfo[]> {
   const system = getSystemModels();
   const rows = await db.select().from(orgModels).where(scopedWhere(orgModels, { orgId }));
   // The default is an org-level pointer: when set, exactly that id is the
@@ -153,44 +155,58 @@ export async function listOrgModels(
   const now = toISORequired(new Date());
 
   // Resolve apiShape/providerId/baseUrl per row (the DB row no longer stores
-  // them — they derive from the credential's `providerId`). Two modes:
-  //   - default: decrypt each credential (`loadInferenceCredentials`); a row
-  //     with an unreachable credential (deleted upstream, dead OAuth, decrypt
-  //     failure) is dropped — surfacing it would confuse the UI.
-  //   - metadataOnly: resolve from the registry WITHOUT touching the secret
-  //     (`loadCredentialMetadata`). Skips the decrypt for callers that only need
-  //     the protocol family (e.g. the chat model picker); the real secret is
-  //     resolved later at inference time. A row whose credential/provider is
-  //     gone is still dropped. mapRow below reads only providerId/apiShape/
-  //     baseUrl, so both resolvers feed it the same shape.
+  // them — they derive from the credential's `providerId`) plus the credential's
+  // liveness, through ONE predicate for every row:
+  //
+  //   `loadInferenceCredentials(...) === null`
+  //
+  // That was the old DROP predicate; it is now the FLAG predicate — the exact
+  // same test, so no new semantics: a row that used to disappear now appears
+  // flagged. Applied to api-key rows too, not just oauth2 ones: an api-key blob
+  // that no longer decrypts (a key rotation that retired a kid still in use, DB
+  // corruption) is just as dead as a revoked refresh token, and listing it as
+  // healthy would only move the failure to inference time. One decrypt per model
+  // per call — exactly what the pre-flag default path already did.
+  //
+  // A live probe is also authoritative for the display fields (it resolves the
+  // base URL through `effectiveBaseUrl`), so it is tried FIRST and the
+  // registry-metadata query only runs on the rare dead path. `null` metadata
+  // (credential row gone, or a `providerId` with no registry entry) STILL drops
+  // the row — with no provider there is nothing to render. Recovering those rows
+  // is out of scope for this fix.
   const credByRow = new Map<
     string,
-    { providerId: string; apiShape: ModelApiShape; baseUrl: string }
+    {
+      providerId: string;
+      apiShape: ModelApiShape;
+      baseUrl: string;
+      needsReconnection: boolean;
+    }
   >();
   await Promise.all(
     rows.map(async (r) => {
-      const creds = opts?.metadataOnly
-        ? await loadCredentialMetadata(r.credentialId, orgId)
-        : await loadInferenceCredentials(orgId, r.credentialId);
-      if (!creds) return;
-      // `metadataOnly` skips the decrypt, so it cannot see the OAuth blob's
-      // `needsReconnection` flag — a dead OAuth credential would otherwise
-      // leak into the model picker as a selectable (but unusable) model.
-      // Route OAuth rows through the decrypt gate (`loadInferenceCredentials`
-      // returns null for dead credentials), matching the default listing.
-      // api-key credentials can never be "dead", so they skip this probe.
-      if (opts?.metadataOnly && getModelProvider(creds.providerId)?.authMode === "oauth2") {
-        const live = await loadInferenceCredentials(orgId, r.credentialId);
-        if (!live) return;
+      const live = await loadInferenceCredentials(orgId, r.credentialId);
+      if (live) {
+        credByRow.set(r.id, {
+          providerId: live.providerId,
+          apiShape: live.apiShape,
+          baseUrl: live.baseUrl,
+          needsReconnection: false,
+        });
+        return;
       }
-      credByRow.set(r.id, creds);
+      const meta = await loadCredentialMetadata(r.credentialId, orgId);
+      if (!meta) return;
+      credByRow.set(r.id, { ...meta, needsReconnection: true });
     }),
   );
-  const reachableRows = rows.filter((r) => credByRow.has(r.id));
+  // "renderable", not "reachable": a dead-credential row is kept (flagged) —
+  // only a row with no resolvable provider is dropped.
+  const renderableRows = rows.filter((r) => credByRow.has(r.id));
 
-  return mergeSystemAndDb<ModelDefinition, (typeof reachableRows)[number], OrgModelInfo>({
+  return mergeSystemAndDb<ModelDefinition, (typeof renderableRows)[number], OrgModelInfo>({
     system,
-    rows: reachableRows,
+    rows: renderableRows,
     mapSystem: (id, def): OrgModelInfo => ({
       id,
       ...resolveModelMetadata(
@@ -205,6 +221,9 @@ export async function listOrgModels(
       modelId: def.modelId,
       enabled: def.enabled !== false,
       is_default: pointer !== null ? id === pointer : def.isDefault === true,
+      // System (env) models read their key from `SYSTEM_PROVIDER_KEYS` — no
+      // stored blob to be revoked or to stop decrypting, so never "dead".
+      needs_reconnection: false,
       aliased: def.aliased === true,
       iconUrl: def.iconUrl ?? null,
       source: "built-in",
@@ -229,6 +248,7 @@ export async function listOrgModels(
         modelId: row.modelId,
         enabled: row.enabled,
         is_default: pointer !== null && row.id === pointer,
+        needs_reconnection: creds.needsReconnection,
         aliased: row.aliased,
         // DB custom models declare no icon — the client resolves it from the
         // (visible) apiShape/baseUrl. Aliases live in env, never this table.
@@ -246,8 +266,9 @@ export async function listOrgModels(
 /**
  * Fetch a single org model by id, projected through the exact same serializer
  * as {@link listOrgModels} (so a mutation's return shape matches `GET`/list
- * byte-for-byte). Returns `undefined` when the id is unknown or its backing
- * credential is unreachable (the row is then absent from the list too).
+ * byte-for-byte). Returns `undefined` when the id is unknown or its credential
+ * row/provider is gone (the row is then absent from the list too). A dead
+ * credential is NOT such a case — it resolves, flagged `needs_reconnection`.
  *
  * Used by the create/update handlers to return the full resource instead of an
  * id-only stub (issue #646). Deliberately re-runs `listOrgModels` rather than
@@ -261,10 +282,10 @@ export async function getOrgModel(orgId: string, id: string): Promise<OrgModelIn
 
 /**
  * Raw custom-model row fetch — NO credential resolution, NO reachability
- * filtering. {@link getOrgModel} deliberately drops rows whose backing
- * credential is unreachable, which makes it unusable as the *pre-state* read
- * for update-time invariant checks (a row must be inspectable even when its
- * credential is dead). Exposes exactly the fields the update-time invariants
+ * filtering. {@link getOrgModel} still drops rows whose credential row/provider
+ * is gone, which makes it unusable as the *pre-state* read for update-time
+ * invariant checks (a row must be inspectable whatever its credential's
+ * state). Exposes exactly the fields the update-time invariants
  * need: alias fields, plus the stored modelId + token-budget overrides (the
  * effective-state `maxTokens < contextWindow` check). System (env) models are
  * not rows — callers gate on `isSystemModel` first.
@@ -508,6 +529,20 @@ export async function seedOrgModelsForCredential(
  * per-row flag flip — so there is nothing to keep transactionally consistent.
  */
 export async function setDefaultModel(orgId: string, modelDbId: string | null): Promise<void> {
+  // A model on a dead credential is now LISTED rather than silently dropped
+  // (so it can be inspected and detached), which also puts it within a
+  // client's reach here. Refuse it: the pointer feeds every run and chat, and
+  // resolution of a dead model fails at inference time. The check lives in this
+  // service — NOT in `createDefaultPointer`, which is shared byte-for-byte with
+  // `org-proxies` and must stay generic. `modelNeedsReconnection` is the single
+  // predicate (system ids, unknown rows and non-UUIDs all answer false, so the
+  // pointer helper below still owns the 404).
+  if (modelDbId !== null && (await modelNeedsReconnection(orgId, modelDbId))) {
+    throw conflict(
+      "model_needs_reconnection",
+      "This model's provider credential must be reconnected before it can be the default model. Reconnect the credential, or pick another model.",
+    );
+  }
   // Validate the target before storing it (mirrors the integration set-default
   // guard). A system id is trusted via the registry; a custom id must be a row
   // the org owns.
@@ -771,13 +806,20 @@ export async function loadModel(orgId: string, modelDbId: string): Promise<Resol
 
 /**
  * Disambiguate the `loadModel(...) === null` result for an org (DB) model: is it
- * null because the model is missing/disabled, or because its OAuth credential is
- * flagged `needsReconnection` (which `loadInferenceCredentials` treats as dead)?
+ * null because the model is missing/disabled, or because its credential can no
+ * longer serve inference at all — an OAuth credential flagged
+ * `needsReconnection`, a stored blob that no longer decrypts, or a
+ * provider/base-URL that no longer resolves?
  *
- * Returns `true` only for the second case — an enabled DB model whose OAuth
- * credential needs reconnection — so a caller can surface an actionable
- * "reconnect" instead of a misleading "not found / not enabled". System models
- * and non-UUID ids are never reconnection cases (`false`).
+ * Returns `true` only for the second case — an enabled DB model with a dead
+ * credential — so a caller can surface an actionable "reconnect" instead of a
+ * misleading "not found / not enabled". System models and non-UUID ids are never
+ * reconnection cases (`false`).
+ *
+ * The liveness test is deliberately the SAME call {@link listOrgModels} flags
+ * `needs_reconnection` with, so the read surface (the badge) and the write
+ * surface (the 409 in {@link setDefaultModel}) can never disagree about whether
+ * a given model is dead.
  */
 export async function modelNeedsReconnection(orgId: string, modelDbId: string): Promise<boolean> {
   if (isSystemModel(modelDbId)) return false;
@@ -796,8 +838,7 @@ export async function modelNeedsReconnection(orgId: string, modelDbId: string): 
   }
   if (!row || !row.enabled || !row.credentialId) return false;
 
-  const cred = await loadCredentialRow(row.credentialId, orgId);
-  return !!cred && cred.blob.kind === "oauth" && !!cred.blob.needsReconnection;
+  return (await loadInferenceCredentials(orgId, row.credentialId)) === null;
 }
 
 /**

--- a/apps/api/src/services/org-models.ts
+++ b/apps/api/src/services/org-models.ts
@@ -806,20 +806,28 @@ export async function loadModel(orgId: string, modelDbId: string): Promise<Resol
 
 /**
  * Disambiguate the `loadModel(...) === null` result for an org (DB) model: is it
- * null because the model is missing/disabled, or because its credential can no
- * longer serve inference at all — an OAuth credential flagged
- * `needsReconnection`, a stored blob that no longer decrypts, or a
- * provider/base-URL that no longer resolves?
+ * null because the model is missing/disabled, or because its stored credential
+ * can no longer serve inference — an OAuth credential flagged
+ * `needsReconnection`, or (either auth mode) a blob that no longer decrypts?
  *
- * Returns `true` only for the second case — an enabled DB model with a dead
- * credential — so a caller can surface an actionable "reconnect" instead of a
- * misleading "not found / not enabled". System models and non-UUID ids are never
- * reconnection cases (`false`).
+ * Returns `true` only for that second case, so a caller can surface an
+ * actionable "reconnect" instead of a misleading "not found / not enabled".
  *
- * The liveness test is deliberately the SAME call {@link listOrgModels} flags
- * `needs_reconnection` with, so the read surface (the badge) and the write
- * surface (the 409 in {@link setDefaultModel}) can never disagree about whether
- * a given model is dead.
+ * Scope, precisely — `true` requires ALL of: an existing DB row (system models
+ * and non-UUID ids answer `false`), that is `enabled`, whose credential fails
+ * {@link loadInferenceCredentials} AND still resolves through
+ * {@link loadCredentialMetadata}. That last conjunct is what keeps this aligned
+ * with what {@link listOrgModels} actually RENDERS as dead: a row whose
+ * credential row is gone, or whose `providerId` has no registry entry (its
+ * provider module was dropped from `MODULES`), is not listed at all — and its
+ * credential is fine, so "reconnect it" would be advice that fixes nothing
+ * about a row the client cannot even see. The fix there is to restore the
+ * provider.
+ *
+ * One divergence from the list is deliberate: a DISABLED row on a dead
+ * credential is flagged by the list (which flags regardless of `enabled`) but
+ * answers `false` here. It is inert either way — `resolveModel` cascades past
+ * it — and the actionable advice for it is "enable it", not "reconnect".
  */
 export async function modelNeedsReconnection(orgId: string, modelDbId: string): Promise<boolean> {
   if (isSystemModel(modelDbId)) return false;
@@ -838,7 +846,10 @@ export async function modelNeedsReconnection(orgId: string, modelDbId: string): 
   }
   if (!row || !row.enabled || !row.credentialId) return false;
 
-  return (await loadInferenceCredentials(orgId, row.credentialId)) === null;
+  // The list's two tests, in its order: dead for inference, but still
+  // renderable. See the doc block for why the second one is not redundant.
+  if ((await loadInferenceCredentials(orgId, row.credentialId)) !== null) return false;
+  return (await loadCredentialMetadata(row.credentialId, orgId)) !== null;
 }
 
 /**
@@ -1029,8 +1040,24 @@ export async function testModelConfig(config: {
 /** Test a saved model by ID (loads from DB/system registry then delegates to testModelConfig). */
 export async function testModelConnection(orgId: string, modelDbId: string): Promise<TestResult> {
   const model = await loadModel(orgId, modelDbId);
-  if (!model)
+  if (!model) {
+    // A dead-credential model is LISTED (flagged) while `loadModel` still
+    // refuses it, and the settings table offers "Test" on every listed row —
+    // so this is reached with the row on screen in front of the user. Answer
+    // with the surface's normal failed result: the route turns only
+    // `MODEL_NOT_FOUND` into a 404, and "Model not found" is the one thing
+    // that is demonstrably untrue here.
+    if (await modelNeedsReconnection(orgId, modelDbId)) {
+      return {
+        ok: false,
+        latency: 0,
+        error: "NEEDS_RECONNECTION",
+        message:
+          "This model's provider credential must be reconnected before it can be tested. Reconnect it in the Model Provider Keys tab.",
+      };
+    }
     return { ok: false, latency: 0, error: "MODEL_NOT_FOUND", message: "Model not found" };
+  }
 
   return testModelConfig(model);
 }

--- a/apps/api/test/helpers/seed.ts
+++ b/apps/api/test/helpers/seed.ts
@@ -26,7 +26,7 @@ import {
   orgInvitations,
   packageVersions,
 } from "@appstrate/db/schema";
-import type { InferInsertModel, InferSelectModel } from "drizzle-orm";
+import { eq, type InferInsertModel, type InferSelectModel } from "drizzle-orm";
 
 // ─── Packages / Agents ───────────────────────────────────
 
@@ -382,6 +382,29 @@ export async function seedOrgModelProviderOAuth(
     })
     .returning();
   return row!;
+}
+
+/**
+ * Make a seeded model-provider credential undecryptable the way production
+ * would: a key rotation retires a kid rows still reference, or the stored bytes
+ * are damaged. The envelope stays syntactically valid (`v1:<kid>:<base64>`,
+ * real kid) and only the ciphertext is flipped, so it fails GCM authentication
+ * exactly as a wrong key does — the read paths swallow that into `null` and
+ * must never throw.
+ */
+export async function corruptCredentialBlob(credentialId: string): Promise<void> {
+  const [row] = await db
+    .select({ credentialsEncrypted: modelProviderCredentials.credentialsEncrypted })
+    .from(modelProviderCredentials)
+    .where(eq(modelProviderCredentials.id, credentialId))
+    .limit(1);
+  const [version, kid, payload] = row!.credentialsEncrypted.split(":");
+  const packed = Buffer.from(payload!, "base64");
+  packed[packed.length - 1] = packed[packed.length - 1]! ^ 0xff;
+  await db
+    .update(modelProviderCredentials)
+    .set({ credentialsEncrypted: `${version}:${kid}:${packed.toString("base64")}` })
+    .where(eq(modelProviderCredentials.id, credentialId));
 }
 
 // ─── Org Models ───────────────────────────────────────────

--- a/apps/api/test/integration/routes/models.test.ts
+++ b/apps/api/test/integration/routes/models.test.ts
@@ -16,7 +16,7 @@ import {
   seedOrgModelProviderOAuth,
 } from "../../helpers/seed.ts";
 import { db } from "@appstrate/db/client";
-import { orgModels, organizations } from "@appstrate/db/schema";
+import { modelProviderCredentials, orgModels, organizations } from "@appstrate/db/schema";
 import { eq, and } from "drizzle-orm";
 import { initSystemModelProviderKeys } from "../../../src/services/model-registry.ts";
 import { listCatalogModels } from "../../../src/services/pricing-catalog.ts";
@@ -804,6 +804,143 @@ describe("Models API", () => {
 
       expect(res.status).toBe(204);
       expect(await res.text()).toBe("");
+    });
+  });
+
+  /**
+   * The production deadlock, walked end to end over HTTP.
+   *
+   * `listOrgModels` used to DROP a model whose credential could no longer serve
+   * inference, while `org_models.credential_id` (ON DELETE RESTRICT) kept that
+   * credential undeletable: the model was invisible, so it could not be
+   * detached, so the credential could not be deleted. The service-level tests
+   * pin the serializer; only these pin the sequence a user actually performs —
+   * in particular the final credential DELETE, without which a future
+   * reachability guard on `DELETE /api/models/:id` would reinstate the
+   * deadlock with the whole suite green.
+   */
+  describe("dead credential — end-to-end recovery over HTTP", () => {
+    /** A `needsReconnection` OAuth credential with one enabled model bound to it. */
+    async function seedDeadPair(label: string) {
+      const cred = await seedOrgModelProviderOAuth({
+        orgId: ctx.orgId,
+        providerId: TEST_OAUTH_PROVIDER_ID,
+        label: `${label} credential`,
+        needsReconnection: true,
+      });
+      const model = await seedOrgModel({
+        orgId: ctx.orgId,
+        credentialId: cred.id,
+        label,
+        modelId: "gpt-4o",
+        enabled: true,
+      });
+      return { cred, model };
+    }
+
+    it("lists the dead model, detaches it, then deletes the credential (204, not 409 credential_in_use)", async () => {
+      const { cred, model } = await seedDeadPair("Dead model");
+
+      // 1. It surfaces on GET — through the real serializer + alias projection.
+      const list = await app.request("/api/models", { headers: authHeaders(ctx) });
+      expect(list.status).toBe(200);
+      const listed = ((await list.json()) as any).data.find((m: any) => m.id === model.id);
+      expect(listed).toBeDefined();
+      expect(listed.needs_reconnection).toBe(true);
+
+      // 2. …so it can be detached,
+      const delModel = await app.request(`/api/models/${model.id}`, {
+        method: "DELETE",
+        headers: authHeaders(ctx),
+      });
+      expect(delModel.status).toBe(204);
+
+      // 3. …which releases the FK. This is the 409 the user could never escape.
+      const delCred = await app.request(`/api/model-provider-credentials/${cred.id}`, {
+        method: "DELETE",
+        headers: authHeaders(ctx),
+      });
+      expect(delCred.status).toBe(204);
+    });
+
+    it("refuses a dead model as the org default — 409 model_needs_reconnection", async () => {
+      const { model } = await seedDeadPair("Dead default candidate");
+
+      const res = await app.request("/api/models/default", {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({ modelId: model.id }),
+      });
+
+      expect(res.status).toBe(409);
+      expect(((await res.json()) as any).code).toBe("model_needs_reconnection");
+
+      const [org] = await db
+        .select({ defaultModelId: organizations.defaultModelId })
+        .from(organizations)
+        .where(eq(organizations.id, ctx.orgId))
+        .limit(1);
+      expect(org!.defaultModelId).toBeNull();
+    });
+
+    it("still accepts a model whose credential's providerId is unregistered", async () => {
+      // NOT a 409: the credential is healthy — its provider module was dropped
+      // from `MODULES`, which is why the model is absent from GET /api/models
+      // in the first place. "Reconnect this credential" would be misdirection
+      // about a row the client cannot even see; the fix is to restore the
+      // module. So this behaves exactly as it did before the flag existed.
+      const { cred, model } = await seedDeadPair("Orphaned provider");
+      await db
+        .update(modelProviderCredentials)
+        .set({ providerId: "@gone/provider" })
+        .where(eq(modelProviderCredentials.id, cred.id));
+
+      const list = await app.request("/api/models", { headers: authHeaders(ctx) });
+      expect(((await list.json()) as any).data.find((m: any) => m.id === model.id)).toBeUndefined();
+
+      const res = await app.request("/api/models/default", {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({ modelId: model.id }),
+      });
+      // 204, not 200: the write lands, but the handler re-reads the list to
+      // echo the effective default and the row is not in it. Pre-existing
+      // shape, unchanged by this branch — the assertion of record is the
+      // stored pointer below.
+      expect(res.status).toBe(204);
+
+      const [org] = await db
+        .select({ defaultModelId: organizations.defaultModelId })
+        .from(organizations)
+        .where(eq(organizations.id, ctx.orgId))
+        .limit(1);
+      expect(org!.defaultModelId).toBe(model.id);
+    });
+
+    it("answers the Test action with a failed result, not a 404, on a dead model", async () => {
+      // The settings table renders "Test" on every listed row, dead ones
+      // included — a 404 "Model not found" about a row on screen is the wrong
+      // answer. Same envelope the client already renders for a failed probe.
+      const { model } = await seedDeadPair("Dead test target");
+
+      const res = await app.request(`/api/models/${model.id}/test`, {
+        method: "POST",
+        headers: authHeaders(ctx),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.ok).toBe(false);
+      expect(body.error).toBe("NEEDS_RECONNECTION");
+      expect(body.message).toContain("reconnected");
+    });
+
+    it("still 404s the Test action for a model id that does not exist", async () => {
+      const res = await app.request(`/api/models/${crypto.randomUUID()}/test`, {
+        method: "POST",
+        headers: authHeaders(ctx),
+      });
+      expect(res.status).toBe(404);
     });
   });
 

--- a/apps/api/test/integration/services/model-provider-credentials.test.ts
+++ b/apps/api/test/integration/services/model-provider-credentials.test.ts
@@ -43,6 +43,7 @@ import {
   resetModelProviders,
 } from "../../../src/services/model-providers/registry.ts";
 import { seedTestModelProviders } from "../../helpers/model-providers.ts";
+import { corruptCredentialBlob } from "../../helpers/seed.ts";
 import { initSystemModelProviderKeys } from "../../../src/services/model-registry.ts";
 
 const PLAINTEXT = "sk-test-plaintext-do-not-leak-12345";
@@ -458,6 +459,44 @@ describe("model-provider-credentials service — aggregator + inference loader",
       expect(oauth!.id).toBe(imported.credentialId);
       expect(oauth!.oauth_email).toBe("user@example.com");
       expect(oauth!.needs_reconnection).toBe(false);
+    });
+
+    it("flags a credential whose blob no longer decrypts, in either auth mode", async () => {
+      // The models tab badges such a credential's models "unavailable" and
+      // sends the user here to reconnect or replace it. Before this, the flag
+      // was OAuth-only and read off the decrypted blob — so an undecryptable
+      // blob (`blob === null`, hence `isOauth === false`) rendered as a
+      // perfectly healthy credential with no Reconnect button.
+      const ctx = await createTestContext({ orgSlug: "agg-list-corrupt" });
+      const apiKeyId = await createApiKeyCredential({
+        orgId: ctx.orgId,
+        userId: ctx.user.id,
+        label: "OpenAI",
+        providerId: "openai",
+        apiKey: PLAINTEXT,
+      });
+      const oauthId = await createOAuthCredential({
+        orgId: ctx.orgId,
+        userId: ctx.user.id,
+        label: "Subscription",
+        providerId: TEST_OAUTH,
+        accessToken: "a",
+        refreshToken: "r",
+        expiresAt: null,
+      });
+      await corruptCredentialBlob(apiKeyId);
+      await corruptCredentialBlob(oauthId);
+
+      const list = await listOrgModelProviderCredentials(ctx.orgId);
+      expect(list.find((k) => k.id === apiKeyId)!.needs_reconnection).toBe(true);
+      const oauth = list.find((k) => k.id === oauthId)!;
+      expect(oauth.needs_reconnection).toBe(true);
+      // `authMode` comes from the registry, not the blob, so the Reconnect
+      // button (gated on authMode === "oauth2" && needs_reconnection) shows.
+      expect(oauth.authMode).toBe("oauth2");
+      // Same verdict as the inference path, which is what the model list flags on.
+      expect(await loadInferenceCredentials(ctx.orgId, apiKeyId)).toBeNull();
+      expect(await loadInferenceCredentials(ctx.orgId, oauthId)).toBeNull();
     });
   });
 

--- a/apps/api/test/integration/services/org-models-needs-reconnection.test.ts
+++ b/apps/api/test/integration/services/org-models-needs-reconnection.test.ts
@@ -29,6 +29,7 @@ import { ApiError } from "../../../src/lib/errors.ts";
 import { db, truncateAll } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
 import {
+  corruptCredentialBlob,
   seedOrgModel,
   seedOrgModelProviderKey,
   seedOrgModelProviderOAuth,
@@ -75,24 +76,6 @@ describe("org-models — dead OAuth credential is listed, not hidden", () => {
       enabled: true,
     });
     return { cred, model };
-  }
-
-  /**
-   * Make a stored credential undecryptable the way production would: a key
-   * rotation retires a kid rows still reference, or the bytes are damaged. The
-   * envelope stays syntactically valid (`v1:<kid>:<base64>`, real kid, longer
-   * than IV+tag) and only the ciphertext is flipped, so it fails GCM
-   * authentication exactly as a wrong key does. `decryptBlob` swallows that into
-   * `null` — nothing must throw out of the read paths.
-   */
-  async function corruptBlob(credentialId: string, envelope: string) {
-    const [version, kid, payload] = envelope.split(":");
-    const packed = Buffer.from(payload!, "base64");
-    packed[packed.length - 1] = packed[packed.length - 1]! ^ 0xff;
-    await db
-      .update(modelProviderCredentials)
-      .set({ credentialsEncrypted: `${version}:${kid}:${packed.toString("base64")}` })
-      .where(eq(modelProviderCredentials.id, credentialId));
   }
 
   it("lists a model whose OAuth credential needs reconnection, flagged", async () => {
@@ -143,7 +126,7 @@ describe("org-models — dead OAuth credential is listed, not hidden", () => {
 
   it("flags an api-key model whose stored blob no longer decrypts", async () => {
     const { cred, model } = await seedApiKeyModel();
-    await corruptBlob(cred.id, cred.credentialsEncrypted);
+    await corruptCredentialBlob(cred.id);
 
     const listed = (await listOrgModels(ctx.orgId)).find((m) => m.id === model.id);
     // Listed (so it can be detached/deleted) but never presented as usable.
@@ -168,6 +151,14 @@ describe("org-models — dead OAuth credential is listed, not hidden", () => {
 
     const listed = (await listOrgModels(ctx.orgId)).find((m) => m.id === model.id);
     expect(listed).toBeUndefined();
+
+    // …and the predicate agrees with the list on this row. The credential is
+    // healthy — only its provider module is gone — so answering `true` here
+    // would 409 `PUT /api/models/default` with "reconnect this credential",
+    // advice that fixes nothing, about a row the client cannot even see. The
+    // fix is to restore the module; until then this behaves as it did before
+    // the flag existed.
+    expect(await modelNeedsReconnection(ctx.orgId, model.id)).toBe(false);
   });
 
   it("refuses to make a dead model the org default (409 model_needs_reconnection)", async () => {
@@ -194,7 +185,7 @@ describe("org-models — dead OAuth credential is listed, not hidden", () => {
     // 200: the list badged the model dead while the setter happily pointed the
     // org default at it. Pin that the two surfaces agree.
     const { cred, model } = await seedApiKeyModel();
-    await corruptBlob(cred.id, cred.credentialsEncrypted);
+    await corruptCredentialBlob(cred.id);
 
     let thrown: unknown;
     try {
@@ -216,6 +207,14 @@ describe("org-models — dead OAuth credential is listed, not hidden", () => {
     // Disabled: `loadModel` is null for the row regardless of its credential,
     // so "needs reconnection" must stay false — the caller's answer is
     // "not enabled", not "go reconnect".
+    //
+    // This is the one place the predicate deliberately diverges from the list,
+    // which flags a dead-credential row regardless of `enabled`. Both are
+    // right for their surface: the badge explains why a row the user is
+    // looking at is unusable, while a disabled model is inert either way
+    // (`resolveModel` cascades past it) and the step that unblocks it is
+    // "enable it", not "reconnect the credential". Not an oversight — do not
+    // "fix" this to true.
     const { cred } = await seedOAuthModel(true);
     const disabled = await seedOrgModel({
       orgId: ctx.orgId,

--- a/apps/api/test/integration/services/org-models-needs-reconnection.test.ts
+++ b/apps/api/test/integration/services/org-models-needs-reconnection.test.ts
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `listOrgModels` used to DROP any model whose OAuth credential was flagged
+ * `needsReconnection` — while `org_models.credential_id` (ON DELETE RESTRICT)
+ * made that credential undeletable. The model was invisible in the UI, so it
+ * could not be detached, so the credential could not be deleted: a deadlock
+ * observed in production.
+ *
+ * The row is now listed with `needs_reconnection: true` instead. These tests
+ * pin both halves of that contract:
+ *   - the read path SHOWS the dead model (regression), while a missing
+ *     credential row / unregistered provider is still dropped (nothing to
+ *     render), and
+ *   - the write + runtime paths stay FAIL-CLOSED — it cannot become the org
+ *     default, and `loadModel` still resolves it to null.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { eq } from "drizzle-orm";
+import { modelProviderCredentials } from "@appstrate/db/schema";
+import {
+  listOrgModels,
+  loadModel,
+  setDefaultModel,
+  modelNeedsReconnection,
+} from "../../../src/services/org-models.ts";
+import { ApiError } from "../../../src/lib/errors.ts";
+import { db, truncateAll } from "../../helpers/db.ts";
+import { createTestContext, type TestContext } from "../../helpers/auth.ts";
+import {
+  seedOrgModel,
+  seedOrgModelProviderKey,
+  seedOrgModelProviderOAuth,
+} from "../../helpers/seed.ts";
+
+describe("org-models — dead OAuth credential is listed, not hidden", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "deadcredorg" });
+  });
+
+  /** `test-oauth` is the synthetic core `authMode: "oauth2"` provider. */
+  async function seedOAuthModel(needsReconnection: boolean) {
+    const cred = await seedOrgModelProviderOAuth({
+      orgId: ctx.orgId,
+      label: "Subscription",
+      needsReconnection,
+    });
+    const model = await seedOrgModel({
+      orgId: ctx.orgId,
+      credentialId: cred.id,
+      label: "Subscription model",
+      modelId: "gpt-5-codex",
+      enabled: true,
+    });
+    return { cred, model };
+  }
+
+  async function seedApiKeyModel() {
+    const cred = await seedOrgModelProviderKey({
+      orgId: ctx.orgId,
+      label: "OpenAI",
+      apiShape: "openai-completions",
+      baseUrl: "https://api.openai.com/v1",
+      apiKey: "sk-test",
+    });
+    const model = await seedOrgModel({
+      orgId: ctx.orgId,
+      credentialId: cred.id,
+      label: "GPT-4o",
+      modelId: "gpt-4o",
+      enabled: true,
+    });
+    return { cred, model };
+  }
+
+  /**
+   * Make a stored credential undecryptable the way production would: a key
+   * rotation retires a kid rows still reference, or the bytes are damaged. The
+   * envelope stays syntactically valid (`v1:<kid>:<base64>`, real kid, longer
+   * than IV+tag) and only the ciphertext is flipped, so it fails GCM
+   * authentication exactly as a wrong key does. `decryptBlob` swallows that into
+   * `null` — nothing must throw out of the read paths.
+   */
+  async function corruptBlob(credentialId: string, envelope: string) {
+    const [version, kid, payload] = envelope.split(":");
+    const packed = Buffer.from(payload!, "base64");
+    packed[packed.length - 1] = packed[packed.length - 1]! ^ 0xff;
+    await db
+      .update(modelProviderCredentials)
+      .set({ credentialsEncrypted: `${version}:${kid}:${packed.toString("base64")}` })
+      .where(eq(modelProviderCredentials.id, credentialId));
+  }
+
+  it("lists a model whose OAuth credential needs reconnection, flagged", async () => {
+    const { model } = await seedOAuthModel(true);
+
+    const listed = (await listOrgModels(ctx.orgId)).find((m) => m.id === model.id);
+    // The regression: this used to be `undefined`.
+    expect(listed).toBeDefined();
+    expect(listed!.needs_reconnection).toBe(true);
+    // Display fields still resolve (from the registry metadata) so the row can
+    // actually be rendered and acted on.
+    expect(listed!.providerId).toBe("test-oauth");
+    expect(listed!.apiShape).toBe("openai-responses");
+    expect(listed!.baseUrl).toBe("https://example.test/v1");
+    expect(listed!.credentialId).toBe(model.credentialId);
+  });
+
+  it("flags a model on a healthy OAuth credential as false", async () => {
+    const { model } = await seedOAuthModel(false);
+
+    const listed = (await listOrgModels(ctx.orgId)).find((m) => m.id === model.id);
+    expect(listed).toBeDefined();
+    expect(listed!.needs_reconnection).toBe(false);
+    expect(listed!.providerId).toBe("test-oauth");
+    expect(listed!.baseUrl).toBe("https://example.test/v1");
+  });
+
+  it("flags a model on an api-key credential as false, with the decrypt path untouched", async () => {
+    const { cred, model } = await seedApiKeyModel();
+
+    const listed = (await listOrgModels(ctx.orgId)).find((m) => m.id === model.id);
+    expect(listed).toBeDefined();
+    expect(listed!.needs_reconnection).toBe(false);
+    // Same resolver as before the flag existed — the projection must stay
+    // byte-identical to what the run path's credential lookup produces.
+    expect(listed!.providerId).toBe("openai");
+    expect(listed!.apiShape).toBe("openai-responses");
+    expect(listed!.baseUrl).toBe("https://api.openai.com/v1");
+    expect(listed!.credentialId).toBe(cred.id);
+
+    const resolved = await loadModel(ctx.orgId, model.id);
+    expect(resolved).not.toBeNull();
+    expect(resolved!.apiKey).toBe("sk-test");
+    expect(resolved!.providerId).toBe("openai");
+    expect(resolved!.apiShape).toBe("openai-responses");
+    expect(resolved!.baseUrl).toBe("https://api.openai.com/v1");
+  });
+
+  it("flags an api-key model whose stored blob no longer decrypts", async () => {
+    const { cred, model } = await seedApiKeyModel();
+    await corruptBlob(cred.id, cred.credentialsEncrypted);
+
+    const listed = (await listOrgModels(ctx.orgId)).find((m) => m.id === model.id);
+    // Listed (so it can be detached/deleted) but never presented as usable.
+    expect(listed).toBeDefined();
+    expect(listed!.needs_reconnection).toBe(true);
+    expect(listed!.providerId).toBe("openai");
+    // Fail-closed at the runtime boundary, exactly like a dead OAuth row.
+    expect(await loadModel(ctx.orgId, model.id)).toBeNull();
+  });
+
+  it("still drops a model whose credential has an unregistered providerId", async () => {
+    const { cred, model } = await seedApiKeyModel();
+    // The credential ROW cannot be deleted while the model references it
+    // (ON DELETE RESTRICT) — the reachable way to lose the provider is a
+    // `providerId` with no registry entry (module removed from MODULES).
+    // Without one there is no apiShape/baseUrl to render, so the row stays
+    // dropped; recovering it is out of scope here.
+    await db
+      .update(modelProviderCredentials)
+      .set({ providerId: "@gone/provider" })
+      .where(eq(modelProviderCredentials.id, cred.id));
+
+    const listed = (await listOrgModels(ctx.orgId)).find((m) => m.id === model.id);
+    expect(listed).toBeUndefined();
+  });
+
+  it("refuses to make a dead model the org default (409 model_needs_reconnection)", async () => {
+    const { model } = await seedOAuthModel(true);
+    expect(await modelNeedsReconnection(ctx.orgId, model.id)).toBe(true);
+
+    let thrown: unknown;
+    try {
+      await setDefaultModel(ctx.orgId, model.id);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ApiError);
+    expect((thrown as ApiError).status).toBe(409);
+    expect((thrown as ApiError).code).toBe("model_needs_reconnection");
+
+    // The pointer was never written — the org default is untouched.
+    const listed = await listOrgModels(ctx.orgId);
+    expect(listed.find((m) => m.id === model.id)!.is_default).toBe(false);
+  });
+
+  it("refuses an api-key model whose blob no longer decrypts as the org default", async () => {
+    // Before `modelNeedsReconnection` used the list's predicate, this returned
+    // 200: the list badged the model dead while the setter happily pointed the
+    // org default at it. Pin that the two surfaces agree.
+    const { cred, model } = await seedApiKeyModel();
+    await corruptBlob(cred.id, cred.credentialsEncrypted);
+
+    let thrown: unknown;
+    try {
+      await setDefaultModel(ctx.orgId, model.id);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(ApiError);
+    expect((thrown as ApiError).status).toBe(409);
+    expect((thrown as ApiError).code).toBe("model_needs_reconnection");
+  });
+
+  it("keeps modelNeedsReconnection false for a healthy model and for a disabled one", async () => {
+    // The broadened predicate must not swallow the early returns that own the
+    // callers' 404 / fall-through semantics.
+    const { model: healthy } = await seedApiKeyModel();
+    expect(await modelNeedsReconnection(ctx.orgId, healthy.id)).toBe(false);
+
+    // Disabled: `loadModel` is null for the row regardless of its credential,
+    // so "needs reconnection" must stay false — the caller's answer is
+    // "not enabled", not "go reconnect".
+    const { cred } = await seedOAuthModel(true);
+    const disabled = await seedOrgModel({
+      orgId: ctx.orgId,
+      credentialId: cred.id,
+      label: "Disabled on a dead credential",
+      modelId: "gpt-5-codex",
+      enabled: false,
+    });
+    expect(await modelNeedsReconnection(ctx.orgId, disabled.id)).toBe(false);
+  });
+
+  it("still sets the org default for a healthy model", async () => {
+    const { model } = await seedOAuthModel(false);
+
+    await setDefaultModel(ctx.orgId, model.id);
+
+    const listed = (await listOrgModels(ctx.orgId)).find((m) => m.id === model.id);
+    expect(listed!.is_default).toBe(true);
+  });
+
+  it("keeps loadModel fail-closed for a dead model", async () => {
+    const { model } = await seedOAuthModel(true);
+    // The security-relevant half: listing the row must NOT make it resolvable
+    // for inference. The runtime path is unchanged.
+    expect(await loadModel(ctx.orgId, model.id)).toBeNull();
+  });
+});

--- a/apps/api/test/unit/services/project-aliased-model.test.ts
+++ b/apps/api/test/unit/services/project-aliased-model.test.ts
@@ -28,6 +28,7 @@ const base: OrgModelInfo = {
   cost: { input: 0.27, output: 1.1, cacheRead: 0.07, cacheWrite: 0.27 },
   enabled: true,
   is_default: false,
+  needs_reconnection: false,
   aliased: false,
   iconUrl: null,
   source: "built-in",
@@ -72,6 +73,16 @@ describe("projectAliasedModel", () => {
     expect(json).not.toContain("deepseek");
     expect(json).not.toContain("deepseek-chat");
     expect(json).not.toContain("api.deepseek.com");
+  });
+
+  it("preserves needs_reconnection on an aliased model", () => {
+    // An availability bit, not part of the backing: it names no provider,
+    // endpoint or upstream id. An aliased DB row can sit on a dead OAuth
+    // credential, and the operator surface needs to know why it is unusable.
+    const out = projectAliasedModel({ ...base, aliased: true, needs_reconnection: true });
+    expect(out.needs_reconnection).toBe(true);
+    expect(out.providerId).toBeNull(); // backing still hidden
+    expect(out.baseUrl).toBeNull();
   });
 
   it("preserves a declared iconUrl on an aliased model", () => {

--- a/apps/cli/src/commands/models.ts
+++ b/apps/cli/src/commands/models.ts
@@ -45,6 +45,9 @@ export async function modelsListCommand(opts: ModelsListOptions): Promise<void> 
       const suffixes: string[] = [];
       if (m.isDefault) suffixes.push("default");
       if (!m.enabled) suffixes.push("disabled");
+      // Listed, but the resolver refuses it — say so here, since this listing
+      // is what the resolver's error tells the user to consult.
+      if (m.needs_reconnection === true) suffixes.push("needs-reconnection");
       if (!PROXY_SUPPORTED_APIS.has(m.apiShape)) suffixes.push("proxy-unsupported");
       const suffix = suffixes.length > 0 ? ` [${suffixes.join(", ")}]` : "";
       process.stdout.write(`  ${m.id.padEnd(36)}  ${m.apiShape.padEnd(24)}  ${m.label}${suffix}\n`);

--- a/apps/cli/src/commands/run/model.ts
+++ b/apps/cli/src/commands/run/model.ts
@@ -219,6 +219,18 @@ export async function resolvePresetModel(inputs: PresetResolutionInputs): Promis
   return { model, apiKey };
 }
 
+/**
+ * A listed-but-dead preset. Fails here rather than at the first LLM call:
+ * `GET /api/models` no longer hides such a preset, so without this the id
+ * would resolve and the run would die at the llm-proxy with an opaque error.
+ */
+function deadPresetError(presetId: string): ModelResolutionError {
+  return new ModelResolutionError(
+    `Preset "${presetId}" can no longer be used for inference`,
+    "Its credential needs to be reconnected in Settings → Models. Pick another preset, or run with --model-source env.",
+  );
+}
+
 function pickPreset(presets: ModelPreset[], requestedId?: string): ModelPreset {
   if (presets.length === 0) {
     throw new ModelResolutionError(
@@ -241,9 +253,11 @@ function pickPreset(presets: ModelPreset[], requestedId?: string): ModelPreset {
         "Pick another preset or ask an admin to enable it.",
       );
     }
+    if (match.needs_reconnection === true) throw deadPresetError(requestedId);
     return match;
   }
   const defaultPreset = presets.find((p) => p.isDefault && p.enabled);
+  if (defaultPreset?.needs_reconnection === true) throw deadPresetError(defaultPreset.id);
   if (!defaultPreset) {
     throw new ModelResolutionError(
       "No default preset is set on this instance",

--- a/apps/cli/src/lib/models.ts
+++ b/apps/cli/src/lib/models.ts
@@ -26,6 +26,14 @@ export interface ModelPreset {
   apiShape: string;
   enabled: boolean;
   isDefault: boolean;
+  /**
+   * The preset's stored credential can no longer serve inference. Such a
+   * preset is LISTED by `GET /api/models` (so it can be reconnected or
+   * deleted) but resolving one would only fail later at the llm-proxy.
+   * Optional + `!== true` semantics: an instance older than this CLI does
+   * not send the field, and absent means live.
+   */
+  needs_reconnection?: boolean;
   source: "built-in" | "custom";
   contextWindow: number | null;
   maxTokens: number | null;

--- a/apps/cli/test/run-model.test.ts
+++ b/apps/cli/test/run-model.test.ts
@@ -322,6 +322,57 @@ describe("resolvePresetModel — proxy routing per protocol", () => {
     expect(apiKey).not.toContain("sk-ant-oat");
   });
 
+  it("rejects a requested preset whose credential is dead, naming the real reason", async () => {
+    // `GET /api/models` now LISTS such a preset instead of hiding it, so the
+    // id resolves — without the liveness gate the run would reach the
+    // llm-proxy and die there. "No preset matches" would be a lie: it exists.
+    await expect(
+      resolvePresetModel({
+        profileName: "default",
+        modelId: "preset_dead",
+        instance: "https://app.example.com",
+        bearerToken: "ask_test",
+        orgId: "org_1",
+        presetsLoader: async () => [
+          makePreset({
+            id: "preset_dead",
+            apiShape: "openai-completions",
+            needs_reconnection: true,
+          }),
+        ],
+      }),
+    ).rejects.toThrow(/can no longer be used for inference/);
+  });
+
+  it("rejects a dead org default rather than reporting no default is set", async () => {
+    await expect(
+      resolvePresetModel({
+        profileName: "default",
+        instance: "https://app.example.com",
+        bearerToken: "ask_test",
+        orgId: "org_1",
+        presetsLoader: async () => [
+          makePreset({
+            id: "preset_dead_default",
+            apiShape: "openai-completions",
+            needs_reconnection: true,
+          }),
+        ],
+      }),
+    ).rejects.toThrow(/preset_dead_default.*can no longer be used/);
+  });
+
+  it("treats an absent needs_reconnection as live (older instance)", async () => {
+    const { model } = await resolvePresetModel({
+      profileName: "default",
+      instance: "https://app.example.com",
+      bearerToken: "ask_test",
+      orgId: "org_1",
+      presetsLoader: async () => [PRESET_OPENAI],
+    });
+    expect(model.id).toBe("preset_openai");
+  });
+
   it("rejects unsupported protocols with an actionable hint", async () => {
     await expect(
       resolvePresetModel({

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -5225,6 +5225,8 @@ export interface components {
             reasoning?: boolean | null;
             enabled: boolean;
             is_default: boolean;
+            /** @description True when the model's stored credential can no longer be used for inference — an OAuth credential flagged as needing reconnection, or (either auth mode) a stored secret that no longer decrypts. The model is listed so it can be inspected, detached or deleted, but it is not usable for inference and cannot be made the organization default. Always false for built-in models, which read their key from the environment. */
+            needs_reconnection: boolean;
             /** @description Managed-model flag. When true, the binding (`modelId`, `apiShape`, `baseUrl`, `credentialId`, capabilities/cost) is not exposed in this projection — these fields are `null`; render a managed badge. */
             aliased: boolean;
             /** @description Display-icon key for the UI (a client provider-icon key, e.g. `anthropic`, `openai`). A deliberate public choice on the model — decoupled from the provider, so a managed model can show an icon without exposing its binding. `null` means resolve the icon from the (visible) `apiShape`/`baseUrl`, or fall back to a generic icon. */
@@ -13243,10 +13245,7 @@ export interface operations {
     };
     listModels: {
         parameters: {
-            query?: {
-                /** @description When true, resolve each model's protocol family and base URL from the provider registry WITHOUT decrypting its credential. Faster for callers that only need to pick a model (e.g. the chat model picker); a model whose secret is unusable is not filtered and surfaces an error only at inference time. */
-                metadata_only?: boolean;
-            };
+            query?: never;
             header?: {
                 /** @description Organization ID. Required for cookie auth. Not needed for API key auth (org resolved from key). */
                 "X-Org-Id"?: components["parameters"]["XOrgId"];
@@ -13281,6 +13280,7 @@ export interface operations {
                      *           "source": "built-in",
                      *           "enabled": true,
                      *           "is_default": false,
+                     *           "needs_reconnection": false,
                      *           "aliased": false,
                      *           "credentialId": "pk_abc123",
                      *           "contextWindow": 128000,
@@ -13403,6 +13403,15 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
+            /** @description The model's stored credential can no longer be used for inference (`model_needs_reconnection`) — see the `needs_reconnection` field on `OrgModel`. Such a model is listed so it can be inspected or detached, but it cannot become the organization default: every run and chat would fail at inference time. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetail"];
+                };
+            };
         };
     };
     searchOpenRouterModels: {

--- a/apps/web/src/components/default-cell.tsx
+++ b/apps/web/src/components/default-cell.tsx
@@ -12,7 +12,10 @@ import { Button } from "@appstrate/ui/components/button";
  *
  * `canSetDefault` lets a surface hide the button on rows that can never become
  * default (e.g. an integration auth with a single eligible client). When the
- * row is neither the default nor settable, nothing renders.
+ * row is neither the default nor settable, nothing renders. `disabled` is the
+ * other half of that choice — the row *is* of a kind that can be the default
+ * but this one currently cannot, which the user is owed an explanation for:
+ * pass `disabledTitle` (same contract as `RunAgentButton`).
  */
 export function DefaultCell({
   isDefault,
@@ -21,6 +24,7 @@ export function DefaultCell({
   onSetDefault,
   canSetDefault = true,
   disabled = false,
+  disabledTitle,
   testId,
 }: {
   isDefault: boolean;
@@ -29,6 +33,7 @@ export function DefaultCell({
   onSetDefault: () => void;
   canSetDefault?: boolean;
   disabled?: boolean;
+  disabledTitle?: string;
   testId?: string;
 }) {
   if (isDefault) {
@@ -41,6 +46,7 @@ export function DefaultCell({
       variant="ghost"
       className="h-7 text-xs"
       disabled={disabled}
+      title={disabled ? disabledTitle : undefined}
       onClick={onSetDefault}
       data-testid={testId}
     >

--- a/apps/web/src/components/default-cell.tsx
+++ b/apps/web/src/components/default-cell.tsx
@@ -14,8 +14,9 @@ import { Button } from "@appstrate/ui/components/button";
  * default (e.g. an integration auth with a single eligible client). When the
  * row is neither the default nor settable, nothing renders. `disabled` is the
  * other half of that choice — the row *is* of a kind that can be the default
- * but this one currently cannot, which the user is owed an explanation for:
- * pass `disabledTitle` (same contract as `RunAgentButton`).
+ * but this one currently cannot. The reason belongs elsewhere in the row: the
+ * button carries `disabled:pointer-events-none`, so it is not a hover target
+ * and a `title` on it would never surface.
  */
 export function DefaultCell({
   isDefault,
@@ -24,7 +25,6 @@ export function DefaultCell({
   onSetDefault,
   canSetDefault = true,
   disabled = false,
-  disabledTitle,
   testId,
 }: {
   isDefault: boolean;
@@ -33,7 +33,6 @@ export function DefaultCell({
   onSetDefault: () => void;
   canSetDefault?: boolean;
   disabled?: boolean;
-  disabledTitle?: string;
   testId?: string;
 }) {
   if (isDefault) {
@@ -46,7 +45,6 @@ export function DefaultCell({
       variant="ghost"
       className="h-7 text-xs"
       disabled={disabled}
-      title={disabled ? disabledTitle : undefined}
       onClick={onSetDefault}
       data-testid={testId}
     >

--- a/apps/web/src/components/model-availability-badge.tsx
+++ b/apps/web/src/components/model-availability-badge.tsx
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { useTranslation } from "react-i18next";
+import { Badge } from "@appstrate/ui/components/badge";
+import { isModelSelectable } from "../lib/model-selectability";
+import type { OrgModelInfo } from "../hooks/use-models";
+
+/**
+ * "This model's credential can no longer serve inference" — the read-side
+ * counterpart of `needs_reconnection`. Mirrors the badge the credentials table
+ * already renders for the credential itself, so the two tables read the same.
+ *
+ * Wording is credential-neutral on purpose: the flag is also raised for an
+ * api-key credential whose stored secret no longer decrypts, where
+ * "reconnect the OAuth account" would be wrong advice.
+ */
+export function ModelUnavailableBadge({ className }: { className?: string }) {
+  const { t } = useTranslation("settings");
+  return (
+    <Badge
+      variant="destructive"
+      className={className}
+      title={t("models.credentialUnavailableHint")}
+    >
+      {t("models.credentialUnavailable")}
+    </Badge>
+  );
+}
+
+/**
+ * The same information inline, for the model `<Select>`s: a picker renders
+ * every model but only lets {@link isModelSelectable} ones be chosen, and a
+ * greyed row with no stated reason is what made this bug confusing in the
+ * first place. A `<span>` rather than the `<Badge>` (a `<div>`) because Radix
+ * puts `SelectItem` children inside `SelectItemText`'s span — and clones them
+ * into the closed trigger, so a pinned-but-dead model states its reason
+ * without opening the dropdown.
+ *
+ * Renders nothing for a selectable model.
+ */
+export function ModelUnselectableNote({ model }: { model: OrgModelInfo }) {
+  const { t } = useTranslation("settings");
+  if (isModelSelectable(model)) return null;
+  if (model.needs_reconnection) {
+    return (
+      <span className="text-destructive text-xs" title={t("models.credentialUnavailableHint")}>
+        ({t("models.credentialUnavailable")})
+      </span>
+    );
+  }
+  return <span className="text-muted-foreground text-xs">({t("models.disabled")})</span>;
+}

--- a/apps/web/src/components/package-detail/agent-configuration-tab.tsx
+++ b/apps/web/src/components/package-detail/agent-configuration-tab.tsx
@@ -16,6 +16,8 @@ import { useUploadClient } from "../../hooks/use-upload";
 import { getModelIcon } from "../icons";
 import { useProvidersRegistry } from "../../hooks/use-model-provider-credentials";
 import { useModels, useAgentModel, useSetAgentModel } from "../../hooks/use-models";
+import { isModelSelectable } from "../../lib/model-selectability";
+import { ModelUnselectableNote } from "../model-availability-badge";
 import { useProxies, useAgentProxy, useSetAgentProxy } from "../../hooks/use-proxies";
 import { usePackageDetail } from "../../hooks/use-packages";
 import { useSaveConfig } from "../../hooks/use-mutations";
@@ -79,7 +81,9 @@ function ModelSection({ packageId }: { packageId: string }) {
   if (!orgModels || orgModels.length === 0) return null;
 
   const agentModelId = agentModel?.modelId;
-  const orgDefaultModel = orgModels.find((m) => m.is_default && m.enabled);
+  // Unfiltered on purpose — see the same call in `run-overrides-panel.tsx`:
+  // the inherited default must be named even when it is unusable.
+  const orgDefaultModel = orgModels.find((m) => m.is_default);
 
   return (
     <div className="border-border bg-card space-y-3 rounded-lg border p-4">
@@ -94,17 +98,21 @@ function ModelSection({ packageId }: { packageId: string }) {
         </SelectTrigger>
         <SelectContent>
           <SelectItem value="__inherit__">
-            {orgDefaultModel
-              ? t("models.agent.inherit", { ns: "settings", name: orgDefaultModel.label })
-              : t("models.agent.inheritNoDefault", { ns: "settings" })}
+            <span className="inline-flex items-center gap-1.5">
+              {orgDefaultModel
+                ? t("models.agent.inherit", { ns: "settings", name: orgDefaultModel.label })
+                : t("models.agent.inheritNoDefault", { ns: "settings" })}
+              {orgDefaultModel && <ModelUnselectableNote model={orgDefaultModel} />}
+            </span>
           </SelectItem>
           {orgModels.map((m) => {
             const MIcon = getModelIcon(m, registry ?? []);
             return (
-              <SelectItem key={m.id} value={m.id}>
+              <SelectItem key={m.id} value={m.id} disabled={!isModelSelectable(m)}>
                 <span className="inline-flex items-center gap-1.5">
                   {MIcon && <MIcon className="size-3.5" />}
                   {m.label}
+                  <ModelUnselectableNote model={m} />
                 </span>
               </SelectItem>
             );

--- a/apps/web/src/components/run-modal.tsx
+++ b/apps/web/src/components/run-modal.tsx
@@ -9,6 +9,7 @@ import type { SchemaWrapper, JSONSchemaObject } from "@appstrate/core/form";
 import { useSchemaFormLabels } from "../hooks/use-schema-form-labels";
 import { useUploadClient } from "../hooks/use-upload";
 import { useModels, useAgentModel } from "../hooks/use-models";
+import { isModelSelectable } from "../lib/model-selectability";
 import type { AgentDetail } from "@appstrate/shared-types";
 
 interface RunModalProps {
@@ -121,8 +122,8 @@ function RunModalForm({
  * the run will use BEFORE triggering. The org default is resolved at run
  * creation, so a default changed mid-session silently applies to the next
  * run — this line makes that visible at trigger time. A stale agent pin
- * (model deleted/disabled) falls back to the org default, matching
- * `resolveModel` server-side.
+ * (model deleted/disabled/on a dead credential) falls back to the org default,
+ * matching `resolveModel` server-side.
  */
 function ResolvedModelHint({ packageId }: { packageId: string }) {
   const { t } = useTranslation(["agents"]);
@@ -131,11 +132,29 @@ function ResolvedModelHint({ packageId }: { packageId: string }) {
 
   if (!orgModels || orgModels.length === 0) return null;
 
-  const pinned = agentModel?.modelId
-    ? orgModels.find((m) => m.id === agentModel.modelId && m.enabled)
+  // Candidates are found WITHOUT the selectability filter, then filtered — so
+  // when the cascade resolves to nothing we still know which model failed it
+  // and can name it, instead of rendering an empty line for a run that is
+  // about to fail with no explanation.
+  const pinnedCandidate = agentModel?.modelId
+    ? orgModels.find((m) => m.id === agentModel.modelId)
     : undefined;
-  const resolved = pinned ?? orgModels.find((m) => m.is_default && m.enabled);
-  if (!resolved) return null;
+  const defaultCandidate = orgModels.find((m) => m.is_default);
+  const pinned =
+    pinnedCandidate && isModelSelectable(pinnedCandidate) ? pinnedCandidate : undefined;
+  const resolved =
+    pinned ??
+    (defaultCandidate && isModelSelectable(defaultCandidate) ? defaultCandidate : undefined);
+
+  if (!resolved) {
+    const dead = defaultCandidate ?? pinnedCandidate;
+    if (!dead) return null;
+    return (
+      <p className="text-destructive text-xs" data-testid="run-resolved-model">
+        {t("input.modelUnavailable", { name: dead.label })}
+      </p>
+    );
+  }
 
   const source = pinned ? t("input.modelSourceAgent") : t("input.modelSourceOrgDefault");
 

--- a/apps/web/src/components/run-modal.tsx
+++ b/apps/web/src/components/run-modal.tsx
@@ -133,9 +133,8 @@ function ResolvedModelHint({ packageId }: { packageId: string }) {
   if (!orgModels || orgModels.length === 0) return null;
 
   // Candidates are found WITHOUT the selectability filter, then filtered — so
-  // when the cascade resolves to nothing we still know which model failed it
-  // and can name it, instead of rendering an empty line for a run that is
-  // about to fail with no explanation.
+  // when the cascade resolves to nothing we still know which model failed it,
+  // instead of rendering an empty line for a run that is about to fail.
   const pinnedCandidate = agentModel?.modelId
     ? orgModels.find((m) => m.id === agentModel.modelId)
     : undefined;
@@ -147,7 +146,10 @@ function ResolvedModelHint({ packageId }: { packageId: string }) {
     (defaultCandidate && isModelSelectable(defaultCandidate) ? defaultCandidate : undefined);
 
   if (!resolved) {
-    const dead = defaultCandidate ?? pinnedCandidate;
+    // Only a dead credential earns a line. A merely disabled candidate renders
+    // nothing, as before — the message names the credential as the cause and
+    // would be a false statement for a healthy model that is switched off.
+    const dead = [defaultCandidate, pinnedCandidate].find((m) => m?.needs_reconnection);
     if (!dead) return null;
     return (
       <p className="text-destructive text-xs" data-testid="run-resolved-model">

--- a/apps/web/src/components/run-overrides-panel.tsx
+++ b/apps/web/src/components/run-overrides-panel.tsx
@@ -15,6 +15,8 @@ import { useSchemaFormLabels } from "../hooks/use-schema-form-labels";
 import { useUploadClient } from "../hooks/use-upload";
 import type { JSONSchemaObject, SchemaWrapper } from "@appstrate/core/form";
 import { useModels } from "../hooks/use-models";
+import { isModelSelectable } from "../lib/model-selectability";
+import { ModelUnselectableNote } from "./model-availability-badge";
 import { useProxies } from "../hooks/use-proxies";
 import { useProvidersRegistry } from "../hooks/use-model-provider-credentials";
 import { getModelIcon } from "./icons";
@@ -165,7 +167,11 @@ export function RunOverridesPanel({
     }
   };
 
-  const orgDefaultModel = orgModels?.find((m) => m.is_default && m.enabled);
+  // No selectability filter: "inherit" must keep naming the org default even
+  // when that default is unusable — an unlabelled "inherit" row would hide the
+  // very thing the run is about to fail on. The label carries the reason
+  // instead (ModelUnselectableNote below).
+  const orgDefaultModel = orgModels?.find((m) => m.is_default);
   const orgDefaultProxy = orgProxies?.find((p) => p.is_default && p.enabled);
 
   const modelSelectValue = value.model_id_override ?? persistedModelId ?? INHERIT;
@@ -181,21 +187,28 @@ export function RunOverridesPanel({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
+              {/* "Inherit" stays selectable even when the default is dead: it
+                  is the absence of an override, so disabling it would trap a
+                  user who wants to clear one. */}
               <SelectItem value={INHERIT}>
-                {orgDefaultModel
-                  ? t("run.overrides.modelInheritWithDefault", {
-                      ns: "agents",
-                      name: orgDefaultModel.label,
-                    })
-                  : t("run.overrides.modelInherit", { ns: "agents" })}
+                <span className="inline-flex items-center gap-1.5">
+                  {orgDefaultModel
+                    ? t("run.overrides.modelInheritWithDefault", {
+                        ns: "agents",
+                        name: orgDefaultModel.label,
+                      })
+                    : t("run.overrides.modelInherit", { ns: "agents" })}
+                  {orgDefaultModel && <ModelUnselectableNote model={orgDefaultModel} />}
+                </span>
               </SelectItem>
               {orgModels.map((m) => {
                 const MIcon = getModelIcon(m, registry ?? []);
                 return (
-                  <SelectItem key={m.id} value={m.id}>
+                  <SelectItem key={m.id} value={m.id} disabled={!isModelSelectable(m)}>
                     <span className="inline-flex items-center gap-1.5">
                       {MIcon && <MIcon className="size-3.5" />}
                       {m.label}
+                      <ModelUnselectableNote model={m} />
                     </span>
                   </SelectItem>
                 );

--- a/apps/web/src/hooks/test/use-agent-readiness.test.ts
+++ b/apps/web/src/hooks/test/use-agent-readiness.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The model half of the run-button gate. `resolvesToUsableModel` has to mirror
+ * the server cascade in `resolveModel` (agent pin → org default): a green Run
+ * button that ends in an inference error, or a greyed one for a run the server
+ * would have happily resolved, are both wrong.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { resolvesToUsableModel } from "../use-agent-readiness";
+import type { OrgModelInfo } from "../use-models";
+
+function model(over: Partial<OrgModelInfo>): OrgModelInfo {
+  return {
+    id: "m1",
+    label: "Claude",
+    apiShape: "anthropic-messages",
+    providerId: "anthropic",
+    providerName: "Anthropic",
+    baseUrl: "https://api.anthropic.com",
+    modelId: "claude-sonnet-4",
+    enabled: true,
+    is_default: false,
+    needs_reconnection: false,
+    aliased: false,
+    iconUrl: null,
+    source: "custom",
+    credentialId: "c1",
+    created_by: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+const DEFAULT_OK = model({ id: "m_default", is_default: true });
+
+describe("resolvesToUsableModel", () => {
+  it("accepts a usable pin", () => {
+    expect(resolvesToUsableModel([model({ id: "m_pin" })], "m_pin")).toBe(true);
+  });
+
+  it("accepts a usable org default with no pin", () => {
+    expect(resolvesToUsableModel([DEFAULT_OK], null)).toBe(true);
+  });
+
+  it("falls back to the org default when the pin is dead", () => {
+    // `resolveModel` step 1 returns null for a dead pin and drops to step 2.
+    const pin = model({ id: "m_pin", needs_reconnection: true });
+    expect(resolvesToUsableModel([pin, DEFAULT_OK], "m_pin")).toBe(true);
+  });
+
+  it("falls back to the org default when the pin is not listed at all", () => {
+    expect(resolvesToUsableModel([DEFAULT_OK], "m_deleted")).toBe(true);
+  });
+
+  it("rejects a dead pin with a dead default — nothing left to resolve", () => {
+    const pin = model({ id: "m_pin", needs_reconnection: true });
+    const dead = model({ id: "m_default", is_default: true, needs_reconnection: true });
+    expect(resolvesToUsableModel([pin, dead], "m_pin")).toBe(false);
+  });
+
+  it("rejects a disabled org default", () => {
+    expect(resolvesToUsableModel([model({ is_default: true, enabled: false })], null)).toBe(false);
+  });
+
+  it("rejects a catalog with no default at all", () => {
+    expect(resolvesToUsableModel([model({ id: "m_other" })], null)).toBe(false);
+  });
+
+  it("rejects an empty catalog", () => {
+    expect(resolvesToUsableModel([], "m_pin")).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/use-agent-readiness.ts
+++ b/apps/web/src/hooks/use-agent-readiness.ts
@@ -8,15 +8,24 @@ import { isPromptEmpty, findMissingDependencies } from "@appstrate/core/validati
 import { isModelSelectable } from "../lib/model-selectability";
 
 /**
- * A pin the org can no longer see (row deleted, or its credential/provider
- * gone so `GET /api/models` drops it) is not a failure here — the server falls
- * through to the org default for exactly that case. Only a pin that IS listed
- * and is unusable counts as "no model from the pin".
+ * Will a run get a model? Mirrors the server cascade (`resolveModel`): the
+ * agent pin wins when it is usable, otherwise the org default is tried.
+ *
+ * A pin alone is NOT enough — a pinned model on a dead credential resolves to
+ * null server-side, so counting it would green-light a run that cannot reach
+ * any inference endpoint. An unusable pin is not fatal either: `resolveModel`
+ * falls through to the org default, whether the pin is unusable or absent from
+ * the list entirely (row deleted, or its provider gone).
+ *
+ * Exported for its unit test — the hook below is the only production caller.
  */
-function isPinUsable(orgModels: OrgModelInfo[], agentModelId?: string | null): boolean {
-  if (!agentModelId) return false;
-  const pinned = orgModels.find((m) => m.id === agentModelId);
-  return pinned ? isModelSelectable(pinned) : false;
+export function resolvesToUsableModel(
+  orgModels: OrgModelInfo[],
+  agentModelId?: string | null,
+): boolean {
+  const pinned = agentModelId ? orgModels.find((m) => m.id === agentModelId) : undefined;
+  if (pinned && isModelSelectable(pinned)) return true;
+  return orgModels.some((m) => m.is_default && isModelSelectable(m));
 }
 
 export function useAgentReadiness(
@@ -37,16 +46,8 @@ export function useAgentReadiness(
       hasConfigSchema: !!(
         configSchema?.properties && Object.keys(configSchema.properties).length > 0
       ),
-      // Mirrors the server cascade (`resolveModel`): the agent pin wins when
-      // it is usable, otherwise the org default is tried. A pin alone is NOT
-      // enough — a pinned model on a dead credential resolves to null server
-      // side, so counting it as "has a model" would green-light a run that
-      // cannot reach any inference endpoint.
-      hasModel:
-        orgModels !== undefined
-          ? isPinUsable(orgModels, agentModelId) ||
-            orgModels.some((m) => m.is_default && isModelSelectable(m))
-          : true,
+      // Unknown catalog (still loading) is optimistic — don't flash "no model".
+      hasModel: orgModels !== undefined ? resolvesToUsableModel(orgModels, agentModelId) : true,
       hasPrompt: detail ? !isPromptEmpty(detail.prompt ?? "") : false,
       hasRequiredSkills: detail
         ? findMissingDependencies(

--- a/apps/web/src/hooks/use-agent-readiness.ts
+++ b/apps/web/src/hooks/use-agent-readiness.ts
@@ -5,6 +5,19 @@ import type { AgentDetail } from "@appstrate/shared-types";
 import type { OrgModelInfo } from "./use-models";
 import type { JSONSchemaObject } from "@appstrate/core/form";
 import { isPromptEmpty, findMissingDependencies } from "@appstrate/core/validation";
+import { isModelSelectable } from "../lib/model-selectability";
+
+/**
+ * A pin the org can no longer see (row deleted, or its credential/provider
+ * gone so `GET /api/models` drops it) is not a failure here — the server falls
+ * through to the org default for exactly that case. Only a pin that IS listed
+ * and is unusable counts as "no model from the pin".
+ */
+function isPinUsable(orgModels: OrgModelInfo[], agentModelId?: string | null): boolean {
+  if (!agentModelId) return false;
+  const pinned = orgModels.find((m) => m.id === agentModelId);
+  return pinned ? isModelSelectable(pinned) : false;
+}
 
 export function useAgentReadiness(
   detail: AgentDetail | undefined,
@@ -24,9 +37,15 @@ export function useAgentReadiness(
       hasConfigSchema: !!(
         configSchema?.properties && Object.keys(configSchema.properties).length > 0
       ),
+      // Mirrors the server cascade (`resolveModel`): the agent pin wins when
+      // it is usable, otherwise the org default is tried. A pin alone is NOT
+      // enough — a pinned model on a dead credential resolves to null server
+      // side, so counting it as "has a model" would green-light a run that
+      // cannot reach any inference endpoint.
       hasModel:
         orgModels !== undefined
-          ? !!agentModelId || orgModels.some((m) => m.is_default && m.enabled)
+          ? isPinUsable(orgModels, agentModelId) ||
+            orgModels.some((m) => m.is_default && isModelSelectable(m))
           : true,
       hasPrompt: detail ? !isPromptEmpty(detail.prompt ?? "") : false,
       hasRequiredSkills: detail

--- a/apps/web/src/lib/model-selectability.ts
+++ b/apps/web/src/lib/model-selectability.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { OrgModelInfo } from "../hooks/use-models";
+
+/**
+ * Can this model be picked for a run or a chat?
+ *
+ * Two independent ways a LISTED model is unusable, and every selection surface
+ * must honour both — they are exactly the two `loadModel()` returns null for:
+ *
+ *  - `enabled: false` — the row is switched off.
+ *  - `needs_reconnection` — its stored credential can no longer serve
+ *    inference (an OAuth credential flagged for reconnection, or, for either
+ *    auth mode, a secret that no longer decrypts).
+ *
+ * Such a model is listed on purpose: it used to be dropped from
+ * `GET /api/models`, which made it invisible, hence impossible to detach,
+ * which pinned its credential behind a permanent 409 `credential_in_use`.
+ * The read surface now shows it so it can be inspected and deleted — so
+ * "renderable" is deliberately NOT this predicate. Listing surfaces (the
+ * settings table, the onboarding recap) show everything and mark the state;
+ * only the *choice* is gated here.
+ */
+export function isModelSelectable(model: OrgModelInfo): boolean {
+  return model.enabled && !model.needs_reconnection;
+}

--- a/apps/web/src/lib/test/model-selectability.test.ts
+++ b/apps/web/src/lib/test/model-selectability.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "bun:test";
+import { isModelSelectable } from "../model-selectability";
+import type { OrgModelInfo } from "../../hooks/use-models";
+
+function model(over: Partial<OrgModelInfo>): OrgModelInfo {
+  return {
+    id: "m1",
+    label: "Claude",
+    apiShape: "anthropic-messages",
+    providerId: "anthropic",
+    providerName: "Anthropic",
+    baseUrl: "https://api.anthropic.com",
+    modelId: "claude-sonnet-4",
+    enabled: true,
+    is_default: false,
+    needs_reconnection: false,
+    aliased: false,
+    iconUrl: null,
+    source: "custom",
+    credentialId: "c1",
+    created_by: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("isModelSelectable", () => {
+  it("enabled + live credential → selectable", () => {
+    expect(isModelSelectable(model({}))).toBe(true);
+  });
+
+  it("disabled → not selectable", () => {
+    expect(isModelSelectable(model({ enabled: false }))).toBe(false);
+  });
+
+  it("dead credential → not selectable even though the row is listed", () => {
+    expect(isModelSelectable(model({ needs_reconnection: true }))).toBe(false);
+  });
+
+  it("disabled AND dead → not selectable", () => {
+    expect(isModelSelectable(model({ enabled: false, needs_reconnection: true }))).toBe(false);
+  });
+
+  it("built-in models read their key from the env, so they stay selectable", () => {
+    expect(isModelSelectable(model({ source: "built-in", credentialId: null }))).toBe(true);
+  });
+
+  it("an alias (binding projected away) is judged on the same two fields", () => {
+    const alias = model({ aliased: true, apiShape: null, modelId: null, credentialId: null });
+    expect(isModelSelectable(alias)).toBe(true);
+    expect(isModelSelectable({ ...alias, needs_reconnection: true })).toBe(false);
+  });
+});

--- a/apps/web/src/lib/test/model-selectability.test.ts
+++ b/apps/web/src/lib/test/model-selectability.test.ts
@@ -39,18 +39,4 @@ describe("isModelSelectable", () => {
   it("dead credential → not selectable even though the row is listed", () => {
     expect(isModelSelectable(model({ needs_reconnection: true }))).toBe(false);
   });
-
-  it("disabled AND dead → not selectable", () => {
-    expect(isModelSelectable(model({ enabled: false, needs_reconnection: true }))).toBe(false);
-  });
-
-  it("built-in models read their key from the env, so they stay selectable", () => {
-    expect(isModelSelectable(model({ source: "built-in", credentialId: null }))).toBe(true);
-  });
-
-  it("an alias (binding projected away) is judged on the same two fields", () => {
-    const alias = model({ aliased: true, apiShape: null, modelId: null, credentialId: null });
-    expect(isModelSelectable(alias)).toBe(true);
-    expect(isModelSelectable({ ...alias, needs_reconnection: true })).toBe(false);
-  });
 });

--- a/apps/web/src/locales/en/agents.json
+++ b/apps/web/src/locales/en/agents.json
@@ -167,6 +167,7 @@
   "input.modelResolved": "Model: {{name}} ({{source}})",
   "input.modelSourceAgent": "agent setting",
   "input.modelSourceOrgDefault": "organization default",
+  "input.modelUnavailable": "Model {{name}} is unavailable — its credential can no longer be used for inference.",
   "schedule.titleNew": "New schedule",
   "schedule.titleEdit": "Edit schedule",
   "schedule.name": "Name (optional)",

--- a/apps/web/src/locales/en/chat.json
+++ b/apps/web/src/locales/en/chat.json
@@ -16,5 +16,6 @@
   "run.status.failed": "Failed",
   "run.status.timeout": "Timed out",
   "run.status.cancelled": "Cancelled",
-  "run.status.done": "Finished"
+  "run.status.done": "Finished",
+  "model.needsReconnection": "Reconnection required"
 }

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -454,6 +454,8 @@
   "models.deleteConfirm": "Delete model \"{{label}}\"?",
   "models.default": "Default",
   "models.disabled": "Disabled",
+  "models.credentialUnavailable": "Credential unavailable",
+  "models.credentialUnavailableHint": "This model's credential can no longer be used for inference — reconnect or replace it in the Model Provider Keys tab.",
   "models.alias": "Managed",
   "models.aliasHidden": "Managed model",
   "models.setDefault": "Set as default",

--- a/apps/web/src/locales/fr/agents.json
+++ b/apps/web/src/locales/fr/agents.json
@@ -167,6 +167,7 @@
   "input.modelResolved": "Modèle : {{name}} ({{source}})",
   "input.modelSourceAgent": "réglage de l'agent",
   "input.modelSourceOrgDefault": "défaut de l'organisation",
+  "input.modelUnavailable": "Modèle {{name}} indisponible : ses identifiants ne peuvent plus être utilisés pour l'inférence.",
   "schedule.titleNew": "Nouvelle planification",
   "schedule.titleEdit": "Modifier la planification",
   "schedule.name": "Nom (optionnel)",

--- a/apps/web/src/locales/fr/chat.json
+++ b/apps/web/src/locales/fr/chat.json
@@ -16,5 +16,6 @@
   "run.status.failed": "Échec",
   "run.status.timeout": "Expiré",
   "run.status.cancelled": "Annulé",
-  "run.status.done": "Terminé"
+  "run.status.done": "Terminé",
+  "model.needsReconnection": "Reconnexion requise"
 }

--- a/apps/web/src/locales/fr/settings.json
+++ b/apps/web/src/locales/fr/settings.json
@@ -454,6 +454,8 @@
   "models.deleteConfirm": "Supprimer le modèle \"{{label}}\" ?",
   "models.default": "Par défaut",
   "models.disabled": "Inactif",
+  "models.credentialUnavailable": "Identifiants indisponibles",
+  "models.credentialUnavailableHint": "Les identifiants de ce modèle ne peuvent plus être utilisés pour l'inférence — à reconnecter ou à remplacer dans l'onglet Clés de providers de modèles.",
   "models.alias": "Géré",
   "models.aliasHidden": "Modèle géré",
   "models.setDefault": "Définir par défaut",

--- a/apps/web/src/pages/onboarding/done-step.tsx
+++ b/apps/web/src/pages/onboarding/done-step.tsx
@@ -12,6 +12,7 @@ import { useAppConfig } from "../../hooks/use-app-config";
 import { useModels } from "../../hooks/use-models";
 import { useBilling } from "../../hooks/use-billing";
 import { $api } from "../../api/client";
+import { ModelUnavailableBadge } from "../../components/model-availability-badge";
 import { CheckCircle2 } from "lucide-react";
 
 export function OnboardingDoneStep() {
@@ -32,6 +33,9 @@ export function OnboardingDoneStep() {
   );
 
   const defaultModel = models?.find((m) => m.is_default);
+  // A default whose credential is dead is not a completed step — it is named
+  // and marked (recap surface), but it doesn't get the green check.
+  const modelReady = !!defaultModel && !defaultModel.needs_reconnection;
   const invitationCount = orgData?.invitations?.length ?? 0;
 
   if (!orgId) return null;
@@ -73,9 +77,7 @@ export function OnboardingDoneStep() {
           <div className="flex items-center gap-3">
             <CheckCircle2
               size={20}
-              className={
-                defaultModel ? "shrink-0 text-green-500" : "text-muted-foreground shrink-0"
-              }
+              className={modelReady ? "shrink-0 text-green-500" : "text-muted-foreground shrink-0"}
             />
             <div className="flex-1">
               <h3 className="text-sm font-semibold">{t("onboarding.summaryModel")}</h3>
@@ -83,6 +85,7 @@ export function OnboardingDoneStep() {
                 {defaultModel ? defaultModel.label : t("onboarding.summaryModelNone")}
               </span>
             </div>
+            {defaultModel?.needs_reconnection && <ModelUnavailableBadge className="shrink-0" />}
           </div>
         </div>
 

--- a/apps/web/src/pages/onboarding/model-step.tsx
+++ b/apps/web/src/pages/onboarding/model-step.tsx
@@ -16,6 +16,7 @@ import { OnboardingQuickConnect } from "../../components/onboarding-quick-connec
 import { useModels, useModelFormHandler } from "../../hooks/use-models";
 import { useProvidersRegistry } from "../../hooks/use-model-provider-credentials";
 import { getModelIcon } from "../../components/icons";
+import { ModelUnavailableBadge } from "../../components/model-availability-badge";
 
 export function OnboardingModelStep() {
   const { t } = useTranslation(["settings", "common"]);
@@ -73,6 +74,9 @@ export function OnboardingModelStep() {
                       <div className="truncate text-sm font-medium">{m.label}</div>
                       <div className="text-muted-foreground truncate text-xs">{m.modelId}</div>
                     </div>
+                    {/* Recap list, not a picker: it shows every seeded model,
+                        so a dead one must say so rather than look configured. */}
+                    {m.needs_reconnection && <ModelUnavailableBadge className="shrink-0" />}
                     {m.is_default && (
                       <Badge variant="success" className="shrink-0 text-[0.65rem]">
                         {t("models.default")}

--- a/apps/web/src/pages/org-settings/models.tsx
+++ b/apps/web/src/pages/org-settings/models.tsx
@@ -47,6 +47,7 @@ import { Spinner } from "../../components/spinner";
 import { TestResultSpan } from "../../components/test-result-span";
 import { InlineEditableLabel } from "../../components/inline-editable-label";
 import { SourceBadge } from "../../components/source-badge";
+import { ModelUnavailableBadge } from "../../components/model-availability-badge";
 import { DefaultCell } from "../../components/default-cell";
 
 function ModelsList({
@@ -106,6 +107,7 @@ function ModelsList({
                             {t("models.disabled")}
                           </Badge>
                         )}
+                        {m.needs_reconnection && <ModelUnavailableBadge />}
                       </div>
                     </TableCell>
                     <TableCell>
@@ -120,11 +122,19 @@ function ModelsList({
                       </div>
                     </TableCell>
                     <TableCell>
+                      {/* Shown but disabled, not hidden: `PUT /api/models/default`
+                          answers 409 `model_needs_reconnection` for such a row,
+                          and a control that silently vanishes is what made this
+                          state impossible to reason about. Delete stays enabled
+                          below — detaching the model is how the user frees the
+                          credential. */}
                       <DefaultCell
                         isDefault={m.is_default}
                         defaultLabel={t("models.default")}
                         setLabel={t("models.setDefault")}
                         onSetDefault={() => onSetDefault(m)}
+                        disabled={m.needs_reconnection}
+                        disabledTitle={t("models.credentialUnavailableHint")}
                         testId={`set-default-model-${m.id}`}
                       />
                     </TableCell>

--- a/apps/web/src/pages/org-settings/models.tsx
+++ b/apps/web/src/pages/org-settings/models.tsx
@@ -125,16 +125,15 @@ function ModelsList({
                       {/* Shown but disabled, not hidden: `PUT /api/models/default`
                           answers 409 `model_needs_reconnection` for such a row,
                           and a control that silently vanishes is what made this
-                          state impossible to reason about. Delete stays enabled
-                          below — detaching the model is how the user frees the
-                          credential. */}
+                          state impossible to reason about. The why is on the
+                          row's `ModelUnavailableBadge` (first cell), whose
+                          `title` sits on a hoverable element. */}
                       <DefaultCell
                         isDefault={m.is_default}
                         defaultLabel={t("models.default")}
                         setLabel={t("models.setDefault")}
                         onSetDefault={() => onSetDefault(m)}
                         disabled={m.needs_reconnection}
-                        disabledTitle={t("models.credentialUnavailableHint")}
                         testId={`set-default-model-${m.id}`}
                       />
                     </TableCell>
@@ -294,8 +293,14 @@ function CredentialsSection({
                     </TableCell>
                     <TableCell>
                       {pk.needs_reconnection ? (
+                        // The flag also fires on a stored secret that no longer
+                        // decrypts, which reaches api-key credentials — where
+                        // the fix is to re-enter the key (Edit), not to
+                        // reconnect an account.
                         <Badge variant="destructive">
-                          {t("credentials.oauth.needsReconnection")}
+                          {isOauth
+                            ? t("credentials.oauth.needsReconnection")
+                            : t("models.credentialUnavailable")}
                         </Badge>
                       ) : pk.source === "built-in" ? (
                         <span className="text-muted-foreground text-xs">{t("source.builtIn")}</span>

--- a/apps/web/src/pages/unified-package-detail.tsx
+++ b/apps/web/src/pages/unified-package-detail.tsx
@@ -22,6 +22,7 @@ import { useCurrentApplicationId } from "../hooks/use-current-application";
 import { LoadingState } from "../components/page-states";
 import { getVersionRedirect, hasActualChanges } from "../lib/version-helpers";
 import { packageDetailPath } from "../lib/package-paths";
+import { isModelSelectable } from "../lib/model-selectability";
 import { primaryDisplayFile, companionDisplayFile } from "../lib/package-files";
 import { AlertTriangle } from "lucide-react";
 
@@ -119,7 +120,7 @@ function ModelRequiredAlert() {
   const { t } = useTranslation(["settings", "agents"]);
   const { data: models } = useModels();
 
-  const hasAnyModel = models?.some((m) => m.is_default && m.enabled);
+  const hasAnyModel = models?.some((m) => m.is_default && isModelSelectable(m));
   if (hasAnyModel || hasAnyModel === undefined) return null;
 
   return (

--- a/packages/core/src/chat-contract.ts
+++ b/packages/core/src/chat-contract.ts
@@ -56,8 +56,10 @@ export interface SubscriptionChatModel {
  * Outcome of resolving the chosen model row for a chat turn.
  *   - `{ subscription: false }` — an API-key / unknown provider → the chat's
  *     generic ai-sdk (llm-proxy) path handles it.
- *   - `{ subscription: true, needsReconnection: true }` — an oauth2 model whose
- *     credential is dead → the chat surfaces a reconnect prompt.
+ *   - `{ subscription: true, needsReconnection: true }` — a model whose stored
+ *     credential is dead (oauth flagged needs-reconnection, or a stored secret
+ *     that no longer decrypts) → the chat surfaces a reconnect prompt. Nothing
+ *     is resolvable either way, so this is purely which error the user sees.
  *   - `{ subscription: true, model }` — an oauth2 model with a fresh token → the
  *     Pi subscription chat engine drives it.
  */

--- a/packages/module-chat/src/chat-stream.ts
+++ b/packages/module-chat/src/chat-stream.ts
@@ -479,11 +479,7 @@ export async function handleChatStream(
   const pinnedAppId = c.req.header("x-application-id");
   const phaseAStart = Date.now();
   const [models, applicationId] = await Promise.all([
-    // metadata_only (skip credential decrypt) is safe only when an explicit
-    // model is pinned — that id came from the filtered picker, so it's reachable.
-    // Without a pin we resolve the org default from the full filtered list, so a
-    // dead-credential default is dropped rather than picked → inference error.
-    listModels(origin, inferenceHeaders, platformFetch, { metadataOnly: Boolean(modelId) }),
+    listModels(origin, inferenceHeaders, platformFetch),
     pinnedAppId
       ? Promise.resolve(pinnedAppId)
       : resolveDefaultApplicationId(origin, headers, orgId, platformFetch),

--- a/packages/module-chat/src/llm.ts
+++ b/packages/module-chat/src/llm.ts
@@ -16,6 +16,7 @@ import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
 import type { LanguageModel } from "ai";
 import { badGateway, invalidRequest } from "@appstrate/core/api-errors";
 import { CHAT_USABLE_FAMILIES } from "./chat-families.ts";
+import { isModelLive } from "./model-liveness.ts";
 import { logger } from "./logger.ts";
 
 const LLM_PROXY_PATH = "/api/llm-proxy";
@@ -65,12 +66,11 @@ export function pickModel(models: OrgModel[], modelId?: string): OrgModel {
       "Aucun modèle utilisable par le chat n'est configuré. Connectez un modèle par clé API (Anthropic, OpenAI, Mistral) ou un abonnement Claude Code dans Settings → Models.",
     );
   }
-  // `/api/models` LISTS a model whose credential can no longer serve inference
-  // instead of dropping it (the row has to stay visible for the user to
-  // reconnect or delete it), so the liveness gate lives here: without it a
-  // gone-dead org default would be picked and fail deep inside the provider
-  // with an opaque error.
-  const pool = usable.filter((m) => m.needs_reconnection !== true);
+  // Liveness is the second gate, on top of enabled + chat-usable family:
+  // without it a gone-dead org default would be picked and fail deep inside
+  // the provider with an opaque error. The picker (`ui/`) renders those rows
+  // instead of hiding them — same predicate, different answer to give.
+  const pool = usable.filter(isModelLive);
   const chosen = modelId
     ? pool.find((m) => m.id === modelId || m.modelId === modelId)
     : (pool.find((m) => m.is_default) ?? pool[0]);

--- a/packages/module-chat/src/llm.ts
+++ b/packages/module-chat/src/llm.ts
@@ -31,25 +31,20 @@ export interface OrgModel {
   enabled?: boolean;
   /** snake_case to match the `/api/models` wire field — camelCase silently never matches. */
   is_default?: boolean;
+  /**
+   * The model's credential can no longer serve inference (revoked OAuth refresh
+   * token, or a stored blob that no longer decrypts). Same snake_case wire
+   * convention as {@link is_default}.
+   */
+  needs_reconnection?: boolean;
 }
 
 export async function listModels(
   origin: string,
   headers: Record<string, string>,
   platformFetch: typeof fetch,
-  opts?: { metadataOnly?: boolean },
 ): Promise<OrgModel[]> {
-  // `metadata_only` skips the per-model credential decrypt + reachability filter
-  // — faster, but it also stops dropping models whose credential is dead
-  // (needs-reconnection). Safe ONLY when the caller will match an explicit,
-  // user-picked id (that id came from the browser's filtered picker, so it is
-  // already reachable). For DEFAULT resolution (no explicit id) we must use the
-  // full filtered list, or a dead org-default would be picked and fail at
-  // inference. The caller passes `metadataOnly` accordingly.
-  const url = opts?.metadataOnly
-    ? `${origin}/api/models?metadata_only=true`
-    : `${origin}/api/models`;
-  const res = await platformFetch(url, { headers });
+  const res = await platformFetch(`${origin}/api/models`, { headers });
   if (!res.ok) throw badGateway(`/api/models returned ${res.status}`);
   // `/api/models` answers with the Stripe-canonical list envelope
   // `{ object: "list", data, hasMore }` (apps/api `listResponse`, and the
@@ -64,16 +59,34 @@ export async function listModels(
 
 export function pickModel(models: OrgModel[], modelId?: string): OrgModel {
   // `enabled` is opt-out: a missing flag counts as enabled.
-  const pool = models.filter((m) => m.enabled !== false && CHAT_USABLE_FAMILIES.has(m.apiShape));
-  if (pool.length === 0 && models.some((m) => m.enabled !== false)) {
+  const usable = models.filter((m) => m.enabled !== false && CHAT_USABLE_FAMILIES.has(m.apiShape));
+  if (usable.length === 0 && models.some((m) => m.enabled !== false)) {
     throw invalidRequest(
       "Aucun modèle utilisable par le chat n'est configuré. Connectez un modèle par clé API (Anthropic, OpenAI, Mistral) ou un abonnement Claude Code dans Settings → Models.",
     );
   }
+  // `/api/models` LISTS a model whose credential can no longer serve inference
+  // instead of dropping it (the row has to stay visible for the user to
+  // reconnect or delete it), so the liveness gate lives here: without it a
+  // gone-dead org default would be picked and fail deep inside the provider
+  // with an opaque error.
+  const pool = usable.filter((m) => m.needs_reconnection !== true);
   const chosen = modelId
     ? pool.find((m) => m.id === modelId || m.modelId === modelId)
     : (pool.find((m) => m.is_default) ?? pool[0]);
   if (!chosen) {
+    // A dead model is one the user HAS: neither "configure a model" (the
+    // family fallback above) nor "not an enabled model" (below) names the fix.
+    // Covers both the explicitly pinned dead id and the all-models-dead case,
+    // where `usable` is non-empty but `pool` is not.
+    const dead = modelId
+      ? usable.some((m) => m.id === modelId || m.modelId === modelId)
+      : usable.length > 0;
+    if (dead) {
+      throw invalidRequest(
+        "Le modèle sélectionné ne peut plus servir l'inférence : sa connexion doit être rétablie dans Settings → Models.",
+      );
+    }
     throw invalidRequest(
       modelId
         ? `Model "${modelId}" is not an enabled model on this instance.`

--- a/packages/module-chat/src/model-liveness.ts
+++ b/packages/module-chat/src/model-liveness.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Can this model's credential still serve inference?
+ *
+ * `GET /api/models` LISTS a model whose credential went dead (revoked OAuth
+ * refresh token, or a stored blob that no longer decrypts) instead of dropping
+ * it — the row has to stay visible for the user to reconnect or delete it. So
+ * every consumer has to apply the gate itself: the server picker (`llm.ts`),
+ * the stored-selection reconcile and the picker rendering (`ui/`).
+ *
+ * `!== true` rather than truthiness: the field is optional on the wire and
+ * absent on an older instance, which means live.
+ *
+ * Structural parameter so both row shapes pass unchanged — `OrgModel`
+ * (`llm.ts`, server) and `OrgModelOption` (`ui/models-data.ts`, browser).
+ * Kept in its own dependency-free leaf, like `chat-families.ts`, because
+ * `llm.ts` pulls the AI SDK and the logger and must not reach the browser
+ * bundle.
+ */
+export function isModelLive(model: { needs_reconnection?: boolean }): boolean {
+  return model.needs_reconnection !== true;
+}

--- a/packages/module-chat/src/ui/index.tsx
+++ b/packages/module-chat/src/ui/index.tsx
@@ -43,6 +43,7 @@ import type {
 import { ThreadList, ActiveConversationTitle } from "./thread-list.tsx";
 import { ModelSelect } from "./model-select.tsx";
 import { fetchModels, type OrgModelOption } from "./models-data.ts";
+import { isModelLive } from "../model-liveness.ts";
 import {
   loadHistory,
   markSessionRead,
@@ -147,7 +148,7 @@ export function ChatPage({
       // whose credential went dead is listed (the picker marks it, unpickable)
       // but must not be kept as the stored selection nor adopted as the
       // fallback — the server would reject it on the next send.
-      const live = list.filter((m) => !m.needs_reconnection);
+      const live = list.filter(isModelLive);
       const cur = getSelectedModel();
       if (cur && live.some((m) => m.id === cur)) return;
       setSelectedModel((live.find((m) => m.is_default) ?? live[0])?.id ?? null);

--- a/packages/module-chat/src/ui/index.tsx
+++ b/packages/module-chat/src/ui/index.tsx
@@ -143,10 +143,14 @@ export function ChatPage({
   useEffect(() => {
     void fetchModels(getHeaders).then((list) => {
       setModels(list);
-      // Reconcile a stale/absent stored selection to the org default.
+      // Reconcile a stale/absent stored selection to the org default. A model
+      // whose credential went dead is listed (the picker marks it, unpickable)
+      // but must not be kept as the stored selection nor adopted as the
+      // fallback — the server would reject it on the next send.
+      const live = list.filter((m) => !m.needs_reconnection);
       const cur = getSelectedModel();
-      if (cur && list.some((m) => m.id === cur)) return;
-      setSelectedModel((list.find((m) => m.is_default) ?? list[0])?.id ?? null);
+      if (cur && live.some((m) => m.id === cur)) return;
+      setSelectedModel((live.find((m) => m.is_default) ?? live[0])?.id ?? null);
     });
   }, [getHeaders]);
 

--- a/packages/module-chat/src/ui/model-select.tsx
+++ b/packages/module-chat/src/ui/model-select.tsx
@@ -11,6 +11,7 @@
 import { useEffect, useRef, useState } from "react";
 import { CheckIcon, ChevronDownIcon } from "lucide-react";
 import type { OrgModelOption } from "./models-data.ts";
+import { useChatHost } from "./runtime-context.ts";
 
 /** Group/button label for a managed model — provider-neutral, binding not exposed. */
 const MANAGED_LABEL = "Géré";
@@ -52,6 +53,7 @@ function groupByProvider(models: OrgModelOption[]): ProviderGroup[] {
 export function ModelSelect({ models, selectedId, onSelect }: Props) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
+  const { t } = useChatHost();
 
   useEffect(() => {
     if (!open) return;
@@ -82,24 +84,37 @@ export function ModelSelect({ models, selectedId, onSelect }: Props) {
               </div>
               {group.models.map((m) => {
                 const isSelected = m.id === selectedId;
+                // Listed but unusable: its credential can no longer serve
+                // inference. Shown (so the model doesn't just vanish, and the
+                // user learns what to fix) but not pickable — the server's
+                // `pickModel` refuses it anyway.
+                const dead = m.needs_reconnection === true;
                 return (
                   <button
                     key={m.id}
                     type="button"
+                    disabled={dead}
                     onClick={() => {
                       onSelect(m.id);
                       setOpen(false);
                     }}
                     className={`flex w-full items-center justify-start gap-2 rounded-md px-2 py-1.5 text-left text-sm ${
-                      isSelected
-                        ? "bg-accent text-accent-foreground"
-                        : "hover:bg-accent hover:text-accent-foreground"
+                      dead
+                        ? "text-muted-foreground cursor-not-allowed"
+                        : isSelected
+                          ? "bg-accent text-accent-foreground"
+                          : "hover:bg-accent hover:text-accent-foreground"
                     }`}
                   >
                     <CheckIcon
                       className={`size-3.5 shrink-0 ${isSelected ? "opacity-100" : "opacity-0"}`}
                     />
                     <span className="flex-1 truncate text-left">{m.label ?? m.modelId}</span>
+                    {dead && (
+                      <span className="text-destructive shrink-0 text-[0.65rem] whitespace-nowrap">
+                        {t("model.needsReconnection")}
+                      </span>
+                    )}
                   </button>
                 );
               })}

--- a/packages/module-chat/src/ui/model-select.tsx
+++ b/packages/module-chat/src/ui/model-select.tsx
@@ -11,6 +11,7 @@
 import { useEffect, useRef, useState } from "react";
 import { CheckIcon, ChevronDownIcon } from "lucide-react";
 import type { OrgModelOption } from "./models-data.ts";
+import { isModelLive } from "../model-liveness.ts";
 import { useChatHost } from "./runtime-context.ts";
 
 /** Group/button label for a managed model — provider-neutral, binding not exposed. */
@@ -88,7 +89,7 @@ export function ModelSelect({ models, selectedId, onSelect }: Props) {
                 // inference. Shown (so the model doesn't just vanish, and the
                 // user learns what to fix) but not pickable — the server's
                 // `pickModel` refuses it anyway.
-                const dead = m.needs_reconnection === true;
+                const dead = !isModelLive(m);
                 return (
                   <button
                     key={m.id}

--- a/packages/module-chat/src/ui/models-data.ts
+++ b/packages/module-chat/src/ui/models-data.ts
@@ -24,6 +24,7 @@ const orgModelOptionSchema = z.object({
   providerName: z.string().nullable().optional(),
   label: z.string().nullable(),
   is_default: z.boolean().optional(),
+  needs_reconnection: z.boolean().optional(),
   enabled: z.boolean().optional(),
   aliased: z.boolean().optional(),
 });
@@ -45,6 +46,12 @@ export interface OrgModelOption {
   label: string | null;
   /** snake_case to match the `/api/models` wire field (org-models.ts). */
   is_default?: boolean;
+  /**
+   * The model's credential can no longer serve inference (revoked OAuth, or a
+   * stored blob that no longer decrypts). Listed but not selectable — the
+   * picker shows it marked so the user can see WHY it disappeared from use.
+   */
+  needs_reconnection?: boolean;
   enabled?: boolean;
   /** Model-alias flag — selectable in chat without exposing the backing model. */
   aliased?: boolean;

--- a/packages/module-chat/test/list-models.test.ts
+++ b/packages/module-chat/test/list-models.test.ts
@@ -41,15 +41,16 @@ describe("listModels", () => {
     expect(await listModels(ORIGIN, {}, fetchReturning({}))).toEqual([]);
   });
 
-  it("requests the metadata-only variant when asked", async () => {
+  it("requests the plain catalog URL — no query variant", async () => {
+    // The retired `?metadata_only=true` variant used to skip the credential
+    // decrypt; the route no longer reads the parameter (a row must be decrypted
+    // to know its liveness), and liveness now rides the listed rows as
+    // `needs_reconnection`. One URL, one shape.
     let seen = "";
     const spy = (async (url: string | URL | Request) => {
       seen = String(url);
       return new Response(JSON.stringify({ object: "list", data: [], hasMore: false }));
     }) as typeof fetch;
-
-    await listModels(ORIGIN, {}, spy, { metadataOnly: true });
-    expect(seen).toBe(`${ORIGIN}/api/models?metadata_only=true`);
 
     await listModels(ORIGIN, {}, spy);
     expect(seen).toBe(`${ORIGIN}/api/models`);

--- a/packages/module-chat/test/model-liveness.test.ts
+++ b/packages/module-chat/test/model-liveness.test.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The single liveness gate shared by the server picker (`llm.ts`) and the two
+ * browser call sites (`ui/index.tsx` reconcile, `ui/model-select.tsx`). What is
+ * worth pinning is the wire convention, not the boolean: `needs_reconnection`
+ * is optional on `/api/models` and absent on an instance older than the field,
+ * which must read as live rather than as a missing-property falsy accident.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { isModelLive } from "../src/model-liveness.ts";
+
+describe("isModelLive", () => {
+  it("treats an absent flag as live", () => {
+    expect(isModelLive({})).toBe(true);
+  });
+
+  it("only `true` is dead", () => {
+    expect(isModelLive({ needs_reconnection: false })).toBe(true);
+    expect(isModelLive({ needs_reconnection: true })).toBe(false);
+  });
+});

--- a/packages/module-chat/test/pick-model.test.ts
+++ b/packages/module-chat/test/pick-model.test.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Liveness gate in `pickModel`.
+ *
+ * `GET /api/models` used to DROP a model whose credential can no longer serve
+ * inference; it now LISTS it carrying `needs_reconnection: true` (the row has to
+ * stay visible for the user to reconnect or delete it, and its credential is
+ * undeletable while the row references it). The chat therefore has to do the
+ * filtering itself — otherwise a default that went dead after being chosen is
+ * picked and the turn fails deep inside the provider with an opaque error.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { pickModel, type OrgModel } from "../src/llm.ts";
+
+function model(id: string, over: Partial<OrgModel> = {}): OrgModel {
+  return { id, modelId: `upstream-${id}`, apiShape: "openai-completions", ...over };
+}
+
+describe("pickModel liveness", () => {
+  it("skips a dead model when resolving the org default", () => {
+    const dead = model("preset_dead", { is_default: true, needs_reconnection: true });
+    const live = model("preset_live");
+    expect(pickModel([dead, live]).id).toBe("preset_live");
+  });
+
+  it("treats an absent flag as live", () => {
+    // `needs_reconnection` is snake_case on the wire and absent on older rows —
+    // the gate must be `=== true`, never truthiness on a camelCase typo.
+    expect(pickModel([model("preset_1", { is_default: true })]).id).toBe("preset_1");
+  });
+
+  it("still honours an explicit id", () => {
+    const chosen = pickModel(
+      [model("preset_default", { is_default: true }), model("preset_pinned")],
+      "preset_pinned",
+    );
+    expect(chosen.id).toBe("preset_pinned");
+  });
+
+  it("refuses an explicitly pinned dead model with the reconnection message", () => {
+    // Not "is not an enabled model" — the model exists and is enabled; only its
+    // credential is gone, and that is the fix to name.
+    expect(() =>
+      pickModel([model("preset_dead", { needs_reconnection: true })], "preset_dead"),
+    ).toThrow(/reconnexion|rétablie/i);
+  });
+
+  it("fails clearly when every model is dead", () => {
+    // The user HAS a chat-usable model, so the family fallback ("configure a
+    // model") would send them chasing the wrong fix.
+    expect(() =>
+      pickModel([
+        model("preset_a", { is_default: true, needs_reconnection: true }),
+        model("preset_b", { needs_reconnection: true }),
+      ]),
+    ).toThrow(/rétablie/i);
+  });
+
+  it("keeps the family fallback for a configured but unusable family", () => {
+    // Unchanged path: nothing chat-usable at all is a different diagnosis.
+    expect(() => pickModel([model("preset_1", { apiShape: "google-generative-ai" })])).toThrow(
+      /Aucun modèle utilisable/,
+    );
+  });
+});

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -675,6 +675,19 @@ export interface OrgModelInfo extends ModelMetadata {
   enabled: boolean;
   is_default: boolean;
   /**
+   * True when the model's stored credential can no longer be used for
+   * inference — an OAuth credential flagged `needsReconnection` (revoked
+   * refresh token), or, for either auth mode, a stored blob that no longer
+   * decrypts (e.g. a key rotation that retired a kid still in use). The model
+   * is listed (so it can be inspected/detached/deleted) but must never be
+   * selectable for inference. Always false for built-in/system models, which
+   * read their key from the environment and have no stored blob.
+   *
+   * snake_case on purpose: mirrors {@link ModelProviderCredentialInfo.needs_reconnection}
+   * and `IntegrationConnection.needs_reconnection` on the same wire.
+   */
+  needs_reconnection: boolean;
+  /**
    * Model-alias flag (LLM-gateway alias pattern). When true, the `id` is a
    * public alias; user-facing surfaces strip the real binding (`modelId`,
    * `apiShape`, `baseUrl`, `credentialId`, capabilities/cost). Clients render


### PR DESCRIPTION
## The bug

A user could not delete their `Claude (2)` model provider. The API answered `409 credential_in_use` forever, and the configuration blocking the delete was nowhere in the UI.

Traced on production:

1. `org_models.credential_id` is `ON DELETE RESTRICT`, so a credential cannot be deleted while any model references it.
2. `listOrgModels` **dropped** every model whose credential could no longer serve inference — `loadInferenceCredentials()` returns `null` for an OAuth blob flagged `needsReconnection`, and the row was filtered out of `GET /api/models`.
3. So the two models on that credential were invisible → impossible to detach → the credential was permanently undeletable.

Production had three credentials in that state across two organizations.

## The fix

Such a model is now **listed**, carrying a new `needs_reconnection: boolean` on `OrgModel`, and stays deletable — detaching it is what frees the credential.

The flag reuses the old drop predicate verbatim (`loadInferenceCredentials(...) === null`), so no new semantics: a row that used to disappear now appears flagged. It covers api-key rows too — a stored blob that no longer decrypts (an encryption-key rotation retiring a kid still in use, DB corruption) is as dead as a revoked refresh token, and listing it as healthy would only move the failure to inference time. A row whose credential row or provider no longer resolves is still dropped; with no provider there is nothing to render.

Everything that could *use* the model stays fail-closed:

| Surface | Behaviour |
|---|---|
| `loadModel` / `resolveModel` | unchanged — still resolves a dead model to `null` |
| `PUT /api/models/default` | new `409 model_needs_reconnection` |
| chat `pickModel` | refuses it, with a message that says reconnect rather than "no model configured" |
| SPA pickers | rendered greyed and marked, never selectable |
| CLI `--model` | refused client-side, naming the real reason |
| `DELETE /api/models/:id` | deliberately **not** gated — this is the escape hatch |

Nothing is hidden anywhere. A model that silently vanishes is what made this state impossible to reason about in the first place.

## Notable decisions

- **One predicate.** `modelNeedsReconnection` is the same test the list flags with, so the badge and the 409 cannot disagree. Its guard lives in `setDefaultModel`, not in the generic `createDefaultPointer` helper shared with org-proxies.
- **One deliberate divergence**, documented: a *disabled* row on a dead credential is flagged in the list but not by the predicate. It is inert either way, and the actionable advice there is "enable it", not "reconnect".
- **`metadata_only` removed** from `GET /api/models`. It became provably inert: a row must be decrypted to know its liveness, so there was nothing left for a caller to skip. An old client that still sends it is unaffected — the route simply stops reading it.
- The SPA's "is this model usable" test was duplicated as a bare `m.enabled` check across five surfaces, and the two model `<Select>`s had no filter at all (they already offered disabled models). One `isModelSelectable()` predicate now owns it.

## Review

An adversarial pass over the branch found no blockers and two important issues, both fixed here (see the last two commits):

- `modelNeedsReconnection` fired for a row the list does not render — removing an opt-in provider module from `MODULES` turned `PUT /api/models/default` from 200 into a 409 blaming a healthy credential.
- The credentials tab showed a credential whose blob no longer decrypts as healthy, while the models tab badged it and pointed the user *at that tab*.

Plus: an inert `title` on a `pointer-events-none` button, a hint blaming the credential for a merely-disabled model, a green check on a dead default in onboarding, three spellings of the same predicate in module-chat, and an untouched CLI.

## Testing

- New route-level test walking the exact production sequence: list the dead model → `DELETE /api/models/:id` → `DELETE /api/model-provider-credentials/:id` returns **204**, not 409. Without it, a future reachability guard on the model delete would reinstate this deadlock with the suite green.
- Service-level coverage for the flag (OAuth dead, healthy, api-key, undecryptable blob, unregistered provider), the 409, and `loadModel` staying fail-closed.
- `pickModel`'s five branches, the CLI refusal, and the `useAgentReadiness` cascade mirror (an unusable pin must fall through to the org default — getting that backwards disables the Run button for runs that succeed).
- `bun run check`, `verify:openapi`, `detect:breaking` green. 5119 tests pass; the single failure is `llm_usage durable retry`, which times out under full-suite load and passes in isolation on `main` too.

## Known gaps, not fixed here

- `detect:breaking` never inspects query parameters or anything nested under array `items`, so it is blind to both spec changes in this PR. Both are safe on their merits (Hono ignores an unknown query param; a new required *response* field is additive for readers), but the gate passing is not evidence.
- `apps/cli` reads `p.isDefault` where the wire sends `is_default`, so `--model-source preset` without `--model` is already permanently broken. Pre-existing, unrelated, left for its own change.
- `POST /api/models/seed` answers `notFound("Credential not found")` for a dead credential — pre-existing, more reachable now that the tab flags such rows.

## Production follow-up

No migration needed. Once deployed, the three stuck credentials become deletable from the UI: their models now appear in Settings → Models, marked, with delete enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
