### PR TITLE
refactor(chat): remove five post-#982 cost-vs-evidence leftovers

### DIFF
--- a/apps/api/src/services/input-parser.ts
+++ b/apps/api/src/services/input-parser.ts
@@ -451,12 +451,10 @@ export function assertDocsWithinCap(files: { size: number }[], maxBytes: number)
  * `documents × 5 MiB`. Bounding it keeps the per-run streaming memory floor flat
  * regardless of document count.
  *
- * Exported as the single per-run document fan-out bound: any other per-document
- * loop on the run-launch path (e.g. the inline-run prompt-repair ACL probe)
- * reuses it rather than picking a second number. A probe is strictly cheaper
- * than the stream it precedes, so this ceiling is safe for both.
+ * Module-private: its one consumer is the `mapWithConcurrency` fan-out below
+ * that streams resolved uploads into the run workspace.
  */
-export const DOC_STREAM_CONCURRENCY = 4;
+const DOC_STREAM_CONCURRENCY = 4;
 
 /**
  * Map over `items` running at most `limit` callbacks concurrently, preserving

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -23,9 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   by `1*SP`, so a conformant `authorization: bearer ey…` must match, which
   `startsWith("Bearer ")` rejects. First release carrying the subpath — a module
   built against an earlier core must parse the header itself.
-- `@appstrate/core/run-and-wait-client` — `RUN_RESULT_INLINE_MAX_BYTES` (32 KB),
-  `runResultExceedsInlineLimit()` and `truncateRunAndWaitPayload()`: a run result
-  over the cap is cut to a usable head that points back at the run, whose
+- `@appstrate/core/run-and-wait-client` — `RUN_RESULT_INLINE_MAX_BYTES` (32 KB) and
+  `truncateRunAndWaitPayload()`: a run result over the cap is cut to a usable
+  head that points back at the run, whose
   `runs.result` already holds the whole payload (`getRun` returns it) — no copy is
   made. `launchRunAndWait` forwards the new `context_documents` argument (inline
   runs only).

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -11,8 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `@appstrate/core/chat-turn-metadata` — the chat turn's TIME budget alongside its
   existing step budget: `CHAT_TURN_DEADLINE_MS`, `CHAT_TURN_SAFETY_MARGIN_MS`,
-  `CHAT_MIN_RUN_BUDGET_MS`, `CHAT_THIN_RUN_BUDGET_MS`, `CHAT_LAUNCH_THRESHOLD_MS`,
-  plus the pure
+  `CHAT_MIN_RUN_BUDGET_MS`, `CHAT_LAUNCH_THRESHOLD_MS`, plus the pure
   `computeTurnRunBudget()`, `formatBudgetDuration()` and `formatTurnBudgetNote()`.
   Both chat engines derive a child call's wait from an absolute turn deadline
   instead of silently taking `RUN_AND_WAIT_MAX_MS` (30 min), which is three times

--- a/packages/core/src/chat-turn-metadata.ts
+++ b/packages/core/src/chat-turn-metadata.ts
@@ -101,16 +101,11 @@ export function formatBudgetDuration(ms: number): string {
  * then refuse it. A model arbitrating on the wrong number is worse than one
  * shown no number at all — that is the whole point of A5.
  */
-export function formatTurnBudgetNote(input: {
-  remainingMs: number;
-  stepsUsed: number;
-  maxSteps?: number;
-}): string {
-  const maxSteps = input.maxSteps ?? CHAT_MAX_STEPS;
+export function formatTurnBudgetNote(input: { remainingMs: number; stepsUsed: number }): string {
   const launchThreshold = formatBudgetDuration(CHAT_LAUNCH_THRESHOLD_MS);
   return (
     `[turn budget] ${formatBudgetDuration(input.remainingMs)} left in this turn, ` +
-    `step ${input.stepsUsed}/${maxSteps}. ` +
+    `step ${input.stepsUsed}/${CHAT_MAX_STEPS}. ` +
     `A run_and_wait launch needs at least ${launchThreshold} left or it is refused; ` +
     `anything not written into your reply before the turn ends is lost.`
   );

--- a/packages/core/src/chat-turn-metadata.ts
+++ b/packages/core/src/chat-turn-metadata.ts
@@ -40,9 +40,6 @@ export const CHAT_TURN_SAFETY_MARGIN_MS = 45_000;
  */
 export const CHAT_MIN_RUN_BUDGET_MS = 90_000;
 
-/** Above the floor but tight enough that the launch deserves a `warn` trace. */
-export const CHAT_THIN_RUN_BUDGET_MS = 3 * 60_000;
-
 /**
  * Remaining turn time a launch actually requires — THE number every
  * model-facing message must quote.
@@ -64,8 +61,6 @@ export interface TurnRunBudget {
   maxMs: number;
   /** Whether a run may be launched at all (`maxMs >= CHAT_MIN_RUN_BUDGET_MS`). */
   launchable: boolean;
-  /** Launchable, but under {@link CHAT_THIN_RUN_BUDGET_MS} — worth a warn. */
-  thin: boolean;
 }
 
 /**
@@ -78,7 +73,7 @@ export function computeTurnRunBudget(turnDeadlineAt: number, now: number): TurnR
   const remainingMs = Math.max(0, turnDeadlineAt - now);
   const maxMs = Math.max(0, remainingMs - CHAT_TURN_SAFETY_MARGIN_MS);
   const launchable = maxMs >= CHAT_MIN_RUN_BUDGET_MS;
-  return { remainingMs, maxMs, launchable, thin: launchable && maxMs < CHAT_THIN_RUN_BUDGET_MS };
+  return { remainingMs, maxMs, launchable };
 }
 
 /** Compact human duration for model-facing budget text ("4m12s", "45s"). */

--- a/packages/core/src/run-and-wait-client.ts
+++ b/packages/core/src/run-and-wait-client.ts
@@ -158,22 +158,6 @@ function serializedResultBytes(value: unknown): Uint8Array | null {
 }
 
 /**
- * Does this run result overrun the inline tool-result ceiling? The WRITE side of
- * the spill (the platform's finalize path) asks this so both sides use one
- * threshold and one measurement.
- *
- * The two sides do not measure byte-identical inputs: the writer measures the
- * in-process object, the reader measures the same value after a `jsonb`
- * round-trip (which reorders keys but preserves length). A disagreement is
- * therefore benign in both directions — an unused spill document, or an
- * untruncated payload, never a truncation with no pointer.
- */
-export function runResultExceedsInlineLimit(result: unknown): boolean {
-  const bytes = serializedResultBytes(result);
-  return bytes !== null && bytes.length > RUN_RESULT_INLINE_MAX_BYTES;
-}
-
-/**
  * Truncate an oversized `result` on a terminal run_and_wait payload, replacing
  * it with a usable HEAD that points back at the run holding the whole thing.
  *

--- a/packages/core/test/run-and-wait-truncation.test.ts
+++ b/packages/core/test/run-and-wait-truncation.test.ts
@@ -20,7 +20,6 @@ import { describe, expect, it } from "bun:test";
 import {
   RUN_RESULT_INLINE_MAX_BYTES,
   runAndWaitStepsWithDocuments,
-  runResultExceedsInlineLimit,
   truncateRunAndWaitPayload,
   type RunAndWaitDocument,
 } from "../src/run-and-wait-client.ts";
@@ -41,29 +40,6 @@ const reportDocument: RunAndWaitDocument = {
   mime: "text/html",
   size: 22_846,
 };
-
-describe("run result inline limit", () => {
-  it("measures the serialized result and only fires on a strict overrun", () => {
-    expect(runResultExceedsInlineLimit(resultOfExactlyBytes(RUN_RESULT_INLINE_MAX_BYTES))).toBe(
-      false,
-    );
-    expect(runResultExceedsInlineLimit(resultOfExactlyBytes(RUN_RESULT_INLINE_MAX_BYTES + 1))).toBe(
-      true,
-    );
-  });
-
-  it("does not fire on the sizes that produced the audited incident (9–11.6 KB)", () => {
-    expect(runResultExceedsInlineLimit(resultOfExactlyBytes(9_057))).toBe(false);
-    expect(runResultExceedsInlineLimit(resultOfExactlyBytes(11_583))).toBe(false);
-  });
-
-  it("reports false for an unserializable result rather than throwing", () => {
-    const cyclic: Record<string, unknown> = {};
-    cyclic.self = cyclic;
-    expect(runResultExceedsInlineLimit(cyclic)).toBe(false);
-    expect(runResultExceedsInlineLimit(undefined)).toBe(false);
-  });
-});
 
 describe("truncateRunAndWaitPayload", () => {
   const base = { id: "run_1", packageId: "@acme/writer", status: "success", done: true };
@@ -112,6 +88,20 @@ describe("truncateRunAndWaitPayload", () => {
     });
     expect(out.truncated).toBe(true);
     expect(String(out.message)).toContain("getRun");
+  });
+
+  it("leaves the sizes that produced the audited incident alone (9–11.6 KB)", () => {
+    for (const size of [9_057, 11_583]) {
+      const payload = { ...base, result: resultOfExactlyBytes(size) };
+      expect(truncateRunAndWaitPayload(payload)).toBe(payload);
+    }
+  });
+
+  it("passes an unserializable result through rather than throwing", () => {
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const payload = { ...base, result: cyclic };
+    expect(truncateRunAndWaitPayload(payload)).toBe(payload);
   });
 
   it("leaves a resultless payload alone", () => {

--- a/packages/module-chat/src/chat-stream.ts
+++ b/packages/module-chat/src/chat-stream.ts
@@ -172,7 +172,6 @@ export function prepareAiSdkChatStep({
   const budgetNote = formatTurnBudgetNote({
     remainingMs: turnDeadlineAt - now,
     stepsUsed: stepNumber,
-    maxSteps: CHAT_MAX_STEPS,
   });
 
   if (!isFinalChatStep(stepNumber, CHAT_MAX_STEPS)) {
@@ -299,9 +298,8 @@ export interface ArmedTurnDeadline {
 export function armTurnDeadline(
   controller: AbortController,
   deadlineAt: number,
-  deadlineMs: number = CHAT_TURN_DEADLINE_MS,
 ): ArmedTurnDeadline {
-  const deadlineReason = new ChatTurnDeadlineError(deadlineMs);
+  const deadlineReason = new ChatTurnDeadlineError(CHAT_TURN_DEADLINE_MS);
   let fired = false;
   const timer = setTimeout(
     () => {
@@ -346,14 +344,11 @@ export function createTurnClosureStream(options: {
   abortReason?: () => unknown;
   /** Turn metadata for the synthesized `finish` chunk (same builder as the nominal path). */
   buildMetadata: (finishReason: ChatTurnFinishReason) => ChatMessageMetadata;
-  /** Ceiling quoted to the user. Defaults to the shared turn deadline. */
-  deadlineMs?: number;
   /** Notice part id (tests pin it). */
   newId?: () => string;
   /** Observability seam — called once when the deadline actually closed the turn. */
   onDeadline?: () => void;
 }): TransformStream<UIMessageChunk, UIMessageChunk> {
-  const deadlineMs = options.deadlineMs ?? CHAT_TURN_DEADLINE_MS;
   const newId = options.newId ?? (() => crypto.randomUUID());
   // A turn that published its own `finish` closed on its own terms; an abort
   // racing in just after it must not overwrite that ending with a truncation
@@ -376,7 +371,10 @@ export function createTurnClosureStream(options: {
       });
       if (!closure.deadlineReached) return;
       options.onDeadline?.();
-      for (const chunk of turnNoticeChunks(newId(), turnDeadlineNoticeText(deadlineMs))) {
+      for (const chunk of turnNoticeChunks(
+        newId(),
+        turnDeadlineNoticeText(CHAT_TURN_DEADLINE_MS),
+      )) {
         controller.enqueue(chunk);
       }
       controller.enqueue({

--- a/packages/module-chat/src/pi-chat/turn-control.ts
+++ b/packages/module-chat/src/pi-chat/turn-control.ts
@@ -98,11 +98,8 @@ export function createStepCapController(options: {
   modelCallCount: () => number;
   /** Model calls allowed to use tools. Defaults to the shared chat budget. */
   budget?: number;
-  /** Prompt of the closing call. Defaults to the shared final-step directive. */
-  finalStepPrompt?: string;
 }): StepCapController {
   const budget = options.budget ?? CHAT_TOOL_STEP_BUDGET;
-  const finalStepPrompt = options.finalStepPrompt ?? CHAT_FINAL_STEP_SYSTEM_PROMPT;
   let fired = false;
   // Batches spared because one of their results carries a connect offer. Keyed
   // by the shared assistant message so the whole batch is spared, not just the
@@ -133,7 +130,7 @@ export function createStepCapController(options: {
       // Tools are snapshotted per run by the agent loop, so they can only be
       // dropped between runs — which is precisely what this closing call is.
       session.setActiveToolsByName([]);
-      await session.prompt(finalStepPrompt);
+      await session.prompt(CHAT_FINAL_STEP_SYSTEM_PROMPT);
     },
   };
 }

--- a/packages/module-chat/src/run-budget.ts
+++ b/packages/module-chat/src/run-budget.ts
@@ -104,18 +104,11 @@ export function decideRunAndWaitBudget(
     };
   }
 
-  if (budget.thin) {
-    // The low `deadline.remaining_ms` we want visible in traces: the run WILL
-    // start, but it is racing the turn that hosts it.
-    log.warn("chat run_and_wait launched on a thin turn budget", {
-      engine: ctx.engine,
-      chatSessionId: ctx.chatSessionId ?? null,
-      remainingMs: budget.remainingMs,
-      runBudgetMs: budget.maxMs,
-      safetyMarginMs: CHAT_TURN_SAFETY_MARGIN_MS,
-    });
-  }
-
+  // Past the floor there is exactly one outcome and no middle tier: the launch
+  // is granted, silently. A "tight budget" warn used to sit here, keyed on a
+  // 3-minute threshold nothing derived and nothing consumed — no alert, no
+  // dashboard, no runbook — and it could not have fired on the incident above
+  // this file documents (22 s left is a refusal, not a warn).
   return { launch: true, maxMs: budget.maxMs };
 }
 

--- a/packages/module-chat/test/ai-sdk-turn-deadline.test.ts
+++ b/packages/module-chat/test/ai-sdk-turn-deadline.test.ts
@@ -149,7 +149,7 @@ async function runTurn(options: {
   const turnDeadline =
     options.deadlineInMs === undefined
       ? undefined
-      : armTurnDeadline(generation, Date.now() + options.deadlineInMs, CHAT_TURN_DEADLINE_MS);
+      : armTurnDeadline(generation, Date.now() + options.deadlineInMs);
   const stopReason = new Error("stopped by user");
   if (options.stopInMs !== undefined) {
     setTimeout(() => generation.abort(stopReason), options.stopInMs);
@@ -302,7 +302,7 @@ describe("createTurnClosureStream", () => {
 describe("armTurnDeadline", () => {
   it("aborts the turn at the ceiling with a tagged reason", async () => {
     const controller = new AbortController();
-    const armed = armTurnDeadline(controller, Date.now() + 5, CHAT_TURN_DEADLINE_MS);
+    const armed = armTurnDeadline(controller, Date.now() + 5);
 
     await new Promise((r) => setTimeout(r, 40));
 
@@ -315,7 +315,7 @@ describe("armTurnDeadline", () => {
 
   it("does not outlive the turn — disarming cancels the abort", async () => {
     const controller = new AbortController();
-    const armed = armTurnDeadline(controller, Date.now() + 5, CHAT_TURN_DEADLINE_MS);
+    const armed = armTurnDeadline(controller, Date.now() + 5);
     armed.disarm();
 
     await new Promise((r) => setTimeout(r, 40));
@@ -325,7 +325,7 @@ describe("armTurnDeadline", () => {
 
   it("reports an explicit stop as-is (the ceiling never fired)", () => {
     const controller = new AbortController();
-    const armed = armTurnDeadline(controller, Date.now() + 60_000, CHAT_TURN_DEADLINE_MS);
+    const armed = armTurnDeadline(controller, Date.now() + 60_000);
     const stop = new Error("stopped by user");
     controller.abort(stop);
     armed.disarm();

--- a/packages/module-chat/test/chat-turn-budget.test.ts
+++ b/packages/module-chat/test/chat-turn-budget.test.ts
@@ -42,14 +42,6 @@ describe("computeTurnRunBudget", () => {
     expect(budget.remainingMs).toBe(CHAT_TURN_DEADLINE_MS);
     expect(budget.maxMs).toBe(CHAT_TURN_DEADLINE_MS - CHAT_TURN_SAFETY_MARGIN_MS);
     expect(budget.launchable).toBe(true);
-    expect(budget.thin).toBe(false);
-  });
-
-  it("flags a thin — but still launchable — budget", () => {
-    const budget = computeTurnRunBudget(NOW + 2 * 60_000 + CHAT_TURN_SAFETY_MARGIN_MS, NOW);
-    expect(budget.maxMs).toBe(2 * 60_000);
-    expect(budget.launchable).toBe(true);
-    expect(budget.thin).toBe(true);
   });
 
   it("refuses below the launch floor", () => {
@@ -68,7 +60,7 @@ describe("computeTurnRunBudget", () => {
 
   it("clamps a deadline already in the past (never negative)", () => {
     const budget = computeTurnRunBudget(NOW - 60_000, NOW);
-    expect(budget).toEqual({ remainingMs: 0, maxMs: 0, launchable: false, thin: false });
+    expect(budget).toEqual({ remainingMs: 0, maxMs: 0, launchable: false });
   });
 });
 
@@ -86,7 +78,9 @@ describe("decideRunAndWaitBudget", () => {
     expect(warnings).toEqual([]);
   });
 
-  it("warns when a run launches on a thin budget (the low remaining_ms trace)", () => {
+  it("grants a tight — but still launchable — budget just as silently", () => {
+    // Past the floor there is one outcome and no middle tier: only a REFUSAL
+    // warns. Two minutes of run budget used to trip a "thin budget" warn.
     const { log, warnings } = captureLogger();
     const decision = decideRunAndWaitBudget(
       {
@@ -98,13 +92,7 @@ describe("decideRunAndWaitBudget", () => {
       log,
     );
     expect(decision).toEqual({ launch: true, maxMs: 2 * 60_000 });
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]?.message).toContain("thin turn budget");
-    expect(warnings[0]?.fields).toMatchObject({
-      engine: "subscription",
-      chatSessionId: "chs_1",
-      runBudgetMs: 2 * 60_000,
-    });
+    expect(warnings).toEqual([]);
   });
 
   it("refuses below the floor with an actionable, non-error payload", () => {

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -542,6 +542,18 @@ const OUTPUT_REPROMPT_INSTRUCTION =
 /** Minimal Pi SDK session surface needed to issue the corrective turn. */
 export interface PromptableSession {
   prompt(message: string): Promise<unknown>;
+  /**
+   * Names of the tools the agent could actually call on its last turn
+   * (SDK: `agent.state.tools`). Used as the resolvability probe before
+   * narrowing the tool set — see {@link maybeRepromptForOutput}.
+   */
+  getActiveToolNames(): string[];
+  /**
+   * Narrow the tool set for the next turn. The SDK resolves each name against
+   * its tool registry and SILENTLY DROPS the ones it cannot find, so an
+   * unresolvable name yields a tool-less turn rather than an error.
+   */
+  setActiveToolsByName(toolNames: string[]): void;
 }
 
 /**
@@ -561,7 +573,16 @@ export interface PromptableSession {
  * instruction to call `output` from work it has already done, another turn is
  * spent without a hypothesis.
  *
- * Guards (all four must pass):
+ * The corrective turn is narrowed to `output` alone
+ * (`setActiveToolsByName([...])`) — the "do not call any other tool" clause of
+ * {@link OUTPUT_REPROMPT_INSTRUCTION} is a request the model may ignore, the
+ * tool set is not. Intentional behaviour change: on this turn the agent can no
+ * longer research, run bash, read/edit/write files, publish documents, write
+ * memory or call any integration — it can only emit the structured result it
+ * already owes. Narrowing is itself guarded (guard 5) because the SDK ignores
+ * unknown tool names silently.
+ *
+ * Guards (five must pass; the fifth gates the narrowing, not the turn):
  *  1. `output` is wired as a terminal tool — mirrors `runtime-pi/entrypoint.ts`,
  *     which passes `terminalTools: ["output"]` only when the agent declared the
  *     `output` runtime tool. Without it there is no output contract to enforce.
@@ -573,6 +594,9 @@ export interface PromptableSession {
  *  4. the last assistant turn is not a terminal failure — a session that ended
  *     on a provider error or a provider-side abort cannot answer, so the extra
  *     round-trip would only add cost to an already-failed run.
+ *  5. (narrowing only) `output` is in `session.getActiveToolNames()` — proof
+ *     that the SDK registry resolves that exact name. When it does not, the
+ *     corrective turn goes out UNRESTRICTED rather than tool-less.
  *
  * Emits an `appstrate.progress` breadcrumb at `warn` level carrying
  * `data.event = "output_reprompt"` BEFORE the retry — the same event channel
@@ -617,6 +641,31 @@ export async function maybeRepromptForOutput(opts: {
       level: "warn",
     })
     .catch(() => {});
+
+  // Make the "call `output`, nothing else" contract mechanical. Prompt text
+  // alone left the whole tool surface live on the corrective turn (built-in
+  // `read`/`bash`/`edit`/`write` plus every registered runtime + integration
+  // extension), so a drifting model could burn a second research loop on a turn
+  // that exists only to emit a result it already has.
+  //
+  // Conditional because `setActiveToolsByName` resolves names against the SDK
+  // tool registry and silently DROPS the misses (`AgentSession` — registry
+  // `get()` miss = tool skipped, no throw): narrowing to an `output` the
+  // registry does not hold would hand the turn ZERO tools and guarantee the
+  // failure this whole function exists to prevent. `getActiveToolNames()` is
+  // the honest probe — those names come out of the SAME registry lookup
+  // (`agent.state.tools`, only populated on a registry hit), so `output`
+  // appearing there proves the narrowing resolves. `terminalTools` cannot
+  // substitute: it only says how the RUNNER was configured, not what the SDK
+  // registry ended up holding.
+  //
+  // Narrowing also rebuilds the base system prompt from the resource loader,
+  // which re-reads the loader's `systemPrompt` (the agent prompt this runner
+  // passes to `DefaultResourceLoader` above) — the agent's own instructions
+  // survive; only the tool section of the prompt shrinks.
+  if (session.getActiveToolNames().includes(OUTPUT_TERMINAL_TOOL)) {
+    session.setActiveToolsByName([OUTPUT_TERMINAL_TOOL]);
+  }
 
   const race = opts.race ?? (<T>(promise: Promise<T>): Promise<T> => promise);
   await race(session.prompt(OUTPUT_REPROMPT_INSTRUCTION));

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -522,36 +522,62 @@ const OUTPUT_TERMINAL_TOOL = "output";
 
 /**
  * `run_logs` event name carried in the re-prompt breadcrumb's `data`, so
- * operators can measure how often models drift off the output contract
+ * operators can measure output-contract drift
  * (`SELECT count(*) FROM run_logs WHERE data->>'event' = 'output_reprompt'`).
  */
 const OUTPUT_REPROMPT_EVENT = "output_reprompt";
 
 /**
- * The single corrective turn. Deliberately narrow: call `output` from what
- * you already have — no new research, no other tool — so the extra turn costs
- * one completion, not another research loop.
+ * The only tools the corrective turn may use.
+ *
+ * `output` is the point of the turn. `read` is there because the findings may
+ * no longer be in context: this platform tells agents a deliverable belongs in
+ * the run's `outputs/` directory (`@appstrate/core/run-and-wait-client`), and
+ * Pi auto-compaction (on unless `MODEL_COMPACTION_ENABLED=false`, see
+ * {@link derivePiCompactionSettings}) can summarise the detailed history away
+ * before the loop settles — leaving a model whose report is on disk but not in
+ * context to fabricate the required fields. `read` recovers work already done
+ * and already paid for; it is not research.
+ *
+ * Everything else stays out: no `bash`, no `edit`/`write`, no
+ * `publish_document`, no memory write, no integration tool.
  */
+const OUTPUT_REPROMPT_TOOLS = [OUTPUT_TERMINAL_TOOL, "read"];
+
+/** Model-facing text for the corrective turn — must match {@link OUTPUT_REPROMPT_TOOLS}. */
 const OUTPUT_REPROMPT_INSTRUCTION =
   "You ended your turn without calling the `output` tool. This agent declares an " +
   "output schema, so the run cannot be delivered until `output` is called exactly " +
   "once with all required fields. Call `output` NOW, using only the work you have " +
-  "already done in this session. Do not run any further research, do not call any " +
-  "other tool, and do not reply with plain text.";
+  "already done in this session. You may use `read` to re-open files you wrote " +
+  "yourself (your `outputs/` directory) if their contents are no longer in " +
+  "context; do not call any other tool, do not research anything new, and do not " +
+  "reply with plain text.";
 
 /** Minimal Pi SDK session surface needed to issue the corrective turn. */
 export interface PromptableSession {
   prompt(message: string): Promise<unknown>;
   /**
-   * Names of the tools the agent could actually call on its last turn
-   * (SDK: `agent.state.tools`). Used as the resolvability probe before
-   * narrowing the tool set — see {@link maybeRepromptForOutput}.
+   * Tools the agent could actually call on its last turn — the same registry
+   * lookup {@link PromptableSession.setActiveToolsByName} performs, so it is
+   * the honest probe for what a narrowing would resolve.
    */
   getActiveToolNames(): string[];
   /**
-   * Narrow the tool set for the next turn. The SDK resolves each name against
-   * its tool registry and SILENTLY DROPS the ones it cannot find, so an
-   * unresolvable name yields a tool-less turn rather than an error.
+   * Narrow the tool set for the next turn. SDK contract (`pi-coding-agent`
+   * `core/agent-session.js:562-581`), stated once and relied on by every caller:
+   *  - unresolvable names are **silently dropped**, no throw — a list that
+   *    resolves to nothing yields a TOOL-LESS turn, so callers must probe with
+   *    {@link PromptableSession.getActiveToolNames} rather than trust their own
+   *    configuration.
+   *  - it also rebuilds `agent.state.systemPrompt` from the resource loader:
+   *    the agent's own instructions survive, only the tool section shrinks.
+   *  - cost: rewriting both blocks invalidates the Anthropic prompt-cache
+   *    prefix (prefix-based over tools → system → messages; breakpoints sit on
+   *    the system block and the LAST tool definition — `pi-ai`
+   *    `providers/anthropic.js:672,926`), so the next turn re-reads the whole
+   *    session at full input price. Accepted: a fabricated or absent `output`
+   *    fails the entire run.
    */
   setActiveToolsByName(toolNames: string[]): void;
 }
@@ -562,51 +588,43 @@ export interface PromptableSession {
  *
  * Why here and not at finalize: the platform only discovers the missing
  * `output` when it validates the terminal `RunResult`
- * (`services/run-event-ingestion.ts`), long after the container is gone and
- * the agent's context has been destroyed — the answer existed in the model's
- * head and was thrown away after being fully paid for. The runner is the only
- * place where the session is still alive. The platform-side validation stays
- * exactly as it is; it is now the safety net rather than the first line of
- * defence.
+ * (`services/run-event-ingestion.ts`) — container gone, context destroyed, run
+ * fully paid for. The runner is the only place where the session is still
+ * alive; the platform-side validation is unchanged and becomes the safety net.
  *
- * Exactly one attempt, never a loop: if the model ignores an explicit
- * instruction to call `output` from work it has already done, another turn is
- * spent without a hypothesis.
+ * Exactly one attempt, never a loop: a model that ignores an explicit
+ * instruction to call `output` from work it has already done gets no second
+ * hypothesis.
  *
- * The corrective turn is narrowed to `output` alone
- * (`setActiveToolsByName([...])`) — the "do not call any other tool" clause of
- * {@link OUTPUT_REPROMPT_INSTRUCTION} is a request the model may ignore, the
- * tool set is not. Intentional behaviour change: on this turn the agent can no
- * longer research, run bash, read/edit/write files, publish documents, write
- * memory or call any integration — it can only emit the structured result it
- * already owes. Narrowing is itself guarded (guard 5) because the SDK ignores
- * unknown tool names silently.
+ * The turn is narrowed to {@link OUTPUT_REPROMPT_TOOLS} — the prompt's "no
+ * other tool" clause is a request the model may ignore, the tool set is not.
+ * Intentional behaviour change: everything that constant excludes becomes
+ * uncallable for this turn.
  *
- * Guards (five must pass; the fifth gates the narrowing, not the turn):
+ * Guards (the first four decide the turn; the fifth only shapes the narrowing):
  *  1. `output` is wired as a terminal tool — mirrors `runtime-pi/entrypoint.ts`,
- *     which passes `terminalTools: ["output"]` only when the agent declared the
- *     `output` runtime tool. Without it there is no output contract to enforce.
+ *     which passes it only when the agent declared the `output` runtime tool.
+ *     Without it there is no output contract to enforce.
  *  2. no terminal tool completed — a successful `output` means the run is
  *     already semantically done (and the SDK loop was aborted early).
- *  3. the run was not cancelled / timed out — `signal` here is the runner's
- *     combined controller (user cancel + timeout watchdog). A dead run must not
- *     be resurrected for one more LLM call.
+ *  3. the run was not cancelled / timed out — `signal` is the runner's combined
+ *     controller (user cancel + watchdog); a dead run is not resurrected.
  *  4. the last assistant turn is not a terminal failure — a session that ended
- *     on a provider error or a provider-side abort cannot answer, so the extra
- *     round-trip would only add cost to an already-failed run.
- *  5. (narrowing only) `output` is in `session.getActiveToolNames()` — proof
- *     that the SDK registry resolves that exact name. When it does not, the
- *     corrective turn goes out UNRESTRICTED rather than tool-less.
+ *     on a provider error or abort cannot answer, so the round-trip would only
+ *     add cost to an already-failed run.
+ *  5. (narrowing only) request just the {@link OUTPUT_REPROMPT_TOOLS} the
+ *     registry resolves, per the silent-drop contract on
+ *     {@link PromptableSession.setActiveToolsByName}: no `output` → no
+ *     narrowing at all (unrestricted beats tool-less); no `read` → `output`
+ *     alone.
  *
- * Emits an `appstrate.progress` breadcrumb at `warn` level carrying
- * `data.event = "output_reprompt"` BEFORE the retry — the same event channel
- * every other runner-side lifecycle signal uses (see `runtime-ready.ts`), so
- * the drift is measurable in `run_logs` without a second reporting path. Sink
- * failures are swallowed: losing the breadcrumb must never cost the run its
- * corrective turn.
+ * Emits a warn-level `appstrate.progress` breadcrumb carrying
+ * `data.event = "output_reprompt"` BEFORE the retry — the channel every other
+ * runner-side lifecycle signal uses (`runtime-ready.ts`), so drift is
+ * measurable in `run_logs` without a second reporting path. Sink failures are
+ * swallowed: losing the breadcrumb must never cost the run its turn.
  *
- * Exported for unit testing — the production caller is
- * `PiRunner.executeSession`.
+ * Exported for unit testing; the production caller is `PiRunner.executeSession`.
  *
  * @returns `true` when the corrective turn was issued, `false` when a guard
  *   declined it.
@@ -642,29 +660,12 @@ export async function maybeRepromptForOutput(opts: {
     })
     .catch(() => {});
 
-  // Make the "call `output`, nothing else" contract mechanical. Prompt text
-  // alone left the whole tool surface live on the corrective turn (built-in
-  // `read`/`bash`/`edit`/`write` plus every registered runtime + integration
-  // extension), so a drifting model could burn a second research loop on a turn
-  // that exists only to emit a result it already has.
-  //
-  // Conditional because `setActiveToolsByName` resolves names against the SDK
-  // tool registry and silently DROPS the misses (`AgentSession` — registry
-  // `get()` miss = tool skipped, no throw): narrowing to an `output` the
-  // registry does not hold would hand the turn ZERO tools and guarantee the
-  // failure this whole function exists to prevent. `getActiveToolNames()` is
-  // the honest probe — those names come out of the SAME registry lookup
-  // (`agent.state.tools`, only populated on a registry hit), so `output`
-  // appearing there proves the narrowing resolves. `terminalTools` cannot
-  // substitute: it only says how the RUNNER was configured, not what the SDK
-  // registry ended up holding.
-  //
-  // Narrowing also rebuilds the base system prompt from the resource loader,
-  // which re-reads the loader's `systemPrompt` (the agent prompt this runner
-  // passes to `DefaultResourceLoader` above) — the agent's own instructions
-  // survive; only the tool section of the prompt shrinks.
-  if (session.getActiveToolNames().includes(OUTPUT_TERMINAL_TOOL)) {
-    session.setActiveToolsByName([OUTPUT_TERMINAL_TOOL]);
+  // Make the "call `output`, nothing else" contract mechanical — prompt text
+  // alone left the whole tool surface live. Filtered through the registry
+  // probe, never `terminalTools` (runner config, not SDK truth).
+  const resolvable = new Set(session.getActiveToolNames());
+  if (resolvable.has(OUTPUT_TERMINAL_TOOL)) {
+    session.setActiveToolsByName(OUTPUT_REPROMPT_TOOLS.filter((name) => resolvable.has(name)));
   }
 
   const race = opts.race ?? (<T>(promise: Promise<T>): Promise<T> => promise);

--- a/packages/runner-pi/test/helpers.ts
+++ b/packages/runner-pi/test/helpers.ts
@@ -51,9 +51,9 @@ export interface FakeSession extends BridgeableSession, PromptableSession {
 /**
  * @param opts.toolRegistry names the SDK tool registry resolves. Mirrors
  *   production: the four Pi built-ins plus the `output` runtime tool that
- *   `runtime-pi/mcp/direct.ts` registers verbatim under `tool.name`. Pass a
- *   registry WITHOUT `"output"` to reproduce the (defended) case where the
- *   runner was configured with a terminal tool the SDK never resolved.
+ *   `runtime-pi/mcp/direct.ts` registers verbatim under `tool.name`. Drop
+ *   `"output"` (or `"read"`) from it to reproduce the defended cases where a
+ *   name the corrective turn asks for is one the SDK never resolved.
  */
 export function createFakeSession(opts: { toolRegistry?: string[] } = {}): FakeSession {
   const listeners: Array<(event: unknown) => void> = [];
@@ -75,10 +75,9 @@ export function createFakeSession(opts: { toolRegistry?: string[] } = {}): FakeS
     setActiveToolsByName(toolNames: string[]) {
       session.setActiveToolsCalls.push([...toolNames]);
       session.callLog.push("set_active_tools");
-      // Same semantics as the SDK's `AgentSession.setActiveToolsByName`:
-      // unknown names are silently dropped, so restricting to a name the
-      // registry does not hold leaves the turn with ZERO tools. A fake that
-      // accepted every name would make the regression test vacuous.
+      // Silent-drop semantics, per the SDK contract documented on
+      // `PromptableSession.setActiveToolsByName`. A fake that accepted every
+      // name would make the narrowing tests vacuous.
       session.activeTools = toolNames.filter((name) => toolRegistry.has(name));
     },
     async prompt(message: string) {

--- a/packages/runner-pi/test/helpers.ts
+++ b/packages/runner-pi/test/helpers.ts
@@ -36,11 +36,29 @@ export interface FakeSession extends BridgeableSession, PromptableSession {
   aborts: number;
   /** Test hook: drives what the session does during a `prompt()` turn. */
   onPrompt?: (message: string) => void | Promise<void>;
+  /** Every `setActiveToolsByName()` argument, in order (raw, pre-resolution). */
+  setActiveToolsCalls: string[][];
+  /**
+   * Ordered trace of the two calls that must happen in sequence — a
+   * `"set_active_tools"` entry followed by `"prompt"` proves the tool set was
+   * narrowed BEFORE the corrective turn went out.
+   */
+  callLog: Array<"set_active_tools" | "prompt">;
+  /** Tools the agent may call on the next turn, after registry resolution. */
+  activeTools: string[];
 }
 
-export function createFakeSession(): FakeSession {
+/**
+ * @param opts.toolRegistry names the SDK tool registry resolves. Mirrors
+ *   production: the four Pi built-ins plus the `output` runtime tool that
+ *   `runtime-pi/mcp/direct.ts` registers verbatim under `tool.name`. Pass a
+ *   registry WITHOUT `"output"` to reproduce the (defended) case where the
+ *   runner was configured with a terminal tool the SDK never resolved.
+ */
+export function createFakeSession(opts: { toolRegistry?: string[] } = {}): FakeSession {
   const listeners: Array<(event: unknown) => void> = [];
   const messages: unknown[] = [];
+  const toolRegistry = new Set(opts.toolRegistry ?? ["read", "bash", "edit", "write", "output"]);
   const session: FakeSession = {
     subscribe(cb) {
       listeners.push(cb);
@@ -48,8 +66,24 @@ export function createFakeSession(): FakeSession {
     state: { messages },
     prompts: [],
     aborts: 0,
+    setActiveToolsCalls: [],
+    callLog: [],
+    activeTools: [...toolRegistry],
+    getActiveToolNames() {
+      return [...session.activeTools];
+    },
+    setActiveToolsByName(toolNames: string[]) {
+      session.setActiveToolsCalls.push([...toolNames]);
+      session.callLog.push("set_active_tools");
+      // Same semantics as the SDK's `AgentSession.setActiveToolsByName`:
+      // unknown names are silently dropped, so restricting to a name the
+      // registry does not hold leaves the turn with ZERO tools. A fake that
+      // accepted every name would make the regression test vacuous.
+      session.activeTools = toolNames.filter((name) => toolRegistry.has(name));
+    },
     async prompt(message: string) {
       session.prompts.push(message);
+      session.callLog.push("prompt");
       await session.onPrompt?.(message);
     },
     emit(event) {

--- a/packages/runner-pi/test/output-reprompt.test.ts
+++ b/packages/runner-pi/test/output-reprompt.test.ts
@@ -217,8 +217,8 @@ describe("maybeRepromptForOutput — guards", () => {
   });
 });
 
-describe("maybeRepromptForOutput — corrective turn is restricted to `output`", () => {
-  it("exposes ONLY `output` on the corrective turn, and narrows before prompting", async () => {
+describe("maybeRepromptForOutput — corrective turn is restricted to `output` + `read`", () => {
+  it("exposes ONLY `output` and `read` on the corrective turn, and narrows before prompting", async () => {
     const sink = createInternalCapture();
     const session = createFakeSession();
     const bridge = installSessionBridge(session, sink, RUN_ID, { terminalTools: ["output"] });
@@ -235,20 +235,69 @@ describe("maybeRepromptForOutput — corrective turn is restricted to `output`",
 
     expect(reprompted).toBe(true);
     // The prompt text asks for "no other tool"; the tool set enforces it.
-    expect(session.setActiveToolsCalls).toEqual([["output"]]);
-    expect(session.activeTools).toEqual(["output"]);
+    // `read` stays so the model can recover a report it wrote to `outputs/`
+    // and that auto-compaction has since summarised out of its context.
+    expect(session.setActiveToolsCalls).toEqual([["output", "read"]]);
+    expect(session.activeTools).toEqual(["output", "read"]);
     // Ordering matters: narrowing after the prompt would be a no-op for the
     // very turn it is meant to constrain.
     expect(session.callLog).toEqual(["set_active_tools", "prompt"]);
     expect(session.prompts).toHaveLength(1);
   });
 
+  it("tells the model it may re-read its own files — never forbids the one tool it grants", async () => {
+    const sink = createInternalCapture();
+    const session = createFakeSession();
+    const bridge = installSessionBridge(session, sink, RUN_ID, { terminalTools: ["output"] });
+
+    endTurn(session, { role: "assistant", stopReason: "stop", content: [] });
+
+    await maybeRepromptForOutput({
+      session,
+      bridge,
+      terminalTools: ["output"],
+      sink,
+      runId: RUN_ID,
+    });
+
+    const instruction = session.prompts[0] ?? "";
+    // Model-facing text must match the tool set it is issued with.
+    expect(instruction).toContain("`read`");
+    expect(instruction).toContain("`outputs/`");
+    // The pre-`read` clause, which forbade exactly what the turn now grants.
+    expect(instruction).not.toContain("do not call any other tool, and do not reply");
+  });
+
+  it("degrades to `output` alone when the SDK registry has no `read`", async () => {
+    const sink = createInternalCapture();
+    // `read` is a best-effort addition: the SDK would silently drop it anyway,
+    // but asking for a name that cannot resolve hides which tools the turn
+    // really got. Narrowing must still happen — `output` is what matters.
+    const session = createFakeSession({ toolRegistry: ["bash", "edit", "write", "output"] });
+    const bridge = installSessionBridge(session, sink, RUN_ID, { terminalTools: ["output"] });
+
+    endTurn(session, { role: "assistant", stopReason: "stop", content: [] });
+
+    const reprompted = await maybeRepromptForOutput({
+      session,
+      bridge,
+      terminalTools: ["output"],
+      sink,
+      runId: RUN_ID,
+    });
+
+    expect(reprompted).toBe(true);
+    expect(session.setActiveToolsCalls).toEqual([["output"]]);
+    expect(session.activeTools).toEqual(["output"]);
+    expect(session.callLog).toEqual(["set_active_tools", "prompt"]);
+  });
+
   it("does NOT narrow — and never issues a tool-less turn — when the SDK registry has no `output`", async () => {
     const sink = createInternalCapture();
     // `terminalTools` says the runner was configured with `output`, but the SDK
-    // registry never resolved that name. `setActiveToolsByName(["output"])`
-    // would silently produce ZERO tools, so the turn must go out unrestricted
-    // and let the platform's finalize-time validation stay the fallback.
+    // registry never resolved that name. Narrowing would leave only `read` (or
+    // nothing), so the turn must go out unrestricted and let the platform's
+    // finalize-time validation stay the fallback.
     const session = createFakeSession({ toolRegistry: ["read", "bash", "edit", "write"] });
     const bridge = installSessionBridge(session, sink, RUN_ID, { terminalTools: ["output"] });
 

--- a/packages/runner-pi/test/output-reprompt.test.ts
+++ b/packages/runner-pi/test/output-reprompt.test.ts
@@ -217,6 +217,81 @@ describe("maybeRepromptForOutput — guards", () => {
   });
 });
 
+describe("maybeRepromptForOutput — corrective turn is restricted to `output`", () => {
+  it("exposes ONLY `output` on the corrective turn, and narrows before prompting", async () => {
+    const sink = createInternalCapture();
+    const session = createFakeSession();
+    const bridge = installSessionBridge(session, sink, RUN_ID, { terminalTools: ["output"] });
+
+    endTurn(session, { role: "assistant", stopReason: "stop", content: [] });
+
+    const reprompted = await maybeRepromptForOutput({
+      session,
+      bridge,
+      terminalTools: ["output"],
+      sink,
+      runId: RUN_ID,
+    });
+
+    expect(reprompted).toBe(true);
+    // The prompt text asks for "no other tool"; the tool set enforces it.
+    expect(session.setActiveToolsCalls).toEqual([["output"]]);
+    expect(session.activeTools).toEqual(["output"]);
+    // Ordering matters: narrowing after the prompt would be a no-op for the
+    // very turn it is meant to constrain.
+    expect(session.callLog).toEqual(["set_active_tools", "prompt"]);
+    expect(session.prompts).toHaveLength(1);
+  });
+
+  it("does NOT narrow — and never issues a tool-less turn — when the SDK registry has no `output`", async () => {
+    const sink = createInternalCapture();
+    // `terminalTools` says the runner was configured with `output`, but the SDK
+    // registry never resolved that name. `setActiveToolsByName(["output"])`
+    // would silently produce ZERO tools, so the turn must go out unrestricted
+    // and let the platform's finalize-time validation stay the fallback.
+    const session = createFakeSession({ toolRegistry: ["read", "bash", "edit", "write"] });
+    const bridge = installSessionBridge(session, sink, RUN_ID, { terminalTools: ["output"] });
+
+    endTurn(session, { role: "assistant", stopReason: "stop", content: [] });
+
+    const reprompted = await maybeRepromptForOutput({
+      session,
+      bridge,
+      terminalTools: ["output"],
+      sink,
+      runId: RUN_ID,
+    });
+
+    expect(reprompted).toBe(true);
+    expect(session.setActiveToolsCalls).toEqual([]);
+    expect(session.activeTools).toEqual(["read", "bash", "edit", "write"]);
+    expect(session.callLog).toEqual(["prompt"]);
+    expect(session.prompts).toHaveLength(1);
+    expect(repromptEvents(sink.events)).toHaveLength(1);
+  });
+
+  it("leaves the tool set untouched when a guard declines the corrective turn", async () => {
+    const sink = createInternalCapture();
+    const session = createFakeSession();
+    const bridge = installSessionBridge(session, sink, RUN_ID, { terminalTools: ["output"] });
+
+    callOutput(session);
+    endTurn(session, { role: "assistant", stopReason: "stop", content: [] });
+
+    const reprompted = await maybeRepromptForOutput({
+      session,
+      bridge,
+      terminalTools: ["output"],
+      sink,
+      runId: RUN_ID,
+    });
+
+    expect(reprompted).toBe(false);
+    expect(session.setActiveToolsCalls).toEqual([]);
+    expect(session.activeTools).toEqual(["read", "bash", "edit", "write", "output"]);
+  });
+});
+
 describe("PiRunner.run — missing-output re-prompt end to end", () => {
   it("issues one corrective turn and finalizes the run when the retry delivers output", async () => {
     const sink = createCaptureSink();


### PR DESCRIPTION
Closes #996.

Five removals identified by the post-#982 cost-vs-evidence audit, one commit each, plus one review-remediation commit.

## What changed

| # | Change | Commit |
|---|---|---|
| 1 | The missing-output corrective turn now enforces its tool contract mechanically instead of asking for it | `2114f82` + `81541bb` |
| 2 | `runResultExceedsInlineLimit` deleted — its consumer went away in `f6ec1246`, `truncateRunAndWaitPayload()` already owns the threshold | `35e36c4` |
| 3 | The thin-budget warning tier deleted — 180,000 ms had no derivation and nothing consumed the warning | `7602e15` |
| 4 | Four zero-variant options collapsed to their shared constants | `8452fc2` |
| 5 | `DOC_STREAM_CONCURRENCY` un-exported — zero importers since the prompt-URI repair path was deleted | `d26a30a` |

## The one behaviour change

The corrective turn is narrowed with `setActiveToolsByName(...)`, so `no other tool` stops being a request the model may ignore. On that turn the agent can no longer run bash, mutate files, publish documents, write memory, call an integration, or start a second research loop.

**It is narrowed to `output` + `read`, not `output` alone** — a deliberate deviation from the acceptance criterion in #996, decided after an adversarial review found a reachable failure the issue had not considered:

1. the agent writes its findings to `outputs/report.md`, which is what this platform's own model-facing text instructs;
2. the session is long, so Pi auto-compaction (on unless `MODEL_COMPACTION_ENABLED=false`) summarises the detailed history away;
3. the agent ends the turn without calling `output`;
4. with `output` alone active, the findings are neither in context nor reachable — the model must fabricate the required fields.

`read` recovers work already done and already paid for; it is not research. The model-facing instruction was rewritten to match, since a prompt forbidding the one tool the turn grants is worse than no instruction.

Two safety properties are pinned by tests: no `output` in the SDK registry → no narrowing at all (unrestricted beats tool-less), and no `read` → narrows to `output` alone.

## Cost this carries

`setActiveToolsByName` rewrites both `agent.state.tools` and `agent.state.systemPrompt`. Anthropic's cache is prefix-based over `tools → system → messages` with breakpoints on the system block and the last tool definition, so the corrective turn re-reads the session at full input price instead of cache-read price. Accepted — a fabricated or absent `output` fails the entire run — and now documented at the seam rather than left implicit.

## Compatibility

- No OpenAPI, database, migration, persisted-shape or AFPS change.
- The two removed `@appstrate/core` symbols and the removed `formatTurnBudgetNote` input have never shipped: npm serves `5.0.0`, there is no `core@6.0.0` tag, and all three sat under `## [Unreleased]`. The changelog entries were corrected in place rather than moved to `Removed`, which is right for symbols no consumer can hold.
- The only removed log line (`chat run_and_wait launched on a thin turn budget`) has zero consumers repo-wide.
- No user-facing or model-facing string changed anywhere else — the refusal payload, deadline notice, and budget note are byte-identical.

## Verification

- `bun run check` — 33/33 tasks, clean (one pre-existing `react-refresh` warning in an untouched file).
- `bun test packages/{runner-pi,module-chat,core}/test` — 1275 pass, 0 fail.
- `apps/api` unit suite — 1256 pass, 0 fail; input-parser integration — 25 pass, 0 fail.
- Mutation-checked: a narrowing that runs unconditionally, or one that runs after `prompt()`, fails the new tests.

## Follow-up, not in this PR

Tracked as #1010: `isFinalChatStep(stepNumber, maxSteps = CHAT_MAX_STEPS)` carries the same zero-variant option — its only production caller passes `CHAT_MAX_STEPS`, its tests take the default, and no other value exists. It is not listed in #996, so it was left alone rather than silently widening the scope.

One difference matters and is why it needs its own decision rather than a quiet fold-in: unlike the four options collapsed here, **this one has shipped** — it is in `core@5.0.0`, which is npm's `latest`. Removing the parameter is a source break, free only if it lands before the (untagged, unpublished) `core@6.0.0` major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
