### PR TITLE
test(oidc): lock in RFC 9207 iss on the authorization response (#953)

### DIFF
--- a/apps/api/src/modules/oidc/test/integration/services/oauth-flows.test.ts
+++ b/apps/api/src/modules/oidc/test/integration/services/oauth-flows.test.ts
@@ -90,15 +90,15 @@ function randomVerifier(): string {
 }
 
 /**
- * Extract the authorization code from a consent-endpoint response. The
+ * Extract the client callback URL from a consent-endpoint response. The
  * plugin's response shape depends on its version — 302 with a `Location`
  * header, or 200 with a JSON body containing the redirect URL under one
  * of `redirect_uri` / `redirectURI` / `url`.
  */
-async function extractCodeFromConsentResponse(res: Response): Promise<string | null> {
+async function extractCallbackFromConsentResponse(res: Response): Promise<URL | null> {
   const loc = res.headers.get("location");
   if (loc) {
-    return new URL(loc, "http://localhost").searchParams.get("code");
+    return new URL(loc, "http://localhost");
   }
   const json = (await res.json()) as {
     redirect_uri?: string;
@@ -107,7 +107,11 @@ async function extractCodeFromConsentResponse(res: Response): Promise<string | n
   };
   const redirectUri = json.redirect_uri ?? json.redirectURI ?? json.url;
   if (!redirectUri) return null;
-  return new URL(redirectUri).searchParams.get("code");
+  return new URL(redirectUri);
+}
+
+async function extractCodeFromConsentResponse(res: Response): Promise<string | null> {
+  return (await extractCallbackFromConsentResponse(res))?.searchParams.get("code") ?? null;
 }
 
 async function registerClient(
@@ -219,6 +223,7 @@ describe("OAuth 2.1 Authorization Code + PKCE end-to-end", () => {
       scopes_supported?: string[];
       response_types_supported?: string[];
       code_challenge_methods_supported?: string[];
+      authorization_response_iss_parameter_supported?: boolean;
     };
     expect(body.issuer).toBeTruthy();
     expect(body.token_endpoint).toContain("/oauth2/token");
@@ -228,6 +233,10 @@ describe("OAuth 2.1 Authorization Code + PKCE end-to-end", () => {
     expect(body.scopes_supported).toContain("offline_access");
     expect(body.response_types_supported).toContain("code");
     expect(body.code_challenge_methods_supported).toContain("S256");
+    // RFC 9207 (#953): a client that reads this flag — Codex's MCP login does —
+    // rejects any authorization response whose `iss` is absent or mismatched.
+    // The runtime counterpart is asserted on the final client callback below.
+    expect(body.authorization_response_iss_parameter_supported).toBe(true);
   });
 
   it("mints an access token via the full PKCE flow through the module consent handler", async () => {
@@ -267,6 +276,9 @@ describe("OAuth 2.1 Authorization Code + PKCE end-to-end", () => {
     // Better Auth has signed the query — both params must be present.
     expect(consentUrl.searchParams.get("sig")).toBeTruthy();
     expect(consentUrl.searchParams.get("exp")).toBeTruthy();
+    // This hop is internal (authorize → our consent page), not an
+    // authorization response: it must NOT be stamped with `iss`.
+    expect(consentUrl.searchParams.get("iss")).toBeNull();
 
     // ── Step 2 ── GET the consent page to obtain the CSRF token + cookie.
     const consentPageRes = await app.request(consentUrl.pathname + consentUrl.search, {
@@ -310,8 +322,22 @@ describe("OAuth 2.1 Authorization Code + PKCE end-to-end", () => {
     });
     expect([200, 302]).toContain(consentRes.status);
 
-    const code = await extractCodeFromConsentResponse(consentRes);
+    const callback = await extractCallbackFromConsentResponse(consentRes);
+    expect(callback).not.toBeNull();
+    // The callback lands on the registered redirect_uri, untouched apart from
+    // the authorization-response params.
+    expect(callback!.origin + callback!.pathname).toBe("https://satellite.example.com/callback");
+    const code = callback!.searchParams.get("code");
     expect(code).toBeTruthy();
+    expect(callback!.searchParams.get("state")).toBe(state);
+    // RFC 9207 (#953): the final client callback carries `iss`, and it matches
+    // the issuer advertised in the authorization-server metadata exactly —
+    // Codex's MCP login refuses the response otherwise. This is the runtime
+    // half of the discovery assertion above; the two must never drift apart.
+    const discovery = (await (
+      await app.request("/.well-known/oauth-authorization-server")
+    ).json()) as { issuer: string };
+    expect(callback!.searchParams.get("iss")).toBe(discovery.issuer);
 
     // ── Step 4 ── Exchange code + PKCE verifier for tokens. Must succeed.
     // CRITICAL: `resource` is REQUIRED on the token request for the plugin


### PR DESCRIPTION
Closes #953.

## What the issue claimed

Codex MCP OAuth login fails because some authorization-response paths omit the RFC 9207 `iss` parameter even though discovery advertises support for it, with the behavior "inconsistent across the authorization handler and the custom consent handler".

## What is actually happening

Not reproducible on `main`. Every acceptance criterion in the issue is already met.

`@better-auth/oauth-provider@1.7.0-beta.4` (pinned since #606, 2026-06-08 — before the issue was filed) funnels **both** the authorize path and the consent path through a single `redirectWithAuthorizationCode()`, which sets `iss` unconditionally; error redirects get it too via `formatErrorURL()`; and `authServerMetadata()` advertises `authorization_response_iss_parameter_supported: true`.

On our side, `maybeJsonRedirectToLocation` (`apps/api/src/modules/oidc/routes.ts`) copies Better Auth's URL verbatim into the `Location` header — it never rebuilds the callback — and `serveOAuthServerConfig` returns the metadata document unmodified. No Appstrate code path constructs a client callback itself.

Measured against a real PKCE flow with a DCR-registered loopback client (`http://127.0.0.1:1455/callback`, the shape Codex uses):

```
metadata issuer:  http://localhost:3000/api/auth
iss_supported:    true
final callback:   302 -> http://127.0.0.1:1455/callback
                        ?code=...&state=xyz&iss=http%3A%2F%2Flocalhost%3A3000%2Fapi%2Fauth
```

## What this PR changes

Only the test file — no behavior change. None of the above was asserted anywhere, so an upstream regression or a drift between the advertised issuer and the stamped one would have shipped silently. `oauth-flows.test.ts` now asserts, in the existing full-PKCE test:

- the final client callback lands on the registered `redirect_uri`, with `code` and `state` unchanged;
- its `iss` equals the `issuer` in the live discovery document (fetched in the same test, so the two cannot drift);
- the internal authorize → consent hop is **not** stamped with `iss`;
- discovery advertises `authorization_response_iss_parameter_supported: true`.

`extractCodeFromConsentResponse` was widened to `extractCallbackFromConsentResponse` (returns the whole URL) and kept as a thin wrapper for the two other call sites.

13/13 tests in the file pass; prettier, eslint and tsc are clean.

## Adjacent gap, filed separately

The issue's repro step "register an OAuth client with a loopback redirect URI" does fail in production — but through the admin API, not through `iss`. Tracked separately rather than here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)