### PR TITLE
fix(llm-usage): stop paging operators for a refusal that costs nothing (#997)

### DIFF
--- a/apps/api/src/services/llm-usage-ledger.ts
+++ b/apps/api/src/services/llm-usage-ledger.ts
@@ -131,60 +131,42 @@ const runNotTerminalSql = sql`NOT EXISTS (
     )})
 )`;
 
-/** The monotonic columns of one runner snapshot, as SQL expressions. */
-interface RunnerSnapshotSql {
+/**
+ * The two dimensions the advance rule compares, per side. The four token
+ * buckets never matter individually — only their COALESCE'd total does — so
+ * each side carries one pre-summed token expression rather than four columns.
+ */
+interface AdvanceableSql {
   costUsd: SQL;
-  inputTokens: SQL;
-  outputTokens: SQL;
-  cacheReadTokens: SQL;
-  cacheWriteTokens: SQL;
+  totalTokens: SQL<number | null>;
 }
 
-/** The stored side: the conflicting row's own columns. */
-const storedSnapshotSql: RunnerSnapshotSql = {
+/** The stored side: the conflicting row's own columns (NULL on no such row). */
+const storedAdvanceableSql: AdvanceableSql = {
   costUsd: sql`${llmUsage.costUsd}`,
-  inputTokens: sql`${llmUsage.inputTokens}`,
-  outputTokens: sql`${llmUsage.outputTokens}`,
-  cacheReadTokens: sql`${llmUsage.cacheReadTokens}`,
-  cacheWriteTokens: sql`${llmUsage.cacheWriteTokens}`,
+  totalTokens: sql<number | null>`(${llmUsage.inputTokens} + ${llmUsage.outputTokens}
+    + COALESCE(${llmUsage.cacheReadTokens}, 0) + COALESCE(${llmUsage.cacheWriteTokens}, 0))`,
 };
 
 /** The candidate side inside an upsert: Postgres' `EXCLUDED` pseudo-row. */
-const excludedSnapshotSql: RunnerSnapshotSql = {
+const excludedAdvanceableSql: AdvanceableSql = {
   costUsd: sql`EXCLUDED.cost_usd`,
-  inputTokens: sql`EXCLUDED.input_tokens`,
-  outputTokens: sql`EXCLUDED.output_tokens`,
-  cacheReadTokens: sql`EXCLUDED.cache_read_tokens`,
-  cacheWriteTokens: sql`EXCLUDED.cache_write_tokens`,
+  totalTokens: sql<number | null>`(EXCLUDED.input_tokens + EXCLUDED.output_tokens
+    + COALESCE(EXCLUDED.cache_read_tokens, 0) + COALESCE(EXCLUDED.cache_write_tokens, 0))`,
 };
 
 /**
- * The same candidate as bound parameters, so {@link runnerAdvancesSql} can be
- * evaluated outside an upsert. Every value is cast: a bound parameter reaches
- * Postgres untyped, and `$1 + $2` alone is not resolvable.
+ * Cumulative token total of an entry — the SINGLE definition of the incoming
+ * side's arithmetic, used both to build the comparison and to report it. `?? 0`
+ * is what `COALESCE(…, 0)` does on the stored side above.
  */
-function entrySnapshotSql(entry: LlmUsageEntry): RunnerSnapshotSql {
-  return {
-    costUsd: sql`${entry.costUsd}::double precision`,
-    inputTokens: sql`${entry.inputTokens}::integer`,
-    outputTokens: sql`${entry.outputTokens}::integer`,
-    cacheReadTokens: sql`${entry.cacheReadTokens ?? null}::integer`,
-    cacheWriteTokens: sql`${entry.cacheWriteTokens ?? null}::integer`,
-  };
-}
-
-/**
- * Cumulative token total of a snapshot — the measure the level-2 tiebreak
- * compares, and the one the refusal diagnostic reports. Shared so the figure an
- * operator reads is by construction the figure the predicate weighed; NULL for
- * an unmatched LEFT JOIN (no stored row), 0-COALESCED per cache arm otherwise.
- */
-function snapshotTotalTokensSql(snapshot: RunnerSnapshotSql): SQL<number | null> {
-  return sql<number | null>`(
-    ${snapshot.inputTokens} + ${snapshot.outputTokens}
-      + COALESCE(${snapshot.cacheReadTokens}, 0)
-      + COALESCE(${snapshot.cacheWriteTokens}, 0)
-  )`;
+function entryTotalTokens(entry: LlmUsageEntry): number {
+  return (
+    entry.inputTokens +
+    entry.outputTokens +
+    (entry.cacheReadTokens ?? 0) +
+    (entry.cacheWriteTokens ?? 0)
+  );
 }
 
 /**
@@ -203,18 +185,18 @@ function snapshotTotalTokensSql(snapshot: RunnerSnapshotSql): SQL<number | null>
  * and the finalize fallback can never regress either dimension.
  *
  * Built once for the two sites that MUST agree on it: the upsert's `setWhere`
- * (candidate = {@link excludedSnapshotSql}) and the refusal diagnostic
+ * (candidate = {@link excludedAdvanceableSql}) and the refusal diagnostic
  * {@link traceRejectedTerminalRunnerWrite} (candidate = the entry's bound
  * values), so the diagnostic can never contradict the write it explains.
  * Evaluates to NULL when there is no row to compare against (an unmatched LEFT
  * JOIN) — the diagnostic reads that as "would have inserted".
  */
-function runnerAdvancesSql(candidate: RunnerSnapshotSql): SQL<boolean | null> {
+function runnerAdvancesSql(candidate: AdvanceableSql): SQL<boolean | null> {
   return sql<boolean | null>`(
-    ${candidate.costUsd} > ${storedSnapshotSql.costUsd}
+    ${candidate.costUsd} > ${storedAdvanceableSql.costUsd}
     OR (
-      ${candidate.costUsd} = ${storedSnapshotSql.costUsd}
-      AND ${snapshotTotalTokensSql(candidate)} > ${snapshotTotalTokensSql(storedSnapshotSql)}
+      ${candidate.costUsd} = ${storedAdvanceableSql.costUsd}
+      AND ${candidate.totalTokens} > ${storedAdvanceableSql.totalTokens}
     )
   )`;
 }
@@ -283,7 +265,7 @@ export async function recordLlmUsage(
             // being non-terminal — see {@link runNotTerminalSql}: a settled row
             // has already been claimed by its serial id, so growing it strands
             // the delta.
-            setWhere: sql`${runNotTerminalSql} AND ${runnerAdvancesSql(excludedSnapshotSql)}`,
+            setWhere: sql`${runNotTerminalSql} AND ${runnerAdvancesSql(excludedAdvanceableSql)}`,
           })
           .returning({ id: llmUsage.id })
       : opts.onConflict === "proxy-idempotent"
@@ -341,14 +323,19 @@ export async function recordLlmUsage(
  * took the plain path.
  */
 async function traceRejectedTerminalRunnerWrite(executor: Db, entry: LlmUsageEntry): Promise<void> {
-  const incoming = entrySnapshotSql(entry);
+  const incomingTotalTokens = entryTotalTokens(entry);
+  // Bound parameters reach Postgres untyped; the casts pin them instead of
+  // leaning on the surrounding operands to resolve them.
+  const incoming: AdvanceableSql = {
+    costUsd: sql`${entry.costUsd}::double precision`,
+    totalTokens: sql<number | null>`${incomingTotalTokens}::integer`,
+  };
   try {
     const [row] = await executor
       .select({
         status: runs.status,
         storedCostUsd: llmUsage.costUsd,
-        storedTotalTokens: snapshotTotalTokensSql(storedSnapshotSql),
-        incomingTotalTokens: snapshotTotalTokensSql(incoming),
+        storedTotalTokens: storedAdvanceableSql.totalTokens,
         advances: runnerAdvancesSql(incoming),
       })
       .from(runs)
@@ -369,32 +356,33 @@ async function traceRejectedTerminalRunnerWrite(executor: Db, entry: LlmUsageEnt
       incomingCostUsd: entry.costUsd,
       refusedDeltaUsd: entry.costUsd - (row.storedCostUsd ?? 0),
       storedTotalTokens: row.storedTotalTokens,
-      incomingTotalTokens: row.incomingTotalTokens,
-      refusedDeltaTokens: (row.incomingTotalTokens ?? 0) - (row.storedTotalTokens ?? 0),
+      incomingTotalTokens,
+      refusedDeltaTokens: incomingTotalTokens - (row.storedTotalTokens ?? 0),
     });
   } catch (err) {
-    // Explaining a no-op must never break the write: `recordLlmUsageReliably`
-    // always rethrows for runner rows, and the finalize barrier calls it with
-    // `required: true` outside any transaction, so a throw here would fail
-    // `finalizeRun` and leave the run unsettled. It stays at `error` because an
-    // unassessed refusal may be a real billing loss and a diagnostic that cannot
-    // run in a billing path is itself actionable — noisy only if the SELECT
-    // breaks systematically, and bounded by a query that runs solely on a no-op.
-    // Catching cannot un-poison the `appstrate.metric` caller's ingestion
-    // transaction, which stays safe by its own design (the runner's next
-    // cumulative snapshot supersedes — see `run-launcher/appstrate-event-sink.ts`).
+    // Reported at `error`, not warn: an unassessed refusal may be a real billing
+    // loss, and a diagnostic that cannot run in a billing path is itself
+    // actionable. The honest cost — runner no-ops are NOT rare (every duplicate
+    // cumulative metric event is one, not just the #997 finalize replay), so a
+    // systematically failing SELECT reproduces #997 at a higher volume than
+    // #997 itself.
     logger.error("llm_usage: could not assess a refused runner snapshot", {
       runId: entry.runId,
       orgId: entry.orgId,
       incomingCostUsd: entry.costUsd,
-      // Summed in TS, not by {@link snapshotTotalTokensSql}: the DB read is what
-      // just failed, so only the entry's own values are still in hand.
-      incomingTotalTokens:
-        entry.inputTokens +
-        entry.outputTokens +
-        (entry.cacheReadTokens ?? 0) +
-        (entry.cacheWriteTokens ?? 0),
+      incomingTotalTokens,
       error: getErrorMessage(err),
     });
+    // Swallowing is for ONE caller: the finalize barrier passes no executor
+    // (`recordLlmUsage` resolves `opts.executor ?? db`) and runs outside any
+    // transaction, where a throw would fail a `required: true` write and leave a
+    // finished run permanently unsettled. A caller-supplied executor is an open
+    // transaction (`appstrate.metric` ingestion), and swallowing inside one is
+    // worse than a missing log line: on PGlite the callback then resolves,
+    // drizzle sends COMMIT, Postgres turns it into ROLLBACK, and the sink
+    // answers 2xx having lost the run_log row, the ledger write and the sequence
+    // advance. Rethrowing keeps that path's documented recovery — the runner
+    // re-POSTs and its next cumulative snapshot supersedes.
+    if (executor !== db) throw err;
   }
 }

--- a/apps/api/src/services/llm-usage-ledger.ts
+++ b/apps/api/src/services/llm-usage-ledger.ts
@@ -131,7 +131,7 @@ const runNotTerminalSql = sql`NOT EXISTS (
     )})
 )`;
 
-/** The monotonic columns of a candidate runner snapshot, as SQL expressions. */
+/** The monotonic columns of one runner snapshot, as SQL expressions. */
 interface RunnerSnapshotSql {
   costUsd: SQL;
   inputTokens: SQL;
@@ -139,6 +139,15 @@ interface RunnerSnapshotSql {
   cacheReadTokens: SQL;
   cacheWriteTokens: SQL;
 }
+
+/** The stored side: the conflicting row's own columns. */
+const storedSnapshotSql: RunnerSnapshotSql = {
+  costUsd: sql`${llmUsage.costUsd}`,
+  inputTokens: sql`${llmUsage.inputTokens}`,
+  outputTokens: sql`${llmUsage.outputTokens}`,
+  cacheReadTokens: sql`${llmUsage.cacheReadTokens}`,
+  cacheWriteTokens: sql`${llmUsage.cacheWriteTokens}`,
+};
 
 /** The candidate side inside an upsert: Postgres' `EXCLUDED` pseudo-row. */
 const excludedSnapshotSql: RunnerSnapshotSql = {
@@ -165,6 +174,20 @@ function entrySnapshotSql(entry: LlmUsageEntry): RunnerSnapshotSql {
 }
 
 /**
+ * Cumulative token total of a snapshot — the measure the level-2 tiebreak
+ * compares, and the one the refusal diagnostic reports. Shared so the figure an
+ * operator reads is by construction the figure the predicate weighed; NULL for
+ * an unmatched LEFT JOIN (no stored row), 0-COALESCED per cache arm otherwise.
+ */
+function snapshotTotalTokensSql(snapshot: RunnerSnapshotSql): SQL<number | null> {
+  return sql<number | null>`(
+    ${snapshot.inputTokens} + ${snapshot.outputTokens}
+      + COALESCE(${snapshot.cacheReadTokens}, 0)
+      + COALESCE(${snapshot.cacheWriteTokens}, 0)
+  )`;
+}
+
+/**
  * SQL predicate: `candidate` strictly ADVANCES the conflicting runner row.
  *
  * Runner rows are cumulative snapshots — tokens and cost grow together — so the
@@ -188,15 +211,10 @@ function entrySnapshotSql(entry: LlmUsageEntry): RunnerSnapshotSql {
  */
 function runnerAdvancesSql(candidate: RunnerSnapshotSql): SQL<boolean | null> {
   return sql<boolean | null>`(
-    ${candidate.costUsd} > ${llmUsage.costUsd}
+    ${candidate.costUsd} > ${storedSnapshotSql.costUsd}
     OR (
-      ${candidate.costUsd} = ${llmUsage.costUsd}
-      AND ${candidate.inputTokens} + ${candidate.outputTokens}
-            + COALESCE(${candidate.cacheReadTokens}, 0)
-            + COALESCE(${candidate.cacheWriteTokens}, 0)
-          > ${llmUsage.inputTokens} + ${llmUsage.outputTokens}
-            + COALESCE(${llmUsage.cacheReadTokens}, 0)
-            + COALESCE(${llmUsage.cacheWriteTokens}, 0)
+      ${candidate.costUsd} = ${storedSnapshotSql.costUsd}
+      AND ${snapshotTotalTokensSql(candidate)} > ${snapshotTotalTokensSql(storedSnapshotSql)}
     )
   )`;
 }
@@ -323,12 +341,15 @@ export async function recordLlmUsage(
  * took the plain path.
  */
 async function traceRejectedTerminalRunnerWrite(executor: Db, entry: LlmUsageEntry): Promise<void> {
+  const incoming = entrySnapshotSql(entry);
   try {
     const [row] = await executor
       .select({
         status: runs.status,
         storedCostUsd: llmUsage.costUsd,
-        advances: runnerAdvancesSql(entrySnapshotSql(entry)),
+        storedTotalTokens: snapshotTotalTokensSql(storedSnapshotSql),
+        incomingTotalTokens: snapshotTotalTokensSql(incoming),
+        advances: runnerAdvancesSql(incoming),
       })
       .from(runs)
       .leftJoin(llmUsage, and(eq(llmUsage.runId, runs.id), eq(llmUsage.source, "runner")))
@@ -336,25 +357,43 @@ async function traceRejectedTerminalRunnerWrite(executor: Db, entry: LlmUsageEnt
       .limit(1);
     if (!row || !(terminalRunStatusValues as readonly string[]).includes(row.status)) return;
     if (row.advances === false) return;
+    // BOTH dimensions, because a refusal can lose either one: a zero-cost model
+    // holds `cost_usd` flat while tokens climb, so a token-only loss reports
+    // three zeroes on the cost side. `refusedDeltaTokens > 0` is what separates
+    // it from a benign replay — never `refusedDeltaUsd`.
     logger.error("llm_usage: refused a runner snapshot on an already-settled run", {
       runId: entry.runId,
       orgId: entry.orgId,
       runStatus: row.status,
-      // Both cumulative totals, plus the delta that will never be billed.
       storedCostUsd: row.storedCostUsd,
       incomingCostUsd: entry.costUsd,
       refusedDeltaUsd: entry.costUsd - (row.storedCostUsd ?? 0),
+      storedTotalTokens: row.storedTotalTokens,
+      incomingTotalTokens: row.incomingTotalTokens,
+      refusedDeltaTokens: (row.incomingTotalTokens ?? 0) - (row.storedTotalTokens ?? 0),
     });
   } catch (err) {
     // Explaining a no-op must never break the write: `recordLlmUsageReliably`
     // always rethrows for runner rows, and the finalize barrier calls it with
     // `required: true` outside any transaction, so a throw here would fail
-    // `finalizeRun` and leave the run unsettled. This cannot un-poison the
-    // `appstrate.metric` caller's ingestion transaction, which stays safe by its
-    // own design (the runner's next cumulative snapshot supersedes the lost
-    // write — see `run-launcher/appstrate-event-sink.ts`).
-    logger.warn("llm_usage: refusal diagnostic failed", {
+    // `finalizeRun` and leave the run unsettled. It stays at `error` because an
+    // unassessed refusal may be a real billing loss and a diagnostic that cannot
+    // run in a billing path is itself actionable — noisy only if the SELECT
+    // breaks systematically, and bounded by a query that runs solely on a no-op.
+    // Catching cannot un-poison the `appstrate.metric` caller's ingestion
+    // transaction, which stays safe by its own design (the runner's next
+    // cumulative snapshot supersedes — see `run-launcher/appstrate-event-sink.ts`).
+    logger.error("llm_usage: could not assess a refused runner snapshot", {
       runId: entry.runId,
+      orgId: entry.orgId,
+      incomingCostUsd: entry.costUsd,
+      // Summed in TS, not by {@link snapshotTotalTokensSql}: the DB read is what
+      // just failed, so only the entry's own values are still in hand.
+      incomingTotalTokens:
+        entry.inputTokens +
+        entry.outputTokens +
+        (entry.cacheReadTokens ?? 0) +
+        (entry.cacheWriteTokens ?? 0),
       error: getErrorMessage(err),
     });
   }

--- a/apps/api/src/services/llm-usage-ledger.ts
+++ b/apps/api/src/services/llm-usage-ledger.ts
@@ -44,9 +44,10 @@
  * `llm-usage-retry.ts` for durable recovery.
  */
 
+import { getErrorMessage } from "@appstrate/core/errors";
 import { db, type Db } from "@appstrate/db/client";
 import { llmUsage, runs, terminalRunStatusValues } from "@appstrate/db/schema";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, sql, type SQL } from "drizzle-orm";
 import { logger } from "../lib/logger.ts";
 
 /** Credential set that reached the upstream provider for a ledger row. */
@@ -130,6 +131,76 @@ const runNotTerminalSql = sql`NOT EXISTS (
     )})
 )`;
 
+/** The monotonic columns of a candidate runner snapshot, as SQL expressions. */
+interface RunnerSnapshotSql {
+  costUsd: SQL;
+  inputTokens: SQL;
+  outputTokens: SQL;
+  cacheReadTokens: SQL;
+  cacheWriteTokens: SQL;
+}
+
+/** The candidate side inside an upsert: Postgres' `EXCLUDED` pseudo-row. */
+const excludedSnapshotSql: RunnerSnapshotSql = {
+  costUsd: sql`EXCLUDED.cost_usd`,
+  inputTokens: sql`EXCLUDED.input_tokens`,
+  outputTokens: sql`EXCLUDED.output_tokens`,
+  cacheReadTokens: sql`EXCLUDED.cache_read_tokens`,
+  cacheWriteTokens: sql`EXCLUDED.cache_write_tokens`,
+};
+
+/**
+ * The same candidate as bound parameters, so {@link runnerAdvancesSql} can be
+ * evaluated outside an upsert. Every value is cast: a bound parameter reaches
+ * Postgres untyped, and `$1 + $2` alone is not resolvable.
+ */
+function entrySnapshotSql(entry: LlmUsageEntry): RunnerSnapshotSql {
+  return {
+    costUsd: sql`${entry.costUsd}::double precision`,
+    inputTokens: sql`${entry.inputTokens}::integer`,
+    outputTokens: sql`${entry.outputTokens}::integer`,
+    cacheReadTokens: sql`${entry.cacheReadTokens ?? null}::integer`,
+    cacheWriteTokens: sql`${entry.cacheWriteTokens ?? null}::integer`,
+  };
+}
+
+/**
+ * SQL predicate: `candidate` strictly ADVANCES the conflicting runner row.
+ *
+ * Runner rows are cumulative snapshots — tokens and cost grow together — so the
+ * row must only ever advance:
+ *   1. a strictly higher cumulative cost wins; else
+ *   2. an EQUAL cost with a strictly higher total token count wins.
+ * Level 2 is what keeps a zero-cost model (free model / no catalog rate /
+ * zero-rate tokens) correct: its cost stays constant at 0 while token counts
+ * keep climbing, so a cost-only rule would freeze the token columns at their
+ * first values. Both levels use STRICT inequalities, so an exact duplicate
+ * replay (same cost AND same tokens) is a no-op that re-emits nothing — that
+ * idempotence is load-bearing for cursor consumers. Out-of-order metric events
+ * and the finalize fallback can never regress either dimension.
+ *
+ * Built once for the two sites that MUST agree on it: the upsert's `setWhere`
+ * (candidate = {@link excludedSnapshotSql}) and the refusal diagnostic
+ * {@link traceRejectedTerminalRunnerWrite} (candidate = the entry's bound
+ * values), so the diagnostic can never contradict the write it explains.
+ * Evaluates to NULL when there is no row to compare against (an unmatched LEFT
+ * JOIN) — the diagnostic reads that as "would have inserted".
+ */
+function runnerAdvancesSql(candidate: RunnerSnapshotSql): SQL<boolean | null> {
+  return sql<boolean | null>`(
+    ${candidate.costUsd} > ${llmUsage.costUsd}
+    OR (
+      ${candidate.costUsd} = ${llmUsage.costUsd}
+      AND ${candidate.inputTokens} + ${candidate.outputTokens}
+            + COALESCE(${candidate.cacheReadTokens}, 0)
+            + COALESCE(${candidate.cacheWriteTokens}, 0)
+          > ${llmUsage.inputTokens} + ${llmUsage.outputTokens}
+            + COALESCE(${llmUsage.cacheReadTokens}, 0)
+            + COALESCE(${llmUsage.cacheWriteTokens}, 0)
+    )
+  )`;
+}
+
 /**
  * Append one row to `llm_usage`.
  *
@@ -177,20 +248,9 @@ export async function recordLlmUsage(
       ? await executor
           .insert(llmUsage)
           .values(values)
-          // Two-level monotonic upsert on the partial unique index. Runner rows
-          // are cumulative snapshots — tokens and cost grow together — so the row
-          // must only ever advance:
-          //   1. a strictly higher cumulative cost wins; else
-          //   2. an EQUAL cost with a strictly higher total token count wins.
-          // Level 2 is what keeps a zero-cost model (free model / no catalog rate
-          // / zero-rate tokens) correct: its cost stays constant at 0 while token
-          // counts keep climbing, so a cost-only rule would freeze the token
-          // columns at their first values. Both levels use STRICT inequalities, so
-          // an exact duplicate replay (same cost AND same tokens) is a no-op that
-          // re-emits nothing — that idempotence is load-bearing for cursor
-          // consumers. Out-of-order metric events and the finalize fallback can
-          // never regress either dimension. Token columns are bumped alongside the
-          // cost so the snapshot stays consistent.
+          // Two-level monotonic upsert on the partial unique index — see
+          // {@link runnerAdvancesSql} for the advance rule. Token columns are
+          // bumped alongside the cost so the snapshot stays consistent.
           .onConflictDoUpdate({
             target: llmUsage.runId,
             targetWhere: sql`source = 'runner' AND run_id IS NOT NULL`,
@@ -205,21 +265,7 @@ export async function recordLlmUsage(
             // being non-terminal — see {@link runNotTerminalSql}: a settled row
             // has already been claimed by its serial id, so growing it strands
             // the delta.
-            setWhere: sql`
-              ${runNotTerminalSql}
-              AND (
-                EXCLUDED.cost_usd > ${llmUsage.costUsd}
-                OR (
-                  EXCLUDED.cost_usd = ${llmUsage.costUsd}
-                  AND EXCLUDED.input_tokens + EXCLUDED.output_tokens
-                        + COALESCE(EXCLUDED.cache_read_tokens, 0)
-                        + COALESCE(EXCLUDED.cache_write_tokens, 0)
-                      > ${llmUsage.inputTokens} + ${llmUsage.outputTokens}
-                        + COALESCE(${llmUsage.cacheReadTokens}, 0)
-                        + COALESCE(${llmUsage.cacheWriteTokens}, 0)
-                )
-              )
-            `,
+            setWhere: sql`${runNotTerminalSql} AND ${runnerAdvancesSql(excludedSnapshotSql)}`,
           })
           .returning({ id: llmUsage.id })
       : opts.onConflict === "proxy-idempotent"
@@ -254,26 +300,62 @@ export async function recordLlmUsage(
 
 /**
  * Log the post-settlement rejection of a late runner snapshot (see
- * {@link runNotTerminalSql}). Called only when the monotonic upsert wrote
- * nothing, and only for runner rows: reads the run's status plus the stored
- * total so the operator sees exactly how much spend was refused and on which
- * run. A run row that vanished (deleted mid-flight) is not a rejection — the
- * conflicting row was detached to `run_id = NULL` and the insert took the plain
- * path.
+ * {@link runNotTerminalSql}) — but ONLY when that snapshot would genuinely have
+ * advanced the stored row. Called only when the monotonic upsert wrote nothing,
+ * and only for runner rows.
+ *
+ * A no-op upsert has two unrelated causes: the terminal barrier refused a real
+ * delta (billing loss — the error below), or the snapshot was an equal-or-lower
+ * cumulative replay with nothing to add (benign — silence). Every successful run
+ * produces one of the latter, which is why a status-only test drowned the real
+ * losses under one error per run (issue #997): `run-launcher/execute-background.ts`
+ * defensively synthesises a finalize on ANY clean container exit, and
+ * `synthesiseFinalize` carries no cost, so finalize's terminal ledger barrier
+ * re-submits the run's own last snapshot at `costUsd: 0` once the run settled.
+ *
+ * The advance test is the SAME predicate the upsert gates on
+ * ({@link runnerAdvancesSql}), evaluated in Postgres against the stored row, so
+ * the diagnostic cannot drift from the write it explains — and no comparison
+ * value crosses the SQL/TS boundary. Only a definitive `false` is silence: NULL
+ * means the run carries no runner row, i.e. the snapshot would have INSERTed, so
+ * it is still reported. A run row that vanished (deleted mid-flight) is not a
+ * rejection — the conflicting row was detached to `run_id = NULL` and the insert
+ * took the plain path.
  */
 async function traceRejectedTerminalRunnerWrite(executor: Db, entry: LlmUsageEntry): Promise<void> {
-  const [row] = await executor
-    .select({ status: runs.status, storedCost: llmUsage.costUsd })
-    .from(runs)
-    .leftJoin(llmUsage, and(eq(llmUsage.runId, runs.id), eq(llmUsage.source, "runner")))
-    .where(eq(runs.id, entry.runId!))
-    .limit(1);
-  if (!row || !(terminalRunStatusValues as readonly string[]).includes(row.status)) return;
-  logger.error("llm_usage: refused a runner snapshot on an already-settled run", {
-    runId: entry.runId,
-    orgId: entry.orgId,
-    runStatus: row.status,
-    storedCostUsd: row.storedCost,
-    refusedCostUsd: entry.costUsd,
-  });
+  try {
+    const [row] = await executor
+      .select({
+        status: runs.status,
+        storedCostUsd: llmUsage.costUsd,
+        advances: runnerAdvancesSql(entrySnapshotSql(entry)),
+      })
+      .from(runs)
+      .leftJoin(llmUsage, and(eq(llmUsage.runId, runs.id), eq(llmUsage.source, "runner")))
+      .where(eq(runs.id, entry.runId!))
+      .limit(1);
+    if (!row || !(terminalRunStatusValues as readonly string[]).includes(row.status)) return;
+    if (row.advances === false) return;
+    logger.error("llm_usage: refused a runner snapshot on an already-settled run", {
+      runId: entry.runId,
+      orgId: entry.orgId,
+      runStatus: row.status,
+      // Both cumulative totals, plus the delta that will never be billed.
+      storedCostUsd: row.storedCostUsd,
+      incomingCostUsd: entry.costUsd,
+      refusedDeltaUsd: entry.costUsd - (row.storedCostUsd ?? 0),
+    });
+  } catch (err) {
+    // Explaining a no-op must never break the write: `recordLlmUsageReliably`
+    // always rethrows for runner rows, and the finalize barrier calls it with
+    // `required: true` outside any transaction, so a throw here would fail
+    // `finalizeRun` and leave the run unsettled. This cannot un-poison the
+    // `appstrate.metric` caller's ingestion transaction, which stays safe by its
+    // own design (the runner's next cumulative snapshot supersedes the lost
+    // write — see `run-launcher/appstrate-event-sink.ts`).
+    logger.warn("llm_usage: refusal diagnostic failed", {
+      runId: entry.runId,
+      error: getErrorMessage(err),
+    });
+  }
 }

--- a/apps/api/test/integration/services/llm-usage-settlement.test.ts
+++ b/apps/api/test/integration/services/llm-usage-settlement.test.ts
@@ -131,8 +131,10 @@ async function runnerRow(runId: string) {
  * orphan sweep, container crash): a `RunResult` that carries no `cost`.
  *
  * Delegates to the REAL entry point rather than re-deriving one, so these tests
- * break if the synthesis path stops reconstructing the run's usage from
- * `runs.tokenUsage` or stops going through finalize's terminal barrier.
+ * break if the synthesis path stops going through finalize's terminal barrier.
+ * They do NOT pin its reconstruction of the usage from `runs.tokenUsage`:
+ * `finalizeRun` performs the identical reconstruction for every non-success
+ * terminal, so on this `failed` shape the two paths are indistinguishable.
  */
 async function synthesisedFinalize(runId: string): Promise<void> {
   await synthesiseFinalize(runId, {
@@ -175,17 +177,22 @@ async function settledRunWithLateSnapshot(
 /**
  * The one-sided report both diagnostic-failure paths emit before they diverge.
  * One-sided by necessity: the DB read is what failed, so only the entry's own
- * values survive — no stored total, hence neither delta. The incoming token
- * total (400 + 200, no cache buckets) is summed in TS on this path, the single
- * place that formula is duplicated away from SQL.
+ * values survive — no stored total, hence neither delta. Derived from the
+ * refused entry rather than hardcoded, so retuning the fixture above cannot
+ * fail these tests with a diff pointing at the wrong place; the token total is
+ * summed here in TS, the single place that formula lives away from SQL.
  */
-function expectUnassessedRefusal(call: unknown[] | undefined, runId: string, orgId: string): void {
+function expectUnassessedRefusal(call: unknown[] | undefined, late: LlmUsageEntry): void {
   expect(call?.[0]).toBe("llm_usage: could not assess a refused runner snapshot");
   expect(call?.[1]).toEqual({
-    runId,
-    orgId,
-    incomingCostUsd: 9,
-    incomingTotalTokens: 600,
+    runId: late.runId,
+    orgId: late.orgId,
+    incomingCostUsd: late.costUsd,
+    incomingTotalTokens:
+      late.inputTokens +
+      late.outputTokens +
+      (late.cacheReadTokens ?? 0) +
+      (late.cacheWriteTokens ?? 0),
     error: "connection terminated unexpectedly",
   });
 }
@@ -459,7 +466,7 @@ describe("llm_usage settlement — terminal barrier and post-settlement immutabi
     // explanation failed.
     expect((await runnerRow(runId))!.costUsd).toBe(2);
     expect(errorSpy).toHaveBeenCalledTimes(1);
-    expectUnassessedRefusal(errorSpy.mock.calls[0], runId, ctx.orgId);
+    expectUnassessedRefusal(errorSpy.mock.calls[0], late);
   });
 
   it("the same failure on the finalize barrier's executor-less path is reported and SWALLOWED", async () => {
@@ -488,7 +495,7 @@ describe("llm_usage settlement — terminal barrier and post-settlement immutabi
     expect(refused).toBeNull();
     expect((await runnerRow(runId))!.costUsd).toBe(2);
     expect(errorSpy).toHaveBeenCalledTimes(1);
-    expectUnassessedRefusal(errorSpy.mock.calls[0], runId, ctx.orgId);
+    expectUnassessedRefusal(errorSpy.mock.calls[0], late);
   });
 
   it("the same snapshot IS applied while the run is still open", async () => {

--- a/apps/api/test/integration/services/llm-usage-settlement.test.ts
+++ b/apps/api/test/integration/services/llm-usage-settlement.test.ts
@@ -16,6 +16,15 @@
  *   2. POST-SETTLEMENT IMMUTABILITY — a snapshot arriving after the run went
  *      terminal (a durable-retry replay, a losing concurrent finalize) is
  *      REFUSED, not silently applied to a row someone already billed;
+ *   2b. AND THE REFUSAL IS REPORTED WITH A SIGNAL-TO-NOISE RATIO OF 1 — a
+ *      refusal that loses billable spend emits exactly one `logger.error`
+ *      carrying the two cumulative totals and the delta nobody will bill; a
+ *      refusal that loses NOTHING is silent. The distinction is the whole
+ *      point: `run-launcher/execute-background.ts` synthesises a finalize on
+ *      EVERY clean container exit, so every successful run replays its own
+ *      last snapshot at `costUsd: 0` after settling. A status-only test drowned
+ *      the real losses under one error per run (issue #997). Both halves are
+ *      asserted below — the noise floor as well as the alarm;
  *   3. NO DURABLE QUEUE FOR RUNNER ROWS — a failed runner write propagates
  *      instead of being deferred, because a deferred replay could only land
  *      after settlement, where (2) refuses it.
@@ -25,7 +34,7 @@
  * cursor read, not merely documented for consumers.
  */
 
-import { describe, it, expect, beforeEach } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { eq, sql } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
 import { llmUsage, runs } from "@appstrate/db/schema";
@@ -34,13 +43,18 @@ import type { Db } from "@appstrate/db/client";
 import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
 import { seedPackage } from "../../helpers/seed.ts";
+import { logger } from "../../../src/lib/logger.ts";
 import { recordLlmUsage } from "../../../src/services/llm-usage-ledger.ts";
 import {
   recordLlmUsageReliably,
   initLlmUsageRetryWorker,
   _resetLlmUsageRetryWorkerForTests,
 } from "../../../src/services/llm-usage-retry.ts";
-import { getRunSinkContext, finalizeRun } from "../../../src/services/run-event-ingestion.ts";
+import {
+  getRunSinkContext,
+  finalizeRun,
+  synthesiseFinalize,
+} from "../../../src/services/run-event-ingestion.ts";
 import {
   computeRunCost,
   listLlmUsage,
@@ -104,22 +118,46 @@ async function runnerRow(runId: string) {
   return row;
 }
 
-/** Terminal closure exactly as the platform synthesises it: no cost, no usage. */
+/**
+ * Terminal closure exactly as the platform synthesises it (stall watchdog, boot
+ * orphan sweep, container crash): a `RunResult` that carries no `cost`.
+ *
+ * Delegates to the REAL entry point rather than re-deriving one, so these tests
+ * break if the synthesis path stops reconstructing the run's usage from
+ * `runs.tokenUsage` or stops going through finalize's terminal barrier.
+ */
 async function synthesisedFinalize(runId: string): Promise<void> {
-  const run = await getRunSinkContext(runId);
-  const result = emptyRunResult();
-  result.status = "failed";
-  result.error = { message: "Server restarted while run was in progress." };
-  await finalizeRun({ run: run!, result });
+  await synthesiseFinalize(runId, {
+    status: "failed",
+    error: { message: "Server restarted while run was in progress." },
+  });
 }
+
+/**
+ * The refusal alarm's exact message. Pinned as a constant because operators
+ * alert on the literal string — a reworded log is a broken alert, not a
+ * cosmetic change.
+ */
+const REFUSAL_MESSAGE = "llm_usage: refused a runner snapshot on an already-settled run";
 
 describe("llm_usage settlement — terminal barrier and post-settlement immutability", () => {
   let ctx: TestContext;
+  // The refusal diagnostic is observable ONLY through the logger, and its value
+  // is as much in what it does NOT say as in what it does — so it is spied on
+  // for every test here, and installed LAST so the fixture's own writes never
+  // count towards an assertion.
+  let errorSpy: ReturnType<typeof spyOn<typeof logger, "error">>;
 
   beforeEach(async () => {
     await truncateAll();
     ctx = await createTestContext({ orgSlug: "settleorg" });
     await seedPackage({ id: AGENT, orgId: ctx.orgId, type: "agent" });
+    errorSpy = spyOn(logger, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    // Restored per test so sibling files sharing this process keep a real logger.
+    errorSpy.mockRestore();
   });
 
   it("a runner snapshot arriving after the run settled is refused, leaving the billed total intact", async () => {
@@ -180,6 +218,208 @@ describe("llm_usage settlement — terminal barrier and post-settlement immutabi
     expect(row!.costUsd).toBe(5);
     expect(row!.inputTokens).toBe(100);
     expect(await computeRunCost(runId, ctx.orgId)).toBe(5);
+
+    // …and it is LOUD. This is money the platform consumed and will never
+    // invoice, so the only way an operator learns about it is this line. It
+    // fires exactly once (nothing before it in this test refused anything real)
+    // and carries the whole picture: both cumulative totals plus the delta —
+    // $4 — which is the figure a human acts on. Asserting the arithmetic, not
+    // just the presence of a field, is what stops a future refactor from
+    // reporting the incoming total as the loss.
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const [message, fields] = errorSpy.mock.calls[0]!;
+    expect(message).toBe(REFUSAL_MESSAGE);
+    expect(fields).toEqual({
+      runId,
+      orgId: ctx.orgId,
+      runStatus: "failed",
+      storedCostUsd: 5,
+      incomingCostUsd: 9,
+      refusedDeltaUsd: 4,
+    });
+  });
+
+  it("the platform's defensive second finalize of a settled run is refused SILENTLY (issue #997)", async () => {
+    // The whole production shape, end to end, on the real code path. A container
+    // exits 0 after POSTing its own finalize; `execute-background.ts` synthesises
+    // a success finalize anyway (it cannot know the container already did), and
+    // `synthesiseFinalize` carries no cost — so finalize's terminal barrier
+    // re-submits the run's OWN last snapshot at `costUsd: 0` onto a row that is
+    // already settled. The upsert refuses it, correctly: nothing is lost, the
+    // stored total already dominates. Reporting that as a billing loss produced
+    // ~25 bogus error lines per container lifetime in production (issue #997),
+    // every one of them with a refused amount of 0.
+    const runId = await seedSinkRun(ctx, { tokenUsage: { input_tokens: 100, output_tokens: 50 } });
+
+    // 1. The container's own finalize: cost + usage, barrier writes, CAS settles.
+    const run = await getRunSinkContext(runId);
+    const result = emptyRunResult();
+    result.status = "success";
+    result.cost = 5;
+    result.usage = { input_tokens: 100, output_tokens: 50 };
+    await finalizeRun({ run: run!, result });
+
+    const settled = await listLlmUsage({});
+    expect(settled).toHaveLength(1);
+    expect(settled[0]!.settled).toBe(true);
+    expect(settled[0]!.costUsd).toBe(5);
+
+    // 2. The defensive synthesis that follows every clean container exit.
+    await synthesiseFinalize(runId, { status: "success" });
+
+    // The row is untouched (post-settlement immutability holds) …
+    const row = await runnerRow(runId);
+    expect(row!.costUsd).toBe(5);
+    expect(row!.inputTokens).toBe(100);
+    expect(row!.outputTokens).toBe(50);
+    // … and the run keeps the terminal status its first finalize won.
+    const [runRow] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(runRow!.status).toBe("success");
+
+    // The assertion this test exists for: not one error line for the entire
+    // lifecycle. A benign trailing replay is not an incident.
+    expect(errorSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("an exact duplicate replay on a settled run is refused silently", async () => {
+    // Idempotence, seen from the diagnostic's side: the durable-retry replay of
+    // a snapshot that already landed loses nothing, so it must not page anyone.
+    // Both levels of the advance rule use STRICT inequalities precisely so this
+    // case is a no-op rather than a re-emitted row.
+    const runId = await seedSinkRun(ctx, { tokenUsage: null });
+    const entry = {
+      source: "runner" as const,
+      orgId: ctx.orgId,
+      runId,
+      credentialSource: "system" as const,
+      inputTokens: 100,
+      outputTokens: 50,
+      costUsd: 3,
+    };
+    await recordLlmUsage(entry, { onConflict: "runner-monotonic" });
+    await synthesisedFinalize(runId);
+
+    expect(await recordLlmUsage(entry, { onConflict: "runner-monotonic" })).toBeNull();
+
+    expect((await runnerRow(runId))!.costUsd).toBe(3);
+    expect(errorSpy).toHaveBeenCalledTimes(0);
+  });
+
+  it("a late EQUAL-cost snapshot with more cached tokens is still reported — the zero-cost-model loss", async () => {
+    // A model with no catalog rate (or a cache-only turn) holds `cost_usd` at a
+    // constant while the token columns keep climbing. The refused delta is $0,
+    // yet the loss is real: those tokens will never reach the ledger. A
+    // cost-only advance test would have called this benign and stayed quiet, so
+    // the diagnostic reuses the upsert's OWN two-level predicate — and this test
+    // is what proves the COALESCE'd cache arms are actually wired into it, by
+    // moving nothing but `cacheWriteTokens`.
+    const runId = await seedSinkRun(ctx, { tokenUsage: null });
+    await recordLlmUsage(
+      {
+        source: "runner",
+        orgId: ctx.orgId,
+        runId,
+        credentialSource: "system",
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheWriteTokens: 10,
+        costUsd: 2,
+      },
+      { onConflict: "runner-monotonic" },
+    );
+    await synthesisedFinalize(runId);
+
+    const late = await recordLlmUsage(
+      {
+        source: "runner",
+        orgId: ctx.orgId,
+        runId,
+        credentialSource: "system",
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheWriteTokens: 30,
+        costUsd: 2,
+      },
+      { onConflict: "runner-monotonic" },
+    );
+    expect(late).toBeNull();
+    expect((await runnerRow(runId))!.cacheWriteTokens).toBe(10);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const [message, fields] = errorSpy.mock.calls[0]!;
+    expect(message).toBe(REFUSAL_MESSAGE);
+    // NOTE the honest consequence of a token-only loss: `refusedDeltaUsd` is 0,
+    // exactly like the benign #997 replay. The two are distinguishable by the
+    // presence of the line, never by that field.
+    expect(fields).toEqual({
+      runId,
+      orgId: ctx.orgId,
+      runStatus: "failed",
+      storedCostUsd: 2,
+      incomingCostUsd: 2,
+      refusedDeltaUsd: 0,
+    });
+  });
+
+  it("a diagnostic that itself fails degrades to a warn and never fails the refused write", async () => {
+    // The diagnostic added a SELECT to a path that previously did no I/O at all,
+    // and it runs inside the terminal barrier, which calls the ledger with
+    // `required: true` — a throw here would fail `finalizeRun` and leave a
+    // finished run permanently unsettled. That is a strictly worse failure than
+    // the missing log line it was meant to produce.
+    //
+    // Expressed through the service's own DI seam (`opts.executor`): an executor
+    // whose INSERT is real but whose SELECT faults isolates the diagnostic query
+    // as the single point of failure. No `mock.module()` (AGENTS.md).
+    const runId = await seedSinkRun(ctx, { tokenUsage: null });
+    await recordLlmUsage(
+      {
+        source: "runner",
+        orgId: ctx.orgId,
+        runId,
+        credentialSource: "system",
+        inputTokens: 100,
+        outputTokens: 50,
+        costUsd: 2,
+      },
+      { onConflict: "runner-monotonic" },
+    );
+    await synthesisedFinalize(runId);
+
+    const diagnosticBlindExecutor = {
+      insert: db.insert.bind(db),
+      select() {
+        throw new Error("connection terminated unexpectedly");
+      },
+    } as unknown as Db;
+
+    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+    try {
+      // A genuinely advancing snapshot, so the diagnostic is definitely reached.
+      const late = await recordLlmUsage(
+        {
+          source: "runner",
+          orgId: ctx.orgId,
+          runId,
+          credentialSource: "system",
+          inputTokens: 400,
+          outputTokens: 200,
+          costUsd: 9,
+        },
+        { onConflict: "runner-monotonic", executor: diagnosticBlindExecutor },
+      );
+      // The write itself still reports its outcome normally.
+      expect(late).toBeNull();
+      expect((await runnerRow(runId))!.costUsd).toBe(2);
+      // The failure is visible rather than swallowed …
+      expect(warnSpy.mock.calls.map(([m]) => m)).toContain("llm_usage: refusal diagnostic failed");
+      // … and, honestly stated: when the diagnostic cannot run, the real loss
+      // goes UNREPORTED. Silence here is a known consequence of not letting the
+      // explanation break the write, not evidence that nothing was lost.
+      expect(errorSpy).toHaveBeenCalledTimes(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("the same snapshot IS applied while the run is still open", async () => {

--- a/apps/api/test/integration/services/llm-usage-settlement.test.ts
+++ b/apps/api/test/integration/services/llm-usage-settlement.test.ts
@@ -17,14 +17,19 @@
  *      terminal (a durable-retry replay, a losing concurrent finalize) is
  *      REFUSED, not silently applied to a row someone already billed;
  *   2b. AND THE REFUSAL IS REPORTED WITH A SIGNAL-TO-NOISE RATIO OF 1 — a
- *      refusal that loses billable spend emits exactly one `logger.error`
- *      carrying the two cumulative totals and the delta nobody will bill; a
- *      refusal that loses NOTHING is silent. The distinction is the whole
- *      point: `run-launcher/execute-background.ts` synthesises a finalize on
- *      EVERY clean container exit, so every successful run replays its own
- *      last snapshot at `costUsd: 0` after settling. A status-only test drowned
- *      the real losses under one error per run (issue #997). Both halves are
- *      asserted below — the noise floor as well as the alarm;
+ *      refusal that loses something emits exactly one `logger.error`; a refusal
+ *      that loses NOTHING is silent. The distinction is the whole point:
+ *      `run-launcher/execute-background.ts` synthesises a finalize on EVERY
+ *      clean container exit, so every successful run replays its own last
+ *      snapshot at `costUsd: 0` after settling. A status-only test drowned the
+ *      real losses under one error per run (issue #997). Both halves are
+ *      asserted below — the noise floor as well as the alarm.
+ *      The report carries BOTH dimensions (stored / incoming / refused delta,
+ *      in USD *and* in total tokens) because a refusal can lose either one
+ *      alone: the advance rule is two-level, so a zero-cost model — free tier,
+ *      no catalog rate, cache-only turn — loses tokens while its cost delta
+ *      stays flat at 0. A one-dimensional payload would render exactly that
+ *      loss class indistinguishable from the #997 noise;
  *   3. NO DURABLE QUEUE FOR RUNNER ROWS — a failed runner write propagates
  *      instead of being deferred, because a deferred replay could only land
  *      after settlement, where (2) refuses it.
@@ -222,10 +227,11 @@ describe("llm_usage settlement — terminal barrier and post-settlement immutabi
     // …and it is LOUD. This is money the platform consumed and will never
     // invoice, so the only way an operator learns about it is this line. It
     // fires exactly once (nothing before it in this test refused anything real)
-    // and carries the whole picture: both cumulative totals plus the delta —
-    // $4 — which is the figure a human acts on. Asserting the arithmetic, not
-    // just the presence of a field, is what stops a future refactor from
-    // reporting the incoming total as the loss.
+    // and carries the whole picture on BOTH dimensions: the two cumulative
+    // totals plus the refused delta, in USD ($4) and in tokens (600 − 150).
+    // Those two deltas are the figures a human acts on. Asserting the
+    // arithmetic, not just the presence of the fields, is what stops a future
+    // refactor from reporting an incoming total as the loss.
     expect(errorSpy).toHaveBeenCalledTimes(1);
     const [message, fields] = errorSpy.mock.calls[0]!;
     expect(message).toBe(REFUSAL_MESSAGE);
@@ -236,6 +242,9 @@ describe("llm_usage settlement — terminal barrier and post-settlement immutabi
       storedCostUsd: 5,
       incomingCostUsd: 9,
       refusedDeltaUsd: 4,
+      storedTotalTokens: 150,
+      incomingTotalTokens: 600,
+      refusedDeltaTokens: 450,
     });
   });
 
@@ -307,12 +316,18 @@ describe("llm_usage settlement — terminal barrier and post-settlement immutabi
 
   it("a late EQUAL-cost snapshot with more cached tokens is still reported — the zero-cost-model loss", async () => {
     // A model with no catalog rate (or a cache-only turn) holds `cost_usd` at a
-    // constant while the token columns keep climbing. The refused delta is $0,
-    // yet the loss is real: those tokens will never reach the ledger. A
+    // constant while the token columns keep climbing. The refused COST delta is
+    // $0, yet the loss is real: those tokens will never reach the ledger. A
     // cost-only advance test would have called this benign and stayed quiet, so
     // the diagnostic reuses the upsert's OWN two-level predicate — and this test
     // is what proves the COALESCE'd cache arms are actually wired into it, by
     // moving nothing but `cacheWriteTokens`.
+    //
+    // This is also the test that pins `refusedDeltaTokens` as the sound alert
+    // predicate. On this loss class every cost field reads 0, exactly like the
+    // benign #997 replay; the token delta is the ONLY figure that separates
+    // them. An operator (or a downstream alert) keying on `refusedDeltaUsd > 0`
+    // would silently drop precisely the losses level 2 exists to catch.
     const runId = await seedSinkRun(ctx, { tokenUsage: null });
     await recordLlmUsage(
       {
@@ -348,9 +363,8 @@ describe("llm_usage settlement — terminal barrier and post-settlement immutabi
     expect(errorSpy).toHaveBeenCalledTimes(1);
     const [message, fields] = errorSpy.mock.calls[0]!;
     expect(message).toBe(REFUSAL_MESSAGE);
-    // NOTE the honest consequence of a token-only loss: `refusedDeltaUsd` is 0,
-    // exactly like the benign #997 replay. The two are distinguishable by the
-    // presence of the line, never by that field.
+    // Cost side: three zeroes' worth of signal. Token side: 160 → 180, a
+    // refused delta of 20 — the whole reason the payload carries both.
     expect(fields).toEqual({
       runId,
       orgId: ctx.orgId,
@@ -358,10 +372,13 @@ describe("llm_usage settlement — terminal barrier and post-settlement immutabi
       storedCostUsd: 2,
       incomingCostUsd: 2,
       refusedDeltaUsd: 0,
+      storedTotalTokens: 160,
+      incomingTotalTokens: 180,
+      refusedDeltaTokens: 20,
     });
   });
 
-  it("a diagnostic that itself fails degrades to a warn and never fails the refused write", async () => {
+  it("a diagnostic that itself fails still reports the refusal, minus the stored-side figures", async () => {
     // The diagnostic added a SELECT to a path that previously did no I/O at all,
     // and it runs inside the terminal barrier, which calls the ledger with
     // `required: true` — a throw here would fail `finalizeRun` and leave a
@@ -393,33 +410,42 @@ describe("llm_usage settlement — terminal barrier and post-settlement immutabi
       },
     } as unknown as Db;
 
-    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
-    try {
-      // A genuinely advancing snapshot, so the diagnostic is definitely reached.
-      const late = await recordLlmUsage(
-        {
-          source: "runner",
-          orgId: ctx.orgId,
-          runId,
-          credentialSource: "system",
-          inputTokens: 400,
-          outputTokens: 200,
-          costUsd: 9,
-        },
-        { onConflict: "runner-monotonic", executor: diagnosticBlindExecutor },
-      );
-      // The write itself still reports its outcome normally.
-      expect(late).toBeNull();
-      expect((await runnerRow(runId))!.costUsd).toBe(2);
-      // The failure is visible rather than swallowed …
-      expect(warnSpy.mock.calls.map(([m]) => m)).toContain("llm_usage: refusal diagnostic failed");
-      // … and, honestly stated: when the diagnostic cannot run, the real loss
-      // goes UNREPORTED. Silence here is a known consequence of not letting the
-      // explanation break the write, not evidence that nothing was lost.
-      expect(errorSpy).toHaveBeenCalledTimes(0);
-    } finally {
-      warnSpy.mockRestore();
-    }
+    // A genuinely advancing snapshot, so the diagnostic is definitely reached.
+    const late = await recordLlmUsage(
+      {
+        source: "runner",
+        orgId: ctx.orgId,
+        runId,
+        credentialSource: "system",
+        inputTokens: 400,
+        outputTokens: 200,
+        costUsd: 9,
+      },
+      { onConflict: "runner-monotonic", executor: diagnosticBlindExecutor },
+    );
+    // The write itself still reports its outcome normally — no throw reaches
+    // the barrier, and the settled row is untouched.
+    expect(late).toBeNull();
+    expect((await runnerRow(runId))!.costUsd).toBe(2);
+
+    // The refusal is NOT downgraded to a warn and NOT swallowed: an unassessed
+    // refusal may be a real billing loss, so it stays at error level under a
+    // DISTINCT message — an operator can tell "we lost X" from "we could not
+    // work out whether we lost anything", and alert on both.
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const [message, fields] = errorSpy.mock.calls[0]!;
+    expect(message).toBe("llm_usage: could not assess a refused runner snapshot");
+    // Honestly stated: the report is one-sided. The DB read is what failed, so
+    // only the entry's own values survive — no stored total, hence no delta.
+    // The incoming token total is summed in TS here (400 + 200, no cache
+    // buckets set), the one place that formula is duplicated.
+    expect(fields).toEqual({
+      runId,
+      orgId: ctx.orgId,
+      incomingCostUsd: 9,
+      incomingTotalTokens: 600,
+      error: "connection terminated unexpectedly",
+    });
   });
 
   it("the same snapshot IS applied while the run is still open", async () => {

--- a/apps/api/test/integration/services/llm-usage-settlement.test.ts
+++ b/apps/api/test/integration/services/llm-usage-settlement.test.ts
@@ -29,7 +29,10 @@
  *      alone: the advance rule is two-level, so a zero-cost model — free tier,
  *      no catalog rate, cache-only turn — loses tokens while its cost delta
  *      stays flat at 0. A one-dimensional payload would render exactly that
- *      loss class indistinguishable from the #997 noise;
+ *      loss class indistinguishable from the #997 noise. And the reporting is
+ *      subordinate to the write: it may never cost a caller its transaction,
+ *      which is why the assessment's own failure is swallowed for exactly one
+ *      caller (the executor-less finalize barrier) and rethrown for every other;
  *   3. NO DURABLE QUEUE FOR RUNNER ROWS — a failed runner write propagates
  *      instead of being deferred, because a deferred replay could only land
  *      after settlement, where (2) refuses it.
@@ -49,7 +52,7 @@ import { truncateAll } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
 import { seedPackage } from "../../helpers/seed.ts";
 import { logger } from "../../../src/lib/logger.ts";
-import { recordLlmUsage } from "../../../src/services/llm-usage-ledger.ts";
+import { recordLlmUsage, type LlmUsageEntry } from "../../../src/services/llm-usage-ledger.ts";
 import {
   recordLlmUsageReliably,
   initLlmUsageRetryWorker,
@@ -144,6 +147,48 @@ async function synthesisedFinalize(runId: string): Promise<void> {
  * cosmetic change.
  */
 const REFUSAL_MESSAGE = "llm_usage: refused a runner snapshot on an already-settled run";
+
+/**
+ * A settled run holding a $2 / 150-token cumulative snapshot, plus the late
+ * snapshot that would genuinely advance it ($9 / 600 tokens) — i.e. one the
+ * diagnostic is guaranteed to reach. Shared by the two diagnostic-failure tests,
+ * which are identical up to who supplies the executor.
+ */
+async function settledRunWithLateSnapshot(
+  ctx: TestContext,
+): Promise<{ runId: string; late: LlmUsageEntry }> {
+  const runId = await seedSinkRun(ctx, { tokenUsage: null });
+  const stored: LlmUsageEntry = {
+    source: "runner",
+    orgId: ctx.orgId,
+    runId,
+    credentialSource: "system",
+    inputTokens: 100,
+    outputTokens: 50,
+    costUsd: 2,
+  };
+  await recordLlmUsage(stored, { onConflict: "runner-monotonic" });
+  await synthesisedFinalize(runId);
+  return { runId, late: { ...stored, inputTokens: 400, outputTokens: 200, costUsd: 9 } };
+}
+
+/**
+ * The one-sided report both diagnostic-failure paths emit before they diverge.
+ * One-sided by necessity: the DB read is what failed, so only the entry's own
+ * values survive — no stored total, hence neither delta. The incoming token
+ * total (400 + 200, no cache buckets) is summed in TS on this path, the single
+ * place that formula is duplicated away from SQL.
+ */
+function expectUnassessedRefusal(call: unknown[] | undefined, runId: string, orgId: string): void {
+  expect(call?.[0]).toBe("llm_usage: could not assess a refused runner snapshot");
+  expect(call?.[1]).toEqual({
+    runId,
+    orgId,
+    incomingCostUsd: 9,
+    incomingTotalTokens: 600,
+    error: "connection terminated unexpectedly",
+  });
+}
 
 describe("llm_usage settlement — terminal barrier and post-settlement immutability", () => {
   let ctx: TestContext;
@@ -378,31 +423,27 @@ describe("llm_usage settlement — terminal barrier and post-settlement immutabi
     });
   });
 
-  it("a diagnostic that itself fails still reports the refusal, minus the stored-side figures", async () => {
-    // The diagnostic added a SELECT to a path that previously did no I/O at all,
-    // and it runs inside the terminal barrier, which calls the ledger with
-    // `required: true` — a throw here would fail `finalizeRun` and leave a
-    // finished run permanently unsettled. That is a strictly worse failure than
-    // the missing log line it was meant to produce.
+  // The next two tests are a PAIR. Both fault the diagnostic's SELECT on a
+  // settled run and both must produce the identical one-sided report; they
+  // differ only in who supplied the executor, which is what decides whether the
+  // error is then rethrown. Splitting hairs over one boolean is the point: it is
+  // the whole difference between "a finished run never settles" and "a 2xx
+  // response silently rolled back the caller's transaction".
+  it("a diagnostic failure inside a caller's transaction is reported AND rethrown", async () => {
+    // A caller-supplied executor means an OPEN transaction — the
+    // `appstrate.metric` ingestion path. Swallowing there is worse than a missing
+    // log line: the callback resolves, drizzle sends COMMIT, Postgres (measured
+    // on PGlite, which is what these tests run on) turns it into ROLLBACK, and
+    // the sink answers 2xx having lost the run_log row, the ledger write AND the
+    // sequence advance — with nobody informed. Rethrowing restores that path's
+    // documented recovery: the ingestion transaction aborts, the sequence does
+    // not advance, the runner re-POSTs, and its next cumulative snapshot
+    // supersedes.
     //
-    // Expressed through the service's own DI seam (`opts.executor`): an executor
-    // whose INSERT is real but whose SELECT faults isolates the diagnostic query
-    // as the single point of failure. No `mock.module()` (AGENTS.md).
-    const runId = await seedSinkRun(ctx, { tokenUsage: null });
-    await recordLlmUsage(
-      {
-        source: "runner",
-        orgId: ctx.orgId,
-        runId,
-        credentialSource: "system",
-        inputTokens: 100,
-        outputTokens: 50,
-        costUsd: 2,
-      },
-      { onConflict: "runner-monotonic" },
-    );
-    await synthesisedFinalize(runId);
-
+    // Faulted through the service's own DI seam (`opts.executor`): a real INSERT
+    // with a throwing SELECT isolates the diagnostic query as the single point
+    // of failure. No `mock.module()` (AGENTS.md).
+    const { runId, late } = await settledRunWithLateSnapshot(ctx);
     const diagnosticBlindExecutor = {
       insert: db.insert.bind(db),
       select() {
@@ -410,42 +451,44 @@ describe("llm_usage settlement — terminal barrier and post-settlement immutabi
       },
     } as unknown as Db;
 
-    // A genuinely advancing snapshot, so the diagnostic is definitely reached.
-    const late = await recordLlmUsage(
-      {
-        source: "runner",
-        orgId: ctx.orgId,
-        runId,
-        credentialSource: "system",
-        inputTokens: 400,
-        outputTokens: 200,
-        costUsd: 9,
-      },
-      { onConflict: "runner-monotonic", executor: diagnosticBlindExecutor },
-    );
-    // The write itself still reports its outcome normally — no throw reaches
-    // the barrier, and the settled row is untouched.
-    expect(late).toBeNull();
-    expect((await runnerRow(runId))!.costUsd).toBe(2);
+    await expect(
+      recordLlmUsage(late, { onConflict: "runner-monotonic", executor: diagnosticBlindExecutor }),
+    ).rejects.toThrow("connection terminated unexpectedly");
 
-    // The refusal is NOT downgraded to a warn and NOT swallowed: an unassessed
-    // refusal may be a real billing loss, so it stays at error level under a
-    // DISTINCT message — an operator can tell "we lost X" from "we could not
-    // work out whether we lost anything", and alert on both.
+    // The settled row is untouched either way — the refusal happened, only its
+    // explanation failed.
+    expect((await runnerRow(runId))!.costUsd).toBe(2);
     expect(errorSpy).toHaveBeenCalledTimes(1);
-    const [message, fields] = errorSpy.mock.calls[0]!;
-    expect(message).toBe("llm_usage: could not assess a refused runner snapshot");
-    // Honestly stated: the report is one-sided. The DB read is what failed, so
-    // only the entry's own values survive — no stored total, hence no delta.
-    // The incoming token total is summed in TS here (400 + 200, no cache
-    // buckets set), the one place that formula is duplicated.
-    expect(fields).toEqual({
-      runId,
-      orgId: ctx.orgId,
-      incomingCostUsd: 9,
-      incomingTotalTokens: 600,
-      error: "connection terminated unexpectedly",
+    expectUnassessedRefusal(errorSpy.mock.calls[0], runId, ctx.orgId);
+  });
+
+  it("the same failure on the finalize barrier's executor-less path is reported and SWALLOWED", async () => {
+    // No executor means no transaction: the terminal barrier calls the ledger
+    // with `required: true` outside one, so a throw would fail `finalizeRun`
+    // before its CAS and leave a finished run permanently unsettled — strictly
+    // worse than the log line it replaces. This is the one caller the swallow
+    // exists for, and the branch that carries the risk if the condition is ever
+    // simplified away.
+    //
+    // `executor === db` here by construction (`opts.executor ?? db`), so the
+    // fault has to be injected on `db` itself. Spying the method is narrower
+    // than the alternatives and is restored immediately — see the note in the
+    // comment below.
+    const { runId, late } = await settledRunWithLateSnapshot(ctx);
+    const selectSpy = spyOn(db, "select").mockImplementation(() => {
+      throw new Error("connection terminated unexpectedly");
     });
+    // Restored on BOTH outcomes: a leaked `db.select` would break every sibling
+    // test in this process, including the `runnerRow` read two lines down.
+    const refused = await recordLlmUsage(late, { onConflict: "runner-monotonic" }).finally(() =>
+      selectSpy.mockRestore(),
+    );
+
+    // Resolves normally, reporting the no-op outcome the barrier expects.
+    expect(refused).toBeNull();
+    expect((await runnerRow(runId))!.costUsd).toBe(2);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expectUnassessedRefusal(errorSpy.mock.calls[0], runId, ctx.orgId);
   });
 
   it("the same snapshot IS applied while the run is still open", async () => {


### PR DESCRIPTION
Fixes #997.

## The noise, and why it was noise

`traceRejectedTerminalRunnerWrite` logged at `error` whenever the `runner-monotonic` upsert wrote nothing on a run that had already settled — without checking whether the incoming snapshot carried anything the stored row did not already have.

Every successful run produces exactly one such no-op, by design: `run-launcher/execute-background.ts` defensively synthesises a `success` finalize after **any** container that exits 0, including one that already POSTed its own finalize. `synthesiseFinalize` carries no `cost` but reconstructs `usage` from `runs.tokenUsage`, so finalize's terminal ledger barrier re-submits the run's own last snapshot at `costUsd: 0` onto a row that is already settled. Refused, correctly — and then reported as a billing loss. That is the 25 lines per container lifetime, all refusing `0`.

## What changed

**The alarm now fires if and only if something was actually refused.** The advance test is the same predicate the upsert gates on — factored into `runnerAdvancesSql` and evaluated in Postgres against the stored row, with the upsert passing the `EXCLUDED` pseudo-row and the diagnostic passing the entry's bound values. The diagnostic cannot drift from the write it explains, and no comparison value crosses the SQL/TS boundary. Only a definitive `false` is silence: a NULL (no runner row to compare against, i.e. the snapshot would have inserted) is still reported.

**The report covers both dimensions.** The upsert's level-2 tiebreak exists for a zero-cost model, whose `cost_usd` stays flat while token counts climb — so a token-only loss used to report `storedCostUsd == incomingCostUsd == refusedDeltaUsd == 0`, indistinguishable from the noise just silenced. An operator reacting to #997 by alerting on `refusedDeltaUsd > 0` would have dropped precisely the loss class the tiebreak was written for. The payload now carries the token totals and their delta, computed by the same expression the predicate weighs; `refusedDeltaTokens > 0` is a sound alert predicate for the whole class. The message string is unchanged so existing greps keep working.

**Explaining a no-op can never break the write.** `recordLlmUsageReliably` always rethrows for runner rows, and the finalize barrier calls it with `required: true`, so an unguarded diagnostic failure would fail `finalizeRun` and leave a finished run unsettled. The diagnostic is wrapped — but the swallow is scoped to that one caller, which passes no executor and runs outside any transaction. When the caller supplied an executor (the `appstrate.metric` ingestion transaction), the error is logged and rethrown: swallowing there is worse than a missing log line, because on PGlite the callback then resolves, drizzle sends COMMIT, Postgres converts it to ROLLBACK, and the sink answers 2xx having lost the run_log row, the ledger write and the sequence advance. Rethrowing restores that path's documented recovery — the runner re-POSTs and its next cumulative snapshot supersedes. A failure that could not be assessed is reported at `error` under a distinct message, so "we lost X" and "we could not work out whether we lost anything" stay greppable apart.

## Answering the issue's open question

The diagnostic is not dead code, but it is unreachable through normal operation. Writers carrying a cost are the `appstrate.metric` ingestion path (protected: the sequence CAS locks the `runs` row, so `runNotTerminalSql` always sees a live run) and the container-posted finalize (the winner, which writes before its own CAS). Every synthesised terminal — cancel, watchdog, orphan sweep, exit-code, timeout — carries `cost: null`. A non-zero refusal therefore needs two concurrent container-posted finalizes with a strictly growing cumulative, e.g. a runner re-POSTing after a network retry. Rare, real, and exactly the silent billing loss the function was written to catch — so it keeps `error` level.

## Verification

- `bun run check` — green (tsc + eslint + prettier across packages, OpenAPI validation).
- `apps/api/test/integration/services/llm-usage-settlement.test.ts` — 14 pass, on PGlite (`TEST_TIER=0`) and on Docker Postgres. The `services/` tree: 842 pass, 0 fail.
- The upsert's rendered SQL was diffed against `origin/main` via `.toSQL()`: token-identical modulo precedence-neutral parentheses, byte-identical parameter list. The refactor changes what the diagnostic asks, never what the upsert does.
- Each new invariant was mutation-checked (drop the advance gate, drop the token delta, drop the subtraction, swap the two totals' sides, make the catch swallow unconditionally, make it rethrow unconditionally) — every mutation fails a test.

## Known residuals

- `executor !== db` is a proxy for "the caller is inside a transaction". It is correct for all current callers — and strictly better than the obvious `opts.executor !== undefined`, which would have wrongly rethrown on the non-transactional `persistRunEvent(db, …)` sink path — but it is enforced by nothing beyond the comment. It can only fail loud (an unsettled run), never silent.
- `refusedDeltaTokens` can be negative when a re-priced snapshot advances on cost while reporting fewer tokens. Honest per line; do not sum it across incidents without clamping.
- The `could not assess` line carries no delta, so an alert keyed on `refusedDeltaTokens > 0` will not fire for it. If both should page, the alert has to be message-based.

Unrelated to this branch: running the entire `apps/api/test/integration` tree in one process fails `"absorbs a failed PROXY write into the durable queue and the worker PERSISTS it"` on a 5s timeout. It passes at file and directory scope, and still fails with every line of this branch's tests inert — a pre-existing load-sensitive poll, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
