### PR TITLE
ci(release): raise build-and-push timeout to 90 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,19 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # 90, not 30. These are multi-arch builds (`linux/amd64,linux/arm64`) whose
+    # `linux/arm64` half runs under QEMU emulation on an amd64 runner, and the
+    # only thing that normally keeps them short is the `type=gha` layer cache.
+    # That cache is a single repo-wide 10 GB LRU shared with every other
+    # workflow, so an ordinary run of Test/Firecracker/preview between two
+    # releases can evict it. A warm build of the `appstrate` image takes ~7-9
+    # min (beta.41: 6m44, beta.42: 8m41); the cold build that follows an
+    # eviction emulates the whole web bundle on arm64 and blew past 30 min,
+    # which cancelled v1.0.0-beta.43 mid-flight and burnt the tag (release.yml
+    # has no `workflow_dispatch`, so a cancelled release costs a version bump).
+    # The ceiling exists to catch a genuinely hung build, not to bound a cold
+    # cache — keep it well above the cold-build cost.
+    timeout-minutes: 90
     strategy:
       matrix:
         # ⚠️  DUPLICATED MATRIX — keep in lockstep with the identical `include:`


### PR DESCRIPTION
## Problem

`v1.0.0-beta.43` was cancelled mid-release. Not a code failure — the `build-and-push` job hit its own `timeout-minutes: 30`:

```
19:45:54  job start
19:48:05  last progress line (@appstrate/web:build, amd64)
20:15:54  ##[error]The operation was canceled.
```

Exactly 30 minutes.

## Cause

The matrix builds `linux/amd64,linux/arm64`, so the arm64 half runs under QEMU emulation on an amd64 runner. What normally keeps that cheap is `cache-from/to: type=gha` — but the GitHub Actions cache is a single **repo-wide 10 GB LRU** shared with every other workflow. Test, Firecracker and preview runs between two releases can evict it.

Same job, warm cache:

| Release | Duration |
| --- | --- |
| beta.41 | 6m44s |
| beta.42 | 8m41s |
| beta.43 | >30m → cancelled |

That is an outlier, not a drift: the cold build re-emulated the whole web bundle on arm64.

## Why it costs a version

`release.yml` only triggers on `push: tags: [v*]` and has no `workflow_dispatch`. Tags are protected, so a cancelled release cannot be resumed — recovery is a version bump. beta.43 is burnt; the release ships as beta.44.

## Change

`timeout-minutes: 30` → `90` on `build-and-push`, matching the sign/release job further down the file. The ceiling still catches a genuinely hung build; it no longer treats a cold cache as a failure.

Not addressed here (deliberately): shrinking the cache footprint, or dropping arm64 from the server image. Both are real options with their own trade-offs — dropping arm64 would break self-hosters and Apple Silicon dev — and neither belongs in the middle of a release.