### PR TITLE
fix(core): lead the publish_document description with its real value + state the hidden-file policy

### DIFF
--- a/docs/architecture/DOCUMENTS.md
+++ b/docs/architecture/DOCUMENTS.md
@@ -104,7 +104,7 @@ An external repository can guarantee none of the three. Integrations therefore s
 - **`POST /api/runs/:runId/documents`** (`routes/runs-events.ts`) — guarded by `verifyRunUploadSignature` (sink HMAC over an empty body, agent-side), streaming raw bytes with metadata via headers. `createDocumentFromStream` enforces the per-file + per-run caps mid-stream (`createHashingCounter` with caps), the org quota transactionally, and dedups by `(run, sha256, name)` for at-least-once retries. Dedup is enforced in two layers: a fast-path pre-commit SELECT, and — for the concurrent-publish race where both callers pass that SELECT — a partial **unique index** `(run_id, sha256, name) WHERE purpose = 'agent_output'`, whose violation the commit path catches and resolves to the same existing row (dedup 200). A genuinely new publish (201) also emits a **`document.published`** audit event attributed to the run's actor; a dedup replay (200) does not.
 - **`publish_document` runtime tool** (opt-in via `manifest.runtime_tools`) — reads a workspace file, POSTs it to that route (signed), and emits the canonical **`document.published`** event via `_meta["dev.appstrate/events"]`. Unlike the pure event-emitter runtime tools it has an injected HTTP uploader (built in the entrypoint, not `buildRuntimeToolDefs`).
 - **`workspace/outputs/` sweep** — at finalize the entrypoint uploads any not-yet-published file in `outputs/` (dedup by sha256), emitting the events before `events/finalize` (OpenAI annotation-loss lesson). Uploads are bounded-concurrent (3 at a time) and each POST retries (3 attempts) on transient failures (network error, timeout, 5xx, 429 — honouring `Retry-After`); a file abandoned after retries is logged as a dropped deliverable and never blocks finalize.
-  - **Hidden files are excluded by default.** The sweep skips any entry whose relative path has a segment starting with `.` — dotfiles like `.env`/`.netrc` and everything under a hidden dir like `.git/`. Since it publishes to a wider, durable, org-visible surface, an agent that inadvertently writes a secret dotfile under `outputs/` must not have it exfiltrated automatically. The explicit `publish_document` tool is unaffected: a deliberate publish of a dotfile is still allowed.
+  - **Hidden files are excluded by default.** The sweep skips any entry whose relative path has a segment starting with `.` — dotfiles like `.env`/`.netrc` and everything under a hidden dir like `.git/`. Since it publishes to a wider, durable, org-visible surface, an agent that inadvertently writes a secret dotfile under `outputs/` must not have it exfiltrated automatically. The explicit `publish_document` tool is unaffected: a deliberate publish of a dotfile is still allowed — see "Hidden-file policy" under Hardening for why the asymmetry is deliberate.
 
 `document.published` is ingested into a `run_log` and forwarded over SSE (`run_update` / `run_log`), so run page and chat cards update live.
 
@@ -188,6 +188,22 @@ The platform MCP server (`apps/api/src/modules/mcp/`) surfaces documents to exte
 ## Hardening
 
 A cross-cutting summary of the guarantees the sections above rely on, and where they are enforced. The details are in the referenced sections; this is the map.
+
+### Hidden-file policy — implicit sweep filters, explicit tool does not
+
+The hidden-path filter (`runtime-pi/publish.ts`, any segment starting with `.`) is an **implicit-publish** control, not a containment boundary. It applies to the `outputs/` sweep and **deliberately does not apply to `publish_document`**; the tool publishes any regular file inside the workspace, dotfile or not (locked by a test in `runtime-pi/test/publish.test.ts`).
+
+The split is drawn on intent, because that is the only place it buys anything:
+
+- The **sweep** publishes whatever happens to be in a directory — including a `.env` an unrelated tool dropped there, which the agent never meant as a deliverable. Filtering is the difference between a mistake and a durable, org-visible document.
+- The **tool** is a per-call decision with an explicit path. Refusing hidden paths there (outright, or unless a `name` is passed) removes **no capability** from a prompt-injected agent: `cp .env outputs/notes.txt` — or `publish_document({ path: "copy.txt" })` after the same copy — publishes the identical bytes under a non-hidden name. It would only cost a legitimate publish of a dotfile, and it is the kind of control that reads as a boundary while enforcing nothing.
+
+**Threat model, stated plainly.** An agent whose manifest enables `publish_document` can surface any workspace file it can read as an org-visible `agent_output` document — that is the tool's purpose, and prompt injection can aim it. What bounds the exposure is not the path shape:
+
+- the document is attached to the run, so it inherits the run's container ACL (see "ACL") — never wider than who can already read the run;
+- reads are gated by `documents:read` and the capability matrix; preview goes through a short-lived signed token on a cookie-less route (see "Preview security").
+
+So the mitigation lives where the capability is granted (`manifest.runtime_tools` is opt-in per agent), not in a filename check. **Enable `publish_document` only on agents whose workspace you would accept seeing published.**
 
 ### Identity model — display name vs workspace name (D-naming)
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `buildPublishDocumentDef()` — the `publish_document` tool description now leads with what
+  only the tool can do (publish DURING the run, get the durable `document://` URI back) instead
+  of steering agents away from it. The `outputs/` sweep is unconditional and shares the same
+  uploader, so the previous "use this tool only to publish a deliverable that lives elsewhere in
+  the workspace" named the one replaceable case and hid the reason to call it at all. Behaviour
+  and schema are unchanged.
 - `ChatTurnFinishReason` gains `"deadline"` — a turn cut by the engine's
   wall-clock ceiling is no longer disguised as its last step's provider reason.
 - `ModelProviderDefinition.featuredModels` widens from `readonly string[]` to

--- a/packages/core/src/runtime-tool-defs.ts
+++ b/packages/core/src/runtime-tool-defs.ts
@@ -412,10 +412,14 @@ export function buildPublishDocumentDef(uploader: DocumentUploader): RuntimeTool
     descriptor: {
       name: "publish_document",
       description:
-        "Publish a file you created in the workspace (e.g. an HTML report, a CSV, a PDF) as a " +
-        "durable document attached to this run. Returns a stable `document://` URI. Files written " +
-        "under `./outputs/` are published automatically at the end of the run — use this tool only " +
-        "to publish a deliverable that lives elsewhere in the workspace.",
+        "Publish a workspace file (e.g. an HTML report, a CSV, a PDF) as a durable document " +
+        "attached to this run, right now: the document appears while the run is still going and " +
+        "the call returns its stable `document://` URI. Use it whenever you need to reference, " +
+        "link or send the document within this same run — cite the URI in your output, hand it to " +
+        "another tool — or to see an upload failure in time to react. Files written under " +
+        "`./outputs/` are published automatically at the end of the run, which is enough for a " +
+        "plain end-of-run deliverable, but that happens after you are done: you never get their " +
+        "URIs.",
       inputSchema: {
         type: "object",
         additionalProperties: false,

--- a/runtime-pi/test/publish.test.ts
+++ b/runtime-pi/test/publish.test.ts
@@ -793,6 +793,19 @@ describe("buildPublishDocumentDef (publish_document tool)", () => {
     expect(result.isError).toBe(true);
   });
 
+  it("leads its description with the publish-now + `document://` URI value", () => {
+    // The `outputs/` sweep is unconditional and shares the same uploader, so
+    // what the tool alone can do is publish DURING the run and hand back the
+    // durable URI. A description that reads "use this tool only to publish a
+    // deliverable that lives elsewhere" names the one replaceable case and
+    // hides that one, so an agent never calls it at the right moment.
+    const description = buildPublishDocumentDef(makeUploader(new Set())).descriptor.description!;
+
+    expect(description).toContain("document://");
+    expect(description.indexOf("document://")).toBeLessThan(description.indexOf("./outputs/"));
+    expect(description).not.toContain("use this tool only");
+  });
+
   it("still publishes an explicitly-chosen dotfile (hidden filter is sweep-only)", async () => {
     // The hidden-file exclusion applies ONLY to the implicit outputs sweep; an
     // agent deliberately publishing a dotfile via the tool is honoured.


### PR DESCRIPTION
Closes #1016.

Two small, independent changes. No behaviour or schema change — the tool's inputs, outputs, uploader and the sweep's filter are all untouched.

## 1. `publish_document` description leads with its non-replaceable value

`packages/core/src/runtime-tool-defs.ts`

The `outputs/` sweep is unconditional and shares the same uploader, so the old wording ("use this tool only to publish a deliverable that lives elsewhere in the workspace") named the one *replaceable* case and hid the two that are not: publishing **during** the run, and getting the durable `document://` URI back in time to cite it, link it, or hand it to another tool. An agent reading that had no reason to call the tool at the right moment.

New description leads with publish-now + the returned URI, then mentions the `outputs/` fallback for a plain end-of-run deliverable and why it is not equivalent (it happens after the agent is done, so the URIs are never available to it).

A regression test in `runtime-pi/test/publish.test.ts` locks the ordering: `document://` must appear before `./outputs/`, and the "use this tool only" steer must be gone. Verified it fails against the pre-fix description.

## 2. Dotfile asymmetry: exemption **kept**, and written down

`docs/architecture/DOCUMENTS.md` — new "Hidden-file policy" section under Hardening, plus a cross-reference from the sweep bullet.

Decision: keep the exemption. Refusing hidden paths in the tool removes **no capability** from a prompt-injected agent — `cp .env outputs/notes.txt` publishes the identical bytes under a non-hidden name — so it would cost a legitimate dotfile publish while reading as a boundary that enforces nothing. The filter is an *implicit-publish* control (the sweep publishes whatever happens to be in a directory); the tool is an explicit per-call decision.

The section states the threat model plainly: an agent with `publish_document` enabled can surface any readable workspace file as an org-visible `agent_output` document. What bounds it is the run's container ACL (never wider than who can already read the run) and `documents:read` + the signed-token preview route — not a filename check. The mitigation lives at the grant (`manifest.runtime_tools` is opt-in per agent).

## Verification

- `bun test` on `packages/core/test`, `runtime-pi/test`, `packages/runner-pi/test`, `packages/afps-runtime/test` — all green.
- `prettier --check` + `eslint` on the touched files — clean.
- `typecheck` on `packages/core` and `runtime-pi` — clean.
- Smoke: drove the real `buildPublishDocumentDef` uploader path against a local HTTP endpoint standing in for `POST /api/runs/:runId/documents` (no Docker daemon available in the run environment, so the full stack was not startable). Four scenarios pass, including the explicit dotfile publish.
- The full `bun run check` was **not** run to completion — the environment capped memory at 1.5 GiB and repo-wide ESLint / web type-coverage were OOM-killed. CI is the authority on that gate.

## Follow-up (from the issue, not done here)

The falsifying check — count production agent manifests listing `publish_document` in `runtime_tools`; if it stays zero, re-litigate keeping the tool at all.
