### PR TITLE
refactor(core): collapse isFinalChatStep's zero-variant maxSteps parameter (#1010)

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -234,6 +234,16 @@ with no importer anywhere is deleted.
   (`droppedRuntimeTools: []` for a synthesised manifest). It is required rather
   than optional so readers never need a `?? []`.
 
+- **`@appstrate/core/chat-turn-metadata` — `isFinalChatStep` loses its
+  `maxSteps` parameter.** The signature is now `(stepNumber: number) => boolean`
+  and the function reads `CHAT_MAX_STEPS` directly. The parameter defaulted to
+  that same constant and no call site ever passed anything else, in this
+  repository or outside it — an option with one possible value is not
+  flexibility, it is a second place the step ceiling can be stated. Callers
+  passing the constant explicitly drop the argument; callers already relying on
+  the default are unaffected. Landed inside this major precisely because it is a
+  source break on a symbol that shipped in `5.0.0` (see #1010).
+
 ### Removed (BREAKING)
 
 - **The `report` runtime tool is gone.** It was a deprecated compatibility

--- a/packages/core/src/chat-turn-metadata.ts
+++ b/packages/core/src/chat-turn-metadata.ts
@@ -154,8 +154,8 @@ export function mergeTurnMetadata(
   };
 }
 
-export function isFinalChatStep(stepNumber: number, maxSteps = CHAT_MAX_STEPS): boolean {
-  return stepNumber >= maxSteps - 1;
+export function isFinalChatStep(stepNumber: number): boolean {
+  return stepNumber >= CHAT_MAX_STEPS - 1;
 }
 
 export function turnMetadataFromMessage(message: unknown): AppstrateTurnMetadata | null {

--- a/packages/module-chat/src/chat-stream.ts
+++ b/packages/module-chat/src/chat-stream.ts
@@ -174,7 +174,7 @@ export function prepareAiSdkChatStep({
     stepsUsed: stepNumber,
   });
 
-  if (!isFinalChatStep(stepNumber, CHAT_MAX_STEPS)) {
+  if (!isFinalChatStep(stepNumber)) {
     return {
       instructions: [aiSdkCachedSystemMessage(system), aiSdkStepTrailerMessage(budgetNote)],
     };


### PR DESCRIPTION
> ⚠️ **Vérification incomplète dans le sandbox** — ouverte en brouillon pour cette
> seule raison. Toutes les vérifications que j'ai pu exécuter sont vertes, mais
> `bun run check` n'a **pas** pu être lancé en un bloc : le conteneur d'exécution est
> plafonné à 1,5 Go de RAM (`/sys/fs/cgroup/memory.max` = `1610612736`) et la commande
> est tuée par l'OOM killer (exit 137) sur `lint` puis sur `@appstrate/mcp-transport#typecheck`.
> Les tâches du gate ont donc été relancées **une par une** (détail plus bas).
> Non exécutés, à confirmer par la CI :
> - `bun run check` en tant que commande unique ;
> - `typecheck` de `@appstrate/module-chat` sur le graphe complet (OOM — **et il OOM
>   identiquement sur la baseline sans ce diff**, prouvé par `git stash`) ; le fichier
>   modifié `chat-stream.ts` typecheck seul, avec ses imports transitifs, sans erreur ;
> - `lint` sur l'ensemble du monorepo (ESLint ciblé sur les 2 fichiers touchés : vert) ;
> - `verify:openapi`, `verify:api-types`, `verify:type-coverage`,
>   `verify:compose-defaults`, `build:system-packages:check` — non atteints avant l'OOM ;
> - `test:integration` / `test:e2e` — pas de démon Docker, pas de navigateur.

Closes #1010.

## Contexte

`isFinalChatStep` porte un paramètre optionnel `maxSteps` dont **une seule valeur
existe** dans tout le dépôt. C'est le cinquième cas de la même famille que les quatre
options collapsées dans #1007, laissé de côté à l'époque parce qu'il n'était pas
énuméré dans #996 et que le folder aurait élargi la PR en silence.

## Cause racine

| Fait | Emplacement |
|---|---|
| Signature à collapser | `packages/core/src/chat-turn-metadata.ts:157` |
| Constante par défaut | `packages/core/src/chat-turn-metadata.ts:14` (`CHAT_MAX_STEPS = 16`) |
| Unique appelant de production | `packages/module-chat/src/chat-stream.ts:177` — passait `CHAT_MAX_STEPS` |
| Appels de test | `packages/core/test/chat-turn-metadata.test.ts:94-96` — prenaient le défaut |

`grep -rn "isFinalChatStep(" packages/ apps/` ne renvoie aucun autre appelant. Zéro
valeur alternative, en production comme en test : l'option n'est pas de la flexibilité,
c'est un second endroit où le plafond de steps peut être énoncé.

## La condition de timing — vérifiée, et elle tient

L'issue conditionne explicitement ce changement : il n'est gratuit que s'il atterrit
**avant** le tag `core@6.0.0`. Contrôle fait au moment d'écrire cette PR :

- `GET /git/matching-refs/tags/core@` → dernier tag **`core@5.0.0`** (`578ba18`).
  **Aucun tag `core@6.0.0`.**
- `packages/core/package.json:3` → `"version": "6.0.0"` (bumpé, non taggé).
- `packages/core/CHANGELOG.md:59` → section `## [6.0.0]` rédigée, déjà porteuse de
  `### Changed (BREAKING)` et `### Removed (BREAKING)`.

La fenêtre est donc ouverte : la rupture embarque dans un majeur que les consommateurs
doivent déjà absorber. **Si `6.0.0` est taggé avant que cette PR ne soit mergée, il
faut fermer #1010 plutôt que de la merger** — c'est la règle posée par l'issue
elle-même, et elle survit à cette PR.

## Approche

1. `isFinalChatStep(stepNumber: number): boolean`, le corps lit `CHAT_MAX_STEPS`.
2. `chat-stream.ts:177` perd l'argument redondant. L'import `CHAT_MAX_STEPS` (l.54)
   **reste** — encore utilisé l.807, 881, 884.
3. Une entrée dans `### Changed (BREAKING)` de `6.0.0`.

### Alternatives écartées

| Alternative | Raison |
|---|---|
| `@deprecated` puis retrait plus tard | Cycle de dépréciation pour une option que personne n'utilise ; l'issue tranche « Not worth it » |
| Majeur dédié `core@7.0.0` | Coûte un cycle lockstep à 5 consommateurs pour un XS |
| Ne rien faire | Défendable seulement si `6.0.0` était taggé — il ne l'est pas |
| Entrée sous `[Unreleased] → Removed` | Exclu par l'issue : l'entrée appartient au majeur qui la porte |
| Ajouter un test d'arité `@ts-expect-error` | L'issue fixe « tests unchanged », et `tsc` est déjà cette garde (`TS2554`, démontré ci-dessous) |

`Changed (BREAKING)` et non `Removed (BREAKING)` : la fonction survit, c'est sa
signature qui se resserre ; les entrées de `Removed` sont toutes des suppressions de
symbole entier.

## Phases & commits

| Phase | Commit | Contenu |
|---|---|---|
| P1 | `46ab125` | Collapse du paramètre + appelant aligné + entrée changelog (3 fichiers, +13 −3) |

Une seule phase : séparer le code du changelog aurait laissé un commit intermédiaire
où une rupture publiée n'est pas documentée.

## Tests

| Vérification | Commande | Résultat |
|---|---|---|
| Format (gate complet) | `bun run format:check` | ✅ `All matched files use Prettier code style!` |
| Typecheck `@appstrate/core` | `cd packages/core && bun run typecheck` | ✅ exit 0 |
| Typecheck du fichier modifié | `bunx tsc --noEmit` sur `chat-stream.ts` + imports transitifs | ✅ exit 0 |
| Lint des fichiers touchés | `bunx eslint packages/core/src/chat-turn-metadata.ts packages/module-chat/src/chat-stream.ts` | ✅ exit 0 |
| Tests core + module-chat | `TEST_TIER=0 bun test packages/module-chat/test packages/core/test` | ✅ **1102 pass, 0 fail**, 2281 assertions |
| Bornes 14/15/16 | `TEST_TIER=0 bun test packages/core/test/chat-turn-metadata.test.ts` | ✅ 8 pass — **fichier de test non modifié** |
| OpenAPI | `bun run detect:breaking` | ✅ `PASSED — 0 breaking, 0 non-breaking` |
| Conformance | `bun run conformance:check` | ✅ `tier=gate packages=66 → PASS` |
| Contrat de module | `bun run verify:module-contract` | ✅ 34 entrées, no drift |
| Isolation des modules | `bun run verify:module-isolation` | ✅ 109 fichiers, 7 modules |
| Casing des manifestes | `bun run lint:manifest-casing` | ✅ OK |
| Typecheck des scripts | `bun run typecheck:scripts` | ✅ exit 0 |

### La garde d'arité est mécanique

Aucun test n'a été ajouté, parce que `tsc` couvre déjà exactement ce que ce test
aurait couvert. Vérifié en remettant l'appel d'origine :

```
$ sed -i 's/isFinalChatStep(stepNumber)/isFinalChatStep(stepNumber, CHAT_MAX_STEPS)/' \
    packages/module-chat/src/chat-stream.ts
$ bunx tsc --noEmit …
packages/module-chat/src/chat-stream.ts(177,36): error TS2554: Expected 1 arguments, but got 2.
```

### Les tests de bornes ne sont pas décoratifs

```
$ sed -i 's/>= CHAT_MAX_STEPS - 1/>= CHAT_MAX_STEPS/' packages/core/src/chat-turn-metadata.ts
$ TEST_TIER=0 bun test packages/core/test/chat-turn-metadata.test.ts
 7 pass, 1 fail
```

## Smoke e2e

La stack complète n'est pas démarrable ici (Docker absent). Et le changement est un
refactor de signature dans une fonction pure : il n'a pas de surface HTTP qu'un `curl`
observerait. Le substitut retenu exécute donc le **vrai seam de production**
`prepareAiSdkChatStep` (`chat-stream.ts:177`), sans recopier la moindre logique :

```
PASS  isFinalChatStep.length === 1 (maxSteps collapsed)
PASS  isFinalChatStep(14) === false / (15) === true / (16) === true
PASS  CHAT_MAX_STEPS === 16
PASS  step 14 keeps tools active (no activeTools override)   → got undefined
PASS  step 15 is the tool-less closing call                  → got []
PASS  budget-reached marker fires exactly once over steps 0..15
SMOKE OK — 0 failure
```

Le script a été supprimé après exécution : il n'est pas dans le commit.

## Limites de vérification

- `bun run check` en un bloc : **non exécuté** (OOM à 1,5 Go). Tâches relancées
  individuellement, toutes vertes ; 5 tâches du gate n'ont pas été atteintes
  (`verify:openapi`, `verify:api-types`, `verify:type-coverage`,
  `verify:compose-defaults`, `build:system-packages:check`).
- `typecheck` de `module-chat` sur le graphe complet : OOM, **y compris sans ce diff**.
- `test:integration`, `test:e2e`, tests Docker : pas de démon Docker, pas de navigateur.
- L'absence d'usage de `isFinalChatStep` chez les cinq consommateurs externes
  (`registry`, `cloud`, `portal`, `connect-helper`, `module-claude-code`) est reprise
  de l'issue — **je n'ai pas pu la re-vérifier**, ces dépôts ne sont pas accessibles
  depuis le sandbox.

## Risques / points de revue humaine

1. **Le timing est la seule vraie décision.** Re-vérifier qu'aucun tag `core@6.0.0`
   n'a été poussé entre-temps. Si oui : fermer #1010, ne pas merger.
2. **Rupture source assumée** sur un symbole publié en `5.0.0` — documentée au
   changelog, gratuite uniquement dans la fenêtre ci-dessus.
3. Comportement runtime strictement inchangé : `stepNumber >= CHAT_MAX_STEPS - 1` est
   exactement ce que calculait l'appel précédent.

---
🤖 Ouverte par un agent automatisé.
