### PR TITLE
fix(release): unblock the core 6.0.0 publish

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -61,9 +61,9 @@ jobs:
           fi
 
       # ── Precondition for the lockstep gate below ────────────────────────────
-      # `check-consumer-versions.ts` reads five consumer repos through the
-      # GitHub contents API. ALL FIVE ARE PRIVATE (registry, cloud, portal,
-      # connect-helper, module-claude-code). `secrets.GITHUB_TOKEN` is scoped to
+      # `check-consumer-versions.ts` reads four consumer repos through the
+      # GitHub contents API. ALL FOUR ARE PRIVATE (registry, cloud, portal,
+      # connect-helper). `secrets.GITHUB_TOKEN` is scoped to
       # THIS repo only, so for a private consumer the API answers 404 — and the
       # script treats 404 as "not present, skipping" (a legitimate outcome for a
       # repo that genuinely has no package.json at that path, so the script
@@ -87,7 +87,7 @@ jobs:
             echo "CONSUMER_LOCKSTEP_TOKEN is set — the lockstep gate can read the private consumer repos."
             exit 0
           fi
-          MSG="CONSUMER_LOCKSTEP_TOKEN is not set. Every consumer repo (appstrate/registry, cloud, portal, connect-helper, module-claude-code) is private, so the fallback GITHUB_TOKEN gets a 404 on all of them and the lockstep gate verifies NOTHING while reporting success."
+          MSG="CONSUMER_LOCKSTEP_TOKEN is not set. Every consumer repo (appstrate/registry, cloud, portal, connect-helper) is private, so the fallback GITHUB_TOKEN gets a 404 on all of them and the lockstep gate verifies NOTHING while reporting success."
           if [ "$CONSUMER_DRIFT_POLICY" = "fail" ]; then
             echo "::error title=Consumer lockstep gate cannot run::${MSG} Fix: add a repository secret CONSUMER_LOCKSTEP_TOKEN (PAT or GitHub App token with contents:read on those repos). To publish anyway, set the repository variable CONSUMER_DRIFT_POLICY to 'warn' or 'off' — a deliberate, auditable bypass."
             {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,69 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- `@appstrate/core/chat-turn-metadata` — the chat turn's TIME budget alongside its
-  existing step budget: `CHAT_TURN_DEADLINE_MS`, `CHAT_TURN_SAFETY_MARGIN_MS`,
-  `CHAT_MIN_RUN_BUDGET_MS`, `CHAT_LAUNCH_THRESHOLD_MS`, plus the pure
-  `computeTurnRunBudget()`, `formatBudgetDuration()` and `formatTurnBudgetNote()`.
-  Both chat engines derive a child call's wait from an absolute turn deadline
-  instead of silently taking `RUN_AND_WAIT_MAX_MS` (30 min), which is three times
-  longer than a turn.
-- `@appstrate/core/bearer` — `parseBearer()`, the `Authorization` header parser
-  the module-authoring contract now points `authStrategies()` at: RFC 9110 §11.4
-  makes the auth-scheme a case-insensitive token separated from the credentials
-  by `1*SP`, so a conformant `authorization: bearer ey…` must match, which
-  `startsWith("Bearer ")` rejects. First release carrying the subpath — a module
-  built against an earlier core must parse the header itself.
-- `@appstrate/core/run-and-wait-client` — `RUN_RESULT_INLINE_MAX_BYTES` (32 KB) and
-  `truncateRunAndWaitPayload()`: a run result over the cap is cut to a usable
-  head that points back at the run, whose
-  `runs.result` already holds the whole payload (`getRun` returns it) — no copy is
-  made. `launchRunAndWait` forwards the new `context_documents` argument (inline
-  runs only).
-
-- `@appstrate/core/module` — `CatalogModelSelector`, `ModelIdSelection` and the
-  `isCatalogModelSelector()` narrowing guard: a model provider can declare its
-  model lists as `{ catalogFamilies, generations }` instead of enumerating ids.
-  The platform resolves a selector against its vendored pricing catalog on every
-  read, so a new vendor generation reaches the picker with the weekly catalog
-  refresh and no module edit. Meant for providers that track the vendor's
-  current generation and cannot probe (`claude-code`); an explicit array stays
-  right when the served set is defined outside the catalog (`codex`).
-
-### Changed
-
-- `buildPublishDocumentDef()` — the `publish_document` tool description now leads with what
-  only the tool can do (publish DURING the run, get the durable `document://` URI back) instead
-  of steering agents away from it. The `outputs/` sweep is unconditional and shares the same
-  uploader, so the previous "use this tool only to publish a deliverable that lives elsewhere in
-  the workspace" named the one replaceable case and hid the reason to call it at all. Behaviour
-  and schema are unchanged.
-- `ChatTurnFinishReason` gains `"deadline"` — a turn cut by the engine's
-  wall-clock ceiling is no longer disguised as its last step's provider reason.
-- `ModelProviderDefinition.featuredModels` widens from `readonly string[]` to
-  `ModelIdSelection` (`readonly string[] | CatalogModelSelector`), and
-  `modelDiscoveryCandidates` with it. **Asymmetric for consumers**: a module
-  that only WRITES these fields — every module passing an array — compiles
-  unchanged, since the array arm is unchanged. Code that READS
-  `def.featuredModels` as a `string[]` (mapping, spreading, `.includes()`) stops
-  compiling and must narrow with `isCatalogModelSelector()` first, or resolve
-  the selection platform-side.
-
-### Removed
-
-- `appendFinalStepSystemPrompt()` — the final-step directive is now carried as a
-  separate system block rather than concatenated, leaving this with no importer.
-
 ## [6.0.0] — 2026-07-26
 
 Major release grouping every contract change the repository accumulated after
 `5.0.0` into ONE coordinated break, so consumers pay a single lockstep cycle:
 the `report` runtime tool is retired in favour of published documents,
 `checkUsageAllowed` gains a required argument, two module-contract signatures
-that were optional-but-always-supplied become required, and a set of exports
-with no importer anywhere is deleted.
+that were optional-but-always-supplied become required, a model provider's
+`featuredModels` / `modelDiscoveryCandidates` widen to `ModelIdSelection` and
+break every READER of those fields, `ChatTurnFinishReason` gains a `"deadline"`
+member that breaks exhaustive switches, `isFinalChatStep` loses its `maxSteps`
+parameter, and a set of exports with no importer anywhere is deleted.
 
 > **Release ordering — consumers FIRST, then the tag.** `@appstrate/afps-shared`
 > stays at `^0.3.1` (already published, nothing to release before this).
@@ -144,6 +92,46 @@ with no importer anywhere is deleted.
   selects the OAuth request shape from `apiKey.includes("sk-ant-oat")` alone, so
   a placeholder missing that marker silently emits the api-key shape and
   upstream rejects it. Non-breaking; nothing existing changes meaning.
+
+- `@appstrate/core/chat-turn-metadata` — the chat turn's TIME budget alongside its
+  existing step budget: `CHAT_TURN_DEADLINE_MS`, `CHAT_TURN_SAFETY_MARGIN_MS`,
+  `CHAT_MIN_RUN_BUDGET_MS`, `CHAT_LAUNCH_THRESHOLD_MS`, plus the pure
+  `computeTurnRunBudget()`, `formatBudgetDuration()` and `formatTurnBudgetNote()`.
+  Both chat engines derive a child call's wait from an absolute turn deadline
+  instead of silently taking `RUN_AND_WAIT_MAX_MS` (30 min), which is three times
+  longer than a turn.
+
+- `@appstrate/core/bearer` — `parseBearer()`, the `Authorization` header parser
+  the module-authoring contract now points `authStrategies()` at: RFC 9110 §11.4
+  makes the auth-scheme a case-insensitive token separated from the credentials
+  by `1*SP`, so a conformant `authorization: bearer ey…` must match, which
+  `startsWith("Bearer ")` rejects. First release carrying the subpath — a module
+  built against an earlier core must parse the header itself.
+
+- `@appstrate/core/run-and-wait-client` — `RUN_RESULT_INLINE_MAX_BYTES` (32 KB) and
+  `truncateRunAndWaitPayload()`: a run result over the cap is cut to a usable
+  head that points back at the run, whose
+  `runs.result` already holds the whole payload (`getRun` returns it) — no copy is
+  made. `launchRunAndWait` forwards the new `context_documents` argument (inline
+  runs only).
+
+- `@appstrate/core/module` — `CatalogModelSelector`, `ModelIdSelection` and the
+  `isCatalogModelSelector()` narrowing guard: a model provider can declare its
+  model lists as `{ catalogFamilies, generations }` instead of enumerating ids.
+  The platform resolves a selector against its vendored pricing catalog on every
+  read, so a new vendor generation reaches the picker with the weekly catalog
+  refresh and no module edit. Meant for providers that track the vendor's
+  current generation and cannot probe (`claude-code`); an explicit array stays
+  right when the served set is defined outside the catalog (`codex`).
+
+### Changed
+
+- `buildPublishDocumentDef()` — the `publish_document` tool description now leads with what
+  only the tool can do (publish DURING the run, get the durable `document://` URI back) instead
+  of steering agents away from it. The `outputs/` sweep is unconditional and shares the same
+  uploader, so the previous "use this tool only to publish a deliverable that lives elsewhere in
+  the workspace" named the one replaceable case and hid the reason to call it at all. Behaviour
+  and schema are unchanged.
 
 ### Changed (BREAKING)
 
@@ -250,6 +238,20 @@ with no importer anywhere is deleted.
   the default are unaffected. Landed inside this major precisely because it is a
   source break on a symbol that shipped in `5.0.0` (see #1010).
 
+- `ChatTurnFinishReason` gains `"deadline"` — a turn cut by the engine's
+  wall-clock ceiling is no longer disguised as its last step's provider reason.
+  Breaking for readers: widening the union stops any exhaustive `switch` over it
+  from compiling until the new member is handled.
+
+- `ModelProviderDefinition.featuredModels` widens from `readonly string[]` to
+  `ModelIdSelection` (`readonly string[] | CatalogModelSelector`), and
+  `modelDiscoveryCandidates` with it. **Asymmetric for consumers**: a module
+  that only WRITES these fields — every module passing an array — compiles
+  unchanged, since the array arm is unchanged. Code that READS
+  `def.featuredModels` as a `string[]` (mapping, spreading, `.includes()`) stops
+  compiling and must narrow with `isCatalogModelSelector()` first, or resolve
+  the selection platform-side.
+
 ### Removed (BREAKING)
 
 - **The `report` runtime tool is gone.** It was a deprecated compatibility
@@ -297,6 +299,9 @@ with no importer anywhere is deleted.
   `packageTypeEnum.options` under another name. Use
   `packageTypeEnum.options` (the enum itself is live and re-exported from
   `@afps-spec/schema`).
+
+- `appendFinalStepSystemPrompt()` — the final-step directive is now carried as a
+  separate system block rather than concatenated, leaving this with no importer.
 
 - **`@appstrate/core/semver` — `satisfiesRange()` removed.** No caller.
   `matchVersion`, `isValidRange`, `normalizeVersion`, `compareVersionsDesc`,

--- a/scripts/check-consumer-versions.ts
+++ b/scripts/check-consumer-versions.ts
@@ -22,13 +22,29 @@ interface Consumer {
 /**
  * Every repo outside this monorepo that resolves `@appstrate/core` from npm.
  *
- * A repo missing from this list is invisible to the gate and drifts silently:
- * `connect-helper` and `module-claude-code` both did, and `module-claude-code`
- * sat on `^2.19.0` — three majors behind — still declaring
- * `ModelProviderDefinition.oauthWireFormat`, a field core removed in 3.0.0.
- * The rule: if it appears in the monorepo's dependency graph as an npm
- * consumer, it belongs here. Workspace packages inside this repo do NOT (they
- * resolve `workspace:*` and can never drift).
+ * A repo missing from this list is invisible to the gate and drifts silently.
+ * That is not a hypothetical — it is why the list exists: `connect-helper` and
+ * the then-standalone `appstrate/module-claude-code` were both absent, and
+ * `module-claude-code` sat on `^2.19.0` — three majors behind — still
+ * declaring `ModelProviderDefinition.oauthWireFormat`, a field core had
+ * removed in 3.0.0. Nobody noticed until someone read its `package.json` by
+ * hand.
+ *
+ * That anecdote is now history: PR #460 (2026-05-14) moved the module in-tree
+ * as `packages/module-claude-code`, and the standalone repo is dead. It is
+ * therefore NOT in the list below, per rule 3.
+ *
+ * The rule, in three parts:
+ *
+ *   1. A repo OUTSIDE this monorepo that resolves `@appstrate/core` from npm
+ *      belongs here — that is the entire membership test.
+ *   2. A package INSIDE this monorepo never does. It resolves `workspace:*`
+ *      (see `packages/module-claude-code/package.json`) and cannot drift, so
+ *      listing it would gate the publish on a version that does not exist.
+ *   3. A repo absorbed in-tree must be REMOVED here, in the same pass that
+ *      absorbs it. Its default branch keeps whatever range it last published
+ *      forever, and nothing consumes it any more — so leaving it in reports a
+ *      permanent failure that no bump anywhere can clear.
  */
 const CONSUMERS: Consumer[] = [
   {
@@ -40,9 +56,6 @@ const CONSUMERS: Consumer[] = [
   // Published to npm (public package, private source repo) — installed by
   // end users via `npx`, so a stale core range ships to them directly.
   { repo: "appstrate/connect-helper", paths: ["package.json"] },
-  // Standalone module repo: consumes core as a PEER dependency, which is why
-  // peerDependencies is inspected below alongside deps/devDeps.
-  { repo: "appstrate/module-claude-code", paths: ["package.json"] },
 ];
 
 const DEPENDENCY_NAME = "@appstrate/core";
@@ -145,10 +158,13 @@ async function main(): Promise<void> {
         continue;
       }
 
-      // `peerDependencies` is inspected too: a module repo declares core as a
-      // peer (the host platform supplies it), and that range is exactly the
-      // compatibility claim the module makes to operators. Reading only
-      // deps/devDeps let a peer-only consumer drift unchecked.
+      // `peerDependencies` is inspected too: an out-of-tree module repo
+      // declares core as a peer (the host platform supplies it), and that
+      // range is exactly the compatibility claim the module makes to
+      // operators. Reading only deps/devDeps let a peer-only consumer drift
+      // unchecked. No CONSUMERS entry is peer-only today — the one that was
+      // (`module-claude-code`) moved in-tree — but the read stays so the next
+      // out-of-tree module is covered the day it is listed.
       const deps = {
         ...(pkg.dependencies as Record<string, string> | undefined),
         ...(pkg.devDependencies as Record<string, string> | undefined),


### PR DESCRIPTION
Prerequisite for tagging `core@6.0.0`. Must land on `main` **before** the tag is pushed — the tag points at a commit, and both defects below would otherwise ship inside it.

## 1. The lockstep gate names a dead repo

`scripts/check-consumer-versions.ts` listed `appstrate/module-claude-code`. That repo stopped consuming core from npm on 2026-05-14, when #460 moved the module in-tree as `packages/module-claude-code` (`workspace:*`). Its default branch still pins `^2.19.0` and always will.

Pins verified live against the GitHub contents API:

| Consumer | pin on default branch |
| --- | --- |
| registry (×3 package.json) | `^2.13.0` |
| portal | `^2.10.8` |
| connect-helper | `^2.19.0` |
| cloud | `^5.0.0` |
| ~~module-claude-code~~ | `^2.19.0` — dead repo |

The dead entry is an unclearable failure: no bump anywhere could ever satisfy it, so it would have blocked **every** future core publish, not just this one.

Gate semantics are deliberately untouched — `cMaj !== lMaj` still fails, `CONSUMER_DRIFT_POLICY` and the fail-closed fetch-error branch are byte-identical. The only code change is removing the array element; everything else is comments. The JSDoc keeps the drift anecdote (it is *why* the list exists) but files it as history and states the membership rule, including the part that was violated: a repo absorbed in-tree must be removed in the same pass that absorbs it.

## 2. The changelog files shipped changes as unreleased

`packages/core/CHANGELOG.md` carried an `## [Unreleased]` section above `## [6.0.0]` whose seven entries are **already in the 6.0.0 tree**. Each was verified present before being moved (`./bearer` in `package.json`, `parseBearer()` in `src/bearer.ts`, `ModelIdSelection` in `src/module.ts`, `"deadline"` in `src/chat-turn-metadata.ts`, and `appendFinalStepSystemPrompt` confirmed absent repo-wide). Nothing was moved unverified; nothing was left behind.

Two of them are **breaking for consumers** and were invisible where they sat:

- `featuredModels` / `modelDiscoveryCandidates` widening from `readonly string[]` to `ModelIdSelection` — asymmetric: writers passing arrays compile unchanged, *readers* treating it as `string[]` do not.
- `ChatTurnFinishReason` gaining `"deadline"` — breaks exhaustive switches.

Both now sit under `### Changed (BREAKING)`, and the 6.0.0 intro enumerates the widening alongside the other breaks.

## Verification

- `bun run check` — 33/33 tasks pass.
- `tsc --noEmit -p scripts/tsconfig.json` passes, and the edited script typechecks clean under that config's effective options.
- No test covers `check-consumer-versions.ts`. None exists to break, and none was invented for a list edit.

## Known gaps, deliberately left

- `scripts/tsconfig.json` `include` covers only `verify-module-contract.ts` and `verify-package-resolves.ts`, so `check-consumer-versions.ts` sits outside the repo's own typecheck gate. Pre-existing.
- ESLint's flat config does not cover `scripts/` at all. Pre-existing.
- `.claude/commands/audit-casing.md` also names the dead repo, as a sibling-checkout target rather than an npm consumer. Different concern, untouched.

## Separately worth knowing

Publishing a **major** is currently impossible without a deliberate bypass, independently of this PR: consumers cannot bump to `^6.0.0` before 6.0.0 exists on npm (their CI runs `bun install --frozen-lockfile`), yet the gate fails on any major mismatch. Minors are fine — one minor behind is only a warning. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)