### PR TITLE
fix: DX papercuts — package list contract wording, CLI 307 passthrough, retired `dependencies.tools` (#1021)

### DIFF
--- a/apps/api/src/openapi/parameters.ts
+++ b/apps/api/src/openapi/parameters.ts
@@ -108,7 +108,10 @@ export const parameters = {
     in: "query" as const,
     required: false,
     description:
-      "When `true`, narrows the list to packages installed and enabled in the current application.",
+      "When `true`, narrows the list to packages installed and enabled in the current " +
+      "application — system packages with no install row drop out. Integrations are the one " +
+      "exception: they are filtered on effective activation, so an environment-provided " +
+      "system integration stays listed even though it has no install row.",
     schema: { type: "string", enum: ["true"] as const },
   },
 } as const;

--- a/apps/api/src/openapi/paths/packages.ts
+++ b/apps/api/src/openapi/paths/packages.ts
@@ -422,7 +422,11 @@ export const packagesPaths = {
       operationId: "listSkills",
       tags: ["Packages"],
       summary: "List skills",
-      description: "List all skills (system + org) in the organization.",
+      description:
+        "List the skills available to the current application (`X-Application-Id`): system " +
+        "packages, plus organization packages installed in this application. Organization " +
+        "packages that exist but are not installed here are NOT returned — for the " +
+        "organization-wide catalogue with per-application install state, use `GET /api/library`.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -887,7 +891,12 @@ export const packagesPaths = {
       operationId: "listAgentPackages",
       tags: ["Packages"],
       summary: "List agent packages",
-      description: "List all agent packages (system + org) in the organization.",
+      description:
+        "List the agent packages available to the current application (`X-Application-Id`): " +
+        "system packages, plus organization packages installed in this application. " +
+        "Organization packages that exist but are not installed here are NOT returned — for " +
+        "the organization-wide catalogue with per-application install state, use " +
+        "`GET /api/library`.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -1665,7 +1674,12 @@ export const packagesPaths = {
       operationId: "listIntegrationPackages",
       tags: ["Packages"],
       summary: "List integration packages",
-      description: "List all integration packages (system + org) in the organization.",
+      description:
+        "List the integration packages available to the current application " +
+        "(`X-Application-Id`): system packages, plus organization packages installed in this " +
+        "application. Organization packages that exist but are not installed here are NOT " +
+        "returned — for the organization-wide catalogue with per-application install state, " +
+        "use `GET /api/library`.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -2245,7 +2259,12 @@ export const packagesPaths = {
       operationId: "listMcpServerPackages",
       tags: ["Packages"],
       summary: "List MCP-server packages",
-      description: "List all MCP-server packages (system + org) in the organization.",
+      description:
+        "List the MCP-server packages available to the current application " +
+        "(`X-Application-Id`): system packages, plus organization packages installed in this " +
+        "application. Organization packages that exist but are not installed here are NOT " +
+        "returned — for the organization-wide catalogue with per-application install state, " +
+        "use `GET /api/library`.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },

--- a/apps/api/src/openapi/paths/packages.ts
+++ b/apps/api/src/openapi/paths/packages.ts
@@ -1,5 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * Shared tail of the four per-type list descriptions (skills / agents /
+ * integrations / mcp-servers) — only the leading noun differs.
+ */
+const listPackagesSharedDescription =
+  "system packages, plus organization packages installed in this application. " +
+  "Organization packages that exist but are not installed here are NOT returned — for " +
+  "the organization-wide catalogue with per-application install state, use " +
+  "`GET /api/library`.";
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Mutation response schemas (issue #657)
 //
@@ -423,10 +433,8 @@ export const packagesPaths = {
       tags: ["Packages"],
       summary: "List skills",
       description:
-        "List the skills available to the current application (`X-Application-Id`): system " +
-        "packages, plus organization packages installed in this application. Organization " +
-        "packages that exist but are not installed here are NOT returned — for the " +
-        "organization-wide catalogue with per-application install state, use `GET /api/library`.",
+        "List the skills available to the current application (`X-Application-Id`): " +
+        listPackagesSharedDescription,
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -893,10 +901,7 @@ export const packagesPaths = {
       summary: "List agent packages",
       description:
         "List the agent packages available to the current application (`X-Application-Id`): " +
-        "system packages, plus organization packages installed in this application. " +
-        "Organization packages that exist but are not installed here are NOT returned — for " +
-        "the organization-wide catalogue with per-application install state, use " +
-        "`GET /api/library`.",
+        listPackagesSharedDescription,
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -1676,10 +1681,8 @@ export const packagesPaths = {
       summary: "List integration packages",
       description:
         "List the integration packages available to the current application " +
-        "(`X-Application-Id`): system packages, plus organization packages installed in this " +
-        "application. Organization packages that exist but are not installed here are NOT " +
-        "returned — for the organization-wide catalogue with per-application install state, " +
-        "use `GET /api/library`.",
+        "(`X-Application-Id`): " +
+        listPackagesSharedDescription,
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -2261,10 +2264,8 @@ export const packagesPaths = {
       summary: "List MCP-server packages",
       description:
         "List the MCP-server packages available to the current application " +
-        "(`X-Application-Id`): system packages, plus organization packages installed in this " +
-        "application. Organization packages that exist but are not installed here are NOT " +
-        "returned — for the organization-wide catalogue with per-application install state, " +
-        "use `GET /api/library`.",
+        "(`X-Application-Id`): " +
+        listPackagesSharedDescription,
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -1745,6 +1745,9 @@ export function createPackagesRouter() {
     // time rather than chasing the runtime LoginError later. Also lift the
     // validator's `_meta` Appendix B regex soft-fail warnings to the same
     // channel so publishers see them on import.
+    // No retired-dependency-key warning here, unlike the bundle path: this
+    // route parses through `parseZipWithSkillFallback`, which rejects them
+    // outright, so such a manifest is a 400 long before this line.
     const installWarnings = [
       ...collectConnectLoginWarnings(manifest),
       ...collectMetaWarnings(manifest),

--- a/apps/api/src/services/bundle-import.ts
+++ b/apps/api/src/services/bundle-import.ts
@@ -53,6 +53,7 @@ import { logger } from "../lib/logger.ts";
 import {
   collectConnectLoginWarnings,
   collectMetaWarnings,
+  collectRetiredDependencyKeyWarnings,
 } from "./integration-install-warnings.ts";
 
 // Pinned mtime — must match the bundle writer exactly for cross-format
@@ -335,6 +336,16 @@ export async function importBundle(
     // "consumers MUST NOT reject unknown `_meta` keys"). Lift them to the
     // install-warning channel so publishers see them.
     for (const w of collectMetaWarnings(parsedZip.manifest)) {
+      warnings.push(`${identity}: ${w}`);
+    }
+
+    // Same READ-direction rationale as the runtime-tools drop above: this
+    // manifest was validated with `retiredRuntimeTools: "drop"`, so a retired
+    // AFPS 1.x `dependencies` key (`tools` / `providers`) is tolerated instead
+    // of rejected. It is inert — nothing reads it — so the import succeeds; the
+    // warning is how the operator learns the dependencies declared under it
+    // were never honoured and that a republish removes the key.
+    for (const w of collectRetiredDependencyKeyWarnings(parsedZip.manifest)) {
       warnings.push(`${identity}: ${w}`);
     }
 

--- a/apps/api/src/services/integration-install-warnings.ts
+++ b/apps/api/src/services/integration-install-warnings.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { META_NAMESPACE_KEY_REGEX } from "@appstrate/core/validation";
+import { findRetiredDependencyKeys } from "@appstrate/core/dependencies";
 
 /**
  * Install-time warnings for `integration` manifests whose `connect.login`
@@ -112,6 +113,29 @@ export function collectConnectLoginWarnings(manifest: unknown): string[] {
   }
 
   return warnings;
+}
+
+/**
+ * Collect install-time warnings for AFPS 1.x `dependencies` keys AFPS 2.0
+ * retired (`tools` → `mcp_servers`, `providers` → `integrations`).
+ *
+ * Author input carrying one is REJECTED upstream by `validateManifest` — this
+ * channel exists for the other direction: a manifest the platform already holds
+ * (a published, integrity-checked artifact re-ingested through a bundle) cannot
+ * be repaired in place, so it is validated with `retiredRuntimeTools: "drop"`
+ * and keeps its retired key. The key is inert (no reader has ever read it), so
+ * nothing is stripped and nothing breaks — but the operator should learn that
+ * the dependencies declared under it were never honoured, and that a republish
+ * is the fix.
+ *
+ * Applies to ALL package types — every type's manifest may declare
+ * `dependencies`. Pure function; returns `[]` for a clean manifest.
+ */
+export function collectRetiredDependencyKeyWarnings(manifest: unknown): string[] {
+  return findRetiredDependencyKeys(manifest).map(
+    ({ key, replacement }) =>
+      `dependencies.${key} is a retired AFPS 1.x key (renamed to dependencies.${replacement}) and is ignored — republish to remove it`,
+  );
 }
 
 /**

--- a/apps/api/test/integration/routes/packages-import-bundle.test.ts
+++ b/apps/api/test/integration/routes/packages-import-bundle.test.ts
@@ -415,6 +415,67 @@ describe("POST /api/packages/import-bundle — import", () => {
     expect((row!.draftManifest as Record<string, unknown>).runtime_tools).toEqual(["output"]);
   });
 
+  // ── retired AFPS 1.x dependency keys: import-bundle is the READ direction ──
+  //
+  // `dependencies.tools` (now `mcp_servers`) is inert — no reader has ever read
+  // it — so a package published with it is not broken, just carrying dead
+  // vocabulary. Aborting the whole bundle over it would be gratuitous, and the
+  // source artifact is immutable so there is nothing to repair upstream. Import
+  // succeeds; the warning is how the operator learns a republish is the fix.
+  //
+  // Kills the mutation "stop pushing the retired-dependency-key warning" and
+  // the mutation "reject retired dependency keys unconditionally" (which would
+  // 400 this request and, worse, break every already-published package).
+  it("imports a package carrying a retired dependency key and warns instead of aborting", async () => {
+    const agentId = "@importorg/legacy-dep-keys" as const;
+    const afps = buildAfps({
+      manifest: {
+        name: agentId,
+        version: "1.0.0",
+        type: "agent",
+        schema_version: "0.1",
+        display_name: "Legacy Dep Keys",
+        author: "tester",
+        dependencies: { tools: { "@appstrate/report": "^1.0.0" } },
+      },
+      content: "Legacy prompt.",
+      type: "agent",
+    });
+
+    const form = new FormData();
+    form.append("file", new Blob([afps]), "legacy-deps.afps");
+    const res = await app.request("/api/packages/import-bundle", {
+      method: "POST",
+      body: form,
+      headers: authHeaders(ctx),
+    });
+    if (res.status !== 201) {
+      throw new Error(`unexpected ${res.status}: ${await res.text()}`);
+    }
+    const body = (await res.json()) as {
+      imported: Array<{ identity: string; status: string }>;
+      warnings: string[];
+    };
+    expect(body.imported).toHaveLength(1);
+    expect(body.imported[0]!.status).toBe("inserted");
+
+    const warning = body.warnings.find((w) => w.includes("dependencies.tools"));
+    expect(warning).toBeDefined();
+    expect(warning).toContain(agentId);
+    expect(warning).toContain("dependencies.mcp_servers");
+
+    // Tolerated means LEFT ALONE — the stored draft keeps the retired key
+    // verbatim, so the import never rewrites a published manifest's bytes.
+    const [row] = await db
+      .select({ draftManifest: packages.draftManifest })
+      .from(packages)
+      .where(eq(packages.id, agentId))
+      .limit(1);
+    expect((row!.draftManifest as Record<string, unknown>).dependencies).toEqual({
+      tools: { "@appstrate/report": "^1.0.0" },
+    });
+  });
+
   it("returns status=reused on a second import of the same bundle", async () => {
     const sourceCtx = await createTestContext({ orgSlug: "srcidem" });
     const { bytes } = await seedAndExportBundle({

--- a/apps/api/test/integration/routes/packages.test.ts
+++ b/apps/api/test/integration/routes/packages.test.ts
@@ -900,6 +900,148 @@ describe("Packages API", () => {
       expect(await readDraftRuntimeTools(id)).toEqual(["log"]);
     });
 
+    // ── retired AFPS 1.x dependency keys: same direction split (#1021) ──
+    //
+    // AFPS 1.x had `dependencies.tools` / `dependencies.providers`; AFPS 2.0
+    // renamed them to `mcp_servers` / `integrations`. Every reader destructures
+    // exactly the three canonical maps, so the retired spelling is INERT — it
+    // used to validate and then be silently ignored, shipping an agent whose
+    // declared dependency is never resolved. Author input must reject.
+    async function putManifestDependencies(
+      packageId: string,
+      lockVersion: number | null | undefined,
+      dependencies: Record<string, unknown>,
+    ): Promise<Response> {
+      return app.request(`/api/packages/agents/${packageId}`, {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          manifest: {
+            name: packageId,
+            version: "0.2.0",
+            type: "agent",
+            schema_version: "0.1",
+            display_name: "Dependency Vocabulary Agent",
+            dependencies,
+          },
+          content: "Updated prompt.",
+          lock_version: lockVersion,
+        }),
+      });
+    }
+
+    it("rejects an update whose manifest declares dependencies.tools", async () => {
+      const agent = await seedAgent({
+        id: "@pkgorg/retired-dep-tools",
+        orgId: ctx.orgId,
+        createdBy: ctx.user.id,
+      });
+
+      const res = await putManifestDependencies("@pkgorg/retired-dep-tools", agent.lockVersion, {
+        tools: { "@appstrate/report": "^1.0.0" },
+      });
+
+      expect(res.status).toBe(400);
+      const body = JSON.stringify(await res.json());
+      // The error must name the retired key AND its replacement — a bare
+      // "invalid manifest" leaves the author with nowhere to go.
+      expect(body).toContain("dependencies.tools");
+      expect(body).toContain("dependencies.mcp_servers");
+
+      // Not a partial write — the seeded draft is untouched.
+      const [row] = await db
+        .select({ draftManifest: packages.draftManifest })
+        .from(packages)
+        .where(eq(packages.id, "@pkgorg/retired-dep-tools"))
+        .limit(1);
+      expect((row!.draftManifest as Record<string, unknown>).dependencies).toBeUndefined();
+    });
+
+    it("rejects an update whose manifest declares dependencies.providers", async () => {
+      const agent = await seedAgent({
+        id: "@pkgorg/retired-dep-providers",
+        orgId: ctx.orgId,
+        createdBy: ctx.user.id,
+      });
+
+      const res = await putManifestDependencies(
+        "@pkgorg/retired-dep-providers",
+        agent.lockVersion,
+        { providers: { "@appstrate/gmail": "^1.0.0" } },
+      );
+
+      expect(res.status).toBe(400);
+      const body = JSON.stringify(await res.json());
+      expect(body).toContain("dependencies.providers");
+      expect(body).toContain("dependencies.integrations");
+    });
+
+    it("accepts the canonical dependency maps and an unrelated extension key", async () => {
+      // Control: the rejects above are caused by the retired KEYS, not by the
+      // mere presence of `dependencies`. `dependencies` stays a loose object
+      // (AFPS §10 extensibility) — closing it is explicitly NOT the fix.
+      const id = "@pkgorg/canonical-deps";
+      const agent = await seedAgent({ id, orgId: ctx.orgId, createdBy: ctx.user.id });
+
+      const res = await putManifestDependencies(id, agent.lockVersion, {
+        skills: {},
+        mcp_servers: {},
+        integrations: {},
+        _meta: { "dev.appstrate/note": "still legal" },
+      });
+
+      expect(res.status).toBe(200);
+      const [row] = await db
+        .select({ draftManifest: packages.draftManifest })
+        .from(packages)
+        .where(eq(packages.id, id))
+        .limit(1);
+      const deps = (row!.draftManifest as Record<string, unknown>).dependencies as Record<
+        string,
+        unknown
+      >;
+      expect(deps._meta).toEqual({ "dev.appstrate/note": "still legal" });
+    });
+
+    it("carries a stored draft with a retired dependency key forward untouched", async () => {
+      // Read direction: a draft written before the guard existed must stay
+      // editable. A content-only save carries it forward — tolerated, and NOT
+      // rewritten (this validator never mutates stored bytes).
+      const id = "@pkgorg/legacy-dep-agent";
+      const agent = await seedAgent({
+        id,
+        orgId: ctx.orgId,
+        createdBy: ctx.user.id,
+        draftManifest: {
+          name: id,
+          version: "0.1.0",
+          type: "agent",
+          schema_version: "0.1",
+          display_name: "Legacy Dep Agent",
+          dependencies: { tools: { "@appstrate/report": "^1.0.0" } },
+        },
+      });
+
+      const res = await app.request(`/api/packages/agents/${id}`, {
+        method: "PUT",
+        headers: authHeaders(ctx, { "Content-Type": "application/json" }),
+        body: JSON.stringify({
+          content: "Only the prompt changed.",
+          lock_version: agent.lockVersion,
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      const [row] = await db
+        .select({ draftManifest: packages.draftManifest })
+        .from(packages)
+        .where(eq(packages.id, id))
+        .limit(1);
+      expect((row!.draftManifest as Record<string, unknown>).dependencies).toEqual({
+        tools: { "@appstrate/report": "^1.0.0" },
+      });
+    });
+
     it("deletes a package the org owns even when its scope differs from the org slug", async () => {
       await seedAgent({
         id: "@otherscope/deletable-agent",
@@ -1480,6 +1622,46 @@ describe("Packages API", () => {
       expect(res.status).toBe(400);
       const body = (await res.json()) as any;
       expect(JSON.stringify(body)).toContain("runtime_tools");
+    });
+
+    // Same WRITE direction, applied to the retired AFPS 1.x dependency keys
+    // (#1021). An uploaded .afps is author input and locally repairable — the
+    // error names the key and its replacement, so the operator edits one line.
+    it("returns 400 for a retired dependencies key (author input rejects)", async () => {
+      const enc = (s: string) => new TextEncoder().encode(s);
+      const afps = zipSync({
+        "manifest.json": enc(
+          JSON.stringify({
+            name: "@pkgorg/dep-vocab-agent",
+            version: "1.0.0",
+            type: "agent",
+            schema_version: "0.1",
+            display_name: "Dependency Vocabulary Agent",
+            dependencies: { tools: { "@appstrate/report": "^1.0.0" } },
+          }),
+        ),
+        "prompt.md": enc("You are an agent."),
+      });
+      const formData = new FormData();
+      formData.append("file", new File([new Uint8Array(afps)], "agent.afps"));
+      const res = await app.request("/api/packages/import", {
+        method: "POST",
+        headers: authHeaders(ctx),
+        body: formData,
+      });
+
+      expect(res.status).toBe(400);
+      const body = JSON.stringify(await res.json());
+      expect(body).toContain("dependencies.tools");
+      expect(body).toContain("dependencies.mcp_servers");
+
+      // Nothing was persisted — the reject is not a partial write.
+      const [row] = await db
+        .select({ id: packages.id })
+        .from(packages)
+        .where(eq(packages.id, "@pkgorg/dep-vocab-agent"))
+        .limit(1);
+      expect(row).toBeUndefined();
     });
 
     it("imports an agent whose runtime_tools are all still selectable", async () => {

--- a/apps/api/test/integration/routes/runs-remote-registry.test.ts
+++ b/apps/api/test/integration/routes/runs-remote-registry.test.ts
@@ -238,6 +238,56 @@ describe("POST /api/runs/remote — kind: registry", () => {
     expect(run!.versionRef).toBe(version);
   });
 
+  it("still runs a published version whose manifest carries a retired AFPS 1.x dependency key", async () => {
+    // Same doctrine as the retired-`runtime_tools` test above, applied to the
+    // `dependencies.tools` / `dependencies.providers` keys AFPS 2.0 retired
+    // (#1021). Author input rejects them; a PUBLISHED manifest carrying one
+    // must keep validating, because it is re-validated on every run and the
+    // artifact is immutable + integrity-checked — closing `dependencies` would
+    // make such an agent permanently unrunnable with no repair path.
+    const version = "2.2.0";
+    const manifest = {
+      ...publishedManifest(version),
+      dependencies: { tools: { "@appstrate/report": "^1.0.0" } },
+    } as unknown as Record<string, unknown>;
+
+    // Non-vacuity guard: the WRITE direction must still refuse this exact
+    // manifest, otherwise the 201 below proves nothing.
+    expect(validateManifest(manifest).valid).toBe(false);
+
+    await seedPackage({
+      orgId: ctx.orgId,
+      id: "@acme/briefing",
+      type: "agent",
+      draftManifest: manifest,
+      draftContent: PROMPT,
+    });
+    const versionRow = await seedPackageVersion({
+      packageId: "@acme/briefing",
+      version,
+      integrity: "sha256-test",
+      artifactSize: 1024,
+      manifest,
+    });
+    await db
+      .insert(packageDistTags)
+      .values({ packageId: "@acme/briefing", tag: "latest", versionId: versionRow.id });
+    await uploadPackageZip("@acme/briefing", version, buildMinimalZip(manifest, PROMPT));
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, "@acme/briefing");
+
+    const res = await post({
+      source: { kind: "registry", packageId: "@acme/briefing", stage: "published", spec: version },
+      applicationId: ctx.defaultAppId,
+      input: {},
+    });
+
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { id: string };
+    const [run] = await db.select().from(runs).where(eq(runs.id, body.id)).limit(1);
+    expect(run!.packageId).toBe("@acme/briefing");
+    expect(run!.versionRef).toBe(version);
+  });
+
   it("rejects a published version whose stored manifest is malformed with 500", async () => {
     // The counterpart of the test above, and what makes it mean something: a
     // stored manifest the validator refuses DOES fail the run. So the 201

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -458,7 +458,7 @@ Every row below is a direct drop-in: an agent can replace `curl` with `appstrate
 | `curl -T file`                  | `appstrate api -T file /x`            | PUT by default; `-T -` for stdin                  |
 | `curl -i`                       | `appstrate api -i`                    | status line + headers on stdout                   |
 | `curl -I`                       | `appstrate api -I`                    | HEAD only                                         |
-| `curl -L`                       | `appstrate api -L`                    | cross-origin hops strip `Authorization`           |
+| `curl -L`                       | `appstrate api -L`                    | cross-origin: `Authorization` dropped, `-H` kept  |
 | `curl -k`                       | `appstrate api -k`                    | skip TLS verification (this request)              |
 | `curl -o out`                   | `appstrate api -o out`                | body → file                                       |
 | `curl -s` / `-sS`               | `appstrate api -s` / `-sS`            | silence / silence-but-errors                      |
@@ -474,6 +474,8 @@ Every row below is a direct drop-in: an agent can replace `curl` with `appstrate
 | `curl -A 'UA'`                  | `appstrate api -A 'UA'`               | shortcut; `-H` still wins                         |
 | `curl -e https://ref`           | `appstrate api -e https://ref`        | Referer shortcut                                  |
 | `curl -b 'k=v'`                 | `appstrate api -b 'k=v'`              | literal only; cookie-jar files rejected           |
+
+**About `-L`.** A `Location` is chosen by the server and is never re-validated against your profile origin, so following it is opt-in. On a cross-origin hop the runtime drops `Authorization` and `Cookie`, but every custom `-H` header you pass — plus `X-Org-Id` / `X-Application-Id` — is forwarded to that host. Don't pass a second credential via `-H` and assume `-L` is safe. Without `-L`, a 3xx is surfaced un-followed (usually an empty body, exit 0) and the CLI prints a hint on stderr naming the `Location`.
 
 #### Write-out variables (`-w`)
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -606,7 +606,7 @@ program
   )
   .option(
     "-L, --location",
-    "Follow redirects (cross-origin hops strip Authorization per WHATWG fetch)",
+    "Follow redirects to whatever host the server names in Location. Cross-origin hops drop Authorization/Cookie (WHATWG fetch) but STILL forward your -H headers and X-Org-Id/X-Application-Id.",
   )
   .option(
     "-k, --insecure",

--- a/apps/cli/src/commands/api.ts
+++ b/apps/cli/src/commands/api.ts
@@ -20,7 +20,11 @@
  *   - apiFetchRaw injects `Content-Type: application/json` when a body
  *     is present — would corrupt multipart (kills the boundary) and
  *     binary payloads. We never set a default Content-Type.
- *   - apiFetchRaw hard-codes `redirect` and has no TLS-skip hook.
+ *   - apiFetchRaw never sets `redirect`, so it inherits fetch's
+ *     default (`follow`). We default to `manual`: a `Location` is
+ *     picked by the server and never re-validated against the profile
+ *     origin, so following it is opt-in (`-L`). apiFetchRaw also has
+ *     no TLS-skip hook.
  *
  * Known caveats (documented in --help + README):
  *   - Large stdin uploads: prefer `@file` over `@-` (Bun memory
@@ -59,6 +63,12 @@ export { isHttpMethod } from "./api/method.ts";
 export { HostMismatchError } from "./api/url.ts";
 export type { WriteOutMetrics } from "./api/write-out.ts";
 export type { ApiCommandIO, ApiCommandOptions } from "./api/types.ts";
+
+/**
+ * Statuses fetch treats as redirects (WHATWG fetch §4.4). Used to
+ * decide whether an un-followed response deserves the `-L` hint.
+ */
+const REDIRECT_STATUS = new Set([301, 302, 303, 307, 308]);
 
 export async function apiCommand(
   opts: ApiCommandOptions,
@@ -363,7 +373,31 @@ export async function apiCommand(
       io.stderr.write(`Session may be expired — run: appstrate login --profile ${profileName}\n`);
     }
 
-    // 9. Output.
+    // 9. Soft UX hint when a 3xx is surfaced un-followed. `redirect:
+    //    "manual"` is the deliberate default (see `api/retry.ts`), and
+    //    a redirect response usually carries no body at all (Hono's
+    //    `c.redirect()` sends none) — so without this the user gets a
+    //    0-byte file and exit 0 with nothing explaining why (#1021).
+    //    Skipped for `-I`/HEAD: a bodyless response is the expected
+    //    shape there, not an anomaly. The exit code is deliberately
+    //    left alone — `-f` / `--fail-with-body` already turn a 3xx
+    //    into exit 22, and scripts rely on the default staying 0.
+    //    Same gate as the 401 hint: silenced by `-s`, not restored by
+    //    `-sS`. Scoped to the fetch redirect statuses, not all of 3xx:
+    //    a 304 is bodyless by design and a 300 does carry a body —
+    //    neither is a papercut.
+    if (REDIRECT_STATUS.has(res.status) && !opts.location && !opts.head && !opts.silent) {
+      const location = res.headers.get("location");
+      io.stderr.write(
+        `HTTP ${res.status} redirect not followed — the response body is likely empty${
+          location ? ` (Location: ${location})` : ""
+        }.\n` +
+          `Re-run with -L to follow it. Cross-origin hops drop Authorization/Cookie, ` +
+          `but your -H headers and X-Org-Id/X-Application-Id are forwarded to that host.\n`,
+      );
+    }
+
+    // 10. Output.
     //    -f,  --fail (curl-aligned): non-2xx → body suppressed,
     //         exit 22 (4xx) / 25 (5xx).
     //    --fail-with-body: non-2xx → body still on stdout, exit 22/25.
@@ -423,7 +457,7 @@ export async function apiCommand(
     }
 
     cleanup();
-    // 10. Final exit code.
+    // 11. Final exit code.
     const code = failMode ? (res.status >= 500 ? 25 : 22) : 0;
     return exit(code);
   } finally {

--- a/apps/cli/test/api-command.integration.test.ts
+++ b/apps/cli/test/api-command.integration.test.ts
@@ -334,6 +334,55 @@ describe("apiCommand integration — redirect + Authorization", () => {
     expect(redirects.length).toBe(1);
     const followed = primary.calls.filter((c) => c.path === "/json");
     expect(followed.length).toBe(0);
+    // …and the un-followed 3xx is explained on stderr, never on stdout
+    // (stdout stays pipe-safe).
+    const err = decode(captured.stderr);
+    expect(err).toContain("HTTP 302 redirect not followed");
+    expect(err).toContain("/json");
+    expect(err).toContain("-L");
+    expect(decode(captured.stdout)).not.toContain("redirect not followed");
+  });
+
+  it("307 with an empty body (the #1021 papercut) → 0 bytes, exit 0, stderr hint", async () => {
+    const outPath = join(tmpDir, "out.md");
+    const captured = makeIO();
+    await run({ method: "GET", path: "/redirect/307", output: outPath }, captured);
+    // Exit code deliberately unchanged: scripts depend on the default
+    // staying 0 (use -f / --fail-with-body for failure semantics).
+    expect(captured.exitCode.value).toBe(0);
+    expect((await readFile(outPath)).byteLength).toBe(0);
+    const err = decode(captured.stderr);
+    expect(err).toContain("HTTP 307 redirect not followed");
+    expect(err).toMatch(/Location: http:\/\/127\.0\.0\.1:\d+\/json/);
+    expect(err).toContain("Re-run with -L");
+    // The security caveat must not read as "-L is safe".
+    expect(err).toContain("-H");
+    // Nothing on stdout — the whole point of routing the hint to stderr.
+    expect(decode(captured.stdout)).toBe("");
+  });
+
+  it("-s suppresses the redirect hint", async () => {
+    const captured = makeIO();
+    await run({ method: "GET", path: "/redirect/307", silent: true }, captured);
+    expect(captured.exitCode.value).toBe(0);
+    expect(decode(captured.stderr)).toBe("");
+  });
+
+  it("-I/HEAD on a 3xx does not print the hint (bodyless is expected there)", async () => {
+    const captured = makeIO();
+    await run({ method: "HEAD", path: "/redirect/307", head: true, include: true }, captured);
+    expect(captured.exitCode.value).toBe(0);
+    expect(decode(captured.stdout)).toMatch(/^HTTP\/1\.1 307 /);
+    expect(decode(captured.stderr)).toBe("");
+  });
+
+  it("-L on the 307 follows it and delivers the real body", async () => {
+    const captured = makeIO();
+    await run({ method: "GET", path: "/redirect/307", location: true }, captured);
+    expect(captured.exitCode.value).toBe(0);
+    expect(decode(captured.stdout)).toContain('"ok":true');
+    // Followed → no hint.
+    expect(decode(captured.stderr)).toBe("");
   });
 });
 

--- a/apps/cli/test/fixtures/test-server.ts
+++ b/apps/cli/test/fixtures/test-server.ts
@@ -105,6 +105,17 @@ export async function startTestServer(
           // Point same-origin to /json.
           return Response.redirect(new URL("/json", req.url).toString(), 302);
         }
+        case "/redirect/307": {
+          // 307 with a ZERO-byte body — the exact shape of
+          // `GET /api/documents/{id}/content` when S3 has a public
+          // endpoint (Hono's `c.redirect()` sends no body). Reproduces
+          // the "0 bytes, exit 0, no warning" papercut (#1021).
+          calls.push(log);
+          return new Response(null, {
+            status: 307,
+            headers: { Location: new URL("/json", req.url).toString() },
+          });
+        }
         case "/redirect/cross": {
           // Cross-origin redirect — target points at the peer server.
           calls.push(log);

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -2840,7 +2840,7 @@ export interface paths {
         };
         /**
          * List agent packages
-         * @description List all agent packages (system + org) in the organization.
+         * @description List the agent packages available to the current application (`X-Application-Id`): system packages, plus organization packages installed in this application. Organization packages that exist but are not installed here are NOT returned — for the organization-wide catalogue with per-application install state, use `GET /api/library`.
          */
         get: operations["listAgentPackages"];
         put?: never;
@@ -3068,7 +3068,7 @@ export interface paths {
         };
         /**
          * List integration packages
-         * @description List all integration packages (system + org) in the organization.
+         * @description List the integration packages available to the current application (`X-Application-Id`): system packages, plus organization packages installed in this application. Organization packages that exist but are not installed here are NOT returned — for the organization-wide catalogue with per-application install state, use `GET /api/library`.
          */
         get: operations["listIntegrationPackages"];
         put?: never;
@@ -3236,7 +3236,7 @@ export interface paths {
         };
         /**
          * List MCP-server packages
-         * @description List all MCP-server packages (system + org) in the organization.
+         * @description List the MCP-server packages available to the current application (`X-Application-Id`): system packages, plus organization packages installed in this application. Organization packages that exist but are not installed here are NOT returned — for the organization-wide catalogue with per-application install state, use `GET /api/library`.
          */
         get: operations["listMcpServerPackages"];
         put?: never;
@@ -3404,7 +3404,7 @@ export interface paths {
         };
         /**
          * List skills
-         * @description List all skills (system + org) in the organization.
+         * @description List the skills available to the current application (`X-Application-Id`): system packages, plus organization packages installed in this application. Organization packages that exist but are not installed here are NOT returned — for the organization-wide catalogue with per-application install state, use `GET /api/library`.
          */
         get: operations["listSkills"];
         put?: never;
@@ -5890,7 +5890,7 @@ export interface components {
         PackageScope: string;
         /** @description Package name */
         PackageName: string;
-        /** @description When `true`, narrows the list to packages installed and enabled in the current application. */
+        /** @description When `true`, narrows the list to packages installed and enabled in the current application — system packages with no install row drop out. Integrations are the one exception: they are filtered on effective activation, so an environment-provided system integration stays listed even though it has no install row. */
         PackageActiveFilter: "true";
     };
     requestBodies: never;
@@ -14917,7 +14917,7 @@ export interface operations {
     listAgentPackages: {
         parameters: {
             query?: {
-                /** @description When `true`, narrows the list to packages installed and enabled in the current application. */
+                /** @description When `true`, narrows the list to packages installed and enabled in the current application — system packages with no install row drop out. Integrations are the one exception: they are filtered on effective activation, so an environment-provided system integration stays listed even though it has no install row. */
                 active?: components["parameters"]["PackageActiveFilter"];
             };
             header?: {
@@ -15711,7 +15711,7 @@ export interface operations {
     listIntegrationPackages: {
         parameters: {
             query?: {
-                /** @description When `true`, narrows the list to packages installed and enabled in the current application. */
+                /** @description When `true`, narrows the list to packages installed and enabled in the current application — system packages with no install row drop out. Integrations are the one exception: they are filtered on effective activation, so an environment-provided system integration stays listed even though it has no install row. */
                 active?: components["parameters"]["PackageActiveFilter"];
             };
             header?: {
@@ -16270,7 +16270,7 @@ export interface operations {
     listMcpServerPackages: {
         parameters: {
             query?: {
-                /** @description When `true`, narrows the list to packages installed and enabled in the current application. */
+                /** @description When `true`, narrows the list to packages installed and enabled in the current application — system packages with no install row drop out. Integrations are the one exception: they are filtered on effective activation, so an environment-provided system integration stays listed even though it has no install row. */
                 active?: components["parameters"]["PackageActiveFilter"];
             };
             header?: {
@@ -16841,7 +16841,7 @@ export interface operations {
     listSkills: {
         parameters: {
             query?: {
-                /** @description When `true`, narrows the list to packages installed and enabled in the current application. */
+                /** @description When `true`, narrows the list to packages installed and enabled in the current application — system packages with no install row drop out. Integrations are the one exception: they are filtered on effective activation, so an environment-provided system integration stays listed even though it has no install row. */
                 active?: components["parameters"]["PackageActiveFilter"];
             };
             header?: {

--- a/apps/web/src/components/agent-editor/test/utils.test.ts
+++ b/apps/web/src/components/agent-editor/test/utils.test.ts
@@ -13,7 +13,7 @@ import {
   manifestToMetadata,
   metadataToManifestPatch,
   getRuntimeTools,
-  withNormalizedRuntimeTools,
+  withNormalizedManifest,
   setRuntimeTools,
 } from "../utils";
 import type { SchemaField } from "../schema-section";
@@ -602,16 +602,16 @@ describe("getRuntimeTools", () => {
   });
 });
 
-// ─── withNormalizedRuntimeTools ──────────────────
+// ─── withNormalizedManifest ──────────────────
 
-// Delegates to `dropRetiredRuntimeTools` (`@appstrate/core`), which is gated on
-// `type: "agent"` — the fixtures carry it because the only call site
-// (`package-editor.tsx`) runs in the agent branch on a stored AFPS manifest,
-// where `type` is required by the schema.
-describe("withNormalizedRuntimeTools", () => {
+// Delegates to `dropRetiredRuntimeTools` + `dropRetiredDependencyKeys`
+// (`@appstrate/core`). The former is gated on `type: "agent"` — the fixtures
+// carry it because the only call site (`package-editor.tsx`) runs in the agent
+// branch on a stored AFPS manifest, where `type` is required by the schema.
+describe("withNormalizedManifest", () => {
   it("strips a retired id from the manifest loaded into the editor", () => {
     const m = { type: "agent", name: "@o/a", runtime_tools: ["report", "log"] };
-    expect(withNormalizedRuntimeTools(m)).toEqual({
+    expect(withNormalizedManifest(m)).toEqual({
       type: "agent",
       name: "@o/a",
       runtime_tools: ["log"],
@@ -620,15 +620,15 @@ describe("withNormalizedRuntimeTools", () => {
 
   it("removes the field entirely when nothing valid remains", () => {
     expect(
-      withNormalizedRuntimeTools({ type: "agent", name: "@o/a", runtime_tools: ["report"] }),
+      withNormalizedManifest({ type: "agent", name: "@o/a", runtime_tools: ["report"] }),
     ).toEqual({ type: "agent", name: "@o/a" });
   });
 
   it("returns the same reference when there is nothing to drop", () => {
     const m = { type: "agent", name: "@o/a", runtime_tools: ["output"] };
-    expect(withNormalizedRuntimeTools(m)).toBe(m);
+    expect(withNormalizedManifest(m)).toBe(m);
     const noField = { type: "agent", name: "@o/a" };
-    expect(withNormalizedRuntimeTools(noField)).toBe(noField);
+    expect(withNormalizedManifest(noField)).toBe(noField);
   });
 
   // Settled empty-array representation, checked on the editor side of the
@@ -639,8 +639,55 @@ describe("withNormalizedRuntimeTools", () => {
   // editor and core cannot drift on the empty case again.
   it("leaves an author-written empty runtime_tools untouched on load", () => {
     const m = { type: "agent", name: "@o/a", runtime_tools: [] };
-    expect(withNormalizedRuntimeTools(m)).toBe(m);
-    expect(withNormalizedRuntimeTools(m)).toHaveProperty("runtime_tools");
+    expect(withNormalizedManifest(m)).toBe(m);
+    expect(withNormalizedManifest(m)).toHaveProperty("runtime_tools");
+  });
+
+  // A draft can acquire a retired AFPS 1.x dependency key by importing a bundle
+  // assembled from a legacy published version (that path tolerates it). The
+  // author-direction save then REJECTS it, on a field the editor cannot
+  // display — so it has to go on load, or the agent becomes uneditable (#1021).
+  it("strips a retired AFPS 1.x dependency key on load", () => {
+    const m = {
+      type: "agent",
+      name: "@o/a",
+      dependencies: { tools: { "@appstrate/report": "^1.0.0" }, skills: { "@o/s": "^1.0.0" } },
+    };
+    expect(withNormalizedManifest(m)).toEqual({
+      type: "agent",
+      name: "@o/a",
+      dependencies: { skills: { "@o/s": "^1.0.0" } },
+    });
+  });
+
+  it("leaves an emptied dependencies map as {} — the shape the editor itself mints", () => {
+    expect(
+      withNormalizedManifest({
+        type: "agent",
+        name: "@o/a",
+        dependencies: { providers: { "@o/gmail": "^1.0.0" } },
+      }),
+    ).toEqual({ type: "agent", name: "@o/a", dependencies: {} });
+  });
+
+  it("leaves the canonical dependency maps and an extension key untouched", () => {
+    const m = {
+      type: "agent",
+      name: "@o/a",
+      dependencies: { skills: {}, mcp_servers: {}, integrations: {}, _meta: { "dev.x/y": 1 } },
+    };
+    expect(withNormalizedManifest(m)).toBe(m);
+  });
+
+  it("strips a retired runtime tool and a retired dependency key in one pass", () => {
+    expect(
+      withNormalizedManifest({
+        type: "agent",
+        name: "@o/a",
+        runtime_tools: ["report", "log"],
+        dependencies: { tools: {} },
+      }),
+    ).toEqual({ type: "agent", name: "@o/a", runtime_tools: ["log"], dependencies: {} });
   });
 });
 

--- a/apps/web/src/components/agent-editor/utils.ts
+++ b/apps/web/src/components/agent-editor/utils.ts
@@ -18,6 +18,7 @@ import {
 import { AFPS_SCHEMA_URLS, dropRetiredRuntimeTools } from "@appstrate/core/validation";
 import { isSelectableRuntimeTool } from "@appstrate/core/runtime-tools-catalog";
 import {
+  dropRetiredDependencyKeys,
   isToolsWildcard,
   parseManifestIntegrations,
   writeManifestIntegrations,
@@ -145,24 +146,36 @@ export function getRuntimeTools(m: Record<string, unknown>): string[] {
 }
 
 /**
- * Return the manifest with `runtime_tools` reduced to the ids the platform
- * still offers. Applied when an existing agent is loaded into the editor, so
- * a retired id persisted long ago (e.g. `report`) silently disappears on the
- * next save instead of round-tripping forever — the user is never shown an
- * error for a field the editor cannot even display.
+ * Return the manifest with every piece of vocabulary the platform retired
+ * removed, applied ONCE when an existing agent is loaded into the editor:
  *
- * Delegates to `dropRetiredRuntimeTools` from `@appstrate/core` — the SAME
- * function the publish path runs (`services/package-versions.ts`). The editor
- * used to reimplement it and the two drifted on the empty case, so an agent
- * whose only tool was retired serialised differently depending on which path
- * saved it. One implementation, one byte sequence. Core is type-gated
+ *   - `runtime_tools` reduced to the ids the platform still offers, so a
+ *     retired id persisted long ago (e.g. `report`) silently disappears on the
+ *     next save instead of round-tripping forever;
+ *   - the retired AFPS 1.x `dependencies` keys (`tools` → `mcp_servers`,
+ *     `providers` → `integrations`) dropped, for the same reason — a draft can
+ *     acquire one by importing a bundle assembled from a legacy published
+ *     version, and the author-direction save rejects it (#1021).
+ *
+ * In both cases the user would otherwise be shown an error for a field the
+ * editor cannot even display, with no way to clear it. Typing either into the
+ * raw-JSON tab still surfaces the rejection — this normalises on LOAD only.
+ *
+ * Both halves delegate to `@appstrate/core` — `dropRetiredRuntimeTools` is the
+ * SAME function the publish path runs (`services/package-versions.ts`). The
+ * editor used to reimplement it and the two drifted on the empty case, so an
+ * agent whose only tool was retired serialised differently depending on which
+ * path saved it. One implementation, one byte sequence. Core is type-gated
  * (`type: "agent"`), which is exactly this call site: `package-editor.tsx`
  * invokes it only in the agent branch.
  *
+ * One function rather than a chain the call site composes, so a future
+ * retirement is added here and cannot be forgotten at the call site.
+ *
  * Returns the same reference when there is nothing to drop.
  */
-export function withNormalizedRuntimeTools(m: Record<string, unknown>): Record<string, unknown> {
-  return dropRetiredRuntimeTools(m).manifest;
+export function withNormalizedManifest(m: Record<string, unknown>): Record<string, unknown> {
+  return dropRetiredDependencyKeys(dropRetiredRuntimeTools(m).manifest).manifest;
 }
 
 /**

--- a/apps/web/src/components/agent-editor/utils.ts
+++ b/apps/web/src/components/agent-editor/utils.ts
@@ -175,7 +175,7 @@ export function getRuntimeTools(m: Record<string, unknown>): string[] {
  * Returns the same reference when there is nothing to drop.
  */
 export function withNormalizedManifest(m: Record<string, unknown>): Record<string, unknown> {
-  return dropRetiredDependencyKeys(dropRetiredRuntimeTools(m).manifest).manifest;
+  return dropRetiredDependencyKeys(dropRetiredRuntimeTools(m).manifest);
 }
 
 /**

--- a/apps/web/src/pages/package-editor.tsx
+++ b/apps/web/src/pages/package-editor.tsx
@@ -43,7 +43,7 @@ import {
   setResourceEntries,
   getRuntimeTools,
   setRuntimeTools,
-  withNormalizedRuntimeTools,
+  withNormalizedManifest,
   toResourceEntry,
   fieldsToSchema,
 } from "../components/agent-editor/utils";
@@ -575,7 +575,7 @@ export function PackageEditorPage({ type }: { type: PackageType }) {
     const initialState: AgentEditorState =
       isEdit && agentDetail
         ? {
-            manifest: withNormalizedRuntimeTools(agentDetail.manifest ?? {}),
+            manifest: withNormalizedManifest(agentDetail.manifest ?? {}),
             prompt: agentDetail.prompt || "",
             lock_version: agentDetail.lock_version,
           }

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -44,7 +44,7 @@ export interface Dependencies {
  * validating (and therefore keep running) forever. See
  * {@link import("./validation.ts").RetiredRuntimeToolsPolicy}.
  */
-export const RETIRED_DEPENDENCY_KEYS = {
+const RETIRED_DEPENDENCY_KEYS = {
   tools: "mcp_servers",
   providers: "integrations",
 } as const satisfies Record<string, keyof Dependencies>;
@@ -64,10 +64,7 @@ export interface RetiredDependencyKeyUse {
  * List the retired AFPS 1.x `dependencies` keys a manifest declares.
  *
  * Type-agnostic: every package type may carry `dependencies`, and the retired
- * spelling is equally inert on all of them — every reader in the platform
- * destructures exactly `{ skills, mcp_servers, integrations }` (see
- * {@link extractDependencies}), so a `dependencies.tools` entry declares a
- * dependency that is then silently ignored.
+ * spelling is equally inert on all of them ({@link RETIRED_DEPENDENCY_KEYS}).
  *
  * Pure and non-mutating: returns what was found, decides nothing. Callers
  * apply the direction-dependent policy — reject on author input, warn (never
@@ -100,31 +97,25 @@ export function findRetiredDependencyKeys(manifest: unknown): RetiredDependencyK
  * — where the key is rejected — would fail on a field the editor cannot even
  * display. Normalising on LOAD makes the key disappear on the next save
  * instead, while typing one into a raw-JSON tab still surfaces the rejection.
- *
- * Nothing is lost: the key is inert by definition — no reader has ever read it
- * (see {@link extractDependencies}) — so the dependencies declared under it
- * were never resolved.
+ * Nothing is lost — the key is inert ({@link RETIRED_DEPENDENCY_KEYS}).
  *
  * Purely structural: no Zod round-trip, surviving keys keep their order, and
  * the input is returned by the SAME reference when there is nothing to drop.
  * An emptied `dependencies` is left as `{}` rather than deleted — `{}` is the
  * shape the editor itself mints for a fresh agent, so both writers agree.
  *
- * NOT wired into any stored/published path: a published artifact is immutable
- * and integrity-checked, so rewriting its bytes to remove an inert key would
- * change its hash for no functional gain. There the key is tolerated and
- * surfaced as an install warning.
+ * NOT wired into any stored/published path — there the key is tolerated and
+ * surfaced as an install warning instead.
  */
-export function dropRetiredDependencyKeys(manifest: Record<string, unknown>): {
-  manifest: Record<string, unknown>;
-  dropped: RetiredDependencyKey[];
-} {
+export function dropRetiredDependencyKeys(
+  manifest: Record<string, unknown>,
+): Record<string, unknown> {
   const found = findRetiredDependencyKeys(manifest);
-  if (found.length === 0) return { manifest, dropped: [] };
+  if (found.length === 0) return manifest;
 
   const deps = { ...(manifest.dependencies as Record<string, unknown>) };
   for (const { key } of found) delete deps[key];
-  return { manifest: { ...manifest, dependencies: deps }, dropped: found.map((f) => f.key) };
+  return { ...manifest, dependencies: deps };
 }
 
 /**

--- a/packages/core/src/dependencies.ts
+++ b/packages/core/src/dependencies.ts
@@ -22,6 +22,111 @@ export interface Dependencies {
   integrations?: Record<string, string>;
 }
 
+// ─────────────────────────────────────────────
+// Retired dependency vocabulary (AFPS 1.x → 2.0)
+// ─────────────────────────────────────────────
+
+/**
+ * The `dependencies` map keys AFPS 1.x defined and AFPS 2.0 retired, each
+ * mapped to the key that replaced it.
+ *
+ * A table rather than a chain of per-key `if`s so the two directions that
+ * consume it — the author-input rejection ({@link findRetiredDependencyKeys},
+ * folded into `validateManifest`) and the install-time warning (API layer) —
+ * can never enumerate a different set, and so adding a future retirement is
+ * one line here.
+ *
+ * These keys are NOT closed out by the schema, and deliberately so: AFPS
+ * mandates extensibility for objects it does not explicitly close (§10), so
+ * `dependencies` stays a loose object and `dependencies._meta` remains legal.
+ * The rejection below is a POLICY on author input, not a shape constraint —
+ * which is what lets already-published manifests carrying a retired key keep
+ * validating (and therefore keep running) forever. See
+ * {@link import("./validation.ts").RetiredRuntimeToolsPolicy}.
+ */
+export const RETIRED_DEPENDENCY_KEYS = {
+  tools: "mcp_servers",
+  providers: "integrations",
+} as const satisfies Record<string, keyof Dependencies>;
+
+/** A `dependencies` map key retired by AFPS 2.0. */
+export type RetiredDependencyKey = keyof typeof RETIRED_DEPENDENCY_KEYS;
+
+/** One retired `dependencies` key found on a manifest, with its replacement. */
+export interface RetiredDependencyKeyUse {
+  /** The retired key as it appears in the manifest (e.g. `"tools"`). */
+  key: RetiredDependencyKey;
+  /** The AFPS 2.0 key that replaced it (e.g. `"mcp_servers"`). */
+  replacement: keyof Dependencies;
+}
+
+/**
+ * List the retired AFPS 1.x `dependencies` keys a manifest declares.
+ *
+ * Type-agnostic: every package type may carry `dependencies`, and the retired
+ * spelling is equally inert on all of them — every reader in the platform
+ * destructures exactly `{ skills, mcp_servers, integrations }` (see
+ * {@link extractDependencies}), so a `dependencies.tools` entry declares a
+ * dependency that is then silently ignored.
+ *
+ * Pure and non-mutating: returns what was found, decides nothing. Callers
+ * apply the direction-dependent policy — reject on author input, warn (never
+ * rewrite) on already-persisted manifests.
+ */
+export function findRetiredDependencyKeys(manifest: unknown): RetiredDependencyKeyUse[] {
+  if (typeof manifest !== "object" || manifest === null) return [];
+  const deps = (manifest as { dependencies?: unknown }).dependencies;
+  if (typeof deps !== "object" || deps === null || Array.isArray(deps)) return [];
+
+  const found: RetiredDependencyKeyUse[] = [];
+  for (const [key, replacement] of Object.entries(RETIRED_DEPENDENCY_KEYS)) {
+    // `hasOwnProperty.call`, not `Object.hasOwn` — core is compiled against
+    // the web app's older `lib` target too. Own-property only: an inherited
+    // key was not authored.
+    if (Object.prototype.hasOwnProperty.call(deps, key)) {
+      found.push({ key: key as RetiredDependencyKey, replacement });
+    }
+  }
+  return found;
+}
+
+/**
+ * Strip the retired AFPS 1.x `dependencies` keys from an EDITABLE manifest.
+ *
+ * The mirror image of `dropRetiredRuntimeTools` in `validation.ts`, and used
+ * for the same reason: an agent whose draft carries a retired key (imported
+ * from a bundle assembled out of a legacy published version, say) would
+ * otherwise round-trip it forever, and the first save through the author path
+ * — where the key is rejected — would fail on a field the editor cannot even
+ * display. Normalising on LOAD makes the key disappear on the next save
+ * instead, while typing one into a raw-JSON tab still surfaces the rejection.
+ *
+ * Nothing is lost: the key is inert by definition — no reader has ever read it
+ * (see {@link extractDependencies}) — so the dependencies declared under it
+ * were never resolved.
+ *
+ * Purely structural: no Zod round-trip, surviving keys keep their order, and
+ * the input is returned by the SAME reference when there is nothing to drop.
+ * An emptied `dependencies` is left as `{}` rather than deleted — `{}` is the
+ * shape the editor itself mints for a fresh agent, so both writers agree.
+ *
+ * NOT wired into any stored/published path: a published artifact is immutable
+ * and integrity-checked, so rewriting its bytes to remove an inert key would
+ * change its hash for no functional gain. There the key is tolerated and
+ * surfaced as an install warning.
+ */
+export function dropRetiredDependencyKeys(manifest: Record<string, unknown>): {
+  manifest: Record<string, unknown>;
+  dropped: RetiredDependencyKey[];
+} {
+  const found = findRetiredDependencyKeys(manifest);
+  if (found.length === 0) return { manifest, dropped: [] };
+
+  const deps = { ...(manifest.dependencies as Record<string, unknown>) };
+  for (const { key } of found) delete deps[key];
+  return { manifest: { ...manifest, dependencies: deps }, dropped: found.map((f) => f.key) };
+}
+
 /**
  * Wildcard literal for {@link IntegrationConfiguration.tools} / {@link
  * ManifestIntegrationEntry.tools} (AFPS §4.4). When set, the agent forgoes

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -15,6 +15,7 @@ import {
 import { integrationManifestSchema, type IntegrationManifest } from "./integration.ts";
 import { mcpServerManifestSchema, type McpServerManifest } from "./mcp-server.ts";
 import { SELECTABLE_RUNTIME_TOOLS, isSelectableRuntimeTool } from "./runtime-tools-catalog.ts";
+import { findRetiredDependencyKeys } from "./dependencies.ts";
 
 export { integrationManifestSchema, type IntegrationManifest };
 export { mcpServerManifestSchema, type McpServerManifest };
@@ -418,25 +419,50 @@ export function dropRetiredRuntimeTools(manifest: Record<string, unknown>): {
 }
 
 /**
- * How {@link validateManifest} treats `runtime_tools` ids the platform retired
- * (or an author simply mistyped) — the one behaviour that MUST differ by
- * direction:
+ * How {@link validateManifest} treats the manifest vocabulary the platform
+ * retired — the one behaviour that MUST differ by direction. It governs BOTH
+ * retired kinds, because they are two expressions of a single question ("is
+ * this manifest author input, or something already persisted?") and splitting
+ * them into two flags would let a future call site set one and forget the
+ * other, which is precisely how the author-input rejection was lost once
+ * already (#1021):
+ *
+ *   1. `runtime_tools` ids the platform retired (or an author mistyped).
+ *   2. `dependencies` keys AFPS 2.0 retired — `tools` (now `mcp_servers`) and
+ *      `providers` (now `integrations`), see {@link RETIRED_DEPENDENCY_KEYS}.
+ *
+ * The two policy values:
  *
  *   - `"reject"` (default) — the manifest is AUTHOR INPUT (create, update,
  *     import, an inline manifest from an API client, a repo-authored system
  *     package). A retired or misspelled id is a mistake the author must see;
- *     silently dropping it ships an agent missing a tool with no signal.
+ *     silently dropping it ships an agent missing a tool with no signal, and a
+ *     retired dependency key declares a dependency no reader will ever honour.
  *   - `"drop"` — the manifest was ALREADY PERSISTED (a stored draft, a
  *     published version snapshot). Those cannot be fixed in place — a
- *     published artifact is immutable by construction — so the retired ids are
- *     stripped and the manifest stays valid and runnable. Read
- *     {@link ValidateManifestResult.droppedRuntimeTools} to log what went.
+ *     published artifact is immutable by construction — so:
+ *       - retired `runtime_tools` ids are stripped and the manifest stays valid
+ *         and runnable (read {@link ValidateManifestResult.droppedRuntimeTools}
+ *         to log what went), and
+ *       - a retired `dependencies` key is TOLERATED, left exactly where it is.
+ *         It is inert (no reader has ever read it) so there is nothing to strip,
+ *         and rewriting a stored manifest's bytes here would change its
+ *         integrity hash. Surfacing it belongs to the install-warning channel,
+ *         not to this validator.
+ *
+ * The name is historical — the flag predates the dependency-key rule and is
+ * part of the published `@appstrate/core` surface, so it is kept rather than
+ * renamed for a nicety.
  */
 export type RetiredRuntimeToolsPolicy = "reject" | "drop";
 
 /** Options for {@link validateManifest}. */
 export interface ValidateManifestOptions {
-  /** Direction-dependent handling of retired `runtime_tools` ids. Default `"reject"`. */
+  /**
+   * Direction-dependent handling of retired manifest vocabulary — retired
+   * `runtime_tools` ids AND retired AFPS 1.x `dependencies` keys. Default
+   * `"reject"` (author input). See {@link RetiredRuntimeToolsPolicy}.
+   */
   retiredRuntimeTools?: RetiredRuntimeToolsPolicy;
 }
 
@@ -468,6 +494,28 @@ export function validateManifest(
   }
   const obj = raw as Record<string, unknown>;
   const type = obj.type;
+
+  // AFPS 1.x retired dependency vocabulary. `dependencies.tools` /
+  // `dependencies.providers` still PARSE — `dependencies` is a loose object by
+  // spec (§10 extensibility) and closing it would make every already-published
+  // manifest that carries one permanently unvalidatable, hence unrunnable, with
+  // no repair path. They are simply never read: every consumer destructures
+  // `{ skills, mcp_servers, integrations }`. So on the author direction they are
+  // rejected here, naming the replacement key, instead of being accepted and
+  // silently ignored (#1021). Checked before the type dispatch because every
+  // package type may declare `dependencies`.
+  if (options?.retiredRuntimeTools !== "drop") {
+    const retiredDeps = findRetiredDependencyKeys(obj);
+    if (retiredDeps.length > 0) {
+      return {
+        valid: false,
+        errors: retiredDeps.map(
+          ({ key, replacement }) =>
+            `dependencies.${key}: \`dependencies.${key}\` is a retired AFPS 1.x key — rename it to \`dependencies.${replacement}\`. No consumer reads it, so the dependencies declared under it are silently ignored.`,
+        ),
+      };
+    }
+  }
 
   // AFPS (§3.4): mcp-server identity lives at the manifest root —
   // `type: "mcp-server"`, `name`, `schema_version`, and `dependencies` are

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -429,7 +429,7 @@ export function dropRetiredRuntimeTools(manifest: Record<string, unknown>): {
  *
  *   1. `runtime_tools` ids the platform retired (or an author mistyped).
  *   2. `dependencies` keys AFPS 2.0 retired — `tools` (now `mcp_servers`) and
- *      `providers` (now `integrations`), see {@link RETIRED_DEPENDENCY_KEYS}.
+ *      `providers` (now `integrations`).
  *
  * The two policy values:
  *
@@ -495,15 +495,10 @@ export function validateManifest(
   const obj = raw as Record<string, unknown>;
   const type = obj.type;
 
-  // AFPS 1.x retired dependency vocabulary. `dependencies.tools` /
-  // `dependencies.providers` still PARSE — `dependencies` is a loose object by
-  // spec (§10 extensibility) and closing it would make every already-published
-  // manifest that carries one permanently unvalidatable, hence unrunnable, with
-  // no repair path. They are simply never read: every consumer destructures
-  // `{ skills, mcp_servers, integrations }`. So on the author direction they are
-  // rejected here, naming the replacement key, instead of being accepted and
-  // silently ignored (#1021). Checked before the type dispatch because every
-  // package type may declare `dependencies`.
+  // AFPS 1.x retired dependency vocabulary: on the author direction, reject
+  // and name the replacement key (#1021). See {@link RetiredRuntimeToolsPolicy}
+  // for why the keys still parse. Checked before the type dispatch because
+  // every package type may declare `dependencies`.
   if (options?.retiredRuntimeTools !== "drop") {
     const retiredDeps = findRetiredDependencyKeys(obj);
     if (retiredDeps.length > 0) {

--- a/packages/core/test/dependencies.test.ts
+++ b/packages/core/test/dependencies.test.ts
@@ -7,18 +7,11 @@ import {
   dropRetiredDependencyKeys,
   findRetiredDependencyKeys,
   parseManifestIntegrations,
-  RETIRED_DEPENDENCY_KEYS,
   writeManifestIntegrations,
 } from "../src/dependencies.ts";
 import type { DepEntry } from "../src/dependencies.ts";
 
 describe("findRetiredDependencyKeys", () => {
-  it("maps every retired AFPS 1.x key to its AFPS 2.0 replacement", () => {
-    // Pins the registry itself — the rejection and the install warning both
-    // enumerate it, so a silent change here changes both directions at once.
-    expect(RETIRED_DEPENDENCY_KEYS).toEqual({ tools: "mcp_servers", providers: "integrations" });
-  });
-
   it("finds dependencies.tools", () => {
     expect(findRetiredDependencyKeys({ dependencies: { tools: { "@a/b": "^1.0.0" } } })).toEqual([
       { key: "tools", replacement: "mcp_servers" },
@@ -67,26 +60,24 @@ describe("findRetiredDependencyKeys", () => {
 
 describe("dropRetiredDependencyKeys", () => {
   it("drops the retired key and keeps the canonical maps", () => {
-    const { manifest, dropped } = dropRetiredDependencyKeys({
+    const manifest = dropRetiredDependencyKeys({
       name: "@a/agent",
       dependencies: { tools: { "@a/t": "^1.0.0" }, skills: { "@a/s": "^1.0.0" } },
     });
-    expect(dropped).toEqual(["tools"]);
     expect(manifest.dependencies).toEqual({ skills: { "@a/s": "^1.0.0" } });
   });
 
   it("drops every retired key at once", () => {
-    const { dropped, manifest } = dropRetiredDependencyKeys({
+    const manifest = dropRetiredDependencyKeys({
       dependencies: { tools: {}, providers: {} },
     });
-    expect(dropped).toEqual(["tools", "providers"]);
     expect(manifest.dependencies).toEqual({});
   });
 
   // Structural, not a canonicaliser: surviving keys keep their order and
   // unknown fields survive, so the result can be serialised without surprises.
   it("preserves key order and unrelated fields", () => {
-    const { manifest } = dropRetiredDependencyKeys({
+    const manifest = dropRetiredDependencyKeys({
       name: "@a/agent",
       dependencies: { skills: {}, tools: {}, _meta: { "dev.x/y": 1 } },
       custom_field: "must-survive",
@@ -101,10 +92,9 @@ describe("dropRetiredDependencyKeys", () => {
 
   it("returns the same reference when there is nothing to drop", () => {
     const clean = { name: "@a/agent", dependencies: { skills: {} } };
-    expect(dropRetiredDependencyKeys(clean)).toEqual({ manifest: clean, dropped: [] });
-    expect(dropRetiredDependencyKeys(clean).manifest).toBe(clean);
+    expect(dropRetiredDependencyKeys(clean)).toBe(clean);
     const noDeps = { name: "@a/agent" };
-    expect(dropRetiredDependencyKeys(noDeps).manifest).toBe(noDeps);
+    expect(dropRetiredDependencyKeys(noDeps)).toBe(noDeps);
   });
 
   it("does not mutate the input", () => {

--- a/packages/core/test/dependencies.test.ts
+++ b/packages/core/test/dependencies.test.ts
@@ -4,10 +4,115 @@ import { describe, expect, it } from "bun:test";
 import {
   extractDependencies,
   detectCycle,
+  dropRetiredDependencyKeys,
+  findRetiredDependencyKeys,
   parseManifestIntegrations,
+  RETIRED_DEPENDENCY_KEYS,
   writeManifestIntegrations,
 } from "../src/dependencies.ts";
 import type { DepEntry } from "../src/dependencies.ts";
+
+describe("findRetiredDependencyKeys", () => {
+  it("maps every retired AFPS 1.x key to its AFPS 2.0 replacement", () => {
+    // Pins the registry itself — the rejection and the install warning both
+    // enumerate it, so a silent change here changes both directions at once.
+    expect(RETIRED_DEPENDENCY_KEYS).toEqual({ tools: "mcp_servers", providers: "integrations" });
+  });
+
+  it("finds dependencies.tools", () => {
+    expect(findRetiredDependencyKeys({ dependencies: { tools: { "@a/b": "^1.0.0" } } })).toEqual([
+      { key: "tools", replacement: "mcp_servers" },
+    ]);
+  });
+
+  it("finds dependencies.providers", () => {
+    expect(findRetiredDependencyKeys({ dependencies: { providers: {} } })).toEqual([
+      { key: "providers", replacement: "integrations" },
+    ]);
+  });
+
+  it("returns nothing for the canonical maps or an unrelated extension key", () => {
+    expect(
+      findRetiredDependencyKeys({
+        dependencies: {
+          skills: { "@a/s": "^1.0.0" },
+          mcp_servers: { "@a/m": "^1.0.0" },
+          integrations: { "@a/i": "^1.0.0" },
+          _meta: { "dev.appstrate/x": 1 },
+        },
+      }),
+    ).toEqual([]);
+  });
+
+  it("returns nothing for a manifest with no or malformed dependencies", () => {
+    expect(findRetiredDependencyKeys({})).toEqual([]);
+    expect(findRetiredDependencyKeys({ dependencies: null })).toEqual([]);
+    expect(findRetiredDependencyKeys({ dependencies: ["tools"] })).toEqual([]);
+    expect(findRetiredDependencyKeys(null)).toEqual([]);
+    expect(findRetiredDependencyKeys("nope")).toEqual([]);
+  });
+
+  // `Object.hasOwn`, not truthiness: an explicit `tools: {}` or `tools: null`
+  // is still the retired key being authored.
+  it("detects the key even when its value is empty or null", () => {
+    expect(findRetiredDependencyKeys({ dependencies: { tools: {} } })).toHaveLength(1);
+    expect(findRetiredDependencyKeys({ dependencies: { tools: null } })).toHaveLength(1);
+  });
+
+  it("does not treat an inherited key as declared", () => {
+    const deps = Object.create({ tools: { "@a/b": "^1.0.0" } }) as Record<string, unknown>;
+    expect(findRetiredDependencyKeys({ dependencies: deps })).toEqual([]);
+  });
+});
+
+describe("dropRetiredDependencyKeys", () => {
+  it("drops the retired key and keeps the canonical maps", () => {
+    const { manifest, dropped } = dropRetiredDependencyKeys({
+      name: "@a/agent",
+      dependencies: { tools: { "@a/t": "^1.0.0" }, skills: { "@a/s": "^1.0.0" } },
+    });
+    expect(dropped).toEqual(["tools"]);
+    expect(manifest.dependencies).toEqual({ skills: { "@a/s": "^1.0.0" } });
+  });
+
+  it("drops every retired key at once", () => {
+    const { dropped, manifest } = dropRetiredDependencyKeys({
+      dependencies: { tools: {}, providers: {} },
+    });
+    expect(dropped).toEqual(["tools", "providers"]);
+    expect(manifest.dependencies).toEqual({});
+  });
+
+  // Structural, not a canonicaliser: surviving keys keep their order and
+  // unknown fields survive, so the result can be serialised without surprises.
+  it("preserves key order and unrelated fields", () => {
+    const { manifest } = dropRetiredDependencyKeys({
+      name: "@a/agent",
+      dependencies: { skills: {}, tools: {}, _meta: { "dev.x/y": 1 } },
+      custom_field: "must-survive",
+    });
+    expect(Object.keys(manifest)).toEqual(["name", "dependencies", "custom_field"]);
+    expect(Object.keys(manifest.dependencies as Record<string, unknown>)).toEqual([
+      "skills",
+      "_meta",
+    ]);
+    expect(manifest.custom_field).toBe("must-survive");
+  });
+
+  it("returns the same reference when there is nothing to drop", () => {
+    const clean = { name: "@a/agent", dependencies: { skills: {} } };
+    expect(dropRetiredDependencyKeys(clean)).toEqual({ manifest: clean, dropped: [] });
+    expect(dropRetiredDependencyKeys(clean).manifest).toBe(clean);
+    const noDeps = { name: "@a/agent" };
+    expect(dropRetiredDependencyKeys(noDeps).manifest).toBe(noDeps);
+  });
+
+  it("does not mutate the input", () => {
+    const input = { dependencies: { tools: { "@a/t": "^1.0.0" } } };
+    dropRetiredDependencyKeys(input);
+    expect(input.dependencies.tools).toEqual({ "@a/t": "^1.0.0" });
+  });
+});
 
 describe("extractDependencies", () => {
   it("manifest with skills and integrations", () => {

--- a/packages/core/test/validation.test.ts
+++ b/packages/core/test/validation.test.ts
@@ -196,6 +196,91 @@ describe("validateManifest", () => {
     expect(result.valid && result.droppedRuntimeTools).toEqual(["report"]);
   });
 
+  // AFPS 1.x had `dependencies.tools` / `dependencies.providers`; AFPS 2.0
+  // renamed them to `mcp_servers` / `integrations`. Every reader destructures
+  // exactly `{ skills, mcp_servers, integrations }`, so the retired spelling is
+  // inert — accepting it silently ships an agent whose dependency is never
+  // resolved (#1021). Same direction split as the runtime-tools policy:
+  // author input rejects, an already-persisted manifest is tolerated.
+  it("rejects dependencies.tools on the author path, naming the replacement key", () => {
+    const result = validateManifest(
+      validAgentManifest({ dependencies: { tools: { "@appstrate/report": "^1.0.0" } } }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toStartWith("dependencies.tools:");
+    expect(result.errors[0]).toContain("dependencies.mcp_servers");
+  });
+
+  it("rejects dependencies.providers on the author path, naming the replacement key", () => {
+    const result = validateManifest(
+      validAgentManifest({ dependencies: { providers: { "@appstrate/gmail": "^1.0.0" } } }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toStartWith("dependencies.providers:");
+    expect(result.errors[0]).toContain("dependencies.integrations");
+  });
+
+  it("rejects every retired dependency key at once", () => {
+    const result = validateManifest(
+      validAgentManifest({ dependencies: { tools: {}, providers: {}, skills: {} } }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors).toHaveLength(2);
+  });
+
+  // Not agent-specific: any package type may declare `dependencies`.
+  it("rejects a retired dependency key on a non-agent manifest", () => {
+    const result = validateManifest(
+      validSkillManifest({ dependencies: { tools: { "@test/x": "^1.0.0" } } }),
+    );
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toStartWith("dependencies.tools:");
+  });
+
+  // THE anti-regression: a published manifest carrying the retired key is
+  // re-validated on every run (`registry-run-resolver`). Rejecting it there
+  // would 500 the run of an agent that can never be repaired in place, because
+  // a published artifact is immutable + integrity-checked.
+  it("tolerates a retired dependency key on the read path, untouched", () => {
+    const stored = validAgentManifest({
+      dependencies: {
+        tools: { "@appstrate/report": "^1.0.0" },
+        skills: { "@test/skill": "^1.0.0" },
+      },
+    });
+    const result = validateManifest(stored, { retiredRuntimeTools: "drop" });
+    expect(result.valid).toBe(true);
+    const deps = (result.manifest as Record<string, unknown>).dependencies as Record<
+      string,
+      unknown
+    >;
+    // Tolerated means LEFT ALONE — this validator never rewrites stored bytes.
+    expect(deps.tools).toEqual({ "@appstrate/report": "^1.0.0" });
+    expect(deps.skills).toEqual({ "@test/skill": "^1.0.0" });
+  });
+
+  // The fix must not close `dependencies`: AFPS §10 mandates extensibility for
+  // objects it does not explicitly close, so an unknown extension key stays legal.
+  it("accepts the three canonical dependency maps plus an unrelated extension key", () => {
+    const result = validateManifest(
+      validAgentManifest({
+        dependencies: {
+          skills: { "@test/skill": "^1.0.0" },
+          mcp_servers: { "@test/fetch": "^1.0.0" },
+          integrations: { "@test/gmail": "^1.0.0" },
+          _meta: { "dev.appstrate/note": "still legal" },
+        },
+      }),
+    );
+    expect(result.valid).toBe(true);
+    const deps = (result.manifest as Record<string, unknown>).dependencies as Record<
+      string,
+      unknown
+    >;
+    expect(deps._meta).toEqual({ "dev.appstrate/note": "still legal" });
+  });
+
   it("reports no dropped runtime tools when every id is known", () => {
     const result = validateManifest(validAgentManifest({ runtime_tools: ["log"] }), {
       retiredRuntimeTools: "drop",


### PR DESCRIPTION
Fixes items 2, 3 and 4 of #1021. Item 1 (the `$schema` 404) is deliberately left out — it is being handled separately.

All three turned out to be real, but **two of the issue's own proposed remedies would have caused more damage than the papercut**, so this PR resolves the underlying complaints a different way. Details below.

---

## 2 — `GET /api/packages/{type}` documented itself as org-wide

**Verdict: valid, and documentation-only.**

`listOrgItems` has always returned the *application-scoped* catalogue — system packages, plus organization packages with an `application_packages` row for the current `X-Application-Id`. That is intentional and consistent: the same filter backs `GET /api/agents`, and the package **detail** route gates on it through `hasPackageAccess`, so a package the list hides is one the detail route 404s. It is commented in `listOrgItems` itself and locked by tests. Only the four OpenAPI descriptions were wrong.

Why agents looked complete while skills did not: auto-install fires on create / import / fork, and bundle import installs **only the bundle root** (an agent). Skills that arrive as bundle dependencies never get an install row.

**Fix:** say what the endpoints do, and point at `GET /api/library` for the organization-wide catalogue — which already returns these rows *plus* per-application `installed_in` state. Also corrects the `active` parameter description (it drops system packages with no install row, and integrations resolve through effective activation so environment-provided system integrations stay listed).

**`?scope=org` was considered and rejected.** It would duplicate `/api/library` while returning strictly less information; adding it to the list without the detail route would return ids whose detail endpoint 404s, and making detail follow means changing an access-control boundary; it multiplies the `active` matrix with a contradictory cell (`active` is application-relative); and no caller asks for it. If per-type organization-wide listing is ever wanted, a `?type=` filter on `/api/library` is the cheaper move.

No behaviour change, no new query parameter.

## 3 — `appstrate api` wrote 0 bytes on a 307

**Verdict: valid, with one correction to the framing — `-L` already exists and already works.**

The route answers `307` with a presigned `Location` when object storage has a public endpoint (filesystem storage, and S3 without one, proxy-stream a normal `200` — which is why this only reproduces on deployments configured that way). `redirect: "manual"` is a deliberate, test-pinned default, and Hono's `c.redirect()` sends no body, so the passthrough faithfully streamed zero bytes and reported success. The gap was that the default path said **nothing**.

**Fix:** print a hint on stderr naming the status and the `Location`. Everything else is unchanged — default stays `manual`, exit code stays 0, stderr only so piped and `-o` output stay byte-exact, silenced by `-s` like the 401 hint, and skipped for `-I`/HEAD where a bodyless response is expected rather than surprising. Scoped to the fetch redirect statuses rather than all of 3xx: a `304` is bodyless by design and a `300` does carry a body.

**Following redirects by default was considered and rejected**, on measured evidence rather than assumption. On Bun 1.3.11 a cross-origin hop drops `Authorization` and `Cookie` — but **not** custom headers. `buildHeaders` merges arbitrary `-H` values alongside `X-Org-Id`/`X-Application-Id`, and only the *initial* URL is origin-validated, never the `Location`. Making `-L` implicit would turn every `appstrate api` call into a server-directed fetch that forwards user `-H` secrets to a host the server chooses.

That same measurement exposed a documentation bug worth its own mention: the `-L` help text and README said cross-origin hops strip `Authorization`. True, but incomplete in a way that invites a mistake — a reader would reasonably conclude `-L` is safe while passing a second credential via `-H`. Both are corrected. A stale comment claiming `apiFetchRaw` hard-codes `redirect` is also fixed.

## 4 — `dependencies.tools` accepted silently

**Verdict: valid, and it is a regression.**

AFPS 1.0 defined `dependencies.tools` and `dependencies.providers`; AFPS 2.0 renamed them to `mcp_servers` and `integrations`. The platform *did* reject the old spellings at publish time via `assertNoLegacyDepKeys` — until fb318b3bf (#528) deleted that guard along with the 1.x read-fallbacks, on the reasoning that all 1.x back-compat was dead. The read-fallbacks were. The guard was not: it was the author-input rejection.

**The issue's proposed fix — `additionalProperties: false` on `dependencies` — is not implemented, for two independent reasons:**

1. **It breaks published data.** Stored manifests are re-validated on *every run*; a published agent carrying `dependencies.tools` would become permanently unrunnable with a 500 and no repair path, since the artifact is immutable and integrity-checked. That is precisely the failure mode `RetiredRuntimeToolsPolicy` was created to prevent.
2. **It contradicts AFPS.** The spec mandates extensibility for objects it does not explicitly close (§10). `dependencies` is not closed, so `dependencies._meta` is legal today — and `@afps-spec/schema` is a separately published, externally consumed spec. Closing that object is a spec revision, not a schema tweak.

A non-blocking warning alone was also rejected as too weak for author input — that repeats the silent-drop mistake the existing policy doc argues against.

**Fix:** mirror `RetiredRuntimeToolsPolicy` exactly. Reject on author input naming the replacement key; tolerate on already-persisted manifests, unchanged; warn on bundle import through the existing `warnings` channel. The schema is untouched and stays loose — this is a policy on author input, not a shape constraint.

The retired vocabulary lives in one table both the rejection and the warning read, so they cannot enumerate a different set. The direction stays a **single** flag rather than a second one that must co-vary — a call site setting one and forgetting the other is exactly how this regressed the first time. The flag keeps its historical `retiredRuntimeTools` name (documented as governing both) because renaming published `@appstrate/core` surface is a breaking release for a naming nicety.

---

## Heads-up for whoever merges this

The issue notes that one of the reporter's older agents still carries `dependencies.tools`. After this change, **submitting that manifest through the author path returns a 400** — the intended signal, and the parity the issue asks for.

It is mostly self-healing in practice: the agent editor now normalises a loaded draft the same way it already did for retired runtime tools, so opening and saving such an agent silently drops the key. Without that, the agent would be *uneditable* — a 400 on a field the form cannot display. Only the agent branch needs it; the skill and integration editors expose a raw-JSON tab where the key is visible and fixable.

A raw API `PUT` carrying the key still 400s by design. Worth a line in the release notes. Nothing in this repo carries a retired key — all 66 shipped `system-packages/*.afps` manifests were checked structurally (the `tools` field on the mcp-server package is the unrelated MCPB root advisory list).

## Verification

- `bun run check` — 33/33 tasks green (the single `react-refresh` warning in `module-chat` is pre-existing and untouched here).
- `verify:openapi` all checks passed; `detect:breaking` reports no changes against the baseline.
- Targeted suites re-run after review edits: 130 CLI, 855 core + web unit, 972 API integration — 0 failures.
- New coverage: author-direction rejection for both retired keys (unit, route `PUT`, and `/import` ZIP); a **stored published manifest carrying `dependencies.tools` still runs**, with a non-vacuity guard asserting the author direction still refuses the same bytes; bundle import succeeds, returns the warning, and leaves the stored draft byte-identical; `dependencies._meta` and the three canonical maps still accepted, proving the object was not closed; and for the CLI, the 307 papercut end-to-end plus the `-s`, `-I` and `-L` paths and stdout purity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
