### PR TITLE
fix(release): stop the lockstep gate deadlocking on major releases

### DIFF
--- a/scripts/check-consumer-versions.ts
+++ b/scripts/check-consumer-versions.ts
@@ -5,6 +5,8 @@
  * core version goes out.
  *
  * Drift policy:
+ *   - major mismatch      → fail (block publish), EXCEPT one major behind on an
+ *                           X.0.0 release, which is a warning — see `assessDrift`.
  *   - >= 2 minors behind  → fail (block publish).
  *   - 1 minor behind      → warn.
  *   - in sync             → OK.
@@ -92,6 +94,62 @@ function compare(a: [number, number, number], b: [number, number, number]): numb
     if (a[i] !== b[i]) return (a[i] ?? 0) - (b[i] ?? 0);
   }
   return 0;
+}
+
+export type DriftVerdict = "ok" | "warn" | "fail";
+
+export interface DriftAssessment {
+  verdict: DriftVerdict;
+  /** Trailing half of the log line, printed after `<repo>/<path> pins <range> — `. */
+  detail: string;
+}
+
+/**
+ * Decide how bad one consumer's declared range is against the version being
+ * published. Pure — the caller owns fetching, policy and reporting.
+ */
+export function assessDrift(
+  local: [number, number, number],
+  consumer: [number, number, number],
+): DriftAssessment {
+  const [lMaj, lMin, lPatch] = local;
+  const [cMaj, cMin] = consumer;
+  const localLabel = local.join(".");
+
+  if (cMaj !== lMaj) {
+    const isMajorRelease = lMin === 0 && lPatch === 0;
+    const oneMajorBehind = cMaj === lMaj - 1;
+    // A consumer CANNOT declare `^X.0.0` before X.0.0 exists on npm — its own
+    // CI runs `bun install --frozen-lockfile`, which cannot resolve an
+    // unpublished version. So at an X.0.0 release, "exactly one major behind"
+    // is the only state a consumer can possibly be in, and failing it made
+    // every major publish impossible without disabling the whole gate via
+    // CONSUMER_DRIFT_POLICY (issue #1028). Tolerated here and only here: the
+    // next release of that major is not itself a major, so an unbumped
+    // consumer fails hard the very next time core publishes.
+    if (isMajorRelease && oneMajorBehind) {
+      return {
+        verdict: "warn",
+        detail:
+          `1 major behind ${localLabel} — expected during a major release, since the ` +
+          `range cannot be declared before this publish. Bump the consumer to ^${lMaj}.0.0 ` +
+          `right after; it will fail this gate on the next core release.`,
+      };
+    }
+    return { verdict: "fail", detail: `major mismatch with ${localLabel}` };
+  }
+
+  const minorDelta = lMin - cMin;
+  if (minorDelta >= 2) {
+    return { verdict: "fail", detail: `${minorDelta} minors behind ${localLabel}` };
+  }
+  if (minorDelta === 1) {
+    return { verdict: "warn", detail: `1 minor behind ${localLabel}` };
+  }
+  if (compare(consumer, local) < 0) {
+    return { verdict: "ok", detail: "patch-behind, OK" };
+  }
+  return { verdict: "ok", detail: "in sync" };
 }
 
 async function fetchPackageJson(
@@ -182,29 +240,16 @@ async function main(): Promise<void> {
         continue;
       }
 
-      const [cMaj, cMin] = consumerVersion;
-      if (cMaj !== lMaj) {
-        const msg = `${consumer.repo}/${path} pins ${range} but local is ${localPkg.version} (major mismatch)`;
-        console.error(`  ✗ ${msg}`);
+      const { verdict, detail } = assessDrift(localVersion, consumerVersion);
+      const line = `${consumer.repo}/${path} pins ${range} — ${detail}`;
+      if (verdict === "fail") {
+        console.error(`  ✗ ${line}`);
         failures++;
-        continue;
-      }
-
-      const minorDelta = lMin - cMin;
-      if (minorDelta >= 2) {
-        console.error(
-          `  ✗ ${consumer.repo}/${path} pins ${range} — ${minorDelta} minors behind ${localPkg.version}`,
-        );
-        failures++;
-      } else if (minorDelta === 1) {
-        console.warn(
-          `  ! ${consumer.repo}/${path} pins ${range} — 1 minor behind ${localPkg.version}`,
-        );
+      } else if (verdict === "warn") {
+        console.warn(`  ! ${line}`);
         warnings++;
-      } else if (compare(consumerVersion, localVersion) < 0) {
-        console.log(`  ✓ ${consumer.repo}/${path} pins ${range} — patch-behind, OK`);
       } else {
-        console.log(`  ✓ ${consumer.repo}/${path} pins ${range} — in sync`);
+        console.log(`  ✓ ${line}`);
       }
     }
   }
@@ -219,7 +264,11 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => {
-  console.error(err instanceof Error ? err.stack : String(err));
-  process.exit(1);
-});
+// Guarded so the test file can import `assessDrift` without the module
+// hitting the GitHub API on import.
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err instanceof Error ? err.stack : String(err));
+    process.exit(1);
+  });
+}

--- a/scripts/test/check-consumer-versions.test.ts
+++ b/scripts/test/check-consumer-versions.test.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Severity table for the `@appstrate/core` lockstep gate. This decision gates
+ * an irreversible `npm publish`, so every branch is pinned here — including the
+ * major-release carve-out from issue #1028 (a consumer cannot declare `^X.0.0`
+ * before X.0.0 exists on npm, so at an X.0.0 release "one major behind" is the
+ * only reachable state) and the non-major case that keeps the gate's teeth.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { assessDrift } from "../check-consumer-versions.ts";
+
+type V = [number, number, number];
+
+const verdict = (local: V, consumer: V) => assessDrift(local, consumer).verdict;
+
+describe("assessDrift — major mismatch", () => {
+  it("warns when a MAJOR release finds a consumer exactly one major behind (#1028)", () => {
+    expect(verdict([6, 0, 0], [5, 0, 0])).toBe("warn");
+    expect(verdict([6, 0, 0], [5, 4, 2])).toBe("warn");
+  });
+
+  it("names the bump the consumer owes so the warning cannot read as an exemption", () => {
+    const { detail } = assessDrift([6, 0, 0], [5, 0, 0]);
+    expect(detail).toContain("^6.0.0");
+    expect(detail).toContain("next core release");
+  });
+
+  it("fails a MAJOR release when the consumer is two or more majors behind", () => {
+    expect(verdict([6, 0, 0], [4, 0, 0])).toBe("fail");
+    expect(verdict([6, 0, 0], [2, 13, 0])).toBe("fail");
+  });
+
+  it("fails a NON-major release even when the consumer is one major behind", () => {
+    // The teeth: a consumer that never bumps after the major is caught by the
+    // very next core publish.
+    expect(verdict([6, 0, 1], [5, 0, 0])).toBe("fail");
+    expect(verdict([6, 1, 0], [5, 0, 0])).toBe("fail");
+    expect(verdict([6, 1, 3], [5, 9, 9])).toBe("fail");
+  });
+
+  it("fails when the consumer is AHEAD by a major, including on a major release", () => {
+    expect(verdict([6, 0, 0], [7, 0, 0])).toBe("fail");
+    expect(verdict([6, 1, 0], [7, 0, 0])).toBe("fail");
+  });
+});
+
+describe("assessDrift — same major", () => {
+  it("warns at 1 minor behind", () => {
+    expect(verdict([6, 3, 0], [6, 2, 0])).toBe("warn");
+    expect(verdict([6, 3, 1], [6, 2, 9])).toBe("warn");
+  });
+
+  it("fails at 2 or more minors behind", () => {
+    expect(verdict([6, 3, 0], [6, 1, 0])).toBe("fail");
+    expect(verdict([6, 12, 0], [6, 0, 0])).toBe("fail");
+  });
+
+  it("is OK when only the patch is behind", () => {
+    expect(assessDrift([6, 2, 4], [6, 2, 1])).toEqual({
+      verdict: "ok",
+      detail: "patch-behind, OK",
+    });
+  });
+
+  it("is OK when in sync", () => {
+    expect(assessDrift([6, 2, 4], [6, 2, 4])).toEqual({ verdict: "ok", detail: "in sync" });
+  });
+
+  it("is OK when the consumer is ahead within the same major (pinned current behaviour)", () => {
+    // Not a state the release flow produces; pinned so a refactor cannot
+    // silently turn it into a publish-blocking failure.
+    expect(assessDrift([6, 2, 0], [6, 5, 0])).toEqual({ verdict: "ok", detail: "in sync" });
+    expect(assessDrift([6, 2, 0], [6, 2, 7])).toEqual({ verdict: "ok", detail: "in sync" });
+  });
+});

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -3,5 +3,10 @@
   "compilerOptions": {
     "types": ["bun"]
   },
-  "include": ["verify-module-contract.ts", "verify-package-resolves.ts"]
+  "include": [
+    "verify-module-contract.ts",
+    "verify-package-resolves.ts",
+    "check-consumer-versions.ts",
+    "test/check-consumer-versions.test.ts"
+  ]
 }


### PR DESCRIPTION
Addresses item 1 of #1028.

## The deadlock

`scripts/check-consumer-versions.ts` gates `npm publish` in `publish-core.yml`. It failed on **any** major mismatch:

```ts
if (cMaj !== lMaj) { failures++; continue; }
```

But a consumer **cannot** declare `^6.0.0` before 6.0.0 exists on npm — its own CI runs `bun install --frozen-lockfile`, which cannot resolve an unpublished version. The gate therefore demanded a state only reachable *after* the event it gates.

Consequence: **publishing any major was impossible** without disabling the gate wholesale via the `CONSUMER_DRIFT_POLICY` repo variable. That is exactly what `core@6.0.0` had to do on 2026-07-27. `CLAUDE.md` documents the intended flow as forward-only — "*then* update `^version` in registry + cloud" — so the gate contradicted the documented process, for majors only.

## The change

At an `X.0.0` release (`localMinor === 0 && localPatch === 0`), a consumer **exactly one major behind** becomes a warning. Nothing else moves:

| Situation | Before | After |
| --- | --- | --- |
| Major release, 1 major behind | fail | **warn** |
| Major release, 2+ majors behind | fail | fail |
| **Non-major** release, 1 major behind | fail | **fail** |
| Consumer ahead by a major | fail | fail |
| 1 minor behind | warn | warn |
| 2+ minors behind | fail | fail |
| patch-behind / in sync | ok | ok |

The third row is what keeps the gate's teeth. A consumer that never bumps after the major is caught by the very next core release, which is not itself a major. The tolerance is one publish wide, not permanent — and the warning text says so, naming the range owed and when it will start failing.

## Testability

The severity table is extracted into an exported pure `assessDrift(local, consumer) → { verdict, detail }`; `main()` calls it and does nothing but format and count. Fetching, `resolvePolicy`, the `off` short-circuit, the fail-closed fetch-error branch, the 404 "not present, skipping" branch and the exit code are untouched.

`main()` is now behind `import.meta.main` so a test can import the module without hitting the GitHub API. The workflow invokes it as `bun scripts/check-consumer-versions.ts`, where that is true. This follows the existing shape of `scripts/refresh-pricing-catalog.ts` and its test.

**There was no test at all** for a script gating an irreversible publish. There are now 10, asserting on the returned verdict rather than console output, including the deadlock case, the non-major "teeth" case, and the consumer-ahead cases pinned so a future refactor cannot silently turn them into publish blockers.

`scripts/tsconfig.json` listed only two of the scripts, so `bun run check` never typechecked this file. Added it and its test — both pass today, so this is coverage rather than a fix.

## Deliberately not changed

- **Prereleases take the carve-out.** `parseSemver` strips the suffix, so publishing `6.0.0-rc.1` against a `^5` consumer now warns. The same deadlock argument applies to it, and special-casing prereleases would add the policy machinery this change exists to avoid. Core has never published one.
- Log lines interpolate the parsed version, so a prerelease suffix would be dropped from the message text. Cosmetic, same never-happened case.
- `publish-core.yml`'s policy handling and its "Assert the lockstep gate can actually run" step.
- ESLint still supplies no config for root `scripts/*.ts`. Pre-existing.

## This does not make the gate green

Items 2 and 3 of #1028 are untouched and out of scope:

- `CONSUMER_LOCKSTEP_TOKEN` still does not exist, so the gate has still never actually executed — private-repo 404s are silently skipped.
- registry `^2.13.0`, portal `^2.10.8` and connect-helper `^2.19.0` are **four** majors behind, which this change still fails hard, by design.

So the next core publish still needs the bypass until those are ported. What this removes is the *structural* deadlock, so that once the backlog is cleared the gate can work without a permanent escape hatch.

## Verification

```
$ TEST_TIER=0 bun test scripts/test/
 15 pass  0 fail  27 expect() calls

$ bunx tsc --noEmit -p scripts/tsconfig.json     # with the widened include
exit=0

$ bunx prettier --check <touched files>
All matched files use Prettier code style!
```

The script was not executed against the live GitHub API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)