### PR TITLE
fix(release): retire registry and portal from the lockstep gate

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -61,9 +61,9 @@ jobs:
           fi
 
       # ── Precondition for the lockstep gate below ────────────────────────────
-      # `check-consumer-versions.ts` reads four consumer repos through the
-      # GitHub contents API. ALL FOUR ARE PRIVATE (registry, cloud, portal,
-      # connect-helper). `secrets.GITHUB_TOKEN` is scoped to
+      # `check-consumer-versions.ts` reads two consumer repos through the
+      # GitHub contents API. BOTH ARE PRIVATE (cloud, connect-helper).
+      # `secrets.GITHUB_TOKEN` is scoped to
       # THIS repo only, so for a private consumer the API answers 404 — and the
       # script treats 404 as "not present, skipping" (a legitimate outcome for a
       # repo that genuinely has no package.json at that path, so the script
@@ -71,8 +71,13 @@ jobs:
       #
       # Net effect without a cross-repo token: the gate prints
       # "0 failure(s), 0 warning(s)" and passes having verified NOTHING. That is
-      # worse than having no gate at all — a fail-closed check that has never
+      # worse than having no gate at all — a fail-closed check that had never
       # once closed. Make the missing precondition loud instead.
+      #
+      # The secret CONSUMER_LOCKSTEP_TOKEN was added on 2026-07-28, so that
+      # failure mode is currently held off — this step is what keeps it that
+      # way. It stays because the day the token expires, is revoked, or loses
+      # `contents:read` on a consumer, the gate would go silently inert again.
       #
       # Bypassing stays possible, but it must be a deliberate act (set the repo
       # variable CONSUMER_DRIFT_POLICY to `warn` or `off`), never the accident
@@ -87,7 +92,7 @@ jobs:
             echo "CONSUMER_LOCKSTEP_TOKEN is set — the lockstep gate can read the private consumer repos."
             exit 0
           fi
-          MSG="CONSUMER_LOCKSTEP_TOKEN is not set. Every consumer repo (appstrate/registry, cloud, portal, connect-helper) is private, so the fallback GITHUB_TOKEN gets a 404 on all of them and the lockstep gate verifies NOTHING while reporting success."
+          MSG="CONSUMER_LOCKSTEP_TOKEN is not set. Every consumer repo (appstrate/cloud, appstrate/connect-helper) is private, so the fallback GITHUB_TOKEN gets a 404 on both of them and the lockstep gate verifies NOTHING while reporting success."
           if [ "$CONSUMER_DRIFT_POLICY" = "fail" ]; then
             echo "::error title=Consumer lockstep gate cannot run::${MSG} Fix: add a repository secret CONSUMER_LOCKSTEP_TOKEN (PAT or GitHub App token with contents:read on those repos). To publish anyway, set the repository variable CONSUMER_DRIFT_POLICY to 'warn' or 'off' — a deliberate, auditable bypass."
             {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -19,55 +19,57 @@ break every READER of those fields, `ChatTurnFinishReason` gains a `"deadline"`
 member that breaks exhaustive switches, `isFinalChatStep` loses its `maxSteps`
 parameter, and a set of exports with no importer anywhere is deleted.
 
-> **Release ordering — consumers FIRST, then the tag.** `@appstrate/afps-shared`
-> stays at `^0.3.1` (already published, nothing to release before this).
+> **Release ordering for a MAJOR — the tag FIRST, then the consumers.**
+> `@appstrate/afps-shared` stays at `^0.3.1` (already published, nothing to
+> release before this); a leaf whose range you _did_ move must still reach npm
+> before core references it.
 >
-> 1. **Bump the five external consumers to `^6.0.0`** in their own repos and
->    push to each repo's **default branch** —
->    `scripts/check-consumer-versions.ts` is the authoritative list and reads
->    each `package.json` off the default branch through the GitHub contents
->    API: `registry` (root + `apps/api` + `apps/web`), `cloud`, `portal`,
->    `connect-helper`, `module-claude-code`. Workspace packages inside this
->    monorepo resolve `workspace:*` and need no bump.
+> 1. **Know who is on the hook.** `scripts/check-consumer-versions.ts` is the
+>    authoritative list and reads each `package.json` off the repo's **default
+>    branch** through the GitHub contents API. Today that is two repos: `cloud`
+>    and `connect-helper`. Workspace packages inside this monorepo resolve
+>    `workspace:*`, cannot drift, and need no bump.
+> 2. **Tag `core@X.0.0` and push it.** The gate _warns_ rather than blocks when
+>    an `X.0.0` release finds a consumer exactly one major behind — a consumer
+>    physically cannot declare `^X.0.0` before X.0.0 exists on npm, since its
+>    own `bun install --frozen-lockfile` could not resolve it (issue #1028,
+>    fixed in #1032).
+> 3. **Bump the consumers to `^X.0.0` right after**, and push to each default
+>    branch. Not optional politeness: the carve-out is scoped to `X.0.0` alone,
+>    so the very next core release — `X.0.1`, `X.1.0`, anything non-major —
+>    fails hard on a consumer still pinned to `^(X-1)`. That is what keeps the
+>    gate's teeth.
 >
->    **Measure this before scheduling the release — for four of the five it is
->    not a version edit.** Actual pins as of 2026-07-26, read off each default
->    branch: `cloud` `^5.0.0`, but `registry` `^2.13.0` (root) / `^2.12.0`
->    (`apps/api`, `apps/web`), `portal` `^2.10.8`, `connect-helper` `^2.19.0`,
->    `module-claude-code` `^2.19.0`. Going to `^6.0.0` means absorbing **four
->    majors** of breaking changes in each of those repos.
+> Do NOT invert this for a major. Bumping consumers first is the deadlock the
+> carve-out removed: `^X.0.0` does not resolve until core is on npm, so each
+> consumer's own CI goes red _and_ the gate blocks the very publish that would
+> unblock it. For a NON-major release there is no carve-out and no ordering
+> question — every consumer must already be on `^X` before you tag.
 >
->    That drift is not new and this release does not cause it — it was simply
->    invisible while the gate fell back to a `GITHUB_TOKEN` that 404'd on every
->    private consumer. Note also that publishing `6.0.0` breaks none of them:
->    a `^2` range keeps resolving 2.x. The gate is a _drift alarm_, not a
->    compatibility guard. So the honest choice at release time is one of:
->    migrate the four repos, publish with an auditable
->    `CONSUMER_DRIFT_POLICY=warn`, or narrow the consumer list in
->    `scripts/check-consumer-versions.ts` to the repos actually kept in
->    lockstep. Decide deliberately; do not discover it when the gate fires.
+> **The gate can block the publish.** `.github/workflows/publish-core.yml` runs
+> it **before** `npm publish`, and a `fail` verdict is `exit 1`. Deliberate —
+> but understand what it is: a _drift alarm_, not a compatibility guard.
+> Publishing a new major breaks no consumer at install time, because a `^2`
+> range keeps resolving 2.x. Bypassing is possible and must stay a deliberate,
+> auditable act: set the repository variable `CONSUMER_DRIFT_POLICY` to `warn`
+> or `off`, and delete it again once the publish is through.
 >
-> 2. **Make sure the repository secret `CONSUMER_LOCKSTEP_TOKEN` exists**
->    (PAT / GitHub App token with `contents:read` on those five repos).
-> 3. **Only then** tag `core@6.0.0` and push it.
->
-> This order is not a preference, it is the only one that can execute:
-> `.github/workflows/publish-core.yml` runs the lockstep gate **before**
-> `npm publish`, and the gate hard-fails on a major mismatch
-> (`cMaj !== lMaj` → `failures++` → `exit 1`). A consumer still pinned to
-> `^5` therefore blocks the publish it was supposedly waiting on.
->
-> The known cost of going first: each consumer's own CI stays red between
-> step 1 and step 3, because `^6.0.0` does not resolve until core is on npm.
-> That window is expected — do not "fix" it by publishing core first.
->
-> **The gate only bites with a token that can read private repos.** All five
+> **The gate only bites with a token that can read private repos.** Both
 > consumers are private; on a 404 the script logs `not present, skipping` and
-> counts nothing, so a missing/underscoped token makes it report
-> `0 failure(s), 0 warning(s)` having verified nothing. The workflow's
-> "Assert the lockstep gate can actually run" step exists precisely to turn
-> that silent pass into a loud failure — bypassing it is the deliberate act of
-> setting the repository variable `CONSUMER_DRIFT_POLICY` to `warn` or `off`.
+> counts nothing, so a missing or underscoped `CONSUMER_LOCKSTEP_TOKEN` (PAT /
+> GitHub App token with `contents:read`) makes it report
+> `0 failure(s), 0 warning(s)` having verified nothing. That secret exists as of
+> 2026-07-28; the workflow's "Assert the lockstep gate can actually run" step is
+> what turns its future absence — expiry, revocation, a scope it no longer
+> covers — back into a loud failure instead of a silent pass.
+>
+> **What actually happened for `6.0.0`:** published 2026-07-27 through the
+> `CONSUMER_DRIFT_POLICY=warn` bypass — variable set, tag pushed, variable
+> deleted immediately. The carve-out in step 2 did not exist yet, and three
+> consumers (`registry`, `portal`, `connect-helper`) were four majors behind on
+> a list that still included them. The list has since been narrowed to the repos
+> actually kept in lockstep: `module-claude-code` left when it was absorbed
+> in-tree (#1026), `registry` and `portal` when those products were retired.
 
 > **Deploy ordering — modules BEFORE the platform**, for the same reason as
 > `5.0.0`: a module implementing `beforeUsage` / `checkUsageAllowed` must be on

--- a/scripts/check-consumer-versions.ts
+++ b/scripts/check-consumer-versions.ts
@@ -34,7 +34,8 @@ interface Consumer {
  *
  * That anecdote is now history: PR #460 (2026-05-14) moved the module in-tree
  * as `packages/module-claude-code`, and the standalone repo is dead. It is
- * therefore NOT in the list below, per rule 3.
+ * therefore NOT in the list below, per rule 3. `registry` and `portal` left the
+ * list the same way and for the same reason — not absorbed, retired.
  *
  * The rule, in three parts:
  *
@@ -43,18 +44,14 @@ interface Consumer {
  *   2. A package INSIDE this monorepo never does. It resolves `workspace:*`
  *      (see `packages/module-claude-code/package.json`) and cannot drift, so
  *      listing it would gate the publish on a version that does not exist.
- *   3. A repo absorbed in-tree must be REMOVED here, in the same pass that
- *      absorbs it. Its default branch keeps whatever range it last published
+ *   3. A repo that STOPS consuming core from npm must be REMOVED here, in the
+ *      same pass that stops it — whether it was absorbed in-tree, retired or
+ *      archived. Its default branch keeps whatever range it last published
  *      forever, and nothing consumes it any more — so leaving it in reports a
  *      permanent failure that no bump anywhere can clear.
  */
 const CONSUMERS: Consumer[] = [
-  {
-    repo: "appstrate/registry",
-    paths: ["package.json", "apps/api/package.json", "apps/web/package.json"],
-  },
   { repo: "appstrate/cloud", paths: ["package.json"] },
-  { repo: "appstrate/portal", paths: ["package.json"] },
   // Published to npm (public package, private source repo) — installed by
   // end users via `npx`, so a stale core range ships to them directly.
   { repo: "appstrate/connect-helper", paths: ["package.json"] },


### PR DESCRIPTION
Closes the last blocker in #1028. With this and appstrate/connect-helper#6 (merged), the lockstep gate should pass **without a bypass for the first time**.

## The dead entries

`registry` and `portal` no longer consume `@appstrate/core`. Their default branches keep the range they last published, forever:

| Path | Pin |
| --- | --- |
| `registry/package.json` | `^2.13.0` |
| `registry/apps/api/package.json` | `^2.12.0` |
| `registry/apps/web/package.json` | `^2.12.0` |
| `portal/package.json` | `^2.10.8` |

Five failing paths that **no bump anywhere could ever clear** — the same class of dead entry #1026 removed for `module-claude-code`, and enough on its own to block every future core publish.

The membership rule was too narrow to have caught this: rule 3 only covered a repo "absorbed in-tree". Registry and portal were not absorbed, they were retired — same consequence, different cause. It now covers any repo that stops consuming core from npm, whatever the reason.

Remaining list: `cloud` (`^6.0.0`) and `connect-helper` (`^6.0.0` as of appstrate/connect-helper#6).

## The changelog's release instructions were inverted

`packages/core/CHANGELOG.md`'s 6.0.0 section carries a blockquote that is not a record of what changed — it is **the procedure for performing a core major release**, which someone will read at 7.0.0. Its central instruction had become actively harmful:

> Bump the five external consumers to `^6.0.0` … **then** tag `core@6.0.0` and push it.
> The known cost of going first: each consumer's own CI stays red between step 1 and step 3 … That window is expected — do not "fix" it by publishing core first.

That is exactly the deadlock #1032 removed. A consumer physically cannot declare `^X.0.0` before X.0.0 exists on npm, so the gate now *warns* instead of failing when an `X.0.0` release finds a consumer one major behind. **The order is inverted: tag first, bump right after.**

Rewritten with the carve-out's scope stated explicitly — it applies to `X.0.0` alone, so a consumer that never bumps fails hard on the next non-major release. The ordering advice is only safe stated alongside that.

Also corrected there: five consumers → two; `CONSUMER_LOCKSTEP_TOKEN` is no longer an outstanding task (created 2026-07-28). The *reason* it matters is kept — a 404 makes the gate log `not present, skipping` and report `0 failure(s)` having verified nothing — reframed as what the precondition step guards against going forward: expiry, revocation, a scope it no longer covers.

Added a short factual record of how 6.0.0 actually shipped: through the `CONSUMER_DRIFT_POLICY=warn` bypass, set and deleted around the tag push. That part genuinely is history and belongs in a changelog.

One sentence in the workflow was corrected the same way: it asserted in the present perfect that the gate "has never once closed", which stopped being true when the secret was created.

## Not changed

- Gate semantics: `assessDrift()`, `CONSUMER_DRIFT_POLICY` handling, the fail-closed fetch-error branch, the 404 skip — all untouched. The only code change is removing two array elements.
- `scripts/test/check-consumer-versions.test.ts` — every assertion calls `assessDrift` with literal version tuples; nothing references `CONSUMERS`, repo names, or list length. No test needed changing, and none was added: a "the list has N entries" test is a tautology that breaks on every legitimate edit.
- The `module-claude-code` drift anecdote in the JSDoc. It is *why* the list exists and stays as history.
- The "Deploy ordering — modules BEFORE the platform" blockquote below, still true.

## Known structural issue, not fixed here

This process documentation lives inside a released version's changelog entry, which is why it went stale twice in three days — a changelog entry is append-only by convention and never re-read for correctness. It would be better placed in `publish-core.yml`'s own header, where anyone editing the gate has it open, or in a dedicated `docs/` release runbook. Only the forward-looking instructions should move; the 6.0.0 record should stay. Deliberately out of scope here.

## Verification

```
$ bunx tsc --noEmit -p scripts/tsconfig.json      exit=0
$ TEST_TIER=0 bun test scripts/test/              15 pass, 0 fail
$ bunx prettier --check <touched files>           clean
```

The script was not executed against the live GitHub API from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)