### PR TITLE
fix(cli,api): detach instead of cancelling a remote run on a non-interactive signal (#1020)

### DIFF
--- a/apps/api/src/services/run-event-ingestion.ts
+++ b/apps/api/src/services/run-event-ingestion.ts
@@ -39,7 +39,7 @@ import {
   recordDocumentPartialPublication,
 } from "@appstrate/core/telemetry";
 import { persistRunEvent, writeRunnerLedgerRow } from "./run-launcher/appstrate-event-sink.ts";
-import { updateRun, appendRunLog, computeRunSpend } from "./state/runs.ts";
+import { updateRun, appendRunLog, computeRunSpend, readLastEmittedOutput } from "./state/runs.ts";
 import { createRunNotifications } from "./state/notifications.ts";
 import {
   addMemories as addUnifiedMemories,
@@ -827,7 +827,55 @@ export async function synthesiseFinalize(
   const lastKnownUsage = await readLastKnownUsage(runId);
   if (lastKnownUsage) result.usage = lastKnownUsage;
 
+  await applyRecoveredOutput(run, result);
+
   await finalizeRun({ run, result });
+}
+
+/**
+ * Attach the structured deliverable the agent already emitted to a terminal
+ * `RunResult` the PLATFORM synthesised — every path where the runner never
+ * posted its own finalize ({@link synthesiseFinalize}'s callers, plus the
+ * stall watchdog, which builds its own `emptyRunResult()`).
+ *
+ * WHY: the `output` runtime tool is persisted at emit time as a `run_logs`
+ * row, but `runs.result` is written only at finalize, from the RunResult the
+ * runner posts. A synthesised terminal carries an `emptyRunResult()`, so a
+ * run whose agent had ALREADY delivered its output ended with
+ * `runs.result = null` — the payload survived on disk but was invisible to
+ * `GET /api/runs/:id`, the dashboard and the CLI's `--output` (issue #1020).
+ *
+ * RECOVER, NEVER FABRICATE: only a payload that is actually persisted AND a
+ * plain record is attached. No row, or a row whose `data` is null, leaves
+ * `result.output` exactly as `emptyRunResult()` set it (null) — an agent
+ * that never called `output` must keep producing a null result, and the
+ * empty `{}` that output-schema validation reports as "never called the
+ * tool" must never be manufactured here.
+ *
+ * FILL IN, NEVER OVERWRITE: a `result` that already carries an `output` is
+ * returned untouched (and costs no DB round-trip). A runner-supplied output
+ * is the authoritative statement of what the run produced — including a
+ * deliberate re-emission ordering this helper's "last row" cannot see — and
+ * recovery never second-guesses it. Both call sites pass an
+ * `emptyRunResult()` today; the guard is what keeps that from being a
+ * precondition a third caller can silently violate.
+ *
+ * LAST ROW WINS: `output` has replace-on-emit semantics, so the highest
+ * `run_logs.id` (append-only) is the payload the agent last meant to
+ * deliver — see `readLastEmittedOutput`.
+ *
+ * PAYLOAD ONLY: the caller's terminal status is untouched. A cancelled run
+ * stays `cancelled`, a timeout stays `timeout`; recovering an output never
+ * feeds `mapTerminalStatus`. It does legitimately change the outcome of the
+ * output-schema validation `finalizeRunImpl` runs on a synthesised
+ * `success` — a run that really did emit a valid payload now stays
+ * `success` instead of being failed for "finished without calling the
+ * required `output` tool".
+ */
+export async function applyRecoveredOutput(run: RunSinkContext, result: RunResult): Promise<void> {
+  if (result.output !== null && result.output !== undefined) return;
+  const emitted = await readLastEmittedOutput({ runId: run.id, orgId: run.orgId });
+  if (isPlainRecord(emitted)) result.output = emitted;
 }
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/api/src/services/run-watchdog.ts
+++ b/apps/api/src/services/run-watchdog.ts
@@ -43,7 +43,7 @@ import { and, isNotNull, isNull, lt, sql } from "drizzle-orm";
 import { db, isEmbeddedDb } from "@appstrate/db/client";
 import { runs } from "@appstrate/db/schema";
 import { logger } from "../lib/logger.ts";
-import { finalizeRun, getRunSinkContext } from "./run-event-ingestion.ts";
+import { applyRecoveredOutput, finalizeRun, getRunSinkContext } from "./run-event-ingestion.ts";
 import { stopWorkloadAndWait } from "./stop-workload.ts";
 import { emptyRunResult } from "@appstrate/afps-runtime/runner";
 import { getErrorMessage } from "@appstrate/core/errors";
@@ -228,6 +228,18 @@ async function finalizeStalledRun(runId: string, stallThresholdSeconds: number):
       runId,
     });
   }
+
+  // A runner that stalled AFTER its agent emitted `output` still produced a
+  // deliverable — durable in `run_logs`, but dropped by this path, which
+  // builds its own `emptyRunResult()` instead of going through
+  // `synthesiseFinalize`. Payload only: the terminal stays `failed`.
+  //
+  // Read AFTER the stop: a stalled runner is not necessarily a dead one (see
+  // above), so a still-live workload can emit `output` during the stop window
+  // — reading before it would miss exactly the payload this exists to save.
+  // Same ordering as the cancel path (`abortRun` → `stopWorkloadAndWait` →
+  // `synthesiseFinalize`, which reads inside).
+  await applyRecoveredOutput(run, result);
 
   await finalizeRun({ run, result });
 }

--- a/apps/api/src/services/state/runs.ts
+++ b/apps/api/src/services/state/runs.ts
@@ -1529,6 +1529,49 @@ export async function listRunLogs(args: {
 }
 
 /**
+ * Last structured payload the agent emitted through the `output` runtime
+ * tool, read back from the `run_logs` row the `output.emitted` ingestion
+ * path wrote (`type='result'`, `event='output'` — see `persistRunEvent`).
+ *
+ * WHY this read exists: `output` is persisted the moment it is emitted, but
+ * `runs.result` is only written at finalize from the RunResult the runner
+ * posts. Every platform-synthesised terminal (cancel, timeout, stall,
+ * orphan sweep) therefore has to recover the deliverable from here, or it
+ * drops a payload that is already on disk (issue #1020).
+ *
+ * Ordered by the append-only `run_logs.id` DESC: `output` has
+ * replace-on-emit semantics, so the highest id is the payload the agent
+ * last meant to deliver.
+ *
+ * Returns the raw JSONB value as `unknown` — the column's TS type is a
+ * write-side assertion, not a runtime guarantee, so the caller narrows.
+ * A row whose `data` is null reads back as `null` and MUST NOT be turned
+ * into an empty object by the caller.
+ *
+ * Org-scoped like {@link listRunLogs} — `run_logs` has no `applicationId`
+ * column; app-scoped callers verify run ownership separately.
+ */
+export async function readLastEmittedOutput(args: {
+  runId: string;
+  orgId: string;
+}): Promise<unknown> {
+  const [row] = await db
+    .select({ data: runLogs.data })
+    .from(runLogs)
+    .where(
+      and(
+        eq(runLogs.runId, args.runId),
+        eq(runLogs.orgId, args.orgId),
+        eq(runLogs.type, "result"),
+        eq(runLogs.event, "output"),
+      ),
+    )
+    .orderBy(desc(runLogs.id))
+    .limit(1);
+  return row?.data ?? null;
+}
+
+/**
  * List all in-flight run IDs at server startup. The caller (boot) feeds
  * each id through `synthesiseFinalize` so the same lifecycle that fires
  * for clean termination (terminal log, onRunStatusChange) also

--- a/apps/api/test/integration/routes/runs-output-recovery.test.ts
+++ b/apps/api/test/integration/routes/runs-output-recovery.test.ts
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Platform-synthesised terminals must recover the structured deliverable the
+ * agent already emitted (issue #1020).
+ *
+ * The `output` runtime tool is persisted at emit time as a `run_logs` row
+ * (`type='result'`, `event='output'`), but `runs.result` is written only at
+ * finalize from the RunResult the runner posts. On every path where the
+ * runner never posts its own finalize — user cancel, timeout, container
+ * crash, stall watchdog, boot orphan sweep — the platform synthesises an
+ * empty RunResult, so a run whose agent HAD delivered its output used to end
+ * with `runs.result = null`: recoverable on disk, invisible to
+ * `GET /api/runs/:id`, the dashboard and the CLI's `--output`.
+ *
+ * The invariant these tests pin is "recover, never fabricate": only an
+ * actually persisted payload lands on `runs.result`. A run whose agent never
+ * called `output` must keep producing a null result, exactly as before.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { eq } from "drizzle-orm";
+import { db } from "@appstrate/db/client";
+import { runs } from "@appstrate/db/schema";
+import { encrypt } from "@appstrate/connect";
+import { sign } from "@appstrate/afps-runtime/events";
+import { getTestApp } from "../../helpers/app.ts";
+import { truncateAll } from "../../helpers/db.ts";
+import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
+import { seedPackage } from "../../helpers/seed.ts";
+import {
+  applyRecoveredOutput,
+  getRunSinkContext,
+  synthesiseFinalize,
+} from "../../../src/services/run-event-ingestion.ts";
+import { emptyRunResult } from "@appstrate/afps-runtime/runner";
+
+const app = getTestApp();
+
+const RUN_SECRET = "a".repeat(43); // matches mintSinkCredentials base64url(32 bytes)
+
+function signedHeaders(body: string) {
+  const headers = sign({
+    msgId: `msg_${crypto.randomUUID()}`,
+    timestampSec: Math.floor(Date.now() / 1000),
+    body,
+    secret: RUN_SECRET,
+  });
+  return {
+    "Content-Type": "application/json",
+    "webhook-id": headers["webhook-id"],
+    "webhook-timestamp": headers["webhook-timestamp"],
+    "webhook-signature": headers["webhook-signature"],
+  };
+}
+
+async function seedRunWithSink(ctx: TestContext, packageId: string): Promise<string> {
+  const runId = `run_${crypto.randomUUID().replace(/-/g, "").slice(0, 16)}`;
+  await db.insert(runs).values({
+    id: runId,
+    packageId,
+    orgId: ctx.orgId,
+    applicationId: ctx.defaultAppId,
+    status: "running",
+    runOrigin: "platform",
+    sinkSecretEncrypted: encrypt(RUN_SECRET),
+    sinkExpiresAt: new Date(Date.now() + 3600_000),
+    startedAt: new Date(),
+    // Non-zero usage so finalize's zero-token liveness heuristic does not
+    // flip a synthesised `success` to `failed` for unrelated reasons.
+    tokenUsage: { input_tokens: 100, output_tokens: 50 },
+  });
+  return runId;
+}
+
+/**
+ * Emit `output` through the real signed ingestion endpoint — the same path
+ * the sidecar's `output` tool takes — so the tests exercise the row shape
+ * production actually writes rather than a hand-built one.
+ */
+async function emitOutput(
+  runId: string,
+  data: Record<string, unknown> | undefined,
+  sequence: number,
+): Promise<void> {
+  const body = JSON.stringify({
+    specversion: "1.0",
+    type: "output.emitted",
+    source: `/afps/runs/${runId}`,
+    id: `msg_${crypto.randomUUID()}`,
+    time: new Date().toISOString(),
+    datacontenttype: "application/json",
+    data: data === undefined ? {} : { data },
+    sequence,
+  });
+  const res = await app.request(`/api/runs/${runId}/events`, {
+    method: "POST",
+    headers: signedHeaders(body),
+    body,
+  });
+  expect(res.status).toBe(200);
+}
+
+async function readRun(runId: string) {
+  const [row] = await db
+    .select({ status: runs.status, error: runs.error, result: runs.result })
+    .from(runs)
+    .where(eq(runs.id, runId))
+    .limit(1);
+  return row!;
+}
+
+describe("platform-synthesised terminals — emitted `output` recovery", () => {
+  let ctx: TestContext;
+  const agentId = "@recovery/plain-agent";
+  const schemaAgentId = "@recovery/schema-agent";
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ email: "recovery@test.dev", orgSlug: "recovery-org" });
+    await seedPackage({ orgId: ctx.orgId, id: agentId, type: "agent" });
+    await seedPackage({
+      orgId: ctx.orgId,
+      id: schemaAgentId,
+      type: "agent",
+      draftManifest: {
+        name: schemaAgentId,
+        version: "0.1.0",
+        type: "agent",
+        description: "Agent with a declared output schema",
+        runtime_tools: ["output"],
+        output: {
+          schema: {
+            type: "object",
+            required: ["answer"],
+            additionalProperties: false,
+            properties: { answer: { type: "string" } },
+          },
+        },
+      },
+    });
+  });
+
+  it("cancel AFTER an output emission keeps the deliverable on runs.result", async () => {
+    const runId = await seedRunWithSink(ctx, agentId);
+    await emitOutput(runId, { answer: "42", items: [1, 2, 3] }, 1);
+
+    const res = await app.request(`/api/runs/${runId}/cancel`, {
+      method: "POST",
+      headers: authHeaders(ctx),
+    });
+    expect(res.status).toBe(200);
+
+    const row = await readRun(runId);
+    // Payload recovered — and the terminal state is untouched by it.
+    expect((row.result as { output?: unknown } | null)?.output).toEqual({
+      answer: "42",
+      items: [1, 2, 3],
+    });
+    expect(row.status).toBe("cancelled");
+    expect(row.error).toBe("Cancelled by user");
+  });
+
+  it("cancel with NO output emission leaves runs.result null (never fabricate)", async () => {
+    const runId = await seedRunWithSink(ctx, agentId);
+
+    const res = await app.request(`/api/runs/${runId}/cancel`, {
+      method: "POST",
+      headers: authHeaders(ctx),
+    });
+    expect(res.status).toBe(200);
+
+    const row = await readRun(runId);
+    expect(row.result).toBeNull();
+    expect(row.status).toBe("cancelled");
+    expect(row.error).toBe("Cancelled by user");
+  });
+
+  it("several emissions — the last row (highest id) wins", async () => {
+    // `output` is replace-on-emit, so the newest row is the payload the agent
+    // meant to deliver; `run_logs.id` is the append-only ordering key.
+    const runId = await seedRunWithSink(ctx, agentId);
+    await emitOutput(runId, { attempt: 1 }, 1);
+    await emitOutput(runId, { attempt: 2 }, 2);
+    await emitOutput(runId, { attempt: 3, final: true }, 3);
+
+    const res = await app.request(`/api/runs/${runId}/cancel`, {
+      method: "POST",
+      headers: authHeaders(ctx),
+    });
+    expect(res.status).toBe(200);
+
+    const row = await readRun(runId);
+    expect((row.result as { output?: unknown } | null)?.output).toEqual({
+      attempt: 3,
+      final: true,
+    });
+  });
+
+  it("an output row with a null payload does not become a truthy empty object", async () => {
+    // Defensive: the sink writes `data: null` when the event carried none.
+    // Recovering that as `{}` would fabricate a deliverable the agent never
+    // produced (and, on a success terminal, would read as "output was called").
+    const runId = await seedRunWithSink(ctx, agentId);
+    await emitOutput(runId, undefined, 1);
+
+    const res = await app.request(`/api/runs/${runId}/cancel`, {
+      method: "POST",
+      headers: authHeaders(ctx),
+    });
+    expect(res.status).toBe(200);
+
+    expect((await readRun(runId)).result).toBeNull();
+  });
+
+  it("synthesised success + declared output schema: an emitted valid payload stays success", async () => {
+    // Container exited 0 without posting its own finalize (execute-background
+    // synthesises success). Pre-fix this ALWAYS validated `{}` against the
+    // schema and flipped the run to failed with the "never called `output`"
+    // message, even though the agent had delivered a conforming payload.
+    const runId = await seedRunWithSink(ctx, schemaAgentId);
+    await emitOutput(runId, { answer: "42" }, 1);
+
+    await synthesiseFinalize(runId, { status: "success", durationMs: 100 });
+
+    const row = await readRun(runId);
+    expect(row.status).toBe("success");
+    expect(row.error).toBeNull();
+    expect((row.result as { output?: unknown } | null)?.output).toEqual({ answer: "42" });
+  });
+
+  it("synthesised success + declared output schema: no emission still fails with the tool wording", async () => {
+    // Regression guard for the other half of the invariant — nothing is
+    // fabricated, so the "agent never called `output`" verdict is unchanged.
+    const runId = await seedRunWithSink(ctx, schemaAgentId);
+
+    await synthesiseFinalize(runId, { status: "success", durationMs: 100 });
+
+    const row = await readRun(runId);
+    expect(row.status).toBe("failed");
+    expect(row.error).toMatch(/without calling the required `output` tool/);
+    expect(row.result).toBeNull();
+  });
+
+  it("synthesised success + declared output schema: a non-conforming emission still fails", async () => {
+    // Recovery feeds validation the REAL payload, so a schema violation is
+    // reported as such (and the payload is flagged, not dropped).
+    const runId = await seedRunWithSink(ctx, schemaAgentId);
+    await emitOutput(runId, { wrong: 1 }, 1);
+
+    await synthesiseFinalize(runId, { status: "success", durationMs: 100 });
+
+    const row = await readRun(runId);
+    expect(row.status).toBe("failed");
+    expect(row.error).toMatch(/Output validation failed/);
+    expect((row.result as { output?: unknown } | null)?.output).toEqual({ wrong: 1 });
+  });
+
+  it("never overwrites an output the caller already carries", async () => {
+    // `applyRecoveredOutput` is exported, so a future caller could hand it a
+    // RunResult that already holds a runner-supplied output. That statement is
+    // authoritative — recovery fills in what is missing, it never overrules.
+    const runId = await seedRunWithSink(ctx, agentId);
+    await emitOutput(runId, { fromRunLogs: true }, 1);
+
+    const run = (await getRunSinkContext(runId))!;
+    const result = emptyRunResult();
+    result.status = "success";
+    result.output = { fromRunner: true };
+
+    await applyRecoveredOutput(run, result);
+
+    expect(result.output).toEqual({ fromRunner: true });
+  });
+
+  it("a synthesised timeout keeps its status while recovering the payload", async () => {
+    // Status is the caller's call; recovery only fills the payload.
+    const runId = await seedRunWithSink(ctx, agentId);
+    await emitOutput(runId, { partial: true }, 1);
+
+    await synthesiseFinalize(runId, {
+      status: "timeout",
+      error: { message: "Run timed out after 300s" },
+    });
+
+    const row = await readRun(runId);
+    expect(row.status).toBe("timeout");
+    expect(row.error).toBe("Run timed out after 300s");
+    expect((row.result as { output?: unknown } | null)?.output).toEqual({ partial: true });
+  });
+});

--- a/apps/api/test/integration/services/run-watchdog.test.ts
+++ b/apps/api/test/integration/services/run-watchdog.test.ts
@@ -244,6 +244,55 @@ describe("run watchdog — unified stall detection", () => {
     expect(row?.cost).toBeCloseTo(0.0234, 5);
   });
 
+  // #1020 — the stall sweep builds its own `emptyRunResult()` (it does not
+  // go through `synthesiseFinalize`), so it has to recover the deliverable
+  // the agent already emitted or the payload stays invisible on a durable
+  // `run_logs` row. Recovery is payload-only: the terminal stays `failed`.
+  it("recovers an emitted output payload onto the failed terminal", async () => {
+    const runId = await seedRun(ctx, "@test/watchdog-agent", {
+      status: "running",
+      lastHeartbeatAt: new Date(Date.now() - 3600_000),
+    });
+    // The row the `output.emitted` ingestion path writes at emit time.
+    await db.insert(runLogs).values({
+      runId,
+      orgId: ctx.orgId,
+      type: "result",
+      event: "output",
+      data: { answer: "42" },
+      level: "info",
+    });
+
+    const finalizedCount = await runWatchdogTick({
+      intervalSeconds: 30,
+      stallThresholdSeconds: 60,
+      maxFinalizesPerTick: 100,
+    });
+
+    expect(finalizedCount).toBe(1);
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    expect(row?.error).toContain("Runner stopped reporting");
+    expect((row?.result as { output?: unknown } | null)?.output).toEqual({ answer: "42" });
+  });
+
+  it("leaves runs.result null when a stalled run emitted no output", async () => {
+    const runId = await seedRun(ctx, "@test/watchdog-agent", {
+      status: "running",
+      lastHeartbeatAt: new Date(Date.now() - 3600_000),
+    });
+
+    await runWatchdogTick({
+      intervalSeconds: 30,
+      stallThresholdSeconds: 60,
+      maxFinalizesPerTick: 100,
+    });
+
+    const [row] = await db.select().from(runs).where(eq(runs.id, runId)).limit(1);
+    expect(row?.status).toBe("failed");
+    expect(row?.result).toBeNull();
+  });
+
   // B1 regression — a stalled runner is not necessarily a dead one. A
   // remote workload (e.g. a firecracker microVM that lost its event
   // path) keeps executing and billing after the row is finalized, so

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -549,13 +549,14 @@ Run-config inheritance (model, proxy, agent config, version pin) is fetched from
 
 **Selected flags**
 
-| Flag            | Purpose                                                                                                                                                |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--proxy <id>`  | Proxy id to associate with the run (overrides the per-app inherited value).                                                                            |
-| `--no-inherit`  | Skip per-application run-config inheritance — flags + env vars + defaults only.                                                                        |
-| `--json`        | Emit canonical RunEvents as JSONL on stdout.                                                                                                           |
-| `-v, --verbose` | Verbose tool-call output: pretty-print args + reveal full results (~2 KB). Honoured only in human mode (without `--json`). Env: `APPSTRATE_VERBOSE=1`. |
-| `-q, --quiet`   | Suppress per-tool output lines (name, args, result). Errors and final summary still print. Mutually exclusive with `--verbose`.                        |
+| Flag                    | Purpose                                                                                                                                                                                                                                                      |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--proxy <id>`          | Proxy id to associate with the run (overrides the per-app inherited value).                                                                                                                                                                                  |
+| `--[no-]cancel-on-exit` | Remote runs only: whether SIGINT/SIGTERM/SIGHUP cancels the platform-side run. Default: on when stdin is a TTY and `--json` is not set (interactive Ctrl-C cancels), off otherwise — the CLI detaches and the run keeps going, like closing a dashboard tab. |
+| `--no-inherit`          | Skip per-application run-config inheritance — flags + env vars + defaults only.                                                                                                                                                                              |
+| `--json`                | Emit canonical RunEvents as JSONL on stdout.                                                                                                                                                                                                                 |
+| `-v, --verbose`         | Verbose tool-call output: pretty-print args + reveal full results (~2 KB). Honoured only in human mode (without `--json`). Env: `APPSTRATE_VERBOSE=1`.                                                                                                       |
+| `-q, --quiet`           | Suppress per-tool output lines (name, args, result). Errors and final summary still print. Mutually exclusive with `--verbose`.                                                                                                                              |
 
 **Tool-call rendering**
 

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -32,25 +32,25 @@ See [`examples/self-hosting/README.md`](../../examples/self-hosting/README.md#ve
 
 ## Commands
 
-| Command               | Purpose                                                                         |
-| --------------------- | ------------------------------------------------------------------------------- |
-| `appstrate install`   | Install Appstrate locally (Tier 0) or bring up a Docker stack (Tiers 1/2/3).    |
-| `appstrate start`     | Start the installed Docker stack (`docker compose up -d`).                      |
-| `appstrate stop`      | Stop the stack — containers off, volumes preserved.                             |
-| `appstrate restart`   | Restart all containers.                                                         |
-| `appstrate logs`      | Stream Compose logs (with `-f` and an optional service-name positional).        |
-| `appstrate status`    | Show container status (`docker compose ps`).                                    |
-| `appstrate uninstall` | Tear down. Default keeps volumes; `--purge` wipes data + the install dir.       |
-| `appstrate login`     | Sign into an instance via RFC 8628 device-flow. Tokens land in the OS keyring.  |
-| `appstrate logout`    | Revoke the active session server-side and wipe local credentials.               |
-| `appstrate whoami`    | Print the identity attached to the active profile.                              |
-| `appstrate token`     | Print metadata about the stored access + refresh tokens (debug).                |
-| `appstrate org`       | List, switch, or create organizations pinned on the active profile.             |
-| `appstrate app`       | List, switch, or create applications pinned on the active profile.              |
-| `appstrate api`       | Authenticated HTTP passthrough to the Appstrate API.                            |
-| `appstrate openapi`   | Explore the active profile's OpenAPI schema without flooding stdout.            |
-| `appstrate run`       | Execute an agent locally — by package id or from a `.afps`/`.afps-bundle` path. |
-| `appstrate runner`    | Install and manage the Firecracker runner daemon on a KVM host.                 |
+| Command               | Purpose                                                                                                     |
+| --------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `appstrate install`   | Install Appstrate locally (Tier 0) or bring up a Docker stack (Tiers 1/2/3).                                |
+| `appstrate start`     | Start the installed Docker stack (`docker compose up -d`).                                                  |
+| `appstrate stop`      | Stop the stack — containers off, volumes preserved.                                                         |
+| `appstrate restart`   | Restart all containers.                                                                                     |
+| `appstrate logs`      | Stream Compose logs (with `-f` and an optional service-name positional).                                    |
+| `appstrate status`    | Show container status (`docker compose ps`).                                                                |
+| `appstrate uninstall` | Tear down. Default keeps volumes; `--purge` wipes data + the install dir.                                   |
+| `appstrate login`     | Sign into an instance via RFC 8628 device-flow. Tokens land in the OS keyring.                              |
+| `appstrate logout`    | Revoke the active session server-side and wipe local credentials.                                           |
+| `appstrate whoami`    | Print the identity attached to the active profile.                                                          |
+| `appstrate token`     | Print metadata about the stored access + refresh tokens (debug).                                            |
+| `appstrate org`       | List, switch, or create organizations pinned on the active profile.                                         |
+| `appstrate app`       | List, switch, or create applications pinned on the active profile.                                          |
+| `appstrate api`       | Authenticated HTTP passthrough to the Appstrate API.                                                        |
+| `appstrate openapi`   | Explore the active profile's OpenAPI schema without flooding stdout.                                        |
+| `appstrate run`       | Execute an agent — a package id runs on the pinned instance, a `.afps`/`.afps-bundle` path runs in-process. |
+| `appstrate runner`    | Install and manage the Firecracker runner daemon on a KVM host.                                             |
 
 All commands accept `--profile <name>` to target a specific profile (see [Profiles](#profiles)).
 
@@ -526,10 +526,12 @@ Subset of curl's format string. Unknown variables pass through verbatim; `\n \r 
 
 ### `appstrate run`
 
-Execute an agent locally via the same Pi runner the platform uses for cloud runs. Two argument forms:
+Execute an agent. The shape of the target picks the execution mode:
 
-- **By package id** — `@scope/agent[@spec]`. The CLI calls `GET /api/agents/{scope}/{name}/bundle` on the pinned instance to download a deterministic `.afps-bundle`, verifies its SRI integrity in memory, and runs it. The bytes are never written to disk — every invocation re-fetches.
-- **By file path** — a local `.afps` or `.afps-bundle` file. No network roundtrip.
+- **By package id** — `@scope/agent[@spec]`. Runs **remotely** by default: the CLI POSTs `/api/agents/{scope}/{name}/run` on the pinned instance (the same path as the dashboard "Run" button), then tails the run's logs and final status. Pass `--local` to run the agent in-process instead — the CLI then calls `GET /api/agents/{scope}/{name}/bundle` to download a deterministic `.afps-bundle`, verifies its SRI integrity in memory, and runs it via the Pi runner. The bytes are never written to disk — every invocation re-fetches.
+- **By file path** — a local `.afps` or `.afps-bundle` file. Runs **locally**, in-process via the Pi runner, with the caller's shell, FS, and env. No network roundtrip for the bundle. `--remote` is rejected on a path target: the CLI does not upload local bundles to the instance.
+
+`--local` and `--remote` are mutually exclusive.
 
 ```sh
 # Run the latest version of an installed agent
@@ -546,6 +548,24 @@ appstrate run ./out/triage-1.2.0.afps-bundle --integrations local --creds-file .
 ```
 
 Run-config inheritance (model, proxy, agent config, version pin) is fetched from `/api/applications/{applicationId}/packages/{scope}/{name}/run-config` and merged with flag/env overrides. Use `--no-inherit` to opt out (deterministic CI).
+
+**Remote runs and process lifetime**
+
+A remote run executes on the instance and outlives the CLI process by design — like closing a dashboard tab. What `SIGINT` / `SIGTERM` / `SIGHUP` does to that run depends on whether a human sent it:
+
+- **Interactive** (stdin is a TTY and `--json` is not set) — the signal **cancels** the run server-side (`POST /api/runs/{runId}/cancel`) and the CLI keeps polling until the run reaches a terminal status, so the final state still prints. Ctrl-C at a keyboard is a cancel intent.
+- **Non-interactive** (`--json`, or stdin is not a TTY: CI, a supervisor, a background shell) — the signal **detaches**. No cancel is sent, the CLI stops tailing, and the run keeps going:
+
+```
+detached — run run_9c1e4f2a is still running on https://app.example.com
+  follow it with: appstrate api GET /api/runs/run_9c1e4f2a
+```
+
+Under `--json` the detach is a single JSONL envelope on stdout instead: `{"type":"appstrate.remote.detached","runId":"…","instance":"…"}`. A detached run has no terminal status, so the CLI writes no `--output` file and prints no `[run complete]` / `[run failed]` line — a fabricated status would be worse than a missing one.
+
+`--cancel-on-exit` / `--no-cancel-on-exit` force either behaviour and take precedence over both auto-rules. They are remote-only: passing either one on a local run is an error, not a silent no-op — an in-process run dies with the CLI and there is nothing to detach from.
+
+Exit codes on the signal path are the conventional POSIX ones (128 + signal number), in both the cancel and the detach case: `130` for SIGINT, `143` for SIGTERM, `129` for SIGHUP.
 
 **Selected flags**
 

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -890,7 +890,15 @@ program
   )
   .option(
     "--remote",
-    'Force remote execution on the pinned instance (same path as the dashboard "Run" button). Default for @scope/agent ids. Path-mode bundles are not yet supported in remote mode.',
+    'Force remote execution on the pinned instance (same path as the dashboard "Run" button). Default for @scope/agent ids. Path-mode bundles are not yet supported in remote mode. Interactively the CLI owns the run\'s lifetime — Ctrl-C cancels it server-side (see --cancel-on-exit).',
+  )
+  .option(
+    "--cancel-on-exit",
+    "Cancel the platform-side run when the CLI receives SIGINT/SIGTERM/SIGHUP. Default: on when stdin is a TTY and --json is not set (interactive Ctrl-C means cancel); off otherwise — the CLI detaches and the run keeps going. --remote only.",
+  )
+  .option(
+    "--no-cancel-on-exit",
+    "Never cancel the platform-side run on a signal: the CLI detaches and the run keeps going on the instance. --remote only.",
   )
   .option(
     "--integrations <mode>",
@@ -981,6 +989,12 @@ program
       // `opts.inherit === false`. Default (no flag) is `undefined` →
       // inheritance enabled.
       noInherit: opts.inherit === false,
+      // Tri-state, unlike `--no-inherit` above: declaring BOTH the
+      // positive flag and its `--no-` negation makes commander leave the
+      // key unset when neither is passed, so `undefined` genuinely means
+      // "auto" (resolved from --json + stdin TTY) rather than "off".
+      // Proven end-to-end in test/run-signal-policy.test.ts.
+      cancelOnExit: typeof opts.cancelOnExit === "boolean" ? opts.cancelOnExit : undefined,
       verbose: opts.verbose === true,
       quiet: opts.quiet === true,
     });

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -92,9 +92,10 @@ import {
   type ExecutionMode,
 } from "./run/mode.ts";
 import { runRemote, RemoteRunError } from "./run/remote-runner.ts";
+import { resolveSignalPolicy, readStdinIsTty } from "./run/signal-policy.ts";
 import { validateConfig } from "@appstrate/core/schema-validation";
 import type { JSONSchemaObject } from "@appstrate/core/form";
-import { onShutdown, shutdownSignal } from "../lib/shutdown.ts";
+import { onShutdown, shutdownSignal, shutdownExitCode } from "../lib/shutdown.ts";
 
 export interface RunCommandOptions {
   profile?: string;
@@ -170,6 +171,15 @@ export interface RunCommandOptions {
    * error. Mutually exclusive with `--local`.
    */
   remote?: boolean;
+  /**
+   * Tri-state `--cancel-on-exit` / `--no-cancel-on-exit`: whether a
+   * SIGINT/SIGTERM/SIGHUP cancels the platform-side run or merely
+   * detaches from it. `undefined` (no flag) auto-resolves from `--json`
+   * + stdin TTY — see `resolveSignalPolicy`. Remote-only: a local run
+   * dies with the CLI regardless, so `validateOptsForMode` rejects the
+   * flag in local mode.
+   */
+  cancelOnExit?: boolean | undefined;
 }
 
 export async function runCommand(opts: RunCommandOptions): Promise<void> {
@@ -584,7 +594,7 @@ async function runCommandLocal(opts: RunCommandOptions): Promise<void> {
     // from `heartbeat?.stop()`. If that happens on the signal path,
     // propagating the rejection would race with — and beat, since
     // commander's path has fewer microtask hops — the coordinator's
-    // `process.exit(130)`, silently turning a user cancel into exit 1.
+    // `process.exit(<signal code>)`, silently turning a user cancel into exit 1.
     // Surface the failure on stderr instead so it remains visible, but
     // don't compete for the exit code.
     await runCleanup().catch((err) => {
@@ -596,12 +606,13 @@ async function runCommandLocal(opts: RunCommandOptions): Promise<void> {
 
   // Defense in depth: the coordinator owns the exit on the signal path
   // (it awaits `runCleanup` via the registered hook, then calls
-  // `process.exit(130)`), and a microtask analysis says its exit fires
+  // `process.exit(…)`), and a microtask analysis says its exit fires
   // before node's natural exit. But that ordering is fragile — a future
   // change inside `coordinator.trigger` that adds an extra `await` could
   // flip the race. This guard is a no-op if the coordinator already
-  // exited, and a backstop if it hasn't.
-  if (shutdownSignal.aborted) process.exit(130);
+  // exited, and a backstop if it hasn't. The code comes from the
+  // coordinator so SIGTERM reports 143 and SIGHUP 129, not a blanket 130.
+  if (shutdownSignal.aborted) process.exit(shutdownExitCode());
 }
 
 // ---------------------------------------------------------------------------
@@ -655,6 +666,15 @@ async function runCommandRemote(
 
   const bundleLabel = `${target.packageId}${target.spec ? `@${target.spec}` : ""}`;
 
+  // What a signal means for the run we're about to trigger. Resolved
+  // before the trigger so the decision is fixed for the whole tail — a
+  // signal arriving mid-run can't race a re-probe of the TTY.
+  const onSignal = resolveSignalPolicy({
+    cancelOnExit: opts.cancelOnExit,
+    json: opts.json ?? false,
+    stdinIsTty: readStdinIsTty(),
+  });
+
   const outcome = await runRemote(
     {
       instance: resolverInputs.instance,
@@ -672,20 +692,27 @@ async function runCommandRemote(
       json: opts.json ?? false,
       ...(opts.output != null ? { outputPath: opts.output } : {}),
       bundleLabel,
+      onSignal,
     },
     shutdownSignal,
   );
 
-  // Match the local path: a non-success terminal status sets
-  // `process.exitCode` so shell `&& chain` works. The shutdown
-  // coordinator owns SIGINT exit (130); we only mark for the
-  // natural-completion path.
-  if (outcome.exitCode !== 0) process.exitCode = outcome.exitCode;
+  // A detached run has no terminal status, so there is nothing to map to
+  // an exit code — the signal that caused the detach owns it (backstop
+  // below). Setting `process.exitCode = 1` here would report a failure
+  // for a run that is very likely about to succeed.
+  if (outcome.kind === "terminal") {
+    // Match the local path: a non-success terminal status sets
+    // `process.exitCode` so shell `&& chain` works. The shutdown
+    // coordinator owns the signal exit; we only mark for the
+    // natural-completion path.
+    if (outcome.exitCode !== 0) process.exitCode = outcome.exitCode;
+  }
 
   // Defense-in-depth backstop matching the local path: if the abort
-  // fired between `runRemote` returning and us getting here, exit 130
-  // explicitly so the CLI doesn't claim natural completion.
-  if (shutdownSignal.aborted) process.exit(130);
+  // fired between `runRemote` returning and us getting here, exit with
+  // the signal's own code so the CLI doesn't claim natural completion.
+  if (shutdownSignal.aborted) process.exit(shutdownExitCode());
 }
 
 /**

--- a/apps/cli/src/commands/run/mode.ts
+++ b/apps/cli/src/commands/run/mode.ts
@@ -51,6 +51,8 @@ export interface ModeResolutionOpts {
   report?: string;
   reportFallback?: string;
   sinkTtl?: number;
+  // Remote-only flag — flagged at validation time when in local mode.
+  cancelOnExit?: boolean | undefined;
 }
 
 export class ExecutionModeError extends Error {
@@ -96,14 +98,28 @@ export function resolveExecutionMode(target: RunTarget, opts: ModeResolutionOpts
 /**
  * Validate that the user-supplied flags are compatible with the resolved
  * execution mode. Local-only flags are rejected in remote mode with a
- * clear hint pointing at `--local` as the opt-in.
+ * clear hint pointing at `--local` as the opt-in, and symmetrically for
+ * remote-only flags in local mode.
  *
  * Kept separate from `resolveExecutionMode` so the dispatch can branch
- * on mode FIRST (allows the local path to call this and ignore remote-
- * only checks symmetrically — currently there are no remote-only flags).
+ * on mode FIRST.
  */
 export function validateOptsForMode(mode: ExecutionMode, opts: ModeResolutionOpts): void {
-  if (mode === "local") return;
+  if (mode === "local") {
+    // `--cancel-on-exit` decides what a signal does to a PLATFORM-side
+    // run. A local run executes in this very process — it dies with the
+    // CLI no matter what — so the flag has nothing to act on. Reject
+    // rather than accept-and-ignore, same contract as the remote branch.
+    if (opts.cancelOnExit !== undefined) {
+      const flag = opts.cancelOnExit ? "--cancel-on-exit" : "--no-cancel-on-exit";
+      throw new ExecutionModeError(
+        `The following flags are not supported in local execution mode:\n` +
+          `  ${flag} — the in-process runner dies with the CLI; there is no platform-side run to keep alive`,
+        "Drop the flag, or pass --remote to run the agent on the pinned instance.",
+      );
+    }
+    return;
+  }
 
   // Remote mode — surface anything that only makes sense locally.
   // `--report*` and `--sink-ttl` are tied to the **local-execution**

--- a/apps/cli/src/commands/run/remote-runner.ts
+++ b/apps/cli/src/commands/run/remote-runner.ts
@@ -32,10 +32,14 @@
  * loop also forces a record fetch on the first iteration so very short
  * runs (success in <1 tick) finalize without a wasted log-poll.
  *
- * Cancellation: on `signal` abort the runner POSTs `/api/runs/:id/cancel`
- * once and continues polling until the run reaches a terminal status.
- * Idempotency-Key on the trigger POST guards against accidental double
- * submission across CLI retries.
+ * Signal handling: what an abort means is the caller's decision, passed
+ * as `onSignal` (see `signal-policy.ts` for how it is resolved).
+ * `"cancel"` POSTs `/api/runs/:id/cancel` once and keeps polling until
+ * the run reaches a terminal status, so the user observes the final
+ * state. `"detach"` leaves the platform-side run untouched and stops
+ * tailing — the run outlives the CLI, exactly like closing a dashboard
+ * tab. Idempotency-Key on the trigger POST guards against accidental
+ * double submission across CLI retries.
  */
 
 import type { EventSink } from "@appstrate/afps-runtime/interfaces";
@@ -115,19 +119,36 @@ export interface RemoteRunLog {
   createdAt?: string;
 }
 
-export interface RemoteRunOutcome {
-  runId: string;
-  status: TerminalRunStatus;
-  /** Final run record fetched from `GET /api/runs/:id`. */
-  record: RemoteRunRecord;
-  /** All logs accumulated during the run. */
-  logs: RemoteRunLog[];
-  /**
-   * Process exit code suggested by the outcome. `0` for success,
-   * `1` for any non-success terminal status (cancelled / failed / timeout).
-   */
-  exitCode: number;
-}
+/**
+ * How the tail ended. A discriminated union rather than an optional
+ * `detached` flag: the detached variant genuinely has no terminal status,
+ * no final record, and no exit code, and the type system should say so —
+ * a caller cannot accidentally read a status the run never reached.
+ */
+export type RemoteRunOutcome =
+  | {
+      kind: "terminal";
+      runId: string;
+      status: TerminalRunStatus;
+      /** Final run record fetched from `GET /api/runs/:id`. */
+      record: RemoteRunRecord;
+      /** All logs accumulated during the run. */
+      logs: RemoteRunLog[];
+      /**
+       * Process exit code suggested by the outcome. `0` for success,
+       * `1` for any non-success terminal status (cancelled / failed / timeout).
+       */
+      exitCode: number;
+    }
+  | {
+      kind: "detached";
+      runId: string;
+      /** Logs accumulated up to the moment the CLI stopped tailing. */
+      logs: RemoteRunLog[];
+      // No `exitCode` on purpose: the run has no terminal state, and on
+      // the signal path the shutdown coordinator owns the process exit
+      // code (128 + signal number).
+    };
 
 export class RemoteRunError extends Error {
   override readonly name = "RemoteRunError";
@@ -170,6 +191,15 @@ export interface RunRemoteOptions {
 
   /** `Idempotency-Key` for the trigger POST. */
   idempotencyKey?: string | undefined;
+
+  /**
+   * What a `signal` abort means for the platform-side run — resolved by
+   * `resolveSignalPolicy` (see `signal-policy.ts`). `"cancel"` POSTs the
+   * cancel endpoint and keeps tailing to the terminal state; `"detach"`
+   * leaves the run running and stops tailing. Defaults to `"cancel"`,
+   * the historical behaviour.
+   */
+  onSignal?: "cancel" | "detach";
 
   /** When true, emit each event as JSONL on stdout. Otherwise human-format. */
   json: boolean;
@@ -223,7 +253,9 @@ export interface RunRemoteOptions {
 }
 
 /**
- * Trigger a remote run and tail it to terminal status.
+ * Trigger a remote run and tail it to terminal status — or, when
+ * `onSignal: "detach"` and a signal arrives, stop tailing and leave the
+ * run alive on the platform.
  *
  * Returns the outcome regardless of success/failure — the caller decides
  * whether to set `process.exitCode`. Throws only on hard failures
@@ -283,12 +315,26 @@ export async function runRemote(
     writeStdout,
   });
 
-  // ─── 2. Cancellation wiring ────────────────────────────────────────
-  // Single-shot cancel POST on the first `abort` event. Polling continues
-  // until the server flips status to `cancelled` (or any other terminal),
-  // so the user always observes the final state before the CLI exits.
+  // ─── 2. Signal wiring ──────────────────────────────────────────────
+  //
+  // `"cancel"`: single-shot cancel POST on the first `abort` event.
+  // Polling continues until the server flips status to `cancelled` (or
+  // any other terminal), so the user always observes the final state
+  // before the CLI exits.
+  //
+  // `"detach"`: no cancel POST at all. The abort only raises a flag the
+  // poll loop reads, so the CLI unwinds while the platform-side run
+  // keeps going. Cancelling here would destroy a healthy run on behalf
+  // of a caller (CI wrapper, supervisor, harness) that only ever asked
+  // the CLI process to go away.
+  const onSignal = opts.onSignal ?? "cancel";
   let cancelRequested = false;
+  let detachRequested = false;
   const onAbort = (): void => {
+    if (onSignal === "detach") {
+      detachRequested = true;
+      return;
+    }
     if (cancelRequested) return;
     cancelRequested = true;
     if (!opts.json) writeStderr(`\nshutdown received, cancelling remote run...\n`);
@@ -324,6 +370,37 @@ export async function runRemote(
   let lastLogId = 0;
   let tick = 0;
   let consecutiveRecordFailures = 0;
+
+  /**
+   * Unwind the detach path: tell the caller where the run went and
+   * return without a terminal state.
+   *
+   * Deliberately does NOT call `consoleSink.finalize(...)`, synthesize
+   * the trailing `appstrate.metric` line, or write the `--output` file.
+   * The run has no terminal status yet — printing `[run complete]` /
+   * `[run failed]` or persisting a RunResult would fabricate one, and a
+   * fabricated status is worse than a missing one for the scripted
+   * callers this path exists for.
+   */
+  const finishDetached = (): RemoteRunOutcome => {
+    if (opts.json) {
+      // Mirrors the kickoff `appstrate.remote.triggered` envelope so a
+      // `jq` pipeline can pair "run started here" with "CLI let go here".
+      writeStdout(
+        JSON.stringify({ type: "appstrate.remote.detached", runId, instance: opts.instance }) +
+          "\n",
+      );
+    } else {
+      writeStderr(`\ndetached — run ${runId} is still running on ${opts.instance}\n`);
+      writeStderr(`  follow it with: appstrate api GET /api/runs/${runId}\n`);
+    }
+    return { kind: "detached", runId, logs: allLogs };
+  };
+
+  // The signal can land before the first poll (a supervisor reaping the
+  // process while the trigger POST was in flight, or an already-aborted
+  // signal passed in). Unwind without opening the loop at all.
+  if (detachRequested) return finishDetached();
 
   while (true) {
     // Logs first — high-frequency, bounded by the cursor.
@@ -377,6 +454,11 @@ export async function runRemote(
       // Sleep aborts are normal once the user hits Ctrl-C — we still
       // want the next loop iteration to fetch the now-cancelled status.
     });
+
+    // Detach is checked here rather than at the top of the loop so the
+    // logs fetched by the iteration in flight when the signal landed are
+    // still rendered before the CLI lets go.
+    if (detachRequested) return finishDetached();
   }
 
   // ─── 4. Final fetch — make sure we have the freshest record + tail logs ──
@@ -432,7 +514,7 @@ export async function runRemote(
     await writeFile(opts.outputPath, JSON.stringify(reconstructedResult, null, 2) + "\n");
   }
 
-  return { runId, status, record: finalRecord, logs: allLogs, exitCode };
+  return { kind: "terminal", runId, status, record: finalRecord, logs: allLogs, exitCode };
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/cli/src/commands/run/signal-policy.ts
+++ b/apps/cli/src/commands/run/signal-policy.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * What a POSIX signal means for a run executing on the platform.
+ *
+ * `appstrate run @scope/agent` (remote mode) triggers a run server-side
+ * and tails it. When the CLI is signalled, two readings are possible and
+ * they are NOT interchangeable:
+ *
+ * - `"cancel"` — the human at the keyboard hit Ctrl-C to stop the agent.
+ *   Cancelling the platform-side run is exactly what they asked for.
+ * - `"detach"` — the process was reaped by something that was never
+ *   talking to the agent: a CI step hitting its wrapper timeout, a
+ *   supervisor recycling a worker, a harness killing a background shell.
+ *   The run is healthy and already paid for; killing it is a side effect
+ *   the caller never asked for. Closing a dashboard tab does not cancel a
+ *   run — a reaped CLI should not either.
+ *
+ * The resolver below picks between the two. `--json` and a non-TTY stdin
+ * both say "nobody is sitting at this terminal to have pressed Ctrl-C",
+ * so the signal is a process-lifecycle event rather than a cancel intent.
+ * An explicit flag always wins, in both directions.
+ *
+ * Why **stdin**, not stdout: Ctrl-C can only be delivered by a
+ * controlling terminal, which is what stdin being a TTY attests to.
+ * Probing stdout would flip the default for the extremely common
+ * interactive `appstrate run … | tee log.txt`, where the user is very
+ * much present and does mean cancel.
+ */
+
+export type SignalPolicy = "cancel" | "detach";
+
+export interface SignalPolicyInputs {
+  /**
+   * Tri-state `--cancel-on-exit` / `--no-cancel-on-exit`: `undefined`
+   * when the user passed neither (auto), otherwise the explicit choice.
+   */
+  cancelOnExit?: boolean | undefined;
+  /** `--json` — machine-readable output implies a machine caller. */
+  json: boolean;
+  /** Whether `process.stdin` is attached to a TTY. See {@link readStdinIsTty}. */
+  stdinIsTty: boolean;
+}
+
+/**
+ * Decide what a SIGINT/SIGTERM/SIGHUP does to the platform-side run.
+ *
+ * Pure by design (every input is injected) so the precedence table is
+ * unit-testable without touching `process`.
+ */
+export function resolveSignalPolicy({
+  cancelOnExit,
+  json,
+  stdinIsTty,
+}: SignalPolicyInputs): SignalPolicy {
+  if (cancelOnExit === true) return "cancel";
+  if (cancelOnExit === false) return "detach";
+  if (json) return "detach";
+  if (!stdinIsTty) return "detach";
+  return "cancel";
+}
+
+/**
+ * Single impure probe, kept out of {@link resolveSignalPolicy} so the
+ * decision stays testable. `process.stdin.isTTY` is `true` on a terminal
+ * and `undefined` otherwise (never `false`), hence the strict compare.
+ */
+export function readStdinIsTty(): boolean {
+  return process.stdin.isTTY === true;
+}

--- a/apps/cli/src/lib/shutdown.ts
+++ b/apps/cli/src/lib/shutdown.ts
@@ -74,6 +74,13 @@ export class ShutdownCoordinator {
   private readonly timeoutMs: number;
   /** Tracks the in-flight shutdown so a second signal can short-circuit. */
   private inFlight: Promise<void> | null = null;
+  /**
+   * Exit code the coordinator will use. Seeded with SIGINT's 130 so a
+   * caller reading it after an abort that did NOT come from a signal
+   * (none exist today — `trigger` is the only aborter — but the getter
+   * must answer something) gets the historical value.
+   */
+  private chosenExitCode: number = SIGNAL_EXIT_CODES.SIGINT;
 
   constructor(options: ShutdownOptions = {}) {
     this.exit = options.exit ?? ((code) => process.exit(code));
@@ -82,6 +89,17 @@ export class ShutdownCoordinator {
 
   get signal(): AbortSignal {
     return this.controller.signal;
+  }
+
+  /**
+   * Exit code chosen by the last `trigger()` — 130 (SIGINT), 143
+   * (SIGTERM) or 129 (SIGHUP). Subcommands that keep their own
+   * `process.exit` backstop on the signal path read it instead of
+   * hardcoding 130: a CLI killed by SIGTERM must report 143, and
+   * scripted callers (CI, supervisors) branch on those codes.
+   */
+  get exitCode(): number {
+    return this.chosenExitCode;
   }
 
   /** Returns an unregister function — symmetric with EventTarget's `addEventListener` API. */
@@ -97,6 +115,7 @@ export class ShutdownCoordinator {
    * call (typically a second Ctrl-C) bypasses cleanup and exits.
    */
   async trigger(reason: string, exitCode: number): Promise<void> {
+    this.chosenExitCode = exitCode;
     if (this.inFlight !== null) {
       this.exit(exitCode);
       return;
@@ -135,6 +154,12 @@ export const coordinator = new ShutdownCoordinator();
 
 export const shutdownSignal: AbortSignal = coordinator.signal;
 export const onShutdown = (hook: ShutdownHook): (() => void) => coordinator.onShutdown(hook);
+/**
+ * The exit code the singleton coordinator resolved for the current
+ * shutdown. Read by subcommand `process.exit` backstops so they report
+ * the code of the signal that actually arrived (130/143/129).
+ */
+export const shutdownExitCode = (): number => coordinator.exitCode;
 
 let signalHandlersInstalled = false;
 

--- a/apps/cli/test/run-mode.test.ts
+++ b/apps/cli/test/run-mode.test.ts
@@ -93,7 +93,7 @@ describe("resolveExecutionMode — flag conflict", () => {
 });
 
 describe("validateOptsForMode — local mode", () => {
-  it("never rejects in local mode (every flag is supported locally)", () => {
+  it("accepts every local-execution flag", () => {
     expect(() =>
       validateOptsForMode("local", {
         snapshot: "/tmp/s.json",
@@ -108,11 +108,34 @@ describe("validateOptsForMode — local mode", () => {
       }),
     ).not.toThrow();
   });
+
+  it.each([
+    ["--cancel-on-exit", { cancelOnExit: true }],
+    ["--no-cancel-on-exit", { cancelOnExit: false }],
+  ])("rejects %s in local mode (no platform-side run to keep alive)", (flag, opts) => {
+    try {
+      validateOptsForMode("local", opts);
+      throw new Error("expected throw");
+    } catch (err) {
+      if (!(err instanceof ExecutionModeError)) throw err;
+      expect(err.message).toContain(flag);
+      expect(err.hint).toMatch(/--remote/);
+    }
+  });
+
+  it("stays silent when the tri-state flag is absent", () => {
+    expect(() => validateOptsForMode("local", { cancelOnExit: undefined })).not.toThrow();
+  });
 });
 
 describe("validateOptsForMode — remote mode", () => {
   it("accepts an empty opts object", () => {
     expect(() => validateOptsForMode("remote", {})).not.toThrow();
+  });
+
+  it("accepts --cancel-on-exit in both directions (remote-only flag)", () => {
+    expect(() => validateOptsForMode("remote", { cancelOnExit: true })).not.toThrow();
+    expect(() => validateOptsForMode("remote", { cancelOnExit: false })).not.toThrow();
   });
 
   it("accepts --integrations=remote (the implicit default)", () => {

--- a/apps/cli/test/run-remote-runner.test.ts
+++ b/apps/cli/test/run-remote-runner.test.ts
@@ -14,6 +14,7 @@ import {
   runRemote,
   RemoteRunError,
   type RunRemoteOptions,
+  type RemoteRunOutcome,
   type RemoteRunRecord,
   type RemoteRunLog,
 } from "../src/commands/run/remote-runner.ts";
@@ -167,6 +168,23 @@ function withCapturedWriters(opts: RunRemoteOptions): RunRemoteOptions {
   };
 }
 
+/**
+ * Most tests drive the runner all the way to a terminal status.
+ * `runRemote` returns a discriminated union (terminal | detached), so
+ * narrow once here instead of repeating the `kind` check in every
+ * assertion block. Fails loudly if the runner detached unexpectedly.
+ */
+async function runToTerminal(
+  opts: RunRemoteOptions,
+  signal: AbortSignal,
+): Promise<Extract<RemoteRunOutcome, { kind: "terminal" }>> {
+  const outcome = await runRemote(opts, signal);
+  if (outcome.kind !== "terminal") {
+    throw new Error(`expected a terminal outcome, got kind="${outcome.kind}"`);
+  }
+  return outcome;
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -276,7 +294,7 @@ describe("runRemote — happy path", () => {
     );
 
     const opts = withCapturedWriters(buildBaseOpts({ fetchImpl }));
-    const outcome = await runRemote(opts, new AbortController().signal);
+    const outcome = await runToTerminal(opts, new AbortController().signal);
 
     expect(outcome.runId).toBe("run_test_1");
     expect(outcome.status).toBe("success");
@@ -337,7 +355,7 @@ describe("runRemote — happy path", () => {
     );
 
     const opts = withCapturedWriters(buildBaseOpts({ fetchImpl }));
-    const outcome = await runRemote(opts, new AbortController().signal);
+    const outcome = await runToTerminal(opts, new AbortController().signal);
 
     expect(outcome.status).toBe("success");
     expect(outcome.logs.map((l) => l.id)).toEqual([1, 2, 3]);
@@ -577,7 +595,7 @@ describe("runRemote — non-success terminals", () => {
     );
 
     const opts = withCapturedWriters(buildBaseOpts({ fetchImpl }));
-    const outcome = await runRemote(opts, new AbortController().signal);
+    const outcome = await runToTerminal(opts, new AbortController().signal);
     expect(outcome.status).toBe("failed");
     expect(outcome.exitCode).toBe(1);
     // Local sink renders failures as `[run failed] <message>` on stdout
@@ -602,7 +620,7 @@ describe("runRemote — non-success terminals", () => {
       calls,
     );
 
-    const outcome = await runRemote(
+    const outcome = await runToTerminal(
       withCapturedWriters(buildBaseOpts({ fetchImpl })),
       new AbortController().signal,
     );
@@ -653,15 +671,16 @@ describe("runRemote — cancellation", () => {
     };
     const wrapped = wrappedImpl as unknown as typeof fetch;
 
-    const outcome = await runRemote(
+    const outcome = await runToTerminal(
       withCapturedWriters(buildBaseOpts({ fetchImpl: wrapped })),
       ctrl.signal,
     );
 
     expect(outcome.status).toBe("cancelled");
     expect(outcome.exitCode).toBe(1);
-    const cancelCall = calls.find((c) => c.method === "POST" && c.url.endsWith("/cancel"));
-    expect(cancelCall).toBeDefined();
+    expect(outcome.kind).toBe("terminal");
+    const cancelCalls = calls.filter((c) => c.method === "POST" && c.url.endsWith("/cancel"));
+    expect(cancelCalls).toHaveLength(1);
   });
 
   it("does not double-fire cancel on repeated abort events", async () => {
@@ -688,6 +707,142 @@ describe("runRemote — cancellation", () => {
 
     const cancelCalls = calls.filter((c) => c.method === "POST" && c.url.endsWith("/cancel"));
     expect(cancelCalls).toHaveLength(1);
+  });
+});
+
+describe("runRemote — detach on signal (issue #1020)", () => {
+  /**
+   * Script a run that NEVER reaches a terminal status, so the only way
+   * out of the poll loop is the detach path. The wrapped fetch aborts
+   * after the first record poll — the same shape the cancel tests use.
+   */
+  function makeNeverTerminating(runId: string, calls: FetchCall[]): typeof fetch {
+    return makeFetchImpl(
+      {
+        [`POST /api/agents/@system/hello-world/run`]: { status: 201, body: { id: runId } },
+        [`GET /api/runs/${runId}/logs`]: {
+          status: 200,
+          body: { object: "list", data: [], hasMore: false },
+        },
+        [`GET /api/runs/${runId}`]: {
+          status: 200,
+          body: recordSummary({ id: runId, status: "running" }),
+        },
+        // Routed but never expected to be hit — an unrouted fetch would
+        // throw and mask the assertion we actually care about.
+        [`POST /api/runs/${runId}/cancel`]: { status: 200, body: { ok: true } },
+      },
+      calls,
+    );
+  }
+
+  function abortAfterFirstRecordPoll(
+    impl: typeof fetch,
+    runId: string,
+    ctrl: AbortController,
+  ): typeof fetch {
+    let recordHits = 0;
+    const wrapped = async (
+      input: string | URL | Request,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      const res = await impl(input, init);
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.endsWith(`/api/runs/${runId}`) && (init?.method ?? "GET").toUpperCase() === "GET") {
+        recordHits++;
+        if (recordHits === 1) ctrl.abort();
+      }
+      return res;
+    };
+    return wrapped as unknown as typeof fetch;
+  }
+
+  it("does not cancel, prints the detach notice, writes no --output file", async () => {
+    const calls: FetchCall[] = [];
+    const ctrl = new AbortController();
+    const fetchImpl = abortAfterFirstRecordPoll(
+      makeNeverTerminating("run_d", calls),
+      "run_d",
+      ctrl,
+    );
+
+    const outcome = await runRemote(
+      withCapturedWriters(
+        buildBaseOpts({
+          fetchImpl,
+          onSignal: "detach",
+          outputPath: "/tmp/appstrate-detach-should-not-exist.json",
+        }),
+      ),
+      ctrl.signal,
+    );
+
+    expect(outcome.kind).toBe("detached");
+    expect(outcome.runId).toBe("run_d");
+
+    // The whole point of the issue: a healthy platform-side run survives.
+    const cancelCalls = calls.filter((c) => c.method === "POST" && c.url.endsWith("/cancel"));
+    expect(cancelCalls).toHaveLength(0);
+
+    const stderr = writers.stderr.join("");
+    expect(stderr).toContain("detached — run run_d is still running on https://app.example.com");
+    expect(stderr).toContain("appstrate api GET /api/runs/run_d");
+    // No fabricated terminal state: no finalize line, no output file.
+    expect(writers.stdout.join("")).not.toMatch(/\[run (complete|failed)\]/);
+    expect(Object.keys(writers.files)).toHaveLength(0);
+  });
+
+  it("--json emits exactly one appstrate.remote.detached envelope and no finalize", async () => {
+    const calls: FetchCall[] = [];
+    const ctrl = new AbortController();
+    const fetchImpl = abortAfterFirstRecordPoll(
+      makeNeverTerminating("run_dj", calls),
+      "run_dj",
+      ctrl,
+    );
+
+    const outcome = await runRemote(
+      withCapturedWriters(buildBaseOpts({ fetchImpl, json: true, onSignal: "detach" })),
+      ctrl.signal,
+    );
+
+    expect(outcome.kind).toBe("detached");
+    const envelopes = writers.stdout
+      .join("")
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .map((line) => JSON.parse(line) as { type?: string; runId?: string; instance?: string });
+    const detached = envelopes.filter((e) => e.type === "appstrate.remote.detached");
+    expect(detached).toHaveLength(1);
+    expect(detached[0]).toEqual({
+      type: "appstrate.remote.detached",
+      runId: "run_dj",
+      instance: "https://app.example.com",
+    });
+    // Pairs with the kickoff envelope, and nothing claims a result.
+    expect(envelopes.filter((e) => e.type === "appstrate.remote.triggered")).toHaveLength(1);
+    expect(envelopes.some((e) => e.type === "appstrate.finalize")).toBe(false);
+    expect(writers.stderr.join("")).toBe("");
+  });
+
+  it("detaches without polling at all when the signal already fired", async () => {
+    // A supervisor can reap the process while the trigger POST is still
+    // in flight: the run exists server-side, the CLI must let go without
+    // opening the tail loop (and without cancelling).
+    const calls: FetchCall[] = [];
+    const ctrl = new AbortController();
+    ctrl.abort();
+    const fetchImpl = makeNeverTerminating("run_da", calls);
+
+    const outcome = await runRemote(
+      withCapturedWriters(buildBaseOpts({ fetchImpl, onSignal: "detach" })),
+      ctrl.signal,
+    );
+
+    expect(outcome.kind).toBe("detached");
+    expect(calls.filter((c) => c.method === "POST" && c.url.endsWith("/cancel"))).toHaveLength(0);
+    expect(calls.filter((c) => c.url.includes("/logs"))).toHaveLength(0);
   });
 });
 
@@ -771,7 +926,7 @@ describe("runRemote — error paths", () => {
       calls,
     );
 
-    const outcome = await runRemote(
+    const outcome = await runToTerminal(
       withCapturedWriters(buildBaseOpts({ fetchImpl })),
       new AbortController().signal,
     );
@@ -817,7 +972,7 @@ describe("runRemote — log dedup", () => {
       calls,
     );
 
-    const outcome = await runRemote(
+    const outcome = await runToTerminal(
       withCapturedWriters(buildBaseOpts({ fetchImpl, recordPollEveryNTicks: 1 })),
       new AbortController().signal,
     );
@@ -863,7 +1018,7 @@ describe("runRemote — log cursor (?since=)", () => {
       calls,
     );
 
-    const outcome = await runRemote(
+    const outcome = await runToTerminal(
       withCapturedWriters(buildBaseOpts({ fetchImpl, recordPollEveryNTicks: 1 })),
       new AbortController().signal,
     );
@@ -911,7 +1066,7 @@ describe("runRemote — log cursor (?since=)", () => {
       calls,
     );
 
-    const outcome = await runRemote(
+    const outcome = await runToTerminal(
       withCapturedWriters(buildBaseOpts({ fetchImpl, recordPollEveryNTicks: 1 })),
       new AbortController().signal,
     );
@@ -1077,7 +1232,7 @@ describe("runRemote — trigger retry on transient 5xx", () => {
       calls,
     );
 
-    const outcome = await runRemote(
+    const outcome = await runToTerminal(
       withCapturedWriters(buildBaseOpts({ fetchImpl })),
       new AbortController().signal,
     );
@@ -1109,7 +1264,7 @@ describe("runRemote — trigger retry on transient 5xx", () => {
       calls,
     );
 
-    const outcome = await runRemote(
+    const outcome = await runToTerminal(
       withCapturedWriters(buildBaseOpts({ fetchImpl })),
       new AbortController().signal,
     );
@@ -1186,7 +1341,7 @@ describe("runRemote — record-poll resilience", () => {
       calls,
     );
 
-    const outcome = await runRemote(
+    const outcome = await runToTerminal(
       withCapturedWriters(
         buildBaseOpts({
           fetchImpl,

--- a/apps/cli/test/run-signal-policy.test.ts
+++ b/apps/cli/test/run-signal-policy.test.ts
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for `resolveSignalPolicy` — the decision that says whether a
+ * SIGINT/SIGTERM/SIGHUP cancels the platform-side run or merely detaches
+ * from it (issue #1020).
+ *
+ * The resolver is pure (every input injected), so the whole precedence
+ * table is asserted exhaustively rather than sampled.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { Command } from "commander";
+import { resolveSignalPolicy, type SignalPolicy } from "../src/commands/run/signal-policy.ts";
+
+describe("resolveSignalPolicy — precedence table", () => {
+  // Exhaustive over the three inputs: cancelOnExit (true | false |
+  // undefined) × json (true | false) × stdinIsTty (true | false).
+  const cases: {
+    cancelOnExit: boolean | undefined;
+    json: boolean;
+    stdinIsTty: boolean;
+    expected: SignalPolicy;
+    why: string;
+  }[] = [
+    // 1. Explicit --cancel-on-exit wins over everything.
+    {
+      cancelOnExit: true,
+      json: true,
+      stdinIsTty: false,
+      expected: "cancel",
+      why: "--cancel-on-exit beats --json and a non-TTY stdin",
+    },
+    {
+      cancelOnExit: true,
+      json: false,
+      stdinIsTty: false,
+      expected: "cancel",
+      why: "--cancel-on-exit beats a non-TTY stdin",
+    },
+    {
+      cancelOnExit: true,
+      json: true,
+      stdinIsTty: true,
+      expected: "cancel",
+      why: "--cancel-on-exit beats --json",
+    },
+    {
+      cancelOnExit: true,
+      json: false,
+      stdinIsTty: true,
+      expected: "cancel",
+      why: "--cancel-on-exit agrees with the interactive default",
+    },
+    // 2. Explicit --no-cancel-on-exit wins over everything, including a
+    //    fully interactive terminal.
+    {
+      cancelOnExit: false,
+      json: false,
+      stdinIsTty: true,
+      expected: "detach",
+      why: "--no-cancel-on-exit beats the interactive TTY default",
+    },
+    {
+      cancelOnExit: false,
+      json: true,
+      stdinIsTty: true,
+      expected: "detach",
+      why: "--no-cancel-on-exit agrees with --json",
+    },
+    {
+      cancelOnExit: false,
+      json: false,
+      stdinIsTty: false,
+      expected: "detach",
+      why: "--no-cancel-on-exit agrees with a non-TTY stdin",
+    },
+    {
+      cancelOnExit: false,
+      json: true,
+      stdinIsTty: false,
+      expected: "detach",
+      why: "--no-cancel-on-exit agrees with both auto signals",
+    },
+    // 3. --json means a machine is reading — detach even on a TTY.
+    {
+      cancelOnExit: undefined,
+      json: true,
+      stdinIsTty: true,
+      expected: "detach",
+      why: "--json implies a scripted caller even from a terminal",
+    },
+    {
+      cancelOnExit: undefined,
+      json: true,
+      stdinIsTty: false,
+      expected: "detach",
+      why: "--json and a non-TTY stdin both point at detach",
+    },
+    // 4. Non-TTY stdin means nobody could have pressed Ctrl-C.
+    {
+      cancelOnExit: undefined,
+      json: false,
+      stdinIsTty: false,
+      expected: "detach",
+      why: "a reaped background process is a lifecycle event, not a cancel",
+    },
+    // 5. Interactive default.
+    {
+      cancelOnExit: undefined,
+      json: false,
+      stdinIsTty: true,
+      expected: "cancel",
+      why: "interactive Ctrl-C means the user wants the agent stopped",
+    },
+  ];
+
+  for (const c of cases) {
+    it(`cancelOnExit=${String(c.cancelOnExit)} json=${c.json} stdinIsTty=${c.stdinIsTty} → ${c.expected} (${c.why})`, () => {
+      expect(
+        resolveSignalPolicy({
+          cancelOnExit: c.cancelOnExit,
+          json: c.json,
+          stdinIsTty: c.stdinIsTty,
+        }),
+      ).toBe(c.expected);
+    });
+  }
+
+  it("covers every input combination", () => {
+    // Guards the table above against silently losing a row in a future
+    // edit: 3 cancelOnExit states × 2 json × 2 stdinIsTty = 12.
+    expect(cases).toHaveLength(12);
+    const keys = new Set(cases.map((c) => `${String(c.cancelOnExit)}|${c.json}|${c.stdinIsTty}`));
+    expect(keys.size).toBe(12);
+  });
+});
+
+describe("--cancel-on-exit commander tri-state", () => {
+  /**
+   * Mirrors the option pair declared on the `run` command in
+   * `src/cli.ts`. `cli.ts` parses `process.argv` at import time, so it
+   * cannot be loaded from a test — the declaration is restated here and
+   * this test is what proves the shape actually yields three states
+   * (commander only leaves the key unset when BOTH the positive flag and
+   * its `--no-` negation are declared).
+   */
+  function parse(argv: string[]): { cancelOnExit?: unknown } {
+    const program = new Command();
+    program.exitOverride();
+    const run = program
+      .command("run")
+      .argument("<bundle>")
+      .option("--cancel-on-exit", "cancel the platform-side run on a signal")
+      .option("--no-cancel-on-exit", "detach instead of cancelling")
+      .action(() => {});
+    program.parse(["node", "appstrate", "run", "@scope/agent", ...argv]);
+    return run.opts();
+  }
+
+  it("leaves the option undefined when neither flag is passed", () => {
+    expect(parse([]).cancelOnExit).toBeUndefined();
+  });
+
+  it("sets true for --cancel-on-exit", () => {
+    expect(parse(["--cancel-on-exit"]).cancelOnExit).toBe(true);
+  });
+
+  it("sets false for --no-cancel-on-exit", () => {
+    expect(parse(["--no-cancel-on-exit"]).cancelOnExit).toBe(false);
+  });
+
+  it("maps each parsed state to the right policy in a non-interactive shell", () => {
+    // End-to-end shape of the wiring in cli.ts → runCommandRemote: a CI
+    // step (no TTY, no --json) detaches by default and can still force a
+    // cancel with the explicit flag.
+    const asOpt = (raw: unknown): boolean | undefined =>
+      typeof raw === "boolean" ? raw : undefined;
+    const policy = (argv: string[]): SignalPolicy =>
+      resolveSignalPolicy({
+        cancelOnExit: asOpt(parse(argv).cancelOnExit),
+        json: false,
+        stdinIsTty: false,
+      });
+    expect(policy([])).toBe("detach");
+    expect(policy(["--cancel-on-exit"])).toBe("cancel");
+    expect(policy(["--no-cancel-on-exit"])).toBe("detach");
+  });
+});

--- a/apps/cli/test/shutdown.test.ts
+++ b/apps/cli/test/shutdown.test.ts
@@ -139,6 +139,33 @@ describe("ShutdownCoordinator", () => {
     expect(lateCalled).toBe(false);
   });
 
+  it("exposes the exit code chosen by trigger, per signal", async () => {
+    // Subcommands keep a `process.exit` backstop on the signal path and
+    // read this instead of hardcoding 130 — a CLI killed by SIGTERM must
+    // report 143 and by SIGHUP 129, which is what scripted callers (CI
+    // wrappers, supervisors) branch on.
+    for (const [signal, code] of [
+      ["SIGINT", 130],
+      ["SIGTERM", 143],
+      ["SIGHUP", 129],
+    ] as const) {
+      const { coordinator, exitCodes } = makeCoordinator();
+      await coordinator.trigger(signal, code);
+      expect(coordinator.exitCode).toBe(code);
+      expect(exitCodes()).toEqual([code]);
+    }
+  });
+
+  it("defaults the exit code to 130 before any trigger", async () => {
+    // An abort that did not come from a signal has no code of its own;
+    // the historical SIGINT value is the safe answer for a backstop
+    // reading the accessor.
+    const { coordinator } = makeCoordinator();
+    expect(coordinator.exitCode).toBe(130);
+    await coordinator.trigger("SIGHUP", 129);
+    expect(coordinator.exitCode).toBe(129);
+  });
+
   it("hook receives an aborted signal — hooks can branch on shutdown reason", async () => {
     // Hooks that need to know whether they're being called from a
     // signal vs a normal completion path can read `coordinator.signal`.


### PR DESCRIPTION
Fixes #1020.

## The bug

`appstrate run @scope/agent --remote` triggers a run **on the platform** and tails it by polling. The remote runner POSTed `/api/runs/:id/cancel` on *every* abort, and the shutdown coordinator raises that abort for `SIGINT`, `SIGTERM` and `SIGHUP` alike.

Any scripted caller therefore killed a healthy, already-paid-for run: a CI step timing out its wrapper, a supervisor recycling a worker, a harness reaping a background shell. `POST /api/runs/:id/cancel` is a real cancel server-side (`abortRun` → `stopWorkloadAndWait` → `synthesiseFinalize`), so the run ended `cancelled`, full cost booked, deliverable gone — worst at the end of a run, which is exactly where the value is.

The lifetime semantics were also asymmetric: closing a dashboard tab does not cancel a run, closing the CLI did, on the same execution path.

## What changed

### 1. A signal now resolves to a policy, not a reflex (`apps/cli`)

New `run/signal-policy.ts`:

| condition | policy |
| --- | --- |
| `--cancel-on-exit` | cancel |
| `--no-cancel-on-exit` | detach |
| `--json` | detach |
| stdin is not a TTY | detach |
| otherwise | **cancel** (interactive Ctrl-C — unchanged) |

**stdin**, not stdout, is the TTY probe: a Ctrl-C can only be delivered by a controlling terminal, and probing stdout would flip the default for the very common interactive `appstrate run … | tee log.txt`.

On detach the runner issues no cancel, stops tailing, and says where the run went:

```
detached — run run_9c1e4f2a is still running on https://app.example.com
  follow it with: appstrate api GET /api/runs/run_9c1e4f2a
```

(or one `{"type":"appstrate.remote.detached", …}` JSONL envelope under `--json`). It deliberately skips `finalize`, the synthesized metric line and the `--output` write — the run has no terminal state, and fabricating one is worse than omitting it. `runRemote` now returns a `terminal | detached` discriminated union so no caller can read a status the run never reached.

`--cancel-on-exit` / `--no-cancel-on-exit` are remote-only: passing either on a local run is an error, not a silent no-op.

### 2. Exit codes on the signal path

Both backstops in `run.ts` hardcoded `130`, so a CLI killed by SIGTERM reported SIGINT's code. They now read the coordinator's resolved code — 130 / 143 / 129. Scripted callers, the audience of this issue, branch on those.

### 3. An already-emitted `output` is no longer dropped (`apps/api`)

Independent of the signal semantics, and the third ask on the issue.

`output` is persisted the moment it is emitted, as a `run_logs` row. `runs.result` is written only at finalize, from the RunResult the runner posts. So on **every** path where the runner never posts its own finalize — cancel, timeout, non-zero exit, stall watchdog, boot orphan sweep — the platform synthesised an `emptyRunResult()` and the run ended with `runs.result = null`, even when the agent had already delivered a valid payload.

`applyRecoveredOutput` reads the highest-id `result`/`output` row and attaches it before the finalize. Two invariants, both pinned by tests:

- **RECOVER, NEVER FABRICATE** — only an actually persisted plain-record payload is attached. No row, or a row whose `data` is null, leaves `result.output` null. An agent that never called `output` produces exactly the result it produces today.
- **FILL IN, NEVER OVERWRITE** — a runner-supplied `output` is authoritative and returns early, before the read.

The terminal status is never touched. The one behaviour change beyond the payload is the defensive synthesised `success` in `execute-background.ts`: an agent that emitted a valid payload against a declared `output.schema` now stays `success` instead of being failed for "finished without calling the required `output` tool", and a non-conforming payload now reports the real validation error instead of that misleading wording. Both are pinned.

In the stall watchdog the read sits after `stopWorkloadAndWait` — a stalled runner is not necessarily a dead one, so reading before the stop could miss an `output` emitted during the stop window.

### 4. Docs

The README described `appstrate run` as executing "locally" in two places and documented only the bundle-download path, which is reachable only under `--local`. Corrected, plus a "Remote runs and process lifetime" section — the documentation half of the issue.

## Testing

- `bun test apps/cli/test` — **1287 pass / 0 fail**. New `run-signal-policy.test.ts` (precedence table + a commander tri-state proof); `run-remote-runner.test.ts` gains the detach cases (no cancel POST, notice on stderr, no output file, no finalize line, exactly one JSONL envelope, detach-before-first-poll) and tightens the cancel regression to *exactly one* cancel POST; `shutdown.test.ts` covers the per-signal exit codes; `run-mode.test.ts` covers the local-mode rejection.
- API regression subset (recovery, cancel convergence, events ingestion, watchdog, CAS, usage settlement) — **106 pass / 0 fail**. New `runs-output-recovery.test.ts` drives the real `POST /api/runs/:id/cancel` and the real signed event-ingestion endpoint.
- `bun run check` — **33/33 tasks green**.

## Compatibility

Interactive behaviour is unchanged: Ctrl-C at a terminal still cancels. Non-interactive callers stop losing runs. Anyone who *wants* the old behaviour in CI passes `--cancel-on-exit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)