### PR TITLE
docs(release): write down the core release policy; stop naming retired repos

### DIFF
--- a/.claude/commands/audit-casing.md
+++ b/.claude/commands/audit-casing.md
@@ -48,7 +48,7 @@ When invoked, this skill:
    - **Agent C — Drizzle TS schema**: every `pgTable()` in `packages/db/src/schema/*.ts` + module schemas. Confirms TS field property names are camelCase, SQL aliases are snake_case.
    - **Agent D — Frontend consumers**: `apps/web/src/` reads of wire DTOs. Confirms no camelCase reads on snake_case fields (would return undefined at runtime).
    - **Agent E — Carve-outs**: Better Auth tables, OIDC plugin tables, ModelProviderDefinition, profile reads, module hook contracts, CloudEvents, Webhooks, BullMQ, audit logs, SSE transform, JSONB internals.
-   - **Agent F — Cross-repo + tests**: cloud, docs, website, module-claude-code, connect-helper, afps-spec + test fixtures + e2e helpers. Confirms no drift introduced by parallel work.
+   - **Agent F — Cross-repo + tests**: cloud, docs, website, connect-helper, afps-spec + test fixtures + e2e helpers. Confirms no drift introduced by parallel work.
 
 Each sub-agent produces a structured report classified by severity:
 
@@ -115,7 +115,7 @@ The sub-agents are **read-only**. They never modify files. After consolidation, 
 - **Every** Drizzle pgTable in `packages/db/src/schema/` is read
 - **Every** OpenAPI component in `apps/api/src/openapi/` is verified
 - **Every** module under `apps/api/src/modules/` is included
-- Cross-repo: cloud, docs, website, module-claude-code, connect-helper, afps-spec (skip `_dev/`)
+- Cross-repo: cloud, docs, website, connect-helper, afps-spec (skip `_dev/`)
 
 ### Performance
 
@@ -271,7 +271,7 @@ For each carve-out:
 4b. Universal DB convention fields: stay camelCase EVERYWHERE (wire + Drizzle + frontend) — verify
 4c. Profile/Member reads: camelCase displayName — verify no profile.display_name violations
 4d. Module hook contracts (module.ts): camelCase interfaces — verify
-4e. ModelProviderDefinition: camelCase — verify in core-providers, module-claude-code, module-codex
+4e. ModelProviderDefinition: camelCase — verify in the in-tree `apps/api/src/modules/core-providers`, `packages/module-claude-code`, `packages/module-codex`
 4f. Connect-helper internal types: camelCase — verify
 4g. JSONB contracts — SPLIT by exposure (this carve-out ONLY covers JSONB that never crosses the wire verbatim):
     - Internal-only JSONB → producer-defined casing OK: token_usage interior snake_case, runs.metadata.creditsUsed camelCase — verify
@@ -291,7 +291,9 @@ Output: per-carve-out ✅/🔴 verdict + any violation found.
 ```
 Mission: verify cross-repo coherence (skip _dev/) + test fixtures.
 
-Repos: cloud, docs, website, module-claude-code, connect-helper, afps-spec
+Repos: cloud, docs, website, connect-helper, afps-spec
+
+Not in this list, and do not add them back: `module-claude-code` (PR #460 moved it in-tree as `packages/module-claude-code` — already covered by the in-tree `packages/` scope), `registry` and `portal` (retired products, same reason they left the core lockstep gate in #1033).
 
 For each:
 - Grep for any 1.x manifest residue (displayName, schemaVersion, fileConstraints, etc.)

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -1,5 +1,35 @@
 name: Publish @appstrate/core to npm
 
+# ── RELEASE POLICY for @appstrate/core ───────────────────────────────────────
+# Cadence, not numbering, is what costs consumers. Core shipped four majors in
+# nineteen days — 3.0.0 (2026-07-08), 4.0.0 (07-23), 5.0.0 (07-25), 6.0.0
+# (07-27) — and each one forced a lockstep cycle on every consumer. 6.0.0 is
+# the shape to copy: it grouped every contract change accumulated after 5.0.0
+# into ONE coordinated break.
+#
+# 1. BATCH. Breaking changes accumulate under `[Unreleased]` in
+#    packages/core/CHANGELOG.md until a deliberate major. One major per batch,
+#    not one per break. Why "this break is small, ship it now" is never the
+#    reason to skip the batch: out-of-tree modules import a WIDE surface. The
+#    in-tree modules — the only proxy we can measure — reach for 22 distinct
+#    `@appstrate/core/*` subpaths out of 48 exported (top: errors, module,
+#    permissions, platform-types, chat-turn-metadata, chat-contract). Nearly
+#    half the package faces module authors, and this repo cannot see who
+#    imports what.
+# 2. DECOUPLE FROM THE PLATFORM TRAIN. Publish core when a consumer or an
+#    out-of-tree module author needs the change — not on every platform
+#    release. Core's version is not the platform's.
+# 3. DELETING AN EXPORT WITH NO IMPORTER IS STILL TECHNICALLY BREAKING, but it
+#    does not have to TRIGGER a major — it rides in the next batch. And per (1),
+#    "no importer" only ever means none this repo can see.
+#
+# Batching is a deliberate choice about consumer cost, not a workaround for a
+# broken release path: executing a major is cheap since #1032 removed the
+# structural deadlock (an `X.0.0` release tolerates a consumer exactly one
+# major behind — see the release-ordering blockquote in
+# packages/core/CHANGELOG.md).
+# ─────────────────────────────────────────────────────────────────────────────
+
 on:
   push:
     tags:

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -8,7 +8,7 @@ Appstrate is an open-source platform for running autonomous AI agents in sandbox
 
 Appstrate follows a **corporate-backed open-source model** (similar to Supabase). The Appstrate team retains final authority over the project roadmap, architecture, and releases. Community input is welcomed and encouraged through GitHub Issues, Discussions, and the RFC process described below.
 
-The core platform is licensed under [Apache 2.0](./LICENSE). Commercial extensions (cloud billing, registry) are maintained separately in private repositories.
+The core platform is licensed under [Apache 2.0](./LICENSE). Commercial extensions (cloud billing) are maintained separately in private repositories.
 
 ## Roles
 


### PR DESCRIPTION
Two documentation changes, both consequences of this week's core 6.0.0 release chain.

## 1. The release policy now lives in the workflow that runs it

Core shipped **four majors in nineteen days** — verified against npm publish times:

| | |
| --- | --- |
| 3.0.0 | 2026-07-08 |
| 4.0.0 | 2026-07-23 |
| 5.0.0 | 2026-07-25 |
| 6.0.0 | 2026-07-27 |

Each one forced a lockstep cycle on every consumer. The cadence was the cost, not the numbering — and 6.0.0 already demonstrated the fix in its own changelog intro ("grouping every contract change accumulated after 5.0.0 into ONE coordinated break"). That practice was nowhere written as a rule.

**Why the workflow header and not a doc**: the same guidance previously lived in `packages/core/CHANGELOG.md` and went stale twice in three days — most recently telling the reader to bump consumers *before* tagging, advice #1032 had already inverted. A changelog entry for a released version is append-only by convention and never re-read for correctness. This file is what runs when someone pushes a `core@X` tag, and anyone editing the gate has it open.

The policy records the fact that makes batching non-obvious, because it argues against the tempting shortcut:

> out-of-tree modules import a WIDE surface. The in-tree modules — the only proxy we can measure — reach for **22 distinct `@appstrate/core/*` subpaths out of 48 exported** (top: `errors`, `module`, `permissions`, `platform-types`, `chat-turn-metadata`, `chat-contract`). Nearly half the package faces module authors, and this repo cannot see who imports what.

So "nothing imports this, it's not really breaking" is never safe. That reasoning is sound for `cloud` and `connect-helper`, whose imports we *can* read — and wrong the moment a third party exists.

Placed after `name:`, matching `publish-cli.yml` and `publish-afps-shared.yml`.

## 2. Two docs still name retired repos as live

**`.claude/commands/audit-casing.md`** dispatched an agent across `module-claude-code`. That standalone repo died on 2026-05-14 when #460 moved the module in-tree.

The distinction matters and is easy to get wrong: the **in-tree `packages/module-claude-code` is alive** and legitimately an audit target — it is already covered by the exhaustivity clause's `packages/` scope. So only the cross-repo entry goes. Carve-out 4e, which verifies `ModelProviderDefinition` casing, **keeps** it, rewritten to unambiguous in-tree paths (`apps/api/src/modules/core-providers`, `packages/module-claude-code`, `packages/module-codex`) so the bare name cannot be read as the dead repo. The dispatch prompt now names the absent repos and why — the failure mode here is someone helpfully adding them back.

Agent count stays at 6: Agent F still owns five repos plus all test fixtures, so nothing became a stub. No coverage was lost.

**`GOVERNANCE.md`** listed registry alongside cloud billing as a commercial extension. Registry is retired. The sentence draws the open-core boundary rather than enumerating a product catalogue, so cloud billing carries it alone — one word removed. No "registry was retired" aside: that is internal detail with no place in a public governance document.

## Verified rather than assumed

Every figure in the header was checked against the source before being written — npm publish times, the tag dates, the 48 `exports` keys, the 22 imported subpaths, and the 6.0.0 changelog quote (verbatim match). A sweep of `GOVERNANCE.md`, `CONTRIBUTING.md`, `MAINTAINERS.md`, `SECURITY.md` and `README.md` found two remaining hits for "registry"/"portal", both **kept** — the `@appstrate/emails` template registry and the hosted **connect portal** (a live feature backed by `CONNECT_SESSION_SECRET`). Purely lexical collisions with the retired products.

## Found and deliberately not fixed

`packages/core/CHANGELOG.md`'s heading dates drift from the real publish dates — `## [4.0.0] — 2026-07-21` (published 07-23) and `## [6.0.0] — 2026-07-26` (published 07-27). Historical record; correcting it is a separate call. The new header carries the npm dates independently, so nothing here depends on those headings.

## Verification

```
$ bunx prettier --check <touched files>        clean
$ actionlint -ignore 'SC2129' .github/workflows/*.yml   exit=0   # what CI runs
```

Comment-only change to the workflow — gate logic, the precondition step and the `CHANGELOG.md` release-ordering blockquote are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)