### PR TITLE
fix(afps-runtime): surface the workspace tmpfs cap in the agent prompt (#1019)

### DIFF
--- a/apps/api/src/services/run-launcher/prompt-builder.ts
+++ b/apps/api/src/services/run-launcher/prompt-builder.ts
@@ -10,12 +10,12 @@
  *
  *   - `platformName`: `"Appstrate"`
  *   - `uploads`: DB-stored files with platform-sanitised paths
+ *   - `workspaceTmpfsSizeMb`: the operator's workspace cap, when the
+ *     backend actually mounts one (see `promptWorkspaceTmpfsSizeMb`)
  *
  * Every other field flows straight from the bundle — the same code
- * path used by the `appstrate run` CLI. Divergence between platform
- * and CLI is now strictly the two overrides above. Outbound API access
- * is surfaced via integration MCP tools (`{ns}__api_call`), not the
- * prompt.
+ * path used by the `appstrate run` CLI. Outbound API access is surfaced
+ * via integration MCP tools (`{ns}__api_call`), not the prompt.
  *
  * Run history is NOT rendered in the prompt: the runtime wires a
  * typed `run_history` tool (see runtime-pi/entrypoint.ts Phase D) whose
@@ -30,7 +30,23 @@ import {
   renderPlatformPrompt,
   type PlatformPromptIntegration,
 } from "@appstrate/afps-runtime/bundle";
+import { getEnv } from "@appstrate/env";
+import { getExecutionMode } from "../../infra/mode.ts";
 import { fetchIntegrationPromptDocs } from "../integration-service.ts";
+
+/**
+ * Workspace tmpfs cap (MB) to state in the prompt, or 0 to stay silent.
+ *
+ * `WORKSPACE_TMPFS_SIZE_MB` configures a real mount only on the docker
+ * backend (docker-orchestrator.ts, `createIsolationBoundary`). The
+ * process backend gives the run a plain directory under `os.tmpdir()`
+ * without applying this setting, and a module-contributed backend's
+ * workspace is opaque to core. Fail closed on anything but docker:
+ * stating a cap that the selected backend does not use would be misleading.
+ */
+function promptWorkspaceTmpfsSizeMb(): number {
+  return getExecutionMode() === "docker" ? getEnv().WORKSPACE_TMPFS_SIZE_MB : 0;
+}
 
 export async function buildPlatformSystemPrompt(
   context: ExecutionContext,
@@ -65,6 +81,9 @@ export async function buildPlatformSystemPrompt(
   const inputs = buildPlatformPromptInputs(plan.bundle, context, {
     platformName: "Appstrate",
     timeoutSeconds: plan.timeout,
+    // The runtime knows the workspace is capped; without this the agent
+    // does not, and a dependency install dies with ENOSPC mid-run (#1019).
+    workspaceTmpfsSizeMb: promptWorkspaceTmpfsSizeMb(),
     // Deliverables convention (Phase 2): files the agent writes under
     // `./outputs/` are swept and published as durable run documents at
     // finalize. Rendered as a platform-managed section BEFORE the raw prompt

--- a/apps/api/test/unit/prompt-builder.test.ts
+++ b/apps/api/test/unit/prompt-builder.test.ts
@@ -9,6 +9,7 @@ import type {
 } from "../../src/services/run-launcher/types.ts";
 import type { ExecutionContext } from "@appstrate/afps-runtime/types";
 import type { Bundle, BundlePackage, PackageIdentity } from "@appstrate/afps-runtime/bundle";
+import { _resetCacheForTesting } from "@appstrate/env";
 
 interface TestSchemas {
   input?: import("@appstrate/core/form").JSONSchemaObject;
@@ -226,6 +227,51 @@ describe("buildEnrichedPrompt — core structure", () => {
     const ctx = baseContext({ timeout: undefined });
     const prompt = await buildEnrichedPrompt(ctx);
     expect(prompt).not.toContain("**Timeout**");
+  });
+});
+
+// ─── Workspace disk cap (issue #1019) ──────────────────────
+
+describe("buildEnrichedPrompt — workspace disk cap", () => {
+  /** Render a prompt under a given backend + tmpfs cap, then restore the env. */
+  async function promptWithEnv(adapter: string, tmpfsMb?: string): Promise<string> {
+    const prevAdapter = process.env.RUN_ADAPTER;
+    const prevTmpfs = process.env.WORKSPACE_TMPFS_SIZE_MB;
+    process.env.RUN_ADAPTER = adapter;
+    if (tmpfsMb === undefined) delete process.env.WORKSPACE_TMPFS_SIZE_MB;
+    else process.env.WORKSPACE_TMPFS_SIZE_MB = tmpfsMb;
+    _resetCacheForTesting();
+    try {
+      return await buildEnrichedPrompt(baseContext());
+    } finally {
+      if (prevAdapter === undefined) delete process.env.RUN_ADAPTER;
+      else process.env.RUN_ADAPTER = prevAdapter;
+      if (prevTmpfs === undefined) delete process.env.WORKSPACE_TMPFS_SIZE_MB;
+      else process.env.WORKSPACE_TMPFS_SIZE_MB = prevTmpfs;
+      _resetCacheForTesting();
+    }
+  }
+
+  it("states the cap and points bulky work at /tmp on the docker backend", async () => {
+    // The docker backend mounts the workspace as tmpfs, so an agent that
+    // installs dependencies into it dies with ENOSPC unless the prompt says so.
+    const prompt = await promptWithEnv("docker");
+    expect(prompt).toContain("**Disk**: the workspace is a RAM-backed tmpfs capped at 512 MB");
+    expect(prompt).toContain("`/tmp`");
+  });
+
+  it("interpolates the operator's WORKSPACE_TMPFS_SIZE_MB, not a hardcoded default", async () => {
+    const prompt = await promptWithEnv("docker", "2048");
+    expect(prompt).toContain("capped at 2048 MB");
+    expect(prompt).not.toContain("512 MB");
+  });
+
+  it("stays silent when the docker workspace cap does not apply", async () => {
+    // WORKSPACE_TMPFS_SIZE_MB=0 disables the tmpfs even under docker; the
+    // process and Firecracker backends do not apply this docker mount setting.
+    expect(await promptWithEnv("docker", "0")).not.toContain("**Disk**");
+    expect(await promptWithEnv("process")).not.toContain("**Disk**");
+    expect(await promptWithEnv("firecracker")).not.toContain("**Disk**");
   });
 });
 

--- a/packages/afps-runtime/src/bundle/platform-prompt.ts
+++ b/packages/afps-runtime/src/bundle/platform-prompt.ts
@@ -64,6 +64,14 @@ export interface PlatformPromptOptions {
   platformName?: string;
   /** Run timeout in seconds — surfaced in the `## System` section. */
   timeoutSeconds?: number;
+  /**
+   * Size cap (MB) of the RAM-backed workspace, when the runner backs it
+   * with a tmpfs. Surfaced as the `- **Disk**` bullet so the agent keeps
+   * bulky scratch work (dependency installs, clones) off the capped
+   * mount. Omit (or pass 0) on backends whose workspace is disk-backed —
+   * the bullet then renders nothing rather than stating a wrong limit.
+   */
+  workspaceTmpfsSizeMb?: number;
 
   /**
    * Bundled skills catalogue. Skills are workspace file references, not
@@ -171,8 +179,21 @@ export function renderPlatformPrompt(opts: PlatformPromptOptions): string {
       (hasUploads
         ? "Input documents are available under `./documents/` (relative to cwd) and listed in the `## Documents` section below. "
         : "") +
-      "You may use the filesystem for temporary processing during this run only.\n",
+      "You may use the filesystem for temporary processing during this run only.",
   );
+  // Disk bullet (#1019). The workspace bullet above invites filesystem use;
+  // without the cap next to it, any agent running a real dependency install
+  // dies with ENOSPC mid-run and takes every planned verification step down
+  // with it. Rendered only when the caller knows the workspace is tmpfs-backed
+  // (see `workspaceTmpfsSizeMb`) — keep bulky scratch work outside that cap.
+  if (opts.workspaceTmpfsSizeMb) {
+    sections.push(
+      `- **Disk**: the workspace is a RAM-backed tmpfs capped at ${opts.workspaceTmpfsSizeMb} MB. ` +
+        "Keep dependency installs, clones and other bulky scratch work under `/tmp`, " +
+        "outside this workspace cap. Write user deliverables under `./outputs/`.",
+    );
+  }
+  sections.push("");
 
   // --- Communication contract ---
   // The platform parses ONLY the typed events your tools emit. Plain

--- a/packages/afps-runtime/test/bundle/platform-prompt.test.ts
+++ b/packages/afps-runtime/test/bundle/platform-prompt.test.ts
@@ -96,6 +96,43 @@ describe("renderPlatformPrompt", () => {
     expect(out).not.toContain("**Timeout**");
   });
 
+  it("surfaces the workspace tmpfs cap and points bulky work at /tmp (#1019)", () => {
+    const out = renderPlatformPrompt({
+      template: "T",
+      context: ctx(),
+      workspaceTmpfsSizeMb: 512,
+    });
+    const diskLine = out.split("\n").find((line) => line.startsWith("- **Disk**"));
+    expect(diskLine).toBe(
+      "- **Disk**: the workspace is a RAM-backed tmpfs capped at 512 MB. " +
+        "Keep dependency installs, clones and other bulky scratch work under `/tmp`, " +
+        "outside this workspace cap. Write user deliverables under `./outputs/`.",
+    );
+  });
+
+  it("interpolates the operator's actual cap rather than a hardcoded default (#1019)", () => {
+    const out = renderPlatformPrompt({
+      template: "T",
+      context: ctx(),
+      workspaceTmpfsSizeMb: 2048,
+    });
+    expect(out).toContain("capped at 2048 MB");
+    expect(out).not.toContain("512 MB");
+  });
+
+  it("omits the disk line when the workspace is not tmpfs-backed (#1019)", () => {
+    // Absent option (unknown backing) and an explicit 0 (disk-backed volume)
+    // must both stay silent — a wrong cap is worse than no cap.
+    const withoutCap = renderPlatformPrompt({ template: "T", context: ctx() });
+    const withZeroCap = renderPlatformPrompt({
+      template: "T",
+      context: ctx(),
+      workspaceTmpfsSizeMb: 0,
+    });
+    expect(withoutCap).not.toContain("**Disk**");
+    expect(withZeroCap).toBe(withoutCap);
+  });
+
   it("lists skills (tools come from MCP tools/list, never the prompt)", () => {
     const out = renderPlatformPrompt({
       template: "T",


### PR DESCRIPTION
Closes #1019

## Verdict

Issue revalidée le 30 juillet 2026 contre `main` `dce2de348` et sur Appstrate Cloud :

- Cloud exécute `RUN_ADAPTER=docker`;
- `WORKSPACE_TMPFS_SIZE_MB` n'y est pas surchargé, donc le défaut 512 MB s'applique;
- Docker monte toujours `/workspace` en tmpfs avec cette limite;
- le prompt de production ne publiait ni le backing ni le plafond.

#558 a corrigé la livraison du bundle entre conteneurs, pas la capacité du scratch agent. L'upstream
Pi ne peut pas corriger cette omission : Appstrate fournit le `systemPrompt` complet et connaît seul
`WORKSPACE_TMPFS_SIZE_MB`.

## Correctif

Deux commits atomiques, rebased sur le `main` courant :

1. `b7d7c9c7d` — ajoute l'option runtime facultative `workspaceTmpfsSizeMb` et rend un bullet
   `- **Disk**` après `- **Workspace**`.
2. `2bad634fb` — câble la valeur validée depuis la plateforme uniquement sous
   `RUN_ADAPTER=docker`.

Le prompt indique le plafond réel, place les gros installs/clones/scratch sous `/tmp` — hors de ce
plafond — et conserve `./outputs/` pour les livrables utilisateur.

La gate est fail-closed :

- Docker + cap positif : bullet rendu avec la valeur réelle;
- Docker + cap `0` : aucun bullet;
- `process`, Firecracker et backends contribués : aucun bullet, car ce réglage Docker ne décrit pas
  leur stockage.

Une capability générique d'orchestrateur serait prématurée : aucun second backend ne partage
aujourd'hui la sémantique « workspace plafonné + scratch séparé ». Les logs `df`, alertes à 80 %,
tuning de ressources et caches restent hors périmètre.

## Vérification

- `TEST_TIER=0 bun test packages/afps-runtime/test/bundle/platform-prompt.test.ts apps/api/test/unit/prompt-builder.test.ts`
  — **90 pass, 0 fail**
- typechecks complets `@appstrate/afps-runtime` et `@appstrate/api` — **pass**
- ESLint et Prettier ciblés — **pass**
- commitlint sur les deux commits — **pass**
- `bun run check` via le hook pre-push — **33/33 tâches pass**
- `git diff --check` — **pass**
- revue finale indépendante Standards — **GO, 0 finding**
- revue finale indépendante Spec — **GO, 0 finding**

Le lint conserve un warning Fast Refresh préexistant et hors périmètre dans
`packages/module-chat/src/ui/document-attachment.tsx`; aucune erreur.

Le cycle de vie Docker n'est pas modifié par cette PR : les tests verrouillent le renderer et le
câblage du prompt de production, pas le montage tmpfs préexistant.
