### PR TITLE
ci(cli): publish via OIDC trusted publishing instead of a token

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -53,7 +53,22 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
-          registry-url: "https://registry.npmjs.org"
+          # NO `registry-url`. It makes setup-node write
+          # `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into ~/.npmrc,
+          # and npm then tries to authenticate with that value instead of
+          # falling back to OIDC. With NODE_AUTH_TOKEN unset the line resolves
+          # to an EMPTY token, which is worse than no line at all: npm sends it
+          # and the publish fails as unauthenticated rather than exchanging its
+          # OIDC id-token. registry.npmjs.org is already the default registry,
+          # so nothing is lost by dropping the input.
+
+      # Trusted publishing requires npm >= 11.5.1; Node 22 ships npm 10.x.
+      # Without this the publish fails with a confusing auth error rather
+      # than a version complaint.
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       - name: Install dependencies
         run: bun install
@@ -112,9 +127,23 @@ jobs:
 
       - name: Publish to npm
         # Unscoped packages are public by default — no `--access public` needed.
+        #
+        # Authentication is OIDC trusted publishing, NOT a token. `appstrate`
+        # is an unscoped package, so it is owned by a personal account (npm
+        # only lets organizations own scoped packages), and that account runs
+        # 2FA in `auth-and-writes` mode — under which npm refuses every
+        # token-based write with `403 You may not perform that action with
+        # these credentials`. Granular and automation tokens both hit it; the
+        # package sat stuck on 1.0.0-beta.14 from 2026-05-16 for that reason.
+        # `@appstrate/core` is unaffected because it is org-owned, which is why
+        # the same NPM_TOKEN kept publishing core throughout.
+        #
+        # OIDC sidesteps 2FA by design: the identity is the workflow, not a
+        # person. It requires `id-token: write` (declared above) and a Trusted
+        # Publisher registered on npmjs.com for this package, pinned to THIS
+        # workflow filename — renaming this file breaks publishing until the
+        # npm-side configuration is updated to match.
         run: npm publish --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Post-publish smoke test (registry → bunx)
         # Belt-and-suspenders check: pull from the actual registry and


### PR DESCRIPTION
## Why

The npm package `appstrate` has been stuck on **1.0.0-beta.14 since 2026-05-16** while the platform shipped through beta.46. Every publish since has failed. The cause is not the token.

`appstrate` is **unscoped**, so npm requires it to be owned by a personal account — [organizations may only own scoped packages](https://docs.npmjs.com/package-scope-access-level-and-visibility/). That account runs 2FA in `auth-and-writes` mode, under which npm rejects every token-based write:

```
npm error code E403
npm error 403 Forbidden - PUT https://registry.npmjs.org/appstrate
          - You may not perform that action with these credentials.
```

Confirmed against **both** a granular token and a freshly minted automation token — identical failure, while `npm whoami` returned the correct maintainer each time. `@appstrate/core` kept publishing with the same `NPM_TOKEN` throughout, because it is org-owned and therefore governed by the organization's policy rather than the account's 2FA setting. That asymmetry is the whole explanation.

## What was tried first

Moving the package to the `appstrate` organization would have fixed it. It is not possible:

| Route | Result |
|---|---|
| npmjs.com transfer UI | no such option for unscoped packages |
| `npm owner add appstrate appstrate` | `404 User not found` — the argument resolves as a *username* |
| `npm access grant read-write appstrate:developers appstrate` | `EOTP` — the same 2FA wall |

Unpublishing and republishing was considered and rejected: it would permanently burn all 19 published versions (`Once package@version has been used, you can never use it again`), impose a 24h blackout, break `npx appstrate` in flight — and land back on an unscoped personal package with the identical 403. It is also blocked by the same OTP requirement.

## What this does

OIDC removes the person from the loop: the identity is the workflow, so there is no token and no OTP.

- **Drop `registry-url` from `setup-node`.** It writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into `~/.npmrc`; with the variable unset that resolves to an **empty** token which npm sends anyway, failing as unauthenticated instead of falling back to OIDC. `registry.npmjs.org` is already the default registry, so the input bought nothing.
- **Upgrade npm to >= 11.5.1**, the floor for trusted publishing. Node 22 ships npm 10.x, which fails with a misleading auth error rather than a version complaint.
- **Remove `NODE_AUTH_TOKEN`** from the publish step. `id-token: write` was already declared for provenance.

## Required before this can publish

A **Trusted Publisher** must be registered on npmjs.com for the `appstrate` package:

| Field | Value |
|---|---|
| Organization or user | `appstrate` |
| Repository | `appstrate` |
| Workflow filename | `publish-cli.yml` |
| Allowed actions | `npm publish` |

Selecting the action is mandatory — configurations created after 2026-05-20 have no default.

⚠️ The Trusted Publisher is pinned to **this workflow filename**. Renaming `publish-cli.yml` breaks publishing until the npm-side configuration is updated to match.

## Verification

Not verifiable in CI before merge: the code path only runs on a `cli@*` tag, and it cannot succeed until the npm-side Trusted Publisher exists. After merge, `gh workflow run publish-cli.yml --ref main -f version=1.0.0-beta.46` republishes the burnt tag without needing a new one.

Related: this failure is also why the `main` HEAD commit shows a red check — `cli@1.0.0-beta.46` was tagged on it, so the failed publish renders against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)