### PR TITLE
ci(cli): pass --tag latest, required for prereleases under npm 11

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -143,7 +143,19 @@ jobs:
         # Publisher registered on npmjs.com for this package, pinned to THIS
         # workflow filename — renaming this file breaks publishing until the
         # npm-side configuration is updated to match.
-        run: npm publish --provenance
+        #
+        # `--tag latest` is required, not optional: npm >= 11 refuses to
+        # publish a prerelease version without an explicit `--tag`, where
+        # npm 10 silently assigned `latest`. That silent assignment is how
+        # `latest` came to point at 1.0.0-beta.14, and it is the behaviour
+        # consumers depend on — `npx appstrate` resolves the `latest`
+        # dist-tag, so publishing under `beta` instead would leave every
+        # npm-channel user pinned to beta.14 while the tarball for the new
+        # version sat unreachable. Every release on this line is a
+        # `1.0.0-beta.X`, so `latest` IS the release channel. Revisit only
+        # when a stable line ships alongside prereleases and the two need
+        # separate tags.
+        run: npm publish --provenance --tag latest
 
       - name: Post-publish smoke test (registry → bunx)
         # Belt-and-suspenders check: pull from the actual registry and


### PR DESCRIPTION
## Why

Follow-up to #1047. With OIDC authentication working — no more `403` — the publish reached npm and was rejected on a different rule:

```
npm error You must specify a tag using --tag when publishing a prerelease version.
```

npm >= 11 refuses to assign a dist-tag implicitly to a prerelease. npm 10 assigned `latest` silently, which is how `latest` came to point at `1.0.0-beta.14`. #1047 upgraded npm to >= 11.5.1 for trusted publishing, so this rule now applies.

## Why `latest` and not `beta`

The tag choice is load-bearing. `npx appstrate` resolves the **`latest`** dist-tag. Publishing under `beta` would leave every npm-channel user pinned to `1.0.0-beta.14` while the new tarball sat unreachable behind a tag nobody requests — the exact staleness this whole chain of work is meant to end.

Every release on this line is a `1.0.0-beta.X`, so `latest` *is* the release channel. Current state confirms it:

```json
{ "latest": "1.0.0-beta.14" }
```

Revisit only when a stable line ships alongside prereleases and the two need separate tags.

## Verification

Same limit as #1047: the path only runs on publish. The previous run proved authentication now succeeds, so this is the next failure in sequence rather than a speculative fix — the error message names the missing flag exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)