### PR TITLE
ci(core): publish via OIDC trusted publishing instead of a token

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -64,7 +64,21 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
-          registry-url: "https://registry.npmjs.org"
+          # NO `registry-url`. It makes setup-node write
+          # `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into ~/.npmrc,
+          # and npm then authenticates with that value instead of falling back
+          # to OIDC. With NODE_AUTH_TOKEN unset the line resolves to an EMPTY
+          # token, which npm sends anyway — failing as unauthenticated rather
+          # than exchanging its OIDC id-token. registry.npmjs.org is already
+          # the default registry, so the input bought nothing.
+
+      # Trusted publishing requires npm >= 11.5.1; Node 22 ships npm 10.x.
+      # Without this the publish fails with a confusing auth error rather
+      # than a version complaint.
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@latest
+          npm --version
 
       - name: Install dependencies
         run: bun install
@@ -170,9 +184,28 @@ jobs:
         run: bun scripts/verify-package-resolves.ts packages/core
 
       - name: Publish to npm
+        # Authentication is OIDC trusted publishing, NOT a token — same move as
+        # publish-cli.yml, for a different reason. The CLI HAD to migrate: its
+        # package is unscoped, therefore owned by a personal account whose 2FA
+        # is in `auth-and-writes` mode, and npm refuses every token-based write
+        # under it. `@appstrate/core` never hit that wall because it is
+        # org-owned and governed by the organization's policy instead — token
+        # publishes kept working here throughout. This migrates anyway, so the
+        # publish identity is the workflow rather than a long-lived shared
+        # credential, and so NPM_TOKEN can eventually leave the repository.
+        #
+        # No `--tag`: core versions are stable releases (6.0.0, …), and npm
+        # assigns `latest` to those by default. The CLI needs an explicit
+        # `--tag latest` only because every release on that line is a
+        # `1.0.0-beta.X` prerelease, which npm >= 11 refuses to tag
+        # implicitly. Should core ever publish a prerelease, this step will
+        # fail with that same error — which is the correct outcome: a core
+        # prerelease must NOT silently take over the `latest` dist-tag that
+        # every consumer's `^6.0.0` range resolves against.
+        #
+        # Requires a Trusted Publisher on npmjs.com for @appstrate/core,
+        # pinned to THIS workflow filename.
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1


### PR DESCRIPTION
## Why

Mirrors #1047, **for a different reason** — worth stating plainly so nobody later reads this as a bug fix.

The CLI *had* to migrate: `appstrate` is unscoped, therefore owned by a personal account ([organizations may only own scoped packages](https://docs.npmjs.com/package-scope-access-level-and-visibility/)), and that account's 2FA runs in `auth-and-writes` mode — under which npm refuses every token-based write with a `403`. `@appstrate/core` **never hit that wall**: it is org-owned and governed by the organization's policy, which is exactly why the same `NPM_TOKEN` kept publishing core while the CLI was stuck for two months.

So this is hardening applied deliberately, not a repair. The publish identity becomes the workflow rather than a long-lived credential shared across three publish workflows, and `NPM_TOKEN` can eventually leave the repository once `publish-afps-shared.yml` follows.

## Changes

- **Drop `registry-url` from `setup-node`.** It writes `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` into `~/.npmrc`; with the variable unset that resolves to an **empty** token which npm sends anyway, failing as unauthenticated instead of falling back to OIDC.
- **Upgrade npm to >= 11.5.1**, the floor for trusted publishing (Node 22 ships npm 10.x).
- **Remove `NODE_AUTH_TOKEN`** from the publish step. `id-token: write` was already declared.

## Deliberately NOT carried over from #1048

The `--tag latest` flag. Core versions are **stable** releases (`6.0.0`, …) and npm assigns `latest` to those by default. The CLI needs the explicit flag only because every release on that line is a `1.0.0-beta.X` prerelease, which npm >= 11 refuses to tag implicitly.

If core ever publishes a prerelease, this step will fail with that same error — and that is the **correct** outcome. A core prerelease must not silently take over the `latest` dist-tag that every consumer's `^6.0.0` range resolves against.

## Required before the next core release

A Trusted Publisher on npmjs.com for `@appstrate/core`:

| Field | Value |
|---|---|
| Organization or user | `appstrate` |
| Repository | `appstrate` |
| Workflow filename | `publish-core.yml` |
| Allowed actions | `npm publish` |

⚠️ Pinned to **this workflow filename** — renaming `publish-core.yml` breaks publishing until the npm-side configuration is updated.

## Verification

Not verifiable before merge: the path only runs on a `core@*` tag. Unlike #1047 there is no currently-broken publish to prove it against, so the first real verification is the next core release — likely `6.1.0`, which is already due since `packages/core/src` has drifted from the published 6.0.0 by 191 additive lines.

## Follow-up

`publish-afps-shared.yml` is the third and last `NPM_TOKEN` consumer. Migrating it lets the secret be deleted outright. Not included here because each package needs its own npm-side Trusted Publisher configured first, and migrating a workflow ahead of that configuration breaks its publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)