### PR TITLE
chore(core): bump to 6.1.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -252,7 +252,7 @@
     },
     "packages/core": {
       "name": "@appstrate/core",
-      "version": "6.0.0",
+      "version": "6.1.0",
       "dependencies": {
         "@afps-spec/schema": "^0.6.1",
         "@appstrate/afps-shared": "^0.3.1",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,6 +7,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.0] — 2026-07-29
+
+Additive release. It exists because `packages/core/src` had drifted from the
+published `6.0.0` by 191 lines while carrying the same version number — npm and
+the in-tree source were no longer the same code under the same label, which is
+invisible to anyone consuming core from the registry.
+
+### Added
+
+- **`findRetiredDependencyKeys()`**, plus the `RetiredDependencyKey` and
+  `RetiredDependencyKeyUse` types (`@appstrate/core/dependencies`). Lists the
+  AFPS 1.x `dependencies` keys that AFPS 2.0 retired, each paired with its
+  replacement: `tools` → `mcp_servers`, `providers` → `integrations`. Pure and
+  non-mutating — it reports what it found and decides nothing, so callers apply
+  the direction-dependent policy themselves (reject on author input, warn and
+  never rewrite on already-persisted manifests).
+- **`totalTokens()`** (`@appstrate/core/token-usage`). Sums a `TokenUsage`
+  across all four counters, cache creation and cache read included. Summing
+  only `input_tokens + output_tokens` under-reports every cached turn.
+- **`LlmUsageLedgerRow.pricingStatus`** (`@appstrate/core/module`), optional,
+  `"priced" | "partial" | "unpriced" | null`. Lets a reader distinguish a row
+  priced at zero from a row whose price could not be resolved — previously
+  indistinguishable, both surfacing as `0`.
+
+### Changed
+
+- **`validateManifest()` under `retiredRuntimeTools: "reject"` now also rejects
+  retired `dependencies` keys**, naming the replacement key in the error.
+  Author input carrying `dependencies.tools` or `dependencies.providers` was
+  silently accepted and then inert; it now fails at authoring time.
+
+  Note the asymmetry, which is deliberate: this is a policy on author input,
+  not a shape constraint. `dependencies` stays a loose object (AFPS §10
+  mandates extensibility for objects it does not explicitly close), so
+  **already-published manifests carrying a retired key keep validating and keep
+  running**. Only the `"reject"` policy path is affected — a caller that
+  previously passed such a manifest through `validateManifest` and got a pass
+  will now get a failure.
+
 ## [6.0.0] — 2026-07-26
 
 Major release grouping every contract change the repository accumulated after

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@appstrate/core",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Shared validation, storage, and utility library for Appstrate packages",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -38,7 +38,7 @@ import type { OrchestratorRegistration } from "./platform-types.ts";
  * attributes, bundler support). `packages/core/test/core-version.test.ts`
  * asserts it equals the published `version` field, so it cannot drift.
  */
-export const CORE_VERSION = "6.0.0";
+export const CORE_VERSION = "6.1.0";
 
 /** Metadata describing a module. */
 export interface ModuleManifest {


### PR DESCRIPTION
## Why

`packages/core/src` had drifted from the published `6.0.0` by **191 additive lines** while carrying the same version number. npm and the in-tree source were no longer the same code under the same label — invisible to anyone consuming core from the registry, which is the only way out-of-tree modules get it.

Additive only, no export removed, so a **minor**.

## What is in it

### Added

| Export | Subpath | Purpose |
|---|---|---|
| `findRetiredDependencyKeys()`, `RetiredDependencyKey`, `RetiredDependencyKeyUse` | `dependencies` | Lists AFPS 1.x `dependencies` keys retired by AFPS 2.0 — `tools` → `mcp_servers`, `providers` → `integrations` |
| `totalTokens()` | `token-usage` | Sums a `TokenUsage` across all four counters. Summing only input + output under-reports every cached turn |
| `LlmUsageLedgerRow.pricingStatus` | `module` | `"priced" \| "partial" \| "unpriced" \| null` — tells a row priced at zero from a row whose price could not be resolved |

### Changed

`validateManifest()` under `retiredRuntimeTools: "reject"` now also rejects retired `dependencies` keys, naming the replacement.

The asymmetry is deliberate and worth reading before assuming it is a break: this is a **policy on author input**, not a shape constraint. `dependencies` stays a loose object (AFPS §10 mandates extensibility for objects it does not explicitly close), so **already-published manifests carrying a retired key keep validating and keep running**. Only the `"reject"` path changes — a caller that previously passed such a manifest and got a pass now gets a failure.

## Release plan

1. Merge this PR.
2. `git tag core@6.1.0` from the squash commit on `main`, push.
3. `publish-core.yml` runs. **This is the first live exercise of the OIDC trusted publishing from #1049** — core had no broken publish to prove it against, unlike the CLI. It needs the Trusted Publisher registered on npmjs.com for `@appstrate/core`, pinned to `publish-core.yml`.
4. Bump the two consumers to `^6.1.0`: `appstrate/cloud`, `appstrate/connect-helper`.

## Lockstep gate

Both consumers sit at `^6.0.0`. `assessDrift` computes `minorDelta = 1` → **`warn`**, not `fail`. The publish proceeds without needing `CONSUMER_DRIFT_POLICY`, and the consumer bumps in step 4 clear the warning before the next release — where a 2-minor gap *would* fail hard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)