### PR TITLE
fix(release): a 404 on a listed consumer fails the gate, never skips it

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -120,10 +120,19 @@ jobs:
       # worse than having no gate at all — a fail-closed check that had never
       # once closed. Make the missing precondition loud instead.
       #
-      # The secret CONSUMER_LOCKSTEP_TOKEN was added on 2026-07-28, so that
-      # failure mode is currently held off — this step is what keeps it that
-      # way. It stays because the day the token expires, is revoked, or loses
-      # `contents:read` on a consumer, the gate would go silently inert again.
+      # This step checks PRESENCE, which is not the same as CAPABILITY — and
+      # the difference bit on the core@6.1.0 release. The secret was present
+      # (added 2026-07-28) so this step passed, but the token could not read
+      # either private consumer; both 404'd, and the script logged them as
+      # "not present, skipping" and printed `0 failure(s)`. Presence was
+      # verified, capability never was.
+      #
+      # Capability is now enforced where it can actually be observed, in
+      # `check-consumer-versions.ts`: a 404 on a listed consumer throws instead
+      # of returning null, so it lands in the fail-closed catch. This step is
+      # still worth keeping — it names the missing precondition before the
+      # script runs, which is a clearer error than a fetch failure — but the
+      # gate no longer DEPENDS on it being right.
       #
       # Bypassing stays possible, but it must be a deliberate act (set the repo
       # variable CONSUMER_DRIFT_POLICY to `warn` or `off`), never the accident
@@ -138,7 +147,7 @@ jobs:
             echo "CONSUMER_LOCKSTEP_TOKEN is set — the lockstep gate can read the private consumer repos."
             exit 0
           fi
-          MSG="CONSUMER_LOCKSTEP_TOKEN is not set. Every consumer repo (appstrate/cloud, appstrate/connect-helper) is private, so the fallback GITHUB_TOKEN gets a 404 on both of them and the lockstep gate verifies NOTHING while reporting success."
+          MSG="CONSUMER_LOCKSTEP_TOKEN is not set. Every consumer repo (appstrate/cloud, appstrate/connect-helper) is private, so the fallback GITHUB_TOKEN gets a 404 on both of them and no consumer version can be read."
           if [ "$CONSUMER_DRIFT_POLICY" = "fail" ]; then
             echo "::error title=Consumer lockstep gate cannot run::${MSG} Fix: add a repository secret CONSUMER_LOCKSTEP_TOKEN (PAT or GitHub App token with contents:read on those repos). To publish anyway, set the repository variable CONSUMER_DRIFT_POLICY to 'warn' or 'off' — a deliberate, auditable bypass."
             {

--- a/scripts/check-consumer-versions.ts
+++ b/scripts/check-consumer-versions.ts
@@ -149,10 +149,25 @@ export function assessDrift(
   return { verdict: "ok", detail: "in sync" };
 }
 
-async function fetchPackageJson(
+/**
+ * Read one consumer's `package.json` from GitHub.
+ *
+ * Throws on ANY non-2xx, 404 included. That is the whole point: a 404 here is
+ * never "the file is absent". Every repo in {@link CONSUMERS} is a live npm
+ * package and therefore has a `package.json` — so a 404 means the READ failed,
+ * which for a private repo means the token cannot see it.
+ *
+ * Returning null on 404 is what let the gate report `Summary: 0 failure(s)`
+ * while verifying nothing: `CONSUMER_LOCKSTEP_TOKEN` was present but could not
+ * read either private consumer, both 404'd, both were logged as
+ * "not present, skipping", and core@6.1.0 published unverified. The caller
+ * already fails closed on fetch errors — 404 now takes that same path instead
+ * of routing around it.
+ */
+export async function fetchPackageJson(
   repo: string,
   path: string,
-): Promise<Record<string, unknown> | null> {
+): Promise<Record<string, unknown>> {
   const url = `https://api.github.com/repos/${repo}/contents/${path}`;
   const headers: Record<string, string> = {
     Accept: "application/vnd.github.raw+json",
@@ -162,9 +177,19 @@ async function fetchPackageJson(
   if (token) headers.Authorization = `Bearer ${token}`;
 
   const res = await fetch(url, { headers });
-  if (res.status === 404) return null;
   if (!res.ok) {
-    throw new Error(`GET ${url} → ${res.status} ${res.statusText}`);
+    // GitHub returns 404 rather than 403 for a repo the token cannot see, so
+    // it does not leak the repo's existence. Name that here: the message is
+    // the operator's only clue, and "404 Not Found" alone reads as "the file
+    // was deleted" — sending them to look in the wrong place.
+    const hint =
+      res.status === 404
+        ? ` — a listed consumer always has this file, so this is a READ failure, not an absent file.` +
+          ` Check that ${token ? "CONSUMER_LOCKSTEP_TOKEN" : "GITHUB_TOKEN"} still has contents:read on ${repo}` +
+          ` (expired PAT, missing scope, or SSO not authorized). If the repo genuinely stopped consuming` +
+          ` @appstrate/core, remove it from CONSUMERS instead.`
+        : "";
+    throw new Error(`GET ${url} → ${res.status} ${res.statusText}${hint}`);
   }
   return (await res.json()) as Record<string, unknown>;
 }
@@ -190,14 +215,18 @@ async function main(): Promise<void> {
 
   for (const consumer of CONSUMERS) {
     for (const path of consumer.paths) {
-      let pkg: Record<string, unknown> | null;
+      let pkg: Record<string, unknown>;
       try {
         pkg = await fetchPackageJson(consumer.repo, path);
       } catch (err) {
-        // Fail closed: a fetch error (403/rate-limit/outage) means we could
+        // Fail closed: a fetch error (404/403/rate-limit/outage) means we could
         // NOT verify this consumer. Under `fail` policy that is a blocking
         // failure — otherwise a transient GitHub error would let core publish
         // without ever checking its consumers. `warn`/`off` may still bypass.
+        //
+        // 404 reaches here too, deliberately. It used to return null and get
+        // logged as "not present, skipping", which is how a token that could
+        // read neither private consumer still produced `0 failure(s)`.
         const detail = err instanceof Error ? err.message : String(err);
         if (POLICY === "fail") {
           console.error(`  ✗ ${consumer.repo}/${path} — fetch failed, cannot verify (${detail})`);
@@ -206,10 +235,6 @@ async function main(): Promise<void> {
           console.warn(`  ! ${consumer.repo}/${path} — fetch failed (${detail})`);
           warnings++;
         }
-        continue;
-      }
-      if (!pkg) {
-        console.log(`  - ${consumer.repo}/${path} — not present, skipping`);
         continue;
       }
 

--- a/scripts/test/check-consumer-versions.test.ts
+++ b/scripts/test/check-consumer-versions.test.ts
@@ -8,8 +8,8 @@
  * only reachable state) and the non-major case that keeps the gate's teeth.
  */
 
-import { describe, it, expect } from "bun:test";
-import { assessDrift } from "../check-consumer-versions.ts";
+import { describe, it, expect, afterEach } from "bun:test";
+import { assessDrift, fetchPackageJson } from "../check-consumer-versions.ts";
 
 type V = [number, number, number];
 
@@ -73,5 +73,58 @@ describe("assessDrift — same major", () => {
     // silently turn it into a publish-blocking failure.
     expect(assessDrift([6, 2, 0], [6, 5, 0])).toEqual({ verdict: "ok", detail: "in sync" });
     expect(assessDrift([6, 2, 0], [6, 2, 7])).toEqual({ verdict: "ok", detail: "in sync" });
+  });
+});
+
+describe("fetchPackageJson", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function stubFetch(status: number, statusText: string, body?: unknown): void {
+    globalThis.fetch = (async () =>
+      new Response(body === undefined ? null : JSON.stringify(body), {
+        status,
+        statusText,
+      })) as typeof fetch;
+  }
+
+  it("THROWS on 404 instead of reporting an absent file", async () => {
+    // The regression this guards: 404 used to return null, which main() logged
+    // as "not present, skipping" and counted as neither warning nor failure. A
+    // CONSUMER_LOCKSTEP_TOKEN that could read neither private consumer then
+    // produced `Summary: 0 failure(s)` having verified nothing, and
+    // core@6.1.0 published unchecked. Every listed consumer is a live npm
+    // package and therefore HAS a package.json, so 404 is always a read
+    // failure — it must reach main()'s fail-closed catch.
+    stubFetch(404, "Not Found");
+    await expect(fetchPackageJson("appstrate/cloud", "package.json")).rejects.toThrow(/404/);
+  });
+
+  it("names the token and the likely causes in the 404 message", async () => {
+    // The message is the operator's only clue. Bare "404 Not Found" reads as
+    // "the file was deleted" and sends them to look in the wrong place.
+    stubFetch(404, "Not Found");
+    const err = await fetchPackageJson("appstrate/cloud", "package.json").catch(
+      (e: unknown) => e as Error,
+    );
+    expect(err.message).toContain("READ failure");
+    expect(err.message).toContain("contents:read");
+    expect(err.message).toContain("appstrate/cloud");
+  });
+
+  it("still throws on other non-2xx statuses", async () => {
+    stubFetch(403, "Forbidden");
+    await expect(fetchPackageJson("appstrate/cloud", "package.json")).rejects.toThrow(/403/);
+  });
+
+  it("returns the parsed package.json on success", async () => {
+    stubFetch(200, "OK", {
+      name: "@appstrate/cloud",
+      dependencies: { "@appstrate/core": "^6.1.0" },
+    });
+    const pkg = await fetchPackageJson("appstrate/cloud", "package.json");
+    expect(pkg.name).toBe("@appstrate/cloud");
   });
 });


### PR DESCRIPTION
## The bug

The `core@6.1.0` publish printed a clean bill of health having verified **nothing**:

```
- appstrate/cloud/package.json — not present, skipping
- appstrate/connect-helper/package.json — not present, skipping
Summary: 0 failure(s), 0 warning(s)
```

Both files exist — verified by reading them with a working token. `CONSUMER_LOCKSTEP_TOKEN` could not read either private repo, GitHub answered **404** (it returns 404 rather than 403 so it does not leak a private repo's existence), `fetchPackageJson` mapped that to `null`, and `main()` logged it as a benign absence — counted as neither warning nor failure.

This is the exact fail-open the gate was rewritten to eliminate, reached by a path the rewrite left open. The `catch` block one line above **already** fails closed on fetch errors, with a comment explaining why. 404 routed around it.

## The fix

404 stops being special. `fetchPackageJson` throws on any non-2xx and lands in that same fail-closed catch.

A listed consumer is a live npm package and therefore **has** a `package.json` — its absence can only mean the read failed. The error message names the token, the likely causes (expired PAT, missing scope, SSO not authorized) and the legitimate alternative (remove it from `CONSUMERS` if it genuinely stopped consuming core), because a bare `404 Not Found` reads as "the file was deleted" and sends the operator to the wrong place.

The workflow's `Assert the lockstep gate can actually run` step is kept but **demoted in the comments**: it checks PRESENCE, and presence is not capability — it passed on the 6.1.0 release while the token was unusable. Capability is now enforced where it can actually be observed, at the fetch.

## Verification

| Scenario | Before | After |
|---|---|---|
| Unusable token | `0 failure(s)`, exit 0 | **2 failures, exit 1** |
| Working token | — | reads both, `in sync`, exit 0 |
| Genuine 404, valid token | returned `null` | **throws with the hint** |

```
✓ appstrate/cloud/package.json pins >=6.1.0 — in sync
✓ appstrate/connect-helper/package.json pins ^6.1.0 — in sync
```

Four new tests cover the fetch behaviour, including the regression itself. Suite: 14 pass. `bun run check`: 33/33.

## ⚠️ Operational consequence

**The token is still broken.** This PR only makes the failure loud. The next core publish will now **fail** rather than pass vacuously — which is the point, but it means **renewing `CONSUMER_LOCKSTEP_TOKEN` is a prerequisite for the next release**, not an optional cleanup.

The bypass remains available and auditable: set the repo variable `CONSUMER_DRIFT_POLICY` to `warn` or `off`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)