### PR TITLE
fix(ci): normalise the whole jailer path chain, and assert it before the smoke

### DIFF
--- a/.github/workflows/firecracker.yml
+++ b/.github/workflows/firecracker.yml
@@ -202,26 +202,46 @@ jobs:
           # jailed VMMs (FIRECRACKER_JAILER=on is the orchestrator default).
           sudo install -m 0755 "/tmp/release-${FC_VERSION}-${ARCH}/jailer-${FC_VERSION}-${ARCH}" /usr/local/bin/jailer
           # The jailer input trust-chain check (initializeJailer →
-          # assertTrustedPathChain) walks EVERY parent of FIRECRACKER_BIN up
-          # to `/` and refuses any component that is group/world-writable or
-          # not root-owned — exactly as it would on a misconfigured production
-          # host. Runner images violate that on the /usr/local chain, so
-          # tighten the whole chain and not just the leaf:
+          # assertTrustedPathChain) walks EVERY parent of the binary up to `/`
+          # and refuses any component that is group/world-writable or not
+          # root-owned — exactly as it would on a misconfigured production
+          # host. Runner images violate that somewhere on the /usr/local/bin
+          # chain, and WHICH component varies by runner instance: /usr/local/bin
+          # ships mode 777, and /usr/local or even /usr can come owned by uid
+          # 1001 (the `runner` user). It does not track the image tag —
+          # ubuntu24/20260726.254 was observed both passing and failing within
+          # the same three hours — so it cannot be handled by pinning an image.
           #
-          #   /usr/local/bin  ships mode 777 (group/world-writable)
-          #   /usr/local      is SOMETIMES owned by uid 1001 (the `runner`
-          #                   user) instead of root
-          #
-          # "Sometimes" is the point, and it does not track the image tag —
-          # ubuntu24/20260726.254 was observed both passing (main, full smoke)
-          # and failing twice on a rerun within the same three hours. Which
-          # runner instance you land on is what decides it, so this cannot be
-          # handled by pinning or avoiding an image; tighten unconditionally.
-          #
-          # /usr and / are root-owned 0755 already, so the walk stops clean
-          # above /usr/local. Nothing in the remaining steps writes there.
-          sudo chown root:root /usr/local /usr/local/bin
-          sudo chmod 0755 /usr/local /usr/local/bin
+          # Walk the same chain the guard walks instead of naming components:
+          # a previous attempt fixed /usr/local by hand and the failure simply
+          # moved up to /usr. `chmod go-w` clears exactly the bits the guard
+          # rejects and leaves everything else alone.
+          for bin in /usr/local/bin/firecracker /usr/local/bin/jailer; do
+            p="$(dirname "$bin")"
+            while [ "$p" != "/" ]; do
+              sudo chown root:root "$p"
+              sudo chmod go-w "$p"
+              p="$(dirname "$p")"
+            done
+          done
+          # Assert the invariant HERE. The guard runs ~90s into the smoke,
+          # inside the orchestrator, so an unmet precondition surfaced there
+          # reads as a product failure; surfaced here it reads as what it is.
+          # `/` is asserted but never chown'd — if the root inode itself is
+          # wrong, failing loudly is the only correct move.
+          for bin in /usr/local/bin/firecracker /usr/local/bin/jailer; do
+            p="$bin"
+            while :; do
+              owner="$(stat -c '%u' "$p")"
+              [ "$owner" = "0" ] || { echo "::error::$p is owned by uid $owner, not root"; exit 1; }
+              mode="$(stat -c '%a' "$p")"; mode="${mode: -3}"
+              if [ $(( ${mode:1:1} & 2 )) -ne 0 ] || [ $(( ${mode:2:1} & 2 )) -ne 0 ]; then
+                echo "::error::$p is group/world-writable (mode $mode)"; exit 1
+              fi
+              [ "$p" != "/" ] || break
+              p="$(dirname "$p")"
+            done
+          done
           firecracker --version
           jailer --version
 

--- a/.github/workflows/firecracker.yml
+++ b/.github/workflows/firecracker.yml
@@ -201,14 +201,27 @@ jobs:
           # The jailer ships in the SAME verified tarball — the smoke boots
           # jailed VMMs (FIRECRACKER_JAILER=on is the orchestrator default).
           sudo install -m 0755 "/tmp/release-${FC_VERSION}-${ARCH}/jailer-${FC_VERSION}-${ARCH}" /usr/local/bin/jailer
-          # GitHub runner images ship /usr/local/bin group/world-writable
-          # (mode 777) — the jailer input trust-chain check (initializeJailer
-          # → assertTrustedPathChain) rightly refuses a writable component on
-          # the FIRECRACKER_BIN path, exactly as it would on a misconfigured
-          # production host. Tighten to the standard root-owned 0755; nothing
-          # in the remaining steps writes there.
-          sudo chown root:root /usr/local/bin
-          sudo chmod 0755 /usr/local/bin
+          # The jailer input trust-chain check (initializeJailer →
+          # assertTrustedPathChain) walks EVERY parent of FIRECRACKER_BIN up
+          # to `/` and refuses any component that is group/world-writable or
+          # not root-owned — exactly as it would on a misconfigured production
+          # host. Runner images violate that on the /usr/local chain, so
+          # tighten the whole chain and not just the leaf:
+          #
+          #   /usr/local/bin  ships mode 777 (group/world-writable)
+          #   /usr/local      is SOMETIMES owned by uid 1001 (the `runner`
+          #                   user) instead of root
+          #
+          # "Sometimes" is the point, and it does not track the image tag —
+          # ubuntu24/20260726.254 was observed both passing (main, full smoke)
+          # and failing twice on a rerun within the same three hours. Which
+          # runner instance you land on is what decides it, so this cannot be
+          # handled by pinning or avoiding an image; tighten unconditionally.
+          #
+          # /usr and / are root-owned 0755 already, so the walk stops clean
+          # above /usr/local. Nothing in the remaining steps writes there.
+          sudo chown root:root /usr/local /usr/local/bin
+          sudo chmod 0755 /usr/local /usr/local/bin
           firecracker --version
           jailer --version
 

--- a/.github/workflows/firecracker.yml
+++ b/.github/workflows/firecracker.yml
@@ -216,6 +216,11 @@ jobs:
           # a previous attempt fixed /usr/local by hand and the failure simply
           # moved up to /usr. `chmod go-w` clears exactly the bits the guard
           # rejects and leaves everything else alone.
+          # Record the pre-normalisation state. Without it a green run is
+          # silent about WHICH runner it drew, and the whole difficulty here
+          # was that the broken state appears on only some instances.
+          echo "--- path chain before normalisation ---"
+          stat -c '%n uid=%u mode=%a' / /usr /usr/local /usr/local/bin
           for bin in /usr/local/bin/firecracker /usr/local/bin/jailer; do
             p="$(dirname "$bin")"
             while [ "$p" != "/" ]; do


### PR DESCRIPTION
## Symptom

`smoke` fails intermittently, on any branch, with no repo change behind it:

```
error: Firecracker jailer: "/usr/local" (in the path of FIRECRACKER_BIN) is owned
by uid 1001, not root — the jailer executes this input as the VMM; only
root-owned chains are trusted.
```

The 327 unit tests in that job still pass. It is the `End-to-end smoke (real microVM, jailed VMM)` step that cannot start.

## Cause

`assertTrustedPathChain` (`apps/api/src/modules/firecracker/orchestrator.ts:686`) walks **every parent** of the binary up to `/` and refuses any component that is group/world-writable or not root-owned.

The `Install Firecracker` step only ever tightened the leaf — `/usr/local/bin`, which runner images ship mode 777. Everything above it was left exactly as the runner provided it, so the job was always one unlucky runner away from failing.

Which component is wrong **varies by runner instance**, and it does not track the image tag:

| Image | Time | Branch | Smoke |
|---|---|---|---|
| `20260726.254` | 15:02 | main | success (full smoke ran) |
| `20260720.247` | 15:20 | branch | success |
| `20260726.254` | 16:58 | branch | **FAILURE** — `/usr/local` uid 1001 |
| `20260726.254` | 17:05 | branch | **FAILURE** (rerun) |
| `20260726.254` | 17:20 | branch | **FAILURE** — `/usr` uid 1001, *after* `/usr/local` was fixed |

The same tag sits on both sides, so pinning or avoiding an image does not help.

## What the first attempt got wrong

It chown'd `/usr/local` by name and claimed in a comment that `/usr` and `/` were already root-owned. The 17:20 run executed that chown and then failed on `/usr`. **That is a negative end-to-end reproduction, not a verification gap** — naming components one at a time cannot work against a guard that walks the whole chain.

## Fix

Walk the same chain the guard walks, deriving the components from the binary paths rather than listing them:

- `chmod go-w` clears exactly the bits `assertTrustedPathChain` rejects (`0o022`) and leaves everything else alone.
- The invariant is then **asserted in this step**. The guard otherwise runs ~90s into the smoke from inside the orchestrator, where an unmet precondition reads as a product failure; asserted here it reads as what it is, and it fails before the expensive part.
- `/` is asserted but never chown'd — if the root inode is wrong, failing loudly is the only correct move.

**The guard is not relaxed.** It refused a genuinely untrusted path chain, which is what it exists to do; the runner is what stopped satisfying it.

## Verification

Reproduced in an `ubuntu:24.04` container, with a negative control so that a pass means something:

| Chain state | Expected | Result |
|---|---|---|
| clean | pass | pass |
| `/usr/local/bin` mode 777 | caught | caught |
| `/usr` owned by uid 1001 | caught | caught |
| `/usr/local` mode 775 (group-write only) | caught | caught |
| `/usr/local/bin` mode 1755 (sticky) | pass | pass |

Normalising the reproduced broken state (`/usr` + `/usr/local` at uid 1001, `/usr/local/bin` at 777) yields `0 755` on all three and the assertion passes.

CI on this PR is the remaining check: it must go green on a runner instance that would previously have failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
