### PR TITLE
fix(packages): make skill-only imports exportable

### DIFF
--- a/apps/api/src/openapi/paths/agents.ts
+++ b/apps/api/src/openapi/paths/agents.ts
@@ -648,7 +648,7 @@ export const agentsPaths = {
       tags: ["Agents"],
       summary: "Export an agent as an .afps-bundle",
       description:
-        "Streams a canonical multi-package .afps-bundle archive containing the agent and all its transitive dependencies. The archive is deterministic (byte-identical across calls with the same inputs) and carries per-file RECORD hashes plus a bundle-level SRI digest (also echoed in the `X-Bundle-Integrity` response header). Two modes: `?source=published` (default) exports the version installed for this application (falls back to the `latest` dist-tag, or pass `?version=` to pin); `?source=draft` bundles the agent's current draft state — used by the CLI's run-by-id flow to mirror the dashboard Run button on never-published agents. `?source=draft` cannot be combined with `?version=`.",
+        "Streams a canonical multi-package .afps-bundle archive containing the agent and all its transitive dependencies. The archive is deterministic (byte-identical across calls with the same inputs) and carries per-file RECORD hashes plus a bundle-level SRI digest (also echoed in the `X-Bundle-Integrity` response header). Two modes: `?source=published` (default) exports the version installed for this application (falls back to the `latest` dist-tag, or pass `?version=` to pin); `?source=draft` bundles the agent's current draft state — used by the CLI's run-by-id flow to mirror the dashboard Run button on never-published agents. `?source=draft` cannot be combined with `?version=`. Assembly reads the same stored artifacts a run does, so it reports the same coded bundle failures — see the 422 and 500 responses.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -702,7 +702,28 @@ export const agentsPaths = {
         "401": { $ref: "#/components/responses/Unauthorized" },
         "403": { $ref: "#/components/responses/Forbidden" },
         "404": { $ref: "#/components/responses/NotFound" },
+        "422": {
+          description:
+            "The bundle cannot be assembled from stored artifacts. `dependency_unresolved`: a declared dependency resolves to no published version, or it resolved but its artifact is absent from storage or out of this organization's scope — the detail names the dependency. `bundle_invalid`: a stored archive or manifest is malformed or exceeds an archive limit (for example an archive with no `manifest.json` at its root); the package must be republished. `bundle_signature_invalid`: rejected by `AFPS_SIGNATURE_POLICY`",
+          headers: {
+            "Request-Id": { $ref: "#/components/headers/RequestId" },
+          },
+          content: {
+            "application/problem+json": {
+              schema: { $ref: "#/components/schemas/ProblemDetail" },
+            },
+          },
+        },
         "429": { $ref: "#/components/responses/RateLimited" },
+        "500": {
+          description:
+            "Unexpected server error (`internal_error`), or a dependency artifact's bytes no longer match the integrity hash recorded when that version was published (`bundle_integrity_mismatch`) — corruption or tampering at rest; retrying will not help, republish the named dependency or contact the operator",
+          content: {
+            "application/problem+json": {
+              schema: { $ref: "#/components/schemas/ProblemDetail" },
+            },
+          },
+        },
       },
     },
   },

--- a/apps/api/src/routes/agents.ts
+++ b/apps/api/src/routes/agents.ts
@@ -42,6 +42,7 @@ import {
   resolveExportVersion,
 } from "../services/bundle-assembly.ts";
 import { writeBundleToBuffer } from "@appstrate/afps-runtime/bundle";
+import { toBundleApiError } from "../services/run-launcher/bundle-error-mapping.ts";
 import { rateLimit } from "../middleware/rate-limit.ts";
 import { recordAuditFromContext } from "../services/audit.ts";
 import { SCOPED_PACKAGE_ROUTE } from "./scoped-package-route.ts";
@@ -507,19 +508,37 @@ export function createAgentsRouter() {
       // the manifest itself (and without trusting a tag that may have moved
       // between bundle download and run creation).
       let versionLabel: string;
-      let bundle;
-      if (useDraft) {
-        bundle = await buildBundleFromAgentDraft(agent, scope, { builder: "appstrate-platform" });
-        versionLabel = "draft";
-      } else {
-        versionLabel = await resolveExportVersion(agent.id, scope, versionSpec);
-        bundle = await buildBundleForAgentExport(agent.id, scope, {
-          versionSpec: versionLabel,
-          metadata: { builder: "appstrate-platform" },
-        });
+      let bytes: Uint8Array;
+      try {
+        let bundle;
+        if (useDraft) {
+          bundle = await buildBundleFromAgentDraft(agent, scope, { builder: "appstrate-platform" });
+          versionLabel = "draft";
+        } else {
+          versionLabel = await resolveExportVersion(agent.id, scope, versionSpec);
+          bundle = await buildBundleForAgentExport(agent.id, scope, {
+            versionSpec: versionLabel,
+            metadata: { builder: "appstrate-platform" },
+          });
+        }
+        // Serialization stays inside the try: `writeBundleToBuffer` re-validates
+        // the assembled map and raises the same `BundleError` family, so leaving
+        // it outside would keep that throw on the untyped path.
+        bytes = writeBundleToBuffer(bundle);
+      } catch (err) {
+        // Export reads the same stored artifacts a run does and reaches
+        // dependencies through the same catalog, so it raises the same
+        // bundle-layer errors. Map them onto the RFC 9457 contract the run path
+        // already uses; without this they reach the global handler as an opaque
+        // `500 internal_error`.
+        //
+        // Anything the mapper does not own returns null and rethrows untouched,
+        // keeping its own status — the 404s from `resolveExportVersion`, the 400
+        // from an invalid draft manifest.
+        const mapped = toBundleApiError(err);
+        if (mapped) throw mapped;
+        throw err;
       }
-
-      const bytes = writeBundleToBuffer(bundle);
       const parsed = parseScopedName(agent.id);
       const safeName = parsed ? `${parsed.scope}-${parsed.name}` : "bundle";
 

--- a/apps/api/src/routes/packages.ts
+++ b/apps/api/src/routes/packages.ts
@@ -1545,9 +1545,29 @@ export function createPackagesRouter() {
 
   // --- Shared import logic (used by /import and /import-github) ---
 
+  /** A parsed package plus the exact bytes that must be published for it. */
+  interface ParsedImport {
+    parsed: ReturnType<typeof parsePackageZip>;
+    /**
+     * Bytes to store as the version's content — NOT necessarily the upload.
+     * INVARIANT: this buffer and `parsed.files` declare the same
+     * `manifest.json`. Readers of a published artifact take the manifest from
+     * the archive (`extractRootFromAfps`), so a disagreement publishes a
+     * version that cannot be assembled.
+     */
+    artifact: Buffer;
+  }
+
   /**
    * Shared ZIP parse for `POST /import` (operator uploads a file) and
    * `POST /import-github` (fetch a repo directory).
+   *
+   * Returns the artifact with the parse because only this function knows
+   * whether they are the same bytes: an ordinary AFPS parse publishes the
+   * upload verbatim (re-zipping would drop whatever the parser doesn't model —
+   * a detached signature above all — and invalidate any signature over the
+   * original bytes), while the skill-only fallback must rebuild the archive
+   * because it synthesizes the `manifest.json` the upload lacks.
    *
    * WRITE direction — retired/unknown `runtime_tools` ids REJECT. Both routes
    * are author input, not content the platform already holds:
@@ -1572,17 +1592,22 @@ export function createPackagesRouter() {
    * Passed explicitly rather than left to the default so the choice reads as
    * deliberate at the call site.
    */
-  async function parseZipWithSkillFallback(
-    zipBytes: Uint8Array,
-    orgSlug: string,
-  ): Promise<ReturnType<typeof parsePackageZip>> {
+  async function parseZipWithSkillFallback(upload: Buffer, orgSlug: string): Promise<ParsedImport> {
+    const zipBytes = new Uint8Array(upload);
     try {
-      return parsePackageZip(zipBytes, { retiredRuntimeTools: "reject" });
+      const parsed = parsePackageZip(zipBytes, { retiredRuntimeTools: "reject" });
+      return { parsed, artifact: upload };
     } catch (err) {
       if (err instanceof PackageZipError && err.code === "MISSING_MANIFEST") {
         const result = await tryParseSkillOnlyZip(zipBytes, orgSlug);
         if (result.ok) {
-          return result.parsed;
+          // `result.parsed.files` is the upload's entries (wrapper prefix
+          // stripped) plus the synthesized `manifest.json`. `zipArtifact` is
+          // deterministic, so identical content still yields identical bytes.
+          return {
+            parsed: result.parsed,
+            artifact: Buffer.from(zipArtifact(result.parsed.files)),
+          };
         }
         if (result.reason === "unchanged") {
           throw conflict("skill_unchanged", "This skill already exists with the same content");
@@ -1606,10 +1631,16 @@ export function createPackagesRouter() {
     }
   }
 
+  /**
+   * Persist a parsed import. `artifact` is the {@link ParsedImport} buffer, not
+   * the raw upload: it is both what gets stored and what every integrity
+   * comparison below is made against, so the two cannot disagree about which
+   * bytes this version is.
+   */
   async function handleImport(
     c: Context<AppEnv>,
     parsed: ReturnType<typeof parsePackageZip>,
-    buffer: Buffer,
+    artifact: Buffer,
     force: boolean,
     source: "zip" | "github",
   ) {
@@ -1682,7 +1713,7 @@ export function createPackagesRouter() {
       if (!force && importedVersion) {
         const existingVer = await getVersionForDownload(packageId, importedVersion);
         if (existingVer) {
-          const importedIntegrity = computeIntegrity(new Uint8Array(buffer));
+          const importedIntegrity = computeIntegrity(new Uint8Array(artifact));
           if (existingVer.integrity !== importedIntegrity) {
             throw conflict(
               "integrity_mismatch",
@@ -1727,7 +1758,7 @@ export function createPackagesRouter() {
         userId: user.id,
         content,
         files,
-        zipBuffer: buffer,
+        zipBuffer: artifact,
       });
     } catch (err) {
       const message = getErrorMessage(err);
@@ -1765,12 +1796,12 @@ export function createPackagesRouter() {
     if (existing && force && importedVersionForReplace) {
       const existingVer = await getVersionForDownload(packageId, importedVersionForReplace);
       if (existingVer) {
-        const importedIntegrity = computeIntegrity(new Uint8Array(buffer));
+        const importedIntegrity = computeIntegrity(new Uint8Array(artifact));
         if (existingVer.integrity !== importedIntegrity) {
           await replaceVersionContent({
             packageId,
             version: importedVersionForReplace,
-            zipBuffer: buffer,
+            zipBuffer: artifact,
             manifest: manifest as Record<string, unknown>,
           });
         }
@@ -1893,12 +1924,11 @@ export function createPackagesRouter() {
       throw invalidRequest("Only .afps and .zip files are accepted");
     }
 
-    const buffer = Buffer.from(await file.arrayBuffer());
-    const zipBytes = new Uint8Array(buffer);
+    const upload = Buffer.from(await file.arrayBuffer());
 
-    const parsed = await parseZipWithSkillFallback(zipBytes, c.get("orgSlug"));
+    const { parsed, artifact } = await parseZipWithSkillFallback(upload, c.get("orgSlug"));
 
-    return handleImport(c, parsed, buffer, c.req.query("force") === "true", "zip");
+    return handleImport(c, parsed, artifact, c.req.query("force") === "true", "zip");
   });
 
   // POST /api/packages/import-github — import a package from a GitHub URL
@@ -1920,11 +1950,12 @@ export function createPackagesRouter() {
       throw err;
     }
 
-    const buffer = Buffer.from(zipBytes);
+    const { parsed, artifact } = await parseZipWithSkillFallback(
+      Buffer.from(zipBytes),
+      c.get("orgSlug"),
+    );
 
-    const parsed = await parseZipWithSkillFallback(zipBytes, c.get("orgSlug"));
-
-    return handleImport(c, parsed, buffer, false, "github");
+    return handleImport(c, parsed, artifact, false, "github");
   });
 
   // GET /api/packages/:scope/:name/:version/download — download a versioned package ZIP

--- a/apps/api/src/services/post-install-package.ts
+++ b/apps/api/src/services/post-install-package.ts
@@ -109,13 +109,12 @@ export async function postInstallPackage(params: {
   // row diverge from the ZIP — and pinned runs read the manifest FROM the ZIP,
   // so the divergence would be silent.
   //
-  // ONE caller breaks the "`files` and `zipBuffer` carry the same manifest"
-  // assumption: the skill-only-ZIP fallback (`routes/packages.ts`, the
-  // `handleImport(c, parsed, buffer, …)` call on the `/import` routes) passes
-  // the ORIGINAL upload, which by construction has no `manifest.json` — that
-  // absence is what triggered the fallback — while `files` carries the manifest
-  // synthesized from `SKILL.md`. There the stored row is the only manifest
-  // there is; nothing diverges because the ZIP declares none.
+  // PRECONDITION: `zipBuffer` and `files` declare the same `manifest.json`.
+  // Callers that synthesize a manifest (the skill-only-ZIP fallback on the
+  // `/import` routes) must rebuild the archive before calling, not pass the
+  // original upload — otherwise the row is fine while the stored archive is
+  // unreadable to `extractRootFromAfps`, and every bundle export and pinned run
+  // touching the package fails.
   await createVersionAndUpload({
     packageId,
     version,

--- a/apps/api/src/services/run-launcher/bundle-error-mapping.ts
+++ b/apps/api/src/services/run-launcher/bundle-error-mapping.ts
@@ -40,11 +40,29 @@ interface UnresolvedDependency {
   versionSpec: string;
 }
 
-/** Render `details.missing` from a `DEPENDENCY_UNRESOLVED` error as a quoted list. */
+/**
+ * Turn a `DEPENDENCY_UNRESOLVED` error into a sentence naming what failed and
+ * what to do about it.
+ *
+ * The code is raised from two places whose remedies differ:
+ *
+ *   - the closure walk (`buildBundleFromCatalog`) collects every pin that
+ *     resolved to NO version into `details.missing` — publish the dependency or
+ *     change the pin.
+ *   - a catalog's `fetch()` fails on ONE already-resolved dependency whose bytes
+ *     are unusable (absent from storage, or out of the org's scope) and carries
+ *     `details.identity` — the pin resolved, so "fix the pin" would misdirect.
+ */
 function formatUnresolved(details: unknown): string {
-  const missing = (details as { missing?: UnresolvedDependency[] } | undefined)?.missing;
-  if (!missing || missing.length === 0) return "a declared dependency";
-  return missing.map((m) => `'${m.name}@${m.versionSpec}'`).join(", ");
+  const ctx = details as { missing?: UnresolvedDependency[]; identity?: string } | undefined;
+  if (ctx?.missing && ctx.missing.length > 0) {
+    const names = ctx.missing.map((m) => `'${m.name}@${m.versionSpec}'`).join(", ");
+    return `Could not resolve ${names} against published versions — publish the dependency, fix the pin, or pass \`dependency_overrides\` to run a working copy.`;
+  }
+  if (typeof ctx?.identity === "string") {
+    return `Dependency '${ctx.identity}' resolved to a published version whose artifact could not be loaded — republish that version, or pass \`dependency_overrides\` to run a working copy.`;
+  }
+  return "Could not resolve a declared dependency against published versions — publish the dependency, fix the pin, or pass `dependency_overrides` to run a working copy.";
 }
 
 /**
@@ -75,7 +93,7 @@ export function toBundleApiError(err: unknown): ApiError | null {
         status: 422,
         code: "dependency_unresolved",
         title: "Dependency Unresolved",
-        detail: `Could not resolve ${formatUnresolved(err.details)} against published versions — publish the dependency, fix the pin, or pass \`dependency_overrides\` to run a working copy.`,
+        detail: formatUnresolved(err.details),
       });
 
     case "INTEGRITY_MISMATCH":

--- a/apps/api/src/services/run-launcher/db-package-catalog.ts
+++ b/apps/api/src/services/run-launcher/db-package-catalog.ts
@@ -20,6 +20,7 @@
 import { and, desc, eq, isNull, or } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
 import { getErrorMessage } from "@appstrate/core/errors";
+import { asRecord } from "@appstrate/core/safe-json";
 import { resolveVersionString } from "@appstrate/core/semver";
 import { logger } from "../../lib/logger.ts";
 import { packages, packageVersions, packageDistTags } from "@appstrate/db/schema";
@@ -175,12 +176,28 @@ export class DbPackageCatalog implements PackageCatalog {
       }
       return bundlePackage;
     } catch (err) {
-      if (err instanceof BundleError) throw err;
-      throw new BundleError(
-        "ARCHIVE_INVALID",
-        `DbPackageCatalog: failed to extract ${identity}: ${getErrorMessage(err)}`,
-        { identity },
-      );
+      // `extractRootFromAfps` is handed bytes, not a catalog entry, so its
+      // message names no package — a manifest-less artifact reports only
+      // ".afps archive missing manifest.json at root". Callers surface that
+      // text as an error `detail`, so this is the last boundary that can say
+      // WHICH dependency is broken. Attach the identity here.
+      //
+      // The original `code` is carried through rather than flattened to
+      // `ARCHIVE_INVALID` so the typed diagnostic detail still distinguishes a
+      // missing manifest from a limits or archive-structure failure.
+      const code = err instanceof BundleError ? err.code : "ARCHIVE_INVALID";
+      const reason = getErrorMessage(err);
+      // The HTTP response is a 4xx (the org republishes to fix it), but a
+      // corrupt artifact at rest still warrants an operator trail.
+      logger.warn("DbPackageCatalog: stored artifact could not be extracted", {
+        identity,
+        code,
+        reason,
+      });
+      throw new BundleError(code, `stored artifact for ${identity} is unreadable: ${reason}`, {
+        ...asRecord(err instanceof BundleError ? err.details : undefined),
+        identity,
+      });
     }
   }
 }

--- a/apps/api/test/integration/routes/agents-bundle-export.test.ts
+++ b/apps/api/test/integration/routes/agents-bundle-export.test.ts
@@ -10,6 +10,8 @@
  *   - No credentials leak (response bytes contain no connection secrets)
  *   - 404 on non-existent version
  *   - RBAC: 404 when agent is not accessible to the app
+ *   - Bundle-layer failures over stored dependency artifacts surface as coded
+ *     RFC 9457 422s naming the dependency, not as an opaque 500
  */
 
 import { describe, it, expect, beforeEach } from "bun:test";
@@ -25,8 +27,8 @@ import { and, eq } from "drizzle-orm";
 import * as storage from "@appstrate/db/storage";
 import { computeIntegrity } from "@appstrate/core/integrity";
 import { readBundleFromBuffer } from "@appstrate/afps-runtime/bundle";
+import { AGENT_PACKAGES_BUCKET, versionZipKey } from "../../../src/services/package-storage.ts";
 
-const BUCKET = "agent-packages";
 const app = getTestApp();
 
 function enc(s: string): Uint8Array {
@@ -57,11 +59,30 @@ async function seedVersionedPackage(opts: {
   manifest: Record<string, unknown>;
   content?: string;
   setLatest?: boolean;
+  /**
+   * Publish these bytes instead of a well-formed AFPS. The recorded integrity
+   * still matches them, so the SRI gate passes and any failure is attributable
+   * to the archive's contents rather than to corruption.
+   */
+  artifact?: Uint8Array;
+  /**
+   * Create the version row with NO object behind it. `truncateAll()` resets the
+   * database but not object storage, so absence has to be asserted by deleting
+   * the key: a leftover object from an earlier test would otherwise be found
+   * with a hash that no longer matches this row, turning the intended
+   * `dependency_unresolved` into an `INTEGRITY_MISMATCH`.
+   */
+  absentArtifact?: boolean;
 }): Promise<{ versionId: number; version: string }> {
   await seedPackage({ id: opts.id, type: opts.type, orgId: opts.orgId });
-  const afps = buildAfps(opts.manifest, opts.content ?? "content");
+  const afps = opts.artifact ?? buildAfps(opts.manifest, opts.content ?? "content");
   const integrity = computeIntegrity(afps);
-  await storage.uploadFile(BUCKET, `${opts.id}/${opts.version}.afps`, Buffer.from(afps));
+  const key = versionZipKey(opts.id, opts.version);
+  if (opts.absentArtifact) {
+    await storage.deleteFile(AGENT_PACKAGES_BUCKET, key);
+  } else {
+    await storage.uploadFile(AGENT_PACKAGES_BUCKET, key, Buffer.from(afps));
+  }
   const pv = await seedPackageVersion({
     packageId: opts.id,
     version: opts.version,
@@ -318,6 +339,153 @@ describe("GET /api/agents/:scope/:name/bundle — export", () => {
     expect(res.status).toBe(404);
     const body = (await res.json()) as { detail: string };
     expect(body.detail).toContain("publish a version first");
+  });
+
+  // ── Bundle-layer failures over stored dependency artifacts ──
+  //
+  // These assemble from real stored state, so they prove the route reaches
+  // `toBundleApiError` at all — without it each one is an opaque 500 carrying
+  // neither a code nor the name of the package to fix.
+
+  /** Root agent depending on `@exportorg/dep-skill@^1.0.0`, installed + exportable. */
+  async function seedRootWithDependency(ctx: TestContext): Promise<void> {
+    const rootPkgId = "@exportorg/dep-root" as const;
+    await seedVersionedPackage({
+      id: rootPkgId,
+      type: "agent",
+      version: "1.0.0",
+      orgId: ctx.orgId,
+      manifest: {
+        name: rootPkgId,
+        version: "1.0.0",
+        type: "agent",
+        schema_version: "0.1",
+        display_name: "DepRoot",
+        author: "tester",
+        dependencies: { skills: { "@exportorg/dep-skill": "^1.0.0" } },
+      },
+      setLatest: true,
+    });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, rootPkgId);
+  }
+
+  async function exportDepRoot(ctx: TestContext) {
+    return app.request(`/api/agents/@exportorg/dep-root/bundle`, { headers: authHeaders(ctx) });
+  }
+
+  it("maps a dependency archive with no manifest.json to 422 bundle_invalid naming it", async () => {
+    await seedRootWithDependency(ctx);
+    // The artifact the pre-fix skill-only import published: SKILL.md and
+    // nothing else, integrity recorded over those same bytes.
+    await seedVersionedPackage({
+      id: "@exportorg/dep-skill",
+      type: "skill",
+      version: "1.0.0",
+      orgId: ctx.orgId,
+      manifest: {
+        name: "@exportorg/dep-skill",
+        version: "1.0.0",
+        type: "skill",
+        schema_version: "0.1",
+      },
+      artifact: zipSync({ "SKILL.md": enc("---\nname: dep-skill\n---\n\nBody.") }),
+      setLatest: true,
+    });
+
+    const res = await exportDepRoot(ctx);
+
+    expect(res.status).toBe(422);
+    expect(res.headers.get("Content-Type")).toContain("application/problem+json");
+    const body = (await res.json()) as { code: string; detail: string };
+    expect(body.code).toBe("bundle_invalid");
+    expect(body.detail).toContain("@exportorg/dep-skill@1.0.0");
+    expect(body.detail).toContain("BUNDLE_JSON_INVALID");
+  });
+
+  it("maps a dependency whose manifest identity disagrees with the published row to 422 bundle_invalid", async () => {
+    await seedRootWithDependency(ctx);
+    // Published as 1.0.0, but the stored archive's manifest says 1.0.1 — the
+    // shape a republish-under-the-wrong-version leaves behind. Integrity is
+    // recorded over these same bytes, so the SRI and signature gates both pass
+    // and the only fault is the identity disagreement itself.
+    //
+    // `buildBundleFromCatalog` is what detects the mismatch, comparing each
+    // fetched dependency against the identity it resolved. What this PR adds is
+    // the export route's error boundary: that BundleError now surfaces as the
+    // RFC 9457 422 asserted below instead of an untyped 500.
+    await seedVersionedPackage({
+      id: "@exportorg/dep-skill",
+      type: "skill",
+      version: "1.0.0",
+      orgId: ctx.orgId,
+      manifest: {
+        name: "@exportorg/dep-skill",
+        version: "1.0.0",
+        type: "skill",
+        schema_version: "0.1",
+      },
+      artifact: buildAfps(
+        {
+          name: "@exportorg/dep-skill",
+          version: "1.0.1",
+          type: "skill",
+          schema_version: "0.1",
+          display_name: "Dep",
+          author: "tester",
+        },
+        "Body.",
+      ),
+      setLatest: true,
+    });
+
+    const res = await exportDepRoot(ctx);
+
+    expect(res.status).toBe(422);
+    expect(res.headers.get("Content-Type")).toContain("application/problem+json");
+    const body = (await res.json()) as { code: string; detail: string };
+    expect(body.code).toBe("bundle_invalid");
+    // Detail names both the resolved identity and the one the stored manifest
+    // claims, so an operator reads a manifest disagreement, not corrupt bytes.
+    expect(body.detail).toContain("@exportorg/dep-skill@1.0.0");
+    expect(body.detail).toContain("@exportorg/dep-skill@1.0.1");
+    expect(body.detail).toContain("BUNDLE_JSON_INVALID");
+  });
+
+  it("maps a dependency version whose object is absent to 422 dependency_unresolved", async () => {
+    await seedRootWithDependency(ctx);
+    // Object storage outlives truncateAll(); seed stale bytes so absentArtifact
+    // must remove them. Without the delete these bytes are found with a hash
+    // that no longer matches the row below, and the export fails as a
+    // 500 INTEGRITY_MISMATCH instead of the 422 under test.
+    await storage.uploadFile(
+      AGENT_PACKAGES_BUCKET,
+      versionZipKey("@exportorg/dep-skill", "1.0.0"),
+      Buffer.from(zipSync({ "SKILL.md": enc("---\nname: dep-skill\n---\n\nBody.") })),
+    );
+    await seedVersionedPackage({
+      id: "@exportorg/dep-skill",
+      type: "skill",
+      version: "1.0.0",
+      orgId: ctx.orgId,
+      manifest: {
+        name: "@exportorg/dep-skill",
+        version: "1.0.0",
+        type: "skill",
+        schema_version: "0.1",
+      },
+      absentArtifact: true,
+      setLatest: true,
+    });
+
+    const res = await exportDepRoot(ctx);
+
+    expect(res.status).toBe(422);
+    const body = (await res.json()) as { code: string; detail: string };
+    expect(body.code).toBe("dependency_unresolved");
+    expect(body.detail).toContain("@exportorg/dep-skill@1.0.0");
+    // The pin resolved — pointing the operator at the version range would send
+    // them to fix something that is already correct.
+    expect(body.detail).not.toContain("fix the pin");
   });
 
   it("returns 404 when the agent is not accessible to the app", async () => {

--- a/apps/api/test/integration/routes/packages-import-skill-fallback.test.ts
+++ b/apps/api/test/integration/routes/packages-import-skill-fallback.test.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `POST /api/packages/import` — which bytes each import path publishes.
+ *
+ * A bare skill ZIP (`SKILL.md`, no `manifest.json`) gets its manifest
+ * synthesized from the frontmatter, so the archive must be rebuilt before it is
+ * published; readers of a published artifact take the manifest from the archive,
+ * not from the DB row. Every other import must publish the upload untouched.
+ *
+ * Both halves assert on the PUBLISHED artifact through `DbPackageCatalog` — the
+ * reader the run and export paths use — not on the parse result.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { zipSync } from "fflate";
+import { eq } from "drizzle-orm";
+import { getTestApp } from "../../helpers/app.ts";
+import { truncateAll, db } from "../../helpers/db.ts";
+import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
+import { packageVersions } from "@appstrate/db/schema";
+import { computeIntegrity } from "@appstrate/core/integrity";
+import { formatPackageIdentity } from "@appstrate/afps-runtime/bundle";
+import { DbPackageCatalog } from "../../../src/services/run-launcher/db-package-catalog.ts";
+import { downloadVersionZip } from "../../../src/services/package-storage.ts";
+
+const app = getTestApp();
+
+const enc = (s: string) => new TextEncoder().encode(s);
+
+const SKILL_MD = "---\nname: my-skill\ndescription: A test skill.\n---\n\nBody.";
+
+async function importFile(ctx: TestContext, bytes: Uint8Array, filename: string) {
+  const formData = new FormData();
+  formData.append("file", new File([bytes], filename));
+  return app.request("/api/packages/import", {
+    method: "POST",
+    headers: authHeaders(ctx),
+    body: formData,
+  });
+}
+
+/** The single published version row for `packageId`. */
+async function onlyVersion(packageId: string) {
+  const rows = await db
+    .select()
+    .from(packageVersions)
+    .where(eq(packageVersions.packageId, packageId));
+  expect(rows).toHaveLength(1);
+  return rows[0]!;
+}
+
+describe("POST /api/packages/import — published artifact bytes", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "fallbackorg" });
+  });
+
+  it("publishes a reconstructed, catalog-readable artifact for a skill-only ZIP", async () => {
+    const upload = new Uint8Array(zipSync({ "SKILL.md": enc(SKILL_MD) }));
+    const res = await importFile(ctx, upload, "my-skill.zip");
+    expect(res.status).toBe(201);
+
+    const packageId = `@${ctx.org.slug}/my-skill`;
+    expect(await res.json()).toMatchObject({ packageId, version: "1.0.0", type: "skill" });
+
+    // Not the upload: those bytes declare no manifest.
+    const row = await onlyVersion(packageId);
+    expect(row.integrity).not.toBe(computeIntegrity(upload));
+    // `downloadVersionZip` refuses bytes that do not hash to the recorded
+    // integrity, so a non-null return proves row and object agree.
+    expect(await downloadVersionZip(packageId, row.version, row.integrity)).not.toBeNull();
+
+    const pkg = await new DbPackageCatalog({ orgId: ctx.orgId }).fetch(
+      formatPackageIdentity(packageId as `@${string}/${string}`, "1.0.0"),
+    );
+    expect(pkg.manifest).toMatchObject({ name: packageId, version: "1.0.0", type: "skill" });
+    // Reconstruction adds the manifest; it does not rewrite the payload.
+    expect(new TextDecoder().decode(pkg.files.get("SKILL.md")!)).toBe(SKILL_MD);
+  });
+
+  it("publishes an ordinary AFPS upload byte-identically", async () => {
+    const packageId = "@fallbackorg/authored-skill";
+    const upload = new Uint8Array(
+      zipSync({
+        "manifest.json": enc(
+          JSON.stringify({
+            name: packageId,
+            version: "2.1.0",
+            type: "skill",
+            schema_version: "0.1",
+            display_name: "Authored Skill",
+          }),
+        ),
+        "SKILL.md": enc("---\nname: authored-skill\n---\n\nBody."),
+        // A detached signature is the byte that must not be rewritten: any
+        // re-zip would invalidate it.
+        "SIGNATURE.jws": enc("detached-signature-placeholder"),
+      }),
+    );
+
+    expect((await importFile(ctx, upload, "authored.afps")).status).toBe(201);
+
+    const row = await onlyVersion(packageId);
+    expect(row.integrity).toBe(computeIntegrity(upload));
+    expect(
+      new Uint8Array((await downloadVersionZip(packageId, row.version, row.integrity))!),
+    ).toEqual(upload);
+
+    const pkg = await new DbPackageCatalog({ orgId: ctx.orgId }).fetch(
+      formatPackageIdentity(packageId as `@${string}/${string}`, "2.1.0"),
+    );
+    expect(pkg.files.has("SIGNATURE.jws")).toBe(true);
+  });
+});

--- a/apps/api/test/unit/bundle-error-mapping.test.ts
+++ b/apps/api/test/unit/bundle-error-mapping.test.ts
@@ -55,6 +55,25 @@ describe("toBundleApiError", () => {
       expect(mapped!.message).toContain("dependency_overrides");
     });
 
+    // `fetch()` raises the same code for an already-RESOLVED package whose
+    // bytes turned out to be unusable, carrying `details.identity` instead of
+    // `details.missing`. Before #1018 that shape hit the empty-`missing`
+    // fallback: "a declared dependency" with no name, and advice to fix a pin
+    // that had in fact resolved perfectly.
+    it("names the package and drops the pin advice when only `details.identity` is set", () => {
+      const mapped = toBundleApiError(
+        new BundleError("DEPENDENCY_UNRESOLVED", "no ZIP in storage", {
+          identity: "@acme/skill-x@1.0.0",
+        }),
+      );
+
+      expect(mapped!.status).toBe(422);
+      expect(mapped!.code).toBe("dependency_unresolved");
+      expect(mapped!.message).toContain("@acme/skill-x@1.0.0");
+      expect(mapped!.message).toContain("dependency_overrides");
+      expect(mapped!.message).not.toContain("fix the pin");
+    });
+
     it("degrades to a generic phrase when `details.missing` is absent or empty", () => {
       for (const details of [undefined, {}, { missing: [] }]) {
         const mapped = toBundleApiError(new BundleError("DEPENDENCY_UNRESOLVED", "x", details));

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -228,7 +228,7 @@ export interface paths {
         };
         /**
          * Export an agent as an .afps-bundle
-         * @description Streams a canonical multi-package .afps-bundle archive containing the agent and all its transitive dependencies. The archive is deterministic (byte-identical across calls with the same inputs) and carries per-file RECORD hashes plus a bundle-level SRI digest (also echoed in the `X-Bundle-Integrity` response header). Two modes: `?source=published` (default) exports the version installed for this application (falls back to the `latest` dist-tag, or pass `?version=` to pin); `?source=draft` bundles the agent's current draft state — used by the CLI's run-by-id flow to mirror the dashboard Run button on never-published agents. `?source=draft` cannot be combined with `?version=`.
+         * @description Streams a canonical multi-package .afps-bundle archive containing the agent and all its transitive dependencies. The archive is deterministic (byte-identical across calls with the same inputs) and carries per-file RECORD hashes plus a bundle-level SRI digest (also echoed in the `X-Bundle-Integrity` response header). Two modes: `?source=published` (default) exports the version installed for this application (falls back to the `latest` dist-tag, or pass `?version=` to pin); `?source=draft` bundles the agent's current draft state — used by the CLI's run-by-id flow to mirror the dashboard Run button on never-published agents. `?source=draft` cannot be combined with `?version=`. Assembly reads the same stored artifacts a run does, so it reports the same coded bundle failures — see the 422 and 500 responses.
          */
         get: operations["exportAgentBundle"];
         put?: never;
@@ -6382,7 +6382,26 @@ export interface operations {
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
             404: components["responses"]["NotFound"];
+            /** @description The bundle cannot be assembled from stored artifacts. `dependency_unresolved`: a declared dependency resolves to no published version, or it resolved but its artifact is absent from storage or out of this organization's scope — the detail names the dependency. `bundle_invalid`: a stored archive or manifest is malformed or exceeds an archive limit (for example an archive with no `manifest.json` at its root); the package must be republished. `bundle_signature_invalid`: rejected by `AFPS_SIGNATURE_POLICY` */
+            422: {
+                headers: {
+                    "Request-Id": components["headers"]["RequestId"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetail"];
+                };
+            };
             429: components["responses"]["RateLimited"];
+            /** @description Unexpected server error (`internal_error`), or a dependency artifact's bytes no longer match the integrity hash recorded when that version was published (`bundle_integrity_mismatch`) — corruption or tampering at rest; retrying will not help, republish the named dependency or contact the operator */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetail"];
+                };
+            };
         };
     };
     saveAgentConfig: {


### PR DESCRIPTION
## Summary

- rebuild a valid AFPS artifact when the skill-only ZIP fallback synthesizes `manifest.json`
- use those reconstructed bytes consistently for integrity checks, version storage, and force replacement while preserving ordinary AFPS uploads byte-for-byte
- map bundle construction and serialization failures on agent export to the existing RFC 9457 bundle error contract
- enrich dependency artifact failures with the concrete package identity and document the reachable `422` / `500` responses

Closes #1018.

## Diagnosis

The issue is legitimate, but the reported creation path was not.

The affected production version was created through `import:github`. Its database draft/files contained the synthesized manifest, while its immutable stored artifact contained only `SKILL.md`. Draft reads therefore worked, but every published reader failed with `BUNDLE_JSON_INVALID` because `manifest.json` was absent from the archive.

The JSON editor publish path had already been made atomic in #910. The remaining bug was the shared skill-only fallback used by ZIP and GitHub imports: it returned synthesized parsed files but passed the original manifest-less upload to version storage.

On the pre-fix code, the regression tests reproduce both failure modes:

- the published dependency cannot be fetched by `DbPackageCatalog`
- agent export returns an opaque `500 internal_error` instead of an actionable typed error

## Implementation

1. Return the parsed import together with the exact artifact bytes that represent it.
   - ordinary AFPS: publish the original upload unchanged
   - skill-only fallback: deterministically rebuild the archive from the parsed files plus synthesized manifest
2. Feed that artifact through every integrity, upload, and replacement path.
3. Keep both bundle construction and `writeBundleToBuffer` inside the export route's typed error boundary.
4. Preserve the underlying `BundleError` code, attach dependency identity at the catalog boundary, and distinguish an unresolved pin from an already-resolved but unusable artifact.
5. Update OpenAPI and generated client types without sweeping unrelated baseline drift into this PR.

## Repairing existing versions

No new repair endpoint is added. Existing immutable versions can already be replaced deliberately by importing a complete archive through `POST /api/packages/import?force=true`. Rebuilding an immutable published version automatically from mutable draft state would add a second repair primitive and weaken provenance without evidence that it is needed.

## Validation

- focused regression suites: **27 passed, 0 failed**
- `packages/afps-runtime` + `packages/core`: **1,421 passed, 0 failed**
- `bun run check`: **33/33 tasks passed**
- full API suite: **3,571 passed, 82 skipped, 1 unrelated timeout**
  - `llm_usage durable retry ... worker PERSISTS it` exceeds its 5 s test timeout
  - reproduced with the issue changes reverted; no related source or test is touched here

No schema or migration changes.
