### PR TITLE
fix(release): close remaining lockstep fail-open paths

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -104,77 +104,17 @@ jobs:
             exit 1
           fi
 
-      # ── Precondition for the lockstep gate below ────────────────────────────
       # Release procedure (ordering, bypass, token): docs/deployment/RELEASING_CORE.md
       #
-      # `check-consumer-versions.ts` reads two consumer repos through the
-      # GitHub contents API. BOTH ARE PRIVATE (cloud, connect-helper).
-      # `secrets.GITHUB_TOKEN` is scoped to
-      # THIS repo only, so for a private consumer the API answers 404 — and the
-      # script treats 404 as "not present, skipping" (a legitimate outcome for a
-      # repo that genuinely has no package.json at that path, so the script
-      # cannot tell the two apart).
-      #
-      # Net effect without a cross-repo token: the gate prints
-      # "0 failure(s), 0 warning(s)" and passes having verified NOTHING. That is
-      # worse than having no gate at all — a fail-closed check that had never
-      # once closed. Make the missing precondition loud instead.
-      #
-      # This step checks PRESENCE, which is not the same as CAPABILITY — and
-      # the difference bit on the core@6.1.0 release. The secret was present
-      # (added 2026-07-28) so this step passed, but the token could not read
-      # either private consumer; both 404'd, and the script logged them as
-      # "not present, skipping" and printed `0 failure(s)`. Presence was
-      # verified, capability never was.
-      #
-      # Capability is now enforced where it can actually be observed, in
-      # `check-consumer-versions.ts`: a 404 on a listed consumer throws instead
-      # of returning null, so it lands in the fail-closed catch. This step is
-      # still worth keeping — it names the missing precondition before the
-      # script runs, which is a clearer error than a fetch failure — but the
-      # gate no longer DEPENDS on it being right.
-      #
-      # Bypassing stays possible, but it must be a deliberate act (set the repo
-      # variable CONSUMER_DRIFT_POLICY to `warn` or `off`), never the accident
-      # of an absent secret.
-      - name: Assert the lockstep gate can actually run
-        working-directory: .
-        env:
-          LOCKSTEP_TOKEN: ${{ secrets.CONSUMER_LOCKSTEP_TOKEN }}
-          CONSUMER_DRIFT_POLICY: ${{ vars.CONSUMER_DRIFT_POLICY || 'fail' }}
-        run: |
-          if [ -n "$LOCKSTEP_TOKEN" ]; then
-            echo "CONSUMER_LOCKSTEP_TOKEN is set — the lockstep gate can read the private consumer repos."
-            exit 0
-          fi
-          MSG="CONSUMER_LOCKSTEP_TOKEN is not set. Every consumer repo (appstrate/cloud, appstrate/connect-helper) is private, so the fallback GITHUB_TOKEN gets a 404 on both of them and no consumer version can be read."
-          if [ "$CONSUMER_DRIFT_POLICY" = "fail" ]; then
-            echo "::error title=Consumer lockstep gate cannot run::${MSG} Fix: add a repository secret CONSUMER_LOCKSTEP_TOKEN (PAT or GitHub App token with contents:read on those repos). To publish anyway, set the repository variable CONSUMER_DRIFT_POLICY to 'warn' or 'off' — a deliberate, auditable bypass."
-            {
-              echo "### ❌ Consumer lockstep gate: NOT EXECUTED"
-              echo ""
-              echo "${MSG}"
-            } >> "$GITHUB_STEP_SUMMARY"
-            exit 1
-          fi
-          echo "::warning title=Consumer lockstep gate NOT executed::${MSG} CONSUMER_DRIFT_POLICY=${CONSUMER_DRIFT_POLICY} — publishing without verifying consumer versions."
-          {
-            echo "### ⚠️ Consumer lockstep gate: NOT EXECUTED"
-            echo ""
-            echo "${MSG}"
-            echo ""
-            echo "Bypassed on purpose via \`CONSUMER_DRIFT_POLICY=${CONSUMER_DRIFT_POLICY}\`."
-          } >> "$GITHUB_STEP_SUMMARY"
-
+      # Both consumers are private, so there is deliberately no GITHUB_TOKEN
+      # fallback. The script handles every non-2xx according to policy. Only
+      # exact `warn` and `off` values bypass; unknown values fail closed.
       - name: Check consumer-repo lockstep
         working-directory: .
         env:
-          # No `|| secrets.GITHUB_TOKEN` fallback: it cannot read the private
-          # consumer repos, and silently degrading to it is exactly what made
-          # this gate inert. The step above guarantees this is non-empty unless
-          # CONSUMER_DRIFT_POLICY was deliberately relaxed.
           GITHUB_TOKEN: ${{ secrets.CONSUMER_LOCKSTEP_TOKEN }}
-          # `fail` blocks publish if any consumer is >= 2 minors behind.
+          # `fail` blocks on any blocking drift verdict, an unreadable consumer,
+          # or an unparsable range. One-major-behind at X.0.0 remains a warning.
           # Set to `warn` for an emergency hotfix that intentionally outpaces
           # consumers, or `off` to bypass entirely.
           CONSUMER_DRIFT_POLICY: ${{ vars.CONSUMER_DRIFT_POLICY || 'fail' }}

--- a/docs/deployment/RELEASING_CORE.md
+++ b/docs/deployment/RELEASING_CORE.md
@@ -67,22 +67,22 @@ unbumped consumer does not stay quiet, it blocks the next publish.
 block the publish under the default `fail` policy; `warn` reports them without
 blocking, `off` skips the check entirely.
 
-| Consumer state                              | Verdict                                 |
-| ------------------------------------------- | --------------------------------------- |
-| Major mismatch                              | fail                                    |
-| Exactly one major behind, **at an `X.0.0`** | warn (see step 2)                       |
-| ≥ 2 minors behind                           | fail                                    |
-| 1 minor behind                              | warn                                    |
-| In sync, or patch-behind                    | ok                                      |
-| Ahead within the same major                 | ok — logged as `in sync`                |
-| Fetch error (403, rate limit, outage)       | fail — "could not verify" is a failure  |
-| 404 on the path                             | logged, counted as nothing              |
-| No `@appstrate/core` in the merged deps     | logged, counted as nothing              |
-| Unparsable range                            | logged, counted as nothing — not a warn |
+| Consumer state                                  | Verdict                                 |
+| ----------------------------------------------- | --------------------------------------- |
+| Major mismatch                                  | fail                                    |
+| Exactly one major behind, **at an `X.0.0`**     | warn (see step 2)                       |
+| ≥ 2 minors behind                               | fail                                    |
+| 1 minor behind                                  | warn                                    |
+| In sync, or patch-behind                        | ok                                      |
+| Ahead within the same major                     | ok — logged as `in sync`                |
+| Fetch error (including 404, rate limit, outage) | fail under `fail`; warning under `warn` |
+| No `@appstrate/core` in the merged deps         | informational log; not counted          |
+| Unparsable range                                | fail under `fail`; warning under `warn` |
 
-A clean run prints `Summary: 0 failure(s), 0 warning(s)` — not proof every
-consumer was assessed: the last three rows produce it too, and an unparsable
-range leaves a listed consumer unassessed. Read the per-consumer lines above it.
+A clean run prints `Summary: 0 failure(s), 0 warning(s)`. It no longer hides a
+failed fetch or an unparsable range: both are counted. It can still include an
+informational "does not depend on `@appstrate/core`" line, so read the
+per-consumer output too.
 
 **It is a drift alarm, not a compatibility guard.** Publishing a new major
 breaks no consumer at install time — a `^2` range keeps resolving 2.x. What the
@@ -100,24 +100,19 @@ _cancelled_ job forces a bump. Never re-point the tag at a new commit.
 
 Both consumers are private, so the repository secret
 **`CONSUMER_LOCKSTEP_TOKEN`** must hold a PAT or GitHub App token with
-`contents:read` on both. Without it the gate passes having verified **nothing**
-— the comment above the gate step in `publish-core.yml` explains the mechanism.
-The secret was added on 2026-07-28; treat any green run from before that date as
-unverified.
-
-The assert step guarding it only tests that the secret is a non-empty string. It
-never calls the API, so a token that still exists but has lost `contents:read`
-on a consumer passes the assert and leaves the gate silently inert (#1041).
+`contents:read` on both. There is no separate preflight and no fallback token:
+the script checks capability with the real contents requests. An absent token or
+a token that cannot read a consumer makes that fetch fail. The strict `fail`
+policy blocks the publish, explicit `warn` reports the failed reads and
+continues, and `off` skips the check before any request.
 
 ## Bypassing — deliberate and auditable
 
 Set the repository **variable** `CONSUMER_DRIFT_POLICY` to `warn` or `off`, and
-**delete it again once the publish is through**. It relaxes both the assert step
-and the gate.
+**delete it again once the publish is through**. `warn` reports without
+blocking; `off` skips the gate entirely.
 
-Unset, the policy is `fail` — and so is any unrecognized value, **in the
-script**: `resolvePolicy` coerces a typo, or wrong case like `FAIL`, back to
-`fail` with a warning. The workflow's assert step does not share that logic — it
-compares the raw string against `"fail"` literally and case-sensitively, so
-`CONSUMER_DRIFT_POLICY=FAIL` takes its warn branch and exits 0 while the script
-still treats the same value as `fail` (#1041).
+The script is the single policy resolver. Only the exact lowercase values
+`warn` and `off` bypass blocking. An absent or unrecognized value — including
+wrong case such as `FAIL`, `WARN` or `OFF` — resolves to `fail`; unrecognized
+values also emit a warning.

--- a/scripts/check-consumer-versions.ts
+++ b/scripts/check-consumer-versions.ts
@@ -68,7 +68,7 @@ const VALID_POLICIES: readonly DriftPolicy[] = ["warn", "fail", "off"];
  * must NOT silently disable blocking — fall back to `fail` with a warning so a
  * misconfigured env can never fail open.
  */
-function resolvePolicy(raw: string | undefined): DriftPolicy {
+export function resolvePolicy(raw: string | undefined): DriftPolicy {
   if (raw === undefined) return "fail";
   if ((VALID_POLICIES as readonly string[]).includes(raw)) return raw as DriftPolicy;
   console.warn(
@@ -147,6 +147,26 @@ export function assessDrift(
     return { verdict: "ok", detail: "patch-behind, OK" };
   }
   return { verdict: "ok", detail: "in sync" };
+}
+
+/**
+ * Assess a consumer's declared range. A range that cannot be parsed is also a
+ * consumer that cannot be verified, so it follows the active enforcement
+ * policy instead of disappearing from the summary.
+ */
+export function assessDeclaredRange(
+  local: [number, number, number],
+  range: string,
+  policy: Exclude<DriftPolicy, "off">,
+): DriftAssessment {
+  const consumer = parseSemver(range);
+  if (!consumer) {
+    return {
+      verdict: policy === "fail" ? "fail" : "warn",
+      detail: `unparsable range "${range}", cannot verify drift`,
+    };
+  }
+  return assessDrift(local, consumer);
 }
 
 /**
@@ -256,13 +276,7 @@ async function main(): Promise<void> {
         continue;
       }
 
-      const consumerVersion = parseSemver(range);
-      if (!consumerVersion) {
-        console.warn(`  ? ${consumer.repo}/${path} — unparsable range "${range}"`);
-        continue;
-      }
-
-      const { verdict, detail } = assessDrift(localVersion, consumerVersion);
+      const { verdict, detail } = assessDeclaredRange(localVersion, range, POLICY);
       const line = `${consumer.repo}/${path} pins ${range} — ${detail}`;
       if (verdict === "fail") {
         console.error(`  ✗ ${line}`);
@@ -286,8 +300,7 @@ async function main(): Promise<void> {
   }
 }
 
-// Guarded so the test file can import `assessDrift` without the module
-// hitting the GitHub API on import.
+// Guarded so tests can import this script without hitting the GitHub API.
 if (import.meta.main) {
   main().catch((err) => {
     console.error(err instanceof Error ? err.stack : String(err));

--- a/scripts/check-consumer-versions.ts
+++ b/scripts/check-consumer-versions.ts
@@ -202,12 +202,16 @@ export async function fetchPackageJson(
     // it does not leak the repo's existence. Name that here: the message is
     // the operator's only clue, and "404 Not Found" alone reads as "the file
     // was deleted" — sending them to look in the wrong place.
+    const authHint = token
+      ? ` Check that CONSUMER_LOCKSTEP_TOKEN still has contents:read on ${repo}` +
+        ` (expired PAT, missing scope, repository not selected, or SSO not authorized).`
+      : ` GITHUB_TOKEN is not configured. Configure it with a token that has contents:read on ${repo};` +
+        ` the publish-core workflow sources GITHUB_TOKEN from the repository secret CONSUMER_LOCKSTEP_TOKEN.`;
     const hint =
       res.status === 404
         ? ` — a listed consumer always has this file, so this is a READ failure, not an absent file.` +
-          ` Check that ${token ? "CONSUMER_LOCKSTEP_TOKEN" : "GITHUB_TOKEN"} still has contents:read on ${repo}` +
-          ` (expired PAT, missing scope, or SSO not authorized). If the repo genuinely stopped consuming` +
-          ` @appstrate/core, remove it from CONSUMERS instead.`
+          authHint +
+          ` If the repo genuinely stopped consuming @appstrate/core, remove it from CONSUMERS instead.`
         : "";
     throw new Error(`GET ${url} → ${res.status} ${res.statusText}${hint}`);
   }

--- a/scripts/test/check-consumer-versions.test.ts
+++ b/scripts/test/check-consumer-versions.test.ts
@@ -128,8 +128,14 @@ describe("assessDeclaredRange", () => {
 
 describe("fetchPackageJson", () => {
   const realFetch = globalThis.fetch;
+  const initialToken = process.env.GITHUB_TOKEN;
   afterEach(() => {
     globalThis.fetch = realFetch;
+    if (initialToken === undefined) {
+      delete process.env.GITHUB_TOKEN;
+    } else {
+      process.env.GITHUB_TOKEN = initialToken;
+    }
   });
 
   // The double assertion is deliberate: the stub implements `fetch`'s call
@@ -164,13 +170,26 @@ describe("fetchPackageJson", () => {
   it("names the token and the likely causes in the 404 message", async () => {
     // The message is the operator's only clue. Bare "404 Not Found" reads as
     // "the file was deleted" and sends them to look in the wrong place.
+    process.env.GITHUB_TOKEN = "test-token";
     stubFetch(404, "Not Found");
     const err = await fetchPackageJson("appstrate/cloud", "package.json").catch(
       (e: unknown) => e as Error,
     );
     expect(err.message).toContain("READ failure");
-    expect(err.message).toContain("contents:read");
+    expect(err.message).toContain("CONSUMER_LOCKSTEP_TOKEN");
+    expect(err.message).toContain("missing scope");
+    expect(err.message).toContain("SSO not authorized");
     expect(err.message).toContain("appstrate/cloud");
+  });
+
+  it("names the publish-core secret when GITHUB_TOKEN is absent", async () => {
+    delete process.env.GITHUB_TOKEN;
+    stubFetch(404, "Not Found");
+    const err = await fetchPackageJson("appstrate/cloud", "package.json").catch(
+      (e: unknown) => e as Error,
+    );
+    expect(err.message).toContain("GITHUB_TOKEN is not configured");
+    expect(err.message).toContain("CONSUMER_LOCKSTEP_TOKEN");
   });
 
   it("still throws on other non-2xx statuses", async () => {

--- a/scripts/test/check-consumer-versions.test.ts
+++ b/scripts/test/check-consumer-versions.test.ts
@@ -8,12 +8,37 @@
  * only reachable state) and the non-major case that keeps the gate's teeth.
  */
 
-import { describe, it, expect, afterEach } from "bun:test";
-import { assessDrift, fetchPackageJson } from "../check-consumer-versions.ts";
+import { describe, it, expect, afterEach, spyOn } from "bun:test";
+import {
+  assessDeclaredRange,
+  assessDrift,
+  fetchPackageJson,
+  resolvePolicy,
+} from "../check-consumer-versions.ts";
 
 type V = [number, number, number];
 
 const verdict = (local: V, consumer: V) => assessDrift(local, consumer).verdict;
+
+describe("resolvePolicy", () => {
+  it("keeps only the exact lowercase policies", () => {
+    expect(resolvePolicy("fail")).toBe("fail");
+    expect(resolvePolicy("warn")).toBe("warn");
+    expect(resolvePolicy("off")).toBe("off");
+  });
+
+  it("fails closed on wrong case and typos", () => {
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      for (const raw of ["FAIL", "WARN", "OFF", "typo"]) {
+        expect(resolvePolicy(raw)).toBe("fail");
+      }
+      expect(warn).toHaveBeenCalledTimes(4);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
 
 describe("assessDrift — major mismatch", () => {
   it("warns when a MAJOR release finds a consumer exactly one major behind (#1028)", () => {
@@ -73,6 +98,31 @@ describe("assessDrift — same major", () => {
     // silently turn it into a publish-blocking failure.
     expect(assessDrift([6, 2, 0], [6, 5, 0])).toEqual({ verdict: "ok", detail: "in sync" });
     expect(assessDrift([6, 2, 0], [6, 2, 7])).toEqual({ verdict: "ok", detail: "in sync" });
+  });
+});
+
+describe("assessDeclaredRange", () => {
+  it("preserves assessDrift for a valid range", () => {
+    expect(assessDeclaredRange([6, 3, 0], "^6.1.0", "fail")).toEqual(
+      assessDrift([6, 3, 0], [6, 1, 0]),
+    );
+    expect(assessDeclaredRange([6, 3, 0], "^6.2.0", "warn")).toEqual(
+      assessDrift([6, 3, 0], [6, 2, 0]),
+    );
+  });
+
+  it("fails an unparsable range under the fail policy", () => {
+    expect(assessDeclaredRange([6, 3, 0], "workspace:*", "fail")).toEqual({
+      verdict: "fail",
+      detail: 'unparsable range "workspace:*", cannot verify drift',
+    });
+  });
+
+  it("warns on an unparsable range under the warn policy", () => {
+    expect(assessDeclaredRange([6, 3, 0], "workspace:*", "warn")).toEqual({
+      verdict: "warn",
+      detail: 'unparsable range "workspace:*", cannot verify drift',
+    });
   });
 });
 


### PR DESCRIPTION
Closes #1041.

## Audit outcome

#1041 was valid when filed, but its main token-capability failure was already
fixed upstream by #1051: the real consumer fetch now throws on every non-2xx,
including the private-repository 404 returned for insufficient access.

That makes the proposed per-consumer `curl` probes redundant. They would repeat
the same requests, duplicate the authoritative `CONSUMERS` list, and need a
second implementation of `fail|warn|off`.

Two real residual problems remained:

- an unparsable consumer range was logged but not counted, so strict mode could
  still publish with `Summary: 0 failure(s), 0 warning(s)`;
- the workflow preflight duplicated policy handling and could report a
  wrong-case or unknown value as a deliberate bypass even though the script
  resolved it to `fail`.

## Changes

- Classify an unparsable declared range as a failure under `fail` and a warning
  under `warn`, using the existing summary and exit paths.
- Pin the policy contract in tests: only exact lowercase `fail|warn|off` values
  are recognized; unknown or wrong-case values fail closed.
- Remove the redundant workflow preflight so the real script fetch is the
  single capability and policy gate.
- Keep missing-token and inaccessible-token failures actionable, including the
  `CONSUMER_LOCKSTEP_TOKEN` repository-secret name.
- Update the workflow comments and `RELEASING_CORE.md` to describe current
  404, range, summary, token, and bypass behavior.

## Deliberately not included

- No duplicate `curl` probes.
- No case normalization: `WARN`/`OFF` remain configuration mistakes, not
  implicit bypasses.
- No unrelated CI-cache, actionlint-trigger, or test-job expansion.
- No semver parser replacement or orchestration framework.

## Commits

1. `fix(release): fail closed on unparsable consumer ranges`
2. `refactor(release): make the script the single lockstep gate`
3. `docs(release): align the core lockstep runbook`

## Verification

- `TEST_TIER=0 bun test scripts/test/check-consumer-versions.test.ts`
  — 20 pass, 0 fail, 41 assertions
- `bun run check` with the same dummy secrets as `.github/workflows/check.yml`
  — 33/33 tasks successful
- `bun run typecheck:scripts`
- `actionlint -ignore 'SC2129' .github/workflows/publish-core.yml`
- Prettier on all four changed files
- `git diff --check origin/main...HEAD`
- Independent final Standards review: 0 findings
- Independent final Spec review: 0 findings
