### PR TITLE
fix(runtime-pi): force SSE through the sidecar

### DIFF
--- a/packages/runner-pi/src/index.ts
+++ b/packages/runner-pi/src/index.ts
@@ -16,7 +16,7 @@ export { deriveProviderFromApi, PROVIDER_BY_API } from "./provider-map.ts";
 // entrypoint can overlap its ~200ms eval with network-bound provisioning
 // instead of paying it on the pre-session boot path. `Type` (pi-ai, cheap) is a
 // static value export for building tool parameter schemas; the SDK type surface
-// (Model/Api/ExtensionFactory/ExtensionAPI/AuthStorage) rides through here so
+// (Model/Api/Transport/ExtensionFactory/ExtensionAPI/AuthStorage) rides through here so
 // consumers (e.g. the chat module's Pi engine) never import the vendor SDK
 // directly — the single-import-surface guard is the barrel.
 export { Type, loadPiCodingAgentSdk, type PiCodingAgentSdk } from "./pi-sdk.ts";
@@ -24,6 +24,7 @@ export type {
   Api,
   KnownApi,
   Model,
+  Transport,
   AuthStorage,
   ExtensionAPI,
   ExtensionFactory,

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -34,6 +34,7 @@ import {
   type Api,
   type KnownApi,
   type Model,
+  type Transport,
 } from "./pi-sdk.ts";
 import { scheduleDeadlineNudges } from "./deadline-nudges.ts";
 import type { ModelApiShape } from "@appstrate/core/sidecar-types";
@@ -112,6 +113,11 @@ export interface PiRunnerOptions {
   authStoragePath?: string;
   /** Pi SDK thinking level. Defaults to `"medium"`. */
   thinkingLevel?: "low" | "medium" | "high";
+  /**
+   * Preferred transport for providers that support multiple transports.
+   * Providers that do not support this option ignore it. Defaults to `"auto"`.
+   */
+  transport?: Transport;
   /**
    * Tool names whose first successful execution ends the run. When one of
    * these tools completes without error the runner aborts the Pi session
@@ -467,6 +473,7 @@ export class PiRunner implements Runner {
       sessionManager: SessionManager.inMemory(),
       settingsManager: SettingsManager.inMemory({
         compaction: budget.compaction,
+        transport: this.opts.transport ?? "auto",
         // Pi SDK's built-in retry (Retry-After honoring + jitter) covers
         // transient 429/5xx upstream — including OpenAI's mid-stream 5xx
         // `server_error`, which the Codex/Responses adapter surfaces as a

--- a/packages/runner-pi/src/pi-sdk.ts
+++ b/packages/runner-pi/src/pi-sdk.ts
@@ -23,7 +23,7 @@ export { Type } from "@mariozechner/pi-ai";
 
 // --- types (erased at runtime) ---
 export type { AuthStorage, ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent";
-export type { Api, KnownApi, Model } from "@mariozechner/pi-ai";
+export type { Api, KnownApi, Model, Transport } from "@mariozechner/pi-ai";
 
 // --- heavy value surface (pi-coding-agent, ~200ms) behind a dynamic import ---
 // `@mariozechner/pi-coding-agent` is the single most expensive module to

--- a/packages/runner-pi/test/pi-runner-transport.test.ts
+++ b/packages/runner-pi/test/pi-runner-transport.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "bun:test";
+import { mkdtemp, mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { PiRunner, type PiModelConfig, type Transport } from "../src/index.ts";
+import { createCaptureSink, makeBundlePackage, makeContext, makeTestBundle } from "./helpers.ts";
+
+const TEST_JWT = [
+  encodeJwtSegment({ alg: "none", typ: "JWT" }),
+  encodeJwtSegment({
+    "https://api.openai.com/auth": { chatgpt_account_id: "acct_test" },
+  }),
+  "placeholder",
+].join(".");
+
+const TEST_BUNDLE = makeTestBundle(
+  makeBundlePackage("@test/codex-transport", "0.0.0", "agent", {}),
+);
+
+function encodeJwtSegment(value: unknown): string {
+  return btoa(JSON.stringify(value)).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function completedResponse(): Response {
+  const event = {
+    type: "response.completed",
+    response: {
+      id: "resp_test",
+      status: "completed",
+      output: [],
+      usage: {
+        input_tokens: 1,
+        input_tokens_details: { cached_tokens: 0 },
+        output_tokens: 1,
+        total_tokens: 2,
+      },
+    },
+  };
+  return new Response(`data: ${JSON.stringify(event)}\n\n`, {
+    headers: { "content-type": "text/event-stream" },
+  });
+}
+
+async function runAgainstLocalCodex(transport?: Transport): Promise<{
+  methods: string[];
+  paths: string[];
+  upgrades: Array<string | null>;
+  accepts: Array<string | null>;
+  status: string | undefined;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "runner-pi-transport-"));
+  const agentDir = join(root, "agent");
+  const methods: string[] = [];
+  const paths: string[] = [];
+  const upgrades: Array<string | null> = [];
+  const accepts: Array<string | null> = [];
+  let server: ReturnType<typeof Bun.serve> | undefined;
+
+  try {
+    await mkdir(agentDir, { recursive: true });
+    server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(request) {
+        methods.push(request.method);
+        paths.push(new URL(request.url).pathname);
+        upgrades.push(request.headers.get("upgrade"));
+        accepts.push(request.headers.get("accept"));
+        if (request.method === "POST") return completedResponse();
+        return new Response("Method Not Allowed", { status: 405 });
+      },
+    });
+
+    const model: PiModelConfig = {
+      id: "gpt-5-codex",
+      name: "gpt-5-codex",
+      api: "openai-codex-responses",
+      provider: "openai",
+      baseUrl: server.url.origin,
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 4_096,
+    };
+    const sink = createCaptureSink();
+    const runner = new PiRunner({
+      model,
+      apiKey: TEST_JWT,
+      systemPrompt: "Answer briefly.",
+      startMessage: "Say done.",
+      cwd: root,
+      agentDir,
+      authStoragePath: join(root, "auth.json"),
+      ...(transport ? { transport } : {}),
+    });
+
+    await runner.run({
+      bundle: TEST_BUNDLE,
+      context: makeContext(),
+      eventSink: sink,
+    });
+
+    expect(sink.finalizeCalls).toBe(1);
+    return {
+      methods,
+      paths,
+      upgrades,
+      accepts,
+      status: sink.finalized?.status,
+    };
+  } finally {
+    if (server) await server.stop(true);
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+describe("PiRunner provider transport", () => {
+  it("keeps the direct default explicit: WebSocket probe then SSE fallback", async () => {
+    const result = await runAgainstLocalCodex();
+
+    expect(result.methods).toEqual(["GET", "POST"]);
+    expect(result.paths).toEqual(["/codex/responses", "/codex/responses"]);
+    expect(result.upgrades).toEqual(["websocket", null]);
+    expect(result.accepts[1]).toBe("text/event-stream");
+    expect(result.status).toBe("success");
+  });
+
+  it("uses SSE directly and finalizes successfully when requested", async () => {
+    const result = await runAgainstLocalCodex("sse");
+
+    expect(result.methods).toEqual(["POST"]);
+    expect(result.paths).toEqual(["/codex/responses"]);
+    expect(result.upgrades).toEqual([null]);
+    expect(result.accepts).toEqual(["text/event-stream"]);
+    expect(result.status).toBe("success");
+  });
+});

--- a/runtime-pi/entrypoint.ts
+++ b/runtime-pi/entrypoint.ts
@@ -837,6 +837,9 @@ function buildPiRunner(): PiRunner {
     agentDir: "/tmp/pi-agent",
     extensionFactories,
     authStoragePath: "/tmp/pi-auth/auth.json",
+    // The sidecar's /llm route is HTTP/SSE-only: Pi's "auto" would first
+    // probe it with a WebSocket GET (405). No-sidecar runs keep the auto default.
+    ...(sidecarUrl ? { transport: "sse" as const } : {}),
     ...(declaredRuntimeTools.includes("output") ? { terminalTools: ["output"] } : {}),
   });
 }

--- a/runtime-pi/entrypoint.ts
+++ b/runtime-pi/entrypoint.ts
@@ -37,7 +37,6 @@ import { writeSync } from "node:fs";
 import * as path from "node:path";
 import type { ExtensionFactory, Api, Model } from "./pi-sdk.ts";
 import {
-  PiRunner,
   prepareBundleForPi,
   buildRuntimeToolExtensions,
   buildPublishDocumentExtension,
@@ -46,6 +45,7 @@ import {
   emitBootProgress,
   startSinkHeartbeat,
   loadPiCodingAgentSdk,
+  type PiRunner,
 } from "@appstrate/runner-pi";
 import { getErrorMessage } from "@appstrate/core/errors";
 import type { IntegrationBootReport } from "@appstrate/core/sidecar-types";
@@ -65,6 +65,7 @@ import type { ExecutionContext, RunEvent } from "@appstrate/afps-runtime/types";
 import { emptyRunResult } from "@appstrate/afps-runtime/runner";
 import { createMcpHttpClient, type AppstrateMcpClient } from "@appstrate/mcp-transport";
 import { parseRuntimeEnv, RuntimeEnvError, scrubSinkEnv } from "./env.ts";
+import { createRuntimePiRunner } from "./pi-runner.ts";
 import { buildMcpDirectFactories } from "./mcp/direct.ts";
 import {
   createRuntimeEventDrainer,
@@ -829,7 +830,8 @@ function buildPiRunner(): PiRunner {
   // communication contract discards anyway. Gated on the manifest selection
   // so a bundle-defined tool that happens to be named `output` (no
   // `runtime_tools` opt-in) keeps the SDK's natural stop.
-  return new PiRunner({
+  return createRuntimePiRunner({
+    sidecarUrl,
     model,
     apiKey: env.modelApiKey,
     systemPrompt,
@@ -837,9 +839,6 @@ function buildPiRunner(): PiRunner {
     agentDir: "/tmp/pi-agent",
     extensionFactories,
     authStoragePath: "/tmp/pi-auth/auth.json",
-    // The sidecar's /llm route is HTTP/SSE-only: Pi's "auto" would first
-    // probe it with a WebSocket GET (405). No-sidecar runs keep the auto default.
-    ...(sidecarUrl ? { transport: "sse" as const } : {}),
     ...(declaredRuntimeTools.includes("output") ? { terminalTools: ["output"] } : {}),
   });
 }

--- a/runtime-pi/pi-runner.ts
+++ b/runtime-pi/pi-runner.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { PiRunner, type PiRunnerOptions } from "@appstrate/runner-pi";
+
+type RuntimePiRunnerOptions = Omit<PiRunnerOptions, "transport"> & {
+  /**
+   * Captured sidecar topology. Required so runtime callers cannot silently
+   * omit the transport decision; `undefined` preserves Pi's direct-run default.
+   */
+  sidecarUrl: string | undefined;
+};
+
+/**
+ * Build the runtime's Pi runner. The sidecar `/llm` route is HTTP/SSE-only;
+ * Pi's `"auto"` would first probe it with a WebSocket GET (405).
+ */
+export function createRuntimePiRunner({
+  sidecarUrl,
+  ...options
+}: RuntimePiRunnerOptions): PiRunner {
+  return new PiRunner({
+    ...options,
+    ...(sidecarUrl ? { transport: "sse" } : {}),
+  });
+}

--- a/runtime-pi/sidecar/app.ts
+++ b/runtime-pi/sidecar/app.ts
@@ -296,6 +296,7 @@ async function passUpstream(
 async function logOauthLlmResponse(
   credentialId: string,
   targetUrl: string,
+  method: string,
   upstream: Response,
 ): Promise<Response> {
   if (upstream.status >= 200 && upstream.status < 300) return upstream;
@@ -316,6 +317,7 @@ async function logOauthLlmResponse(
   logger.warn("oauth llm: upstream response non-2xx", {
     credentialId,
     targetUrl,
+    method,
     status: upstream.status,
     contentType: upstream.headers.get("content-type"),
     responseHeaders,
@@ -727,7 +729,7 @@ export function createApp(deps: AppDeps): Hono {
       return llmFetchErrorResponse(c, targetUrl, err);
     }
 
-    upstream = await logOauthLlmResponse(llmConfig.credentialId, targetUrl, upstream);
+    upstream = await logOauthLlmResponse(llmConfig.credentialId, targetUrl, method, upstream);
 
     // 401 retry: invalidate + force-refresh the token, replay once.
     if (upstream.status === 401) {
@@ -735,7 +737,7 @@ export function createApp(deps: AppDeps): Hono {
       try {
         const refreshed = await tokenCache.forceRefresh(llmConfig.credentialId);
         upstream = await doFetch(buildHeaders(refreshed.accessToken));
-        upstream = await logOauthLlmResponse(llmConfig.credentialId, targetUrl, upstream);
+        upstream = await logOauthLlmResponse(llmConfig.credentialId, targetUrl, method, upstream);
       } catch (err) {
         if (err instanceof NeedsReconnectionError) {
           return c.json(

--- a/runtime-pi/sidecar/test/oauth-llm.test.ts
+++ b/runtime-pi/sidecar/test/oauth-llm.test.ts
@@ -13,8 +13,9 @@
  * and the upstream provider via one `fetchFn` dispatcher.
  */
 
-import { describe, it, expect, mock } from "bun:test";
+import { describe, it, expect, mock, spyOn } from "bun:test";
 import { createApp, type AppDeps } from "../app.ts";
+import { logger } from "../logger.ts";
 import { OAuthTokenCache } from "../oauth-token-cache.ts";
 import type { OAuthTokenResponse } from "@appstrate/core/sidecar-types";
 import type { LlmProxyOauthConfig } from "../helpers.ts";
@@ -183,6 +184,59 @@ describe("/llm/* oauth — no forging", () => {
       body,
     });
     expect(calls[1]!.body).toBe(body);
+  });
+
+  it("logs the forwarded method and status on a redacted upstream 405", async () => {
+    const headerSecret = "header-secret-954";
+    const bodySecret = "body-secret-954";
+    const { fetchFn, calls } = setupFetchMock((url) => {
+      if (url.startsWith(PLATFORM_API)) {
+        return new Response(JSON.stringify(buildOAuthTokenResponse()), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(`upstream echoed Bearer ${bodySecret}`, {
+        status: 405,
+        headers: {
+          "Content-Type": "application/json",
+          "WWW-Authenticate": `Bearer ${headerSecret}`,
+        },
+      });
+    });
+    const warnSpy = spyOn(logger, "warn").mockImplementation(() => {});
+
+    try {
+      const deps = makeDeps(fetchFn);
+      deps.config.llm = OAUTH_CFG;
+      const app = createApp(deps);
+
+      const res = await app.request("/llm/codex/responses", { method: "GET" });
+
+      expect(res.status).toBe(405);
+      const upstreamCalls = calls.filter((call) =>
+        call.url.startsWith("https://api.anthropic.com"),
+      );
+      expect(upstreamCalls).toHaveLength(1);
+      expect(upstreamCalls[0]!.method).toBe("GET");
+
+      const non2xxWarnings = warnSpy.mock.calls.filter(
+        ([message]) => message === "oauth llm: upstream response non-2xx",
+      );
+      expect(non2xxWarnings).toHaveLength(1);
+      const payload = non2xxWarnings[0]![1] as Record<string, unknown>;
+      expect(payload).toMatchObject({
+        credentialId: "conn-oauth",
+        targetUrl: "https://api.anthropic.com/codex/responses",
+        method: "GET",
+        status: 405,
+      });
+      const serializedPayload = JSON.stringify(payload);
+      expect(serializedPayload).not.toContain(headerSecret);
+      expect(serializedPayload).not.toContain(bodySecret);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("retries once on 401 with a force-refreshed token", async () => {

--- a/runtime-pi/test/pi-runner-transport.test.ts
+++ b/runtime-pi/test/pi-runner-transport.test.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PiModelConfig } from "@appstrate/runner-pi";
+import { createApp, type AppDeps } from "../sidecar/app.ts";
+import { createRuntimePiRunner } from "../pi-runner.ts";
+import {
+  createCaptureSink,
+  makeBundlePackage,
+  makeContext,
+  makeTestBundle,
+} from "../../packages/runner-pi/test/helpers.ts";
+
+interface ObservedRequest {
+  method: string;
+  path: string;
+}
+
+const TEST_JWT = [
+  encodeJwtSegment({ alg: "none", typ: "JWT" }),
+  encodeJwtSegment({
+    "https://api.openai.com/auth": { chatgpt_account_id: "acct_test" },
+  }),
+  "placeholder",
+].join(".");
+
+const TEST_BUNDLE = makeTestBundle(
+  makeBundlePackage("@test/runtime-sidecar-transport", "0.0.0", "agent", {}),
+);
+
+function encodeJwtSegment(value: unknown): string {
+  return btoa(JSON.stringify(value)).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function completedResponse(): Response {
+  return new Response(
+    `data: ${JSON.stringify({
+      type: "response.completed",
+      response: {
+        id: "resp_test",
+        status: "completed",
+        output: [],
+        usage: {
+          input_tokens: 1,
+          input_tokens_details: { cached_tokens: 0 },
+          output_tokens: 1,
+          total_tokens: 2,
+        },
+      },
+    })}\n\n`,
+    { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+describe("runtime-pi sidecar transport wiring", () => {
+  it("uses one SSE POST through the sidecar and finalizes successfully", async () => {
+    const root = await mkdtemp(join(tmpdir(), "runtime-pi-transport-"));
+    const agentDir = join(root, "agent");
+    const sidecarRequests: ObservedRequest[] = [];
+    const upstreamRequests: ObservedRequest[] = [];
+    let server: ReturnType<typeof Bun.serve> | undefined;
+
+    try {
+      await mkdir(agentDir, { recursive: true });
+      const fetchFn = (async (input: string | URL | Request, init?: RequestInit) => {
+        const url =
+          input instanceof Request
+            ? new URL(input.url)
+            : new URL(typeof input === "string" ? input : input.href);
+        upstreamRequests.push({
+          method: init?.method ?? (input instanceof Request ? input.method : "GET"),
+          path: url.pathname,
+        });
+        return completedResponse();
+      }) as unknown as typeof fetch;
+      const deps: AppDeps = {
+        config: {
+          platformApiUrl: "http://mock:3000",
+          runToken: "tok",
+          proxyUrl: "",
+          llm: {
+            authMode: "api_key",
+            baseUrl: "https://upstream.example",
+            apiKey: "real-key",
+            placeholder: TEST_JWT,
+          },
+        },
+        cookieJar: new Map(),
+        fetchFn,
+      };
+      const app = createApp(deps);
+      server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch(request) {
+          sidecarRequests.push({
+            method: request.method,
+            path: new URL(request.url).pathname,
+          });
+          return app.fetch(request);
+        },
+      });
+
+      const model: PiModelConfig = {
+        id: "gpt-5-codex",
+        name: "gpt-5-codex",
+        api: "openai-codex-responses",
+        provider: "openai",
+        baseUrl: `${server.url.origin}/llm`,
+        reasoning: false,
+        input: ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 128_000,
+        maxTokens: 4_096,
+      };
+      const sink = createCaptureSink();
+      const runner = createRuntimePiRunner({
+        sidecarUrl: server.url.origin,
+        model,
+        apiKey: TEST_JWT,
+        systemPrompt: "Answer briefly.",
+        startMessage: "Say done.",
+        cwd: root,
+        agentDir,
+        authStoragePath: join(root, "auth.json"),
+      });
+
+      await runner.run({
+        bundle: TEST_BUNDLE,
+        context: makeContext(),
+        eventSink: sink,
+      });
+
+      expect(sidecarRequests).toEqual([{ method: "POST", path: "/llm/codex/responses" }]);
+      expect(upstreamRequests).toEqual([{ method: "POST", path: "/codex/responses" }]);
+      expect(sink.finalizeCalls).toBe(1);
+      expect(sink.finalized?.status).toBe("success");
+    } finally {
+      if (server) await server.stop(true);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- expose Pi's exact `Transport` type through `@appstrate/runner-pi` and accept an explicit transport on `PiRunner`
- force `sse` only for runtime-pi runners attached to the HTTP sidecar; direct consumers retain Pi's `auto` default
- include the forwarded HTTP method in existing OAuth non-2xx sidecar warnings
- add real-SDK regression coverage for both direct `auto` behavior and the full runtime → sidecar → upstream SSE path

## Issue audit

The issue is valid, with one upstream-driven requalification: Pi 0.73.1 now catches a failed Codex WebSocket setup and falls back to SSE, so the reported fatal/stalled run is no longer the current default outcome. The unwanted WebSocket GET and upstream 405 still occur before that fallback, adding avoidable latency and noisy error telemetry.

This change removes that residual failure path without changing direct `PiRunner` behavior or adding provider-specific policy outside the sidecar topology boundary.

## Verification

- `TEST_TIER=0 TMPDIR=/private/tmp bun test packages/runner-pi/test/pi-runner-transport.test.ts runtime-pi/test/pi-runner-transport.test.ts runtime-pi/sidecar/test/oauth-llm.test.ts` — 9 passed, 38 assertions
- `TEST_TIER=0 TMPDIR=/private/tmp bun test packages/runner-pi/test` — 225 passed, 564 assertions
- `bun run check` — 33/33 tasks passed
- `bun run build`
- `bun run build-runtime`
- `bun run build-sidecar`

The runtime smoke uses the real `PiRunner`, the real Hono `/llm` sidecar route, and a fake SSE upstream. It asserts one POST at each hop, no initial GET, and a successful final result.

Closes #954
