### PR TITLE
feat(billing): show each plan's storage entitlement on the plan cards

### DIFF
--- a/apps/web/src/components/plan-card.tsx
+++ b/apps/web/src/components/plan-card.tsx
@@ -3,6 +3,7 @@
 import { useTranslation } from "react-i18next";
 import { Check, Sparkles } from "lucide-react";
 import { cn } from "@appstrate/ui/cn";
+import { formatBytes } from "@appstrate/core/format";
 import { PLAN_ICONS, PLAN_DESCRIPTION_KEYS, type BillingPlanDetail } from "../hooks/use-billing";
 
 interface PlanCardProps {
@@ -27,7 +28,9 @@ function PlanCard({
   return (
     <button
       className={cn(
-        "relative flex h-52 flex-col items-start rounded-xl border p-5 text-left transition-colors",
+        // h-56, not h-52: the fixed height has to hold price + credits +
+        // storage without the entitlement lines wrapping into the description.
+        "relative flex h-56 flex-col items-start rounded-xl border p-5 text-left transition-colors",
         isCurrent
           ? "border-primary bg-primary/5"
           : isUpgrade
@@ -62,6 +65,16 @@ function PlanCard({
             count: plan.credit_quota.toLocaleString(),
           })}
         </span>
+        {/* Storage entitlement — the plan's other metered resource. Omitted
+            entirely when the billing module does not report it, rather than
+            rendering a misleading "0 B". */}
+        {plan.document_storage_bytes !== undefined && (
+          <span className="text-muted-foreground text-xs">
+            {t("onboarding.planStorage", {
+              size: formatBytes(plan.document_storage_bytes),
+            })}
+          </span>
+        )}
       </div>
     </button>
   );

--- a/apps/web/src/components/test/plan-card.test.tsx
+++ b/apps/web/src/components/test/plan-card.test.tsx
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `PlanGrid` rendering tests — the storage entitlement shown next to credits.
+ *
+ * Same harness as `run-context-gauge.test.tsx`: no DOM, so the component is
+ * rendered with `renderToStaticMarkup` and asserted on its HTML, through the
+ * SPA's own i18n singleton so the locale under test is the locale the
+ * assertions use.
+ *
+ * `document_storage_bytes` is optional on the wire: a billing module older than
+ * the release that added it omits the field, and the card must then show
+ * nothing rather than a "0 B" that misrepresents the plan.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { I18nextProvider } from "react-i18next";
+import i18n, { i18nReady } from "../../i18n.ts";
+import type { BillingPlanDetail } from "../../hooks/use-billing.ts";
+import { PlanGrid } from "../plan-card.tsx";
+
+await i18nReady;
+await i18n.changeLanguage("fr");
+
+const GIB = 1024 * 1024 * 1024;
+
+function render(plans: BillingPlanDetail[]): string {
+  return renderToStaticMarkup(
+    <I18nextProvider i18n={i18n}>
+      <PlanGrid plans={plans} currentPlanId="free" />
+    </I18nextProvider>,
+  );
+}
+
+describe("PlanGrid storage entitlement", () => {
+  it("prices storage under the credits of every plan", () => {
+    const html = render([
+      { id: "free", name: "Free", price: 0, credit_quota: 5000, document_storage_bytes: GIB },
+      {
+        id: "pro",
+        name: "Pro",
+        price: 99,
+        credit_quota: 80_000,
+        document_storage_bytes: 100 * GIB,
+      },
+    ]);
+
+    expect(html).toContain("1.0 GB de stockage");
+    expect(html).toContain("100 GB de stockage");
+  });
+
+  it("omits the line entirely when the plan reports no storage entitlement", () => {
+    const html = render([{ id: "free", name: "Free", price: 0, credit_quota: 5000 }]);
+
+    expect(html).toContain("5,000");
+    expect(html).not.toContain("de stockage");
+    // Specifically NOT the misleading zero.
+    expect(html).not.toContain("0 B");
+  });
+});

--- a/apps/web/src/hooks/use-billing.ts
+++ b/apps/web/src/hooks/use-billing.ts
@@ -68,6 +68,13 @@ export interface BillingPlanDetail {
   name: string;
   price: number;
   credit_quota: number;
+  /**
+   * Durable-document storage the plan grants, in bytes. Optional: a cloud
+   * module older than the release that added it omits the field, and a plan
+   * card must still render — the storage line is dropped rather than showing
+   * "0 B" for a plan that actually grants capacity.
+   */
+  document_storage_bytes?: number;
 }
 
 export interface BillingInfo {

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -521,6 +521,7 @@
   "onboarding.planProDescription": "For intensive usage",
   "onboarding.planFreePrice": "Free",
   "onboarding.planCredits": "{{count}} credits / month",
+  "onboarding.planStorage": "{{size}} storage",
   "onboarding.summaryPlan": "Plan",
   "onboarding.modelTitle": "Configure an AI model",
   "onboarding.modelSubtitle": "Add an LLM model to run your agents. You can add more later.",

--- a/apps/web/src/locales/fr/settings.json
+++ b/apps/web/src/locales/fr/settings.json
@@ -521,6 +521,7 @@
   "onboarding.planProDescription": "Pour un usage intensif",
   "onboarding.planFreePrice": "Gratuit",
   "onboarding.planCredits": "{{count}} crédits / mois",
+  "onboarding.planStorage": "{{size}} de stockage",
   "onboarding.summaryPlan": "Plan",
   "onboarding.modelTitle": "Configurer un modèle IA",
   "onboarding.modelSubtitle": "Ajoutez un modèle LLM pour exécuter vos agents. Vous pourrez en ajouter d'autres plus tard.",


### PR DESCRIPTION
## Contexte

Un plan facture deux ressources : les crédits **et** le stockage documentaire durable (`documentStorageBytes` côté cloud, projeté sur la limite de stockage de l'org par `syncOrgStorageEntitlement`). Les cartes de plan n'affichaient que les crédits — le tier de stockage restait invisible jusqu'à ce qu'un run tape la limite.

## Changement

`PlanCard` affiche le stockage sous la ligne de crédits, via `formatBytes` (`@appstrate/core/format`). Une seule modif : `PlanGrid` sert les deux surfaces (onboarding `plan-step.tsx` + `org-settings/billing.tsx`).

`document_storage_bytes` est **optionnel** sur le type `BillingPlanDetail` : un module cloud antérieur à la release qui expose le champ ne l'envoie pas, et la ligne est alors omise — pas de « 0 B » trompeur pour un plan qui accorde de la capacité.

Hauteur de carte `h-52` → `h-56` : la hauteur fixe doit tenir prix + crédits + stockage sans que les lignes passent à la ligne.

## Dépendance

Le champ est produit par la PR cloud correspondante (`appstrate/cloud#…`, branche `feat/plan-storage-tiers`). Sans elle, cette PR est un no-op visuel (champ absent → ligne masquée), donc l'ordre de merge est libre.

## i18n

`onboarding.planStorage` — fr `{{size}} de stockage`, en `{{size}} storage`.

## Tests

`apps/web/src/components/test/plan-card.test.tsx` (nouveau, harnais `renderToStaticMarkup` + i18n singleton, comme `run-context-gauge.test.tsx`) : ligne rendue pour chaque plan qui déclare le champ, et omise — sans « 0 B » — quand il est absent.

`bun run check` vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)