### PR TITLE
fix(ci): make Firecracker smoke faster and more targeted

### DIFF
--- a/.github/workflows/firecracker-dnat.yml
+++ b/.github/workflows/firecracker-dnat.yml
@@ -1,0 +1,144 @@
+name: Firecracker DNAT regression
+
+# Fast regression guard for the guest-to-platform DNAT path. It deliberately
+# keeps the former broad Firecracker trigger: over-triggering a ~20-second
+# network namespace probe is cheaper and safer than coupling this incident
+# guard to the full microVM smoke's narrower rootfs dependency closure.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "apps/api/src/modules/firecracker/**"
+      - "apps/api/src/services/orchestrator/**"
+      - "apps/api/src/services/run-launcher/**"
+      - "apps/api/src/services/connect/**"
+      - "apps/api/src/lib/modules/**"
+      - "packages/core/**"
+      - "packages/env/**"
+      - "runtime-pi/Dockerfile"
+      - "runtime-pi/entrypoint.ts"
+      - "packages/runner-pi/**"
+      - "runtime-pi/sidecar/**"
+      - ".github/workflows/firecracker-dnat.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/api/src/modules/firecracker/**"
+      - "apps/api/src/services/orchestrator/**"
+      - "apps/api/src/services/run-launcher/**"
+      - "apps/api/src/services/connect/**"
+      - "apps/api/src/lib/modules/**"
+      - "packages/core/**"
+      - "packages/env/**"
+      - "runtime-pi/Dockerfile"
+      - "runtime-pi/entrypoint.ts"
+      - "packages/runner-pi/**"
+      - "runtime-pi/sidecar/**"
+      - ".github/workflows/firecracker-dnat.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: firecracker-dnat-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Regression guard for the guest→platform DNAT drop (issue #819, phase 5):
+  # the 3h-of-tcpdump incident where Docker's DNAT rewrote the destination
+  # before the daemon's nft forward hook, so a plain `ip daddr` match missed
+  # and the RFC1918 deny silently killed the platform sink traffic. This job
+  # reproduces a real guest's L3 path with a netns — no microVM, no kernel
+  # build — through the DAEMON'S REAL nft script (buildNftScript output). If
+  # someone reverts the `ct original` forward rule to a plain `ip daddr`, the
+  # generated script changes, the DNAT'd packet hits the deny, and the curl
+  # below fails the job. Fast (<1 min) and self-cleaning.
+  dnat-regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Bun
+        uses: ./.github/actions/bun-setup
+
+      # buildNftScript pulls @appstrate/core (logger/errors) into its import
+      # closure — deps must be installed to render the real script.
+      - name: Install dependencies
+        run: bun install
+
+      - name: Reproduce the guest→platform path through the real nft script
+        run: |
+          set -euo pipefail
+          # The host's own routable IP — a docker-published port lands on it,
+          # and (being RFC1918, e.g. 10.x on GH runners) it sits INSIDE the
+          # egress-deny CIDRs. That is precisely what makes a reverted
+          # `ip daddr` rule fatal: after Docker's DNAT the deny eats the packet.
+          HOST_IP="$(ip route get 1.1.1.1 | awk '{print $7; exit}')"
+          export HOST_IP
+          echo "host IP under test: ${HOST_IP}"
+
+          # Dummy HTTP target behind a PUBLISHED port → Docker installs the
+          # nat/PREROUTING DNAT rule that the daemon's forward accept must
+          # match on its conntrack-original tuple.
+          docker run -d --name fc-dnat-target -p 18080:5678 \
+            hashicorp/http-echo -listen=:5678 -text=ok >/dev/null
+          for _ in $(seq 1 20); do
+            curl -fsS --max-time 2 "http://127.0.0.1:18080" >/dev/null 2>&1 && break
+            sleep 0.5
+          done
+
+          sudo sysctl -qw net.ipv4.ip_forward=1
+
+          # Render the DAEMON'S nft policy with the published port as the
+          # remote platform endpoint, then apply it verbatim.
+          bun -e 'import { buildNftScript } from "./apps/api/src/modules/firecracker/host-net.ts";
+            process.stdout.write(buildNftScript({
+              subnetCidr: "10.231.0.0/16",
+              aliasIp: "10.231.255.1",
+              platformPort: 3000,
+              egressDenyCidrs: ["169.254.0.0/16","10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"],
+              platformForward: { ip: process.env.HOST_IP, port: 18080 },
+            }));' > /tmp/appstrate_fc.nft
+          echo "----- rendered nft ruleset -----"; cat /tmp/appstrate_fc.nft
+          # HOST_IP is already baked into the rendered file — nft -f is static.
+          sudo nft -f /tmp/appstrate_fc.nft
+
+          # Docker sets the iptables FORWARD policy to DROP; mirror what the
+          # daemon does (allowForwardInIptables) so the ONLY differentiator
+          # between pass and fail is the appstrate_fc nft table under test.
+          sudo iptables -I FORWARD -i afc+ -j ACCEPT
+          sudo iptables -I FORWARD -o afc+ -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+          # A "guest": a netns whose HOST-side veth carries the afc* prefix
+          # (so the iifname rules fire) addressed in a run /30 (index 1).
+          sudo ip netns add guest
+          sudo ip link add afcprobe0 type veth peer name afcprobe0p
+          sudo ip link set afcprobe0p netns guest
+          sudo ip addr add 10.231.0.5/30 dev afcprobe0
+          sudo ip link set afcprobe0 up
+          sudo sysctl -qw net.ipv4.conf.afcprobe0.rp_filter=1
+          sudo ip -n guest addr add 10.231.0.6/30 dev afcprobe0p
+          sudo ip -n guest link set afcprobe0p up
+          sudo ip -n guest link set lo up
+          sudo ip -n guest route add default via 10.231.0.5
+
+          echo "curling http://${HOST_IP}:18080 from the guest netns..."
+          # MUST succeed. A reverted `ct original` rule → DNAT'd packet hits
+          # the RFC1918 deny → timeout → this fails the job (the regression).
+          sudo ip netns exec guest curl -fsS --max-time 5 "http://${HOST_IP}:18080"
+          echo "" # http-echo omits a trailing newline
+          echo "guest→platform path OK through the nft policy"
+
+      - name: Cleanup
+        if: always()
+        run: |
+          sudo ip netns del guest 2>/dev/null || true
+          sudo ip link del afcprobe0 2>/dev/null || true
+          sudo nft delete table ip appstrate_fc 2>/dev/null || true
+          sudo iptables -D FORWARD -i afc+ -j ACCEPT 2>/dev/null || true
+          sudo iptables -D FORWARD -o afc+ -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT 2>/dev/null || true
+          docker rm -f fc-dnat-target 2>/dev/null || true

--- a/.github/workflows/firecracker.yml
+++ b/.github/workflows/firecracker.yml
@@ -5,11 +5,14 @@ name: Firecracker smoke
 # boots a REAL microVM through the orchestrator (apps/api/src/modules/firecracker/scripts/dev/).
 # GitHub's Linux runners expose KVM, so this runs on ubuntu-latest.
 #
-# This list mirrors the source closure copied by runtime-pi/Dockerfile,
-# runtime-pi/sidecar/Dockerfile, and Dockerfile.rootfs, plus the two shared
-# orchestrator helpers imported by the Firecracker engine. Keep it aligned with
-# those build inputs: unrelated platform/test changes belong to the generic
-# check/test workflows and must not pay for a microVM boot.
+# This list tracks the runtime-relevant source and manifest inputs consumed by
+# runtime-pi/Dockerfile, runtime-pi/sidecar/Dockerfile, and Dockerfile.rootfs,
+# plus the two shared orchestrator helpers imported by the Firecracker engine.
+# The runtime Dockerfiles copy every workspace manifest so Bun can walk the
+# lockfile, but their filtered build graphs depend on the manifests listed
+# below; dependency-resolution changes are covered by bun.lock. Unrelated
+# platform/test changes belong to the generic check/test workflows and must not
+# pay for a microVM boot.
 
 on:
   push:

--- a/.github/workflows/firecracker.yml
+++ b/.github/workflows/firecracker.yml
@@ -1,43 +1,82 @@
-name: Firecracker
+name: Firecracker smoke
 
 # End-to-end smoke of the Firecracker orchestrator (RUN_ADAPTER=firecracker):
 # builds the guest kernel/rootfs artifacts, runs the focused unit tests, then
 # boots a REAL microVM through the orchestrator (apps/api/src/modules/firecracker/scripts/dev/).
 # GitHub's Linux runners expose KVM, so this runs on ubuntu-latest.
 #
-# Scoped to the paths that can break the guest boot machinery — the generic
-# check/test workflows already cover the platform-side TypeScript.
+# This list mirrors the source closure copied by runtime-pi/Dockerfile,
+# runtime-pi/sidecar/Dockerfile, and Dockerfile.rootfs, plus the two shared
+# orchestrator helpers imported by the Firecracker engine. Keep it aligned with
+# those build inputs: unrelated platform/test changes belong to the generic
+# check/test workflows and must not pay for a microVM boot.
 
 on:
   push:
     branches: [main]
     paths:
       - "apps/api/src/modules/firecracker/**"
-      - "apps/api/src/services/orchestrator/**"
-      - "apps/api/src/services/run-launcher/**"
-      - "apps/api/src/services/connect/**"
-      - "apps/api/src/lib/modules/**"
-      - "packages/core/**"
-      - "packages/env/**"
+      - "apps/api/src/services/orchestrator/sidecar-env.ts"
+      - "apps/api/src/services/orchestrator/subprocess-util.ts"
+      - "apps/api/package.json"
+      - "packages/afps-runtime/src/**"
+      - "packages/afps-runtime/package.json"
+      - "packages/afps-shared/src/**"
+      - "packages/afps-shared/package.json"
+      - "packages/connect/src/**"
+      - "packages/connect/package.json"
+      - "packages/core/src/**"
+      - "packages/core/package.json"
+      - "packages/mcp-transport/src/**"
+      - "packages/mcp-transport/package.json"
+      - "packages/runner-pi/src/**"
+      - "packages/runner-pi/package.json"
+      - "runtime-pi/*.ts"
+      - "runtime-pi/mcp/**"
+      - "runtime-pi/package.json"
       - "runtime-pi/Dockerfile"
-      - "runtime-pi/entrypoint.ts"
-      - "packages/runner-pi/**"
-      - "runtime-pi/sidecar/**"
+      - "runtime-pi/sidecar/*.ts"
+      - "runtime-pi/sidecar/package.json"
+      - "runtime-pi/sidecar/Dockerfile"
+      - ".dockerignore"
+      - "bun.lock"
+      - "bunfig.toml"
+      - "package.json"
+      - "patches/**"
+      - ".github/actions/bun-setup/**"
       - ".github/workflows/firecracker.yml"
   pull_request:
     branches: [main]
     paths:
       - "apps/api/src/modules/firecracker/**"
-      - "apps/api/src/services/orchestrator/**"
-      - "apps/api/src/services/run-launcher/**"
-      - "apps/api/src/services/connect/**"
-      - "apps/api/src/lib/modules/**"
-      - "packages/core/**"
-      - "packages/env/**"
+      - "apps/api/src/services/orchestrator/sidecar-env.ts"
+      - "apps/api/src/services/orchestrator/subprocess-util.ts"
+      - "apps/api/package.json"
+      - "packages/afps-runtime/src/**"
+      - "packages/afps-runtime/package.json"
+      - "packages/afps-shared/src/**"
+      - "packages/afps-shared/package.json"
+      - "packages/connect/src/**"
+      - "packages/connect/package.json"
+      - "packages/core/src/**"
+      - "packages/core/package.json"
+      - "packages/mcp-transport/src/**"
+      - "packages/mcp-transport/package.json"
+      - "packages/runner-pi/src/**"
+      - "packages/runner-pi/package.json"
+      - "runtime-pi/*.ts"
+      - "runtime-pi/mcp/**"
+      - "runtime-pi/package.json"
       - "runtime-pi/Dockerfile"
-      - "runtime-pi/entrypoint.ts"
-      - "packages/runner-pi/**"
-      - "runtime-pi/sidecar/**"
+      - "runtime-pi/sidecar/*.ts"
+      - "runtime-pi/sidecar/package.json"
+      - "runtime-pi/sidecar/Dockerfile"
+      - ".dockerignore"
+      - "bun.lock"
+      - "bunfig.toml"
+      - "package.json"
+      - "patches/**"
+      - ".github/actions/bun-setup/**"
       - ".github/workflows/firecracker.yml"
   workflow_dispatch:
 
@@ -45,107 +84,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: firecracker-${{ github.ref }}
+  group: firecracker-smoke-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # Regression guard for the guest→platform DNAT drop (issue #819, phase 5):
-  # the 3h-of-tcpdump incident where Docker's DNAT rewrote the destination
-  # before the daemon's nft forward hook, so a plain `ip daddr` match missed
-  # and the RFC1918 deny silently killed the platform sink traffic. This job
-  # reproduces a real guest's L3 path with a netns — no microVM, no kernel
-  # build — through the DAEMON'S REAL nft script (buildNftScript output). If
-  # someone reverts the `ct original` forward rule to a plain `ip daddr`, the
-  # generated script changes, the DNAT'd packet hits the deny, and the curl
-  # below fails the job. Fast (<1 min) and self-cleaning.
-  dnat-regression:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Setup Bun
-        uses: ./.github/actions/bun-setup
-
-      # buildNftScript pulls @appstrate/core (logger/errors) into its import
-      # closure — deps must be installed to render the real script.
-      - name: Install dependencies
-        run: bun install
-
-      - name: Reproduce the guest→platform path through the real nft script
-        run: |
-          set -euo pipefail
-          # The host's own routable IP — a docker-published port lands on it,
-          # and (being RFC1918, e.g. 10.x on GH runners) it sits INSIDE the
-          # egress-deny CIDRs. That is precisely what makes a reverted
-          # `ip daddr` rule fatal: after Docker's DNAT the deny eats the packet.
-          HOST_IP="$(ip route get 1.1.1.1 | awk '{print $7; exit}')"
-          export HOST_IP
-          echo "host IP under test: ${HOST_IP}"
-
-          # Dummy HTTP target behind a PUBLISHED port → Docker installs the
-          # nat/PREROUTING DNAT rule that the daemon's forward accept must
-          # match on its conntrack-original tuple.
-          docker run -d --name fc-dnat-target -p 18080:5678 \
-            hashicorp/http-echo -listen=:5678 -text=ok >/dev/null
-          for _ in $(seq 1 20); do
-            curl -fsS --max-time 2 "http://127.0.0.1:18080" >/dev/null 2>&1 && break
-            sleep 0.5
-          done
-
-          sudo sysctl -qw net.ipv4.ip_forward=1
-
-          # Render the DAEMON'S nft policy with the published port as the
-          # remote platform endpoint, then apply it verbatim.
-          bun -e 'import { buildNftScript } from "./apps/api/src/modules/firecracker/host-net.ts";
-            process.stdout.write(buildNftScript({
-              subnetCidr: "10.231.0.0/16",
-              aliasIp: "10.231.255.1",
-              platformPort: 3000,
-              egressDenyCidrs: ["169.254.0.0/16","10.0.0.0/8","172.16.0.0/12","192.168.0.0/16"],
-              platformForward: { ip: process.env.HOST_IP, port: 18080 },
-            }));' > /tmp/appstrate_fc.nft
-          echo "----- rendered nft ruleset -----"; cat /tmp/appstrate_fc.nft
-          # HOST_IP is already baked into the rendered file — nft -f is static.
-          sudo nft -f /tmp/appstrate_fc.nft
-
-          # Docker sets the iptables FORWARD policy to DROP; mirror what the
-          # daemon does (allowForwardInIptables) so the ONLY differentiator
-          # between pass and fail is the appstrate_fc nft table under test.
-          sudo iptables -I FORWARD -i afc+ -j ACCEPT
-          sudo iptables -I FORWARD -o afc+ -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-
-          # A "guest": a netns whose HOST-side veth carries the afc* prefix
-          # (so the iifname rules fire) addressed in a run /30 (index 1).
-          sudo ip netns add guest
-          sudo ip link add afcprobe0 type veth peer name afcprobe0p
-          sudo ip link set afcprobe0p netns guest
-          sudo ip addr add 10.231.0.5/30 dev afcprobe0
-          sudo ip link set afcprobe0 up
-          sudo sysctl -qw net.ipv4.conf.afcprobe0.rp_filter=1
-          sudo ip -n guest addr add 10.231.0.6/30 dev afcprobe0p
-          sudo ip -n guest link set afcprobe0p up
-          sudo ip -n guest link set lo up
-          sudo ip -n guest route add default via 10.231.0.5
-
-          echo "curling http://${HOST_IP}:18080 from the guest netns..."
-          # MUST succeed. A reverted `ct original` rule → DNAT'd packet hits
-          # the RFC1918 deny → timeout → this fails the job (the regression).
-          sudo ip netns exec guest curl -fsS --max-time 5 "http://${HOST_IP}:18080"
-          echo "" # http-echo omits a trailing newline
-          echo "guest→platform path OK through the nft policy"
-
-      - name: Cleanup
-        if: always()
-        run: |
-          sudo ip netns del guest 2>/dev/null || true
-          sudo ip link del afcprobe0 2>/dev/null || true
-          sudo nft delete table ip appstrate_fc 2>/dev/null || true
-          sudo iptables -D FORWARD -i afc+ -j ACCEPT 2>/dev/null || true
-          sudo iptables -D FORWARD -o afc+ -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT 2>/dev/null || true
-          docker rm -f fc-dnat-target 2>/dev/null || true
-
   smoke:
     runs-on: ubuntu-latest
     # Cold cache pays the full ~20 min kernel build + the rootfs docker

--- a/apps/api/src/modules/firecracker/orchestrator.ts
+++ b/apps/api/src/modules/firecracker/orchestrator.ts
@@ -1853,6 +1853,27 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
   private async killVm(vm: VmRecord, graceSeconds: number): Promise<boolean> {
     const proc = vm.proc;
     if (!proc) return true;
+
+    // Bun keeps losing Promise.race timers referenced on its event loop.
+    // Reclaim each timeout even when the VMM exit wins immediately; otherwise
+    // a clean runner shutdown waits for the full grace/reap bound.
+    const exitBeforeTimeout = async (
+      exitPromise: Promise<true>,
+      timeoutMs: number,
+    ): Promise<boolean> => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        return await Promise.race([
+          exitPromise,
+          new Promise<false>((resolve) => {
+            timer = setTimeout(() => resolve(false), timeoutMs);
+          }),
+        ]);
+      } finally {
+        clearTimeout(timer);
+      }
+    };
+
     if (graceSeconds > 0) {
       try {
         await fetch("http://localhost/actions", {
@@ -1869,10 +1890,10 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
         // aarch64 / wedged VMM / socket already gone — fall through to
         // the kill.
       }
-      const exited = await Promise.race([
-        proc.exited.then(() => true),
-        new Promise<false>((r) => setTimeout(() => r(false), graceSeconds * 1000)),
-      ]);
+      const exited = await exitBeforeTimeout(
+        proc.exited.then(() => true as const),
+        graceSeconds * 1000,
+      );
       if (exited) return true;
     }
     try {
@@ -1885,13 +1906,13 @@ export class FirecrackerOrchestrator implements RunOrchestrator {
     // unbounded await here would hang cancel/teardown/shutdown behind
     // one broken VM. Time-box, log loudly, and move on: the leaked
     // process and its resources are reclaimed by the boot-time sweep.
-    const reaped = await Promise.race([
+    const reaped = await exitBeforeTimeout(
       proc.exited.then(
-        () => true,
-        () => true,
+        () => true as const,
+        () => true as const,
       ),
-      new Promise<false>((r) => setTimeout(() => r(false), this.vmmReapTimeoutMs)),
-    ]);
+      this.vmmReapTimeoutMs,
+    );
     if (!reaped) {
       logger.error(
         "VMM did not reap after SIGKILL — possible D-state; leaking the process, " +

--- a/apps/api/src/modules/firecracker/scripts/dev/smoke.ts
+++ b/apps/api/src/modules/firecracker/scripts/dev/smoke.ts
@@ -58,6 +58,28 @@ const FAKE_RUN_TOKEN = "smoke-fake-secret-DEADBEEFCAFE";
  */
 const FAKE_MODEL_KEY = "sk-smoke-fake-model-key-0DEFACED";
 
+const VM_EXIT_TIMEOUT_MS = 90_000;
+
+/**
+ * Bound a VM exit wait without leaving the losing timeout alive. Bun keeps
+ * referenced timers on its event loop, so a bare Promise.race made every
+ * successful smoke wait ~90 seconds after `SMOKE PASS` before the process
+ * could exit. Clearing in `finally` also covers early waitForExit failures.
+ */
+async function withExitTimeout<T>(promise: Promise<T>, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), VM_EXIT_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 function fail(msg: string): never {
   console.error(`SMOKE FAIL: ${msg}`);
   process.exit(1);
@@ -112,6 +134,10 @@ async function assertJailedVmm(runDir: string): Promise<string> {
     "dev",
     "run",
   ]);
+  // Upstream's aarch64 jailer copies the host CPU cache/register identity
+  // files under sys/devices/system/cpu/cpu0 so Firecracker can construct the
+  // guest CPU topology. The x86_64 jailer does not create this directory.
+  if (process.arch === "arm64") allowed.add("sys");
   const entries = await readdir(state.chrootPath);
   const unexpected = entries.filter((e) => !allowed.has(e));
   if (unexpected.length > 0) {
@@ -275,12 +301,7 @@ try {
     await assertConfigDriveOmitsSecret(imagePath, FAKE_MODEL_KEY);
   }
 
-  const exitCode = await Promise.race([
-    orch.waitForExit(agent),
-    new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error("VM did not exit within 90s")), 90_000),
-    ),
-  ]);
+  const exitCode = await withExitTimeout(orch.waitForExit(agent), "VM did not exit within 90s");
   console.log(`==> guest exit marker: ${exitCode} (${Date.now() - bootStart} ms boot→exit)`);
 
   // Console diagnostics for the assertion below + human debugging.
@@ -345,12 +366,10 @@ try {
       boundary2,
     );
     await orch.startWorkload(agent2);
-    const exitCode2 = await Promise.race([
+    const exitCode2 = await withExitTimeout(
       orch.waitForExit(agent2),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("second VM did not exit within 90s")), 90_000),
-      ),
-    ]);
+      "second VM did not exit within 90s",
+    );
     console.log(`==> second guest exit marker: ${exitCode2}`);
     await dumpConsole(boundary2.id, "vm2");
     if (exitCode2 !== 42) {
@@ -392,12 +411,7 @@ try {
       boundary3,
     );
     await orch.startWorkload(agent3);
-    await Promise.race([
-      orch.waitForExit(agent3),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("third VM did not exit within 90s")), 90_000),
-      ),
-    ]);
+    await withExitTimeout(orch.waitForExit(agent3), "third VM did not exit within 90s");
     const console3 = await Bun.file(`${boundary3.id}/console.log`)
       .text()
       .catch(() => "");

--- a/apps/api/src/modules/firecracker/test/unit/firecracker-lifecycle.test.ts
+++ b/apps/api/src/modules/firecracker/test/unit/firecracker-lifecycle.test.ts
@@ -15,7 +15,7 @@
  * asserted here is the orchestrator's contract, not VMM behavior.
  */
 
-import { describe, it, expect, afterEach } from "bun:test";
+import { describe, it, expect, afterEach, spyOn } from "bun:test";
 import { mkdtemp, mkdir, rm, writeFile, chmod } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -417,6 +417,51 @@ describe("cleanupOrphans positive kill path", () => {
 });
 
 describe("bounded VMM reap after SIGKILL (D-state guard)", () => {
+  it("clears losing graceful and reap timers after a prompt VMM exit", async () => {
+    const { exec } = fakeExec();
+    const orch = readyOrchestrator(exec);
+    await orch.createIsolationBoundary("run_prompt_exit");
+    const vm = getVm(orch, "run_prompt_exit");
+    const proc = Bun.spawn(["sh", "-c", "exit 0"]);
+    spawned.push(proc);
+    await proc.exited;
+    vm.proc = proc;
+
+    const reapTimeoutMs = 17;
+    const graceTimeoutMs = 23;
+    Reflect.set(orch, "vmmReapTimeoutMs", reapTimeoutMs);
+    const killVm = Reflect.get(orch, "killVm") as (
+      v: unknown,
+      graceSeconds: number,
+    ) => Promise<boolean>;
+
+    const realClearTimeout = globalThis.clearTimeout.bind(globalThis);
+    const setTimeoutSpy = spyOn(globalThis, "setTimeout");
+    const clearTimeoutSpy = spyOn(globalThis, "clearTimeout");
+    try {
+      // Already-exited proc: both timeout promises lose their race. They
+      // must still be reclaimed or Bun keeps the process alive until the
+      // last timeout expires (10 seconds in production).
+      expect(await killVm.call(orch, vm, graceTimeoutMs / 1000)).toBe(true);
+      expect(await killVm.call(orch, vm, 0)).toBe(true);
+
+      for (const timeoutMs of [graceTimeoutMs, reapTimeoutMs]) {
+        const callIndex = setTimeoutSpy.mock.calls.findIndex(([, delay]) => delay === timeoutMs);
+        expect(callIndex).toBeGreaterThanOrEqual(0);
+        const timer = setTimeoutSpy.mock.results[callIndex]?.value;
+        expect(clearTimeoutSpy.mock.calls.some(([cleared]) => cleared === timer)).toBe(true);
+      }
+    } finally {
+      for (const result of setTimeoutSpy.mock.results) {
+        if (result.type === "return") {
+          realClearTimeout(result.value as ReturnType<typeof setTimeout>);
+        }
+      }
+      clearTimeoutSpy.mockRestore();
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
   it("stopByRunId returns even when the VMM never reaps", async () => {
     const { exec } = fakeExec();
     const orch = readyOrchestrator(exec);


### PR DESCRIPTION
## Summary

- clear losing VM-exit timers in both the smoke harness and production VMM teardown
- split the fast DNAT regression guard from the KVM-backed microVM smoke
- scope the expensive smoke workflow to runtime-relevant rootfs inputs
- accept the CPU identity tree created by the upstream aarch64 jailer during confinement checks

## Why this scope

Recent completed runs consistently hit the kernel/rootfs cache; the measured avoidable cost was the 90-second timer tail after `SMOKE PASS` plus unnecessary workflow coupling and broad triggering. Replacing the kernel builder with release assets needs a separate trusted, version-pinned artifact contract and is intentionally not bundled here.

## Validation

- timer regression reproduced against the old implementation and passes with this fix
- `bun run check`: 33/33 tasks passed
- `actionlint .github/workflows/firecracker.yml .github/workflows/firecracker-dnat.yml`
- Firecracker suite on Linux: 330 passed, 0 failed
- rebuilt the rootfs from the rebased exact head in Lima/KVM and booted all three real microVM smoke scenarios
- the timestamped `SMOKE PASS` and shell process exit occur in the same second, with no residual timer tail
- verified jailed process identity, chroot contents, config-drive secret omission, egress isolation, platform reachability, exit-code propagation, cleanup, and absence of residual Firecracker/TAP/nft state

Relates to #1064
