### PR TITLE
fix(ci): align org switch E2E with home redirect

### DIFF
--- a/e2e/pages/sidebar.ts
+++ b/e2e/pages/sidebar.ts
@@ -31,8 +31,8 @@ export class Sidebar {
   async switchOrg(orgName: string) {
     await this.openSwitcher();
     await this.page.getByText(orgName).click();
-    // Wait for the org switch to take effect — agent list refetches
-    await this.page.waitForLoadState("domcontentloaded");
+    // Organization changes always return to the dashboard.
+    await expect(this.page).toHaveURL("/");
   }
 
   /** Open the app submenu and click an app by name. */

--- a/e2e/tests/organizations/org-switching.ui.spec.ts
+++ b/e2e/tests/organizations/org-switching.ui.spec.ts
@@ -46,7 +46,7 @@ test.describe("Org switching in UI", () => {
     await agents.expectAgentNotVisible(agentB);
   });
 
-  test("Switching org shows the other org agents @critical", async ({
+  test("Switching org returns home and shows the other org agents @critical", async ({
     authedPage: page,
     clientA,
     clientB,
@@ -67,6 +67,8 @@ test.describe("Org switching in UI", () => {
     const sidebar = new Sidebar(page);
     await sidebar.switchOrg(orgB.orgName);
 
+    await page.getByRole("link", { name: "Agents", exact: true }).click();
+    await agents.waitForLoaded();
     await agents.expectAgentVisible(agentB);
     await agents.expectAgentNotVisible(agentA);
   });
@@ -92,6 +94,8 @@ test.describe("Org switching in UI", () => {
     const sidebar = new Sidebar(page);
     await sidebar.switchOrg(orgB.orgName);
 
+    await page.getByRole("link", { name: "Agents", exact: true }).click();
+    await agents.waitForLoaded();
     await agents.expectAgentNotVisible(uniqueAgent);
   });
 });


### PR DESCRIPTION
## Summary

- assert that organization changes return to the dashboard
- navigate back to Agents through the SPA before checking the newly selected organization
- keep the stale-data regression meaningful after the redirect introduced by #1083

## Root cause

PR #1083 intentionally redirects organization switches from `/agents` to `/`. The E2E helper still waited for a document load and the critical scenario searched for agent cards on the dashboard, so the test asserted the previous navigation contract.

## Tests

- `bun run check`
- organization-switching UI spec: 5 passed
- full UI E2E project: 22 passed, 1 skipped