### PR TITLE
feat(orgs): let admins manage member roles

### DIFF
--- a/apps/api/src/lib/permissions.ts
+++ b/apps/api/src/lib/permissions.ts
@@ -148,9 +148,9 @@ const OWNER_PERMISSIONS: ReadonlySet<Permission> = new Set<Permission>([
   "integrations:disconnect",
 ]);
 
-/** Admin: everything except org:delete and members:change-role. */
+/** Admin: everything except deleting the organization. */
 const ADMIN_PERMISSIONS: ReadonlySet<Permission> = new Set<Permission>(
-  [...OWNER_PERMISSIONS].filter((p) => p !== "org:delete" && p !== "members:change-role"),
+  [...OWNER_PERMISSIONS].filter((p) => p !== "org:delete"),
 );
 
 /** Member: use the platform — run agents, manage own connections, schedules. */

--- a/apps/api/src/openapi/paths/organizations.ts
+++ b/apps/api/src/openapi/paths/organizations.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { ASSIGNABLE_ROLES } from "../../services/invitations.ts";
+import { ASSIGNABLE_ORG_ROLES } from "@appstrate/shared-types";
 
 export const organizationsPaths = {
   "/api/orgs": {
@@ -229,7 +229,7 @@ export const organizationsPaths = {
               required: ["email", "role"],
               properties: {
                 email: { type: "string", format: "email" },
-                role: { type: "string", enum: [...ASSIGNABLE_ROLES], default: "member" },
+                role: { type: "string", enum: [...ASSIGNABLE_ORG_ROLES], default: "member" },
               },
             },
           },
@@ -269,7 +269,8 @@ export const organizationsPaths = {
       operationId: "changeMemberRole",
       tags: ["Organizations"],
       summary: "Change member role",
-      description: "Change a member's role within the organization. Owner only.",
+      description:
+        "Change a member's role. Owners can manage any non-owner; admins can manage viewers and members.",
       parameters: [
         { name: "orgId", in: "path", required: true, schema: { type: "string" } },
         { name: "userId", in: "path", required: true, schema: { type: "string" } },
@@ -282,7 +283,7 @@ export const organizationsPaths = {
               type: "object",
               required: ["role"],
               properties: {
-                role: { type: "string", enum: [...ASSIGNABLE_ROLES] },
+                role: { type: "string", enum: [...ASSIGNABLE_ORG_ROLES] },
               },
             },
           },
@@ -342,7 +343,7 @@ export const organizationsPaths = {
       operationId: "changeInvitationRole",
       tags: ["Organizations"],
       summary: "Change invitation role",
-      description: "Change the role assigned to a pending invitation. Owner only.",
+      description: "Change the role assigned to a pending invitation. Admin or owner required.",
       parameters: [
         { name: "orgId", in: "path", required: true, schema: { type: "string" } },
         { name: "invitationId", in: "path", required: true, schema: { type: "string" } },
@@ -355,7 +356,7 @@ export const organizationsPaths = {
               type: "object",
               required: ["role"],
               properties: {
-                role: { type: "string", enum: [...ASSIGNABLE_ROLES] },
+                role: { type: "string", enum: [...ASSIGNABLE_ORG_ROLES] },
               },
             },
           },

--- a/apps/api/src/routes/invitations.ts
+++ b/apps/api/src/routes/invitations.ts
@@ -11,9 +11,9 @@ import {
   markInvitationAccepted,
   getInviterName,
   getOrgName,
-  type AssignableRole,
 } from "../services/invitations.ts";
 import { addMember, getOrgById } from "../services/organizations.ts";
+import type { AssignableOrgRole } from "@appstrate/shared-types";
 
 const router = new Hono();
 
@@ -127,7 +127,7 @@ router.post("/:token/accept", async (c) => {
   const claimed = await db.transaction(async (tx) => {
     const won = await markInvitationAccepted(invitation.id, session.user.id, tx);
     if (!won) return false;
-    await addMember(invitation.orgId, session.user.id, invitation.role as AssignableRole, tx);
+    await addMember(invitation.orgId, session.user.id, invitation.role as AssignableOrgRole, tx);
     return true;
   });
 

--- a/apps/api/src/routes/organizations.ts
+++ b/apps/api/src/routes/organizations.ts
@@ -37,7 +37,6 @@ import {
   getOrgInvitations,
   cancelInvitation,
   updateInvitationRole,
-  ASSIGNABLE_ROLES,
 } from "../services/invitations.ts";
 import { provisionDefaultAgentForOrg } from "../services/default-agent.ts";
 import { effectiveOrgStorageLimit } from "../services/documents.ts";
@@ -47,6 +46,11 @@ import { createDefaultApplication } from "../services/applications.ts";
 import { emitEvent } from "../lib/modules/module-loader.ts";
 import { logger } from "../lib/logger.ts";
 import { recordAuditFromContext } from "../services/audit.ts";
+import {
+  ASSIGNABLE_ORG_ROLES,
+  assignableRolesForMember,
+  canRemoveMember,
+} from "@appstrate/shared-types";
 
 export const createOrgSchema = z.object({
   name: z.string().min(1, "Name is required"),
@@ -60,11 +64,11 @@ export const updateOrgSchema = z.object({
 
 export const addMemberSchema = z.object({
   email: z.email("Email is required"),
-  role: z.enum(ASSIGNABLE_ROLES).default("member"),
+  role: z.enum(ASSIGNABLE_ORG_ROLES).default("member"),
 });
 
 export const updateRoleSchema = z.object({
-  role: z.enum(ASSIGNABLE_ROLES),
+  role: z.enum(ASSIGNABLE_ORG_ROLES),
 });
 
 /**
@@ -80,12 +84,7 @@ export const updateRoleSchema = z.object({
  * computed by the auth pipeline. Cookie sessions (and any other
  * human-session auth method) keep the plain membership-role check.
  */
-async function requireOrgRole(
-  c: Context<AppEnv>,
-  orgId: string,
-  roles: string[],
-  message: string,
-): Promise<void> {
+async function requireOrgRole(c: Context<AppEnv>, orgId: string, roles: string[], message: string) {
   if (c.get("authMethod") === "api_key") {
     throw forbidden("API keys cannot perform organization administration");
   }
@@ -93,6 +92,7 @@ async function requireOrgRole(
   if (!member || !roles.includes(member.role)) {
     throw forbidden(message);
   }
+  return member;
 }
 
 const router = new Hono<AppEnv>();
@@ -409,12 +409,12 @@ router.delete("/:orgId/invitations/:invitationId", async (c) => {
   return c.body(null, 204);
 });
 
-// PUT /api/orgs/:orgId/invitations/:invitationId — change invitation role (owner only)
+// PUT /api/orgs/:orgId/invitations/:invitationId — change invitation role (admin+)
 router.put("/:orgId/invitations/:invitationId", async (c) => {
   const orgId = c.req.param("orgId");
   const invitationId = c.req.param("invitationId");
 
-  await requireOrgRole(c, orgId, ["owner"], "Only the owner can change roles");
+  await requireOrgRole(c, orgId, ["owner", "admin"], "Admin access required to change roles");
 
   const data = await readJsonBody(c, updateRoleSchema);
 
@@ -432,8 +432,7 @@ router.put("/:orgId/invitations/:invitationId", async (c) => {
   });
 
   // Bare updated resource — same serializer as the invitations list in
-  // GET /orgs/:orgId (issue #657). `token` is included because the
-  // endpoint is owner-gated, consistent with the list.
+  // GET /orgs/:orgId (issue #657).
   return c.json({
     id: updated.id,
     email: updated.email,
@@ -446,17 +445,29 @@ router.put("/:orgId/invitations/:invitationId", async (c) => {
 
 // DELETE /api/orgs/:orgId/members/:userId — remove a member (admin+)
 router.delete("/:orgId/members/:userId", async (c) => {
+  const user = c.get("user");
   const orgId = c.req.param("orgId");
   const targetUserId = c.req.param("userId");
 
-  await requireOrgRole(c, orgId, ["owner", "admin"], "Admin access required to remove members");
+  const actor = await requireOrgRole(
+    c,
+    orgId,
+    ["owner", "admin"],
+    "Admin access required to remove members",
+  );
 
   const target = await getOrgMember(orgId, targetUserId);
   if (!target) {
     throw notFound("Member not found");
   }
-  if (target.role === "owner") {
-    throw forbidden("Cannot remove the owner");
+  if (
+    !canRemoveMember({
+      actorRole: actor.role,
+      targetRole: target.role,
+      isSelf: targetUserId === user.id,
+    })
+  ) {
+    throw forbidden("You cannot remove this member");
   }
 
   await removeMember(orgId, targetUserId);
@@ -469,24 +480,33 @@ router.delete("/:orgId/members/:userId", async (c) => {
   return c.body(null, 204);
 });
 
-// PUT /api/orgs/:orgId/members/:userId — change role (owner only)
+// PUT /api/orgs/:orgId/members/:userId — change role (owner/admin hierarchy)
 router.put("/:orgId/members/:userId", async (c) => {
   const user = c.get("user");
   const orgId = c.req.param("orgId");
   const targetUserId = c.req.param("userId");
 
-  await requireOrgRole(c, orgId, ["owner"], "Only the owner can change roles");
+  const actor = await requireOrgRole(
+    c,
+    orgId,
+    ["owner", "admin"],
+    "Admin access required to change roles",
+  );
 
   const data = await readJsonBody(c, updateRoleSchema);
-
-  // Cannot change own role
-  if (targetUserId === user.id) {
-    throw forbidden("Cannot change your own role");
-  }
 
   const target = await getOrgMember(orgId, targetUserId);
   if (!target) {
     throw notFound("Member not found");
+  }
+
+  const assignableRoles = assignableRolesForMember({
+    actorRole: actor.role,
+    targetRole: target.role,
+    isSelf: targetUserId === user.id,
+  });
+  if (!assignableRoles.includes(data.role)) {
+    throw forbidden("You cannot assign this role to this member");
   }
 
   await updateMemberRole(orgId, targetUserId, data.role);

--- a/apps/api/src/services/invitations.ts
+++ b/apps/api/src/services/invitations.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { db } from "@appstrate/db/client";
-import { orgInvitations, organizations, user, profiles, orgRoleEnum } from "@appstrate/db/schema";
+import { orgInvitations, organizations, user, profiles } from "@appstrate/db/schema";
+import type { AssignableOrgRole } from "@appstrate/shared-types";
 import { eq, and, lt, gt, desc } from "drizzle-orm";
 import { getEnv } from "@appstrate/env";
 import { getAppConfig } from "../lib/app-config.ts";
@@ -10,20 +11,6 @@ import { scopedWhere } from "../lib/db-helpers.ts";
 
 /** Accepts either the base client or an open transaction handle. */
 type DbOrTx = typeof db | Parameters<Parameters<typeof db.transaction>[0]>[0];
-
-/** Roles assignable via invitation (excludes owner — transferred, not invited). */
-export const ASSIGNABLE_ROLES = ["viewer", "member", "admin"] as const;
-export type AssignableRole = (typeof ASSIGNABLE_ROLES)[number];
-
-// Compile-time exhaustiveness check: if `orgRoleEnum` gains a new value, this
-// line fails to type-check until it is added to `ASSIGNABLE_ROLES` above (or
-// explicitly excluded like `owner`).
-type _MissingAssignableRoles = Exclude<
-  Exclude<(typeof orgRoleEnum.enumValues)[number], "owner">,
-  AssignableRole
->;
-const _assertAssignableRolesExhaustive: _MissingAssignableRoles extends never ? true : never = true;
-void _assertAssignableRolesExhaustive;
 
 function generateToken(): string {
   return crypto.randomUUID().replace(/-/g, "") + crypto.randomUUID().replace(/-/g, "");
@@ -37,7 +24,7 @@ export async function createInvitation({
 }: {
   email: string;
   orgId: string;
-  role: AssignableRole;
+  role: AssignableOrgRole;
   invitedBy: string;
 }) {
   const normalizedEmail = email.toLowerCase().trim();
@@ -150,7 +137,7 @@ export async function cancelInvitation(invitationId: string, orgId: string) {
 export async function updateInvitationRole(
   invitationId: string,
   orgId: string,
-  role: AssignableRole,
+  role: AssignableOrgRole,
 ) {
   const [updated] = await db
     .update(orgInvitations)

--- a/apps/api/test/integration/middleware/require-permission.test.ts
+++ b/apps/api/test/integration/middleware/require-permission.test.ts
@@ -20,12 +20,15 @@ import {
 } from "../../helpers/auth.ts";
 import { seedPackage } from "../../helpers/seed.ts";
 import { installPackage } from "../../../src/services/application-packages.ts";
-import type { AssignableRole } from "../../../src/services/invitations.ts";
+import type { AssignableOrgRole } from "@appstrate/shared-types";
 
 const app = getTestApp();
 
 /** Build a context for a user with a specific role in the owner's org. */
-async function contextForRole(ownerCtx: TestContext, role: AssignableRole): Promise<TestContext> {
+async function contextForRole(
+  ownerCtx: TestContext,
+  role: AssignableOrgRole,
+): Promise<TestContext> {
   const user = await createTestUser();
   await addOrgMember(ownerCtx.orgId, user.id, role);
   return { ...ownerCtx, user, cookie: user.cookie };

--- a/apps/api/test/integration/routes/organizations.test.ts
+++ b/apps/api/test/integration/routes/organizations.test.ts
@@ -601,6 +601,46 @@ describe("Organizations API", () => {
 
   // Issue #657 — mutations return the bare full resource, not a stub.
   describe("PUT /api/orgs/:orgId/members/:userId", () => {
+    it("lets an admin promote a member to admin", async () => {
+      const ctx = await createTestContext({ orgSlug: "admin-role-org" });
+      const admin = await createTestUser({ email: "admin-role@test.com" });
+      const member = await createTestUser({ email: "member-role@test.com" });
+      await addOrgMember(ctx.orgId, admin.id, "admin");
+      await addOrgMember(ctx.orgId, member.id, "member");
+
+      const res = await app.request(`/api/orgs/${ctx.orgId}/members/${member.id}`, {
+        method: "PUT",
+        headers: { Cookie: admin.cookie, "Content-Type": "application/json" },
+        body: JSON.stringify({ role: "admin" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { role: string };
+      expect(body.role).toBe("admin");
+    });
+
+    it("does not let an admin change a peer admin's role", async () => {
+      const ctx = await createTestContext({ orgSlug: "peer-admin-role-org" });
+      const actor = await createTestUser({ email: "actor-admin@test.com" });
+      const target = await createTestUser({ email: "target-admin@test.com" });
+      await addOrgMember(ctx.orgId, actor.id, "admin");
+      await addOrgMember(ctx.orgId, target.id, "admin");
+
+      const res = await app.request(`/api/orgs/${ctx.orgId}/members/${target.id}`, {
+        method: "PUT",
+        headers: { Cookie: actor.cookie, "Content-Type": "application/json" },
+        body: JSON.stringify({ role: "member" }),
+      });
+
+      expect(res.status).toBe(403);
+
+      const detailRes = await app.request(`/api/orgs/${ctx.orgId}`, {
+        headers: { Cookie: ctx.cookie },
+      });
+      const detail = (await detailRes.json()) as { members: { userId: string; role: string }[] };
+      expect(detail.members.find((member) => member.userId === target.id)?.role).toBe("admin");
+    });
+
     it("returns the bare member DTO (same shape as the members list)", async () => {
       const ctx = await createTestContext({ orgSlug: "roleorg" });
       const member = await createTestUser({ email: "promote@test.com" });
@@ -636,6 +676,28 @@ describe("Organizations API", () => {
   });
 
   describe("PUT /api/orgs/:orgId/invitations/:invitationId", () => {
+    it("lets an admin change a pending invitation's role", async () => {
+      const ctx = await createTestContext({ orgSlug: "admin-invitation-role-org" });
+      const admin = await createTestUser({ email: "invitation-admin@test.com" });
+      await addOrgMember(ctx.orgId, admin.id, "admin");
+      const invitation = await createInvitation({
+        email: "admin-invitee@test.com",
+        orgId: ctx.orgId,
+        role: "member",
+        invitedBy: ctx.user.id,
+      });
+
+      const res = await app.request(`/api/orgs/${ctx.orgId}/invitations/${invitation.id}`, {
+        method: "PUT",
+        headers: { Cookie: admin.cookie, "Content-Type": "application/json" },
+        body: JSON.stringify({ role: "admin" }),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { role: string };
+      expect(body.role).toBe("admin");
+    });
+
     it("returns the bare invitation DTO (same shape as the invitations list)", async () => {
       const ctx = await createTestContext({ orgSlug: "invorg" });
       const invitation = await createInvitation({
@@ -654,7 +716,7 @@ describe("Organizations API", () => {
       expect(res.status).toBe(200);
       const body = (await res.json()) as any;
       // Bare invitation DTO — same shape as the invitations list in
-      // GET /api/orgs/:orgId (token kept: endpoint is owner-gated)
+      // GET /api/orgs/:orgId (token kept in the full invitation DTO)
       expect(body.id).toBe(invitation.id);
       expect(body.role).toBe("admin");
       expect(body.email).toBe("invitee@test.com");
@@ -677,6 +739,42 @@ describe("Organizations API", () => {
   });
 
   describe("DELETE /api/orgs/:orgId/members/:userId", () => {
+    it("lets an admin remove a regular member", async () => {
+      const ctx = await createTestContext({ orgSlug: "admin-remove-member-org" });
+      const admin = await createTestUser({ email: "remove-member-admin@test.com" });
+      const member = await createTestUser({ email: "remove-member@test.com" });
+      await addOrgMember(ctx.orgId, admin.id, "admin");
+      await addOrgMember(ctx.orgId, member.id, "member");
+
+      const res = await app.request(`/api/orgs/${ctx.orgId}/members/${member.id}`, {
+        method: "DELETE",
+        headers: { Cookie: admin.cookie },
+      });
+
+      expect(res.status).toBe(204);
+    });
+
+    it("does not let an admin remove a peer admin", async () => {
+      const ctx = await createTestContext({ orgSlug: "remove-peer-admin-org" });
+      const actor = await createTestUser({ email: "remove-actor@test.com" });
+      const target = await createTestUser({ email: "remove-target@test.com" });
+      await addOrgMember(ctx.orgId, actor.id, "admin");
+      await addOrgMember(ctx.orgId, target.id, "admin");
+
+      const res = await app.request(`/api/orgs/${ctx.orgId}/members/${target.id}`, {
+        method: "DELETE",
+        headers: { Cookie: actor.cookie },
+      });
+
+      expect(res.status).toBe(403);
+
+      const detailRes = await app.request(`/api/orgs/${ctx.orgId}`, {
+        headers: { Cookie: ctx.cookie },
+      });
+      const detail = (await detailRes.json()) as { members: { userId: string }[] };
+      expect(detail.members.some((member) => member.userId === target.id)).toBe(true);
+    });
+
     it("removes the member and returns 204 with an empty body", async () => {
       const ctx = await createTestContext({ orgSlug: "delmemorg" });
       const member = await createTestUser({ email: "leaver@test.com" });

--- a/apps/api/test/unit/permissions.test.ts
+++ b/apps/api/test/unit/permissions.test.ts
@@ -16,10 +16,10 @@ describe("resolvePermissions", () => {
     expect(perms.has("agents:write")).toBe(true);
   });
 
-  it("admin has all except org:delete and members:change-role", () => {
+  it("admin can change member roles but cannot delete the organization", () => {
     const perms = resolvePermissions("admin");
     expect(perms.has("org:delete")).toBe(false);
-    expect(perms.has("members:change-role")).toBe(false);
+    expect(perms.has("members:change-role")).toBe(true);
     expect(perms.has("org:update")).toBe(true);
     expect(perms.has("agents:write")).toBe(true);
     expect(perms.has("members:invite")).toBe(true);

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -2749,7 +2749,7 @@ export interface paths {
         get?: never;
         /**
          * Change invitation role
-         * @description Change the role assigned to a pending invitation. Owner only.
+         * @description Change the role assigned to a pending invitation. Admin or owner required.
          */
         put: operations["changeInvitationRole"];
         post?: never;
@@ -2793,7 +2793,7 @@ export interface paths {
         get?: never;
         /**
          * Change member role
-         * @description Change a member's role within the organization. Owner only.
+         * @description Change a member's role. Owners can manage any non-owner; admins can manage viewers and members.
          */
         put: operations["changeMemberRole"];
         post?: never;

--- a/apps/web/src/hooks/use-permissions.ts
+++ b/apps/web/src/hooks/use-permissions.ts
@@ -16,12 +16,6 @@ export function roleI18nKey(role: OrgRole): string {
   return ROLE_I18N_KEY[role];
 }
 
-/** Assignable roles for invitations (excludes owner). */
-export const INVITE_ROLES = ["viewer", "member", "admin"] as const;
-
-/** All roles including owner (for member role change by owner). */
-export const ALL_ROLES = ["viewer", "member", "admin", "owner"] as const;
-
 /**
  * Role-based permission helpers for UI gating.
  *

--- a/apps/web/src/pages/onboarding/members-step.tsx
+++ b/apps/web/src/pages/onboarding/members-step.tsx
@@ -22,8 +22,9 @@ import {
 } from "../../components/onboarding-layout";
 import { CopyLinkButton } from "../../components/copy-link-button";
 import { $api } from "../../api/client";
-import { roleI18nKey, INVITE_ROLES } from "../../hooks/use-permissions";
+import { roleI18nKey } from "../../hooks/use-permissions";
 import { Spinner } from "../../components/spinner";
+import { ASSIGNABLE_ORG_ROLES, type AssignableOrgRole } from "@appstrate/shared-types";
 
 export function OnboardingMembersStep() {
   const { t } = useTranslation(["settings", "common"]);
@@ -33,7 +34,7 @@ export function OnboardingMembersStep() {
   const { nextRoute, prevRoute } = useOnboardingNav("members");
 
   const [email, setEmail] = useState("");
-  const [role, setRole] = useState<"viewer" | "member" | "admin">("member");
+  const [role, setRole] = useState<AssignableOrgRole>("member");
   const [error, setError] = useState<string | null>(null);
 
   const { data: orgData } = $api.useQuery(
@@ -95,15 +96,12 @@ export function OnboardingMembersStep() {
                 placeholder="email@example.com"
                 required
               />
-              <Select
-                value={role}
-                onValueChange={(v) => setRole(v as "viewer" | "member" | "admin")}
-              >
+              <Select value={role} onValueChange={(v) => setRole(v as AssignableOrgRole)}>
                 <SelectTrigger className="w-[140px]">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {INVITE_ROLES.map((r) => (
+                  {ASSIGNABLE_ORG_ROLES.map((r) => (
                     <SelectItem key={r} value={r}>
                       {t(roleI18nKey(r))}
                     </SelectItem>

--- a/apps/web/src/pages/org-settings/members.tsx
+++ b/apps/web/src/pages/org-settings/members.tsx
@@ -18,26 +18,33 @@ import { useQueryClient } from "@tanstack/react-query";
 import { getErrorMessage } from "@appstrate/core/errors";
 import { $api, type components } from "../../api/client";
 import { useOrg } from "../../hooks/use-org";
-import { usePermissions, roleI18nKey, INVITE_ROLES, ALL_ROLES } from "../../hooks/use-permissions";
+import { useAuth } from "../../hooks/use-auth";
+import { usePermissions, roleI18nKey } from "../../hooks/use-permissions";
 import { ConfirmModal } from "../../components/confirm-modal";
 import { CopyLinkButton } from "../../components/copy-link-button";
 import { LoadingState, ErrorState, EmptyState } from "../../components/page-states";
 import { Spinner } from "../../components/spinner";
 import { toast } from "sonner";
-import type { OrgRole } from "@appstrate/shared-types";
+import {
+  ASSIGNABLE_ORG_ROLES,
+  assignableRolesForMember,
+  canRemoveMember,
+  type AssignableOrgRole,
+} from "@appstrate/shared-types";
 
 type OrgMember = components["schemas"]["OrgMember"];
 
 export function OrgSettingsMembersPage() {
   const { t } = useTranslation(["settings", "common"]);
   const { currentOrg } = useOrg();
-  const { isOwner, isAdmin } = usePermissions();
+  const { user } = useAuth();
+  const { role, isAdmin } = usePermissions();
   const queryClient = useQueryClient();
   const orgId = currentOrg?.id;
 
   const [confirmState, setConfirmState] = useState<{ label: string; id: string } | null>(null);
 
-  const inviteForm = useForm<{ email: string; role: "viewer" | "member" | "admin" }>({
+  const inviteForm = useForm<{ email: string; role: AssignableOrgRole }>({
     defaultValues: { email: "", role: "member" },
   });
   const inviteRole = useWatch({ control: inviteForm.control, name: "role" });
@@ -103,7 +110,7 @@ export function OrgSettingsMembersPage() {
   if (isLoading) return <LoadingState />;
   if (error) return <ErrorState message={getErrorMessage(error)} />;
 
-  const handleInvite = (data: { email: string; role: "viewer" | "member" | "admin" }) => {
+  const handleInvite = (data: { email: string; role: AssignableOrgRole }) => {
     const trimmed = data.email.trim();
     if (!trimmed || !orgId) return;
     addMemberMutation.mutate({
@@ -117,12 +124,11 @@ export function OrgSettingsMembersPage() {
     setConfirmState({ label, id: member.userId });
   };
 
-  const handleRoleChange = (userId: string, role: OrgRole) => {
+  const handleRoleChange = (userId: string, newRole: AssignableOrgRole) => {
     if (!orgId) return;
-    // The wire enum excludes "owner"; the owner row never renders this select.
     changeRoleMutation.mutate({
       params: { path: { orgId, userId } },
-      body: { role: role as "viewer" | "member" | "admin" },
+      body: { role: newRole },
     });
   };
 
@@ -142,15 +148,13 @@ export function OrgSettingsMembersPage() {
               />
               <Select
                 value={inviteRole}
-                onValueChange={(v) =>
-                  inviteForm.setValue("role", v as "viewer" | "member" | "admin")
-                }
+                onValueChange={(v) => inviteForm.setValue("role", v as AssignableOrgRole)}
               >
                 <SelectTrigger className="w-[140px]">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  {INVITE_ROLES.map((r) => (
+                  {ASSIGNABLE_ORG_ROLES.map((r) => (
                     <SelectItem key={r} value={r}>
                       {t(roleI18nKey(r))}
                     </SelectItem>
@@ -174,6 +178,13 @@ export function OrgSettingsMembersPage() {
         {members.map((member) => {
           const label = member.displayName || member.email || member.userId;
           const isMemberOwner = member.role === "owner";
+          const isSelf = member.userId === user?.id;
+          const assignableRoles = role
+            ? assignableRolesForMember({ actorRole: role, targetRole: member.role, isSelf })
+            : [];
+          const canRemove = role
+            ? canRemoveMember({ actorRole: role, targetRole: member.role, isSelf })
+            : false;
           return (
             <div key={member.userId} className="border-border bg-card rounded-lg border p-5">
               <div className="flex items-center gap-3">
@@ -191,19 +202,19 @@ export function OrgSettingsMembersPage() {
                   {t(roleI18nKey(member.role))}
                 </Badge>
               </div>
-              {!isMemberOwner && (
+              {(assignableRoles.length > 0 || canRemove) && (
                 <div className="border-border mt-3 flex gap-2 border-t pt-3">
-                  {isOwner && (
+                  {assignableRoles.length > 0 && (
                     <Select
                       value={member.role}
-                      onValueChange={(v) => handleRoleChange(member.userId, v as OrgRole)}
+                      onValueChange={(v) => handleRoleChange(member.userId, v as AssignableOrgRole)}
                       disabled={changeRoleMutation.isPending}
                     >
                       <SelectTrigger className="w-[140px]">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        {ALL_ROLES.map((r) => (
+                        {assignableRoles.map((r) => (
                           <SelectItem key={r} value={r}>
                             {t(roleI18nKey(r))}
                           </SelectItem>
@@ -211,7 +222,7 @@ export function OrgSettingsMembersPage() {
                       </SelectContent>
                     </Select>
                   )}
-                  {isAdmin && (
+                  {canRemove && (
                     <Button
                       variant="destructive"
                       size="sm"
@@ -247,13 +258,13 @@ export function OrgSettingsMembersPage() {
                   <Badge variant="pending">{t("orgSettings.invited")}</Badge>
                 </div>
                 <div className="border-border mt-3 flex gap-2 border-t pt-3">
-                  {isOwner && (
+                  {isAdmin && (
                     <Select
                       value={inv.role}
                       onValueChange={(v) =>
                         changeInvitationRoleMutation.mutate({
                           params: { path: { orgId: orgId ?? "", invitationId: inv.id } },
-                          body: { role: v as "viewer" | "member" | "admin" },
+                          body: { role: v as AssignableOrgRole },
                         })
                       }
                       disabled={changeInvitationRoleMutation.isPending}
@@ -262,7 +273,7 @@ export function OrgSettingsMembersPage() {
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        {INVITE_ROLES.map((r) => (
+                        {ASSIGNABLE_ORG_ROLES.map((r) => (
                           <SelectItem key={r} value={r}>
                             {t(roleI18nKey(r))}
                           </SelectItem>

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -5,6 +5,13 @@ import type { ModelCost } from "@appstrate/core/module";
 import type { TokenUsage } from "@appstrate/core/token-usage";
 import type { ModelApiShape } from "@appstrate/core/sidecar-types";
 
+export {
+  ASSIGNABLE_ORG_ROLES,
+  assignableRolesForMember,
+  canRemoveMember,
+  type AssignableOrgRole,
+} from "./member-role-policy.ts";
+
 export type { WebhookInfo, WebhookCreateResponse, WebhookDelivery } from "./webhooks.ts";
 import type { AgentIntegrationEntry } from "./integrations.ts";
 export type {

--- a/packages/shared-types/src/member-role-policy.ts
+++ b/packages/shared-types/src/member-role-policy.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { OrgRole } from "@appstrate/core/permissions";
+
+export const ASSIGNABLE_ORG_ROLES = ["viewer", "member", "admin"] as const;
+export type AssignableOrgRole = (typeof ASSIGNABLE_ORG_ROLES)[number];
+
+type MissingAssignableOrgRole = Exclude<Exclude<OrgRole, "owner">, AssignableOrgRole>;
+const assertAssignableOrgRolesExhaustive: MissingAssignableOrgRole extends never ? true : never =
+  true;
+void assertAssignableOrgRolesExhaustive;
+
+interface MemberPolicyContext {
+  actorRole: OrgRole;
+  targetRole: OrgRole;
+  isSelf: boolean;
+}
+
+function canManageMember({ actorRole, targetRole, isSelf }: MemberPolicyContext): boolean {
+  if (isSelf || targetRole === "owner") return false;
+  if (actorRole === "owner") return true;
+  return actorRole === "admin" && (targetRole === "viewer" || targetRole === "member");
+}
+
+export function assignableRolesForMember(
+  context: MemberPolicyContext,
+): readonly AssignableOrgRole[] {
+  return canManageMember(context) ? ASSIGNABLE_ORG_ROLES : [];
+}
+
+export function canRemoveMember(context: MemberPolicyContext): boolean {
+  return canManageMember(context);
+}

--- a/packages/shared-types/test/member-role-policy.test.ts
+++ b/packages/shared-types/test/member-role-policy.test.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "bun:test";
+import { assignableRolesForMember, canRemoveMember } from "../src/index.ts";
+
+describe("assignableRolesForMember", () => {
+  it("lets an admin promote a member to admin", () => {
+    expect(
+      assignableRolesForMember({
+        actorRole: "admin",
+        targetRole: "member",
+        isSelf: false,
+      }),
+    ).toEqual(["viewer", "member", "admin"]);
+  });
+
+  it("lets an owner change another admin's role", () => {
+    expect(
+      assignableRolesForMember({
+        actorRole: "owner",
+        targetRole: "admin",
+        isSelf: false,
+      }),
+    ).toEqual(["viewer", "member", "admin"]);
+  });
+
+  it("enforces the complete actor-target hierarchy", () => {
+    const cases = [
+      ["owner", "viewer", false, ["viewer", "member", "admin"]],
+      ["owner", "member", false, ["viewer", "member", "admin"]],
+      ["admin", "viewer", false, ["viewer", "member", "admin"]],
+      ["admin", "admin", false, []],
+      ["admin", "owner", false, []],
+      ["member", "viewer", false, []],
+      ["viewer", "member", false, []],
+      ["owner", "owner", true, []],
+      ["admin", "admin", true, []],
+    ] as const;
+
+    for (const [actorRole, targetRole, isSelf, expected] of cases) {
+      expect(assignableRolesForMember({ actorRole, targetRole, isSelf })).toEqual(expected);
+    }
+  });
+});
+
+describe("canRemoveMember", () => {
+  it("lets an admin remove regular members but not peer admins", () => {
+    expect(canRemoveMember({ actorRole: "admin", targetRole: "member", isSelf: false })).toBe(true);
+    expect(canRemoveMember({ actorRole: "admin", targetRole: "admin", isSelf: false })).toBe(false);
+  });
+
+  it("enforces the complete removal hierarchy", () => {
+    const cases = [
+      ["owner", "admin", false, true],
+      ["owner", "member", false, true],
+      ["admin", "viewer", false, true],
+      ["admin", "admin", false, false],
+      ["admin", "owner", false, false],
+      ["member", "viewer", false, false],
+      ["owner", "owner", true, false],
+      ["admin", "admin", true, false],
+    ] as const;
+
+    for (const [actorRole, targetRole, isSelf, expected] of cases) {
+      expect(canRemoveMember({ actorRole, targetRole, isSelf })).toBe(expected);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- let organization admins change viewer/member roles, including promotion to admin
- keep owner transfer separate and prevent self-management or changes/removal of owners and peer admins
- let admins change pending invitation roles
- use one shared role policy and assignable-role list across API, web UI, Zod, and OpenAPI

## Policy

- owners can manage any other non-owner
- admins can manage viewers and members, but not owners or other admins
- no actor can change or remove their own membership through the administration flow
- the `owner` role is never assignable from these endpoints

## TDD coverage

- exhaustive actor/target policy tests for role assignment and removal
- HTTP integration tests for admin promotion, peer-admin protection, member removal, and invitation role updates
- RBAC permission regression coverage

## Validation

- `TEST_TIER=0 TMPDIR=/private/tmp bun test packages/shared-types/test/member-role-policy.test.ts apps/api/test/unit/permissions.test.ts apps/api/test/integration/routes/organizations.test.ts` — 79 pass
- `TEST_TIER=0 ... bun run check` — 33/33 tasks pass, including OpenAPI/type generation and 99.09% type coverage
- full Tier 0 run — 9,778 pass, 89 skip; 16 unrelated MITM tests fail locally because Bun 1.3.11 emits a CA key format rejected by the current fixture, and one LLM settlement timeout passed immediately when rerun in isolation
