### PR TITLE
fix(integrations): unify HTTP credential delivery

### DIFF
--- a/apps/api/src/openapi/paths/packages.ts
+++ b/apps/api/src/openapi/paths/packages.ts
@@ -1718,8 +1718,9 @@ export const packagesPaths = {
     post: {
       operationId: "createIntegrationPackage",
       tags: ["Packages"],
-      summary: "Create an integration package",
-      description: "Create a new integration package in the organization packages.",
+      summary: "Create an integration package, including a remote MCP",
+      description:
+        'Create a new integration package in the organization packages. An upstream-hosted MCP endpoint belongs here as an integration with `source.kind: "remote"`; use an MCP-server package only for a local executable referenced by `source.kind: "local"`.',
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },
@@ -2301,8 +2302,9 @@ export const packagesPaths = {
     post: {
       operationId: "createMcpServerPackage",
       tags: ["Packages"],
-      summary: "Create an MCP-server package",
-      description: "Create a new MCP-server package in the organization packages.",
+      summary: "Create a local MCP-server executable package",
+      description:
+        'Create a local executable MCP-server package referenced by an integration with `source.kind: "local"`. For an upstream-hosted MCP endpoint, create an integration package with `source.kind: "remote"` instead.',
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },

--- a/apps/api/src/services/credential-proxy/core.ts
+++ b/apps/api/src/services/credential-proxy/core.ts
@@ -99,9 +99,11 @@ export interface ProxyCallInput {
    * substituted when `substituteBody` is true. A `ReadableStream` is
    * forwarded verbatim (streaming upload path — no substitution possible,
    * no 401-retry). When a `ReadableStream` body is provided and the
-   * upstream returns 401, the result carries `authRefreshed: true` (creds
-   * were refreshed server-side) but the response is passed through as-is —
-   * the caller must replay the next request with a fresh body.
+   * upstream returns 401 after using the platform credential, the result
+   * carries `authRefreshed: true` (creds were refreshed server-side) but the
+   * response is passed through as-is — the caller must replay the next
+   * request with a fresh body. An explicitly allowed caller override is never
+   * attributed to the platform credential and therefore is not refreshed.
    */
   body?: string | Uint8Array | ReadableStream<Uint8Array> | null;
   substituteBody?: boolean;
@@ -345,8 +347,12 @@ export async function proxyCall(input: ProxyCallInput): Promise<ProxyCallResult>
     if (substituted !== template) sensitiveHeaderNames.add(k);
     headers.set(k, substituted);
   }
-  applyInjectedCredentialHeaderToHeaders(headers, resolved);
-  if (resolved.credentialHeaderName) sensitiveHeaderNames.add(resolved.credentialHeaderName);
+  let credentialInjection = applyInjectedCredentialHeaderToHeaders(headers, resolved);
+  if (credentialInjection.kind === "inject") {
+    sensitiveHeaderNames.add(credentialInjection.header.name);
+  } else if (credentialInjection.kind === "caller_override") {
+    sensitiveHeaderNames.add(credentialInjection.headerName);
+  }
 
   // Body substitution (opt-in; body may be bytes). Bun's global fetch
   // accepts string / Uint8Array / ReadableStream directly.
@@ -452,7 +458,7 @@ export async function proxyCall(input: ProxyCallInput): Promise<ProxyCallResult>
   // replayed safely → refresh + retry once. Streaming bodies fall through
   // to the authRefreshed escape-hatch below (caller must re-issue with a
   // fresh body stream).
-  if (res.status === 401 && !isStreamBody) {
+  if (res.status === 401 && !isStreamBody && credentialInjection.kind === "inject") {
     try {
       const refreshedResult = await forceRefreshIntegrationProxyCredentials({
         integrationId: input.integrationId,
@@ -462,17 +468,16 @@ export async function proxyCall(input: ProxyCallInput): Promise<ProxyCallResult>
       });
       const refreshed = refreshedResult?.payload ?? null;
       if (refreshed) {
-        // Rebuild the credential header from the rotated token. We drop
-        // the previous injected header first so `applyInjectedCredentialHeaderToHeaders`
-        // re-installs the new value (its caller-override-wins semantics
-        // would otherwise keep the stale Bearer).
+        // Rebuild the credential header from the rotated token. Drop the
+        // previous platform-injected value first so the refreshed delivery
+        // plan can install its current header name and value cleanly.
+        headers.delete(credentialInjection.header.name);
         if (refreshed.credentialHeaderName) {
-          headers.delete(refreshed.credentialHeaderName);
           // Keep the strip set in sync — the refreshed payload may name a
           // different header than the original resolution.
           sensitiveHeaderNames.add(refreshed.credentialHeaderName);
         }
-        applyInjectedCredentialHeaderToHeaders(headers, refreshed);
+        credentialInjection = applyInjectedCredentialHeaderToHeaders(headers, refreshed);
         res = await performFetch({
           ...fetchInit,
           headers,
@@ -497,7 +502,7 @@ export async function proxyCall(input: ProxyCallInput): Promise<ProxyCallResult>
   // server-side (so the *next* call from the caller uses fresh tokens)
   // but we cannot replay the body — surface authRefreshed so the route
   // can signal the client to retry itself with a fresh body stream.
-  if (res.status === 401 && isStreamBody) {
+  if (res.status === 401 && isStreamBody && credentialInjection.kind === "inject") {
     try {
       await forceRefreshIntegrationProxyCredentials({
         integrationId: input.integrationId,

--- a/apps/api/src/services/orchestrator/docker-orchestrator.ts
+++ b/apps/api/src/services/orchestrator/docker-orchestrator.ts
@@ -18,6 +18,7 @@ import { logger } from "../../lib/logger.ts";
 import { getErrorMessage } from "@appstrate/core/errors";
 import { SIDECAR_MEMORY_BYTES, SIDECAR_NANO_CPUS } from "./constants.ts";
 import { buildBaseSidecarEnv } from "./sidecar-env.ts";
+import { SidecarExitWatcher } from "./sidecar-exit-watcher.ts";
 
 class DockerWorkloadHandle implements WorkloadHandle {
   constructor(
@@ -70,14 +71,25 @@ const DOCKER_SIDECAR_ENDPOINTS: SidecarEndpoints = {
 };
 
 export class DockerOrchestrator implements RunOrchestrator {
-  /**
-   * Set of sidecar container IDs whose exit is expected (run is being
-   * torn down). The {@link watchSidecarExit} watcher consults this set
-   * to suppress the "sidecar exited unexpectedly" log on the cleanup
-   * path. Added in {@link stopWorkload}, consumed by the watcher, and
-   * defensively cleared in {@link removeWorkload} / {@link shutdown}.
-   */
-  private expectedSidecarExits = new Set<string>();
+  private readonly sidecarExitWatcher = new SidecarExitWatcher({
+    waitForExit: (containerId) => docker.waitForExit(containerId),
+    streamLogs: (containerId, signal) => docker.streamLogs(containerId, signal),
+    onUnexpectedExit: ({ runId, containerId, exitCode, tail }) => {
+      logger.error("Sidecar exited before run completed", {
+        runId,
+        containerId,
+        exitCode,
+        ...(tail ? { tail } : {}),
+      });
+    },
+    onWatcherError: ({ runId, containerId, error }) => {
+      logger.debug("Sidecar exit watcher errored", {
+        runId,
+        containerId,
+        error: getErrorMessage(error),
+      });
+    },
+  });
   /**
    * Images verified present in this process's lifetime (pre-pulled at
    * {@link initialize} or ensured by a prior run). {@link ensureImages}
@@ -123,10 +135,7 @@ export class DockerOrchestrator implements RunOrchestrator {
     // Removing it here used to break the runs of a concurrently-running
     // instance, whose cached network ID went stale.
     //
-    // Drop any residual entries — long-lived API processes accumulate
-    // one per timed-out / aborted run because `removeWorkload` always
-    // re-adds after `stopWorkload` consumed the watcher's match.
-    this.expectedSidecarExits.clear();
+    this.sidecarExitWatcher.clearExpectedExits();
   }
 
   async ensureImages(images: string[]): Promise<void> {
@@ -356,69 +365,9 @@ export class DockerOrchestrator implements RunOrchestrator {
     // operators see "sidecar exited 1 (npm not found)" rather than the
     // agent's eventual "deadline exceeded" hand-wave.
     await docker.startContainer(containerId);
-    this.watchSidecarExit(runId, containerId);
+    void this.sidecarExitWatcher.watch(runId, containerId);
 
     return new DockerWorkloadHandle(containerId, runId, "sidecar");
-  }
-
-  /**
-   * Non-blocking watcher: race the sidecar's exit against the run. The
-   * caller never awaits this — its only job is to surface a sidecar
-   * that crashes mid-handshake with a structured log line carrying the
-   * exit code + a snippet of the container's stderr. Without it, a
-   * dead-on-arrival sidecar manifests as an agent-side "MCP connect
-   * deadline exceeded after 30000ms" 30s later, with no platform-side
-   * evidence of root cause.
-   *
-   * Best-effort: errors are swallowed (the orchestrator's main lifecycle
-   * is the source of truth for failure surfaces). Errors here would only
-   * add noise to a path that's already going to fail loudly somewhere.
-   */
-  private watchSidecarExit(runId: string, containerId: string): void {
-    void (async () => {
-      try {
-        const exitCode = await docker.waitForExit(containerId);
-        // Cleanup path stops/removes the sidecar after the run terminates
-        // — those exits are expected and never indicate a problem.
-        if (this.expectedSidecarExits.has(containerId)) {
-          this.expectedSidecarExits.delete(containerId);
-          return;
-        }
-        if (exitCode !== 0) {
-          // Pull a short tail of logs — best-effort, bounded so we
-          // don't keep a generator open forever if logs are streamed.
-          // 2s window: on a busy Docker daemon the multiplexed-stream
-          // parser may not have emitted any complete lines under 500ms
-          // after the exit, which defeats the purpose of the watcher.
-          let tail = "";
-          try {
-            const abort = new AbortController();
-            const timer = setTimeout(() => abort.abort(), 2_000);
-            const lines: string[] = [];
-            for await (const line of docker.streamLogs(containerId, abort.signal)) {
-              lines.push(line);
-              if (lines.length >= 30) break;
-            }
-            clearTimeout(timer);
-            tail = lines.slice(-30).join("\n");
-          } catch {
-            // Swallow — diagnostic is best-effort.
-          }
-          logger.error("Sidecar exited before run completed", {
-            runId,
-            containerId,
-            exitCode,
-            ...(tail ? { tail } : {}),
-          });
-        }
-      } catch (err) {
-        logger.debug("Sidecar exit watcher errored", {
-          runId,
-          containerId,
-          error: getErrorMessage(err),
-        });
-      }
-    })();
   }
 
   async createWorkload(spec: WorkloadSpec, boundary: IsolationBoundary): Promise<WorkloadHandle> {
@@ -474,17 +423,23 @@ export class DockerOrchestrator implements RunOrchestrator {
   }
 
   async stopWorkload(handle: WorkloadHandle, timeoutSeconds?: number): Promise<void> {
-    if (handle.role === "sidecar") this.expectedSidecarExits.add(handle.id);
+    if (handle.role === "sidecar") {
+      await this.sidecarExitWatcher.expectExitDuring(handle.id, () =>
+        docker.stopContainer(handle.id, timeoutSeconds),
+      );
+      return;
+    }
     await docker.stopContainer(handle.id, timeoutSeconds);
   }
 
   async removeWorkload(handle: WorkloadHandle): Promise<void> {
-    // No `expectedSidecarExits.add` here: by the time we're removing the
-    // container its `waitForExit` watcher has already resolved (either
-    // through the happy path or via `stopWorkload`'s suppression). Adding
-    // again would leak one string per run for the process lifetime.
+    if (handle.role === "sidecar") {
+      await this.sidecarExitWatcher.expectExitDuring(handle.id, () =>
+        docker.removeContainer(handle.id),
+      );
+      return;
+    }
     await docker.removeContainer(handle.id);
-    if (handle.role === "sidecar") this.expectedSidecarExits.delete(handle.id);
   }
 
   async waitForExit(handle: WorkloadHandle): Promise<number> {

--- a/apps/api/src/services/orchestrator/docker-orchestrator.ts
+++ b/apps/api/src/services/orchestrator/docker-orchestrator.ts
@@ -451,7 +451,9 @@ export class DockerOrchestrator implements RunOrchestrator {
   }
 
   async stopByRunId(runId: string, timeoutSeconds?: number): Promise<StopResult> {
-    return docker.stopContainersByRun(runId, timeoutSeconds);
+    return this.sidecarExitWatcher.expectRunExitDuring(runId, () =>
+      docker.stopContainersByRun(runId, timeoutSeconds),
+    );
   }
 
   /**

--- a/apps/api/src/services/orchestrator/sidecar-exit-watcher.ts
+++ b/apps/api/src/services/orchestrator/sidecar-exit-watcher.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+export interface UnexpectedSidecarExit {
+  runId: string;
+  containerId: string;
+  exitCode: number;
+  tail?: string;
+}
+
+export interface SidecarExitWatcherError {
+  runId: string;
+  containerId: string;
+  error: unknown;
+}
+
+export interface SidecarExitWatcherDependencies {
+  waitForExit(containerId: string): Promise<number>;
+  streamLogs(containerId: string, signal: AbortSignal): AsyncIterable<string>;
+  onUnexpectedExit(exit: UnexpectedSidecarExit): void;
+  onWatcherError(error: SidecarExitWatcherError): void;
+}
+
+/**
+ * Correlates the sidecar exit watcher with lifecycle teardown calls.
+ *
+ * The expectation is installed before stop/remove starts and is consumed by
+ * the watcher only after Docker reports the exit. Keeping that state across
+ * the teardown await closes the race where remove succeeds just before the
+ * watcher resumes and would otherwise report a normal cleanup as a crash.
+ */
+export class SidecarExitWatcher {
+  private readonly expectedExits = new Set<string>();
+  private readonly watchedContainers = new Set<string>();
+
+  constructor(private readonly dependencies: SidecarExitWatcherDependencies) {}
+
+  async watch(runId: string, containerId: string): Promise<void> {
+    this.watchedContainers.add(containerId);
+    try {
+      const exitCode = await this.dependencies.waitForExit(containerId);
+      if (this.expectedExits.delete(containerId)) return;
+
+      if (exitCode !== 0) {
+        const tail = await this.readLogTail(containerId);
+        this.dependencies.onUnexpectedExit({
+          runId,
+          containerId,
+          exitCode,
+          ...(tail ? { tail } : {}),
+        });
+      }
+    } catch (error) {
+      this.dependencies.onWatcherError({ runId, containerId, error });
+    } finally {
+      this.watchedContainers.delete(containerId);
+      this.expectedExits.delete(containerId);
+    }
+  }
+
+  async expectExitDuring(containerId: string, teardown: () => Promise<void>): Promise<void> {
+    this.expectedExits.add(containerId);
+    try {
+      await teardown();
+    } catch (error) {
+      // The teardown did not complete, so a later exit must not inherit a
+      // stale expectation from the failed attempt.
+      this.expectedExits.delete(containerId);
+      throw error;
+    }
+
+    // If the watcher already completed (or never started), nobody remains to
+    // consume this marker. Otherwise retain it until waitForExit resolves.
+    if (!this.watchedContainers.has(containerId)) {
+      this.expectedExits.delete(containerId);
+    }
+  }
+
+  clearExpectedExits(): void {
+    this.expectedExits.clear();
+  }
+
+  private async readLogTail(containerId: string): Promise<string> {
+    const abort = new AbortController();
+    const timer = setTimeout(() => abort.abort(), 2_000);
+    const lines: string[] = [];
+    try {
+      for await (const line of this.dependencies.streamLogs(containerId, abort.signal)) {
+        lines.push(line);
+        if (lines.length >= 30) break;
+      }
+    } catch {
+      // Diagnostics are best-effort and must not mask the exit itself.
+    } finally {
+      clearTimeout(timer);
+    }
+    return lines.slice(-30).join("\n");
+  }
+}

--- a/apps/api/src/services/orchestrator/sidecar-exit-watcher.ts
+++ b/apps/api/src/services/orchestrator/sidecar-exit-watcher.ts
@@ -23,22 +23,28 @@ export interface SidecarExitWatcherDependencies {
 /**
  * Correlates the sidecar exit watcher with lifecycle teardown calls.
  *
- * The expectation is installed before stop/remove starts and is consumed by
- * the watcher only after Docker reports the exit. Keeping that state across
- * the teardown await closes the race where remove succeeds just before the
- * watcher resumes and would otherwise report a normal cleanup as a crash.
+ * An expectation can target one container or every sidecar in a run. It is
+ * installed before stop/remove starts and consumed only after Docker reports
+ * the exit. Keeping that state across the teardown await closes the race where
+ * cleanup succeeds just before the watcher resumes and would otherwise report
+ * a normal cleanup as a crash.
  */
 export class SidecarExitWatcher {
   private readonly expectedExits = new Set<string>();
+  private readonly expectedRunExits = new Set<string>();
   private readonly watchedContainers = new Set<string>();
+  private readonly watchedRuns = new Set<string>();
 
   constructor(private readonly dependencies: SidecarExitWatcherDependencies) {}
 
   async watch(runId: string, containerId: string): Promise<void> {
     this.watchedContainers.add(containerId);
+    this.watchedRuns.add(runId);
     try {
       const exitCode = await this.dependencies.waitForExit(containerId);
-      if (this.expectedExits.delete(containerId)) return;
+      const expectedContainerExit = this.expectedExits.delete(containerId);
+      const expectedRunExit = this.expectedRunExits.delete(runId);
+      if (expectedContainerExit || expectedRunExit) return;
 
       if (exitCode !== 0) {
         const tail = await this.readLogTail(containerId);
@@ -53,30 +59,56 @@ export class SidecarExitWatcher {
       this.dependencies.onWatcherError({ runId, containerId, error });
     } finally {
       this.watchedContainers.delete(containerId);
+      this.watchedRuns.delete(runId);
       this.expectedExits.delete(containerId);
+      this.expectedRunExits.delete(runId);
     }
   }
 
-  async expectExitDuring(containerId: string, teardown: () => Promise<void>): Promise<void> {
-    this.expectedExits.add(containerId);
+  expectExitDuring<T>(containerId: string, teardown: () => Promise<T>): Promise<T> {
+    return this.expectDuring(
+      containerId,
+      this.expectedExits,
+      () => this.watchedContainers.has(containerId),
+      teardown,
+    );
+  }
+
+  expectRunExitDuring<T>(runId: string, teardown: () => Promise<T>): Promise<T> {
+    return this.expectDuring(
+      runId,
+      this.expectedRunExits,
+      () => this.watchedRuns.has(runId),
+      teardown,
+    );
+  }
+
+  clearExpectedExits(): void {
+    this.expectedExits.clear();
+    this.expectedRunExits.clear();
+  }
+
+  private async expectDuring<T>(
+    key: string,
+    expected: Set<string>,
+    isWatched: () => boolean,
+    teardown: () => Promise<T>,
+  ): Promise<T> {
+    expected.add(key);
+    let result: T;
     try {
-      await teardown();
+      result = await teardown();
     } catch (error) {
       // The teardown did not complete, so a later exit must not inherit a
       // stale expectation from the failed attempt.
-      this.expectedExits.delete(containerId);
+      expected.delete(key);
       throw error;
     }
 
     // If the watcher already completed (or never started), nobody remains to
     // consume this marker. Otherwise retain it until waitForExit resolves.
-    if (!this.watchedContainers.has(containerId)) {
-      this.expectedExits.delete(containerId);
-    }
-  }
-
-  clearExpectedExits(): void {
-    this.expectedExits.clear();
+    if (!isWatched()) expected.delete(key);
+    return result;
   }
 
   private async readLogTail(containerId: string): Promise<string> {

--- a/apps/api/test/helpers/integration-manifests.ts
+++ b/apps/api/test/helpers/integration-manifests.ts
@@ -14,8 +14,19 @@
 import type { IntegrationManifest } from "@appstrate/core/integration";
 
 /** AFPS `delivery.http` header block with a `{$credential.<field>}` value template. */
-export function httpHeaderDelivery(opts: { name: string; prefix?: string; field: string }): {
-  http: { in: "header"; name: string; prefix?: string; value: string };
+export function httpHeaderDelivery(opts: {
+  name: string;
+  prefix?: string;
+  field: string;
+  allowServerOverride?: boolean;
+}): {
+  http: {
+    in: "header";
+    name: string;
+    prefix?: string;
+    value: string;
+    allow_server_override?: boolean;
+  };
 } {
   return {
     http: {
@@ -23,6 +34,7 @@ export function httpHeaderDelivery(opts: { name: string; prefix?: string; field:
       name: opts.name,
       ...(opts.prefix !== undefined ? { prefix: opts.prefix } : {}),
       value: `{$credential.${opts.field}}`,
+      ...(opts.allowServerOverride ? { allow_server_override: true } : {}),
     },
   };
 }

--- a/apps/api/test/integration/services/credential-proxy-injection.test.ts
+++ b/apps/api/test/integration/services/credential-proxy-injection.test.ts
@@ -250,7 +250,7 @@ describe("proxyCall — server-side credential injection (integration-backed)", 
     expect(captured?.["x-api-key"]).toBe("platform-pinned-key");
   });
 
-  it("respects a caller-supplied header when allow_server_override is true", async () => {
+  it("strips an allowed caller override on redirect even when the platform value is empty", async () => {
     const packageId = "@cpinjectorg/override";
     await seedIntegration(
       ctx.orgId,
@@ -261,7 +261,8 @@ describe("proxyCall — server-side credential injection (integration-backed)", 
         auths: {
           api: {
             type: "api_key",
-            authorizedUris: ["https://api.example.com/**"],
+            authorizedUris: ["https://1.1.1.1/**"],
+            allowAllUris: true,
             delivery: httpHeaderDelivery({
               name: "X-Api-Key",
               field: "api_key",
@@ -271,14 +272,23 @@ describe("proxyCall — server-side credential injection (integration-backed)", 
         },
       }),
     );
-    await installAndConnect(ctx, packageId, "api", { api_key: "platform-pinned-key" });
+    await installAndConnect(ctx, packageId, "api", { api_key: "" });
 
-    let captured: Record<string, string> | undefined;
-    const fakeFetch = ((_url: string, init: RequestInit) => {
-      captured = {};
+    const captured: Array<Record<string, string>> = [];
+    const fakeFetch = ((url: string | URL, init: RequestInit) => {
+      const headers: Record<string, string> = {};
       new Headers(init.headers).forEach((v, k) => {
-        captured![k] = v;
+        headers[k] = v;
       });
+      captured.push(headers);
+      if (url.toString().startsWith("https://1.1.1.1")) {
+        return Promise.resolve(
+          new Response(null, {
+            status: 302,
+            headers: { location: "https://8.8.8.8/redirected" },
+          }),
+        );
+      }
       return Promise.resolve(new Response("{}", { status: 401 }));
     }) as unknown as typeof fetch;
 
@@ -287,12 +297,13 @@ describe("proxyCall — server-side credential injection (integration-backed)", 
       actor: { type: "user", id: ctx.user.id },
       integrationId: packageId,
       method: "GET",
-      target: "https://api.example.com/thing",
+      target: "https://1.1.1.1/thing",
       headers: { "x-api-key": "caller-override-key" },
       fetch: fakeFetch,
     });
 
-    expect(captured?.["x-api-key"]).toBe("caller-override-key");
+    expect(captured[0]?.["x-api-key"]).toBe("caller-override-key");
+    expect(captured[1]?.["x-api-key"]).toBeUndefined();
     const [connection] = await db
       .select({ needsReconnection: integrationConnections.needsReconnection })
       .from(integrationConnections)

--- a/apps/api/test/integration/services/credential-proxy-injection.test.ts
+++ b/apps/api/test/integration/services/credential-proxy-injection.test.ts
@@ -22,6 +22,7 @@ import { truncateAll, db } from "../../helpers/db.ts";
 import { createTestContext, type TestContext } from "../../helpers/auth.ts";
 import { seedPackage } from "../../helpers/seed.ts";
 import { applicationPackages, integrationConnections } from "@appstrate/db/schema";
+import { eq } from "drizzle-orm";
 import { encryptCredentialEnvelope } from "@appstrate/connect";
 import type { IntegrationManifest } from "@appstrate/core/integration";
 import { proxyCall, ProxySubstitutionError } from "../../../src/services/credential-proxy/core.ts";
@@ -208,7 +209,7 @@ describe("proxyCall — server-side credential injection (integration-backed)", 
     expect(captured?.authorization).toBeUndefined();
   });
 
-  it("respects a caller-supplied non-Authorization header override", async () => {
+  it("replaces a caller-supplied non-Authorization header by default", async () => {
     const packageId = "@cpinjectorg/dual";
     await seedIntegration(
       ctx.orgId,
@@ -246,7 +247,57 @@ describe("proxyCall — server-side credential injection (integration-backed)", 
       fetch: fakeFetch,
     });
 
+    expect(captured?.["x-api-key"]).toBe("platform-pinned-key");
+  });
+
+  it("respects a caller-supplied header when allow_server_override is true", async () => {
+    const packageId = "@cpinjectorg/override";
+    await seedIntegration(
+      ctx.orgId,
+      localIntegrationManifest({
+        name: packageId,
+        displayName: "Override",
+        description: "Override integration",
+        auths: {
+          api: {
+            type: "api_key",
+            authorizedUris: ["https://api.example.com/**"],
+            delivery: httpHeaderDelivery({
+              name: "X-Api-Key",
+              field: "api_key",
+              allowServerOverride: true,
+            }),
+          },
+        },
+      }),
+    );
+    await installAndConnect(ctx, packageId, "api", { api_key: "platform-pinned-key" });
+
+    let captured: Record<string, string> | undefined;
+    const fakeFetch = ((_url: string, init: RequestInit) => {
+      captured = {};
+      new Headers(init.headers).forEach((v, k) => {
+        captured![k] = v;
+      });
+      return Promise.resolve(new Response("{}", { status: 401 }));
+    }) as unknown as typeof fetch;
+
+    await proxyCall({
+      applicationId: ctx.defaultAppId,
+      actor: { type: "user", id: ctx.user.id },
+      integrationId: packageId,
+      method: "GET",
+      target: "https://api.example.com/thing",
+      headers: { "x-api-key": "caller-override-key" },
+      fetch: fakeFetch,
+    });
+
     expect(captured?.["x-api-key"]).toBe("caller-override-key");
+    const [connection] = await db
+      .select({ needsReconnection: integrationConnections.needsReconnection })
+      .from(integrationConnections)
+      .where(eq(integrationConnections.integrationId, packageId));
+    expect(connection?.needsReconnection).toBe(false);
   });
 
   it("throws ProxySubstitutionError (fail-closed) when the target references an unresolved {{field}}", async () => {

--- a/apps/api/test/unit/services/sidecar-exit-watcher.test.ts
+++ b/apps/api/test/unit/services/sidecar-exit-watcher.test.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "bun:test";
+import {
+  SidecarExitWatcher,
+  type UnexpectedSidecarExit,
+} from "../../../src/services/orchestrator/sidecar-exit-watcher.ts";
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function createWatcher(exit: Promise<number>, unexpected: UnexpectedSidecarExit[]) {
+  return new SidecarExitWatcher({
+    waitForExit: () => exit,
+    streamLogs: async function* () {
+      yield "last sidecar line";
+    },
+    onUnexpectedExit: (event) => unexpected.push(event),
+    onWatcherError: () => {},
+  });
+}
+
+describe("SidecarExitWatcher", () => {
+  it("suppresses an expected exit that resolves after removal completes", async () => {
+    const exit = deferred<number>();
+    const unexpected: UnexpectedSidecarExit[] = [];
+    const watcher = createWatcher(exit.promise, unexpected);
+    const watching = watcher.watch("run-1", "sidecar-1");
+
+    await watcher.expectExitDuring("sidecar-1", async () => {});
+    exit.resolve(137);
+    await watching;
+
+    expect(unexpected).toEqual([]);
+  });
+
+  it("reports an unexpected non-zero exit with its log tail", async () => {
+    const unexpected: UnexpectedSidecarExit[] = [];
+    const watcher = createWatcher(Promise.resolve(1), unexpected);
+
+    await watcher.watch("run-2", "sidecar-2");
+
+    expect(unexpected).toEqual([
+      {
+        runId: "run-2",
+        containerId: "sidecar-2",
+        exitCode: 1,
+        tail: "last sidecar line",
+      },
+    ]);
+  });
+
+  it("rolls back the expectation when teardown fails", async () => {
+    const exit = deferred<number>();
+    const unexpected: UnexpectedSidecarExit[] = [];
+    const watcher = createWatcher(exit.promise, unexpected);
+    const watching = watcher.watch("run-3", "sidecar-3");
+
+    await expect(
+      watcher.expectExitDuring("sidecar-3", async () => {
+        throw new Error("remove failed");
+      }),
+    ).rejects.toThrow("remove failed");
+    exit.resolve(1);
+    await watching;
+
+    expect(unexpected).toHaveLength(1);
+  });
+});

--- a/apps/api/test/unit/services/sidecar-exit-watcher.test.ts
+++ b/apps/api/test/unit/services/sidecar-exit-watcher.test.ts
@@ -42,6 +42,20 @@ describe("SidecarExitWatcher", () => {
     expect(unexpected).toEqual([]);
   });
 
+  it("suppresses an expected exit for a bulk run stop", async () => {
+    const exit = deferred<number>();
+    const unexpected: UnexpectedSidecarExit[] = [];
+    const watcher = createWatcher(exit.promise, unexpected);
+    const watching = watcher.watch("run-bulk", "sidecar-bulk");
+
+    const result = await watcher.expectRunExitDuring("run-bulk", async () => "stopped" as const);
+    exit.resolve(137);
+    await watching;
+
+    expect(result).toBe("stopped");
+    expect(unexpected).toEqual([]);
+  });
+
   it("reports an unexpected non-zero exit with its log tail", async () => {
     const unexpected: UnexpectedSidecarExit[] = [];
     const watcher = createWatcher(Promise.resolve(1), unexpected);

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -3073,8 +3073,8 @@ export interface paths {
         get: operations["listIntegrationPackages"];
         put?: never;
         /**
-         * Create an integration package
-         * @description Create a new integration package in the organization packages.
+         * Create an integration package, including a remote MCP
+         * @description Create a new integration package in the organization packages. An upstream-hosted MCP endpoint belongs here as an integration with `source.kind: "remote"`; use an MCP-server package only for a local executable referenced by `source.kind: "local"`.
          */
         post: operations["createIntegrationPackage"];
         delete?: never;
@@ -3241,8 +3241,8 @@ export interface paths {
         get: operations["listMcpServerPackages"];
         put?: never;
         /**
-         * Create an MCP-server package
-         * @description Create a new MCP-server package in the organization packages.
+         * Create a local MCP-server executable package
+         * @description Create a local executable MCP-server package referenced by an integration with `source.kind: "local"`. For an upstream-hosted MCP endpoint, create an integration package with `source.kind: "remote"` instead.
          */
         post: operations["createMcpServerPackage"];
         delete?: never;

--- a/packages/afps-runtime/src/resolvers/http-delivery.ts
+++ b/packages/afps-runtime/src/resolvers/http-delivery.ts
@@ -76,7 +76,7 @@ export function planHttpDeliveryInjection(
   plan: Pick<HttpDeliveryPlan, "headerName" | "headerPrefix" | "value" | "allowServerOverride">,
   callerHeaderNames: readonly string[],
 ): HttpDeliveryInjectionDecision {
-  if (plan.headerName.length === 0 || plan.value.length === 0) return { kind: "none" };
+  if (plan.headerName.length === 0) return { kind: "none" };
 
   const callerSetHeader = callerHeaderNames.some(
     (name) => name.toLowerCase() === plan.headerName.toLowerCase(),
@@ -84,6 +84,7 @@ export function planHttpDeliveryInjection(
   if (plan.allowServerOverride && callerSetHeader) {
     return { kind: "caller_override", headerName: plan.headerName };
   }
+  if (plan.value.length === 0) return { kind: "none" };
 
   const lowerHeaderName = plan.headerName.toLowerCase();
   const isAuthorization =

--- a/packages/afps-runtime/src/resolvers/http-delivery.ts
+++ b/packages/afps-runtime/src/resolvers/http-delivery.ts
@@ -42,6 +42,67 @@ export interface HttpDeliveryPlan {
 }
 
 /**
+ * Credential-header decision shared by every HTTP delivery topology.
+ *
+ * `caller_override` is distinct from `none`: callers use it to preserve the
+ * manifest-authorised header while avoiding a refresh / reconnection verdict
+ * for a 401 that did not use the platform credential.
+ */
+export type HttpDeliveryInjectionDecision =
+  | { kind: "none" }
+  | { kind: "caller_override"; headerName: string }
+  | { kind: "inject"; header: { name: string; value: string } };
+
+// RFC 9110 `token` grammar. A bare token in Authorization position is an auth
+// scheme and therefore needs one SP before its credentials. Composite prefixes
+// (`Token token=`) and non-Authorization headers (`Cookie: session=`) remain
+// literal AFPS prefixes.
+const HTTP_TOKEN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
+/**
+ * Plan the observable credential-header mutation for one outgoing request.
+ *
+ * This is the single rendering + override-policy seam for remote MCP, MITM,
+ * credential-proxy, and portable `api_call` callers. It never inspects or
+ * normalises `plan.value`: a valid secret whose bytes happen to start with an
+ * auth-scheme word must reach the upstream unchanged (#988).
+ *
+ * AFPS defines `prefix` as literal. Appstrate additionally accepts the legacy
+ * shorthand of a bare auth scheme in `Authorization` / `Proxy-Authorization`
+ * position and inserts the required separator. This compatibility rule is
+ * deliberately based on the separately-declared prefix, never on the secret.
+ */
+export function planHttpDeliveryInjection(
+  plan: Pick<HttpDeliveryPlan, "headerName" | "headerPrefix" | "value" | "allowServerOverride">,
+  callerHeaderNames: readonly string[],
+): HttpDeliveryInjectionDecision {
+  if (plan.headerName.length === 0 || plan.value.length === 0) return { kind: "none" };
+
+  const callerSetHeader = callerHeaderNames.some(
+    (name) => name.toLowerCase() === plan.headerName.toLowerCase(),
+  );
+  if (plan.allowServerOverride && callerSetHeader) {
+    return { kind: "caller_override", headerName: plan.headerName };
+  }
+
+  const lowerHeaderName = plan.headerName.toLowerCase();
+  const isAuthorization =
+    lowerHeaderName === "authorization" || lowerHeaderName === "proxy-authorization";
+  const separator =
+    isAuthorization && plan.headerPrefix.length > 0 && HTTP_TOKEN.test(plan.headerPrefix)
+      ? " "
+      : "";
+
+  return {
+    kind: "inject",
+    header: {
+      name: plan.headerName,
+      value: `${plan.headerPrefix}${separator}${plan.value}`,
+    },
+  };
+}
+
+/**
  * Auth-type defaults for `delivery.http`. `valueFrom` names the credential
  * field to inject, using the **canonical snake_case storage keys** — the same
  * convention the OAuth2 strategy persists (`access_token`) and the AFPS spec

--- a/packages/afps-runtime/src/resolvers/index.ts
+++ b/packages/afps-runtime/src/resolvers/index.ts
@@ -43,8 +43,10 @@ export { resolvePackageRef, readPackageText, readPackageBytes } from "./bundle-a
 // Canonical `delivery.http` credential-injection resolver (shared with
 // `@appstrate/connect`, which re-exports these).
 export {
+  planHttpDeliveryInjection,
   resolveHttpDelivery,
   type HttpDeliveryConfig,
+  type HttpDeliveryInjectionDecision,
   type HttpDeliveryPlan,
 } from "./http-delivery.ts";
 

--- a/packages/afps-runtime/src/resolvers/integration-api-call.ts
+++ b/packages/afps-runtime/src/resolvers/integration-api-call.ts
@@ -426,22 +426,33 @@ export class LocalIntegrationResolver implements IntegrationApiCallResolver {
       }
       const target = substituteVars(req.target, fields);
 
+      const deliveryPlan = resolveLocalDeliveryPlan(meta, entry);
+      const allowsAuthorizationOverride =
+        deliveryPlan?.allowServerOverride === true &&
+        deliveryPlan.headerName.toLowerCase() === "authorization";
+
       // Strip Appstrate transport headers before substitution. Authorization
-      // is different on this LOCAL path: it may be the manifest-authorised
-      // source override, so the shared delivery planner below decides whether
-      // it survives. The remote resolver still strips Authorization because it
-      // authenticates the request to Appstrate itself with that header.
+      // survives on this LOCAL path only when the delivery plan targets that
+      // header and explicitly authorises a caller override. The remote resolver
+      // always strips it because it authenticates to Appstrate with that header.
       const headers: Record<string, string> = {};
       for (const [key, value] of Object.entries(req.headers ?? {})) {
         const lowerKey = key.toLowerCase();
-        if (lowerKey !== "authorization" && RESERVED_TRANSPORT_HEADERS.has(lowerKey)) continue;
+        if (
+          RESERVED_TRANSPORT_HEADERS.has(lowerKey) &&
+          !(lowerKey === "authorization" && allowsAuthorizationOverride)
+        ) {
+          continue;
+        }
         if (referencesCredentialField(value, fields)) substitutesCredential = true;
         headers[key] = substituteVars(value, fields);
       }
       // Inject the credential header locally and capture its name so the
       // shared engine's redirect-follower knows which header to strip on
       // an out-of-boundary cross-origin hop.
-      const injectedCredentialHeader = injectCredential(headers, meta, entry);
+      const injectedCredentialHeader = deliveryPlan
+        ? applyDeliveryPlan(headers, deliveryPlan)
+        : null;
 
       // A call that substitutes a credential field into the agent-controlled
       // URL / headers / body MUST respect the auth's `authorized_uris`
@@ -541,24 +552,18 @@ export class LocalIntegrationResolver implements IntegrationApiCallResolver {
 }
 
 /**
- * Inject the credential header into an outgoing request. Precedence:
+ * Resolve the local credential-delivery plan. Precedence:
  *   1. explicit `entry.injection` override (header name/prefix + template),
  *   2. the integration manifest's `delivery.http` plan (auth-type defaults
  *      applied) — mirrors `@appstrate/connect`'s `resolveHttpDelivery`.
  *
  * When neither yields a header (e.g. `custom` auth with no `delivery.http`),
- * nothing is injected — the agent supplies its own auth via `{{var}}`
- * substitution, as for a `custom` auth.
- *
- * Returns the name of the header it injected (or `null` when nothing was
- * injected) so the caller can hand it to the shared engine's
- * redirect-follower for cross-origin credential stripping.
+ * returns `null` and the caller injects nothing.
  */
-function injectCredential(
-  headers: Record<string, string>,
+function resolveLocalDeliveryPlan(
   meta: ApiCallIntegrationMeta,
   entry: LocalIntegrationCredentialsFile["integrations"][string],
-): string | null {
+): HttpDeliveryPlan | null {
   const fields = entry.fields;
 
   // 1. Explicit override from the creds file.
@@ -569,18 +574,16 @@ function injectCredential(
     if (!rendered) return null;
     const headerName = entry.injection.headerName ?? "Authorization";
     const headerPrefix = entry.injection.headerPrefix ?? "";
-    return applyDeliveryPlan(headers, {
+    return {
       headerName,
       headerPrefix,
       value: rendered,
       allowServerOverride: false,
-    });
+    };
   }
 
   // 2. Manifest `delivery.http` plan (auth-type defaults).
-  const plan = resolveHttpDelivery(meta.authType, fields, meta.http);
-  if (!plan || !plan.headerName) return null;
-  return applyDeliveryPlan(headers, plan);
+  return resolveHttpDelivery(meta.authType, fields, meta.http);
 }
 
 function applyDeliveryPlan(headers: Record<string, string>, plan: HttpDeliveryPlan): string | null {

--- a/packages/afps-runtime/src/resolvers/integration-api-call.ts
+++ b/packages/afps-runtime/src/resolvers/integration-api-call.ts
@@ -59,7 +59,12 @@ import {
 } from "@appstrate/afps-shared/mcp-naming";
 import { guardedFetch, PreflightError, type HostResolver } from "./api-call-engine.ts";
 import { AuthorizedUrisError, ResolverError } from "../errors.ts";
-import { resolveHttpDelivery, type HttpDeliveryConfig } from "./http-delivery.ts";
+import {
+  planHttpDeliveryInjection,
+  resolveHttpDelivery,
+  type HttpDeliveryConfig,
+  type HttpDeliveryPlan,
+} from "./http-delivery.ts";
 import {
   projectHttpDeliveryConfig,
   type AfpsHttpDelivery,
@@ -421,14 +426,15 @@ export class LocalIntegrationResolver implements IntegrationApiCallResolver {
       }
       const target = substituteVars(req.target, fields);
 
-      // Strip agent overrides of reserved transport / credential headers
-      // (case-insensitive) BEFORE substitution + injection, so a tool call
-      // can neither spoof platform-imposed identity headers nor pre-seed the
-      // credential header the resolver is about to set. Platform-injected
-      // values are applied last (in `injectCredential`) and always win.
+      // Strip Appstrate transport headers before substitution. Authorization
+      // is different on this LOCAL path: it may be the manifest-authorised
+      // source override, so the shared delivery planner below decides whether
+      // it survives. The remote resolver still strips Authorization because it
+      // authenticates the request to Appstrate itself with that header.
       const headers: Record<string, string> = {};
       for (const [key, value] of Object.entries(req.headers ?? {})) {
-        if (RESERVED_TRANSPORT_HEADERS.has(key.toLowerCase())) continue;
+        const lowerKey = key.toLowerCase();
+        if (lowerKey !== "authorization" && RESERVED_TRANSPORT_HEADERS.has(lowerKey)) continue;
         if (referencesCredentialField(value, fields)) substitutesCredential = true;
         headers[key] = substituteVars(value, fields);
       }
@@ -563,22 +569,30 @@ function injectCredential(
     if (!rendered) return null;
     const headerName = entry.injection.headerName ?? "Authorization";
     const headerPrefix = entry.injection.headerPrefix ?? "";
-    headers[headerName] = `${headerPrefix}${rendered}`;
-    return headerName;
+    return applyDeliveryPlan(headers, {
+      headerName,
+      headerPrefix,
+      value: rendered,
+      allowServerOverride: false,
+    });
   }
 
   // 2. Manifest `delivery.http` plan (auth-type defaults).
   const plan = resolveHttpDelivery(meta.authType, fields, meta.http);
   if (!plan || !plan.headerName) return null;
-  // `allowServerOverride: false` (default) → strip a caller-supplied header
-  // of the same name before injecting (defence-in-depth, mirrors the sidecar).
-  if (!plan.allowServerOverride) {
-    for (const key of Object.keys(headers)) {
-      if (key.toLowerCase() === plan.headerName.toLowerCase()) delete headers[key];
-    }
+  return applyDeliveryPlan(headers, plan);
+}
+
+function applyDeliveryPlan(headers: Record<string, string>, plan: HttpDeliveryPlan): string | null {
+  const decision = planHttpDeliveryInjection(plan, Object.keys(headers));
+  if (decision.kind === "none") return null;
+  if (decision.kind === "caller_override") return decision.headerName;
+
+  for (const key of Object.keys(headers)) {
+    if (key.toLowerCase() === decision.header.name.toLowerCase()) delete headers[key];
   }
-  headers[plan.headerName] = `${plan.headerPrefix}${plan.value}`;
-  return plan.headerName;
+  headers[decision.header.name] = decision.header.value;
+  return decision.header.name;
 }
 
 // ─────────────────────────────────────────────

--- a/packages/afps-runtime/test/resolvers/http-delivery.test.ts
+++ b/packages/afps-runtime/test/resolvers/http-delivery.test.ts
@@ -168,4 +168,18 @@ describe("planHttpDeliveryInjection", () => {
       header: { name: "Authorization", value: "Bearer secret" },
     });
   });
+
+  it("identifies an allowed caller override even when the platform value is empty", () => {
+    expect(
+      planHttpDeliveryInjection(
+        plan({
+          headerName: "X-Api-Key",
+          headerPrefix: "",
+          value: "",
+          allowServerOverride: true,
+        }),
+        ["x-api-key"],
+      ),
+    ).toEqual({ kind: "caller_override", headerName: "X-Api-Key" });
+  });
 });

--- a/packages/afps-runtime/test/resolvers/http-delivery.test.ts
+++ b/packages/afps-runtime/test/resolvers/http-delivery.test.ts
@@ -9,7 +9,10 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { resolveHttpDelivery } from "../../src/resolvers/http-delivery.ts";
+import {
+  planHttpDeliveryInjection,
+  resolveHttpDelivery,
+} from "../../src/resolvers/http-delivery.ts";
 
 describe("resolveHttpDelivery — defaults per auth type", () => {
   it("oauth2 → Authorization: Bearer <accessToken>", () => {
@@ -89,5 +92,80 @@ describe("resolveHttpDelivery — explicit overrides", () => {
       { allowServerOverride: true },
     );
     expect(plan!.allowServerOverride).toBe(true);
+  });
+});
+
+describe("planHttpDeliveryInjection", () => {
+  const plan = (
+    overrides: Partial<{
+      headerName: string;
+      headerPrefix: string;
+      value: string;
+      allowServerOverride: boolean;
+    }> = {},
+  ) => ({
+    headerName: "Authorization",
+    headerPrefix: "Bearer ",
+    value: "secret",
+    allowServerOverride: false,
+    ...overrides,
+  });
+
+  it("repairs a bare Authorization auth scheme without touching the secret", () => {
+    expect(
+      planHttpDeliveryInjection(
+        plan({ headerPrefix: "Bearer", value: "bearerXYZ-tokenlive_sk_123" }),
+        [],
+      ),
+    ).toEqual({
+      kind: "inject",
+      header: { name: "Authorization", value: "Bearer bearerXYZ-tokenlive_sk_123" },
+    });
+  });
+
+  it("keeps canonical, vendor-composite, and custom-header prefixes literal", () => {
+    expect(planHttpDeliveryInjection(plan(), [])).toEqual({
+      kind: "inject",
+      header: { name: "Authorization", value: "Bearer secret" },
+    });
+    expect(planHttpDeliveryInjection(plan({ headerPrefix: "Token token=" }), [])).toEqual({
+      kind: "inject",
+      header: { name: "Authorization", value: "Token token=secret" },
+    });
+    expect(
+      planHttpDeliveryInjection(
+        plan({ headerName: "Cookie", headerPrefix: "session=", value: "SESS" }),
+        [],
+      ),
+    ).toEqual({
+      kind: "inject",
+      header: { name: "Cookie", value: "session=SESS" },
+    });
+  });
+
+  it("supports arbitrary bare Authorization schemes", () => {
+    for (const headerPrefix of ["Basic", "Zoho-oauthtoken", "AWS4-HMAC-SHA256"]) {
+      expect(planHttpDeliveryInjection(plan({ headerPrefix }), [])).toEqual({
+        kind: "inject",
+        header: { name: "Authorization", value: `${headerPrefix} secret` },
+      });
+    }
+  });
+
+  it("returns none for an empty header name or credential value", () => {
+    expect(planHttpDeliveryInjection(plan({ headerName: "" }), [])).toEqual({ kind: "none" });
+    expect(planHttpDeliveryInjection(plan({ value: "" }), ["Authorization"])).toEqual({
+      kind: "none",
+    });
+  });
+
+  it("lets a case-insensitive caller header win only when explicitly allowed", () => {
+    expect(
+      planHttpDeliveryInjection(plan({ allowServerOverride: true }), ["authorization"]),
+    ).toEqual({ kind: "caller_override", headerName: "Authorization" });
+    expect(planHttpDeliveryInjection(plan(), ["authorization"])).toEqual({
+      kind: "inject",
+      header: { name: "Authorization", value: "Bearer secret" },
+    });
   });
 });

--- a/packages/afps-runtime/test/resolvers/integration-api-call.test.ts
+++ b/packages/afps-runtime/test/resolvers/integration-api-call.test.ts
@@ -547,7 +547,11 @@ describe("LocalIntegrationResolver", () => {
     const tools = await resolver.resolve([{ name: "@acme/api", version: "^1" }], bundle);
     const { ctx } = makeCtx();
     await tools[0]!.execute(
-      { method: "GET", target: "https://api.acme.com/v1/me", headers: { "x-api-key": "forged" } },
+      {
+        method: "GET",
+        target: "https://api.acme.com/v1/me",
+        headers: { "x-api-key": "forged", authorization: "Bearer unrelated" },
+      },
       ctx,
     );
     const h = calls[0]!.init.headers as Record<string, string>;
@@ -555,6 +559,7 @@ describe("LocalIntegrationResolver", () => {
     const apiKeyHeaders = Object.entries(h).filter(([k]) => k.toLowerCase() === "x-api-key");
     expect(apiKeyHeaders).toHaveLength(1);
     expect(apiKeyHeaders[0]![1]).toBe("real");
+    expect(Object.keys(h).some((key) => key.toLowerCase() === "authorization")).toBe(false);
   });
 
   it("preserves a case-insensitive caller header only when allowServerOverride is true", async () => {

--- a/packages/afps-runtime/test/resolvers/integration-api-call.test.ts
+++ b/packages/afps-runtime/test/resolvers/integration-api-call.test.ts
@@ -78,7 +78,13 @@ function makeCtx(): { ctx: ToolContext; events: RunEvent[] } {
 /** apiCall integration manifest helper (api_key auth with delivery.http). */
 function apiKeyIntegrationManifest(
   _name: `@${string}/${string}`,
-  opts: { authorizedUris?: string[]; allowAllUris?: boolean; headerName?: string } = {},
+  opts: {
+    authorizedUris?: string[];
+    allowAllUris?: boolean;
+    headerName?: string;
+    headerPrefix?: string;
+    allowServerOverride?: boolean;
+  } = {},
 ) {
   return {
     integration: {
@@ -96,7 +102,9 @@ function apiKeyIntegrationManifest(
             http: {
               in: "header",
               name: opts.headerName ?? "X-Api-Key",
+              ...(opts.headerPrefix !== undefined ? { prefix: opts.headerPrefix } : {}),
               value: "{$credential.api_key}",
+              ...(opts.allowServerOverride ? { allow_server_override: true } : {}),
             },
           },
         },
@@ -547,6 +555,42 @@ describe("LocalIntegrationResolver", () => {
     const apiKeyHeaders = Object.entries(h).filter(([k]) => k.toLowerCase() === "x-api-key");
     expect(apiKeyHeaders).toHaveLength(1);
     expect(apiKeyHeaders[0]![1]).toBe("real");
+  });
+
+  it("preserves a case-insensitive caller header only when allowServerOverride is true", async () => {
+    const calls: { url: string; init: RequestInit }[] = [];
+    const root = makePackage("@acme/agent", "1.0.0", "agent", {});
+    const integ = makePackage("@acme/api", "1.0.0", "integration", {
+      "integration.json": JSON.stringify(
+        apiKeyIntegrationManifest("@acme/api", {
+          headerName: "Authorization",
+          headerPrefix: "Bearer",
+          allowServerOverride: true,
+        }).integration,
+      ),
+    });
+    const resolver = new LocalIntegrationResolver({
+      resolveHost: async () => ["203.0.113.7"],
+      creds: { version: 1, integrations: { "@acme/api": { fields: { api_key: "server" } } } },
+      fetch: ((url: string, init: RequestInit) => {
+        calls.push({ url, init });
+        return Promise.resolve(new Response("{}", { status: 200 }));
+      }) as typeof fetch,
+    });
+    const tools = await resolver.resolve(
+      [{ name: "@acme/api", version: "^1" }],
+      makeBundle(root, [integ]),
+    );
+    const { ctx } = makeCtx();
+    await tools[0]!.execute(
+      {
+        method: "GET",
+        target: "https://api.acme.com/v1/me",
+        headers: { authorization: "Bearer caller" },
+      },
+      ctx,
+    );
+    expect(calls[0]!.init.headers).toEqual({ authorization: "Bearer caller" });
   });
 
   it("honours an explicit injection override from the creds file", async () => {

--- a/packages/connect/src/integration-credentials.ts
+++ b/packages/connect/src/integration-credentials.ts
@@ -110,7 +110,11 @@ export function buildProxyCredentialsPayload(opts: {
     authorizedUris: [...authorizedUris],
     allowAllUris,
     ...(plan && plan.headerName
-      ? { credentialHeaderName: plan.headerName, credentialHeaderPrefix: plan.headerPrefix }
+      ? {
+          credentialHeaderName: plan.headerName,
+          credentialHeaderPrefix: plan.headerPrefix,
+          credentialAllowServerOverride: plan.allowServerOverride === true,
+        }
       : {}),
     credentialFieldName: PROXY_INJECTED_FIELD,
   };

--- a/packages/connect/src/integration-mitm-planner.ts
+++ b/packages/connect/src/integration-mitm-planner.ts
@@ -49,6 +49,10 @@ import type {
   IntegrationCredentialsPayload,
   ResolvedAuthCredentials,
 } from "./integration-credentials.ts";
+import {
+  planHttpDeliveryInjection,
+  type HttpDeliveryInjectionDecision,
+} from "@appstrate/afps-runtime/resolvers";
 import { matchesAuthorizedUriSpec } from "./proxy-primitives.ts";
 
 // ─────────────────────────────────────────────
@@ -155,7 +159,7 @@ export function planMitmAction(
   const stripped: string[] = [...universalStrip];
 
   if (plan) {
-    // By default the proxy strips a server-supplied header matching the
+    // By default the proxy strips a caller-supplied header matching the
     // injection target (confused-deputy boundary — integration code must not
     // pre-empt the injected credential). The ONE exception is an explicit
     // `allowServerOverride` on an Authorization-typed auth: the manifest author
@@ -171,7 +175,7 @@ export function planMitmAction(
       !plan.allowServerOverride &&
       !looseEquals(plan.headerName, "Authorization")
     ) {
-      // Protect the injected credential header from server override — but ONLY
+      // Protect the injected credential header from caller override — but ONLY
       // when we actually have a credential to inject. An empty delivery value
       // means "no credential yet": e.g. a `connect.tool` session still being
       // acquired at run-start, where the placeholder plan is `value: ""`.
@@ -184,9 +188,10 @@ export function planMitmAction(
     }
   }
 
-  const injectedHeader = plan
-    ? renderInjection(plan, ctx.headerNames, plan.allowServerOverride)
-    : null;
+  const injection: HttpDeliveryInjectionDecision = plan
+    ? planHttpDeliveryInjection(plan, ctx.headerNames)
+    : { kind: "none" };
+  const injectedHeader = injection.kind === "inject" ? injection.header : null;
 
   return {
     matchedAuth: matched,
@@ -198,30 +203,6 @@ export function planMitmAction(
 // ─────────────────────────────────────────────
 // Internals
 // ─────────────────────────────────────────────
-
-/**
- * Render the `{name, value}` pair the listener writes onto the upstream
- * request. Returns `null` when:
- *   - the delivery plan's value is empty (the credential resolver
- *     surfaced an empty field; injecting "Bearer " with no token is a
- *     guaranteed 401 and wastes the round-trip), OR
- *   - `allowServerOverride: true` AND the caller already set the same
- *     header (the manifest opt-in says respect the caller's value).
- */
-function renderInjection(
-  plan: HttpDeliveryPlan,
-  callerHeaderNames: readonly string[],
-  allowServerOverride: boolean,
-): { name: string; value: string } | null {
-  if (plan.value.length === 0) return null;
-  if (allowServerOverride) {
-    const callerSetIt = callerHeaderNames.some((h) => looseEquals(h, plan.headerName));
-    if (callerSetIt) return null;
-  }
-  const prefix = plan.headerPrefix.trim();
-  const value = prefix ? `${prefix} ${plan.value}` : plan.value;
-  return { name: plan.headerName, value };
-}
 
 function looseEquals(a: string, b: string): boolean {
   return a.toLowerCase() === b.toLowerCase();

--- a/packages/connect/src/proxy-primitives.ts
+++ b/packages/connect/src/proxy-primitives.ts
@@ -9,7 +9,11 @@
  * impossible by construction.
  */
 
-import { substituteVars as substituteVarsCore } from "@appstrate/afps-runtime/resolvers";
+import {
+  planHttpDeliveryInjection,
+  substituteVars as substituteVarsCore,
+  type HttpDeliveryInjectionDecision,
+} from "@appstrate/afps-runtime/resolvers";
 
 /**
  * Substitute `{{field}}` placeholders in `input` using `credentials`.
@@ -69,11 +73,17 @@ export interface ProxyCredentialsPayload {
    */
   credentialHeaderName?: string;
   /**
-   * Prefix prepended to the credential value — typically `Bearer` for
-   * OAuth, empty for most API-key providers. When set, the rendered
-   * header is `${prefix} ${credentials[credentialFieldName]}`.
+   * Literal prefix prepended to the credential value — typically `Bearer `
+   * for OAuth, empty for most API-key providers. For compatibility, a bare
+   * RFC auth-scheme token such as `Bearer` gets one separator only when the
+   * target is Authorization or Proxy-Authorization.
    */
   credentialHeaderPrefix?: string;
+  /**
+   * Whether a caller-supplied header with the same name wins. Optional for
+   * rolling compatibility; absent follows the AFPS default (`false`).
+   */
+  credentialAllowServerOverride?: boolean;
   /**
    * Name of the field in `credentials` that holds the secret to inject.
    * Always populated (defaults `access_token` / `api_key` by auth mode)
@@ -87,13 +97,35 @@ export interface ProxyCredentialsPayload {
  * Narrow subset the header-injection helpers actually read. Every
  * `ProxyCredentialsPayload` satisfies this shape trivially — the alias
  * exists so ad-hoc callers (tests, fixture builders) can construct the
- * four fields the injector needs without also filling in `authorizedUris`
+ * fields the injector needs without also filling in `authorizedUris`
  * / `allowAllUris` boilerplate.
  */
 type InjectableCredentials = Pick<
   ProxyCredentialsPayload,
-  "credentials" | "credentialHeaderName" | "credentialHeaderPrefix" | "credentialFieldName"
+  | "credentials"
+  | "credentialHeaderName"
+  | "credentialHeaderPrefix"
+  | "credentialAllowServerOverride"
+  | "credentialFieldName"
 >;
+
+function planInjectedCredentialHeader(
+  creds: InjectableCredentials,
+  callerHeaderNames: readonly string[],
+): HttpDeliveryInjectionDecision {
+  if (!creds.credentialHeaderName) return { kind: "none" };
+  const token = creds.credentials[creds.credentialFieldName];
+  if (!token) return { kind: "none" };
+  return planHttpDeliveryInjection(
+    {
+      headerName: creds.credentialHeaderName,
+      headerPrefix: creds.credentialHeaderPrefix ?? "",
+      value: token,
+      allowServerOverride: creds.credentialAllowServerOverride === true,
+    },
+    callerHeaderNames,
+  );
+}
 
 /**
  * Build the final header-name / header-value pair the proxy injects
@@ -105,31 +137,28 @@ type InjectableCredentials = Pick<
 export function buildInjectedCredentialHeader(
   creds: InjectableCredentials,
 ): { name: string; value: string } | undefined {
-  if (!creds.credentialHeaderName) return undefined;
-  const token = creds.credentials[creds.credentialFieldName];
-  if (!token) return undefined;
-  const prefix = creds.credentialHeaderPrefix?.trim();
-  const value = prefix ? `${prefix} ${token}` : token;
-  return { name: creds.credentialHeaderName, value };
+  const decision = planInjectedCredentialHeader(creds, []);
+  return decision.kind === "inject" ? decision.header : undefined;
 }
 
 /**
  * Apply {@link buildInjectedCredentialHeader} onto an existing header
- * map in-place. Caller headers win on case-insensitive match — if the
- * agent explicitly set the credential header (e.g. passing a per-call
- * token via input), we respect the override rather than clobbering it.
+ * map in-place. The platform credential replaces a case-insensitive caller
+ * match by default. A caller header is preserved only when the manifest
+ * explicitly declares `allowServerOverride: true`.
  */
 export function applyInjectedCredentialHeader(
   headers: Record<string, string>,
   creds: InjectableCredentials,
-): void {
-  const injected = buildInjectedCredentialHeader(creds);
-  if (!injected) return;
-  const lower = injected.name.toLowerCase();
+): HttpDeliveryInjectionDecision {
+  const decision = planInjectedCredentialHeader(creds, Object.keys(headers));
+  if (decision.kind !== "inject") return decision;
+  const lower = decision.header.name.toLowerCase();
   for (const key of Object.keys(headers)) {
-    if (key.toLowerCase() === lower) return; // caller override wins
+    if (key.toLowerCase() === lower) delete headers[key];
   }
-  headers[injected.name] = injected.value;
+  headers[decision.header.name] = decision.header.value;
+  return decision;
 }
 
 /**
@@ -140,16 +169,11 @@ export function applyInjectedCredentialHeader(
 export function applyInjectedCredentialHeaderToHeaders(
   headers: Headers,
   creds: InjectableCredentials,
-): void {
-  const injected = buildInjectedCredentialHeader(creds);
-  if (!injected) return;
-  const lower = injected.name.toLowerCase();
-  let overridden = false;
-  headers.forEach((_v, k) => {
-    if (k.toLowerCase() === lower) overridden = true;
-  });
-  if (overridden) return;
-  headers.set(injected.name, injected.value);
+): HttpDeliveryInjectionDecision {
+  const decision = planInjectedCredentialHeader(creds, [...headers.keys()]);
+  if (decision.kind !== "inject") return decision;
+  headers.set(decision.header.name, decision.header.value);
+  return decision;
 }
 
 /**

--- a/packages/connect/src/proxy-primitives.ts
+++ b/packages/connect/src/proxy-primitives.ts
@@ -114,13 +114,11 @@ function planInjectedCredentialHeader(
   callerHeaderNames: readonly string[],
 ): HttpDeliveryInjectionDecision {
   if (!creds.credentialHeaderName) return { kind: "none" };
-  const token = creds.credentials[creds.credentialFieldName];
-  if (!token) return { kind: "none" };
   return planHttpDeliveryInjection(
     {
       headerName: creds.credentialHeaderName,
       headerPrefix: creds.credentialHeaderPrefix ?? "",
-      value: token,
+      value: creds.credentials[creds.credentialFieldName] ?? "",
       allowServerOverride: creds.credentialAllowServerOverride === true,
     },
     callerHeaderNames,

--- a/packages/connect/test/proxy-primitives.test.ts
+++ b/packages/connect/test/proxy-primitives.test.ts
@@ -196,6 +196,16 @@ describe("buildInjectedCredentialHeader", () => {
     expect(out).toEqual({ name: "Authorization", value: "Bearer abc" });
   });
 
+  it("keeps a composite Authorization prefix literal", () => {
+    const out = buildInjectedCredentialHeader({
+      credentials: { api_key: "abc" },
+      credentialHeaderName: "Authorization",
+      credentialHeaderPrefix: "Token token=",
+      credentialFieldName: "api_key",
+    });
+    expect(out).toEqual({ name: "Authorization", value: "Token token=abc" });
+  });
+
   it("omits the space when no prefix", () => {
     const out = buildInjectedCredentialHeader({
       credentials: { api_key: "secret" },
@@ -237,7 +247,7 @@ describe("applyInjectedCredentialHeader (record)", () => {
     expect(headers).toEqual({ Authorization: "Bearer abc" });
   });
 
-  it("respects a case-insensitive caller override", () => {
+  it("replaces a case-insensitive caller header by default", () => {
     const headers: Record<string, string> = { authorization: "Bearer caller" };
     applyInjectedCredentialHeader(headers, {
       credentials: { access_token: "server" },
@@ -245,7 +255,20 @@ describe("applyInjectedCredentialHeader (record)", () => {
       credentialHeaderPrefix: "Bearer",
       credentialFieldName: "access_token",
     });
+    expect(headers).toEqual({ Authorization: "Bearer server" });
+  });
+
+  it("respects a case-insensitive caller override when explicitly allowed", () => {
+    const headers: Record<string, string> = { authorization: "Bearer caller" };
+    const decision = applyInjectedCredentialHeader(headers, {
+      credentials: { access_token: "server" },
+      credentialHeaderName: "Authorization",
+      credentialHeaderPrefix: "Bearer",
+      credentialAllowServerOverride: true,
+      credentialFieldName: "access_token",
+    });
     expect(headers).toEqual({ authorization: "Bearer caller" });
+    expect(decision).toEqual({ kind: "caller_override", headerName: "Authorization" });
   });
 });
 
@@ -261,7 +284,7 @@ describe("applyInjectedCredentialHeaderToHeaders (Headers instance)", () => {
     expect(headers.get("authorization")).toBe("Bearer abc");
   });
 
-  it("respects a case-insensitive caller override", () => {
+  it("replaces a case-insensitive caller header by default", () => {
     const headers = new Headers({ Authorization: "Bearer caller" });
     applyInjectedCredentialHeaderToHeaders(headers, {
       credentials: { access_token: "server" },
@@ -269,7 +292,20 @@ describe("applyInjectedCredentialHeaderToHeaders (Headers instance)", () => {
       credentialHeaderPrefix: "Bearer",
       credentialFieldName: "access_token",
     });
+    expect(headers.get("authorization")).toBe("Bearer server");
+  });
+
+  it("respects a case-insensitive caller override when explicitly allowed", () => {
+    const headers = new Headers({ Authorization: "Bearer caller" });
+    const decision = applyInjectedCredentialHeaderToHeaders(headers, {
+      credentials: { access_token: "server" },
+      credentialHeaderName: "Authorization",
+      credentialHeaderPrefix: "Bearer",
+      credentialAllowServerOverride: true,
+      credentialFieldName: "access_token",
+    });
     expect(headers.get("authorization")).toBe("Bearer caller");
+    expect(decision).toEqual({ kind: "caller_override", headerName: "Authorization" });
   });
 });
 

--- a/packages/connect/test/proxy-primitives.test.ts
+++ b/packages/connect/test/proxy-primitives.test.ts
@@ -270,6 +270,18 @@ describe("applyInjectedCredentialHeader (record)", () => {
     expect(headers).toEqual({ authorization: "Bearer caller" });
     expect(decision).toEqual({ kind: "caller_override", headerName: "Authorization" });
   });
+
+  it("identifies an allowed caller override when the platform field is empty", () => {
+    const headers: Record<string, string> = { "x-api-key": "caller" };
+    const decision = applyInjectedCredentialHeader(headers, {
+      credentials: { api_key: "" },
+      credentialHeaderName: "X-Api-Key",
+      credentialAllowServerOverride: true,
+      credentialFieldName: "api_key",
+    });
+    expect(headers).toEqual({ "x-api-key": "caller" });
+    expect(decision).toEqual({ kind: "caller_override", headerName: "X-Api-Key" });
+  });
 });
 
 describe("applyInjectedCredentialHeaderToHeaders (Headers instance)", () => {

--- a/packages/core/src/sidecar-types.ts
+++ b/packages/core/src/sidecar-types.ts
@@ -355,8 +355,8 @@ export interface IntegrationSpawnSpec {
   fileMounts?: Record<string, { content_b64: string; mode: string }>;
   /**
    * Phase 1.5 — per-auth `delivery.http` metadata. The sidecar starts a
-   * per-integration MITM HTTPS proxy and uses these plans to inject
-   * `headerName: headerPrefix + value` on every upstream request whose
+   * per-integration MITM HTTPS proxy and uses these plans to apply the shared
+   * header-prefix and caller-override policy on every upstream request whose
    * URL matches an `authorizedUris` pattern of the matching auth.
    *
    * Sensitive (`value` carries the live OAuth access_token / API key);

--- a/runtime-pi/sidecar/api-call-credentials.ts
+++ b/runtime-pi/sidecar/api-call-credentials.ts
@@ -8,10 +8,9 @@
  * core fetches a {@link ProxyCredentialsPayload} per call; here we
  * synthesise one from the integration's resolved `delivery.http` plan:
  *
- *   - the injected header (name/prefix/value) maps to
- *     `credentialHeaderName` / `credentialHeaderPrefix` + a synthetic
- *     credential field holding the rendered token, which
- *     `buildInjectedCredentialHeader` reads via `credentialFieldName`;
+ *   - the injected header plan (name/prefix/value/override policy) maps to
+ *     the proxy payload + a synthetic credential field holding the rendered
+ *     token, which the shared injector reads via `credentialFieldName`;
  *   - the auth's decrypted `fields` are exposed under `credentials` so an
  *     agent can still `{{var}}`-substitute them into the URL / headers /
  *     body;

--- a/runtime-pi/sidecar/credential-proxy.ts
+++ b/runtime-pi/sidecar/credential-proxy.ts
@@ -462,13 +462,15 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
      * logging the secret itself.
      */
     requestHeaderNames: string[];
+    /** Whether this attempt used the platform credential or an allowed caller override. */
+    credentialInjection: "inject" | "caller_override" | "none";
   }> => {
     const resolvedHeaders: Record<string, string> = {};
     for (const [key, value] of Object.entries(callerHeaders)) {
       resolvedHeaders[key] = substituteVars(value, activeCreds.credentials);
     }
     // Server-side credential injection (Authorization, X-Api-Key, …).
-    applyInjectedCredentialHeader(resolvedHeaders, activeCreds);
+    const credentialInjection = applyInjectedCredentialHeader(resolvedHeaders, activeCreds);
     // Re-inject sticky cookies for the integration.
     const storedCookies = cookieJar.get(integrationId);
     if (storedCookies && storedCookies.length) {
@@ -526,6 +528,7 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
         finalUrl: response.url || resolvedUrl,
         hops: 0,
         requestHeaderNames: Object.keys(resolvedHeaders),
+        credentialInjection: credentialInjection.kind,
       };
     }
     const followed = await fetchFollowingRedirectsCapturingCookies({
@@ -534,7 +537,12 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
       fetchFn,
       cookieJar,
       integrationId,
-      injectedCredentialHeader: activeCreds.credentialHeaderName?.toLowerCase() ?? null,
+      injectedCredentialHeader:
+        credentialInjection.kind === "inject"
+          ? credentialInjection.header.name.toLowerCase()
+          : credentialInjection.kind === "caller_override"
+            ? credentialInjection.headerName.toLowerCase()
+            : null,
       authorizedUris: creds.authorizedUris ?? undefined,
       allowAllUris: creds.allowAllUris,
       // Thread the injected DNS resolver into the per-hop SSRF rebind
@@ -546,7 +554,11 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
       // Preserve the sidecar's structured per-hop refusal logging.
       logger,
     });
-    return { ...followed, requestHeaderNames: Object.keys(resolvedHeaders) };
+    return {
+      ...followed,
+      requestHeaderNames: Object.keys(resolvedHeaders),
+      credentialInjection: credentialInjection.kind,
+    };
   };
 
   // 7. First outbound request. Network/timeout errors surface as a
@@ -556,12 +568,14 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
   let upstreamFinalUrl: string = resolvedUrl;
   let upstreamHops = 0;
   let requestHeaderNames: string[] = [];
+  let credentialInjection: "inject" | "caller_override" | "none" = "none";
   try {
     const r = await doUpstreamRequest(creds);
     upstream = r.response;
     upstreamFinalUrl = r.finalUrl;
     upstreamHops = r.hops;
     requestHeaderNames = r.requestHeaderNames;
+    credentialInjection = r.credentialInjection;
   } catch (err) {
     return wrapRequestError(err, resolvedUrl);
   }
@@ -579,6 +593,7 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
     refreshCredentials &&
     config.platformApiUrl &&
     config.runToken &&
+    credentialInjection === "inject" &&
     !reportedAuthFailures.has(integrationId)
   ) {
     const fresh = await refreshCredentials(integrationId).catch(() => null);
@@ -590,6 +605,7 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
           upstreamFinalUrl = r.finalUrl;
           upstreamHops = r.hops;
           requestHeaderNames = r.requestHeaderNames;
+          credentialInjection = r.credentialInjection;
         } catch (err) {
           return wrapRequestError(err, resolvedUrl);
         }
@@ -610,7 +626,11 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
   //    set platform-side by the `/refresh` call above (which returns null on a
   //    terminal credential); here we only gate the one-refresh-attempt-per-run
   //    behaviour and surface a log line.
-  if (upstream.status === 401 && !reportedAuthFailures.has(integrationId)) {
+  if (
+    upstream.status === 401 &&
+    credentialInjection === "inject" &&
+    !reportedAuthFailures.has(integrationId)
+  ) {
     reportedAuthFailures.add(integrationId);
     logger.warn("Upstream returned 401 after refresh attempt", { integrationId });
   }
@@ -631,8 +651,9 @@ export async function executeApiCall(args: ApiCallArgs, deps: ApiCallDeps): Prom
     redirected: upstreamFinalUrl !== resolvedUrl,
     // How the credential was applied: a server-injected header (named, never
     // valued) or no injection at all (URL/query-embedded or anonymous).
-    authMode: creds.credentialHeaderName ? "header" : "none",
-    injectedHeader: creds.credentialHeaderName?.toLowerCase() ?? null,
+    authMode: credentialInjection === "inject" ? "header" : credentialInjection,
+    injectedHeader:
+      credentialInjection === "inject" ? (creds.credentialHeaderName?.toLowerCase() ?? null) : null,
     // Which URL-trust policy gated the call.
     urlPolicy: creds.allowAllUris
       ? "allow_all"

--- a/runtime-pi/sidecar/integrations-boot.ts
+++ b/runtime-pi/sidecar/integrations-boot.ts
@@ -49,6 +49,7 @@ import {
   type AppstrateToolDefinition,
 } from "@appstrate/mcp-transport";
 import { planCaBundle, type CaBundle } from "@appstrate/connect/proxy-ca-planner";
+import { planHttpDeliveryInjection } from "@appstrate/afps-runtime/resolvers";
 import type { IntegrationSpawnSpec } from "@appstrate/core/sidecar-types";
 
 import type { CredentialBundle } from "@appstrate/connect/connect";
@@ -316,10 +317,13 @@ export async function extractBundle(bytes: Uint8Array, namespace: string): Promi
  * Per-request flow:
  *   1. Read `source.snapshot().deliveryPlans[authKey]` — fresh after any
  *      refresh because the source replaces the whole payload in place.
- *   2. Inject `{ headerName: `${headerPrefix}${value}` }` on the outbound.
- *   3. On 401, call `refreshOnUnauthorized(authKey)` (no-op for static
- *      credentials — the source's per-authKey cooldown protects the
- *      platform endpoint from refresh storms) and retry once.
+ *   2. Apply the shared delivery decision: inject the platform credential by
+ *      default, or preserve a same-name caller header only when the manifest
+ *      explicitly allows it.
+ *   3. On 401 from a request that used the platform credential, call
+ *      `refreshOnUnauthorized(authKey)` (no-op for static credentials — the
+ *      source's per-authKey cooldown protects the platform endpoint from
+ *      refresh storms) and retry once. Caller-override 401s pass through.
  *
  * Auth selection: in practice the credentials payload carries EXACTLY ONE
  * auth — the platform's 5-layer connection cascade resolves a single
@@ -371,7 +375,7 @@ export interface ConnectRemoteHttpDeps {
 
 /**
  * Default SSE client builder — wires `SSEClientTransport` from the MCP SDK
- * with our `customFetch` (per-request Bearer + 401-retry). The SDK's SSE
+ * with our `customFetch` (per-request credential + 401-retry). The SDK's SSE
  * transport accepts a `fetch` override under `eventSourceInit` for the
  * stream and `requestInit` for outbound POSTs; we route both through the
  * same custom fetch so credential headers are injected on every hop.
@@ -464,14 +468,13 @@ export async function connectRemoteHttpIntegration(
   }
   const authKey = pickedAuth.authKey;
 
-  // Per-request header reader. Reading from the snapshot on every call
+  // Per-request injection planner. Reading from the snapshot on every call
   // means an OAuth refresh (which swaps `payload` in place) is picked up
   // automatically — no MCP transport restart needed. Static creds
   // (api_key) just return the same value forever.
-  const readHeader = (): { name: string; value: string } | null => {
+  const planInjection = (callerHeaderNames: readonly string[]) => {
     const plan = source.snapshot().deliveryPlans[authKey];
-    if (!plan) return null;
-    return { name: plan.headerName, value: `${plan.headerPrefix}${plan.value}` };
+    return plan ? planHttpDeliveryInjection(plan, callerHeaderNames) : { kind: "none" as const };
   };
 
   // SSRF-guard the egress — ALWAYS (P0-2): `guardedFetch` does per-hop DNS
@@ -494,10 +497,18 @@ export async function connectRemoteHttpIntegration(
   // away — the override stays a faithful drop-in for `fetch`.
   const customFetch: typeof fetch = Object.assign(
     async (input: Parameters<typeof fetch>[0], init: Parameters<typeof fetch>[1]) => {
-      const send = async (): Promise<Response> => {
+      const send = async (): Promise<{ response: Response; credentialInjected: boolean }> => {
         const headers = new Headers(init?.headers);
-        const h = readHeader();
-        if (h) headers.set(h.name, h.value);
+        const injection = planInjection([...headers.keys()]);
+        if (injection.kind === "inject") {
+          headers.set(injection.header.name, injection.header.value);
+        }
+        const sensitiveHeaderName =
+          injection.kind === "inject"
+            ? injection.header.name
+            : injection.kind === "caller_override"
+              ? injection.headerName
+              : null;
         // `guardedFetch` accepts `string | URL`; the MCP transports always
         // call with a URL/string target (headers/body ride in `init`), so a
         // stray `Request` is normalised to its URL for the type.
@@ -508,7 +519,7 @@ export async function connectRemoteHttpIntegration(
         // MCP server the platform-side spawn validation just allowed (internal
         // host explicitly allowlisted by the operator) would be re-blocked here
         // and fail opaquely in-run. Redirect discipline still applies.
-        return guardedFetch(
+        const response = await guardedFetch(
           target,
           { ...init, headers },
           {
@@ -518,17 +529,22 @@ export async function connectRemoteHttpIntegration(
             // builtin authorization/cookie strip set cannot know about it —
             // declare it, or a hostile server 302ing cross-origin would carry
             // the credential to another origin.
-            ...(h ? { sensitiveHeaders: [h.name] } : {}),
+            ...(sensitiveHeaderName ? { sensitiveHeaders: [sensitiveHeaderName] } : {}),
             ...(deps.resolveHost ? { resolve: deps.resolveHost } : {}),
           },
         );
+        return { response, credentialInjected: injection.kind === "inject" };
       };
-      let res = await send();
-      if (res.status === 401 && source.refreshOnUnauthorized) {
+      let attempt = await send();
+      if (
+        attempt.response.status === 401 &&
+        attempt.credentialInjected &&
+        source.refreshOnUnauthorized
+      ) {
         const refreshed = await source.refreshOnUnauthorized(authKey).catch(() => false);
-        if (refreshed) res = await send();
+        if (refreshed) attempt = await send();
       }
-      return res;
+      return attempt.response;
     },
     { preconnect: fetch.preconnect },
   );
@@ -538,7 +554,7 @@ export async function connectRemoteHttpIntegration(
     version: "0.1.0",
   };
   // AFPS §7.1 — dispatch on the manifest's declared transport. Both
-  // branches share the same per-request Bearer + 401-retry closure
+  // branches share the same per-request credential + 401-retry closure
   // (`customFetch` above), so credential injection + refresh semantics
   // are identical across Streamable HTTP and SSE.
   const toolTimeoutMs = toolTimeoutMsFromEnv();

--- a/runtime-pi/sidecar/test/api-call-credentials.test.ts
+++ b/runtime-pi/sidecar/test/api-call-credentials.test.ts
@@ -54,6 +54,7 @@ describe("createApiCallCredentialAdapter", () => {
     const creds = await adapter.fetchCredentials("@scope/integ");
     expect(creds.credentialHeaderName).toBe("Authorization");
     expect(creds.credentialHeaderPrefix).toBe("Bearer ");
+    expect(creds.credentialAllowServerOverride).toBe(false);
     expect(creds.credentialFieldName).toBe(PROXY_INJECTED_FIELD);
     expect(creds.credentials[PROXY_INJECTED_FIELD]).toBe("AT");
     // The raw auth fields stay available for {{var}} substitution.

--- a/runtime-pi/sidecar/test/credential-proxy.test.ts
+++ b/runtime-pi/sidecar/test/credential-proxy.test.ts
@@ -614,6 +614,42 @@ describe("executeApiCall — multi-hop redirect cookie capture (#473)", () => {
     expect(authHeadersSeen[1]!.apiKey).toBeNull();
   });
 
+  it("strips an allowed caller override when the platform credential is empty", async () => {
+    const apiKeysSeen: (string | null)[] = [];
+    const fetchFn = mock(async (url: string | URL, init?: RequestInit) => {
+      const resolvedUrl = typeof url === "string" ? url : url.toString();
+      apiKeysSeen.push(new Headers(init?.headers).get("x-api-key"));
+      if (resolvedUrl.startsWith("https://api.example.com")) {
+        return new Response(null, {
+          status: 302,
+          headers: { location: "https://evil.attacker.com/steal" },
+        });
+      }
+      return new Response("ok", { status: 200 });
+    });
+    const fetchCredentials = mock(async (): Promise<CredentialsResponse> => ({
+      credentials: { access_token: "" },
+      authorizedUris: ["https://api.example.com/**"],
+      allowAllUris: true,
+      credentialHeaderName: "X-Api-Key",
+      credentialAllowServerOverride: true,
+      credentialFieldName: "access_token",
+    }));
+
+    await executeApiCall(
+      {
+        integrationId: "demo",
+        targetUrl: "https://api.example.com/start",
+        method: "GET",
+        callerHeaders: { "x-api-key": "caller-secret" },
+        body: { kind: "none" },
+      },
+      makeDeps({ fetchFn: fetchFn as unknown as typeof fetch, fetchCredentials }),
+    );
+
+    expect(apiKeysSeen).toEqual(["caller-secret", null]);
+  });
+
   it("streaming bodies still use native fetch and only capture final-hop cookies", async () => {
     const fetchFn = mock(
       async (_url: string | URL, _init?: RequestInit) =>

--- a/runtime-pi/sidecar/test/credential-proxy.test.ts
+++ b/runtime-pi/sidecar/test/credential-proxy.test.ts
@@ -209,6 +209,47 @@ describe("executeApiCall — auth-scheme template repair (#988)", () => {
 });
 
 describe("executeApiCall — 401 retry path", () => {
+  it("does not refresh or flag a 401 produced by an allowed caller override", async () => {
+    const fetchFn = mock(
+      async (_input: Parameters<typeof fetch>[0], _init?: RequestInit) =>
+        new Response("caller rejected", { status: 401 }),
+    );
+    const refreshCredentials = mock(async () => null);
+    const deps = makeDeps({
+      fetchFn: fetchFn as unknown as typeof fetch,
+      refreshCredentials,
+      fetchCredentials: mock(async (): Promise<CredentialsResponse> => ({
+        credentials: { access_token: "platform" },
+        authorizedUris: ["https://api.example.com/**"],
+        allowAllUris: false,
+        credentialHeaderName: "Authorization",
+        credentialHeaderPrefix: "Bearer",
+        credentialAllowServerOverride: true,
+        credentialFieldName: "access_token",
+      })),
+    });
+
+    const result = await executeApiCall(
+      {
+        integrationId: "gmail",
+        targetUrl: "https://api.example.com/x",
+        method: "GET",
+        callerHeaders: { authorization: "Bearer caller" },
+        body: { kind: "none" },
+      },
+      deps,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.response.status).toBe(401);
+    const sent = fetchFn.mock.calls[0]![1]! as RequestInit & {
+      headers: Record<string, string>;
+    };
+    expect(sent.headers.authorization).toBe("Bearer caller");
+    expect(refreshCredentials).not.toHaveBeenCalled();
+    expect(deps.reportedAuthFailures.has("gmail")).toBe(false);
+  });
+
   it("refreshes credentials and replays the buffered request once", async () => {
     let callCount = 0;
     const fetchFn = mock(async () => {

--- a/runtime-pi/sidecar/test/integrations-boot-remote-http.test.ts
+++ b/runtime-pi/sidecar/test/integrations-boot-remote-http.test.ts
@@ -34,7 +34,15 @@ function spec(): IntegrationSpawnSpec {
 
 function wire(
   auths: Array<{ authKey: string; authType: string }>,
-  deliveryPlans: Record<string, { headerName: string; headerPrefix: string; value: string }>,
+  deliveryPlans: Record<
+    string,
+    {
+      headerName: string;
+      headerPrefix: string;
+      value: string;
+      allowServerOverride?: boolean;
+    }
+  >,
 ): IntegrationCredentialsWire {
   return {
     auths: auths.map((a) => ({
@@ -43,7 +51,10 @@ function wire(
       authorizedUris: [],
     })),
     deliveryPlans: Object.fromEntries(
-      Object.entries(deliveryPlans).map(([k, p]) => [k, { ...p, allowServerOverride: false }]),
+      Object.entries(deliveryPlans).map(([k, p]) => [
+        k,
+        { ...p, allowServerOverride: p.allowServerOverride === true },
+      ]),
     ),
     expiresAtEpochMs: {},
   } as unknown as IntegrationCredentialsWire;
@@ -103,7 +114,7 @@ describe("connectRemoteHttpIntegration — credential injection", () => {
       ],
       {
         apikey: { headerName: "X-Api-Key", headerPrefix: "", value: "K" },
-        oauth: { headerName: "Authorization", headerPrefix: "Bearer ", value: "TOKEN" },
+        oauth: { headerName: "Authorization", headerPrefix: "Bearer", value: "TOKEN" },
       },
     );
     const { deps, source, getFetch } = makeDeps(initial, async () => true);
@@ -124,6 +135,38 @@ describe("connectRemoteHttpIntegration — credential injection", () => {
     // Cast: TS narrows a `let` assigned only inside a closure back to its
     // initializer type (`null`); the global fetch stub mutates it at runtime.
     expect(seen as string | null).toBe("Bearer TOKEN");
+  });
+
+  it("preserves an allowed caller override and does not refresh it on 401", async () => {
+    const initial = wire([{ authKey: "oauth", authType: "oauth2" }], {
+      oauth: {
+        headerName: "Authorization",
+        headerPrefix: "Bearer",
+        value: "PLATFORM",
+        allowServerOverride: true,
+      },
+    });
+    const { deps, source, getFetch, getRefreshCalls } = makeDeps(initial, async () => true);
+    await connectRemoteHttpIntegration(spec(), source, deps);
+
+    let seen: string | null = null;
+    const status = await withGlobalFetch(
+      (async (_input: unknown, init?: RequestInit) => {
+        seen = new Headers(init?.headers).get("Authorization");
+        return new Response("{}", { status: 401 });
+      }) as unknown as typeof fetch,
+      async () =>
+        (
+          await getFetch()(SERVER_URL, {
+            method: "POST",
+            headers: { authorization: "Bearer CALLER" },
+          })
+        ).status,
+    );
+
+    expect(seen as string | null).toBe("Bearer CALLER");
+    expect(status).toBe(401);
+    expect(getRefreshCalls()).toBe(0);
   });
 
   it("force-refreshes once and retries on a 401", async () => {


### PR DESCRIPTION
## Summary

- centralize HTTP credential-header rendering and override decisions across MITM, remote MCP, local api_call, sidecar proxy, and public credential proxy paths
- preserve literal composite prefixes, repair bare Authorization schemes without inspecting secret bytes, and enforce platform-header precedence unless allow_server_override is explicit
- attribute 401 refresh/reconnection only to requests that actually used the platform credential, while retaining redirect stripping for allowed caller overrides
- clarify in OpenAPI that hosted remote MCP endpoints are integration packages and MCP-server packages are local executables
- suppress false sidecar-crash diagnostics during both stop and direct remove teardown races

## Validation

- 175 focused resolver, proxy, remote MCP, MITM, and sidecar lifecycle tests
- 22 API credential-proxy injection, refresh, and streaming tests
- bun run check: 33/33 tasks passed
- OpenAPI validation passed with 0 breaking changes

## Out of scope

- Point 3 (chat-side secret guidance/guard) is intentionally excluded from this PR.
