### PR TITLE
fix(web): make declared-but-unusable dependencies visible and actionable

### DIFF
--- a/apps/web/src/components/agent-editor/resource-section.tsx
+++ b/apps/web/src/components/agent-editor/resource-section.tsx
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { type ChangeEvent, type ReactNode, useMemo, useRef } from "react";
+import { type ChangeEvent, type ReactNode, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { cn } from "@appstrate/ui/cn";
 import { SectionCard } from "../section-card";
+import { packageListPath } from "../../lib/package-paths";
 import {
   usePackageList,
   useUploadPackage,
@@ -20,8 +21,10 @@ import {
   SelectValue,
 } from "@appstrate/ui/components/select";
 import { Checkbox } from "@appstrate/ui/components/checkbox";
+import { Button } from "@appstrate/ui/components/button";
 import { ShieldCheck, AlertTriangle } from "lucide-react";
 import { Spinner } from "../spinner";
+import { useActivateIntegration } from "../../hooks/use-integrations";
 import type { ResourceEntry } from "./types";
 import { caretRange } from "./utils";
 import { IntegrationToolPicker } from "./integration-tool-picker";
@@ -109,18 +112,33 @@ export function ResourceSection({
     activeOnly: type === "integration",
   });
   const upload = useUploadPackage(type);
+  const activate = useActivateIntegration();
 
   const selectedMap = new Map(selectedEntries.map((e) => [e.id, e]));
 
-  // An agent may still declare an integration that's no longer active here
-  // (uninstalled/disabled since). Those won't come back in the active list, so
-  // surface them in a flagged section — never silently drop a declared
-  // dependency (the run-time gate would reject it with `integration_not_active`).
+  // A declared dependency the catalog does not return: an integration that is no
+  // longer active here (uninstalled/disabled since), or a skill that is simply
+  // not installed. Either way it must stay VISIBLE — it is in the manifest and
+  // the run-time gate will reject it (`integration_not_active` /
+  // `missing_skill`), so hiding it makes the editor claim the agent declares
+  // less than it does. This used to be integration-only, which is how a declared
+  // skill missing from the catalogue rendered as "no skill at all".
+  // Ids declared when the editor opened. Kept because the flagged rows below are
+  // derived from what is CURRENTLY selected: unchecking one removed it from that
+  // set, so the row vanished from the screen entirely and the only way back was
+  // to cancel the whole edit. Anchoring on the opening state keeps the row in
+  // place with its box unticked, which is what "I can undo this" looks like.
+  const [declaredOnOpen] = useState(() => selectedEntries);
+
   const inactiveDeclaredIds = useMemo(() => {
-    if (type !== "integration" || !items) return [];
+    if (!items) return [];
     const present = new Set(items.map((i) => i.id));
-    return selectedEntries.filter((e) => !present.has(e.id)).map((e) => e.id);
-  }, [items, type, selectedEntries]);
+    const declared = new Set([
+      ...declaredOnOpen.map((e) => e.id),
+      ...selectedEntries.map((e) => e.id),
+    ]);
+    return [...declared].filter((id) => !present.has(id));
+  }, [items, selectedEntries, declaredOnOpen]);
 
   const toggle = (id: string) => {
     onChange((prev) => {
@@ -128,8 +146,13 @@ export function ResourceSection({
         return prev.filter((e) => e.id !== id);
       }
       const item = items?.find((i) => i.id === id);
-      if (!item?.version) return prev;
-      return [...prev, { id, version: caretRange(item.version) }];
+      if (item?.version) return [...prev, { id, version: caretRange(item.version) }];
+      // Not in the catalogue, so there is no version to read: this is a
+      // declared-but-missing dependency being re-checked after an unintended
+      // uncheck. Restore the entry exactly as the manifest had it — without this
+      // the box could be emptied but never refilled.
+      const original = declaredOnOpen.find((e) => e.id === id);
+      return original ? [...prev, original] : prev;
     });
   };
 
@@ -186,7 +209,7 @@ export function ResourceSection({
         <>
           <p className="text-muted-foreground text-xs">{emptyLabel}</p>
           <p className="text-muted-foreground text-xs">
-            <Link to="/skills">{t("editor.goToPackages")}</Link>
+            <Link to={packageListPath(type)}>{t("editor.goToPackages")}</Link>
           </p>
         </>
       ) : (
@@ -249,23 +272,43 @@ export function ResourceSection({
             );
           })}
 
-          {/* Declared but no longer active in this app — flagged so the user
-              can drop them (or an admin can re-activate). Uncheck removes the
-              dependency from the manifest. */}
+          {/* Declared but not usable here: an integration that is not active in
+              this application, or a skill that is not installed. Flagged rather
+              than hidden, because the run gate rejects them.
+
+              For an integration the row also carries the cure. The message says
+              "activate it to connect it", and until now nothing on this screen
+              could: the checkbox only removes the dependency. So the one action
+              the sentence asks for had no button anywhere. */}
           {inactiveDeclaredIds.map((id) => (
-            <div key={id} className="border-destructive/40 bg-destructive/5 rounded-md border">
-              <label className="flex cursor-pointer items-center gap-2.5 px-3 py-2">
-                <Checkbox checked onCheckedChange={() => toggle(id)} />
+            <div
+              key={id}
+              className="border-destructive/40 bg-destructive/5 flex items-center gap-2 rounded-md border pr-2"
+            >
+              <label className="flex flex-1 cursor-pointer items-center gap-2.5 px-3 py-2">
+                <Checkbox checked={selectedMap.has(id)} onCheckedChange={() => toggle(id)} />
                 <div className="flex min-w-0 flex-1 flex-col">
                   <span className="flex items-center gap-1.5 truncate text-sm font-medium">
                     {id}
                     <span className="text-destructive inline-flex items-center gap-1 text-xs font-normal">
                       <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-                      {t("editor.integrationInactive")}
+                      {type === "integration"
+                        ? t("editor.integrationInactive")
+                        : t("editor.dependencyMissing")}
                     </span>
                   </span>
                 </div>
               </label>
+              {type === "integration" && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={activate.isPending}
+                  onClick={() => activate.mutate({ params: { path: { packageId: id } } })}
+                >
+                  {activate.isPending ? <Spinner /> : t("editor.activateIntegration")}
+                </Button>
+              )}
             </div>
           ))}
         </div>

--- a/apps/web/src/components/integration-connect/integration-connection-picker.tsx
+++ b/apps/web/src/components/integration-connect/integration-connection-picker.tsx
@@ -13,7 +13,7 @@ import {
   RefreshCw,
   Settings,
 } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Button } from "@appstrate/ui/components/button";
 import { Badge } from "@appstrate/ui/components/badge";
 import {
@@ -41,7 +41,7 @@ import { connectionDisplayLabel } from "./connection-label";
 import { connectableAuthKeys } from "./connectable-auth-keys";
 import { requiredScopesForAgent } from "@appstrate/core/integration";
 import { client } from "../../api/client";
-import { splitPackageRef } from "../../lib/package-paths";
+import { packageDetailPath, splitPackageRef } from "../../lib/package-paths";
 import { isVersioned } from "../../lib/version-selector";
 
 /**
@@ -326,7 +326,18 @@ export function IntegrationConnectionPicker({
           className="text-muted-foreground text-xs"
           data-testid={`member-pick-no-client-${integrationId}`}
         >
-          {t("settings:integration.auth.noClientHint")}
+          {t("settings:integration.auth.noClientHint")}{" "}
+          {/* The sentence names a screen; without the link the reader has to go
+              find it. Points at the integration's Configuration tab, where the
+              OAuth clients table lives. Shown to everyone, admin or not: a
+              non-admin lands on a page that tells them so, which beats a dead
+              sentence, and the tab itself is admin-gated anyway. */}
+          <Link
+            to={`${packageDetailPath("integration", integrationId)}#configuration`}
+            className="underline underline-offset-2"
+          >
+            {t("settings:integration.auth.noClientLink")}
+          </Link>
         </span>
       </div>
     );

--- a/apps/web/src/components/package-detail/agent-integrations-block.tsx
+++ b/apps/web/src/components/package-detail/agent-integrations-block.tsx
@@ -2,7 +2,9 @@
 
 import { useTranslation } from "react-i18next";
 import { Loader2, Puzzle } from "lucide-react";
+import { Button } from "@appstrate/ui/components/button";
 import {
+  useActivateIntegration,
   useIntegrations,
   useIntegrationDetail,
   useIntegrationAgentResolution,
@@ -90,6 +92,7 @@ function IntegrationConnectionCard({
 }: IntegrationConnectionCardProps) {
   const { t } = useTranslation(["agents"]);
   const { data: detail, isPending: detailPending } = useIntegrationDetail(packageId);
+  const activate = useActivateIntegration();
   const displayName = detail?.manifest.display_name ?? packageId;
 
   if (detailPending || !detail) {
@@ -108,11 +111,29 @@ function IntegrationConnectionCard({
   if (!appActive) {
     return (
       <CardShell title={displayName} subtitle={packageId}>
-        <span
-          className="text-destructive max-w-[18rem] text-right text-xs"
-          data-testid={`integration-inactive-${packageId}`}
-        >
-          {t("detail.integrationInactive")}
+        <span className="flex items-center gap-3">
+          <span
+            className="text-destructive max-w-[18rem] text-right text-xs"
+            data-testid={`integration-inactive-${packageId}`}
+          >
+            {t("detail.integrationInactive")}
+          </span>
+          {/* The sentence asks for an activation; without this the reader had to
+              go find the integration page to perform it. A non-admin gets the
+              API's refusal as a toast, which still beats a dead sentence. */}
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={activate.isPending}
+            onClick={() => activate.mutate({ params: { path: { packageId } } })}
+            data-testid={`integration-activate-${packageId}`}
+          >
+            {activate.isPending ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              t("editor.activateIntegration")
+            )}
+          </Button>
         </span>
       </CardShell>
     );

--- a/apps/web/src/hooks/use-integrations.ts
+++ b/apps/web/src/hooks/use-integrations.ts
@@ -90,12 +90,17 @@ export function invalidateIntegrationQueries(qc: QueryClient): Promise<void> {
   return qc.invalidateQueries({
     predicate: (query) => {
       const path = query.queryKey[1];
+      if (typeof path !== "string") return false;
+      // The integration package list is keyed `["packages","integrations",…]`
+      // and its `?active=true` variant is exactly what activation changes — so a
+      // row that just got activated has to stop being served from cache. Without
+      // this, activating left every "not active here" list still saying so.
+      if (query.queryKey[0] === "packages" && path === "integrations") return true;
       return (
-        typeof path === "string" &&
+        path.startsWith("/api/integrations") ||
         // The per-agent connection-readiness query lives under /api/agents but
         // is driven entirely by connection state, so refresh it here too.
-        (path.startsWith("/api/integrations") ||
-          path === "/api/agents/{scope}/{name}/connection-readiness")
+        path === "/api/agents/{scope}/{name}/connection-readiness"
       );
     },
   });

--- a/apps/web/src/locales/en/agents.json
+++ b/apps/web/src/locales/en/agents.json
@@ -236,6 +236,8 @@
   "editor.skillsEmpty": "No skills in packages. Add some from the Packages page.",
   "editor.integrationsEmpty": "No integrations imported. Visit the Integrations marketplace to import one.",
   "editor.integrationInactive": "Not active in this application",
+  "editor.activateIntegration": "Activate",
+  "editor.dependencyMissing": "Not installed in this organization",
   "editor.tabGeneral": "General",
   "editor.tabSchema": "Schemas",
   "editor.tabSkills": "Skills",

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -760,6 +760,7 @@
   "integration.auth.expiresAt": "Expires {{date}}",
   "integration.auth.needsReconnection": "Reconnection needed",
   "integration.auth.noClientHint": "No OAuth client configured — an administrator must register one before an account can be connected.",
+  "integration.auth.noClientLink": "Configure the OAuth client",
   "integration.auth.noClientHintAdmin": "Connections are locked until the OAuth client above is registered.",
   "integration.auth.type.oauth2": "OAuth",
   "integration.auth.type.api_key": "API key",

--- a/apps/web/src/locales/fr/agents.json
+++ b/apps/web/src/locales/fr/agents.json
@@ -236,6 +236,8 @@
   "editor.skillsEmpty": "Aucun skill dans les packages. Ajoutez-en depuis la page Packages.",
   "editor.integrationsEmpty": "Aucune intégration importée. Visitez le marketplace Intégrations pour en importer une.",
   "editor.integrationInactive": "Non active dans cette application",
+  "editor.activateIntegration": "Activer",
+  "editor.dependencyMissing": "Non installé dans cette organisation",
   "editor.tabGeneral": "Général",
   "editor.tabSchema": "Schémas",
   "editor.tabSkills": "Skills",

--- a/apps/web/src/locales/fr/settings.json
+++ b/apps/web/src/locales/fr/settings.json
@@ -760,6 +760,7 @@
   "integration.auth.expiresAt": "Expire le {{date}}",
   "integration.auth.needsReconnection": "Reconnexion requise",
   "integration.auth.noClientHint": "Aucun client OAuth configuré — un administrateur doit l'enregistrer avant de pouvoir connecter un compte.",
+  "integration.auth.noClientLink": "Configurer le client OAuth",
   "integration.auth.noClientHintAdmin": "Connexions verrouillées tant que le client OAuth ci-dessus n'est pas enregistré.",
   "integration.auth.type.oauth2": "OAuth",
   "integration.auth.type.api_key": "Clé API",

--- a/apps/web/src/pages/integration-detail.tsx
+++ b/apps/web/src/pages/integration-detail.tsx
@@ -32,6 +32,10 @@
  */
 
 import { useState } from "react";
+import { useTabWithHash } from "../hooks/use-tab-with-hash";
+
+/** Tab ids, also the URL fragments that select them. */
+const INTEGRATION_TABS = ["connections", "configuration", "tools", "about", "versions"] as const;
 import { useTranslation } from "react-i18next";
 import { useParams } from "react-router-dom";
 import { toast } from "sonner";
@@ -1400,7 +1404,10 @@ export function IntegrationDetailPage() {
   const deletePkg = useDeletePackage("integration");
   const downloadPackage = usePackageDownload(scope, name);
   const { isAdmin } = usePermissions();
-  const [tab, setTab] = useState("connections");
+  // Hash-driven like the agent page, so the tab can be LINKED to. Needed
+  // because "an administrator must register an OAuth client" is only useful if
+  // it can point at the screen where that happens.
+  const [tab, setTab] = useTabWithHash(INTEGRATION_TABS, "connections");
   const [forkOpen, setForkOpen] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [confirmDeactivate, setConfirmDeactivate] = useState(false);
@@ -1475,7 +1482,11 @@ export function IntegrationDetailPage() {
         }
       />
 
-      <Tabs value={tab} onValueChange={setTab} className="mt-2">
+      <Tabs
+        value={tab}
+        onValueChange={(v) => setTab(v as (typeof INTEGRATION_TABS)[number])}
+        className="mt-2"
+      >
         <TabsList>
           <TabsTrigger value="connections" data-testid="tab-connections">
             {t("integration.tabs.connections")}


### PR DESCRIPTION
Five defects in the agent editor and the integration screens, all of the same shape: **the UI names a problem and then offers no way to act on it — or hides the problem entirely.**

Found while building the agent map (#999) and split out of it, because they are independent of that feature and carry their own value. #999 is now stacked on top of this branch.

## The five

| # | Fix | Was |
|---|---|---|
| 1 | `ResourceSection` empty state → `packageListPath(type)` | Linked to `/skills` hardcoded, whatever the resource type — an empty integrations list sent the reader to the skills page |
| 2 | Declared-but-missing dependency stays visible for every type | `inactiveDeclaredIds` was integration-only, so a skill in the manifest but not installed rendered as **"no skill at all"** — the editor claimed the agent declared less than it did, while the run gate would reject it with `missing_skill` |
| 3 | Flagged rows carry an **Activate** button (editor + agent detail card) | The message said "activate it to connect it" and nothing on screen could: the checkbox only removes the dependency |
| 4 | Activating invalidates `["packages","integrations"]` | Every "not active in this application" list kept saying so until a reload — including the one the user had just acted on |
| 5 | Integration page tabs → `useTabWithHash`, and the hint links | "An administrator must register an OAuth client" named a screen without linking to it, because the tab was local state and had no URL |

## Plus one regression in the same code path

Unchecking a flagged dependency used to make its row **disappear**: the list was derived from what is currently selected, so unticking removed it from that set and the only way back was to cancel the whole edit.

The list is now anchored on what was declared when the editor opened, so the box can be unticked and reticked before saving. Re-checking restores the manifest entry verbatim — there is no catalogue version to read for a dependency that is missing from the catalogue, which is why the naive `items.find(...).version` path could empty the box but never refill it.

## On the Activate button and permissions

Shown to everyone, not just admins. A non-admin gets the API's refusal as a toast, which is a worse outcome than nothing only if you think a dead sentence is better than a clear "no". The OAuth-client link is the same call: it points at a tab that is itself admin-gated, so a non-admin lands on a page that tells them so.

Known cosmetic limit: `activate.isPending` is per-hook, not per-row, so with several inactive integrations every Activate button disables and spins together. Not worth a per-row mutation state at this size.

## Verification

- `bun run check`: 33/33
- `bun test apps/web/src`: 334 pass / 0 fail (incl. the locale-key guard both directions)
- Typechecks standalone against `main` — nothing here depends on the agent map

🤖 Generated with [Claude Code](https://claude.com/claude-code)
