### PR TITLE
fix(runtime): add end-to-end model canaries

### DIFF
--- a/.github/workflows/model-runtime-canary.yml
+++ b/.github/workflows/model-runtime-canary.yml
@@ -1,0 +1,90 @@
+name: Model runtime canary
+
+on:
+  schedule:
+    # Nightly, outside the weekly catalog refresh window. Every model listed in
+    # the canary config gets a fresh provider call through Pi + the real sidecar.
+    - cron: "30 4 * * *"
+  workflow_dispatch: {}
+  # Deployment systems may dispatch this event after promotion. It deliberately
+  # runs the same all-model probe as the nightly monitor rather than trusting a
+  # liveness endpoint or a cached result.
+  repository_dispatch:
+    types: [model-runtime-deployed]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: model-runtime-canary
+  cancel-in-progress: false
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Harness-only values required while importing the production registry.
+      # No platform data is read; live provider keys remain in the secret below.
+      BETTER_AUTH_SECRET: model-canary-unused-better-auth-secret
+      UPLOAD_SIGNING_SECRET: model-canary-unused-upload-secret
+      CONNECT_SESSION_SECRET: model-canary-unused-connect-secret
+      RUN_TOKEN_SECRET: model-canary-unused-run-token-secret
+      CONNECTION_ENCRYPTION_KEY: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Bun
+        uses: ./.github/actions/bun-setup
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Probe every configured model
+        id: probe
+        env:
+          # Same schema as SYSTEM_PROVIDER_KEYS. Use dedicated low-quota keys;
+          # enumerate system aliases plus any featured models that must remain
+          # deployable. Never expose this secret to pull_request workflows.
+          MODEL_RUNTIME_CANARY_CONFIG: ${{ secrets.MODEL_RUNTIME_CANARY_CONFIG }}
+        run: |
+          set +e
+          {
+            echo "## Model runtime canary"
+            echo
+            echo "Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            echo
+          } > model-runtime-canary-report.md
+          bun run canary:models 2>&1 | tee -a model-runtime-canary-report.md
+          code=${PIPESTATUS[0]}
+          echo "code=${code}" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload canary report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: model-runtime-canary-report
+          path: model-runtime-canary-report.md
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Open or update tracking issue
+        if: steps.probe.outputs.code != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create model-runtime-canary \
+            --color B60205 \
+            --description "Live Pi + sidecar model conformance" 2>/dev/null || true
+          title="Model runtime canary failed"
+          existing=$(gh issue list --state open --label model-runtime-canary --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body-file model-runtime-canary-report.md
+          else
+            gh issue create --title "$title" --label model-runtime-canary --body-file model-runtime-canary-report.md
+          fi
+          exit 1

--- a/.github/workflows/refresh-pricing-catalog.yml
+++ b/.github/workflows/refresh-pricing-catalog.yml
@@ -27,6 +27,15 @@ jobs:
     # the same gate on the PR this job opens.
     env:
       HUSKY: "0"
+      # The canary reuses the production model registry, whose logger validates
+      # the complete app env at import time. These values are harness-only and
+      # never leave the Actions runner; provider credentials come exclusively
+      # from MODEL_RUNTIME_CANARY_CONFIG below.
+      BETTER_AUTH_SECRET: model-canary-unused-better-auth-secret
+      UPLOAD_SIGNING_SECRET: model-canary-unused-upload-secret
+      CONNECT_SESSION_SECRET: model-canary-unused-connect-secret
+      RUN_TOKEN_SECRET: model-canary-unused-run-token-secret
+      CONNECTION_ENCRYPTION_KEY: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
 
     steps:
       - name: Checkout repository
@@ -66,11 +75,15 @@ jobs:
 
           if [ "$pricing" = false ] && [ "$watch" = false ]; then
             echo "drift=false" >> "$GITHUB_OUTPUT"
+            echo "pricing=false" >> "$GITHUB_OUTPUT"
+            echo "watch=false" >> "$GITHUB_OUTPUT"
             echo "No upstream changes — nothing to commit."
             exit 0
           fi
 
           echo "drift=true" >> "$GITHUB_OUTPUT"
+          echo "pricing=$pricing" >> "$GITHUB_OUTPUT"
+          echo "watch=$watch" >> "$GITHUB_OUTPUT"
           git diff --stat apps/api/src/data
 
           # The PR body is assembled here rather than inlined on the PR step so
@@ -138,6 +151,17 @@ jobs:
 
           echo "body-path=$body" >> "$GITHUB_OUTPUT"
           cat "$body"
+
+      # Trusted workflow only: the bot-generated catalog is uncommitted data on
+      # top of main, never contributor code. Probe every configured runtime
+      # model whose wire-affecting metadata changed before a PR can be opened.
+      # The secret uses the SYSTEM_PROVIDER_KEYS JSON shape with dedicated,
+      # low-quota credentials. Missing configuration fails closed.
+      - name: Probe changed models through Pi + sidecar
+        if: steps.drift.outputs.pricing == 'true'
+        env:
+          MODEL_RUNTIME_CANARY_CONFIG: ${{ secrets.MODEL_RUNTIME_CANARY_CONFIG }}
+        run: bun run canary:models:changed
 
       - name: Open PR
         if: steps.drift.outputs.drift == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,8 @@ jobs:
             packages/runner-pi/ \
             packages/emails/ \
             packages/env/ \
-            packages/ui/
+            packages/ui/ \
+            scripts/test/model-runtime-canary.test.ts
 
       - name: Run public-origin regression
         run: |

--- a/apps/api/src/services/model-providers/model-discovery.ts
+++ b/apps/api/src/services/model-providers/model-discovery.ts
@@ -19,11 +19,11 @@
  *     Discovery is then a truthful no-op: it reports the current list.
  *
  *   - probe (default, when `modelDiscovery` is omitted — API-key providers) —
- *     empirical: a 1-token inference request per candidate, persisting the ids
- *     that answered 2xx. Candidates come from `modelDiscoveryCandidates`
- *     (falling back to `featuredModels`); the platform stays provider-agnostic
- *     and just sends whatever `testModelConfig` builds (generic `/models` wire
- *     format).
+ *     a credential/model-list request per candidate, persisting the candidate
+ *     ids when the provider's `/models`-style endpoint answers 2xx. Candidates
+ *     come from `modelDiscoveryCandidates` (falling back to `featuredModels`).
+ *     This is availability discovery, NOT inference conformance: the separate
+ *     runtime model canary exercises Pi + sidecar + the actual model request.
  *
  * The classification below applies only to the probe path:
  *

--- a/apps/api/src/services/run-launcher/pi.ts
+++ b/apps/api/src/services/run-launcher/pi.ts
@@ -310,6 +310,11 @@ async function runPlatformContainerImpl(
     const containerEnv = buildRuntimePiEnv({
       model: {
         api: llmConfig.apiShape,
+        // Preserve upstream identity even though MODEL_BASE_URL points at the
+        // sidecar. Pi's OpenAI-compatible adapter uses provider/baseUrl to
+        // select protocol quirks (DeepSeek rejects the OpenAI `developer`
+        // role); without this, every proxied provider looks like OpenAI.
+        provider: llmConfig.providerId,
         modelId,
         baseUrl: llmConfig.baseUrl,
         apiKey: llmApiKey,

--- a/apps/api/test/integration/services/run-launcher-no-sidecar.test.ts
+++ b/apps/api/test/integration/services/run-launcher-no-sidecar.test.ts
@@ -234,6 +234,7 @@ describe("run-launcher — sidecar skip decision", () => {
     // the real endpoint never enter the agent env.
     const env = counts.capturedAgentEnv ?? {};
     expect(env.MODEL_ID).toBe("appstrate-medium");
+    expect(env.MODEL_PROVIDER).toBe("deepseek");
     expect(env.MODEL_BASE_URL).toBe("http://fake-sidecar.test:19080/llm");
     expect(JSON.stringify(env)).not.toContain("deepseek-chat");
     expect(JSON.stringify(env)).not.toContain("api.deepseek.com");

--- a/docs/guides/MODEL_RUNTIME_CANARY.md
+++ b/docs/guides/MODEL_RUNTIME_CANARY.md
@@ -1,0 +1,87 @@
+# Model runtime canary
+
+The model runtime canary validates inference, not just credentials or a model
+listing endpoint. Every probe follows the same critical path as an agent run:
+
+```text
+effective SYSTEM_PROVIDER_KEYS model
+  → runtime-pi model construction
+  → Pi SDK request adapter
+  → Hono sidecar (/llm)
+  → pinned upstream provider/model
+```
+
+The provider is the only external boundary. Fallbacks are disabled, Pi retries
+are disabled, and only transient `408`, `429`, or `5xx` results are retried once
+by the canary coordinator. A backup model can therefore never turn a broken
+target into a green result.
+
+## Token budget
+
+- Standard models: at most 4 output tokens.
+- Reasoning models: at most 16 output tokens, because hidden reasoning can
+  consume the entire completion budget before any text appears.
+
+Success means that the target accepts the request and returns a valid Pi stream.
+The canary does not assert exact generated text.
+
+## Configuration
+
+Set the GitHub Actions secret `MODEL_RUNTIME_CANARY_CONFIG` to a JSON array using
+the `SYSTEM_PROVIDER_KEYS` schema. Use dedicated low-quota keys rather than
+production credentials. List every system alias and every featured model that
+must stay deployable.
+
+```json
+[
+  {
+    "id": "canary-deepseek",
+    "providerId": "deepseek",
+    "apiKey": "dedicated-canary-key",
+    "models": [
+      {
+        "id": "appstrate-flash",
+        "modelId": "deepseek-v4-flash",
+        "label": "Appstrate Flash",
+        "aliased": true
+      }
+    ]
+  }
+]
+```
+
+The secret is intentionally required and never exposed to `pull_request`
+workflows. A missing secret makes trusted live gates fail closed.
+
+## Gates
+
+1. Every PR runs the hermetic Pi → sidecar → fake-provider regression suite.
+2. The weekly catalog refresh probes configured models whose capabilities,
+   context window, or maximum output changed before opening its PR. Price-only
+   changes do not trigger inference.
+3. `Model runtime canary` probes every configured model nightly.
+4. A deployment system can dispatch the `model-runtime-deployed`
+   `repository_dispatch` event after promotion to run the same uncached
+   all-model probe.
+
+Run it locally or inside a trusted deployment environment:
+
+```sh
+MODEL_RUNTIME_CANARY_CONFIG='[...]' bun run canary:models
+MODEL_RUNTIME_CANARY_CONFIG='[...]' bun run canary:models:changed
+```
+
+The report contains provider/model ids, target status, latency, and observed
+token usage. It never prints API keys.
+
+## Scope
+
+The raw pricing catalog currently contains hundreds of entries. Live-probing
+all of them on every PR would require credentials for every provider, create
+rate-limit noise, and spend tokens on models the deployment does not serve.
+The exhaustive live set is therefore the explicit canary configuration; the PR
+suite remains exhaustive over deterministic protocol variants.
+
+BYOK credentials stay organization-owned. Their existing connection test is a
+credential/model-list check, not a runtime inference canary; operators can add a
+dedicated credential to the canary config when they need continuous coverage.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "test:e2e": "cd e2e && npx playwright test",
     "test:e2e:api": "cd e2e && npx playwright test --project=api",
     "test:e2e:ui": "cd e2e && npx playwright test --project=ui",
+    "canary:models": "bun scripts/model-runtime-canary.ts --all --require-targets",
+    "canary:models:changed": "bun scripts/model-runtime-canary.ts --changed --require-targets",
     "lint": "eslint . --cache --cache-strategy content",
     "lint:fix": "eslint . --fix && prettier --write \"apps/*/src/**\" \"packages/*/src/**\"",
     "format": "prettier --write \"apps/*/src/**\" \"packages/*/src/**\"",

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -836,10 +836,10 @@ export interface ModelProviderDefinition {
   /**
    * Candidate model ids for discovery — the source list for whichever
    * {@link modelDiscovery} strategy applies. For the default (probe) strategy
-   * the platform probes each one against the connected credential (1-token
-   * inference request) and persists the ids that respond 2xx; for the static
-   * strategy it serves these directly (∩ catalog), resolved on read and never
-   * persisted. Unlike
+   * the platform checks the provider's model-list/credential endpoint and
+   * persists the ids selected from candidates when it responds 2xx; for the
+   * static strategy it serves these directly (∩ catalog), resolved on read
+   * and never persisted. Unlike
    * {@link featuredModels}, ids here do NOT have to exist in the resolved
    * catalog. When omitted, the platform uses `featuredModels`. Irrelevant for
    * api_key providers whose full catalog is exposed.
@@ -852,9 +852,11 @@ export interface ModelProviderDefinition {
   modelDiscoveryCandidates?: ModelIdSelection;
 
   /**
-   * Model-discovery strategy. When omitted, discovery is **empirical** (probe):
-   * the platform issues a 1-token inference request per candidate and persists
-   * the ids that respond 2xx as the credential's `availableModelIds`.
+   * Model-discovery strategy. When omitted, discovery uses a live credential /
+   * model-list probe and persists the candidate ids when the provider answers
+   * 2xx as the credential's `availableModelIds`. This establishes credential
+   * availability, not per-model inference conformance; the runtime model canary
+   * covers the latter through Pi and the sidecar.
    *
    * `{ mode: "static" }` declares that the platform must issue ZERO API calls to
    * discover models: the served set is {@link modelDiscoveryCandidates}

--- a/packages/runner-pi/src/container-env.ts
+++ b/packages/runner-pi/src/container-env.ts
@@ -13,6 +13,12 @@
 export interface RuntimePiModelConfig {
   /** Pi SDK `api` slug — e.g. `"anthropic-messages"`, `"openai-completions"`. */
   api: string;
+  /**
+   * Upstream provider identity used by Pi's compatibility resolver. This must
+   * survive sidecar routing: once `baseUrl` points at `/llm`, URL-based
+   * detection can no longer distinguish DeepSeek, xAI, Cerebras, etc.
+   */
+  provider?: string;
   /** Model identifier passed to the SDK. */
   modelId: string;
   /** Upstream base URL (routed through the sidecar proxy when `apiKey` is set). */
@@ -138,6 +144,8 @@ export function buildRuntimePiEnv(opts: RuntimePiEnvOptions): Record<string, str
     MODEL_API: model.api,
     MODEL_ID: model.modelId,
   };
+
+  if (model.provider) env.MODEL_PROVIDER = model.provider;
 
   if (!opts.noSidecar) {
     // No fallback: a Docker-shaped magic default here would silently

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -118,6 +118,10 @@ export interface PiRunnerOptions {
    * Providers that do not support this option ignore it. Defaults to `"auto"`.
    */
   transport?: Transport;
+  /** Disable the SDK retry loop for conformance probes that must expose the target response verbatim. */
+  disableModelRetry?: boolean;
+  /** Disable Pi's built-in filesystem/shell tools for a minimal connectivity probe. */
+  disableTools?: boolean;
   /**
    * Tool names whose first successful execution ends the run. When one of
    * these tools completes without error the runner aborts the Pi session
@@ -483,10 +487,11 @@ export class PiRunner implements Runner {
         // `MODEL_RETRY_ENABLED=false` on the runtime env when stacking
         // external retry middleware.
         retry:
-          process.env.MODEL_RETRY_ENABLED === "false"
+          this.opts.disableModelRetry || process.env.MODEL_RETRY_ENABLED === "false"
             ? { enabled: false }
             : { enabled: true, maxRetries: 4 },
       }),
+      ...(this.opts.disableTools ? { noTools: "all" as const } : {}),
     });
 
     // Widen the tool set BEFORE the first prompt — see {@link enableSearchTools}

--- a/packages/runner-pi/test/container-env.test.ts
+++ b/packages/runner-pi/test/container-env.test.ts
@@ -28,6 +28,21 @@ describe("buildRuntimePiEnv", () => {
     expect(env.SIDECAR_URL).toBe("http://sidecar:8080");
   });
 
+  it("preserves the upstream provider identity behind the sidecar", () => {
+    const env = buildRuntimePiEnv({
+      model: {
+        api: "openai-completions",
+        provider: "deepseek",
+        modelId: "deepseek-v4-flash",
+        baseUrl: "https://api.deepseek.com/v1",
+      },
+      agentPrompt: "do thing",
+      ...sidecar,
+    });
+
+    expect(env.MODEL_PROVIDER).toBe("deepseek");
+  });
+
   it("throws when a sidecar-backed run omits sidecarUrl", () => {
     expect(() => buildRuntimePiEnv({ model, agentPrompt: "p" })).toThrow(/sidecarUrl is required/);
   });

--- a/runtime-pi/entrypoint.ts
+++ b/runtime-pi/entrypoint.ts
@@ -35,12 +35,11 @@
 import * as fs from "node:fs/promises";
 import { writeSync } from "node:fs";
 import * as path from "node:path";
-import type { ExtensionFactory, Api, Model } from "./pi-sdk.ts";
+import type { ExtensionFactory } from "./pi-sdk.ts";
 import {
   prepareBundleForPi,
   buildRuntimeToolExtensions,
   buildPublishDocumentExtension,
-  deriveProviderFromApi,
   emitRuntimeReady,
   emitBootProgress,
   startSinkHeartbeat,
@@ -66,6 +65,7 @@ import { emptyRunResult } from "@appstrate/afps-runtime/runner";
 import { createMcpHttpClient, type AppstrateMcpClient } from "@appstrate/mcp-transport";
 import { parseRuntimeEnv, RuntimeEnvError, scrubSinkEnv } from "./env.ts";
 import { createRuntimePiRunner } from "./pi-runner.ts";
+import { buildRuntimeModel } from "./model.ts";
 import { buildMcpDirectFactories } from "./mcp/direct.ts";
 import {
   createRuntimeEventDrainer,
@@ -716,24 +716,8 @@ if (declaredRuntimeTools.includes("publish_document")) {
 
 // --- 3. Model + system prompt from env ---
 
-const api = env.modelApi;
-const modelId = env.modelId;
 const systemPrompt = env.agentPrompt;
-
-const model: Model<Api> = {
-  id: modelId,
-  name: modelId,
-  api: api as Api,
-  // Pi SDK AuthStorage key, derived from the api shape. The runner reads
-  // this field directly to register + resolve the API key.
-  provider: deriveProviderFromApi(api),
-  baseUrl: env.modelBaseUrl ?? "",
-  reasoning: env.modelReasoning,
-  input: [...env.modelInput],
-  cost: env.modelCost,
-  contextWindow: env.modelContextWindow,
-  maxTokens: env.modelMaxTokens,
-};
+const model = buildRuntimeModel(env);
 
 // --- 4. Build ExecutionContext from env ---
 

--- a/runtime-pi/env.ts
+++ b/runtime-pi/env.ts
@@ -25,6 +25,11 @@ export interface RuntimeEnv {
   workspaceDir: string;
   /** Pi SDK API slug — e.g. `"anthropic-messages"`, `"openai-completions"`. */
   modelApi: string;
+  /**
+   * Upstream provider identity for Pi compatibility detection. Optional for
+   * backward compatibility with launchers that only supplied MODEL_API.
+   */
+  modelProvider?: string;
   /** Model identifier passed to the SDK. */
   modelId: string;
   /** Optional baseUrl override (sidecar proxy or compatible endpoint). */
@@ -359,6 +364,7 @@ export function parseRuntimeEnv(source: NodeJS.ProcessEnv = process.env): Runtim
     runId: runId!,
     workspaceDir: source.WORKSPACE_DIR || "/workspace",
     modelApi: modelApi!,
+    modelProvider: source.MODEL_PROVIDER || undefined,
     modelId: modelId!,
     modelBaseUrl: modelBaseUrl || undefined,
     modelApiKey: source.MODEL_API_KEY || undefined,

--- a/runtime-pi/model-canary.ts
+++ b/runtime-pi/model-canary.ts
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  BUNDLE_FORMAT_VERSION,
+  bundleIntegrity,
+  computeRecordEntries,
+  recordIntegrity,
+  serializeRecord,
+  type Bundle,
+  type BundlePackage,
+  type PackageIdentity,
+} from "@appstrate/afps-runtime/bundle";
+import type { ModelApiShape } from "@appstrate/core/sidecar-types";
+import type { RunResult } from "@appstrate/afps-runtime/runner";
+import { createApp } from "./sidecar/app.ts";
+import { createRuntimePiRunner } from "./pi-runner.ts";
+import { parseRuntimeEnv } from "./env.ts";
+import { buildRuntimeModel } from "./model.ts";
+
+const STANDARD_MAX_TOKENS = 4;
+const REASONING_MAX_TOKENS = 16;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const CANARY_IDENTITY = "@appstrate/runtime-model-canary@1.0.0" as PackageIdentity;
+
+export interface ModelRuntimeCanaryTarget {
+  /** Public model id used inside the runtime (alias when aliased). */
+  id: string;
+  providerId: string;
+  apiShape: ModelApiShape;
+  baseUrl: string;
+  apiKey: string;
+  /** Real upstream model id. */
+  modelId: string;
+  aliased: boolean;
+  reasoning: boolean | null;
+  input: ReadonlyArray<"text" | "image"> | null;
+  contextWindow: number | null;
+  maxTokens: number | null;
+  cost: { input: number; output: number; cacheRead?: number; cacheWrite?: number } | null;
+}
+
+export interface ModelRuntimeCanaryResult {
+  id: string;
+  providerId: string;
+  modelId: string;
+  ok: boolean;
+  /** Direct target response status observed by the sidecar fetch boundary. */
+  status: number | null;
+  latencyMs: number;
+  error?: string;
+  usage?: RunResult["usage"];
+  cost?: number;
+}
+
+export interface ModelRuntimeCanaryDeps {
+  /** External provider boundary. Tests inject a fake; production uses global fetch. */
+  fetchFn?: typeof fetch;
+  timeoutMs?: number;
+}
+
+function canaryBundle(): Bundle {
+  const manifest = {
+    name: "@appstrate/runtime-model-canary",
+    version: "1.0.0",
+    type: "agent",
+  };
+  const files = new Map<string, Uint8Array>([
+    ["manifest.json", new TextEncoder().encode(JSON.stringify(manifest))],
+  ]);
+  const integrity = recordIntegrity(serializeRecord(computeRecordEntries(files)));
+  const root: BundlePackage = { identity: CANARY_IDENTITY, manifest, files, integrity };
+  const packageIndex = new Map([
+    [CANARY_IDENTITY, { path: "packages/runtime-model-canary/1.0.0/", integrity }],
+  ]);
+  return {
+    bundleFormatVersion: BUNDLE_FORMAT_VERSION,
+    root: CANARY_IDENTITY,
+    packages: new Map([[CANARY_IDENTITY, root]]),
+    integrity: bundleIntegrity(packageIndex),
+  };
+}
+
+function captureSink(): {
+  finalized: RunResult | null;
+  handle: () => Promise<void>;
+  finalize: (result: RunResult) => Promise<void>;
+} {
+  const sink = {
+    finalized: null as RunResult | null,
+    async handle() {},
+    async finalize(result: RunResult) {
+      sink.finalized = result;
+    },
+  };
+  return sink;
+}
+
+/**
+ * Execute one minimal inference through the production Pi adapter and Hono
+ * sidecar. The provider call is the only mocked seam in tests.
+ */
+export async function runModelRuntimeCanary(
+  target: ModelRuntimeCanaryTarget,
+  deps: ModelRuntimeCanaryDeps = {},
+): Promise<ModelRuntimeCanaryResult> {
+  const root = await mkdtemp(join(tmpdir(), "appstrate-model-canary-"));
+  const agentDir = join(root, "agent");
+  const placeholder = `appstrate-canary-${crypto.randomUUID()}`;
+  const startedAt = performance.now();
+  let upstreamStatus: number | null = null;
+  let server: ReturnType<typeof Bun.serve> | undefined;
+
+  try {
+    await mkdir(agentDir, { recursive: true });
+    const externalFetch = deps.fetchFn ?? fetch;
+    const observedFetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      const response = await externalFetch(input, init);
+      upstreamStatus = response.status;
+      return response;
+    }) as typeof fetch;
+    const app = createApp({
+      config: {
+        platformApiUrl: "http://model-canary.invalid",
+        runToken: "model-canary",
+        proxyUrl: "",
+        llm: {
+          authMode: "api_key",
+          baseUrl: target.baseUrl,
+          apiKey: target.apiKey,
+          placeholder,
+          ...(target.aliased ? { modelSwap: { alias: target.id, real: target.modelId } } : {}),
+        },
+      },
+      cookieJar: new Map(),
+      fetchFn: observedFetch,
+    });
+    server = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: app.fetch });
+
+    const tokenLimit = target.reasoning ? REASONING_MAX_TOKENS : STANDARD_MAX_TOKENS;
+    const model = buildRuntimeModel(
+      parseRuntimeEnv({
+        AGENT_RUN_ID: `run_canary_${crypto.randomUUID()}`,
+        APPSTRATE_SINK_URL: "https://model-canary.invalid/events",
+        APPSTRATE_SINK_FINALIZE_URL: "https://model-canary.invalid/events/finalize",
+        APPSTRATE_SINK_SECRET: "model-canary-sink-secret",
+        AGENT_PROMPT: "You are a connectivity probe. Reply with OK.",
+        MODEL_API: target.apiShape,
+        MODEL_PROVIDER: target.providerId,
+        MODEL_ID: target.aliased ? target.id : target.modelId,
+        MODEL_BASE_URL: `${server.url.origin}/llm`,
+        MODEL_API_KEY: placeholder,
+        MODEL_REASONING: target.reasoning ? "true" : "false",
+        MODEL_INPUT: JSON.stringify(target.input ?? ["text"]),
+        MODEL_CONTEXT_WINDOW: String(target.contextWindow ?? 128_000),
+        MODEL_MAX_TOKENS: String(
+          target.maxTokens == null ? tokenLimit : Math.min(target.maxTokens, tokenLimit),
+        ),
+        MODEL_COST: JSON.stringify(target.cost ?? { input: 0, output: 0 }),
+        SIDECAR_URL: server.url.origin,
+      }),
+    );
+    if (target.providerId === "openrouter" && model.api === "openai-completions") {
+      model.compat = {
+        ...model.compat,
+        openRouterRouting: { allow_fallbacks: false, require_parameters: true },
+      };
+    }
+
+    const sink = captureSink();
+    const runner = createRuntimePiRunner({
+      sidecarUrl: server.url.origin,
+      model,
+      apiKey: placeholder,
+      systemPrompt: "You are a connectivity probe. Reply with OK.",
+      startMessage: "Reply OK.",
+      cwd: root,
+      agentDir,
+      authStoragePath: join(root, "auth.json"),
+      disableModelRetry: true,
+      disableTools: true,
+    });
+    const controller = new AbortController();
+    const timeout = setTimeout(
+      () =>
+        controller.abort(
+          new Error(`Model canary timed out after ${deps.timeoutMs ?? DEFAULT_TIMEOUT_MS}ms`),
+        ),
+      deps.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    );
+    try {
+      await runner.run({
+        bundle: canaryBundle(),
+        context: { runId: "run_model_canary", input: {}, memories: [], config: {} },
+        eventSink: sink,
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+
+    const finalized = sink.finalized;
+    const ok =
+      upstreamStatus !== null &&
+      upstreamStatus >= 200 &&
+      upstreamStatus < 300 &&
+      finalized?.status === "success";
+    return {
+      id: target.id,
+      providerId: target.providerId,
+      modelId: target.modelId,
+      ok,
+      status: upstreamStatus,
+      latencyMs: Math.round(performance.now() - startedAt),
+      ...(finalized?.error?.message ? { error: finalized.error.message } : {}),
+      ...(finalized?.usage ? { usage: finalized.usage } : {}),
+      ...(finalized?.cost !== undefined ? { cost: finalized.cost } : {}),
+    };
+  } catch (error) {
+    return {
+      id: target.id,
+      providerId: target.providerId,
+      modelId: target.modelId,
+      ok: false,
+      status: upstreamStatus,
+      latencyMs: Math.round(performance.now() - startedAt),
+      error: error instanceof Error ? error.message : String(error),
+    };
+  } finally {
+    if (server) await server.stop(true);
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/runtime-pi/model.ts
+++ b/runtime-pi/model.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { deriveProviderFromApi } from "@appstrate/runner-pi";
+import type { Api, Model } from "./pi-sdk.ts";
+import type { RuntimeEnv } from "./env.ts";
+
+/**
+ * Build the exact Pi model used by the container runtime.
+ *
+ * `modelBaseUrl` normally points at the per-run sidecar, so Pi cannot infer
+ * provider compatibility from the URL. `MODEL_PROVIDER` preserves the real
+ * upstream identity; the api-derived fallback keeps older/self-hosted
+ * launchers compatible.
+ */
+export function buildRuntimeModel(env: RuntimeEnv): Model<Api> {
+  const api = env.modelApi;
+  const modelId = env.modelId;
+  // Upstream identity is only a compatibility input for the OpenAI-compatible
+  // adapter. Native APIs keep their historical AuthStorage provider key
+  // (`codex` still authenticates under `openai`, Google under `google`, etc.).
+  const provider =
+    api === "openai-completions" && env.modelProvider
+      ? env.modelProvider
+      : deriveProviderFromApi(api);
+  // Pi normally detects OpenAI-compatible quirks from the upstream URL. A
+  // sidecar-backed model only exposes `http://sidecar/llm`, so that signal is
+  // gone. Preserve the URL-derived flags Pi 0.73.1 cannot recover from our
+  // provider ids (`deepseek` is only partially recognised and Appstrate names
+  // Moonshot `moonshot`, while Pi expects `moonshotai`).
+  const compat =
+    api !== "openai-completions"
+      ? undefined
+      : provider === "deepseek"
+        ? { supportsDeveloperRole: false, supportsStore: false }
+        : provider === "moonshot"
+          ? {
+              supportsDeveloperRole: false,
+              supportsStore: false,
+              supportsReasoningEffort: false,
+              maxTokensField: "max_tokens" as const,
+              supportsStrictMode: false,
+            }
+          : undefined;
+  return {
+    id: modelId,
+    name: modelId,
+    api: api as Api,
+    provider,
+    baseUrl: env.modelBaseUrl ?? "",
+    reasoning: env.modelReasoning,
+    input: [...env.modelInput],
+    cost: env.modelCost,
+    contextWindow: env.modelContextWindow,
+    maxTokens: env.modelMaxTokens,
+    ...(compat ? { compat } : {}),
+  };
+}

--- a/runtime-pi/test/env.test.ts
+++ b/runtime-pi/test/env.test.ts
@@ -53,6 +53,7 @@ describe("parseRuntimeEnv — happy path", () => {
       ...VALID,
       WORKSPACE_DIR: "/agent",
       MODEL_BASE_URL: "https://proxy.example.com/v1",
+      MODEL_PROVIDER: "deepseek",
       MODEL_API_KEY: "sk-test",
       MODEL_REASONING: "true",
       MODEL_INPUT: '["text","image"]',
@@ -67,6 +68,7 @@ describe("parseRuntimeEnv — happy path", () => {
     });
     expect(env.workspaceDir).toBe("/agent");
     expect(env.modelBaseUrl).toBe("https://proxy.example.com/v1");
+    expect(env.modelProvider).toBe("deepseek");
     expect(env.modelApiKey).toBe("sk-test");
     expect(env.modelReasoning).toBe(true);
     expect(env.modelInput).toEqual(["text", "image"]);

--- a/runtime-pi/test/model-canary.test.ts
+++ b/runtime-pi/test/model-canary.test.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "bun:test";
+import { runModelRuntimeCanary, type ModelRuntimeCanaryTarget } from "../model-canary.ts";
+
+const TARGET: ModelRuntimeCanaryTarget = {
+  id: "appstrate-flash",
+  providerId: "deepseek",
+  apiShape: "openai-completions",
+  baseUrl: "https://api.deepseek.com/v1",
+  apiKey: "real-key",
+  modelId: "deepseek-v4-flash",
+  aliased: true,
+  reasoning: true,
+  input: ["text"],
+  contextWindow: 131_072,
+  maxTokens: 8_192,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+};
+
+function chatResponse(model: string): Response {
+  const chunks = [
+    {
+      id: "chatcmpl_canary",
+      object: "chat.completion.chunk",
+      created: 0,
+      model,
+      choices: [{ index: 0, delta: { role: "assistant", content: "OK" }, finish_reason: null }],
+    },
+    {
+      id: "chatcmpl_canary",
+      object: "chat.completion.chunk",
+      created: 0,
+      model,
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    },
+  ];
+  return new Response(
+    `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("")}data: [DONE]\n\n`,
+    {
+      headers: { "content-type": "text/event-stream" },
+    },
+  );
+}
+
+describe("runModelRuntimeCanary", () => {
+  it("runs the effective aliased model through Pi and the sidecar", async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    const result = await runModelRuntimeCanary(TARGET, {
+      fetchFn: (async (_input: string | URL | Request, init?: RequestInit) => {
+        bodies.push(JSON.parse(String(init?.body)) as Record<string, unknown>);
+        return chatResponse(TARGET.modelId);
+      }) as typeof fetch,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]?.model).toBe(TARGET.modelId);
+    expect(bodies[0]?.messages).toEqual(
+      expect.arrayContaining([expect.objectContaining({ role: "system" })]),
+    );
+    expect(bodies[0]?.messages).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ role: "developer" })]),
+    );
+    expect(bodies[0]?.max_completion_tokens).toBe(16);
+  });
+
+  it("fails a deterministic provider rejection without retrying or falling back", async () => {
+    let calls = 0;
+    const result = await runModelRuntimeCanary(TARGET, {
+      fetchFn: (async () => {
+        calls++;
+        return Response.json(
+          { error: { message: "Unsupported message role: developer" } },
+          { status: 400 },
+        );
+      }) as unknown as typeof fetch,
+    });
+
+    expect(calls).toBe(1);
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(400);
+    expect(result.error).toContain("400");
+  });
+});

--- a/runtime-pi/test/model.test.ts
+++ b/runtime-pi/test/model.test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "bun:test";
+import { parseRuntimeEnv } from "../env.ts";
+import { buildRuntimeModel } from "../model.ts";
+
+const BASE_ENV = {
+  AGENT_RUN_ID: "run_model_test",
+  APPSTRATE_SINK_URL: "https://api.example.com/events",
+  APPSTRATE_SINK_FINALIZE_URL: "https://api.example.com/events/finalize",
+  APPSTRATE_SINK_SECRET: "abcdefghijklmnopqrstuvwxyz0123456789",
+  MODEL_API: "openai-completions",
+  MODEL_ID: "deepseek-v4-flash",
+  MODEL_BASE_URL: "http://sidecar:8080/llm",
+  MODEL_PROVIDER: "deepseek",
+  MODEL_REASONING: "true",
+  AGENT_PROMPT: "Answer briefly.",
+};
+
+describe("buildRuntimeModel", () => {
+  it("keeps the upstream provider identity when the request URL is the sidecar", () => {
+    const model = buildRuntimeModel(parseRuntimeEnv(BASE_ENV));
+
+    expect(model.provider).toBe("deepseek");
+    expect(model.baseUrl).toBe("http://sidecar:8080/llm");
+    expect(model.reasoning).toBe(true);
+    expect(model.compat).toMatchObject({
+      supportsDeveloperRole: false,
+      supportsStore: false,
+    });
+  });
+
+  it("falls back to the api-derived auth provider for older launchers", () => {
+    const model = buildRuntimeModel(parseRuntimeEnv({ ...BASE_ENV, MODEL_PROVIDER: "" }));
+
+    expect(model.provider).toBe("openai");
+  });
+
+  it("keeps native non-compatible API provider keys unchanged", () => {
+    const model = buildRuntimeModel(
+      parseRuntimeEnv({
+        ...BASE_ENV,
+        MODEL_API: "openai-codex-responses",
+        MODEL_PROVIDER: "codex",
+        MODEL_ID: "gpt-5.4",
+      }),
+    );
+
+    expect(model.provider).toBe("openai");
+  });
+
+  it("preserves Moonshot URL-derived compatibility behind the sidecar", () => {
+    const model = buildRuntimeModel(
+      parseRuntimeEnv({
+        ...BASE_ENV,
+        MODEL_PROVIDER: "moonshot",
+        MODEL_ID: "kimi-k2.5",
+      }),
+    );
+
+    expect(model.compat).toMatchObject({
+      supportsDeveloperRole: false,
+      supportsStore: false,
+      supportsReasoningEffort: false,
+      maxTokensField: "max_tokens",
+      supportsStrictMode: false,
+    });
+  });
+});

--- a/runtime-pi/test/pi-runner-transport.test.ts
+++ b/runtime-pi/test/pi-runner-transport.test.ts
@@ -6,6 +6,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PiModelConfig } from "@appstrate/runner-pi";
 import { createApp, type AppDeps } from "../sidecar/app.ts";
+import { parseRuntimeEnv } from "../env.ts";
+import { buildRuntimeModel } from "../model.ts";
 import { createRuntimePiRunner } from "../pi-runner.ts";
 import {
   createCaptureSink,
@@ -17,6 +19,12 @@ import {
 interface ObservedRequest {
   method: string;
   path: string;
+}
+
+interface OpenAiCompatibleRequest {
+  model?: string;
+  messages?: Array<{ role?: string; content?: unknown }>;
+  thinking?: { type?: string };
 }
 
 const TEST_JWT = [
@@ -52,6 +60,32 @@ function completedResponse(): Response {
       },
     })}\n\n`,
     { headers: { "content-type": "text/event-stream" } },
+  );
+}
+
+function completedChatResponse(model: string): Response {
+  const chunks = [
+    {
+      id: "chatcmpl_test",
+      object: "chat.completion.chunk",
+      created: 0,
+      model,
+      choices: [{ index: 0, delta: { role: "assistant", content: "OK" }, finish_reason: null }],
+    },
+    {
+      id: "chatcmpl_test",
+      object: "chat.completion.chunk",
+      created: 0,
+      model,
+      choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    },
+  ];
+  return new Response(
+    `${chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("")}data: [DONE]\n\n`,
+    {
+      headers: { "content-type": "text/event-stream" },
+    },
   );
 }
 
@@ -137,6 +171,86 @@ describe("runtime-pi sidecar transport wiring", () => {
       expect(sidecarRequests).toEqual([{ method: "POST", path: "/llm/codex/responses" }]);
       expect(upstreamRequests).toEqual([{ method: "POST", path: "/codex/responses" }]);
       expect(sink.finalizeCalls).toBe(1);
+      expect(sink.finalized?.status).toBe("success");
+    } finally {
+      if (server) await server.stop(true);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves DeepSeek compatibility through an aliased sidecar run", async () => {
+    const root = await mkdtemp(join(tmpdir(), "runtime-pi-deepseek-"));
+    const agentDir = join(root, "agent");
+    const requests: OpenAiCompatibleRequest[] = [];
+    let server: ReturnType<typeof Bun.serve> | undefined;
+
+    try {
+      await mkdir(agentDir, { recursive: true });
+      const fetchFn = (async (_input: string | URL | Request, init?: RequestInit) => {
+        const body = String(init?.body ?? "");
+        const parsed = JSON.parse(body) as OpenAiCompatibleRequest;
+        requests.push(parsed);
+        if (parsed.messages?.some((message) => message.role === "developer")) {
+          return Response.json(
+            { error: { message: "Unsupported message role: developer" } },
+            { status: 400 },
+          );
+        }
+        return completedChatResponse("deepseek-v4-flash");
+      }) as unknown as typeof fetch;
+      const app = createApp({
+        config: {
+          platformApiUrl: "http://mock:3000",
+          runToken: "tok",
+          proxyUrl: "",
+          llm: {
+            authMode: "api_key",
+            baseUrl: "https://api.deepseek.com/v1",
+            apiKey: "real-key",
+            placeholder: "canary-placeholder",
+            modelSwap: { alias: "appstrate-flash", real: "deepseek-v4-flash" },
+          },
+        },
+        cookieJar: new Map(),
+        fetchFn,
+      });
+      server = Bun.serve({ hostname: "127.0.0.1", port: 0, fetch: app.fetch });
+
+      const model = buildRuntimeModel(
+        parseRuntimeEnv({
+          AGENT_RUN_ID: "run_deepseek_canary",
+          APPSTRATE_SINK_URL: "https://api.example.com/events",
+          APPSTRATE_SINK_FINALIZE_URL: "https://api.example.com/events/finalize",
+          APPSTRATE_SINK_SECRET: "abcdefghijklmnopqrstuvwxyz0123456789",
+          AGENT_PROMPT: "Answer briefly.",
+          MODEL_API: "openai-completions",
+          MODEL_PROVIDER: "deepseek",
+          MODEL_ID: "appstrate-flash",
+          MODEL_BASE_URL: `${server.url.origin}/llm`,
+          MODEL_REASONING: "true",
+          MODEL_CONTEXT_WINDOW: "131072",
+          MODEL_MAX_TOKENS: "16",
+        }),
+      );
+      const sink = createCaptureSink();
+      const runner = createRuntimePiRunner({
+        sidecarUrl: server.url.origin,
+        model,
+        apiKey: "canary-placeholder",
+        systemPrompt: "Answer briefly.",
+        startMessage: "Reply OK.",
+        cwd: root,
+        agentDir,
+        authStoragePath: join(root, "auth.json"),
+      });
+
+      await runner.run({ bundle: TEST_BUNDLE, context: makeContext(), eventSink: sink });
+
+      expect(requests).toHaveLength(1);
+      expect(requests[0]?.model).toBe("deepseek-v4-flash");
+      expect(requests[0]?.messages?.[0]?.role).toBe("system");
+      expect(requests[0]?.messages?.some((message) => message.role === "developer")).toBe(false);
+      expect(requests[0]?.thinking).toEqual({ type: "enabled" });
       expect(sink.finalized?.status).toBe("success");
     } finally {
       if (server) await server.stop(true);

--- a/scripts/model-runtime-canary.ts
+++ b/scripts/model-runtime-canary.ts
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Live model conformance canary.
+ *
+ * Reads the same shape as SYSTEM_PROVIDER_KEYS, resolves catalog-derived
+ * metadata, then executes each selected model through runtime-pi's real Pi
+ * adapter and Hono sidecar. The external provider is the only remote boundary.
+ *
+ * Required environment:
+ *   MODEL_RUNTIME_CANARY_CONFIG (preferred) or SYSTEM_PROVIDER_KEYS
+ *
+ * Usage:
+ *   bun scripts/model-runtime-canary.ts --all
+ *   bun scripts/model-runtime-canary.ts --changed --base=HEAD
+ */
+
+import coreProvidersModule from "../apps/api/src/modules/core-providers/index.ts";
+import {
+  initSystemModelProviderKeys,
+  getSystemModels,
+} from "../apps/api/src/services/model-registry.ts";
+import {
+  getModelProvider,
+  registerModelProviders,
+  resetModelProviders,
+} from "../apps/api/src/services/model-providers/registry.ts";
+import { lookupCatalogModel } from "../apps/api/src/services/pricing-catalog.ts";
+import {
+  runModelRuntimeCanary,
+  type ModelRuntimeCanaryResult,
+  type ModelRuntimeCanaryTarget,
+} from "../runtime-pi/model-canary.ts";
+
+const PRICING_DIR = "apps/api/src/data/pricing";
+const TRANSIENT_RETRY_DELAY_MS = 2_000;
+const CONCURRENCY = 2;
+
+interface Options {
+  mode: "all" | "changed";
+  base: string;
+  requireTargets: boolean;
+  modelIds: Set<string>;
+}
+
+type CatalogSnapshot = Record<
+  string,
+  {
+    contextWindow?: number;
+    maxTokens?: number | null;
+    capabilities?: string[];
+  }
+>;
+
+function parseOptions(argv: readonly string[]): Options {
+  let mode: Options["mode"] = "all";
+  let base = "HEAD";
+  let requireTargets = false;
+  const modelIds = new Set<string>();
+  for (const arg of argv) {
+    if (arg === "--all") mode = "all";
+    else if (arg === "--changed") mode = "changed";
+    else if (arg === "--require-targets") requireTargets = true;
+    else if (arg.startsWith("--base=")) base = arg.slice("--base=".length);
+    else if (arg.startsWith("--model=")) modelIds.add(arg.slice("--model=".length));
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return { mode, base, requireTargets, modelIds };
+}
+
+function canaryConfig(): unknown[] {
+  const raw = process.env.MODEL_RUNTIME_CANARY_CONFIG ?? process.env.SYSTEM_PROVIDER_KEYS;
+  if (!raw) {
+    throw new Error(
+      "MODEL_RUNTIME_CANARY_CONFIG (or SYSTEM_PROVIDER_KEYS) is required; " +
+        "use a dedicated low-quota credential and list every model this deployment must serve",
+    );
+  }
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed)) throw new Error("Model canary config must be a JSON array");
+  return parsed;
+}
+
+function wireProjection(value: CatalogSnapshot[string] | undefined): string {
+  if (!value) return "missing";
+  return JSON.stringify({
+    contextWindow: value.contextWindow ?? null,
+    maxTokens: value.maxTokens ?? null,
+    capabilities: [...(value.capabilities ?? [])].sort(),
+  });
+}
+
+/** Return model ids whose runtime-affecting catalog metadata changed. */
+export function changedCatalogModelIds(
+  before: CatalogSnapshot,
+  after: CatalogSnapshot,
+): Set<string> {
+  const out = new Set<string>();
+  for (const id of new Set([...Object.keys(before), ...Object.keys(after)])) {
+    if (wireProjection(before[id]) !== wireProjection(after[id])) out.add(id);
+  }
+  return out;
+}
+
+/**
+ * Fail closed when no usable configuration exists, while treating a changed
+ * run with no semantic drift (for example price-only updates) as a valid skip.
+ */
+export function shouldFailEmptyCanarySelection(input: {
+  mode: Options["mode"];
+  requireTargets: boolean;
+  configuredTargetCount: number;
+  explicitModelCount: number;
+}): boolean {
+  if (!input.requireTargets) return false;
+  return input.configuredTargetCount === 0 || input.mode === "all" || input.explicitModelCount > 0;
+}
+
+async function changedCatalogKeys(base: string): Promise<Set<string>> {
+  const diff = Bun.spawnSync({
+    cmd: ["git", "diff", "--name-only", base, "--", PRICING_DIR],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (diff.exitCode !== 0) throw new Error(diff.stderr.toString().trim() || "git diff failed");
+  const paths = diff.stdout
+    .toString()
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.endsWith(".json"));
+  const keys = new Set<string>();
+  for (const path of paths) {
+    const providerId = path.slice(path.lastIndexOf("/") + 1, -".json".length);
+    const previous = Bun.spawnSync({
+      cmd: ["git", "show", `${base}:${path}`],
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const before =
+      previous.exitCode === 0
+        ? (JSON.parse(previous.stdout.toString()) as CatalogSnapshot)
+        : ({} as CatalogSnapshot);
+    const after = (await Bun.file(path).json()) as CatalogSnapshot;
+    for (const modelId of changedCatalogModelIds(before, after)) {
+      keys.add(`${providerId}/${modelId}`);
+    }
+  }
+  return keys;
+}
+
+function resolveTargets(rawConfig: unknown[]): ModelRuntimeCanaryTarget[] {
+  resetModelProviders();
+  registerModelProviders(coreProvidersModule.modelProviders?.() ?? []);
+  initSystemModelProviderKeys(rawConfig);
+  const targets: ModelRuntimeCanaryTarget[] = [];
+  for (const [id, def] of getSystemModels()) {
+    if (def.enabled === false) continue;
+    const provider = getModelProvider(def.providerId);
+    if (!provider) continue;
+    const catalogId = provider.catalogProviderId ?? def.providerId;
+    const catalog = lookupCatalogModel(catalogId, def.modelId);
+    const catalogInput = catalog?.capabilities.filter(
+      (capability): capability is "text" | "image" =>
+        capability === "text" || capability === "image",
+    );
+    targets.push({
+      id,
+      providerId: def.providerId,
+      apiShape: def.apiShape,
+      baseUrl: def.baseUrl,
+      apiKey: def.apiKey,
+      modelId: def.modelId,
+      aliased: def.aliased === true,
+      reasoning: def.reasoning ?? catalog?.capabilities.includes("reasoning") ?? null,
+      input: (def.input as Array<"text" | "image"> | null) ?? catalogInput ?? null,
+      contextWindow: def.contextWindow ?? catalog?.contextWindow ?? null,
+      maxTokens: def.maxTokens ?? catalog?.maxTokens ?? null,
+      cost: def.cost ?? catalog?.cost ?? null,
+    });
+  }
+  return targets;
+}
+
+function isTransient(status: number | null): boolean {
+  return status === 408 || status === 429 || (status !== null && status >= 500);
+}
+
+async function probeWithTransientRetry(
+  target: ModelRuntimeCanaryTarget,
+): Promise<ModelRuntimeCanaryResult> {
+  const first = await runModelRuntimeCanary(target);
+  if (first.ok || !isTransient(first.status)) return first;
+  await Bun.sleep(TRANSIENT_RETRY_DELAY_MS);
+  return runModelRuntimeCanary(target);
+}
+
+async function mapConcurrent<T, R>(
+  values: readonly T[],
+  concurrency: number,
+  fn: (value: T) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(values.length);
+  let cursor = 0;
+  async function worker(): Promise<void> {
+    while (cursor < values.length) {
+      const index = cursor++;
+      results[index] = await fn(values[index]!);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, () => worker()));
+  return results;
+}
+
+function printResults(results: readonly ModelRuntimeCanaryResult[]): void {
+  const lines = [
+    "| Provider | Runtime id | Upstream model | Status | Latency | Tokens |",
+    "| --- | --- | --- | ---: | ---: | ---: |",
+  ];
+  for (const result of results) {
+    const status = result.status ?? "network";
+    const tokens = result.usage
+      ? (result.usage.input_tokens ?? 0) +
+        (result.usage.output_tokens ?? 0) +
+        (result.usage.cache_creation_input_tokens ?? 0) +
+        (result.usage.cache_read_input_tokens ?? 0)
+      : 0;
+    lines.push(
+      `| ${result.providerId} | ${result.id} | ${result.modelId} | ` +
+        `${result.ok ? `✅ ${status}` : `❌ ${status}`} | ${result.latencyMs} ms | ${tokens} |`,
+    );
+    if (result.error) lines.push(`|  |  | error | ${result.error.replaceAll("|", "\\|")} |  |  |`);
+  }
+  process.stdout.write(`${lines.join("\n")}\n`);
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(Bun.argv.slice(2));
+  let targets = resolveTargets(canaryConfig());
+  const configuredTargetCount = targets.length;
+  if (options.modelIds.size > 0) {
+    targets = targets.filter(
+      (target) => options.modelIds.has(target.id) || options.modelIds.has(target.modelId),
+    );
+  }
+  if (options.mode === "changed") {
+    const changed = await changedCatalogKeys(options.base);
+    targets = targets.filter((target) => {
+      const provider = getModelProvider(target.providerId);
+      const catalogId = provider?.catalogProviderId ?? target.providerId;
+      return changed.has(`${catalogId}/${target.modelId}`);
+    });
+  }
+  if (targets.length === 0) {
+    const message = "No configured runtime model matched the requested canary selection.";
+    process.stdout.write(`${message}\n`);
+    if (
+      shouldFailEmptyCanarySelection({
+        mode: options.mode,
+        requireTargets: options.requireTargets,
+        configuredTargetCount,
+        explicitModelCount: options.modelIds.size,
+      })
+    ) {
+      throw new Error(message);
+    }
+    return;
+  }
+  const results = await mapConcurrent(targets, CONCURRENCY, probeWithTransientRetry);
+  printResults(results);
+  if (results.some((result) => !result.ok)) process.exitCode = 1;
+}
+
+if (import.meta.main) {
+  await main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/test/model-runtime-canary.test.ts
+++ b/scripts/test/model-runtime-canary.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "bun:test";
+import { changedCatalogModelIds, shouldFailEmptyCanarySelection } from "../model-runtime-canary.ts";
+
+const entry = (
+  capabilities: string[],
+  overrides: { contextWindow?: number; maxTokens?: number | null; inputCost?: number } = {},
+) => ({
+  contextWindow: overrides.contextWindow ?? 128_000,
+  maxTokens: overrides.maxTokens ?? 8_192,
+  capabilities,
+  cost: { input: overrides.inputCost ?? 1, output: 2 },
+});
+
+describe("changedCatalogModelIds", () => {
+  it("selects runtime-affecting capability and token-window changes", () => {
+    const changed = changedCatalogModelIds(
+      {
+        flash: entry(["text"]),
+        small: entry(["text"]),
+      },
+      {
+        flash: entry(["text", "reasoning"]),
+        small: entry(["text"], { maxTokens: 16_384 }),
+      },
+    );
+
+    expect(changed).toEqual(new Set(["flash", "small"]));
+  });
+
+  it("ignores price-only drift because it cannot change the request protocol", () => {
+    const changed = changedCatalogModelIds(
+      { flash: entry(["text", "reasoning"], { inputCost: 1 }) },
+      { flash: entry(["text", "reasoning"], { inputCost: 99 }) },
+    );
+
+    expect(changed).toEqual(new Set());
+  });
+
+  it("selects added and removed models", () => {
+    expect(changedCatalogModelIds({ old: entry(["text"]) }, { next: entry(["text"]) })).toEqual(
+      new Set(["old", "next"]),
+    );
+  });
+});
+
+describe("shouldFailEmptyCanarySelection", () => {
+  it("allows a changed run to skip when drift is price-only", () => {
+    expect(
+      shouldFailEmptyCanarySelection({
+        mode: "changed",
+        requireTargets: true,
+        configuredTargetCount: 2,
+        explicitModelCount: 0,
+      }),
+    ).toBe(false);
+  });
+
+  it("still fails closed for an empty config or an explicit missing model", () => {
+    expect(
+      shouldFailEmptyCanarySelection({
+        mode: "changed",
+        requireTargets: true,
+        configuredTargetCount: 0,
+        explicitModelCount: 0,
+      }),
+    ).toBe(true);
+    expect(
+      shouldFailEmptyCanarySelection({
+        mode: "changed",
+        requireTargets: true,
+        configuredTargetCount: 2,
+        explicitModelCount: 1,
+      }),
+    ).toBe(true);
+  });
+});

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -5,6 +5,7 @@
   },
   "include": [
     "verify-module-contract.ts",
+    "model-runtime-canary.ts",
     "verify-package-resolves.ts",
     "check-consumer-versions.ts",
     "test/check-consumer-versions.test.ts"


### PR DESCRIPTION
## Summary

- preserve the real upstream provider identity when Pi runs behind the `/llm` sidecar
- restore URL-derived DeepSeek and Moonshot compatibility flags that Pi cannot infer from the sidecar URL
- add a deterministic `PiRunner -> Hono sidecar -> fake provider` regression that rejects the `developer` role
- add a live runtime canary that performs minimal inference through the production Pi + sidecar path with fallbacks and Pi retries disabled
- gate runtime-affecting LiteLLM catalog changes before the refresh PR is opened; price-only drift is skipped
- probe every explicitly configured runtime model nightly and after a `model-runtime-deployed` dispatch, with an issue/report on failure
- correct model-discovery documentation: the existing `/models` probe checks credentials, not inference conformance

## Root cause

The launcher replaced the provider base URL with the sidecar URL before constructing Pi's model. Pi 0.73.1 uses the upstream provider and URL to choose OpenAI-compatible request semantics. Behind the sidecar, DeepSeek was treated as OpenAI and received unsupported `developer` / `store` fields. The same hidden-URL problem affected Moonshot's token and reasoning fields.

The runtime now carries `MODEL_PROVIDER` across the launcher boundary and explicitly pins only the compatibility flags that Pi cannot recover from Appstrate's provider ids. Native API auth-provider keys remain unchanged.

## Validation

- `bun run check` — 33/33 tasks pass
- 117 focused runtime, sidecar, launcher, discovery, and catalog tests pass
- workflow YAML parses and `git diff --check` passes
- live CLI dry selection verified with the production registry and a fake credential

The broader local runtime suite produced 1,052 pass / 3 skip / 16 fail. All 16 failures are pre-existing MITM certificate tests: macOS LibreSSL emits `BEGIN RSA PRIVATE KEY`, while `planCaBundle` currently requires `BEGIN PRIVATE KEY`. The changed test surfaces pass; GitHub's Ubuntu/OpenSSL run remains authoritative for those existing tests.

## Required operational configuration

Add the repository Actions secret `MODEL_RUNTIME_CANARY_CONFIG` using the documented `SYSTEM_PROVIDER_KEYS` JSON shape and dedicated low-quota credentials. The secret does not exist yet. Trusted catalog/nightly/deployment canary workflows intentionally fail closed until it is configured; pull-request workflows never receive it.

See `docs/guides/MODEL_RUNTIME_CANARY.md` for the schema, token budget, gates, and deployment dispatch contract.
