### PR TITLE
fix(models): surface OAuth reconnection after test

### DIFF
--- a/apps/api/src/services/org-models.ts
+++ b/apps/api/src/services/org-models.ts
@@ -30,6 +30,7 @@ import {
 } from "../lib/db-helpers.ts";
 import { mapFetchErrorToTestResult } from "../lib/network-error.ts";
 import { getModelProvider } from "./model-providers/registry.ts";
+import { resolveOAuthTokenForSidecar } from "./model-providers/token-resolver.ts";
 
 // --- Metadata projection ---
 
@@ -1038,6 +1039,16 @@ export async function testModelConfig(config: {
 }
 
 /** Test a saved model by ID (loads from DB/system registry then delegates to testModelConfig). */
+function needsReconnectionTestResult(): TestResult {
+  return {
+    ok: false,
+    latency: 0,
+    error: "NEEDS_RECONNECTION",
+    message:
+      "This model's provider credential must be reconnected before it can be tested. Reconnect it in the Model Provider Keys tab.",
+  };
+}
+
 export async function testModelConnection(orgId: string, modelDbId: string): Promise<TestResult> {
   const model = await loadModel(orgId, modelDbId);
   if (!model) {
@@ -1048,15 +1059,33 @@ export async function testModelConnection(orgId: string, modelDbId: string): Pro
     // `MODEL_NOT_FOUND` into a 404, and "Model not found" is the one thing
     // that is demonstrably untrue here.
     if (await modelNeedsReconnection(orgId, modelDbId)) {
-      return {
-        ok: false,
-        latency: 0,
-        error: "NEEDS_RECONNECTION",
-        message:
-          "This model's provider credential must be reconnected before it can be tested. Reconnect it in the Model Provider Keys tab.",
-      };
+      return needsReconnectionTestResult();
     }
     return { ok: false, latency: 0, error: "MODEL_NOT_FOUND", message: "Model not found" };
+  }
+
+  // An expired OAuth access token is not terminal while its refresh token may
+  // still work. Saved models carry a credential id, so use the canonical
+  // resolver before the provider's offline validation; it rotates recoverable
+  // tokens and persists needsReconnection on missing/revoked refresh tokens.
+  if (model.credentialId && getModelProvider(model.providerId)?.authMode === "oauth2") {
+    try {
+      const token = await resolveOAuthTokenForSidecar(model.credentialId, orgId);
+      return testModelConfig({
+        ...model,
+        apiKey: token.accessToken,
+        accountId: token.accountId ?? model.accountId,
+        expiresAt: token.expiresAt,
+      });
+    } catch (err) {
+      // The resolver owns the terminal/non-terminal policy. Read its persisted
+      // verdict instead of coupling this surface to every terminal error code;
+      // this also catches a transient-failure streak that just escalated.
+      if (await modelNeedsReconnection(orgId, modelDbId)) {
+        return needsReconnectionTestResult();
+      }
+      throw err;
+    }
   }
 
   return testModelConfig(model);

--- a/apps/api/test/integration/routes/models.test.ts
+++ b/apps/api/test/integration/routes/models.test.ts
@@ -957,6 +957,62 @@ describe("Models API", () => {
     });
   });
 
+  describe("OAuth Test action", () => {
+    afterEach(() => restoreFetch());
+
+    it("flags an expired saved credential when its refresh token is revoked", async () => {
+      const credential = await seedOrgModelProviderOAuth({
+        orgId: ctx.orgId,
+        providerId: TEST_OAUTH_PROVIDER_ID,
+        accessToken: "expired-access-token",
+        refreshToken: "revoked-refresh-token",
+        expiresAt: Date.now() - 60_000,
+      });
+      const model = await seedOrgModel({
+        orgId: ctx.orgId,
+        credentialId: credential.id,
+        label: "Gpt (codex)",
+        modelId: "test-model",
+      });
+
+      globalThis.fetch = (async () =>
+        new Response(
+          JSON.stringify({
+            error: "invalid_grant",
+            error_description: "refresh token revoked",
+          }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        )) as unknown as typeof fetch;
+
+      const tested = await app.request(`/api/models/${model.id}/test`, {
+        method: "POST",
+        headers: authHeaders(ctx),
+      });
+
+      expect(tested.status).toBe(200);
+      expect(await tested.json()).toMatchObject({
+        ok: false,
+        error: "NEEDS_RECONNECTION",
+      });
+
+      const credentialsResponse = await app.request("/api/model-provider-credentials", {
+        headers: authHeaders(ctx),
+      });
+      const credentials = (await credentialsResponse.json()) as {
+        data: Array<{ id: string; needs_reconnection: boolean }>;
+      };
+      expect(credentials.data.find((row) => row.id === credential.id)?.needs_reconnection).toBe(
+        true,
+      );
+
+      const modelsResponse = await app.request("/api/models", { headers: authHeaders(ctx) });
+      const models = (await modelsResponse.json()) as {
+        data: Array<{ id: string; needs_reconnection: boolean }>;
+      };
+      expect(models.data.find((row) => row.id === model.id)?.needs_reconnection).toBe(true);
+    });
+  });
+
   /**
    * The production deadlock, walked end to end over HTTP.
    *

--- a/apps/web/src/hooks/test/use-models.test.ts
+++ b/apps/web/src/hooks/test/use-models.test.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
+import { invalidateModelConnectionTestQueries } from "../use-models.ts";
+
+const MODELS_KEY = ["get", "/api/models", { params: { header: { "X-Org-Id": "org_1" } } }];
+const CREDENTIALS_KEY = [
+  "get",
+  "/api/model-provider-credentials",
+  { params: { header: { "X-Org-Id": "org_1" } } },
+];
+const PROXIES_KEY = ["get", "/api/proxies", { params: { header: { "X-Org-Id": "org_1" } } }];
+
+const isInvalidated = (qc: QueryClient, key: readonly unknown[]) =>
+  qc.getQueryState(key)?.isInvalidated;
+
+describe("saved model connection test cache invalidation", () => {
+  it("refreshes the model and credential lists without touching unrelated settings", async () => {
+    const qc = new QueryClient();
+    qc.setQueryData(MODELS_KEY, []);
+    qc.setQueryData(CREDENTIALS_KEY, []);
+    qc.setQueryData(PROXIES_KEY, []);
+
+    await invalidateModelConnectionTestQueries(qc);
+
+    expect(isInvalidated(qc, MODELS_KEY)).toBe(true);
+    expect(isInvalidated(qc, CREDENTIALS_KEY)).toBe(true);
+    expect(isInvalidated(qc, PROXIES_KEY)).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/use-models.ts
+++ b/apps/web/src/hooks/use-models.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { $api, client, type components } from "../api/client";
 import { splitPackageRef } from "../lib/package-paths";
 import { useCurrentOrgId } from "./use-org";
@@ -35,6 +35,14 @@ function useInvalidateModels() {
   };
 }
 
+/** A saved OAuth model test may rotate or terminally flag its backing credential. */
+export async function invalidateModelConnectionTestQueries(qc: QueryClient): Promise<void> {
+  await Promise.all([
+    qc.invalidateQueries({ queryKey: ["get", "/api/models"] }),
+    qc.invalidateQueries({ queryKey: ["get", "/api/model-provider-credentials"] }),
+  ]);
+}
+
 function useCreateModel() {
   const invalidate = useInvalidateModels();
   return $api.useMutation("post", "/api/models", { onSuccess: invalidate });
@@ -56,7 +64,10 @@ export function useSetDefaultModel() {
 }
 
 export function useTestModel() {
-  return $api.useMutation("post", "/api/models/{id}/test");
+  const qc = useQueryClient();
+  return $api.useMutation("post", "/api/models/{id}/test", {
+    onSuccess: () => invalidateModelConnectionTestQueries(qc),
+  });
 }
 
 export interface OpenRouterModel {


### PR DESCRIPTION
## Summary

- resolve saved OAuth model credentials through the canonical refresh path before running the provider test
- persist and return `NEEDS_RECONNECTION` when a refresh token is missing, revoked, or terminally escalated
- invalidate the model and provider-credential queries after Test so the existing reconnect UI appears immediately
- keep the unsaved inline model test offline and side-effect free

## Root cause

The saved-model Test endpoint delegated directly to the provider's offline validation. Codex correctly reported an expired subscription token, but this bypassed the OAuth token resolver that refreshes credentials and persists `needsReconnection`. The UI only offers Reconnect after that persisted flag is visible, and the Test mutation did not refetch either affected query.

## Tests

- TDD regression: the public POST Test endpoint now turns a revoked refresh token into `NEEDS_RECONNECTION`, and both model and credential reads expose `needs_reconnection: true`
- React Query regression: Test invalidates model and credential caches without touching unrelated settings
- `TEST_TIER=0 TMPDIR=/private/tmp bun test` on the pre-rebase snapshot: 9,800 passed, 89 skipped; 16 pre-existing MITM fixture failures from an invalid generated CA key and one LLM retry timeout
- isolated LLM retry rerun: 2 passed, 0 failed
- exact final SHA targeted suites: 74 passed, 0 failed, 266 assertions
- exact final SHA `bun run check -- --force`: 33/33 tasks passed

## Full-suite note

The MITM failures reproduce in the unchanged test file before the listener starts: `planCaBundle` rejects the generated test key because it lacks the `BEGIN PRIVATE KEY` PEM marker. This branch does not touch the connect proxy or settlement test paths.
