### PR TITLE
fix(api): make Docker orchestration safe for rolling deploys

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -35,7 +35,7 @@ import { createUploadsRouter, createUploadContentRouter } from "./routes/uploads
 import { createDocumentsRouter, createDocumentPreviewRouter } from "./routes/documents.ts";
 import { createAdminStorageDeletionRouter } from "./routes/admin-storage-deletion.ts";
 import { createSpaFallbackHandler } from "./routes/spa.ts";
-import healthRouter, { bootGate, markServerReady } from "./routes/health.ts";
+import healthRouter, { bootGate, markServerDraining, markServerReady } from "./routes/health.ts";
 import { createIntegrationsRouter } from "./routes/integrations.ts";
 import { createCredentialProxyRouter } from "./routes/credential-proxy.ts";
 import { createLlmProxyRouter } from "./routes/llm-proxy.ts";
@@ -279,7 +279,12 @@ function buildAppConfigScript(): string {
 
 // Graceful shutdown
 const shutdown = createShutdownHandler(() => {
+  markServerDraining();
   shuttingDown = true;
+});
+process.on("SIGURG", () => {
+  markServerDraining();
+  logger.info("Server draining: readiness disabled");
 });
 process.on("SIGINT", () => void shutdown());
 process.on("SIGTERM", () => void shutdown());

--- a/apps/api/src/openapi/paths/health.ts
+++ b/apps/api/src/openapi/paths/health.ts
@@ -16,7 +16,7 @@ export const healthPaths = {
               schema: {
                 type: "object",
                 properties: {
-                  status: { type: "string", enum: ["healthy", "degraded", "unhealthy"] },
+                  status: { type: "string", enum: ["healthy", "degraded"] },
                   version: {
                     type: "object",
                     properties: {
@@ -60,23 +60,71 @@ export const healthPaths = {
           },
         },
         "503": {
-          description: "Platform unhealthy (database or critical service down)",
+          description: "Platform unavailable while starting, draining, or unhealthy",
           content: {
             "application/json": {
               schema: {
-                type: "object",
-                properties: {
-                  status: { type: "string", enum: ["unhealthy"] },
-                  uptime_ms: { type: "number" },
-                  checks: { type: "object" },
-                },
+                oneOf: [
+                  {
+                    type: "object",
+                    properties: {
+                      status: { type: "string", enum: ["starting", "draining"] },
+                      version: {
+                        type: "object",
+                        properties: {
+                          app: { type: "string" },
+                          commit: { type: "string" },
+                        },
+                        required: ["app"],
+                      },
+                    },
+                    required: ["status", "version"],
+                  },
+                  {
+                    type: "object",
+                    properties: {
+                      status: { type: "string", enum: ["unhealthy"] },
+                      version: {
+                        type: "object",
+                        properties: {
+                          app: { type: "string" },
+                          commit: { type: "string" },
+                        },
+                        required: ["app"],
+                      },
+                      uptime_ms: { type: "number" },
+                      checks: { type: "object" },
+                    },
+                    required: ["status", "version", "uptime_ms", "checks"],
+                  },
+                ],
               },
-              example: {
-                status: "unhealthy",
-                uptime_ms: 3600000,
-                checks: {
-                  database: { status: "unhealthy", latency_ms: 5000 },
-                  agents: { status: "healthy" },
+              examples: {
+                starting: {
+                  summary: "Application boot is still in progress",
+                  value: {
+                    status: "starting",
+                    version: { app: "v1.0.0-beta.49", commit: "5bbe1d9" },
+                  },
+                },
+                draining: {
+                  summary: "Replica has withdrawn readiness before shutdown",
+                  value: {
+                    status: "draining",
+                    version: { app: "v1.0.0-beta.49", commit: "5bbe1d9" },
+                  },
+                },
+                unhealthy: {
+                  summary: "A critical platform dependency is unhealthy",
+                  value: {
+                    status: "unhealthy",
+                    version: { app: "v1.0.0-beta.49", commit: "5bbe1d9" },
+                    uptime_ms: 3600000,
+                    checks: {
+                      database: { status: "unhealthy", latency_ms: 5000 },
+                      agents: { status: "healthy" },
+                    },
+                  },
                 },
               },
             },

--- a/apps/api/src/openapi/paths/health.ts
+++ b/apps/api/src/openapi/paths/health.ts
@@ -16,7 +16,7 @@ export const healthPaths = {
               schema: {
                 type: "object",
                 properties: {
-                  status: { type: "string", enum: ["healthy", "degraded"] },
+                  status: { type: "string", enum: ["healthy", "degraded", "unhealthy"] },
                   version: {
                     type: "object",
                     properties: {

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -42,8 +42,8 @@ export function markServerDraining(): void {
   serverReadiness = "draining";
 }
 
-/** Test-only reset of the module-level readiness flag. */
-export function _resetServerReadyForTesting(): void {
+/** Test-only reset of the module-level readiness state. */
+export function _resetServerReadinessForTesting(): void {
   serverReadiness = "starting";
   agentsHealthy = false;
 }

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -11,7 +11,9 @@ const startedAt = Date.now();
 
 // ─── Readiness ───
 
-let serverReady = false;
+type ServerReadiness = "starting" | "ready" | "draining";
+
+let serverReadiness: ServerReadiness = "starting";
 
 /**
  * Flip the process to "ready". Called once from `index.ts` when
@@ -20,12 +22,26 @@ let serverReady = false;
  * this; see {@link bootGate}.
  */
 export function markServerReady(): void {
-  serverReady = true;
+  if (serverReadiness === "starting") serverReadiness = "ready";
+}
+
+/**
+ * Stop advertising this process as ready before its graceful shutdown starts.
+ *
+ * Rolling deploys trigger this with SIGURG, wait for load balancers to evict
+ * the replica, then send SIGTERM. SIGURG is deliberately used because its
+ * default action is to be ignored: the same hook is therefore safe during the
+ * first rollout from an older image which has no drain-signal handler. Normal
+ * application requests keep flowing during that propagation window so a proxy
+ * which still has the old backend cached does not receive an avoidable 503.
+ */
+export function markServerDraining(): void {
+  serverReadiness = "draining";
 }
 
 /** Test-only reset of the module-level readiness flag. */
 export function _resetServerReadyForTesting(): void {
-  serverReady = false;
+  serverReadiness = "starting";
 }
 
 /**
@@ -46,12 +62,13 @@ export function _resetServerReadyForTesting(): void {
  */
 export function bootGate(): MiddlewareHandler {
   return async (c, next) => {
-    if (serverReady) return next();
+    if (serverReadiness === "ready") return next();
     if (c.req.path === "/health") {
-      return c.json({ status: "starting", version: getVersionInfo() }, 503, {
+      return c.json({ status: serverReadiness, version: getVersionInfo() }, 503, {
         "Retry-After": "1",
       });
     }
+    if (serverReadiness === "draining") return next();
     throw new ApiError({
       status: 503,
       code: "starting",

--- a/apps/api/src/services/docker-cleanup.ts
+++ b/apps/api/src/services/docker-cleanup.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+interface ManagedContainerSummary {
+  Id: string;
+  State: string;
+}
+
+export async function removeTerminalManagedContainers(
+  containers: ManagedContainerSummary[],
+  removeContainer: (containerId: string) => Promise<void>,
+): Promise<number> {
+  const terminalContainers = containers.filter(
+    (container) => container.State === "exited" || container.State === "dead",
+  );
+  const results = await Promise.allSettled(
+    terminalContainers.map((container) => removeContainer(container.Id)),
+  );
+  return results.filter((result) => result.status === "fulfilled").length;
+}

--- a/apps/api/src/services/docker.ts
+++ b/apps/api/src/services/docker.ts
@@ -743,11 +743,22 @@ export async function cleanupOrphanedContainers(): Promise<{
   const containers = (await res.json()) as Array<{
     Id: string;
     Labels: Record<string, string>;
+    State: string;
   }>;
 
-  // Remove all containers in parallel (force=true handles running containers)
-  if (containers.length > 0) {
-    await Promise.allSettled(containers.map((c) => removeContainer(c.Id)));
+  // A second API replica can share this Docker daemon during a rolling deploy.
+  // Its managed containers are not orphans, even though this process did not
+  // create them. The stale-run sweep stops genuine orphans before reaching this
+  // generic cleanup, so only terminal containers are safe to reap here.
+  const terminalContainers = containers.filter(
+    (container) => container.State === "exited" || container.State === "dead",
+  );
+  let containerCount = 0;
+  if (terminalContainers.length > 0) {
+    const results = await Promise.allSettled(
+      terminalContainers.map((container) => removeContainer(container.Id)),
+    );
+    containerCount = results.filter((result) => result.status === "fulfilled").length;
   }
 
   // Clean up orphaned networks by listing Docker networks directly.
@@ -761,7 +772,7 @@ export async function cleanupOrphanedContainers(): Promise<{
   // Docker's "volume in use" check (409) doesn't refuse the delete.
   const volumeCount = await cleanupOrphanedVolumes();
 
-  return { containers: containers.length, networks: networkCount, volumes: volumeCount };
+  return { containers: containerCount, networks: networkCount, volumes: volumeCount };
 }
 
 /**

--- a/apps/api/src/services/docker.ts
+++ b/apps/api/src/services/docker.ts
@@ -2,6 +2,7 @@
 
 import { hostname } from "node:os";
 import { logger } from "../lib/logger.ts";
+import { removeTerminalManagedContainers } from "./docker-cleanup.ts";
 import { getEnv } from "@appstrate/env";
 import { classifyDockerNetworkError, createContainerWithImagePull } from "./docker-errors.ts";
 
@@ -750,16 +751,7 @@ export async function cleanupOrphanedContainers(): Promise<{
   // Its managed containers are not orphans, even though this process did not
   // create them. The stale-run sweep stops genuine orphans before reaching this
   // generic cleanup, so only terminal containers are safe to reap here.
-  const terminalContainers = containers.filter(
-    (container) => container.State === "exited" || container.State === "dead",
-  );
-  let containerCount = 0;
-  if (terminalContainers.length > 0) {
-    const results = await Promise.allSettled(
-      terminalContainers.map((container) => removeContainer(container.Id)),
-    );
-    containerCount = results.filter((result) => result.status === "fulfilled").length;
-  }
+  const containerCount = await removeTerminalManagedContainers(containers, removeContainer);
 
   // Clean up orphaned networks by listing Docker networks directly.
   // This catches networks that leaked when containers were already removed

--- a/apps/api/src/services/orchestrator/docker-orchestrator.ts
+++ b/apps/api/src/services/orchestrator/docker-orchestrator.ts
@@ -19,6 +19,7 @@ import { getErrorMessage } from "@appstrate/core/errors";
 import { SIDECAR_MEMORY_BYTES, SIDECAR_NANO_CPUS } from "./constants.ts";
 import { buildBaseSidecarEnv } from "./sidecar-env.ts";
 import { SidecarExitWatcher } from "./sidecar-exit-watcher.ts";
+import { resolveDockerPlatformApiUrl } from "./platform-api-url.ts";
 
 class DockerWorkloadHandle implements WorkloadHandle {
   constructor(
@@ -458,15 +459,17 @@ export class DockerOrchestrator implements RunOrchestrator {
 
   /**
    * Resolve the base URL the agent container uses to reach the platform API.
-   * Identical logic to {@link createSidecar} — prefer the platform's own
-   * Docker network (keeps traffic on the bridge), fall back to
-   * `PLATFORM_API_URL` env, finally to `host.docker.internal` for local dev.
+   * A configured URL is a stable service address and must win during rolling
+   * deploys, where Docker network inspection may otherwise discover one
+   * short-lived replica alias. Without one, prefer the platform's own Docker
+   * network, then fall back to `host.docker.internal` for local development.
    */
   async resolvePlatformApiUrl(): Promise<string> {
     const env = getEnv();
-    const platformNetwork = await docker.detectPlatformNetwork();
-    if (platformNetwork) return `http://${platformNetwork.hostname}:${env.PORT}`;
-    if (env.PLATFORM_API_URL) return env.PLATFORM_API_URL;
-    return `http://host.docker.internal:${env.PORT}`;
+    return resolveDockerPlatformApiUrl({
+      configuredUrl: env.PLATFORM_API_URL,
+      port: env.PORT,
+      detectPlatformNetwork: docker.detectPlatformNetwork,
+    });
   }
 }

--- a/apps/api/src/services/orchestrator/platform-api-url.ts
+++ b/apps/api/src/services/orchestrator/platform-api-url.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+interface PlatformNetwork {
+  hostname: string;
+}
+
+export async function resolveDockerPlatformApiUrl(options: {
+  configuredUrl?: string;
+  port: number;
+  detectPlatformNetwork: () => Promise<PlatformNetwork | null>;
+}): Promise<string> {
+  if (options.configuredUrl) return options.configuredUrl;
+
+  const platformNetwork = await options.detectPlatformNetwork();
+  if (platformNetwork) return `http://${platformNetwork.hostname}:${options.port}`;
+  return `http://host.docker.internal:${options.port}`;
+}

--- a/apps/api/test/integration/middleware/boot-gate.test.ts
+++ b/apps/api/test/integration/middleware/boot-gate.test.ts
@@ -17,6 +17,8 @@
  *     handler — routes must never run before their dependencies exist.
  *   - Once `markServerReady()` fires, the gate is transparent: requests reach
  *     the real handlers, `/health` runs its real checks.
+ *   - Once `markServerDraining()` fires, `/health` returns 503 while normal
+ *     requests keep flowing until the process receives its shutdown signal.
  *
  * The gate is mounted before EVERY other middleware except request-id /
  * telemetry / client-ip / CORS / body-limit, so this test mounts it the same
@@ -27,6 +29,7 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { Hono } from "hono";
 import healthRouter, {
   bootGate,
+  markServerDraining,
   markServerReady,
   _resetServerReadyForTesting,
 } from "../../../src/routes/health.ts";
@@ -137,5 +140,34 @@ describe("boot gate", () => {
     expect(body.status).not.toBe("starting");
     expect(body.checks).toBeDefined();
     expect(typeof body.uptime_ms).toBe("number");
+  });
+
+  // ─── During a rolling-deploy drain ─────────────────────────────
+
+  it("withdraws readiness without rejecting normal requests", async () => {
+    const app = buildGatedApp();
+    markServerReady();
+    markServerDraining();
+
+    const health = await app.request("/health");
+    expect(health.status).toBe(503);
+    expect(health.headers.get("Retry-After")).toBe("1");
+    expect(await health.json()).toMatchObject({ status: "draining" });
+
+    // The load balancer may need one health-check interval to observe the
+    // transition. Requests routed during that window must still complete.
+    const request = await app.request("/api/agents");
+    expect(request.status).toBe(200);
+    expect(await request.json()).toEqual({ data: [] });
+  });
+
+  it("does not become ready again if boot finishes after draining starts", async () => {
+    const app = buildGatedApp();
+    markServerDraining();
+    markServerReady();
+
+    const health = await app.request("/health");
+    expect(health.status).toBe(503);
+    expect(await health.json()).toMatchObject({ status: "draining" });
   });
 });

--- a/apps/api/test/integration/middleware/boot-gate.test.ts
+++ b/apps/api/test/integration/middleware/boot-gate.test.ts
@@ -31,7 +31,7 @@ import healthRouter, {
   bootGate,
   markServerDraining,
   markServerReady,
-  _resetServerReadyForTesting,
+  _resetServerReadinessForTesting,
 } from "../../../src/routes/health.ts";
 import { errorHandler } from "../../../src/middleware/error-handler.ts";
 import type { AppEnv } from "../../../src/types/index.ts";
@@ -49,12 +49,12 @@ function buildGatedApp(): Hono<AppEnv> {
 
 describe("boot gate", () => {
   beforeEach(() => {
-    _resetServerReadyForTesting();
+    _resetServerReadinessForTesting();
   });
 
   afterEach(() => {
     // Never leave the module-level flag flipped for other suites.
-    _resetServerReadyForTesting();
+    _resetServerReadinessForTesting();
   });
 
   // ─── While starting ────────────────────────────────────

--- a/apps/api/test/integration/services/docker-api.test.ts
+++ b/apps/api/test/integration/services/docker-api.test.ts
@@ -490,13 +490,13 @@ describeRequiresDocker("removeNetwork", () => {
 
 describeRequiresDocker("cleanupOrphanedContainers", () => {
   it(
-    "cleans up labeled containers and networks",
+    "removes terminal managed containers without touching a live replica's containers",
     async () => {
-      // Create containers with the managed label
-      const id1 = await createRawContainer(["sleep", "60"]);
-      const id2 = await createRawContainer(["sleep", "60"]);
-      await startContainer(id1);
-      await startContainer(id2);
+      const liveId = await createRawContainer(["sleep", "60"]);
+      const terminalId = await createRawContainer(["sleep", "60"]);
+      await startContainer(liveId);
+      await startContainer(terminalId);
+      await stopContainer(terminalId);
 
       // Create a network with matching name pattern
       const netName = `appstrate-exec-test-${uid()}`;
@@ -505,21 +505,19 @@ describeRequiresDocker("cleanupOrphanedContainers", () => {
 
       const result = await cleanupOrphanedContainers();
 
-      // Should have removed at least our 2 containers
-      expect(result.containers).toBeGreaterThanOrEqual(2);
+      expect(result.containers).toBeGreaterThanOrEqual(1);
 
-      // Verify containers are gone
-      const res1 = await fetch(`${DOCKER_URL}/containers/${id1}/json`);
-      expect(res1.status).toBe(404);
-      const res2 = await fetch(`${DOCKER_URL}/containers/${id2}/json`);
-      expect(res2.status).toBe(404);
+      const liveRes = await fetch(`${DOCKER_URL}/containers/${liveId}/json`);
+      expect(liveRes.status).toBe(200);
+      const terminalRes = await fetch(`${DOCKER_URL}/containers/${terminalId}/json`);
+      expect(terminalRes.status).toBe(404);
+      untrackContainer(terminalId);
 
       // Verify network was cleaned up (name starts with appstrate-exec-)
       const netRes = await fetch(`${DOCKER_URL}/networks/${netId}`);
       expect(netRes.status).toBe(404);
 
-      // Clear cleanup tracking since cleanupOrphanedContainers handled removal
-      containersToCleanup.length = 0;
+      // The live container remains tracked for afterEach cleanup.
     },
     TIMEOUT,
   );

--- a/apps/api/test/unit/openapi-health-readiness.test.ts
+++ b/apps/api/test/unit/openapi-health-readiness.test.ts
@@ -5,10 +5,12 @@ import { healthPaths } from "../../src/openapi/paths/health.ts";
 
 describe("health OpenAPI readiness contract", () => {
   it("documents every 503 state emitted by the health route and boot gate", () => {
+    const okSchema = healthPaths["/health"].get.responses["200"].content["application/json"].schema;
     const schema = healthPaths["/health"].get.responses["503"].content["application/json"].schema;
     const variants = schema.oneOf;
     const statuses = variants.flatMap((variant) => variant.properties.status.enum);
 
+    expect(okSchema.properties.status.enum).toEqual(["healthy", "degraded", "unhealthy"]);
     expect(statuses.sort()).toEqual(["draining", "starting", "unhealthy"]);
     expect(variants[0]?.required).toEqual(["status", "version"]);
     expect(variants[1]?.required).toEqual(["status", "version", "uptime_ms", "checks"]);

--- a/apps/api/test/unit/openapi-health-readiness.test.ts
+++ b/apps/api/test/unit/openapi-health-readiness.test.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "bun:test";
+import { healthPaths } from "../../src/openapi/paths/health.ts";
+
+describe("health OpenAPI readiness contract", () => {
+  it("documents every 503 state emitted by the health route and boot gate", () => {
+    const schema = healthPaths["/health"].get.responses["503"].content["application/json"].schema;
+    const variants = schema.oneOf;
+    const statuses = variants.flatMap((variant) => variant.properties.status.enum);
+
+    expect(statuses.sort()).toEqual(["draining", "starting", "unhealthy"]);
+    expect(variants[0]?.required).toEqual(["status", "version"]);
+    expect(variants[1]?.required).toEqual(["status", "version", "uptime_ms", "checks"]);
+  });
+});

--- a/apps/api/test/unit/services/docker-cleanup.test.ts
+++ b/apps/api/test/unit/services/docker-cleanup.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "bun:test";
+import { removeTerminalManagedContainers } from "../../../src/services/docker-cleanup.ts";
+
+describe("removeTerminalManagedContainers", () => {
+  it("removes only exited and dead containers", async () => {
+    const removed: string[] = [];
+    const count = await removeTerminalManagedContainers(
+      [
+        { Id: "running", State: "running" },
+        { Id: "restarting", State: "restarting" },
+        { Id: "paused", State: "paused" },
+        { Id: "created", State: "created" },
+        { Id: "exited", State: "exited" },
+        { Id: "dead", State: "dead" },
+      ],
+      async (containerId) => {
+        removed.push(containerId);
+      },
+    );
+
+    expect(removed).toEqual(["exited", "dead"]);
+    expect(count).toBe(2);
+  });
+
+  it("counts only successful removals", async () => {
+    const count = await removeTerminalManagedContainers(
+      [
+        { Id: "removed", State: "exited" },
+        { Id: "failed", State: "dead" },
+      ],
+      async (containerId) => {
+        if (containerId === "failed") throw new Error("Docker refused removal");
+      },
+    );
+
+    expect(count).toBe(1);
+  });
+});

--- a/apps/api/test/unit/services/docker-orchestrator-platform-url.test.ts
+++ b/apps/api/test/unit/services/docker-orchestrator-platform-url.test.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "bun:test";
+import { resolveDockerPlatformApiUrl } from "../../../src/services/orchestrator/platform-api-url.ts";
+
+describe("DockerOrchestrator platform API URL", () => {
+  it("uses the configured stable service URL without requiring Docker discovery", async () => {
+    let discoveryCalls = 0;
+    const result = await resolveDockerPlatformApiUrl({
+      configuredUrl: "http://appstrate:3000",
+      port: 3000,
+      detectPlatformNetwork: async () => {
+        discoveryCalls += 1;
+        return { hostname: "ephemeral-replica" };
+      },
+    });
+
+    expect(result).toBe("http://appstrate:3000");
+    expect(discoveryCalls).toBe(0);
+  });
+
+  it("uses Docker discovery when no stable URL is configured", async () => {
+    await expect(
+      resolveDockerPlatformApiUrl({
+        port: 3000,
+        detectPlatformNetwork: async () => ({ hostname: "appstrate-1" }),
+      }),
+    ).resolves.toBe("http://appstrate-1:3000");
+  });
+
+  it("falls back to the host bridge when Docker discovery finds no platform", async () => {
+    await expect(
+      resolveDockerPlatformApiUrl({
+        port: 3000,
+        detectPlatformNetwork: async () => null,
+      }),
+    ).resolves.toBe("http://host.docker.internal:3000");
+  });
+});

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -20328,7 +20328,7 @@ export interface operations {
                      */
                     "application/json": {
                         /** @enum {string} */
-                        status?: "healthy" | "degraded" | "unhealthy";
+                        status?: "healthy" | "degraded";
                         version?: {
                             app: string;
                             commit?: string;
@@ -20349,32 +20349,28 @@ export interface operations {
                     };
                 };
             };
-            /** @description Platform unhealthy (database or critical service down) */
+            /** @description Platform unavailable while starting, draining, or unhealthy */
             503: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    /**
-                     * @example {
-                     *       "status": "unhealthy",
-                     *       "uptime_ms": 3600000,
-                     *       "checks": {
-                     *         "database": {
-                     *           "status": "unhealthy",
-                     *           "latency_ms": 5000
-                     *         },
-                     *         "agents": {
-                     *           "status": "healthy"
-                     *         }
-                     *       }
-                     *     }
-                     */
                     "application/json": {
                         /** @enum {string} */
-                        status?: "unhealthy";
-                        uptime_ms?: number;
-                        checks?: Record<string, never>;
+                        status: "starting" | "draining";
+                        version: {
+                            app: string;
+                            commit?: string;
+                        };
+                    } | {
+                        /** @enum {string} */
+                        status: "unhealthy";
+                        version: {
+                            app: string;
+                            commit?: string;
+                        };
+                        uptime_ms: number;
+                        checks: Record<string, never>;
                     };
                 };
             };

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -20328,7 +20328,7 @@ export interface operations {
                      */
                     "application/json": {
                         /** @enum {string} */
-                        status?: "healthy" | "degraded";
+                        status?: "healthy" | "degraded" | "unhealthy";
                         version?: {
                             app: string;
                             commit?: string;


### PR DESCRIPTION
## Summary

- preserve running managed containers during boot cleanup so a new API replica cannot remove workloads owned by the live replica
- keep reaping terminal containers after stale runs are stopped
- prefer the configured stable `PLATFORM_API_URL` before ephemeral Docker replica discovery
- expose a monotonic `starting -> ready -> draining` readiness lifecycle
- withdraw `/health` with `SIGURG` before graceful shutdown while continuing requests already routed during load-balancer propagation
- document all emitted readiness states in OpenAPI without breaking the existing 200-response enum, and regenerate the web API types
- add unit, integration, container, and rolling-deployment regression coverage

## Why

A Compose rolling deployment temporarily runs two API replicas against the same Docker daemon. The previous generic orphan sweep force-removed every managed container, including workloads still served by the old replica. Sidecars could also bind to a short-lived container alias instead of the stable Compose service name.

The old replica must also leave the proxy healthy set before it receives `SIGTERM`. `SIGURG` is used for that explicit drain transition because older Linux images ignore it by default, which keeps the first rollout backward compatible.

## Validation

- cleanup and platform URL unit regressions: 11 passed
- Docker cleanup integration regressions: 3 passed
- health/readiness/OpenAPI targeted suites: 18 passed
- OpenAPI structural validation and generated API type verification passed
- breaking-change detection: 0 breaking changes
- production platform container E2E: healthy orchestrator reports Docker healthy; unavailable orchestrator reports Docker unhealthy
- rolling E2E under continuous load: no request errors, maximum 2 application replicas
- deliberately unhealthy replacement rejected; previous healthy replica remained active
