### PR TITLE
fix(health): report agent runtime readiness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,12 @@ jobs:
             --coverage-dir=coverage-public-origin \
             apps/api/src/modules/oidc/test/integration/routes/oauth-public-origin.test.ts
 
+      # The full integration suite is opt-in on PRs, but readiness is a release
+      # invariant: a booted platform must not silently ship as degraded. Keep
+      # this public-endpoint regression mandatory and fast on every PR.
+      - name: Run health readiness regression
+        run: bun test apps/api/test/integration/middleware/boot-gate.test.ts
+
       # Surface the figure in the job summary so humans see it without opening
       # Codecov. Sums LF/LH across the lcov report; informational only (the gate
       # is Codecov). Flagged as partial because it omits the integration suite.

--- a/Dockerfile
+++ b/Dockerfile
@@ -159,7 +159,7 @@ ENV APP_VERSION=${APP_VERSION}
 ENV GIT_SHA=${GIT_SHA}
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
-  CMD wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1
+  CMD bun -e "const r=await fetch('http://127.0.0.1:3000/health');const b=await r.json();process.exit(r.ok&&b.status==='healthy'?0:1)"
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["bun", "apps/api/src/index.ts"]

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -435,8 +435,8 @@ logger.info("Server listening (starting up)", { port: env.PORT });
 // missing durable recovery channel can lose billable spend permanently.
 const bootStartedAt = Date.now();
 void bootBackground()
-  .then(() => {
-    markServerReady();
+  .then(({ agentsHealthy }) => {
+    markServerReady({ agentsHealthy });
     logger.info("Server ready", { port: env.PORT, startupMs: Date.now() - bootStartedAt });
     // Fire-and-forget reachability probe for USERCONTENT_URL (issue #1001).
     // Never awaited, never fatal; runs after readiness so it can't race the

--- a/apps/api/src/lib/boot.ts
+++ b/apps/api/src/lib/boot.ts
@@ -235,7 +235,7 @@ export async function bootCritical(): Promise<void> {
  * A rejection here is fatal exactly as it was when this code lived in a
  * blocking `await boot()`: the caller in `index.ts` exits the process.
  */
-export async function bootBackground(): Promise<void> {
+export async function bootBackground(): Promise<{ agentsHealthy: boolean }> {
   const env = (await import("@appstrate/env")).getEnv();
 
   // Reconcile the loaded system packages into the DB + S3.
@@ -344,17 +344,23 @@ export async function bootBackground(): Promise<void> {
   await initCancelSubscriber();
 
   // Parallel init: orchestrator, scheduler, and DB cleanups are all independent
+  let agentsHealthy = false;
   const parallelInits: Promise<void>[] = [
     // Billing correctness barrier: unlike ancillary workers, this init is not
     // caught/degraded. Boot must fail if the durable metering recovery channel
     // is unavailable; otherwise a transient ledger write failure after
     // provider spend could be lost permanently.
     initLlmUsageRetryWorker(),
-    orchestrator.initialize().catch((err) => {
-      logger.warn("Could not initialize container orchestrator", {
-        error: getErrorMessage(err),
-      });
-    }),
+    orchestrator
+      .initialize()
+      .then(() => {
+        agentsHealthy = true;
+      })
+      .catch((err) => {
+        logger.warn("Could not initialize container orchestrator", {
+          error: getErrorMessage(err),
+        });
+      }),
     initScheduleWorker().catch((err) => {
       logger.warn("Could not initialize schedule worker", {
         error: getErrorMessage(err),
@@ -442,6 +448,8 @@ export async function bootBackground(): Promise<void> {
   // immediately, then polls for due jobs. Purges S3/FS objects whose DB rows
   // were deleted (documents, uploads, run workspaces, org/app/end-user cascades).
   startStorageDeletionWorker();
+
+  return { agentsHealthy };
 }
 
 /**

--- a/apps/api/src/openapi/paths/health.ts
+++ b/apps/api/src/openapi/paths/health.ts
@@ -38,6 +38,7 @@ export const healthPaths = {
                       },
                       agents: {
                         type: "object",
+                        description: "Agent runtime readiness established during platform boot.",
                         properties: {
                           status: { type: "string", enum: ["healthy", "degraded"] },
                         },

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -3,7 +3,6 @@
 import { Hono, type MiddlewareHandler } from "hono";
 import { sql } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
-import { getSystemPackagesByType } from "../services/system-packages.ts";
 import { getVersionInfo } from "../lib/version.ts";
 import { ApiError } from "../lib/errors.ts";
 
@@ -12,20 +11,25 @@ const startedAt = Date.now();
 // ─── Readiness ───
 
 let serverReady = false;
+let agentsHealthy = false;
 
 /**
  * Flip the process to "ready". Called once from `index.ts` when
  * `bootBackground()` resolves — i.e. when orphan cleanup, the system-package
- * DB sync and every worker are done. The port is already bound well before
+ * DB sync and every worker are done. Recoverable boot failures are carried in
+ * `readiness` so `/health` can report a degraded component without keeping the
+ * whole API behind the starting gate. The port is already bound well before
  * this; see {@link bootGate}.
  */
-export function markServerReady(): void {
+export function markServerReady(readiness: { agentsHealthy: boolean }): void {
+  agentsHealthy = readiness.agentsHealthy;
   serverReady = true;
 }
 
 /** Test-only reset of the module-level readiness flag. */
 export function _resetServerReadyForTesting(): void {
   serverReady = false;
+  agentsHealthy = false;
 }
 
 /**
@@ -78,10 +82,11 @@ healthRouter.get("/health", async (c) => {
     checks.database = { status: "unhealthy", latency_ms: Date.now() - dbStart };
   }
 
-  // System packages check
-  const systemAgentCount = getSystemPackagesByType("agent").length;
+  // Agent execution readiness comes from the orchestrator's boot handshake.
+  // System packages are optional catalogue entries and say nothing about
+  // whether the platform can launch a run.
   checks.agents = {
-    status: systemAgentCount > 0 ? "healthy" : "degraded",
+    status: agentsHealthy ? "healthy" : "degraded",
   };
 
   const hasUnhealthy = Object.values(checks).some((c) => c.status === "unhealthy");

--- a/apps/api/test/integration/middleware/boot-gate.test.ts
+++ b/apps/api/test/integration/middleware/boot-gate.test.ts
@@ -110,7 +110,7 @@ describe("boot gate", () => {
     // registered after the bind.
     expect((await app.request("/api/agents")).status).toBe(503);
 
-    markServerReady();
+    markServerReady({ agentsHealthy: true });
 
     const res = await app.request("/api/agents");
     expect(res.status).toBe(200);
@@ -121,21 +121,35 @@ describe("boot gate", () => {
     expect(await spa.text()).toContain("<html>");
   });
 
-  it("hands /health back to the real handler once ready", async () => {
+  it("reports healthy once boot and the agents orchestrator are ready", async () => {
     const app = buildGatedApp();
-    markServerReady();
+    markServerReady({ agentsHealthy: true });
 
     const res = await app.request("/health");
 
-    // The real handler ran: it reports uptime + per-dependency checks, and no
-    // longer carries the `starting` marker.
     const body = (await res.json()) as {
       status: string;
       uptime_ms?: number;
-      checks?: Record<string, unknown>;
+      checks?: { agents?: { status?: string } };
     };
-    expect(body.status).not.toBe("starting");
-    expect(body.checks).toBeDefined();
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("healthy");
+    expect(body.checks?.agents?.status).toBe("healthy");
     expect(typeof body.uptime_ms).toBe("number");
+  });
+
+  it("reports degraded when boot completes without the agents orchestrator", async () => {
+    const app = buildGatedApp();
+    markServerReady({ agentsHealthy: false });
+
+    const res = await app.request("/health");
+    const body = (await res.json()) as {
+      status: string;
+      checks?: { agents?: { status?: string } };
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.status).toBe("degraded");
+    expect(body.checks?.agents?.status).toBe("degraded");
   });
 });

--- a/apps/api/test/integration/routes/health.test.ts
+++ b/apps/api/test/integration/routes/health.test.ts
@@ -11,12 +11,14 @@ describe("GET /health", () => {
     await truncateAll();
   });
 
-  it("returns 200 with healthy or degraded status", async () => {
+  it("returns degraded when the test app bypasses boot", async () => {
     const res = await app.request("/health");
     expect(res.status).toBe(200);
     const body = (await res.json()) as any;
-    // Without boot(), system packages aren't loaded → "degraded" is expected
-    expect(body.status).toBe("degraded"); // Without boot(), no system packages → degraded
+    // getTestApp() deliberately skips boot, so the agents orchestrator was
+    // never initialized and the real handler must report that degradation.
+    expect(body.status).toBe("degraded");
+    expect(body.checks.agents.status).toBe("degraded");
     expect(body.checks.database.status).toBe("healthy");
     expect(body.uptime_ms).toBeGreaterThanOrEqual(0);
   });

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -20340,6 +20340,7 @@ export interface operations {
                                 status?: "healthy" | "unhealthy";
                                 latency_ms?: number;
                             };
+                            /** @description Agent runtime readiness established during platform boot. */
                             agents?: {
                                 /** @enum {string} */
                                 status?: "healthy" | "degraded";


### PR DESCRIPTION
## Summary

- derive `checks.agents` from the real orchestrator boot handshake instead of the presence of obsolete system-agent packages
- keep recoverable orchestrator initialization failures visible as `degraded` while successful boot reports `healthy`
- make the readiness regression mandatory on every PR and make Docker's `HEALTHCHECK` validate `/health` semantically
- document the agent-runtime readiness contract in OpenAPI and regenerate the client type

## Root cause

The 66 shipped system packages contain integrations and an MCP server, but no package of type `agent`. `/health` therefore reported `agents: degraded` on every healthy instance even when the orchestrator initialized and runs succeeded.

## Validation

- TDD regression: observed `Expected: healthy / Received: degraded` before the fix
- `TEST_TIER=0 TMPDIR=/private/tmp bun test apps/api/test/integration/middleware/boot-gate.test.ts apps/api/test/integration/routes/health.test.ts` — 15 pass
- related health/OpenAPI route suites — 95 pass
- `docker build --check .` — no warnings
- `TEST_TIER=0 TMPDIR=/private/tmp bun run check` — 33/33 tasks
- full API integration suite — 2313 pass, 81 skip, 1 unrelated timing-sensitive `llm_usage` retry timeout; the affected file passes 15/15 when rerun in isolation
