### PR TITLE
test(health): gate production container readiness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -188,6 +188,24 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  platform-container-e2e:
+    name: Platform container health e2e
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Bun
+        uses: ./.github/actions/bun-setup
+
+      # Build the production Dockerfile, boot the production compose topology,
+      # and verify both sides of the public readiness contract. This stays
+      # mandatory on every PR: the fast route regression above cannot prove
+      # that Compose still inherits the image's semantic HEALTHCHECK.
+      - name: Run platform container health e2e
+        run: bash scripts/health-container-e2e.sh
+
   runtime-e2e:
     name: Runtime container e2e
     # The runtime-pi document-provisioning spin only reproduces in the BUNDLED

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -400,12 +400,8 @@ services:
       # because the switch requires a platform build whose Docker client can
       # target a TCP `DOCKER_HOST` (see residual note on the proxy service).
       - /var/run/docker.sock:/var/run/docker.sock:ro
-    healthcheck:
-      test: ["CMD-SHELL", "wget -q -O /dev/null http://127.0.0.1:3000/ || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 15s
+    # Intentionally inherit the image's /health readiness probe. A Compose-level
+    # probe on `/` would mask a degraded agent runtime as container-healthy.
     depends_on:
       appstrate-postgres:
         condition: service_healthy

--- a/scripts/health-container-e2e.sh
+++ b/scripts/health-container-e2e.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# End-to-end contract for the production platform image and compose topology.
+#
+# Public seams only:
+#   - GET /health from the built image
+#   - Docker's health state for that running container
+#
+# The positive instance uses the real Docker socket and must be healthy. The
+# negative instance points the same image at a missing socket; boot completes
+# in degraded mode and the image healthcheck must mark the container unhealthy.
+
+set -euo pipefail
+
+readonly E2E_IMAGE="${HEALTH_E2E_IMAGE:-appstrate-health-e2e:local}"
+readonly E2E_PROJECT="${HEALTH_E2E_PROJECT:-appstrate-health-e2e}"
+readonly E2E_PORT="${HEALTH_E2E_PORT:-3317}"
+readonly COMPOSE_FILE="test/setup/docker-compose.health-e2e.yml"
+
+export HEALTH_E2E_IMAGE="$E2E_IMAGE"
+export POSTGRES_USER=e2e
+export POSTGRES_PASSWORD=e2e-postgres-password
+export MINIO_ROOT_USER=e2e-minio
+export MINIO_ROOT_PASSWORD=e2e-minio-password
+export BETTER_AUTH_SECRET=e2e-auth-secret-that-is-at-least-32-characters
+export CONNECTION_ENCRYPTION_KEY=Y2FzgQmlgIRocYT1VUWM+73fQ5zOTPB8sHJxTh1x4qI=
+export UPLOAD_SIGNING_SECRET=e2e-upload-signing-secret
+export RUN_TOKEN_SECRET=e2e-run-token-secret
+export CONNECT_SESSION_SECRET=e2e-connect-session-secret
+export APP_URL="http://127.0.0.1:${E2E_PORT}"
+export PORT="$E2E_PORT"
+
+compose() {
+  docker compose \
+    --project-name "$E2E_PROJECT" \
+    -f docker-compose.yml \
+    -f "$COMPOSE_FILE" \
+    "$@"
+}
+
+cleanup() {
+  compose down --volumes --remove-orphans >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+wait_for_health_body() {
+  local expected="$1"
+  local body=""
+  for _ in $(seq 1 90); do
+    body=$(curl -fsS "http://127.0.0.1:${E2E_PORT}/health" 2>/dev/null || true)
+    if jq -e --arg expected "$expected" '.status == $expected' <<<"$body" >/dev/null 2>&1; then
+      printf '%s' "$body"
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for /health status=$expected; last body: $body" >&2
+  compose logs --no-color appstrate >&2 || true
+  return 1
+}
+
+wait_for_docker_health() {
+  local container_id="$1"
+  local expected="$2"
+  local actual=""
+  for _ in $(seq 1 120); do
+    actual=$(docker inspect "$container_id" --format '{{.State.Health.Status}}')
+    if [ "$actual" = "$expected" ]; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "Timed out waiting for Docker health=$expected; actual=$actual" >&2
+  docker inspect "$container_id" --format '{{json .State.Health}}' >&2
+  return 1
+}
+
+cleanup
+
+if [ "${HEALTH_E2E_SKIP_BUILD:-0}" != "1" ]; then
+  docker build \
+    --build-arg APP_VERSION=health-container-e2e \
+    --build-arg "GIT_SHA=$(git rev-parse HEAD)" \
+    -t "$E2E_IMAGE" \
+    .
+fi
+
+health_config=$(docker image inspect "$E2E_IMAGE" --format '{{json .Config.Healthcheck}}')
+bun -e '
+  const health = JSON.parse(Bun.argv[1]);
+  const command = health.Test?.join(" ") ?? "";
+  if (
+    !command.includes("/health") ||
+    !command.includes("status===\x27healthy\x27") ||
+    health.Interval !== 30_000_000_000 ||
+    health.Timeout !== 10_000_000_000 ||
+    health.StartPeriod !== 15_000_000_000 ||
+    health.Retries !== 3
+  ) {
+    throw new Error("Unexpected image healthcheck: " + JSON.stringify(health));
+  }
+' "$health_config"
+
+echo "==> Healthy orchestrator"
+export HEALTH_E2E_DOCKER_SOCKET=/var/run/docker.sock
+compose up -d appstrate
+positive_body=$(wait_for_health_body healthy)
+jq -e '
+  .status == "healthy" and
+  .checks.database.status == "healthy" and
+  .checks.agents.status == "healthy"
+' <<<"$positive_body" >/dev/null
+positive_id=$(compose ps -q appstrate)
+wait_for_docker_health "$positive_id" healthy
+echo "$positive_body" | jq -c '{status, checks}'
+echo "docker_health=healthy"
+
+compose down --volumes --remove-orphans >/dev/null
+
+echo "==> Unavailable orchestrator"
+export HEALTH_E2E_DOCKER_SOCKET=/tmp/appstrate-health-e2e-missing.sock
+compose up -d appstrate
+negative_body=$(wait_for_health_body degraded)
+jq -e '
+  .status == "degraded" and
+  .checks.database.status == "healthy" and
+  .checks.agents.status == "degraded"
+' <<<"$negative_body" >/dev/null
+negative_id=$(compose ps -q appstrate)
+
+# Docker runs health probes every five seconds during start-period. The old
+# compose-level `wget /` override therefore turned healthy almost immediately,
+# even while the public health contract said degraded. Fail fast on that exact
+# regression before waiting for the image's three post-start failures.
+sleep 7
+early_health=$(docker inspect "$negative_id" --format '{{.State.Health.Status}}')
+if [ "$early_health" = "healthy" ]; then
+  echo "Docker reported healthy while GET /health reported degraded" >&2
+  docker inspect "$negative_id" --format '{{json .Config.Healthcheck}}' >&2
+  exit 1
+fi
+
+wait_for_docker_health "$negative_id" unhealthy
+compose logs --no-color appstrate | grep -q 'Could not initialize container orchestrator'
+echo "$negative_body" | jq -c '{status, checks}'
+echo "docker_health=unhealthy"
+
+echo "Platform container health E2E passed"

--- a/test/setup/docker-compose.health-e2e.yml
+++ b/test/setup/docker-compose.health-e2e.yml
@@ -1,0 +1,26 @@
+services:
+  # Reuse the platform image as a local, already-present stand-in for the two
+  # images the Docker orchestrator verifies at boot. These one-shot services
+  # inherit `entrypoint: ["true"]` from the production compose file.
+  appstrate-pi:
+    image: "${HEALTH_E2E_IMAGE:-appstrate-health-e2e:local}"
+
+  appstrate-sidecar:
+    image: "${HEALTH_E2E_IMAGE:-appstrate-health-e2e:local}"
+
+  appstrate:
+    image: "${HEALTH_E2E_IMAGE:-appstrate-health-e2e:local}"
+    environment:
+      DOCKER_SOCKET: "${HEALTH_E2E_DOCKER_SOCKET:-/var/run/docker.sock}"
+      PI_IMAGE: "${HEALTH_E2E_IMAGE:-appstrate-health-e2e:local}"
+      SIDECAR_IMAGE: "${HEALTH_E2E_IMAGE:-appstrate-health-e2e:local}"
+      MODULES: oidc,webhooks,mcp,core-providers,@appstrate/module-chat
+      S3_BUCKET: appstrate
+      S3_REGION: us-east-1
+      S3_ENDPOINT: http://appstrate-minio:9000
+      AWS_ACCESS_KEY_ID: e2e-minio
+      AWS_SECRET_ACCESS_KEY: e2e-minio-password
+      SYSTEM_PROVIDER_KEYS: "[]"
+      SYSTEM_PROXIES: "[]"
+      SYSTEM_INTEGRATIONS: "[]"
+      LOG_LEVEL: warn


### PR DESCRIPTION
## Summary

- let the production Compose service inherit the semantic `/health` probe from the platform image
- add a reproducible container E2E that builds the root Dockerfile and boots the production Compose topology
- verify both readiness outcomes: working Docker orchestrator → API/container healthy; unavailable orchestrator → API degraded/container unhealthy
- run this container E2E on every PR and push to `main`

## Why

#1095 corrected the API readiness signal, but `docker-compose.yml` still overrode the image healthcheck with `wget /`. That could classify a container as healthy while `GET /health` correctly reported a degraded agent runtime. Keeping the Dockerfile as the single probe source removes that drift.

## Evidence

- red: before removing the Compose override, the new E2E failed with `Docker reported healthy while GET /health reported degraded` and showed the effective `wget /` probe
- green on exact head `aa4da44929afd1f66f4af4a5b239977fefec3f7a`: image `sha256:d50b4e008f384a732fcf27c4ee825ea6c156277e99670ed4d8fac743e70bd9c1`
  - orchestrator available: `GET /health` = `healthy`, Docker = `healthy`
  - orchestrator unavailable: `GET /health` = `degraded`, Docker = `unhealthy` after the Dockerfile retry schedule
- `TEST_TIER=0 TMPDIR=/private/tmp bun run check` — 33/33 tasks
- focused health suites — 15/15 tests
- `shellcheck scripts/health-container-e2e.sh`
- `actionlint .github/workflows/test.yml`
- merged Compose config assertion: no service-level healthcheck override
