### PR TITLE
fix(models): derive generation capabilities from LiteLLM

### DIFF
--- a/.github/workflows/refresh-pricing-catalog.yml
+++ b/.github/workflows/refresh-pricing-catalog.yml
@@ -96,7 +96,14 @@ jobs:
             --volume "$catalog_input:/catalog.json:ro" \
             "$image" /exporter.py /catalog.json > "$output"
 
-          jq --exit-status 'type == "object" and length > 0' "$output" >/dev/null
+          jq --exit-status '
+            type == "object" and length > 0 and
+            all(to_entries[];
+              (.value._appstrate_supported_openai_params == null) or
+              ((.value._appstrate_generation.reasoning.levels | keys) ==
+                ["high", "low", "max", "medium", "minimal", "none", "xhigh"])
+            )
+          ' "$output" >/dev/null
 
           echo "Exported LiteLLM ${version} (${digest}) catalog ${catalog_commit} (${catalog_digest})"
 
@@ -196,7 +203,8 @@ jobs:
           latest stable GitHub release. The exact catalog commit, file digest,
           release tag and immutable OCI image digest are recorded in
           `scripts/litellm-catalog.lock.json`; the isolated exporter asks LiteLLM
-          which OpenAI-compatible request parameters each model supports.
+          to normalize request-parameter support, reasoning-effort values and
+          temperature/reasoning combinations for each model.
 
           Two generated trees, two different consequences:
           - `apps/api/src/data/pricing/*.json` — prices + model metadata, read at

--- a/.github/workflows/refresh-pricing-catalog.yml
+++ b/.github/workflows/refresh-pricing-catalog.yml
@@ -97,11 +97,29 @@ jobs:
             "$image" /exporter.py /catalog.json > "$output"
 
           jq --exit-status '
+            ["supported", "unsupported", "unknown"] as $support |
+            ["openai", "anthropic", "mistral", "gemini", "cerebras", "groq",
+              "xai", "deepseek", "moonshot", "together_ai", "fireworks_ai", "zai"] as $providers |
             type == "object" and length > 0 and
+            any(to_entries[];
+              .value as $entry |
+              $entry.mode == "chat" and ($providers | index($entry.litellm_provider)) != null
+            ) and
             all(to_entries[];
-              (.value._appstrate_supported_openai_params == null) or
-              ((.value._appstrate_generation.reasoning.levels | keys) ==
-                ["high", "low", "max", "medium", "minimal", "none", "xhigh"])
+              .value as $entry |
+              if ($entry.mode == "chat" and ($providers | index($entry.litellm_provider)) != null)
+              then $entry._appstrate_generation as $generation |
+                ($generation | type) == "object" and
+                ($support | index($generation.temperature)) != null and
+                ($support | index($generation.temperatureWithReasoning)) != null and
+                ($support | index($generation.reasoning.supported)) != null and
+                (($generation.reasoning.adaptive == null) or
+                  (($generation.reasoning.adaptive | type) == "boolean")) and
+                (($generation.reasoning.levels | keys) ==
+                  ["high", "low", "max", "medium", "minimal", "none", "xhigh"]) and
+                all($generation.reasoning.levels[]; ($support | index(.)) != null)
+              else true
+              end
             )
           ' "$output" >/dev/null
 

--- a/.github/workflows/refresh-pricing-catalog.yml
+++ b/.github/workflows/refresh-pricing-catalog.yml
@@ -96,34 +96,18 @@ jobs:
             --volume "$catalog_input:/catalog.json:ro" \
             "$image" /exporter.py /catalog.json > "$output"
 
-          jq --exit-status '
-            ["supported", "unsupported", "unknown"] as $support |
-            ["openai", "anthropic", "mistral", "gemini", "cerebras", "groq",
-              "xai", "deepseek", "moonshot", "together_ai", "fireworks_ai", "zai"] as $providers |
-            type == "object" and length > 0 and
-            any(to_entries[];
-              .value as $entry |
-              $entry.mode == "chat" and ($providers | index($entry.litellm_provider)) != null
-            ) and
-            all(to_entries[];
-              .value as $entry |
-              if ($entry.mode == "chat" and ($providers | index($entry.litellm_provider)) != null)
-              then $entry._appstrate_generation as $generation |
-                ($generation | type) == "object" and
-                ($support | index($generation.temperature)) != null and
-                ($support | index($generation.temperatureWithReasoning)) != null and
-                ($support | index($generation.reasoning.supported)) != null and
-                (($generation.reasoning.adaptive == null) or
-                  (($generation.reasoning.adaptive | type) == "boolean")) and
-                (($generation.reasoning.levels | keys) ==
-                  ["high", "low", "max", "medium", "minimal", "none", "xhigh"]) and
-                all($generation.reasoning.levels[]; ($support | index(.)) != null)
-              else true
-              end
-            )
-          ' "$output" >/dev/null
+          jq --exit-status 'type == "object" and length > 0' "$output" >/dev/null
+          normalized_digest="sha256:$(sha256sum "$output" | cut -d ' ' -f 1)"
+          jq \
+            --arg normalized_digest "$normalized_digest" \
+            '.normalizedDigest = $normalized_digest' \
+            "${output_dir}/litellm-catalog.lock.json" \
+            > "${output_dir}/litellm-catalog.lock.tmp.json"
+          mv \
+            "${output_dir}/litellm-catalog.lock.tmp.json" \
+            "${output_dir}/litellm-catalog.lock.json"
 
-          echo "Exported LiteLLM ${version} (${digest}) catalog ${catalog_commit} (${catalog_digest})"
+          echo "Exported LiteLLM ${version} (${digest}) catalog ${catalog_commit} (${catalog_digest}), normalized ${normalized_digest}"
 
       - name: Upload normalized LiteLLM source
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/apps/api/src/data/pricing/anthropic.json
+++ b/apps/api/src/data/pricing/anthropic.json
@@ -45,15 +45,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -76,15 +68,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {

--- a/apps/api/src/data/pricing/anthropic.json
+++ b/apps/api/src/data/pricing/anthropic.json
@@ -10,16 +10,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -40,6 +42,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -49,7 +52,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -70,6 +74,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -79,7 +84,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -101,16 +107,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -132,16 +140,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -163,19 +173,18 @@
     ],
     "generation": {
       "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": true,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "max"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -197,16 +206,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -228,16 +239,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -259,16 +272,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -290,16 +305,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -321,16 +338,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -352,16 +371,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -383,16 +404,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -414,19 +437,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": true,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "max"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -448,19 +470,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": true,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "max"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -482,19 +503,18 @@
     ],
     "generation": {
       "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": true,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "max"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -516,19 +536,18 @@
     ],
     "generation": {
       "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": true,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "max"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -550,19 +569,18 @@
     ],
     "generation": {
       "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": true,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "max"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -584,19 +602,18 @@
     ],
     "generation": {
       "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": true,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "max"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -618,16 +635,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -649,16 +668,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -680,16 +701,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -711,19 +734,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": true,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "max"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -745,19 +767,18 @@
     ],
     "generation": {
       "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": true,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "max"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },

--- a/apps/api/src/data/pricing/anthropic.json
+++ b/apps/api/src/data/pricing/anthropic.json
@@ -10,9 +10,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -42,7 +42,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -74,7 +73,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -107,9 +105,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -140,9 +138,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -173,7 +171,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": true,
@@ -206,9 +203,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -239,9 +236,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -272,9 +269,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -305,9 +302,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -338,9 +335,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -371,9 +368,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -404,9 +401,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -437,9 +434,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": true,
         "levels": {
           "off": "supported",
@@ -470,9 +467,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": true,
         "levels": {
           "off": "supported",
@@ -503,7 +500,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": true,
@@ -536,7 +532,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": true,
@@ -569,7 +564,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": true,
@@ -602,7 +596,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": true,
@@ -635,9 +628,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -668,9 +661,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -701,9 +694,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -734,9 +727,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": true,
         "levels": {
           "off": "supported",
@@ -767,7 +760,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": true,

--- a/apps/api/src/data/pricing/cerebras.json
+++ b/apps/api/src/data/pricing/cerebras.json
@@ -9,9 +9,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -38,7 +38,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -67,7 +66,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -96,7 +94,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -126,9 +123,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -156,9 +153,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -186,9 +183,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",

--- a/apps/api/src/data/pricing/cerebras.json
+++ b/apps/api/src/data/pricing/cerebras.json
@@ -9,16 +9,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -36,6 +38,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -45,7 +48,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -63,6 +67,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -72,7 +77,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -90,6 +96,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -99,7 +106,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -118,16 +126,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -146,16 +156,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -174,16 +186,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },

--- a/apps/api/src/data/pricing/cerebras.json
+++ b/apps/api/src/data/pricing/cerebras.json
@@ -41,15 +41,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -69,15 +61,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -97,15 +81,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {

--- a/apps/api/src/data/pricing/deepseek.json
+++ b/apps/api/src/data/pricing/deepseek.json
@@ -9,9 +9,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -40,9 +40,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -70,9 +70,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -100,9 +100,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -131,9 +131,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -163,9 +163,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -193,9 +193,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -225,9 +225,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",

--- a/apps/api/src/data/pricing/deepseek.json
+++ b/apps/api/src/data/pricing/deepseek.json
@@ -9,16 +9,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -38,16 +40,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -66,16 +70,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -94,16 +100,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -123,16 +131,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -153,16 +163,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -181,16 +193,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -211,16 +225,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },

--- a/apps/api/src/data/pricing/fireworks-ai.json
+++ b/apps/api/src/data/pricing/fireworks-ai.json
@@ -8,6 +8,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -17,7 +18,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -35,6 +37,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -44,7 +47,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -62,6 +66,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -71,7 +76,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -89,6 +95,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -98,7 +105,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -116,6 +124,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -125,7 +134,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -143,6 +153,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -152,7 +163,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -170,6 +182,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -179,7 +192,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -197,6 +211,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -206,7 +221,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -224,6 +240,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -233,7 +250,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -251,6 +269,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -260,7 +279,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -278,6 +298,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -287,7 +308,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -305,6 +327,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -314,7 +337,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -332,6 +356,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -341,7 +366,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -359,6 +385,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -368,7 +395,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -386,6 +414,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -395,7 +424,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -413,6 +443,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -422,7 +453,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -440,6 +472,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -449,7 +482,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -467,6 +501,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -476,7 +511,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -494,6 +530,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -503,7 +540,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -521,6 +559,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -530,7 +569,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -548,6 +588,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -557,7 +598,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -575,6 +617,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -584,7 +627,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -602,6 +646,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -611,7 +656,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -629,6 +675,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -638,7 +685,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -656,6 +704,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -665,7 +714,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -683,6 +733,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -692,7 +743,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -710,6 +762,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -719,7 +772,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -737,6 +791,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -746,7 +801,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -764,6 +820,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -773,7 +830,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -791,6 +849,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -800,7 +859,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -818,6 +878,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -827,7 +888,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -845,6 +907,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -854,7 +917,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -872,6 +936,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -881,7 +946,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -899,6 +965,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -908,7 +975,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -927,16 +995,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -954,6 +1024,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -963,7 +1034,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -981,6 +1053,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -990,7 +1063,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1008,6 +1082,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1017,7 +1092,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1035,6 +1111,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1044,7 +1121,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1062,6 +1140,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1071,7 +1150,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1089,6 +1169,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1098,7 +1179,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1116,6 +1198,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1125,7 +1208,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1143,6 +1227,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1152,7 +1237,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1170,6 +1256,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1179,7 +1266,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1197,6 +1285,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1206,7 +1295,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1224,6 +1314,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1233,7 +1324,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1252,16 +1344,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1280,16 +1374,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1308,16 +1404,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1336,16 +1434,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1365,16 +1465,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1393,6 +1495,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1402,7 +1505,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1420,6 +1524,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1429,7 +1534,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1447,6 +1553,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1456,7 +1563,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1474,6 +1582,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1483,7 +1592,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1501,6 +1611,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1510,7 +1621,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1528,6 +1640,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1537,7 +1650,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1555,6 +1669,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1564,7 +1679,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1582,6 +1698,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1591,7 +1708,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1609,6 +1727,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1618,7 +1737,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1636,6 +1756,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1645,7 +1766,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1663,6 +1785,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1672,7 +1795,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1690,6 +1814,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1699,7 +1824,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1717,6 +1843,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1726,7 +1853,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1744,6 +1872,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1753,7 +1882,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1771,6 +1901,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1780,7 +1911,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1798,6 +1930,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1807,7 +1940,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1825,6 +1959,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1834,7 +1969,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1852,6 +1988,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1861,7 +1998,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1879,6 +2017,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1888,7 +2027,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1906,6 +2046,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1915,7 +2056,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1934,16 +2076,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1962,16 +2106,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1990,16 +2136,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2018,16 +2166,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2046,16 +2196,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2075,16 +2227,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2104,16 +2258,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2133,16 +2289,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2162,16 +2320,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2190,6 +2350,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2199,7 +2360,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2217,6 +2379,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2226,7 +2389,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2244,6 +2408,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2253,7 +2418,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2271,6 +2437,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2280,7 +2447,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2298,6 +2466,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2307,7 +2476,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2325,6 +2495,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2334,7 +2505,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2352,6 +2524,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2361,7 +2534,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2379,6 +2553,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2388,7 +2563,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2406,6 +2582,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2415,7 +2592,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2433,6 +2611,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2442,7 +2621,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2460,6 +2640,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2469,7 +2650,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2487,6 +2669,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2496,7 +2679,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2514,6 +2698,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2523,7 +2708,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2544,16 +2730,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2574,16 +2762,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2602,6 +2792,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2611,7 +2802,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2629,6 +2821,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2638,7 +2831,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2656,6 +2850,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2665,7 +2860,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2683,6 +2879,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2692,7 +2889,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2710,6 +2908,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2719,7 +2918,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2737,6 +2937,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2746,7 +2947,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2764,6 +2966,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2773,7 +2976,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2791,6 +2995,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2800,7 +3005,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2818,6 +3024,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2827,7 +3034,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2845,6 +3053,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2854,7 +3063,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2872,6 +3082,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2881,7 +3092,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2899,6 +3111,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2908,7 +3121,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2926,6 +3140,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2935,7 +3150,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2953,6 +3169,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2962,7 +3179,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -2980,6 +3198,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2989,7 +3208,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3007,6 +3227,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3016,7 +3237,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3034,6 +3256,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3043,7 +3266,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3061,6 +3285,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3070,7 +3295,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3088,6 +3314,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3097,7 +3324,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3116,6 +3344,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3125,7 +3354,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3143,6 +3373,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3152,7 +3383,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3170,6 +3402,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3179,7 +3412,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3197,6 +3431,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3206,7 +3441,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3224,6 +3460,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3233,7 +3470,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3252,6 +3490,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3261,7 +3500,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3279,6 +3519,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3288,7 +3529,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3306,6 +3548,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3315,7 +3558,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3333,6 +3577,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3342,7 +3587,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3360,6 +3606,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3369,7 +3616,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3387,6 +3635,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3396,7 +3645,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3414,6 +3664,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3423,7 +3674,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3441,6 +3693,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3450,7 +3703,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3468,6 +3722,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3477,7 +3732,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3497,16 +3753,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -3527,16 +3785,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -3555,6 +3815,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3564,7 +3825,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3582,6 +3844,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3591,7 +3854,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3609,6 +3873,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3618,7 +3883,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3636,6 +3902,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3645,7 +3912,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3663,6 +3931,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3672,7 +3941,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3690,6 +3960,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3699,7 +3970,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3717,6 +3989,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3726,7 +3999,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3744,6 +4018,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3753,7 +4028,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3771,6 +4047,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3780,7 +4057,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3798,6 +4076,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3807,7 +4086,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3825,6 +4105,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3834,7 +4115,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3852,6 +4134,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3861,7 +4144,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3879,6 +4163,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3888,7 +4173,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3906,6 +4192,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3915,7 +4202,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3933,6 +4221,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3942,7 +4231,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3960,6 +4250,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3969,7 +4260,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -3987,6 +4279,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3996,7 +4289,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4014,6 +4308,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4023,7 +4318,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4041,6 +4337,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4050,7 +4347,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4068,6 +4366,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4077,7 +4376,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4095,6 +4395,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4104,7 +4405,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4122,6 +4424,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4131,7 +4434,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4149,6 +4453,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4158,7 +4463,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4176,6 +4482,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4185,7 +4492,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4203,6 +4511,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4212,7 +4521,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4230,6 +4540,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4239,7 +4550,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4257,6 +4569,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4266,7 +4579,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4284,6 +4598,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4293,7 +4608,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4311,6 +4627,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4320,7 +4637,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4338,6 +4656,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4347,7 +4666,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4365,6 +4685,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4374,7 +4695,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4392,6 +4714,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4401,7 +4724,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4419,6 +4743,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4428,7 +4753,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4446,6 +4772,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4455,7 +4782,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4473,6 +4801,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4482,7 +4811,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4500,6 +4830,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4509,7 +4840,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4527,6 +4859,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4536,7 +4869,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4554,6 +4888,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4563,7 +4898,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4581,6 +4917,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4590,7 +4927,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4608,6 +4946,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4617,7 +4956,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4635,6 +4975,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4644,7 +4985,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4662,6 +5004,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4671,7 +5014,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4689,6 +5033,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4698,7 +5043,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4716,6 +5062,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4725,7 +5072,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4743,6 +5091,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4752,7 +5101,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4770,6 +5120,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4779,7 +5130,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4797,6 +5149,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4806,7 +5159,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4824,6 +5178,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4833,7 +5188,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4851,6 +5207,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4860,7 +5217,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4878,6 +5236,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4887,7 +5246,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4905,6 +5265,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4914,7 +5275,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4932,6 +5294,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4941,7 +5304,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4959,6 +5323,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4968,7 +5333,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -4986,6 +5352,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4995,7 +5362,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5013,6 +5381,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5022,7 +5391,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5040,6 +5410,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5049,7 +5420,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5067,6 +5439,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5076,7 +5449,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5094,6 +5468,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5103,7 +5478,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5121,6 +5497,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5130,7 +5507,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5148,6 +5526,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5157,7 +5536,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5175,6 +5555,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5184,7 +5565,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5202,6 +5584,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5211,7 +5594,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5229,6 +5613,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5238,7 +5623,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5256,6 +5642,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5265,7 +5652,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5283,6 +5671,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5292,7 +5681,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5310,6 +5700,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5319,7 +5710,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5337,6 +5729,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5346,7 +5739,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5364,6 +5758,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5373,7 +5768,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5391,6 +5787,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5400,7 +5797,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5418,6 +5816,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5427,7 +5826,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5445,6 +5845,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5454,7 +5855,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5472,6 +5874,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5481,7 +5884,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5499,6 +5903,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5508,7 +5913,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5526,6 +5932,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5535,7 +5942,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5553,6 +5961,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5562,7 +5971,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5580,6 +5990,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5589,7 +6000,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5607,6 +6019,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5616,7 +6029,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5634,6 +6048,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5643,7 +6058,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5661,6 +6077,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5670,7 +6087,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5688,6 +6106,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5697,7 +6116,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5715,6 +6135,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5724,7 +6145,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5742,6 +6164,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5751,7 +6174,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5769,6 +6193,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5778,7 +6203,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5796,6 +6222,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5805,7 +6232,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5823,6 +6251,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5832,7 +6261,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5850,6 +6280,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5859,7 +6290,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5877,6 +6309,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5886,7 +6319,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5904,6 +6338,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5913,7 +6348,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5932,16 +6368,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -5959,6 +6397,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5968,7 +6407,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -5986,6 +6426,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5995,7 +6436,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6014,16 +6456,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -6041,6 +6485,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6050,7 +6495,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6069,16 +6515,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -6096,6 +6544,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6105,7 +6554,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6123,6 +6573,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6132,7 +6583,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6150,6 +6602,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6159,7 +6612,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6177,6 +6631,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6186,7 +6641,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6204,6 +6660,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6213,7 +6670,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6231,6 +6689,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6240,7 +6699,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6258,6 +6718,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6267,7 +6728,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6285,6 +6747,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6294,7 +6757,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6312,6 +6776,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6321,7 +6786,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6341,16 +6807,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -6369,6 +6837,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6378,7 +6847,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6396,6 +6866,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6405,7 +6876,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6423,6 +6895,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6432,7 +6905,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6450,6 +6924,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6459,7 +6934,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6477,6 +6953,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6486,7 +6963,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6504,6 +6982,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6513,7 +6992,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6531,6 +7011,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6540,7 +7021,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6558,6 +7040,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6567,7 +7050,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6585,6 +7069,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6594,7 +7079,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6612,6 +7098,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6621,7 +7108,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6639,6 +7127,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6648,7 +7137,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6666,6 +7156,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6675,7 +7166,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6693,6 +7185,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6702,7 +7195,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6720,6 +7214,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6729,7 +7224,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6747,6 +7243,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6756,7 +7253,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6774,6 +7272,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6783,7 +7282,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -6802,16 +7302,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -6832,16 +7334,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -6862,16 +7366,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -6891,16 +7397,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -6920,16 +7428,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -6949,16 +7459,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -6978,16 +7490,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -7007,16 +7521,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -7036,16 +7552,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -7065,16 +7583,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -7094,16 +7614,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -7122,6 +7644,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -7131,7 +7654,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -7152,16 +7676,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -7182,16 +7708,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -7212,16 +7740,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -7242,16 +7772,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -7270,6 +7802,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -7279,7 +7812,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -7299,16 +7833,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -7329,16 +7865,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -7359,16 +7897,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },

--- a/apps/api/src/data/pricing/fireworks-ai.json
+++ b/apps/api/src/data/pricing/fireworks-ai.json
@@ -11,15 +11,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -39,15 +31,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -67,15 +51,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -95,15 +71,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -123,15 +91,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -151,15 +111,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -179,15 +131,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -207,15 +151,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -235,15 +171,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -263,15 +191,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -291,15 +211,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -319,15 +231,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -347,15 +251,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -375,15 +271,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -403,15 +291,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -431,15 +311,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -459,15 +331,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -487,15 +351,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -515,15 +371,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -543,15 +391,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -571,15 +411,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -599,15 +431,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -627,15 +451,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -655,15 +471,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -683,15 +491,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -711,15 +511,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -739,15 +531,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -767,15 +551,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -795,15 +571,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -823,15 +591,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -851,15 +611,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -879,15 +631,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -907,15 +651,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -935,15 +671,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -993,15 +721,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1021,15 +741,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1049,15 +761,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1077,15 +781,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1105,15 +801,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1133,15 +821,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1161,15 +841,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1189,15 +861,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1217,15 +881,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1245,15 +901,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1273,15 +921,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1453,15 +1093,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1481,15 +1113,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1509,15 +1133,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1537,15 +1153,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1565,15 +1173,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1593,15 +1193,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1621,15 +1213,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1649,15 +1233,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1677,15 +1253,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1705,15 +1273,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1733,15 +1293,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1761,15 +1313,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1789,15 +1333,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1817,15 +1353,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1845,15 +1373,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1873,15 +1393,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1901,15 +1413,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1929,15 +1433,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1957,15 +1453,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1985,15 +1473,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2288,15 +1768,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2316,15 +1788,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2344,15 +1808,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2372,15 +1828,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2400,15 +1848,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2428,15 +1868,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2456,15 +1888,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2484,15 +1908,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2512,15 +1928,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2540,15 +1948,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2568,15 +1968,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2596,15 +1988,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2624,15 +2008,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2717,15 +2093,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2745,15 +2113,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2773,15 +2133,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2801,15 +2153,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2829,15 +2173,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2857,15 +2193,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2885,15 +2213,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2913,15 +2233,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2941,15 +2253,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2969,15 +2273,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -2997,15 +2293,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3025,15 +2313,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3053,15 +2333,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3081,15 +2353,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3109,15 +2373,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3137,15 +2393,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3165,15 +2413,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3193,15 +2433,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3221,15 +2453,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3250,15 +2474,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3278,15 +2494,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3306,15 +2514,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3334,15 +2534,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3362,15 +2554,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3391,15 +2575,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3419,15 +2595,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3447,15 +2615,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3475,15 +2635,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3503,15 +2655,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3531,15 +2675,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3559,15 +2695,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3587,15 +2715,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3615,15 +2735,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3707,15 +2819,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3735,15 +2839,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3763,15 +2859,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3791,15 +2879,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3819,15 +2899,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3847,15 +2919,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3875,15 +2939,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3903,15 +2959,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3931,15 +2979,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3959,15 +2999,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -3987,15 +3019,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4015,15 +3039,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4043,15 +3059,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4071,15 +3079,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4099,15 +3099,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4127,15 +3119,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4155,15 +3139,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4183,15 +3159,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4211,15 +3179,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4239,15 +3199,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4267,15 +3219,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4295,15 +3239,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4323,15 +3259,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4351,15 +3279,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4379,15 +3299,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4407,15 +3319,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4435,15 +3339,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4463,15 +3359,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4491,15 +3379,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4519,15 +3399,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4547,15 +3419,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4575,15 +3439,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4603,15 +3459,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4631,15 +3479,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4659,15 +3499,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4687,15 +3519,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4715,15 +3539,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4743,15 +3559,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4771,15 +3579,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4799,15 +3599,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4827,15 +3619,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4855,15 +3639,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4883,15 +3659,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4911,15 +3679,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4939,15 +3699,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4967,15 +3719,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -4995,15 +3739,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5023,15 +3759,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5051,15 +3779,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5079,15 +3799,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5107,15 +3819,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5135,15 +3839,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5163,15 +3859,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5191,15 +3879,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5219,15 +3899,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5247,15 +3919,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5275,15 +3939,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5303,15 +3959,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5331,15 +3979,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5359,15 +3999,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5387,15 +4019,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5415,15 +4039,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5443,15 +4059,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5471,15 +4079,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5499,15 +4099,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5527,15 +4119,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5555,15 +4139,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5583,15 +4159,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5611,15 +4179,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5639,15 +4199,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5667,15 +4219,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5695,15 +4239,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5723,15 +4259,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5751,15 +4279,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5779,15 +4299,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5807,15 +4319,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5835,15 +4339,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5863,15 +4359,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5891,15 +4379,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5919,15 +4399,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5947,15 +4419,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -5975,15 +4439,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6003,15 +4459,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6031,15 +4479,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6059,15 +4499,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6087,15 +4519,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6115,15 +4539,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6143,15 +4559,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6201,15 +4609,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6229,15 +4629,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6287,15 +4679,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6345,15 +4729,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6373,15 +4749,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6401,15 +4769,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6429,15 +4789,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6457,15 +4809,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6485,15 +4829,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6513,15 +4849,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6541,15 +4869,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6569,15 +4889,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6629,15 +4941,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6657,15 +4961,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6685,15 +4981,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6713,15 +5001,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6741,15 +5021,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6769,15 +5041,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6797,15 +5061,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6825,15 +5081,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6853,15 +5101,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6881,15 +5121,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6909,15 +5141,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6937,15 +5161,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6965,15 +5181,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -6993,15 +5201,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -7021,15 +5221,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -7049,15 +5241,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -7420,15 +5604,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -7577,15 +5753,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {

--- a/apps/api/src/data/pricing/fireworks-ai.json
+++ b/apps/api/src/data/pricing/fireworks-ai.json
@@ -8,7 +8,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -37,7 +36,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -66,7 +64,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -95,7 +92,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -124,7 +120,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -153,7 +148,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -182,7 +176,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -211,7 +204,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -240,7 +232,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -269,7 +260,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -298,7 +288,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -327,7 +316,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -356,7 +344,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -385,7 +372,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -414,7 +400,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -443,7 +428,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -472,7 +456,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -501,7 +484,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -530,7 +512,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -559,7 +540,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -588,7 +568,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -617,7 +596,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -646,7 +624,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -675,7 +652,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -704,7 +680,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -733,7 +708,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -762,7 +736,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -791,7 +764,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -820,7 +792,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -849,7 +820,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -878,7 +848,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -907,7 +876,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -936,7 +904,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -965,7 +932,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -995,9 +961,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1024,7 +990,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1053,7 +1018,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1082,7 +1046,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1111,7 +1074,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1140,7 +1102,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1169,7 +1130,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1198,7 +1158,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1227,7 +1186,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1256,7 +1214,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1285,7 +1242,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1314,7 +1270,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1344,9 +1299,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1374,9 +1329,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1404,9 +1359,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1434,9 +1389,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1465,9 +1420,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1495,7 +1450,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1524,7 +1478,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1553,7 +1506,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1582,7 +1534,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1611,7 +1562,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1640,7 +1590,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1669,7 +1618,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1698,7 +1646,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1727,7 +1674,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1756,7 +1702,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1785,7 +1730,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1814,7 +1758,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1843,7 +1786,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1872,7 +1814,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1901,7 +1842,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1930,7 +1870,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1959,7 +1898,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1988,7 +1926,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2017,7 +1954,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2046,7 +1982,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2076,9 +2011,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2106,9 +2041,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2136,9 +2071,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2166,9 +2101,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2196,9 +2131,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2227,9 +2162,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2258,9 +2193,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2289,9 +2224,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2320,9 +2255,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2350,7 +2285,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2379,7 +2313,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2408,7 +2341,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2437,7 +2369,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2466,7 +2397,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2495,7 +2425,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2524,7 +2453,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2553,7 +2481,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2582,7 +2509,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2611,7 +2537,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2640,7 +2565,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2669,7 +2593,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2698,7 +2621,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2730,9 +2652,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2762,9 +2684,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2792,7 +2714,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2821,7 +2742,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2850,7 +2770,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2879,7 +2798,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2908,7 +2826,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2937,7 +2854,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2966,7 +2882,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -2995,7 +2910,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3024,7 +2938,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3053,7 +2966,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3082,7 +2994,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3111,7 +3022,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3140,7 +3050,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3169,7 +3078,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3198,7 +3106,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3227,7 +3134,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3256,7 +3162,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3285,7 +3190,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3314,7 +3218,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3344,7 +3247,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3373,7 +3275,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3402,7 +3303,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3431,7 +3331,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3460,7 +3359,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3490,7 +3388,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3519,7 +3416,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3548,7 +3444,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3577,7 +3472,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3606,7 +3500,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3635,7 +3528,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3664,7 +3556,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3693,7 +3584,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3722,7 +3612,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3753,9 +3642,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -3785,9 +3674,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -3815,7 +3704,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3844,7 +3732,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3873,7 +3760,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3902,7 +3788,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3931,7 +3816,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3960,7 +3844,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -3989,7 +3872,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4018,7 +3900,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4047,7 +3928,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4076,7 +3956,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4105,7 +3984,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4134,7 +4012,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4163,7 +4040,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4192,7 +4068,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4221,7 +4096,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4250,7 +4124,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4279,7 +4152,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4308,7 +4180,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4337,7 +4208,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4366,7 +4236,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4395,7 +4264,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4424,7 +4292,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4453,7 +4320,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4482,7 +4348,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4511,7 +4376,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4540,7 +4404,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4569,7 +4432,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4598,7 +4460,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4627,7 +4488,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4656,7 +4516,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4685,7 +4544,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4714,7 +4572,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4743,7 +4600,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4772,7 +4628,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4801,7 +4656,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4830,7 +4684,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4859,7 +4712,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4888,7 +4740,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4917,7 +4768,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4946,7 +4796,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -4975,7 +4824,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5004,7 +4852,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5033,7 +4880,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5062,7 +4908,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5091,7 +4936,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5120,7 +4964,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5149,7 +4992,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5178,7 +5020,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5207,7 +5048,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5236,7 +5076,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5265,7 +5104,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5294,7 +5132,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5323,7 +5160,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5352,7 +5188,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5381,7 +5216,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5410,7 +5244,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5439,7 +5272,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5468,7 +5300,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5497,7 +5328,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5526,7 +5356,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5555,7 +5384,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5584,7 +5412,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5613,7 +5440,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5642,7 +5468,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5671,7 +5496,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5700,7 +5524,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5729,7 +5552,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5758,7 +5580,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5787,7 +5608,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5816,7 +5636,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5845,7 +5664,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5874,7 +5692,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5903,7 +5720,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5932,7 +5748,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5961,7 +5776,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -5990,7 +5804,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6019,7 +5832,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6048,7 +5860,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6077,7 +5888,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6106,7 +5916,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6135,7 +5944,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6164,7 +5972,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6193,7 +6000,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6222,7 +6028,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6251,7 +6056,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6280,7 +6084,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6309,7 +6112,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6338,7 +6140,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6368,9 +6169,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -6397,7 +6198,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6426,7 +6226,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6456,9 +6255,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -6485,7 +6284,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6515,9 +6313,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -6544,7 +6342,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6573,7 +6370,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6602,7 +6398,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6631,7 +6426,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6660,7 +6454,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6689,7 +6482,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6718,7 +6510,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6747,7 +6538,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6776,7 +6566,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6807,9 +6596,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -6837,7 +6626,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6866,7 +6654,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6895,7 +6682,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6924,7 +6710,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6953,7 +6738,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -6982,7 +6766,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -7011,7 +6794,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -7040,7 +6822,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -7069,7 +6850,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -7098,7 +6878,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -7127,7 +6906,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -7156,7 +6934,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -7185,7 +6962,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -7214,7 +6990,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -7243,7 +7018,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -7272,7 +7046,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -7302,9 +7075,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7334,9 +7107,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7366,9 +7139,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7397,9 +7170,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7428,9 +7201,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7459,9 +7232,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7490,9 +7263,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7521,9 +7294,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7552,9 +7325,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7583,9 +7356,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7614,9 +7387,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7644,7 +7417,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -7676,9 +7448,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7708,9 +7480,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7740,9 +7512,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7772,9 +7544,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7802,7 +7574,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -7833,9 +7604,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7865,9 +7636,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -7897,9 +7668,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",

--- a/apps/api/src/data/pricing/google-ai.json
+++ b/apps/api/src/data/pricing/google-ai.json
@@ -9,7 +9,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -40,7 +39,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -71,7 +69,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -102,7 +99,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -133,7 +129,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -164,9 +159,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -196,9 +191,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -228,9 +223,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -260,9 +255,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -290,7 +285,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -319,7 +313,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -348,7 +341,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -379,9 +371,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -411,9 +403,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -442,7 +434,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -474,9 +465,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -506,9 +497,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -538,9 +529,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -570,9 +561,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -601,7 +592,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -632,9 +622,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -664,9 +654,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -696,9 +686,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -728,9 +718,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -760,9 +750,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -791,7 +781,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -822,9 +811,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -854,9 +843,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -886,9 +875,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -918,9 +907,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -949,9 +938,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -981,9 +970,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1012,7 +1001,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1042,7 +1030,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1071,7 +1058,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1100,7 +1086,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,

--- a/apps/api/src/data/pricing/google-ai.json
+++ b/apps/api/src/data/pricing/google-ai.json
@@ -12,15 +12,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -42,15 +34,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -72,15 +56,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -102,15 +78,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -132,15 +100,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -288,15 +248,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -316,15 +268,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -344,15 +288,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -437,15 +373,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -595,15 +523,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -784,15 +704,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1004,15 +916,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1033,15 +937,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1061,15 +957,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1089,15 +977,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {

--- a/apps/api/src/data/pricing/google-ai.json
+++ b/apps/api/src/data/pricing/google-ai.json
@@ -9,6 +9,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -18,7 +19,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -38,6 +40,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -47,7 +50,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -67,6 +71,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -76,7 +81,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -96,6 +102,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -105,7 +112,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -125,6 +133,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -134,7 +143,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -154,16 +164,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -184,16 +196,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -214,16 +228,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -244,16 +260,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -272,6 +290,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -281,7 +300,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -299,6 +319,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -308,7 +329,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -326,6 +348,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -335,7 +358,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -355,16 +379,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -385,16 +411,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -414,6 +442,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -423,7 +452,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -444,16 +474,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -474,16 +506,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -504,16 +538,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -534,16 +570,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -563,6 +601,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -572,7 +611,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -592,16 +632,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -622,16 +664,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -652,16 +696,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -682,16 +728,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -712,16 +760,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -741,6 +791,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -750,7 +801,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -770,16 +822,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -800,16 +854,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -830,16 +886,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -860,16 +918,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -889,16 +949,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -919,16 +981,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -948,6 +1012,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -957,7 +1022,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -976,6 +1042,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -985,7 +1052,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1003,6 +1071,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1012,7 +1081,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1030,6 +1100,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1039,7 +1110,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },

--- a/apps/api/src/data/pricing/groq.json
+++ b/apps/api/src/data/pricing/groq.json
@@ -8,7 +8,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -37,7 +36,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -66,7 +64,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -96,7 +93,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -126,7 +122,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -155,7 +150,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -184,7 +178,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -215,9 +208,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -246,9 +239,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -277,9 +270,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -308,9 +301,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",

--- a/apps/api/src/data/pricing/groq.json
+++ b/apps/api/src/data/pricing/groq.json
@@ -11,15 +11,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -39,15 +31,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -67,15 +51,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -96,15 +72,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -125,15 +93,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -153,15 +113,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -181,15 +133,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {

--- a/apps/api/src/data/pricing/groq.json
+++ b/apps/api/src/data/pricing/groq.json
@@ -8,6 +8,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -17,7 +18,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -35,6 +37,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -44,7 +47,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -62,6 +66,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -71,7 +76,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -90,6 +96,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -99,7 +106,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -118,6 +126,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -127,7 +136,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -145,6 +155,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -154,7 +165,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -172,6 +184,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -181,7 +194,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -201,16 +215,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -230,16 +246,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -259,16 +277,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -288,16 +308,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },

--- a/apps/api/src/data/pricing/mistral.json
+++ b/apps/api/src/data/pricing/mistral.json
@@ -11,15 +11,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -39,15 +31,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -67,15 +51,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -95,15 +71,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -123,15 +91,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -151,15 +111,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -179,15 +131,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -207,15 +151,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -235,15 +171,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -263,15 +191,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -291,15 +211,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -319,15 +231,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -558,15 +462,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -587,15 +483,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -616,15 +504,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -645,15 +525,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -674,15 +546,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -702,15 +566,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -730,15 +586,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -758,15 +606,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -787,15 +627,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -816,15 +648,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -845,15 +669,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -873,15 +689,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -901,15 +709,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -929,15 +729,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -958,15 +750,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1016,15 +800,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1102,15 +878,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1131,15 +899,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1160,15 +920,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1188,15 +940,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1216,15 +960,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1244,15 +980,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1272,15 +1000,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1300,15 +1020,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1328,15 +1040,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1356,15 +1060,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1385,15 +1081,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1414,15 +1102,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1443,15 +1123,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {

--- a/apps/api/src/data/pricing/mistral.json
+++ b/apps/api/src/data/pricing/mistral.json
@@ -8,7 +8,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -37,7 +36,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -66,7 +64,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -95,7 +92,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -124,7 +120,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -153,7 +148,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -182,7 +176,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -211,7 +204,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -240,7 +232,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -269,7 +260,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -298,7 +288,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -327,7 +316,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -357,9 +345,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -387,9 +375,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -417,9 +405,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -447,9 +435,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -477,9 +465,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -507,9 +495,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -537,9 +525,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -567,7 +555,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -597,7 +584,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -627,7 +613,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -657,7 +642,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -687,7 +671,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -716,7 +699,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -745,7 +727,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -774,7 +755,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -804,7 +784,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -834,7 +813,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -864,7 +842,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -893,7 +870,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -922,7 +898,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -951,7 +926,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -981,7 +955,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1011,7 +984,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -1041,7 +1013,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1071,7 +1042,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -1101,7 +1071,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -1130,7 +1099,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1160,7 +1128,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1190,7 +1157,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1219,7 +1185,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1248,7 +1213,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1277,7 +1241,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1306,7 +1269,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1335,7 +1297,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1364,7 +1325,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1393,7 +1353,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1423,7 +1382,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1453,7 +1411,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1483,7 +1440,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,

--- a/apps/api/src/data/pricing/mistral.json
+++ b/apps/api/src/data/pricing/mistral.json
@@ -1007,14 +1007,13 @@
     "maxTokens": null,
     "capabilities": [
       "text",
-      "image",
-      "reasoning"
+      "image"
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -1068,14 +1067,13 @@
     "maxTokens": null,
     "capabilities": [
       "text",
-      "image",
-      "reasoning"
+      "image"
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -1099,14 +1097,13 @@
     "maxTokens": null,
     "capabilities": [
       "text",
-      "image",
-      "reasoning"
+      "image"
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",

--- a/apps/api/src/data/pricing/mistral.json
+++ b/apps/api/src/data/pricing/mistral.json
@@ -8,6 +8,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -17,7 +18,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -35,6 +37,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -44,7 +47,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -62,6 +66,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -71,7 +76,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -89,6 +95,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -98,7 +105,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -116,6 +124,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -125,7 +134,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -143,6 +153,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -152,7 +163,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -170,6 +182,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -179,7 +192,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -197,6 +211,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -206,7 +221,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -224,6 +240,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -233,7 +250,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -251,6 +269,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -260,7 +279,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -278,6 +298,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -287,7 +308,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -305,6 +327,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -314,7 +337,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -333,16 +357,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -361,16 +387,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -389,16 +417,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -417,16 +447,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -445,16 +477,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -473,16 +507,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -501,16 +537,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -529,6 +567,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -538,7 +577,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -557,6 +597,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -566,7 +607,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -585,6 +627,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -594,7 +637,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -613,6 +657,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -622,7 +667,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -641,6 +687,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -650,7 +697,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -668,6 +716,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -677,7 +726,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -695,6 +745,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -704,7 +755,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -722,6 +774,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -731,7 +784,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -750,6 +804,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -759,7 +814,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -778,6 +834,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -787,7 +844,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -806,6 +864,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -815,7 +874,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -833,6 +893,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -842,7 +903,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -860,6 +922,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -869,7 +932,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -887,6 +951,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -896,7 +961,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -915,6 +981,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -924,7 +991,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -944,16 +1012,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -972,6 +1042,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -981,7 +1052,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1001,16 +1073,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -1030,16 +1104,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -1057,6 +1133,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1066,7 +1143,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1085,6 +1163,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1094,7 +1173,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1113,6 +1193,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1122,7 +1203,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1140,6 +1222,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1149,7 +1232,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1167,6 +1251,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1176,7 +1261,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1194,6 +1280,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1203,7 +1290,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1221,6 +1309,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1230,7 +1319,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1248,6 +1338,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1257,7 +1348,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1275,6 +1367,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1284,7 +1377,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1302,6 +1396,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1311,7 +1406,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1330,6 +1426,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1339,7 +1436,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1358,6 +1456,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1367,7 +1466,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1386,6 +1486,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1395,7 +1496,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },

--- a/apps/api/src/data/pricing/moonshot.json
+++ b/apps/api/src/data/pricing/moonshot.json
@@ -17,7 +17,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -45,7 +46,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -69,12 +71,13 @@
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -98,12 +101,13 @@
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -131,7 +135,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -156,12 +161,13 @@
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -186,12 +192,13 @@
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -220,7 +227,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -249,7 +257,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -278,7 +287,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -307,7 +317,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -336,7 +347,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -364,7 +376,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -391,7 +404,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -419,7 +433,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -446,7 +461,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -473,7 +489,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -501,7 +518,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -528,7 +546,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -555,7 +574,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -583,7 +603,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -610,7 +631,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },

--- a/apps/api/src/data/pricing/moonshot.json
+++ b/apps/api/src/data/pricing/moonshot.json
@@ -8,6 +8,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -37,6 +38,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -62,13 +64,13 @@
     "contextWindow": 262144,
     "maxTokens": null,
     "capabilities": [
-      "text",
-      "reasoning"
+      "text"
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -92,13 +94,13 @@
     "contextWindow": 262144,
     "maxTokens": null,
     "capabilities": [
-      "text",
-      "reasoning"
+      "text"
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -126,6 +128,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -152,13 +155,13 @@
     "maxTokens": null,
     "capabilities": [
       "text",
-      "image",
-      "reasoning"
+      "image"
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -183,13 +186,13 @@
     "maxTokens": null,
     "capabilities": [
       "text",
-      "image",
-      "reasoning"
+      "image"
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -218,6 +221,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -248,6 +252,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -278,6 +283,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -308,6 +314,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -338,6 +345,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -367,6 +375,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -395,6 +404,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -424,6 +434,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -452,6 +463,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -480,6 +492,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -509,6 +522,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -537,6 +551,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -565,6 +580,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -594,6 +610,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -622,6 +639,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,

--- a/apps/api/src/data/pricing/moonshot.json
+++ b/apps/api/src/data/pricing/moonshot.json
@@ -8,7 +8,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -38,7 +37,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -68,7 +66,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -98,7 +95,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -128,7 +124,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -159,7 +154,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -190,7 +184,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -221,7 +214,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -252,7 +244,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -283,7 +274,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -314,7 +304,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -345,7 +334,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -375,7 +363,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -404,7 +391,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -434,7 +420,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -463,7 +448,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -492,7 +476,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -522,7 +505,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -551,7 +533,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -580,7 +561,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -610,7 +590,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -639,7 +618,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,

--- a/apps/api/src/data/pricing/moonshot.json
+++ b/apps/api/src/data/pricing/moonshot.json
@@ -11,15 +11,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -40,15 +32,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -127,15 +111,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -217,15 +193,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -247,15 +215,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -277,15 +237,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -307,15 +259,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -337,15 +281,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -366,15 +302,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -394,15 +322,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -423,15 +343,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -451,15 +363,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -479,15 +383,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -508,15 +404,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -536,15 +424,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -564,15 +444,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -593,15 +465,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -621,15 +485,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {

--- a/apps/api/src/data/pricing/openai.json
+++ b/apps/api/src/data/pricing/openai.json
@@ -9,6 +9,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -18,7 +19,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -36,6 +38,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -45,7 +48,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -63,6 +67,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -72,7 +77,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -90,6 +96,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -99,7 +106,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -117,6 +125,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -126,7 +135,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -144,6 +154,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -153,7 +164,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -171,6 +183,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -180,7 +193,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -199,6 +213,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -208,7 +223,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -227,6 +243,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -236,7 +253,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -256,6 +274,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -265,7 +284,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -284,6 +304,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -293,7 +314,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -312,6 +334,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -321,7 +344,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -341,16 +365,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -369,6 +395,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -378,7 +405,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -396,6 +424,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -405,7 +434,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -423,6 +453,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -432,7 +463,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -450,6 +482,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -459,7 +492,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -477,6 +511,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -486,7 +521,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -504,6 +540,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -513,7 +550,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -531,6 +569,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -540,7 +579,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -558,6 +598,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -567,7 +608,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -585,6 +627,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -594,7 +637,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -613,6 +657,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -622,7 +667,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -641,6 +687,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -650,7 +697,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -668,6 +716,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -677,7 +726,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -696,6 +746,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -705,7 +756,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -725,6 +777,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -734,7 +787,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -754,6 +808,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -763,7 +818,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -783,6 +839,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -792,7 +849,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -812,6 +870,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -821,7 +880,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -841,6 +901,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -850,7 +911,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -870,6 +932,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -879,7 +942,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -899,6 +963,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -908,7 +973,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -927,6 +993,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -936,7 +1003,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -956,6 +1024,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -965,7 +1034,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -984,6 +1054,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -993,7 +1064,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1011,6 +1083,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1020,7 +1093,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1038,6 +1112,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1047,7 +1122,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1066,6 +1142,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1075,7 +1152,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1095,6 +1173,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1104,7 +1183,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1123,6 +1203,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1132,7 +1213,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1150,6 +1232,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1159,7 +1242,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1178,6 +1262,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1187,7 +1272,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1207,6 +1293,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1216,7 +1303,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1236,6 +1324,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1245,7 +1334,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1265,6 +1355,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1274,7 +1365,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1294,17 +1386,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unsupported",
+          "off": "supported",
           "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unsupported"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "supported"
         }
       }
     },
@@ -1324,17 +1418,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unsupported",
+          "off": "supported",
           "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unsupported"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "supported"
         }
       }
     },
@@ -1355,16 +1451,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
-          "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unsupported"
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -1385,16 +1483,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
-          "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unsupported"
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -1414,17 +1514,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unsupported",
+          "off": "supported",
           "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unsupported"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "supported"
         }
       }
     },
@@ -1444,17 +1546,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unsupported",
+          "off": "supported",
           "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unsupported"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "supported"
         }
       }
     },
@@ -1474,17 +1578,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unsupported",
+          "off": "supported",
           "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unsupported"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "supported"
         }
       }
     },
@@ -1504,17 +1610,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unsupported",
+          "off": "supported",
           "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unsupported"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "supported"
         }
       }
     },
@@ -1535,16 +1643,18 @@
     ],
     "generation": {
       "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
-          "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unsupported"
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -1564,16 +1674,18 @@
     ],
     "generation": {
       "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
         "levels": {
-          "off": "unsupported",
+          "off": "unknown",
           "minimal": "unknown",
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unsupported"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1594,16 +1706,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unsupported"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "supported"
         }
       }
     },
@@ -1624,16 +1738,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unsupported"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "supported"
         }
       }
     },
@@ -1654,16 +1770,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unsupported"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "supported"
         }
       }
     },
@@ -1684,19 +1802,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "xhigh"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1717,19 +1834,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "xhigh"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1749,17 +1865,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unsupported",
+          "off": "supported",
           "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unsupported"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "supported"
         }
       }
     },
@@ -1779,17 +1897,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unsupported",
+          "off": "supported",
           "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unsupported"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "supported"
         }
       }
     },
@@ -1810,19 +1930,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "supported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "xhigh"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1842,17 +1961,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "unsupported",
+          "max": "supported"
         }
       }
     },
@@ -1873,19 +1994,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "unsupported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "xhigh"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1906,19 +2026,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "unsupported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "xhigh"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1939,19 +2058,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "unsupported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "xhigh"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1972,19 +2090,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "unsupported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "xhigh"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2005,19 +2122,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "unsupported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "xhigh"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2038,19 +2154,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "unsupported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "xhigh"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2071,19 +2186,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "unsupported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "xhigh"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2105,19 +2219,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "unsupported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "xhigh"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2139,19 +2252,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "unsupported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "xhigh"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2173,19 +2285,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
           "minimal": "unsupported",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "supported"
-        },
-        "nativeLevels": {
-          "xhigh": "xhigh"
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2205,16 +2316,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -2232,16 +2345,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -2259,16 +2374,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -2286,16 +2403,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -2313,16 +2432,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -2340,16 +2461,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -2368,17 +2491,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2398,17 +2523,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2428,17 +2555,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2458,17 +2587,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2487,17 +2618,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2516,17 +2649,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2546,17 +2681,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -2576,17 +2713,19 @@
       "reasoning"
     ],
     "generation": {
-      "temperature": "supported",
+      "temperature": "unsupported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },

--- a/apps/api/src/data/pricing/openai.json
+++ b/apps/api/src/data/pricing/openai.json
@@ -360,14 +360,13 @@
     "contextWindow": 200000,
     "maxTokens": 100000,
     "capabilities": [
-      "text",
-      "reasoning"
+      "text"
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -1446,14 +1445,13 @@
     "maxTokens": 16384,
     "capabilities": [
       "text",
-      "image",
-      "reasoning"
+      "image"
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -1478,14 +1476,13 @@
     "maxTokens": 16384,
     "capabilities": [
       "text",
-      "image",
-      "reasoning"
+      "image"
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -1638,14 +1635,13 @@
     "maxTokens": 128000,
     "capabilities": [
       "text",
-      "image",
-      "reasoning"
+      "image"
     ],
     "generation": {
       "temperature": "unsupported",
       "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",

--- a/apps/api/src/data/pricing/openai.json
+++ b/apps/api/src/data/pricing/openai.json
@@ -12,15 +12,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -40,15 +32,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -68,15 +52,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -96,15 +72,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -124,15 +92,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -152,15 +112,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -180,15 +132,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -209,15 +153,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -238,15 +174,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -268,15 +196,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -297,15 +217,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -326,15 +238,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -384,15 +288,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -412,15 +308,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -440,15 +328,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -468,15 +348,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -496,15 +368,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -524,15 +388,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -552,15 +408,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -580,15 +428,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -608,15 +448,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -637,15 +469,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -666,15 +490,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -694,15 +510,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -723,15 +531,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -753,15 +553,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -783,15 +575,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -813,15 +597,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -843,15 +619,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -873,15 +641,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -903,15 +663,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -933,15 +685,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -962,15 +706,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -992,15 +728,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1021,15 +749,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1049,15 +769,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1077,15 +789,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1106,15 +810,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1136,15 +832,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1165,15 +853,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1193,15 +873,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1222,15 +894,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1252,15 +916,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1282,15 +938,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1312,15 +960,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1618,15 +1258,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {

--- a/apps/api/src/data/pricing/openai.json
+++ b/apps/api/src/data/pricing/openai.json
@@ -9,7 +9,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -38,7 +37,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -67,7 +65,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -96,7 +93,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -125,7 +121,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -154,7 +149,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -183,7 +177,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -213,7 +206,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -243,7 +235,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -274,7 +265,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -304,7 +294,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -334,7 +323,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -364,7 +352,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -394,7 +381,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -423,7 +409,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -452,7 +437,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -481,7 +465,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -510,7 +493,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -539,7 +521,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -568,7 +549,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -597,7 +577,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -626,7 +605,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -656,7 +634,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -686,7 +663,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -715,7 +691,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -745,7 +720,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -776,7 +750,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -807,7 +780,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -838,7 +810,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -869,7 +840,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -900,7 +870,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -931,7 +900,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -962,7 +930,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -992,7 +959,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1023,7 +989,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1053,7 +1018,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1082,7 +1046,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1111,7 +1074,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1141,7 +1103,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1172,7 +1133,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1202,7 +1162,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1231,7 +1190,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1261,7 +1219,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1292,7 +1249,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1323,7 +1279,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1354,7 +1309,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1386,7 +1340,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -1418,7 +1371,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -1449,7 +1401,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -1480,7 +1431,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -1512,7 +1462,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -1544,7 +1493,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -1576,7 +1524,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -1608,7 +1555,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -1639,7 +1585,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -1670,7 +1615,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1702,9 +1646,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1734,9 +1678,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1766,9 +1710,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1798,9 +1742,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1830,9 +1774,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1862,7 +1806,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -1894,7 +1837,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -1926,9 +1868,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1958,7 +1900,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -1990,9 +1931,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2022,9 +1963,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2054,9 +1995,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2086,9 +2027,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2118,9 +2059,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2150,9 +2091,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2182,9 +2123,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2215,9 +2156,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2248,9 +2189,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2281,9 +2222,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -2312,7 +2253,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -2341,7 +2281,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -2370,7 +2309,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -2399,7 +2337,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -2428,7 +2365,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -2457,7 +2393,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -2488,7 +2423,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -2520,7 +2454,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -2552,7 +2485,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -2584,7 +2516,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -2615,7 +2546,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -2646,7 +2576,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -2678,7 +2607,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
@@ -2710,7 +2638,6 @@
     ],
     "generation": {
       "temperature": "unsupported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,

--- a/apps/api/src/data/pricing/together-ai.json
+++ b/apps/api/src/data/pricing/together-ai.json
@@ -17,7 +17,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -44,7 +45,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -71,7 +73,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -98,7 +101,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -125,7 +129,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -152,7 +157,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -179,7 +185,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -206,7 +213,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -233,7 +241,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -260,7 +269,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -283,12 +293,13 @@
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -315,7 +326,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -339,12 +351,13 @@
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -367,12 +380,13 @@
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -399,7 +413,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -426,7 +441,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -449,12 +465,13 @@
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -477,12 +494,13 @@
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },

--- a/apps/api/src/data/pricing/together-ai.json
+++ b/apps/api/src/data/pricing/together-ai.json
@@ -8,6 +8,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -36,6 +37,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -64,6 +66,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -92,6 +95,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -120,6 +124,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -148,6 +153,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -176,6 +182,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -204,6 +211,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -232,6 +240,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -260,6 +269,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -284,13 +294,13 @@
     "contextWindow": 128000,
     "maxTokens": 16384,
     "capabilities": [
-      "text",
-      "reasoning"
+      "text"
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -317,6 +327,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -342,13 +353,13 @@
     "maxTokens": null,
     "capabilities": [
       "text",
-      "image",
-      "reasoning"
+      "image"
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -371,13 +382,13 @@
     "contextWindow": 131072,
     "maxTokens": null,
     "capabilities": [
-      "text",
-      "reasoning"
+      "text"
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -404,6 +415,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -432,6 +444,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -456,13 +469,13 @@
     "contextWindow": 200000,
     "maxTokens": null,
     "capabilities": [
-      "text",
-      "reasoning"
+      "text"
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -485,13 +498,13 @@
     "contextWindow": 200000,
     "maxTokens": null,
     "capabilities": [
-      "text",
-      "reasoning"
+      "text"
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",

--- a/apps/api/src/data/pricing/together-ai.json
+++ b/apps/api/src/data/pricing/together-ai.json
@@ -11,15 +11,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -39,15 +31,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -67,15 +51,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -95,15 +71,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -123,15 +91,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -151,15 +111,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -179,15 +131,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -207,15 +151,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -235,15 +171,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -263,15 +191,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -319,15 +239,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -404,15 +316,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -432,15 +336,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {

--- a/apps/api/src/data/pricing/together-ai.json
+++ b/apps/api/src/data/pricing/together-ai.json
@@ -8,7 +8,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -37,7 +36,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -66,7 +64,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -95,7 +92,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -124,7 +120,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -153,7 +148,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -182,7 +176,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -211,7 +204,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -240,7 +232,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -269,7 +260,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -298,7 +288,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -327,7 +316,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -357,7 +345,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -386,7 +373,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -415,7 +401,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -444,7 +429,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -473,7 +457,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -502,7 +485,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,

--- a/apps/api/src/data/pricing/xai.json
+++ b/apps/api/src/data/pricing/xai.json
@@ -11,15 +11,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -39,15 +31,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -67,15 +51,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -96,15 +72,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -125,15 +93,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -154,15 +114,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -182,15 +134,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -211,15 +155,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -240,15 +176,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -269,15 +197,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -298,15 +218,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -513,15 +425,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -541,15 +445,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -602,15 +498,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -632,15 +520,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -725,15 +605,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -754,15 +626,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -783,15 +647,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -844,15 +700,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1066,15 +914,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -1188,15 +1028,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {

--- a/apps/api/src/data/pricing/xai.json
+++ b/apps/api/src/data/pricing/xai.json
@@ -8,6 +8,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -17,7 +18,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -35,6 +37,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -44,7 +47,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -62,6 +66,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -71,7 +76,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -90,6 +96,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -99,7 +106,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -118,6 +126,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -127,7 +136,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -146,6 +156,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -155,7 +166,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -173,6 +185,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -182,7 +195,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -201,6 +215,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -210,7 +225,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -229,6 +245,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -238,7 +255,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -257,6 +275,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -266,7 +285,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -285,6 +305,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -294,7 +315,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -314,16 +336,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -343,16 +367,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -372,16 +398,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -401,16 +429,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -430,16 +460,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -459,16 +491,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -487,6 +521,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -496,7 +531,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -514,6 +550,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -523,7 +560,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -543,16 +581,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -572,6 +612,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -581,7 +622,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -601,6 +643,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -610,7 +653,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -631,16 +675,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -661,16 +707,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -689,6 +737,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -698,7 +747,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -717,6 +767,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -726,7 +777,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -745,6 +797,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -754,7 +807,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -774,16 +828,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -803,6 +859,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -812,7 +869,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -833,16 +891,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -863,16 +923,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -893,16 +955,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -923,16 +987,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -953,16 +1019,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -983,16 +1051,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1012,6 +1082,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1021,7 +1092,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -1040,16 +1112,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1069,16 +1143,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1098,16 +1174,18 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "supported",
+          "minimal": "supported",
+          "low": "supported",
+          "medium": "supported",
+          "high": "supported",
+          "xhigh": "supported",
+          "max": "supported"
         }
       }
     },
@@ -1127,6 +1205,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1136,7 +1215,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },

--- a/apps/api/src/data/pricing/xai.json
+++ b/apps/api/src/data/pricing/xai.json
@@ -8,7 +8,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -37,7 +36,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -66,7 +64,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -96,7 +93,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -126,7 +122,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -156,7 +151,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -185,7 +179,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -215,7 +208,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -245,7 +237,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -275,7 +266,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -305,7 +295,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -336,9 +325,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -367,9 +356,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -398,9 +387,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -429,9 +418,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -460,9 +449,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -491,9 +480,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -521,7 +510,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -550,7 +538,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -581,9 +568,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -612,7 +599,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -643,7 +629,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -675,9 +660,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -707,9 +692,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -737,7 +722,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -767,7 +751,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -797,7 +780,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -828,9 +810,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -859,7 +841,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -891,9 +872,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -923,9 +904,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -955,9 +936,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -987,9 +968,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1019,9 +1000,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1051,9 +1032,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1082,7 +1063,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -1112,9 +1092,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1143,9 +1123,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1174,9 +1154,9 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "supported",
       "reasoning": {
         "supported": "supported",
+        "temperatureCompatible": "supported",
         "adaptive": null,
         "levels": {
           "off": "supported",
@@ -1205,7 +1185,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,

--- a/apps/api/src/data/pricing/zai.json
+++ b/apps/api/src/data/pricing/zai.json
@@ -11,15 +11,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -39,15 +31,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -67,15 +51,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -95,15 +71,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -123,15 +91,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -151,15 +111,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {
@@ -180,15 +132,7 @@
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
-        "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown",
-          "max": "unknown"
-        }
+        "levels": {}
       }
     },
     "cost": {

--- a/apps/api/src/data/pricing/zai.json
+++ b/apps/api/src/data/pricing/zai.json
@@ -8,6 +8,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -36,6 +37,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -64,6 +66,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -92,6 +95,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -120,6 +124,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -148,6 +153,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -177,6 +183,7 @@
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -201,13 +208,13 @@
     "contextWindow": 200000,
     "maxTokens": 128000,
     "capabilities": [
-      "text",
-      "reasoning"
+      "text"
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -232,13 +239,13 @@
     "contextWindow": 200000,
     "maxTokens": 128000,
     "capabilities": [
-      "text",
-      "reasoning"
+      "text"
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -263,13 +270,13 @@
     "contextWindow": 200000,
     "maxTokens": 128000,
     "capabilities": [
-      "text",
-      "reasoning"
+      "text"
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",
@@ -294,13 +301,13 @@
     "contextWindow": 200000,
     "maxTokens": 128000,
     "capabilities": [
-      "text",
-      "reasoning"
+      "text"
     ],
     "generation": {
       "temperature": "supported",
+      "temperatureWithReasoning": "unsupported",
       "reasoning": {
-        "supported": "supported",
+        "supported": "unsupported",
         "adaptive": null,
         "levels": {
           "off": "unsupported",

--- a/apps/api/src/data/pricing/zai.json
+++ b/apps/api/src/data/pricing/zai.json
@@ -8,7 +8,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -37,7 +36,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -66,7 +64,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -95,7 +92,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -124,7 +120,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -153,7 +148,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -183,7 +177,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unknown",
       "reasoning": {
         "supported": "unknown",
         "adaptive": null,
@@ -212,7 +205,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -243,7 +235,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -274,7 +265,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,
@@ -305,7 +295,6 @@
     ],
     "generation": {
       "temperature": "supported",
-      "temperatureWithReasoning": "unsupported",
       "reasoning": {
         "supported": "unsupported",
         "adaptive": null,

--- a/apps/api/src/data/pricing/zai.json
+++ b/apps/api/src/data/pricing/zai.json
@@ -17,7 +17,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -44,7 +45,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -71,7 +73,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -98,7 +101,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -125,7 +129,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -152,7 +157,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -180,7 +186,8 @@
           "low": "unknown",
           "medium": "unknown",
           "high": "unknown",
-          "xhigh": "unknown"
+          "xhigh": "unknown",
+          "max": "unknown"
         }
       }
     },
@@ -203,12 +210,13 @@
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -233,12 +241,13 @@
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -263,12 +272,13 @@
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },
@@ -293,12 +303,13 @@
         "supported": "supported",
         "adaptive": null,
         "levels": {
-          "off": "unknown",
-          "minimal": "unknown",
-          "low": "unknown",
-          "medium": "unknown",
-          "high": "unknown",
-          "xhigh": "unknown"
+          "off": "unsupported",
+          "minimal": "unsupported",
+          "low": "unsupported",
+          "medium": "unsupported",
+          "high": "unsupported",
+          "xhigh": "unsupported",
+          "max": "unsupported"
         }
       }
     },

--- a/apps/api/src/modules/core-providers/index.ts
+++ b/apps/api/src/modules/core-providers/index.ts
@@ -65,6 +65,10 @@ const anthropic: ModelProviderDefinition = {
   baseUrlOverridable: false,
   authMode: "api_key",
   featured: true,
+  // Pi's Anthropic transport intentionally omits temperature whenever
+  // extended thinking is enabled. Reject that combination before inference
+  // instead of presenting a catalog capability the transport cannot honor.
+  generationOverride: { temperatureWithReasoning: "unsupported" },
   featuredModels: featured("anthropic"),
 };
 

--- a/apps/api/src/modules/core-providers/index.ts
+++ b/apps/api/src/modules/core-providers/index.ts
@@ -43,6 +43,7 @@
  */
 
 import type { AppstrateModule, ModelProviderDefinition } from "@appstrate/core/module";
+import { ANTHROPIC_GENERATION_CAPABILITIES_OVERRIDE } from "@appstrate/core/model-generation";
 import autoFeatured from "../../data/featured-models.json" with { type: "json" };
 
 /**
@@ -65,10 +66,9 @@ const anthropic: ModelProviderDefinition = {
   baseUrlOverridable: false,
   authMode: "api_key",
   featured: true,
-  // Pi's Anthropic transport intentionally omits temperature whenever
-  // extended thinking is enabled. Reject that combination before inference
-  // instead of presenting a catalog capability the transport cannot honor.
-  generationOverride: { temperatureWithReasoning: "unsupported" },
+  // Keep LiteLLM's portable support facts, then apply Anthropic wire-level
+  // constraints (temperature with thinking, and minimal → low effort).
+  generationOverride: ANTHROPIC_GENERATION_CAPABILITIES_OVERRIDE,
   featuredModels: featured("anthropic"),
 };
 

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -103,7 +103,7 @@ export const schemas = {
       },
       reasoningLevel: {
         type: ["string", "null"],
-        enum: ["off", "minimal", "low", "medium", "high", "xhigh", null],
+        enum: ["off", "minimal", "low", "medium", "high", "xhigh", "max", null],
         description: "Portable reasoning effort normalized across providers.",
       },
     },
@@ -130,19 +130,19 @@ export const schemas = {
               enum: ["supported", "unsupported", "unknown"],
             },
             propertyNames: {
-              enum: ["off", "minimal", "low", "medium", "high", "xhigh"],
+              enum: ["off", "minimal", "low", "medium", "high", "xhigh", "max"],
             },
           },
           nativeLevels: {
             type: "object",
             description:
-              "Optional provider-native values for portable levels (for example xhigh to max).",
+              "Optional provider-native values for portable levels (for example off to none).",
             additionalProperties: {
               type: "string",
               enum: ["none", "minimal", "low", "medium", "high", "xhigh", "max"],
             },
             propertyNames: {
-              enum: ["off", "minimal", "low", "medium", "high", "xhigh"],
+              enum: ["off", "minimal", "low", "medium", "high", "xhigh", "max"],
             },
           },
         },

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -122,6 +122,12 @@ export const schemas = {
         required: ["supported", "adaptive", "levels"],
         properties: {
           supported: { type: "string", enum: ["supported", "unsupported", "unknown"] },
+          temperatureCompatible: {
+            type: "string",
+            enum: ["supported", "unsupported", "unknown"],
+            description:
+              "Optional compatibility fact for combining a custom temperature with active reasoning. Omission means unknown.",
+          },
           adaptive: { type: ["boolean", "null"] },
           levels: {
             type: "object",

--- a/apps/api/src/services/org-models.ts
+++ b/apps/api/src/services/org-models.ts
@@ -107,7 +107,11 @@ const defaultModel = createDefaultPointer({
 function projectAliasedGenerationCapabilities(
   capabilities: ModelGenerationCapabilities | null,
 ): ModelGenerationCapabilities {
-  const levels = capabilities?.reasoning.levels ?? {};
+  const levels = Object.fromEntries(
+    Object.entries(capabilities?.reasoning.levels ?? {}).filter(
+      ([, support]) => support === "supported",
+    ),
+  ) as ModelGenerationCapabilities["reasoning"]["levels"];
   const temperatureSupported = capabilities?.temperature === "supported";
   const reasoningSupported = capabilities?.reasoning.supported === "supported";
 

--- a/apps/api/src/services/org-models.ts
+++ b/apps/api/src/services/org-models.ts
@@ -108,17 +108,24 @@ function projectAliasedGenerationCapabilities(
   capabilities: ModelGenerationCapabilities | null,
 ): ModelGenerationCapabilities {
   const levels = capabilities?.reasoning.levels ?? {};
+  const temperatureSupported = capabilities?.temperature === "supported";
   const reasoningSupported = capabilities?.reasoning.supported === "supported";
 
   // Alias callers cannot inspect the backing model to compensate for an
   // unknown capability. Expose only catalog-confirmed support and fail closed
   // for unknowns. The runtime still resolves the full, unprojected contract.
   return {
-    temperature: capabilities?.temperature === "supported" ? "supported" : "unsupported",
-    temperatureWithReasoning:
-      capabilities?.temperatureWithReasoning === "supported" ? "supported" : "unsupported",
+    temperature: temperatureSupported ? "supported" : "unsupported",
     reasoning: {
       supported: reasoningSupported ? "supported" : "unsupported",
+      ...(temperatureSupported && reasoningSupported
+        ? {
+            temperatureCompatible:
+              capabilities?.reasoning.temperatureCompatible === "supported"
+                ? "supported"
+                : "unsupported",
+          }
+        : {}),
       adaptive: null,
       levels: reasoningSupported ? { ...levels } : {},
     },

--- a/apps/api/src/services/org-models.ts
+++ b/apps/api/src/services/org-models.ts
@@ -33,7 +33,6 @@ import { getModelProvider } from "./model-providers/registry.ts";
 import { resolveOAuthTokenForSidecar } from "./model-providers/token-resolver.ts";
 import {
   applyModelGenerationCapabilitiesOverride,
-  INHERITED_MODEL_GENERATION_CAPABILITIES,
   UNKNOWN_MODEL_GENERATION_CAPABILITIES,
   type ModelGenerationCapabilities,
 } from "@appstrate/core/model-generation";
@@ -94,9 +93,10 @@ const defaultModel = createDefaultPointer({
  * endpoint (`baseUrl`), upstream id (`modelId`), credential, and every
  * capability/cost field — is nulled. Backing-derived capability/cost fields are
  * dropped too (not just the ids): a distinctive context window or price could
- * identify the real model. Generation uses one constant alias contract instead:
- * controls stay inherited, so clients can hide them and clear stale overrides
- * without learning anything about the backing. Non-aliased models pass through.
+ * identify the real model. The exception is the normalized, portable generation
+ * contract required to render safe temperature/reasoning controls. Provider-
+ * native mappings and adaptive transport details remain private. Non-aliased
+ * models pass through.
  *
  * Applied at the user-facing read boundary (`GET /api/models`, the effective-
  * default response) — NOT inside {@link listOrgModels}, so the operator
@@ -104,6 +104,27 @@ const defaultModel = createDefaultPointer({
  * the full resource they just configured. Resolution (`resolveModel` /
  * `loadModel`) is unaffected — the run executor always gets the real binding.
  */
+function projectAliasedGenerationCapabilities(
+  capabilities: ModelGenerationCapabilities | null,
+): ModelGenerationCapabilities {
+  const levels = capabilities?.reasoning.levels ?? {};
+  const reasoningSupported = capabilities?.reasoning.supported === "supported";
+
+  // Alias callers cannot inspect the backing model to compensate for an
+  // unknown capability. Expose only catalog-confirmed support and fail closed
+  // for unknowns. The runtime still resolves the full, unprojected contract.
+  return {
+    temperature: capabilities?.temperature === "supported" ? "supported" : "unsupported",
+    temperatureWithReasoning:
+      capabilities?.temperatureWithReasoning === "supported" ? "supported" : "unsupported",
+    reasoning: {
+      supported: reasoningSupported ? "supported" : "unsupported",
+      adaptive: null,
+      levels: reasoningSupported ? { ...levels } : {},
+    },
+  };
+}
+
 export function projectAliasedModel(model: OrgModelInfo): OrgModelInfo {
   if (!model.aliased) return model;
   // Allowlist, NOT a denylist (`{ ...model, field: null }`): build the public
@@ -142,15 +163,15 @@ export function projectAliasedModel(model: OrgModelInfo): OrgModelInfo {
     baseUrl: null,
     modelId: null,
     credentialId: null,
-    // Capability/cost — catalog-derived from the REAL model, so they
-    // fingerprint it; drop them too. Generation gets the same fixed contract
-    // for every alias, independent of its backing.
+    // Capability/cost — identifying catalog metadata stays private. Generation
+    // exposes only the portable support vector needed by the controls; native
+    // mappings and adaptive transport semantics stay on the resolved model.
     contextWindow: null,
     maxTokens: null,
     input: null,
     reasoning: null,
     cost: null,
-    generation: INHERITED_MODEL_GENERATION_CAPABILITIES,
+    generation: projectAliasedGenerationCapabilities(model.generation),
   };
 }
 

--- a/apps/api/src/services/pricing-catalog.ts
+++ b/apps/api/src/services/pricing-catalog.ts
@@ -26,7 +26,8 @@
  *     mid-quarter price drops can't silently change historical cost
  *     attribution.
  *
- * Refresh: `bun run scripts/refresh-pricing-catalog.ts --apply`.
+ * Refresh: run `scripts/refresh-pricing-catalog.ts --apply` with
+ * `LITELLM_CATALOG_PATH` pointing at the pinned exporter artifact.
  *
  * The lookup is keyed on **providerId** (not `apiShape`): cerebras,
  * groq, and xai all share `openai-completions` apiShape with different

--- a/apps/api/src/services/run-launcher/pi.ts
+++ b/apps/api/src/services/run-launcher/pi.ts
@@ -48,6 +48,7 @@ import { runWithSpan, currentTraceparent, recordContainerSpawn } from "@appstrat
 import { getEnv } from "@appstrate/env";
 import { getModelProvider } from "../model-providers/registry.ts";
 import type { LlmProxyConfig, SidecarLaunchSpec } from "@appstrate/core/sidecar-types";
+import { toNativeModelReasoningLevel } from "@appstrate/core/model-generation";
 
 /**
  * Grace added to the platform's container watchdog on top of the agent's
@@ -228,8 +229,22 @@ async function runPlatformContainerImpl(
     // Model-alias swap descriptor (LLM-gateway alias pattern). The container is
     // handed the public alias as MODEL_ID (below); the sidecar swaps it for the
     // real upstream id on every call. The real id never enters the container.
+    const requestedReasoningLevel = plan.generationConfig?.reasoningLevel ?? "medium";
+    const nativeReasoningLevel = toNativeModelReasoningLevel(
+      requestedReasoningLevel,
+      llmConfig.generation,
+    );
     const modelSwap = llmConfig.aliased
-      ? { alias: llmConfig.aliasId, real: llmConfig.modelId }
+      ? {
+          alias: llmConfig.aliasId,
+          real: llmConfig.modelId,
+          ...(llmConfig.apiShape === "anthropic-messages" &&
+          llmConfig.generation?.reasoning.adaptive === true &&
+          requestedReasoningLevel !== "off" &&
+          nativeReasoningLevel !== "none"
+            ? { anthropicAdaptiveReasoning: { effort: nativeReasoningLevel } }
+            : {}),
+        }
       : undefined;
 
     let sidecarLlm: LlmProxyConfig | undefined;

--- a/apps/api/test/integration/services/run-launcher-no-sidecar.test.ts
+++ b/apps/api/test/integration/services/run-launcher-no-sidecar.test.ts
@@ -239,6 +239,59 @@ describe("run-launcher — sidecar skip decision", () => {
     expect(JSON.stringify(env)).not.toContain("api.deepseek.com");
   });
 
+  it("keeps adaptive Anthropic reasoning private and restores it in the sidecar", async () => {
+    const { orchestrator, counts } = createCountingFake();
+
+    await runPlatformContainer({
+      runId: "run_adaptive_alias",
+      context: buildContext("run_adaptive_alias"),
+      plan: buildRunPlan({
+        generationConfig: { reasoningLevel: "max" },
+        llmConfig: {
+          providerId: "anthropic",
+          apiShape: "anthropic-messages",
+          baseUrl: "https://api.anthropic.com",
+          modelId: "claude-sonnet-4-6",
+          apiKey: "sk-real-secret",
+          label: "Appstrate Adaptive",
+          isSystemModel: true,
+          aliased: true,
+          aliasId: "appstrate-adaptive",
+          reasoning: true,
+          generation: {
+            temperature: "supported",
+            temperatureWithReasoning: "unsupported",
+            reasoning: {
+              supported: "supported",
+              adaptive: true,
+              levels: { max: "supported" },
+              nativeLevels: { max: "max" },
+            },
+          },
+        },
+      }),
+      sinkCredentials: mintSinkCredentials({
+        runId: "run_adaptive_alias",
+        appUrl: "http://platform:3000",
+        ttlSeconds: 60,
+      }),
+      orchestrator,
+    });
+
+    const llm = counts.capturedSidecarSpec?.llm;
+    if (llm?.authMode !== "api_key") throw new Error(`expected api_key llm, got ${llm?.authMode}`);
+    expect(llm.modelSwap).toEqual({
+      alias: "appstrate-adaptive",
+      real: "claude-sonnet-4-6",
+      anthropicAdaptiveReasoning: { effort: "max" },
+    });
+
+    const env = counts.capturedAgentEnv ?? {};
+    expect(env.MODEL_ID).toBe("appstrate-adaptive");
+    expect(JSON.stringify(env)).not.toContain("claude-sonnet-4-6");
+    expect(env).not.toHaveProperty("MODEL_REASONING_ADAPTIVE");
+  });
+
   it("creates the sidecar when the plan declares at least one integration", async () => {
     const { orchestrator, counts } = createCountingFake();
 

--- a/apps/api/test/integration/services/run-launcher-no-sidecar.test.ts
+++ b/apps/api/test/integration/services/run-launcher-no-sidecar.test.ts
@@ -260,9 +260,9 @@ describe("run-launcher — sidecar skip decision", () => {
           reasoning: true,
           generation: {
             temperature: "supported",
-            temperatureWithReasoning: "unsupported",
             reasoning: {
               supported: "supported",
+              temperatureCompatible: "unsupported",
               adaptive: true,
               levels: { max: "supported" },
               nativeLevels: { max: "max" },

--- a/apps/api/test/unit/pricing-catalog.test.ts
+++ b/apps/api/test/unit/pricing-catalog.test.ts
@@ -163,6 +163,25 @@ describe("vendored catalog invariant — configurable reasoning has a supported 
   });
 });
 
+describe("vendored catalog invariant — sparse reasoning levels", () => {
+  it("omits unknown level facts", () => {
+    const violations = catalogFiles.flatMap((file) => {
+      const entries = JSON.parse(readFileSync(join(dataDir, file), "utf8")) as Record<
+        string,
+        { generation?: { reasoning?: { levels?: Record<string, string> } } }
+      >;
+
+      return Object.entries(entries).flatMap(([modelId, entry]) =>
+        Object.entries(entry.generation?.reasoning?.levels ?? {})
+          .filter(([, support]) => support === "unknown")
+          .map(([level]) => `${file}:${modelId}:${level}`),
+      );
+    });
+
+    expect(violations).toEqual([]);
+  });
+});
+
 describe("vendored catalog invariant — sparse temperature compatibility", () => {
   it("serializes only conclusive pair facts for individually usable controls", () => {
     const pairFacts = catalogFiles.flatMap((file) => {

--- a/apps/api/test/unit/pricing-catalog.test.ts
+++ b/apps/api/test/unit/pricing-catalog.test.ts
@@ -162,3 +162,46 @@ describe("vendored catalog invariant — configurable reasoning has a supported 
     expect(violations).toEqual([]);
   });
 });
+
+describe("vendored catalog invariant — sparse temperature compatibility", () => {
+  it("serializes only conclusive pair facts for individually usable controls", () => {
+    const pairFacts = catalogFiles.flatMap((file) => {
+      const entries = JSON.parse(readFileSync(join(dataDir, file), "utf8")) as Record<
+        string,
+        {
+          generation?: {
+            temperature?: string;
+            reasoning?: {
+              supported?: string;
+              temperatureCompatible?: string;
+            };
+          };
+        }
+      >;
+
+      return Object.entries(entries).flatMap(([modelId, entry]) => {
+        const generation = entry.generation;
+        const compatibility = generation?.reasoning?.temperatureCompatible;
+        return compatibility === undefined ? [] : [{ file, modelId, generation, compatibility }];
+      });
+    });
+
+    expect(pairFacts.length).toBeGreaterThan(0);
+    expect(
+      pairFacts
+        .filter(
+          ({ generation, compatibility }) =>
+            generation?.temperature !== "supported" ||
+            generation.reasoning?.supported !== "supported" ||
+            !["supported", "unsupported"].includes(compatibility),
+        )
+        .map(({ file, modelId }) => `${file}:${modelId}`),
+    ).toEqual([]);
+  });
+
+  it("keeps the known OpenAI incompatibility guard", () => {
+    expect(
+      lookupCatalogModel("openai", "gpt-5.1")?.generation?.reasoning.temperatureCompatible,
+    ).toBe("unsupported");
+  });
+});

--- a/apps/api/test/unit/pricing-catalog.test.ts
+++ b/apps/api/test/unit/pricing-catalog.test.ts
@@ -21,6 +21,9 @@ import {
   lookupCatalogModel,
 } from "../../src/services/pricing-catalog.ts";
 
+const dataDir = join(dirname(dirname(import.meta.dir)), "src/data/pricing");
+const catalogFiles = readdirSync(dataDir).filter((file) => file.endsWith(".json"));
+
 describe("lookupCatalogModel", () => {
   it("returns null for an unknown providerId", () => {
     expect(lookupCatalogModel("not-a-real-provider", "anything")).toBeNull();
@@ -111,14 +114,11 @@ describe("vendored catalog invariant — maxTokens < contextWindow", () => {
   // LiteLLM (devstral, kimi-k2.5, … — known upstream bug). This test pins
   // the on-disk data so a future bad refresh can't reintroduce a cap that
   // crashes the sidecar / pins the compaction threshold at zero.
-  const dataDir = join(dirname(dirname(import.meta.dir)), "src/data/pricing");
-  const files = readdirSync(dataDir).filter((f) => f.endsWith(".json"));
-
   it("vendors at least the 12 known provider files", () => {
-    expect(files.length).toBeGreaterThanOrEqual(12);
+    expect(catalogFiles.length).toBeGreaterThanOrEqual(12);
   });
 
-  for (const file of files) {
+  for (const file of catalogFiles) {
     it(`${file}: every maxTokens is null or strictly below contextWindow`, () => {
       const entries = JSON.parse(readFileSync(join(dataDir, file), "utf8")) as Record<
         string,
@@ -135,4 +135,30 @@ describe("vendored catalog invariant — maxTokens < contextWindow", () => {
       expect(violations).toEqual([]);
     });
   }
+});
+
+describe("vendored catalog invariant — configurable reasoning has a supported effort", () => {
+  it("never advertises reasoning when LiteLLM rejects every active effort", () => {
+    const violations = catalogFiles.flatMap((file) => {
+      const entries = JSON.parse(readFileSync(join(dataDir, file), "utf8")) as Record<
+        string,
+        {
+          generation?: {
+            reasoning?: { supported?: string; levels?: Record<string, string> };
+          };
+        }
+      >;
+      return Object.entries(entries)
+        .filter(([, entry]) => {
+          const reasoning = entry.generation?.reasoning;
+          if (reasoning?.supported !== "supported") return false;
+          return !Object.entries(reasoning.levels ?? {}).some(
+            ([level, support]) => level !== "off" && support === "supported",
+          );
+        })
+        .map(([modelId]) => `${file}:${modelId}`);
+    });
+
+    expect(violations).toEqual([]);
+  });
 });

--- a/apps/api/test/unit/services/project-aliased-model.test.ts
+++ b/apps/api/test/unit/services/project-aliased-model.test.ts
@@ -4,9 +4,9 @@
  * Phase 2 (model alias) — `projectAliasedModel` is the user-facing read
  * boundary that strips a model alias's real binding. A non-aliased model must
  * pass through byte-for-byte; an aliased one must keep only the public surface
- * (id/label/flags/timestamps) and null EVERYTHING that could identify the
- * backing — ids, endpoint, AND catalog-derived capability/cost (a distinctive
- * window or price would itself fingerprint the real model).
+ * (id/label/flags/timestamps) and the portable generation contract required by
+ * the client. Provider-native mappings and every other catalog-derived field
+ * stay private.
  */
 
 import { describe, it, expect } from "bun:test";
@@ -21,7 +21,24 @@ const base: OrgModelInfo = {
   providerName: "OpenAI-compatible (custom)",
   baseUrl: "https://api.deepseek.com/v1",
   modelId: "deepseek-chat",
-  generation: null,
+  generation: {
+    temperature: "unsupported",
+    temperatureWithReasoning: "unsupported",
+    reasoning: {
+      supported: "supported",
+      adaptive: true,
+      levels: {
+        off: "supported",
+        minimal: "unsupported",
+        low: "supported",
+        medium: "supported",
+        high: "supported",
+        xhigh: "supported",
+        max: "supported",
+      },
+      nativeLevels: { off: "none", max: "max" },
+    },
+  },
   input: ["text"],
   contextWindow: 64000,
   maxTokens: 8192,
@@ -44,7 +61,7 @@ describe("projectAliasedModel", () => {
     expect(projectAliasedModel(base)).toEqual(base);
   });
 
-  it("strips the entire backing for an aliased model", () => {
+  it("strips the backing but keeps portable generation capabilities for an alias", () => {
     const out = projectAliasedModel({ ...base, aliased: true });
 
     // Public surface survives.
@@ -54,7 +71,7 @@ describe("projectAliasedModel", () => {
     expect(out.enabled).toBe(true);
     expect(out.source).toBe("built-in");
 
-    // Binding + catalog-derived metadata are all nulled.
+    // Binding + identifying catalog metadata are all nulled.
     // (iconUrl is a deliberate public choice, decoupled from the backing — see
     // the dedicated case below; it must survive the projection.)
     expect(out.apiShape).toBeNull();
@@ -70,7 +87,19 @@ describe("projectAliasedModel", () => {
     expect(out.cost).toBeNull();
     expect(out.generation).toEqual({
       temperature: "unsupported",
-      reasoning: { supported: "unsupported", adaptive: null, levels: {} },
+      reasoning: {
+        supported: "supported",
+        adaptive: null,
+        levels: {
+          off: "supported",
+          minimal: "unsupported",
+          low: "supported",
+          medium: "supported",
+          high: "supported",
+          xhigh: "supported",
+          max: "supported",
+        },
+      },
     });
 
     // Hard guarantee: nothing identifying the backing survives serialization.
@@ -78,6 +107,25 @@ describe("projectAliasedModel", () => {
     expect(json).not.toContain("deepseek");
     expect(json).not.toContain("deepseek-chat");
     expect(json).not.toContain("api.deepseek.com");
+    expect(json).not.toContain("nativeLevels");
+  });
+
+  it("keeps alias controls fail-closed without catalog-confirmed support", () => {
+    const out = projectAliasedModel({
+      ...base,
+      aliased: true,
+      generation: {
+        temperature: "unknown",
+        temperatureWithReasoning: "unknown",
+        reasoning: { supported: "unknown", adaptive: null, levels: {} },
+      },
+    });
+
+    expect(out.generation).toEqual({
+      temperature: "unsupported",
+      temperatureWithReasoning: "unsupported",
+      reasoning: { supported: "unsupported", adaptive: null, levels: {} },
+    });
   });
 
   it("preserves needs_reconnection on an aliased model", () => {

--- a/apps/api/test/unit/services/project-aliased-model.test.ts
+++ b/apps/api/test/unit/services/project-aliased-model.test.ts
@@ -23,7 +23,6 @@ const base: OrgModelInfo = {
   modelId: "deepseek-chat",
   generation: {
     temperature: "unsupported",
-    temperatureWithReasoning: "unsupported",
     reasoning: {
       supported: "supported",
       adaptive: true,
@@ -116,16 +115,49 @@ describe("projectAliasedModel", () => {
       aliased: true,
       generation: {
         temperature: "unknown",
-        temperatureWithReasoning: "unknown",
         reasoning: { supported: "unknown", adaptive: null, levels: {} },
       },
     });
 
     expect(out.generation).toEqual({
       temperature: "unsupported",
-      temperatureWithReasoning: "unsupported",
       reasoning: { supported: "unsupported", adaptive: null, levels: {} },
     });
+  });
+
+  it("fails closed when an alias pair is not explicitly compatible", () => {
+    const out = projectAliasedModel({
+      ...base,
+      aliased: true,
+      generation: {
+        temperature: "supported",
+        reasoning: {
+          supported: "supported",
+          adaptive: null,
+          levels: { low: "supported" },
+        },
+      },
+    });
+
+    expect(out.generation?.reasoning.temperatureCompatible).toBe("unsupported");
+  });
+
+  it("preserves explicitly compatible alias pairs", () => {
+    const out = projectAliasedModel({
+      ...base,
+      aliased: true,
+      generation: {
+        temperature: "supported",
+        reasoning: {
+          supported: "supported",
+          temperatureCompatible: "supported",
+          adaptive: null,
+          levels: { low: "supported" },
+        },
+      },
+    });
+
+    expect(out.generation?.reasoning.temperatureCompatible).toBe("supported");
   });
 
   it("preserves needs_reconnection on an aliased model", () => {

--- a/apps/api/test/unit/services/project-aliased-model.test.ts
+++ b/apps/api/test/unit/services/project-aliased-model.test.ts
@@ -91,7 +91,6 @@ describe("projectAliasedModel", () => {
         adaptive: null,
         levels: {
           off: "supported",
-          minimal: "unsupported",
           low: "supported",
           medium: "supported",
           high: "supported",

--- a/apps/api/test/unit/services/resolve-catalog-defaults.test.ts
+++ b/apps/api/test/unit/services/resolve-catalog-defaults.test.ts
@@ -117,5 +117,19 @@ describe("resolveCatalogDefaults", () => {
         temperature: "unsupported",
       });
     });
+
+    it("rejects temperature combined with reasoning on Anthropic Pi transports", () => {
+      for (const providerId of ["anthropic", "claude-code"]) {
+        const defaults = resolveCatalogDefaults(providerId, "claude-3-7-sonnet-20250219");
+
+        expect(defaults.generation?.temperatureWithReasoning).toBe("unsupported");
+        expect(() =>
+          resolveModelGenerationSettings({
+            capabilities: defaults.generation,
+            override: { temperature: 0.4, reasoningLevel: "low" },
+          }),
+        ).toThrow(ModelGenerationError);
+      }
+    });
   });
 });

--- a/apps/api/test/unit/services/resolve-catalog-defaults.test.ts
+++ b/apps/api/test/unit/services/resolve-catalog-defaults.test.ts
@@ -86,6 +86,32 @@ describe("resolveCatalogDefaults", () => {
       ).toThrow(ModelGenerationError);
     });
 
+    it("exposes LiteLLM's complete Luna reasoning contract through Codex", () => {
+      const codex = resolveCatalogDefaults("codex", "gpt-5.6-luna");
+
+      expect(codex.generation?.reasoning.levels).toEqual({
+        off: "supported",
+        minimal: "unsupported",
+        low: "supported",
+        medium: "supported",
+        high: "supported",
+        xhigh: "supported",
+        max: "supported",
+      });
+      expect(
+        resolveModelGenerationSettings({
+          capabilities: codex.generation,
+          override: { reasoningLevel: "low" },
+        }),
+      ).toEqual({ reasoningLevel: "low" });
+      expect(
+        resolveModelGenerationSettings({
+          capabilities: codex.generation,
+          override: { reasoningLevel: "max" },
+        }),
+      ).toEqual({ reasoningLevel: "max" });
+    });
+
     it("keeps provider transport restrictions on a catalog miss", () => {
       expect(resolveCatalogDefaults("codex", "future-codex-model").generation).toMatchObject({
         temperature: "unsupported",

--- a/apps/api/test/unit/services/resolve-catalog-defaults.test.ts
+++ b/apps/api/test/unit/services/resolve-catalog-defaults.test.ts
@@ -123,6 +123,7 @@ describe("resolveCatalogDefaults", () => {
         const defaults = resolveCatalogDefaults(providerId, "claude-3-7-sonnet-20250219");
 
         expect(defaults.generation?.temperatureWithReasoning).toBe("unsupported");
+        expect(defaults.generation?.reasoning.nativeLevels?.minimal).toBe("low");
         expect(() =>
           resolveModelGenerationSettings({
             capabilities: defaults.generation,

--- a/apps/api/test/unit/services/resolve-catalog-defaults.test.ts
+++ b/apps/api/test/unit/services/resolve-catalog-defaults.test.ts
@@ -122,7 +122,7 @@ describe("resolveCatalogDefaults", () => {
       for (const providerId of ["anthropic", "claude-code"]) {
         const defaults = resolveCatalogDefaults(providerId, "claude-3-7-sonnet-20250219");
 
-        expect(defaults.generation?.temperatureWithReasoning).toBe("unsupported");
+        expect(defaults.generation?.reasoning.temperatureCompatible).toBe("unsupported");
         expect(defaults.generation?.reasoning.nativeLevels?.minimal).toBe("low");
         expect(() =>
           resolveModelGenerationSettings({

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -5108,6 +5108,11 @@ export interface components {
             reasoning: {
                 /** @enum {string} */
                 supported: "supported" | "unsupported" | "unknown";
+                /**
+                 * @description Optional compatibility fact for combining a custom temperature with active reasoning. Omission means unknown.
+                 * @enum {string}
+                 */
+                temperatureCompatible?: "supported" | "unsupported" | "unknown";
                 adaptive: boolean | null;
                 levels: {
                     [key: string]: "supported" | "unsupported" | "unknown";

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -5112,7 +5112,7 @@ export interface components {
                 levels: {
                     [key: string]: "supported" | "unsupported" | "unknown";
                 };
-                /** @description Optional provider-native values for portable levels (for example xhigh to max). */
+                /** @description Optional provider-native values for portable levels (for example off to none). */
                 nativeLevels?: {
                     [key: string]: "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
                 };
@@ -5126,7 +5126,7 @@ export interface components {
              * @description Portable reasoning effort normalized across providers.
              * @enum {string|null}
              */
-            reasoningLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | null;
+            reasoningLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max" | null;
         };
         ModelProviderCredential: {
             id: string;

--- a/apps/web/src/components/model-generation-fields.tsx
+++ b/apps/web/src/components/model-generation-fields.tsx
@@ -2,9 +2,10 @@
 
 import { useTranslation } from "react-i18next";
 import { ModelGenerationControls } from "@appstrate/ui/components/model-generation-controls";
-import type {
-  ModelGenerationCapabilities,
-  ModelGenerationSettings,
+import {
+  mapModelReasoningLevels,
+  type ModelGenerationCapabilities,
+  type ModelGenerationSettings,
 } from "@appstrate/core/model-generation";
 
 export function ModelGenerationFields({
@@ -35,24 +36,10 @@ export function ModelGenerationFields({
         inheritShort: t("models.generation.inheritShort"),
         unsupported: t("models.generation.unsupported"),
         unsupportedShort: t("models.generation.unsupportedShort"),
-        levels: {
-          off: t("models.generation.levels.off"),
-          minimal: t("models.generation.levels.minimal"),
-          low: t("models.generation.levels.low"),
-          medium: t("models.generation.levels.medium"),
-          high: t("models.generation.levels.high"),
-          xhigh: t("models.generation.levels.xhigh"),
-          max: t("models.generation.levels.max"),
-        },
-        shortLevels: {
-          off: t("models.generation.levelsShort.off"),
-          minimal: t("models.generation.levelsShort.minimal"),
-          low: t("models.generation.levelsShort.low"),
-          medium: t("models.generation.levelsShort.medium"),
-          high: t("models.generation.levelsShort.high"),
-          xhigh: t("models.generation.levelsShort.xhigh"),
-          max: t("models.generation.levelsShort.max"),
-        },
+        levels: mapModelReasoningLevels((level) => t(`models.generation.levels.${level}`)),
+        shortLevels: mapModelReasoningLevels((level) =>
+          t(`models.generation.levelsShort.${level}`),
+        ),
       }}
     />
   );

--- a/apps/web/src/components/model-generation-fields.tsx
+++ b/apps/web/src/components/model-generation-fields.tsx
@@ -42,6 +42,7 @@ export function ModelGenerationFields({
           medium: t("models.generation.levels.medium"),
           high: t("models.generation.levels.high"),
           xhigh: t("models.generation.levels.xhigh"),
+          max: t("models.generation.levels.max"),
         },
         shortLevels: {
           off: t("models.generation.levelsShort.off"),
@@ -50,6 +51,7 @@ export function ModelGenerationFields({
           medium: t("models.generation.levelsShort.medium"),
           high: t("models.generation.levelsShort.high"),
           xhigh: t("models.generation.levelsShort.xhigh"),
+          max: t("models.generation.levelsShort.max"),
         },
       }}
     />

--- a/apps/web/src/locales/en/chat.json
+++ b/apps/web/src/locales/en/chat.json
@@ -70,10 +70,12 @@
   "generation.level.medium": "Medium",
   "generation.level.high": "High",
   "generation.level.xhigh": "Extra high",
+  "generation.level.max": "Maximum",
   "generation.levelShort.off": "Off",
   "generation.levelShort.minimal": "Min",
   "generation.levelShort.low": "Low",
   "generation.levelShort.medium": "Med",
   "generation.levelShort.high": "High",
-  "generation.levelShort.xhigh": "Max"
+  "generation.levelShort.xhigh": "XHigh",
+  "generation.levelShort.max": "Max"
 }

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -860,10 +860,12 @@
   "models.generation.levels.medium": "Medium",
   "models.generation.levels.high": "High",
   "models.generation.levels.xhigh": "Extra high",
+  "models.generation.levels.max": "Maximum",
   "models.generation.levelsShort.off": "Off",
   "models.generation.levelsShort.minimal": "Min",
   "models.generation.levelsShort.low": "Low",
   "models.generation.levelsShort.medium": "Med",
   "models.generation.levelsShort.high": "High",
-  "models.generation.levelsShort.xhigh": "Max"
+  "models.generation.levelsShort.xhigh": "XHigh",
+  "models.generation.levelsShort.max": "Max"
 }

--- a/apps/web/src/locales/fr/chat.json
+++ b/apps/web/src/locales/fr/chat.json
@@ -70,10 +70,12 @@
   "generation.level.medium": "Moyen",
   "generation.level.high": "Élevé",
   "generation.level.xhigh": "Très élevé",
+  "generation.level.max": "Maximum",
   "generation.levelShort.off": "Off",
   "generation.levelShort.minimal": "Min.",
   "generation.levelShort.low": "Bas",
   "generation.levelShort.medium": "Moy.",
   "generation.levelShort.high": "Haut",
-  "generation.levelShort.xhigh": "Max"
+  "generation.levelShort.xhigh": "XHigh",
+  "generation.levelShort.max": "Max"
 }

--- a/apps/web/src/locales/fr/settings.json
+++ b/apps/web/src/locales/fr/settings.json
@@ -860,10 +860,12 @@
   "models.generation.levels.medium": "Moyen",
   "models.generation.levels.high": "Élevé",
   "models.generation.levels.xhigh": "Très élevé",
+  "models.generation.levels.max": "Maximum",
   "models.generation.levelsShort.off": "Off",
   "models.generation.levelsShort.minimal": "Min.",
   "models.generation.levelsShort.low": "Bas",
   "models.generation.levelsShort.medium": "Moy.",
   "models.generation.levelsShort.high": "Haut",
-  "models.generation.levelsShort.xhigh": "Max"
+  "models.generation.levelsShort.xhigh": "XHigh",
+  "models.generation.levelsShort.max": "Max"
 }

--- a/apps/web/src/locales/test/locale-keys.test.ts
+++ b/apps/web/src/locales/test/locale-keys.test.ts
@@ -160,12 +160,16 @@ describe("t() keys", () => {
  */
 const DYNAMIC_KEY_PREFIXES = [
   "filter.", // components/document-list-panel.tsx — t(`filter.${p}`)
+  "generation.level.", // packages/module-chat/src/ui/model-select.tsx
+  "generation.levelShort.", // packages/module-chat/src/ui/model-select.tsx
   "integration.auth.type.", // components/integration-connect/{inline-connect-button,integration-connection-picker}.tsx
   "integration.connect.fields.", // components/integration-connect/credential-fields.tsx
   "library.tab.", // pages/library-page.tsx — t(`library.tab.${tab}`)
   "oauthClients.scopeLabels.", // modules/oidc/components/oauth-client-form-modal.tsx
   "oauthClients.signupRoleOption.", // modules/oidc/components/oauth-client-form-modal.tsx
   "packages.type.", // components/package-detail/shared-header.tsx, pages/unified-package-detail.tsx
+  "models.generation.levels.", // components/model-generation-fields.tsx
+  "models.generation.levelsShort.", // components/model-generation-fields.tsx
   "run.artifacts.code.", // components/run-artifacts.ts — artifactFailureCodeKey()
   "run.connSource.", // components/run-info-tab.tsx — t(`run.connSource.${c.source}`)
   "run.status.", // packages/module-chat/src/ui/run-events.ts — runStatusLineKey()

--- a/docs/architecture/MODEL_ALIASES.md
+++ b/docs/architecture/MODEL_ALIASES.md
@@ -44,6 +44,13 @@ the alias never reaches upstream. Two layers hide the backing from users:
    - the platform **LLM gateway** `/api/llm-proxy/*` (direct API/dashboard
      calls).
 
+For an adaptive Anthropic backing, an agent-side Pi session cannot infer the
+transport from the public alias id. The run launcher therefore adds only the
+catalogued native effort to the sidecar's private swap descriptor; the sidecar
+restores `thinking.type: "adaptive"` and `output_config.effort` while swapping
+the request model. Neither the backing id nor the adaptive flag enters the
+agent container.
+
 The usage ledger (`llm_usage`) keeps the real id privately in `real_model` for
 billing/audit; the module-facing service accessor (`listLlmUsage`, exposed as
 `PlatformServices.usage.list`) never projects `real_model`/`api`.

--- a/docs/architecture/MODEL_ALIASES.md
+++ b/docs/architecture/MODEL_ALIASES.md
@@ -29,9 +29,14 @@ The alias **is** the registry `id`. Resolution (`org-models.ts`
 `resolveModel`/`loadModel`) always returns the _real_ binding to the executor;
 the alias never reaches upstream. Two layers hide the backing from users:
 
-1. **Read projection** (`projectAliasedModel`) — strips the binding + every
-   catalog-derived capability/cost field (they fingerprint the real model) from
-   user-facing reads. The operator create/update responses keep the full shape.
+1. **Read projection** (`projectAliasedModel`) — strips the binding, pricing,
+   context window, provider-native generation mappings, and every other
+   identifying catalog field from user-facing reads. It keeps only the
+   normalized portable generation support vector required for safe UI controls;
+   unknown support is projected as unsupported. This vector can narrow the set
+   of possible backing models, an accepted limitation of making aliases
+   configurable without revealing their exact binding. The operator
+   create/update responses keep the full shape.
 2. **Inference-path swap** (`@appstrate/core/model-swap`) — rewrites the `model`
    field alias→real on the request and real→alias on the response, on **both**
    inference paths:

--- a/packages/core/src/model-generation.test.ts
+++ b/packages/core/src/model-generation.test.ts
@@ -3,12 +3,27 @@
 import { describe, expect, it } from "bun:test";
 import {
   applyModelGenerationCapabilitiesOverride,
+  mapModelReasoningLevels,
   ModelGenerationError,
   reconcileModelGenerationSettings,
   resolveModelGenerationSettings,
   toNativeModelReasoningLevel,
   type ModelGenerationCapabilities,
 } from "./model-generation.ts";
+
+describe("mapModelReasoningLevels", () => {
+  it("maps the complete canonical vocabulary", () => {
+    expect(mapModelReasoningLevels((level) => level.toUpperCase())).toEqual({
+      off: "OFF",
+      minimal: "MINIMAL",
+      low: "LOW",
+      medium: "MEDIUM",
+      high: "HIGH",
+      xhigh: "XHIGH",
+      max: "MAX",
+    });
+  });
+});
 
 const capabilities = (
   over: Partial<ModelGenerationCapabilities> = {},

--- a/packages/core/src/model-generation.test.ts
+++ b/packages/core/src/model-generation.test.ts
@@ -3,7 +3,6 @@
 import { describe, expect, it } from "bun:test";
 import {
   applyModelGenerationCapabilitiesOverride,
-  INHERITED_MODEL_GENERATION_CAPABILITIES,
   ModelGenerationError,
   reconcileModelGenerationSettings,
   resolveModelGenerationSettings,
@@ -177,15 +176,6 @@ describe("reconcileModelGenerationSettings", () => {
       ),
     ).toEqual({});
   });
-
-  it("clears every override for the public alias inherit-only contract", () => {
-    expect(
-      reconcileModelGenerationSettings(
-        { temperature: 0.6, reasoningLevel: "high" },
-        INHERITED_MODEL_GENERATION_CAPABILITIES,
-      ),
-    ).toEqual({});
-  });
 });
 
 describe("toNativeModelReasoningLevel", () => {
@@ -201,5 +191,9 @@ describe("toNativeModelReasoningLevel", () => {
         }),
       ),
     ).toBe("max");
+  });
+
+  it("keeps max as a distinct first-class effort", () => {
+    expect(toNativeModelReasoningLevel("max", capabilities())).toBe("max");
   });
 });

--- a/packages/core/src/model-generation.test.ts
+++ b/packages/core/src/model-generation.test.ts
@@ -121,6 +121,34 @@ describe("resolveModelGenerationSettings", () => {
       }),
     ).toThrow("does not support reasoning level 'high'");
   });
+
+  it("rejects a known-incompatible temperature and reasoning pair", () => {
+    expect(() =>
+      resolveModelGenerationSettings({
+        capabilities: capabilities({
+          reasoning: {
+            ...capabilities().reasoning,
+            temperatureCompatible: "unsupported",
+          },
+        }),
+        override: { temperature: 0.4, reasoningLevel: "high" },
+      }),
+    ).toThrow("cannot combine a custom temperature with reasoning");
+  });
+
+  it("does not apply the pair constraint when reasoning is off", () => {
+    expect(
+      resolveModelGenerationSettings({
+        capabilities: capabilities({
+          reasoning: {
+            ...capabilities().reasoning,
+            temperatureCompatible: "unsupported",
+          },
+        }),
+        override: { temperature: 0.4, reasoningLevel: "off" },
+      }),
+    ).toEqual({ temperature: 0.4, reasoningLevel: "off" });
+  });
 });
 
 describe("applyModelGenerationCapabilitiesOverride", () => {
@@ -138,6 +166,14 @@ describe("applyModelGenerationCapabilitiesOverride", () => {
     expect(
       applyModelGenerationCapabilitiesOverride(catalog, { reasoning: { adaptive: null } }),
     ).toMatchObject({ reasoning: { adaptive: null } });
+  });
+
+  it("merges a sparse provider pair constraint into reasoning", () => {
+    expect(
+      applyModelGenerationCapabilitiesOverride(capabilities(), {
+        reasoning: { temperatureCompatible: "unsupported" },
+      }),
+    ).toMatchObject({ reasoning: { temperatureCompatible: "unsupported" } });
   });
 });
 
@@ -160,6 +196,20 @@ describe("reconcileModelGenerationSettings", () => {
   it("preserves object identity when every setting remains compatible", () => {
     const value = { temperature: 0.4, reasoningLevel: "high" } as const;
     expect(reconcileModelGenerationSettings(value, capabilities())).toBe(value);
+  });
+
+  it("drops temperature but keeps reasoning for a known-incompatible pair", () => {
+    expect(
+      reconcileModelGenerationSettings(
+        { temperature: 0.4, reasoningLevel: "high" },
+        capabilities({
+          reasoning: {
+            ...capabilities().reasoning,
+            temperatureCompatible: "unsupported",
+          },
+        }),
+      ),
+    ).toEqual({ reasoningLevel: "high" });
   });
 
   it("removes unconfirmed levels from a known reasoning model", () => {

--- a/packages/core/src/model-generation.ts
+++ b/packages/core/src/model-generation.ts
@@ -18,6 +18,16 @@ export const modelReasoningLevelSchema = z.enum(MODEL_REASONING_LEVELS);
 
 export type ModelReasoningLevel = z.infer<typeof modelReasoningLevelSchema>;
 
+/** Map every portable reasoning level without duplicating the vocabulary. */
+export function mapModelReasoningLevels<T>(
+  map: (level: ModelReasoningLevel) => T,
+): Record<ModelReasoningLevel, T> {
+  return Object.fromEntries(MODEL_REASONING_LEVELS.map((level) => [level, map(level)])) as Record<
+    ModelReasoningLevel,
+    T
+  >;
+}
+
 export const modelNativeReasoningLevelSchema = z.enum([
   "none",
   "minimal",

--- a/packages/core/src/model-generation.ts
+++ b/packages/core/src/model-generation.ts
@@ -76,6 +76,7 @@ export const modelGenerationCapabilitiesSchema = z
     reasoning: z
       .object({
         supported: modelCapabilitySupportSchema.default("unknown"),
+        temperatureCompatible: modelCapabilitySupportSchema.optional(),
         adaptive: z.boolean().nullable().default(null),
         levels: z
           .partialRecord(modelReasoningLevelSchema, modelCapabilitySupportSchema)
@@ -95,20 +96,19 @@ export interface ModelGenerationCapabilitiesOverride {
   temperature?: ModelCapabilitySupport;
   reasoning?: {
     supported?: ModelCapabilitySupport;
+    temperatureCompatible?: ModelCapabilitySupport;
     adaptive?: boolean | null;
     levels?: Partial<Record<ModelReasoningLevel, ModelCapabilitySupport>>;
     nativeLevels?: Partial<Record<ModelReasoningLevel, ModelNativeReasoningLevel>>;
   };
 }
 
-/**
- * Anthropic's adaptive transport has no native `minimal` effort. LiteLLM stays
- * authoritative for whether a model supports the portable level; this adapter
- * only translates that supported value to Anthropic's lowest wire value.
- */
+/** Shared Anthropic wire constraints for API-key and Claude Code transports. */
 export const ANTHROPIC_GENERATION_CAPABILITIES_OVERRIDE = {
-  temperatureWithReasoning: "unsupported",
-  reasoning: { nativeLevels: { minimal: "low" } },
+  reasoning: {
+    temperatureCompatible: "unsupported",
+    nativeLevels: { minimal: "low" },
+  },
 } satisfies ModelGenerationCapabilitiesOverride;
 
 export const UNKNOWN_MODEL_GENERATION_CAPABILITIES: ModelGenerationCapabilities = {
@@ -132,10 +132,13 @@ export function applyModelGenerationCapabilitiesOverride(
     ...capabilities.reasoning.nativeLevels,
     ...override.reasoning?.nativeLevels,
   };
+  const temperatureCompatible =
+    override.reasoning?.temperatureCompatible ?? capabilities.reasoning.temperatureCompatible;
   return {
     temperature: override.temperature ?? capabilities.temperature,
     reasoning: {
       supported: override.reasoning?.supported ?? capabilities.reasoning.supported,
+      ...(temperatureCompatible !== undefined ? { temperatureCompatible } : {}),
       adaptive:
         override.reasoning?.adaptive !== undefined
           ? override.reasoning.adaptive
@@ -173,11 +176,25 @@ export function reconcileModelGenerationSettings(
     next = rest;
   }
 
+  if (
+    next.temperature != null &&
+    next.reasoningLevel != null &&
+    next.reasoningLevel !== "off" &&
+    capabilities?.reasoning.temperatureCompatible === "unsupported"
+  ) {
+    const { temperature: _temperature, ...rest } = next;
+    void _temperature;
+    next = rest;
+  }
+
   return next;
 }
 
 export type ModelGenerationErrorCode =
-  "temperature_unsupported" | "reasoning_unsupported" | "reasoning_level_unsupported";
+  | "temperature_unsupported"
+  | "reasoning_unsupported"
+  | "reasoning_level_unsupported"
+  | "temperature_with_reasoning_unsupported";
 
 export class ModelGenerationError extends Error {
   readonly code: ModelGenerationErrorCode;
@@ -240,6 +257,18 @@ export function resolveModelGenerationSettings({
     throw new ModelGenerationError(
       "reasoning_level_unsupported",
       `The selected model does not support reasoning level '${reasoningLevel}'`,
+    );
+  }
+
+  if (
+    temperature !== undefined &&
+    reasoningLevel !== undefined &&
+    reasoningLevel !== "off" &&
+    parsedCapabilities.reasoning.temperatureCompatible === "unsupported"
+  ) {
+    throw new ModelGenerationError(
+      "temperature_with_reasoning_unsupported",
+      "The selected model cannot combine a custom temperature with reasoning",
     );
   }
 

--- a/packages/core/src/model-generation.ts
+++ b/packages/core/src/model-generation.ts
@@ -101,6 +101,16 @@ export interface ModelGenerationCapabilitiesOverride {
   };
 }
 
+/**
+ * Anthropic's adaptive transport has no native `minimal` effort. LiteLLM stays
+ * authoritative for whether a model supports the portable level; this adapter
+ * only translates that supported value to Anthropic's lowest wire value.
+ */
+export const ANTHROPIC_GENERATION_CAPABILITIES_OVERRIDE = {
+  temperatureWithReasoning: "unsupported",
+  reasoning: { nativeLevels: { minimal: "low" } },
+} satisfies ModelGenerationCapabilitiesOverride;
+
 export const UNKNOWN_MODEL_GENERATION_CAPABILITIES: ModelGenerationCapabilities = {
   temperature: "unknown",
   reasoning: { supported: "unknown", adaptive: null, levels: {} },

--- a/packages/core/src/model-generation.ts
+++ b/packages/core/src/model-generation.ts
@@ -3,8 +3,16 @@
 
 import { z } from "zod";
 
-/** Portable reasoning vocabulary understood by the Appstrate Pi runtime. */
-export const MODEL_REASONING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+/** Portable reasoning vocabulary exposed by LiteLLM and accepted by Appstrate. */
+export const MODEL_REASONING_LEVELS = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
 
 export const modelReasoningLevelSchema = z.enum(MODEL_REASONING_LEVELS);
 

--- a/packages/core/src/model-generation.ts
+++ b/packages/core/src/model-generation.ts
@@ -116,12 +116,6 @@ export const UNKNOWN_MODEL_GENERATION_CAPABILITIES: ModelGenerationCapabilities 
   reasoning: { supported: "unknown", adaptive: null, levels: {} },
 };
 
-/** Public alias contract: provider-specific generation controls stay inherited. */
-export const INHERITED_MODEL_GENERATION_CAPABILITIES: ModelGenerationCapabilities = {
-  temperature: "unsupported",
-  reasoning: { supported: "unsupported", adaptive: null, levels: {} },
-};
-
 /** Merge a provider adapter's stricter transport facts over catalog metadata. */
 export function applyModelGenerationCapabilitiesOverride(
   capabilities: ModelGenerationCapabilities,

--- a/packages/core/src/model-generation.ts
+++ b/packages/core/src/model-generation.ts
@@ -18,6 +18,20 @@ export const modelReasoningLevelSchema = z.enum(MODEL_REASONING_LEVELS);
 
 export type ModelReasoningLevel = z.infer<typeof modelReasoningLevelSchema>;
 
+const ANTHROPIC_REASONING_BUDGET_TOKENS = {
+  minimal: 1024,
+  low: 2048,
+  medium: 4096,
+  high: 8192,
+  xhigh: 16384,
+  max: 32768,
+} satisfies Record<Exclude<ModelReasoningLevel, "off">, number>;
+
+/** Translate portable effort to Anthropic's classic token-budget transport. */
+export function anthropicReasoningBudgetTokens(level: Exclude<ModelReasoningLevel, "off">): number {
+  return ANTHROPIC_REASONING_BUDGET_TOKENS[level];
+}
+
 /** Map every portable reasoning level without duplicating the vocabulary. */
 export function mapModelReasoningLevels<T>(
   map: (level: ModelReasoningLevel) => T,

--- a/packages/core/src/model-swap.ts
+++ b/packages/core/src/model-swap.ts
@@ -27,6 +27,9 @@
  *     snapshot). Both `openai-responses` and `openai-codex-responses` (codex)
  *     are aliasable, so this nesting MUST be covered or the real id leaks in
  *     the stream.
+ *   - `thinking` / `output_config` — request-only correction for an adaptive
+ *     Anthropic backing. Pi sees the public alias, so the sidecar restores the
+ *     catalogued adaptive shape from its private swap descriptor.
  *
  * ERROR surfaces are handled differently: provider error bodies are free-form
  * prose that can name the backing anywhere (model id, hostname, provider
@@ -103,6 +106,24 @@ export function swapRequestModel(bodyText: string, swap: ModelSwap): string {
     const obj = JSON.parse(bodyText) as Record<string, unknown>;
     if (obj && typeof obj === "object" && obj["model"] === swap.alias) {
       obj["model"] = swap.real;
+      const thinking = obj["thinking"];
+      if (
+        swap.anthropicAdaptiveReasoning &&
+        thinking &&
+        typeof thinking === "object" &&
+        (thinking as Record<string, unknown>)["type"] === "enabled"
+      ) {
+        const display = (thinking as Record<string, unknown>)["display"];
+        obj["thinking"] = {
+          type: "adaptive",
+          ...(typeof display === "string" ? { display } : {}),
+        };
+        const outputConfig = obj["output_config"];
+        obj["output_config"] = {
+          ...(outputConfig && typeof outputConfig === "object" ? outputConfig : {}),
+          effort: swap.anthropicAdaptiveReasoning.effort,
+        };
+      }
       return JSON.stringify(obj);
     }
   } catch {

--- a/packages/core/src/sidecar-types.ts
+++ b/packages/core/src/sidecar-types.ts
@@ -10,6 +10,7 @@
  */
 
 import type { IntegrationManifest } from "./integration.ts";
+import type { ModelNativeReasoningLevel } from "./model-generation.ts";
 
 /**
  * Manifest `auths.{key}.delivery.http` block — the header-render config the
@@ -541,12 +542,23 @@ export type ModelApiShape =
  * Matching is by exact value at the known JSON locations (top-level `model`,
  * and `message.model` for Anthropic `message_start`), never a blind string
  * replace — so a model id mentioned inside generated content is never clobbered.
+ * For an adaptive Anthropic backing, the private descriptor can also restore
+ * the adaptive `thinking` shape that Pi cannot infer from the public alias.
  */
 export interface ModelSwap {
   /** Public alias id the agent sends (its `MODEL_ID`). */
   alias: string;
   /** Real upstream model id forwarded to the provider. */
   real: string;
+  /**
+   * Request-scoped Anthropic transport correction for an adaptive backing.
+   * Pi cannot infer adaptive support from a hidden alias id, so the sidecar
+   * restores the catalogued request shape without exposing this fact to the
+   * agent container.
+   */
+  anthropicAdaptiveReasoning?: {
+    effort: Exclude<ModelNativeReasoningLevel, "none">;
+  };
 }
 
 export interface LlmProxyApiKeyConfig {

--- a/packages/module-chat/src/chat-stream.ts
+++ b/packages/module-chat/src/chat-stream.ts
@@ -76,7 +76,6 @@ import {
 import {
   ModelGenerationError,
   modelGenerationSettingsSchema,
-  reconcileModelGenerationSettings,
   resolveModelGenerationSettings,
 } from "@appstrate/core/model-generation";
 
@@ -519,13 +518,9 @@ export async function handleChatStream(
   const chosen = pickModel(models, modelId);
   let generationSettings;
   try {
-    const compatibleGeneration = reconcileModelGenerationSettings(
-      body.generation ?? {},
-      chosen.generation,
-    );
     generationSettings = resolveModelGenerationSettings({
       capabilities: chosen.generation,
-      override: compatibleGeneration,
+      override: body.generation,
     });
   } catch (error) {
     if (error instanceof ModelGenerationError) throw invalidRequest(error.message);

--- a/packages/module-chat/src/llm.ts
+++ b/packages/module-chat/src/llm.ts
@@ -118,7 +118,14 @@ export function applyGenerationToProxyBody(
       model.generation,
     );
     if (model.apiShape === "anthropic-messages") {
-      const budgets = { minimal: 1024, low: 2048, medium: 4096, high: 8192, xhigh: 16384 };
+      const budgets = {
+        minimal: 1024,
+        low: 2048,
+        medium: 4096,
+        high: 8192,
+        xhigh: 16384,
+        max: 32768,
+      };
       if (generation.reasoningLevel === "off") {
         delete payload.thinking;
         delete payload.output_config;

--- a/packages/module-chat/src/llm.ts
+++ b/packages/module-chat/src/llm.ts
@@ -19,6 +19,7 @@ import { CHAT_USABLE_FAMILIES } from "./chat-families.ts";
 import { isModelLive } from "./model-liveness.ts";
 import { logger } from "./logger.ts";
 import {
+  anthropicReasoningBudgetTokens,
   toNativeModelReasoningLevel,
   type ModelGenerationCapabilities,
   type ModelGenerationSettings,
@@ -118,14 +119,6 @@ export function applyGenerationToProxyBody(
       model.generation,
     );
     if (model.apiShape === "anthropic-messages") {
-      const budgets = {
-        minimal: 1024,
-        low: 2048,
-        medium: 4096,
-        high: 8192,
-        xhigh: 16384,
-        max: 32768,
-      };
       if (generation.reasoningLevel === "off") {
         delete payload.thinking;
         delete payload.output_config;
@@ -135,7 +128,7 @@ export function applyGenerationToProxyBody(
       } else {
         payload.thinking = {
           type: "enabled",
-          budget_tokens: budgets[generation.reasoningLevel],
+          budget_tokens: anthropicReasoningBudgetTokens(generation.reasoningLevel),
         };
       }
     } else {

--- a/packages/module-chat/src/pi-chat/engine.ts
+++ b/packages/module-chat/src/pi-chat/engine.ts
@@ -28,7 +28,7 @@ import {
   loadPiCodingAgentSdk,
   derivePiCompactionSettings,
   deriveProviderFromApi,
-  preserveRequestedThinkingLevel,
+  prepareRequestedThinkingLevel,
   type Api,
   type Model,
 } from "@appstrate/runner-pi";
@@ -177,9 +177,10 @@ export function runPiSubscriptionChat(input: PiSubscriptionChatInput): Response 
           contextWindow: model.contextWindow ?? undefined,
           maxTokens: model.maxTokens ?? undefined,
         } as Model<Api>;
-        const sessionModel = preserveRequestedThinkingLevel(
+        const requestedThinkingLevel = input.generation.reasoningLevel ?? "medium";
+        const { model: sessionModel, thinkingLevel } = prepareRequestedThinkingLevel(
           piModel,
-          input.generation.reasoningLevel ?? "medium",
+          requestedThinkingLevel,
         );
 
         // Real subscription token in-memory only — pi-ai emits the OAuth request
@@ -223,7 +224,7 @@ export function runPiSubscriptionChat(input: PiSubscriptionChatInput): Response 
           cwd: "/tmp",
           agentDir: "/tmp/pi-chat",
           model: sessionModel,
-          thinkingLevel: input.generation.reasoningLevel ?? "medium",
+          thinkingLevel,
           authStorage,
           modelRegistry,
           resourceLoader,

--- a/packages/module-chat/src/pi-chat/engine.ts
+++ b/packages/module-chat/src/pi-chat/engine.ts
@@ -178,10 +178,11 @@ export function runPiSubscriptionChat(input: PiSubscriptionChatInput): Response 
           maxTokens: model.maxTokens ?? undefined,
         } as Model<Api>;
         const requestedThinkingLevel = input.generation.reasoningLevel ?? "medium";
-        const { model: sessionModel, thinkingLevel } = prepareRequestedThinkingLevel(
-          piModel,
-          requestedThinkingLevel,
-        );
+        const {
+          model: sessionModel,
+          thinkingLevel,
+          thinkingBudgets,
+        } = prepareRequestedThinkingLevel(piModel, requestedThinkingLevel);
 
         // Real subscription token in-memory only — pi-ai emits the OAuth request
         // shape from it natively (never persisted, never sent to the client).
@@ -231,6 +232,7 @@ export function runPiSubscriptionChat(input: PiSubscriptionChatInput): Response 
           sessionManager: SessionManager.inMemory(),
           settingsManager: SettingsManager.inMemory({
             compaction: derivePiCompactionSettings(piModel).compaction,
+            thinkingBudgets,
             // ONE retry: chat is interactive — a user watches blank "thinking"
             // dots for the whole retry window. One retry absorbs transient
             // blips; anything sturdier (quota 429s, auth failures) fails the

--- a/packages/module-chat/src/ui/model-select.tsx
+++ b/packages/module-chat/src/ui/model-select.tsx
@@ -189,6 +189,7 @@ export function ModelSelect({
                         medium: t("generation.level.medium"),
                         high: t("generation.level.high"),
                         xhigh: t("generation.level.xhigh"),
+                        max: t("generation.level.max"),
                       },
                       shortLevels: {
                         off: t("generation.levelShort.off"),
@@ -197,6 +198,7 @@ export function ModelSelect({
                         medium: t("generation.levelShort.medium"),
                         high: t("generation.levelShort.high"),
                         xhigh: t("generation.levelShort.xhigh"),
+                        max: t("generation.levelShort.max"),
                       },
                     }}
                   />

--- a/packages/module-chat/src/ui/model-select.tsx
+++ b/packages/module-chat/src/ui/model-select.tsx
@@ -17,7 +17,10 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@appstrate/ui/componen
 import type { OrgModelOption } from "./models-data.ts";
 import { isModelLive } from "../model-liveness.ts";
 import { useChatHost } from "./runtime-context.ts";
-import type { ModelGenerationSettings } from "@appstrate/core/model-generation";
+import {
+  mapModelReasoningLevels,
+  type ModelGenerationSettings,
+} from "@appstrate/core/model-generation";
 
 /** Group/button label for a managed model — provider-neutral, binding not exposed. */
 const MANAGED_LABEL = "Géré";
@@ -182,24 +185,10 @@ export function ModelSelect({
                       inheritShort: t("generation.inheritShort"),
                       unsupported: t("generation.unsupported"),
                       unsupportedShort: t("generation.unsupportedShort"),
-                      levels: {
-                        off: t("generation.level.off"),
-                        minimal: t("generation.level.minimal"),
-                        low: t("generation.level.low"),
-                        medium: t("generation.level.medium"),
-                        high: t("generation.level.high"),
-                        xhigh: t("generation.level.xhigh"),
-                        max: t("generation.level.max"),
-                      },
-                      shortLevels: {
-                        off: t("generation.levelShort.off"),
-                        minimal: t("generation.levelShort.minimal"),
-                        low: t("generation.levelShort.low"),
-                        medium: t("generation.levelShort.medium"),
-                        high: t("generation.levelShort.high"),
-                        xhigh: t("generation.levelShort.xhigh"),
-                        max: t("generation.levelShort.max"),
-                      },
+                      levels: mapModelReasoningLevels((level) => t(`generation.level.${level}`)),
+                      shortLevels: mapModelReasoningLevels((level) =>
+                        t(`generation.levelShort.${level}`),
+                      ),
                     }}
                   />
                 )}

--- a/packages/module-chat/test/chat-stream-handler.test.ts
+++ b/packages/module-chat/test/chat-stream-handler.test.ts
@@ -38,6 +38,7 @@ import { handleChatStream, type ChatEnv } from "../src/chat-stream.ts";
 import { mintSessionId } from "../src/session-id.ts";
 import { buildChatPlatformDeps } from "../src/platform-services.ts";
 import { buildModuleInitContext } from "../../../apps/api/src/lib/modules/registry.ts";
+import { errorHandler } from "../../../apps/api/src/middleware/error-handler.ts";
 import { SYSTEM_PROMPT } from "../src/prompt.ts";
 
 /**
@@ -93,6 +94,11 @@ function modelsResponse(): Response {
         apiShape: "openai-completions",
         enabled: true,
         is_default: true,
+        generation: {
+          temperature: "unsupported",
+          temperatureWithReasoning: "unknown",
+          reasoning: { supported: "unsupported", adaptive: null, levels: {} },
+        },
       },
     ],
   });
@@ -224,6 +230,9 @@ describe("handleChatStream (ai-sdk path)", () => {
   /** A `Hono<ChatEnv>` app mirroring what the platform auth pipeline sets. */
   function buildApp(deps: ReturnType<typeof buildChatPlatformDeps>) {
     const app = new Hono<ChatEnv>();
+    // Mirror production's RFC 9457 error boundary so invalid client input is
+    // asserted at the HTTP contract, not as an uncaught handler exception.
+    app.onError((error, context) => errorHandler(error, context as never));
     app.post("/api/chat", (c) => {
       c.set("orgId", ctx.orgId);
       c.set("user", ctx.user);
@@ -236,7 +245,10 @@ describe("handleChatStream (ai-sdk path)", () => {
     return app;
   }
 
-  async function postChat(sessionId: string): Promise<Response> {
+  async function postChat(
+    sessionId: string,
+    generation?: { temperature?: number; reasoningLevel?: string },
+  ): Promise<Response> {
     const { dispatch, capture } = scriptedDispatch();
     // Real platform deps (the same context `init()` gets), with dispatch
     // overridden by the scripted one so no request leaves this process.
@@ -252,10 +264,20 @@ describe("handleChatStream (ai-sdk path)", () => {
       body: JSON.stringify({
         id: sessionId,
         messages: [{ id: "u1", role: "user", parts: [{ type: "text", text: "dis bonjour" }] }],
+        ...(generation ? { generation } : {}),
       }),
     });
     return Object.assign(res, { capture });
   }
+
+  it("rejects generation settings unsupported by the selected model", async () => {
+    const res = (await postChat(mintSessionId(), { temperature: 0.4 })) as Response & {
+      capture: DispatchCapture;
+    };
+
+    expect(res.status).toBe(400);
+    expect(res.capture.inferenceBody).toBeNull();
+  });
 
   it("streams start → text → finish with no error and persists the assistant turn", async () => {
     const sessionId = mintSessionId();

--- a/packages/module-chat/test/chat-stream-handler.test.ts
+++ b/packages/module-chat/test/chat-stream-handler.test.ts
@@ -96,7 +96,6 @@ function modelsResponse(): Response {
         is_default: true,
         generation: {
           temperature: "unsupported",
-          temperatureWithReasoning: "unknown",
           reasoning: { supported: "unsupported", adaptive: null, levels: {} },
         },
       },

--- a/packages/module-chat/test/model-generation.test.ts
+++ b/packages/module-chat/test/model-generation.test.ts
@@ -36,7 +36,6 @@ describe("applyGenerationToProxyBody", () => {
         apiShape: "anthropic-messages",
         generation: {
           temperature: "unsupported",
-          temperatureWithReasoning: "unsupported",
           reasoning: {
             supported: "supported",
             adaptive: true,

--- a/packages/module-chat/test/model-generation.test.ts
+++ b/packages/module-chat/test/model-generation.test.ts
@@ -29,6 +29,30 @@ describe("applyGenerationToProxyBody", () => {
     });
   });
 
+  it("translates portable minimal to Anthropic's native low effort", () => {
+    const body = applyGenerationToProxyBody(
+      JSON.stringify({ model: "preset" }),
+      {
+        apiShape: "anthropic-messages",
+        generation: {
+          temperature: "unsupported",
+          temperatureWithReasoning: "unsupported",
+          reasoning: {
+            supported: "supported",
+            adaptive: true,
+            levels: { minimal: "supported" },
+            nativeLevels: { minimal: "low" },
+          },
+        },
+      },
+      { reasoningLevel: "minimal" },
+    );
+    expect(parse(body)).toMatchObject({
+      thinking: { type: "adaptive" },
+      output_config: { effort: "low" },
+    });
+  });
+
   it("maps classic Anthropic levels to deterministic token budgets", () => {
     const body = applyGenerationToProxyBody(
       "{}",

--- a/packages/module-chat/test/model-generation.test.ts
+++ b/packages/module-chat/test/model-generation.test.ts
@@ -47,6 +47,15 @@ describe("applyGenerationToProxyBody", () => {
     expect(parse(body).reasoning_effort).toBe("xhigh");
   });
 
+  it("keeps max distinct in OpenAI-compatible request bodies", () => {
+    const body = applyGenerationToProxyBody(
+      "{}",
+      { apiShape: "openai-completions", generation: null },
+      { reasoningLevel: "max" },
+    );
+    expect(parse(body).reasoning_effort).toBe("max");
+  });
+
   it("removes Anthropic thinking fields for off", () => {
     const body = applyGenerationToProxyBody(
       JSON.stringify({ thinking: { type: "adaptive" }, output_config: { effort: "high" } }),

--- a/packages/module-claude-code/src/index.ts
+++ b/packages/module-claude-code/src/index.ts
@@ -49,6 +49,7 @@ import type {
   ModelProviderHooks,
 } from "@appstrate/core/module";
 import { validateOfflineExpiry } from "@appstrate/core/module";
+import { ANTHROPIC_GENERATION_CAPABILITIES_OVERRIDE } from "@appstrate/core/model-generation";
 import { ANTHROPIC_OAUTH_PLACEHOLDER_API_KEY } from "@appstrate/core/oauth-bearer-swap";
 
 const claudeCodeHooks: ModelProviderHooks = {
@@ -123,8 +124,9 @@ const claudeCodeProvider: ModelProviderDefinition = {
   // Claude Code (Claude Pro/Max/Team subscription) authenticates against
   // the Anthropic catalog — metadata flows through anthropic.json.
   catalogProviderId: "anthropic",
-  // The shared Pi Anthropic transport drops temperature while thinking.
-  generationOverride: { temperatureWithReasoning: "unsupported" },
+  // Keep LiteLLM's portable support facts, then apply Anthropic wire-level
+  // constraints shared with the API-key provider.
+  generationOverride: ANTHROPIC_GENERATION_CAPABILITIES_OVERRIDE,
   // Both lists are DERIVED from the vendored anthropic catalog rather than
   // hand-enumerated. The Claude subscription serves Anthropic's current
   // generation — it has no published, machine-readable model list, and

--- a/packages/module-claude-code/src/index.ts
+++ b/packages/module-claude-code/src/index.ts
@@ -123,6 +123,8 @@ const claudeCodeProvider: ModelProviderDefinition = {
   // Claude Code (Claude Pro/Max/Team subscription) authenticates against
   // the Anthropic catalog — metadata flows through anthropic.json.
   catalogProviderId: "anthropic",
+  // The shared Pi Anthropic transport drops temperature while thinking.
+  generationOverride: { temperatureWithReasoning: "unsupported" },
   // Both lists are DERIVED from the vendored anthropic catalog rather than
   // hand-enumerated. The Claude subscription serves Anthropic's current
   // generation — it has no published, machine-readable model list, and

--- a/packages/runner-pi/src/container-env.ts
+++ b/packages/runner-pi/src/container-env.ts
@@ -39,7 +39,7 @@ export interface RuntimePiEnvOptions {
   /** Effective model-generation controls resolved by the platform. */
   generation?: {
     temperature?: number | null;
-    reasoningLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh" | null;
+    reasoningLevel?: ModelReasoningLevel | null;
   };
   /** Full enriched system prompt fed to the Pi SDK. */
   agentPrompt: string;

--- a/packages/runner-pi/src/index.ts
+++ b/packages/runner-pi/src/index.ts
@@ -5,6 +5,7 @@ export {
   installSessionBridge,
   derivePiCompactionSettings,
   preserveRequestedThinkingLevel,
+  prepareRequestedThinkingLevel,
   type PiRunnerOptions,
   type PiModelConfig,
   type BridgeableSession,

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -38,9 +38,10 @@ import {
 } from "./pi-sdk.ts";
 import { scheduleDeadlineNudges } from "./deadline-nudges.ts";
 import type { ModelApiShape } from "@appstrate/core/sidecar-types";
-import type {
-  ModelNativeReasoningLevel,
-  ModelReasoningLevel,
+import {
+  anthropicReasoningBudgetTokens,
+  type ModelNativeReasoningLevel,
+  type ModelReasoningLevel,
 } from "@appstrate/core/model-generation";
 import { deriveResponseReserveTokens } from "@appstrate/core/token-budget";
 import type { RunEvent, ExecutionContext } from "@appstrate/afps-runtime/types";
@@ -93,21 +94,39 @@ export function preserveRequestedThinkingLevel(
 }
 
 type PiThinkingLevel = Exclude<ModelReasoningLevel, "max">;
+type PiThinkingBudgetLevel = Exclude<PiThinkingLevel, "off" | "xhigh">;
+type PiThinkingBudgets = Partial<Record<PiThinkingBudgetLevel, number>>;
+
+function prepareAnthropicThinkingBudgets(
+  model: PiModelConfig,
+  level: ModelReasoningLevel,
+): PiThinkingBudgets | undefined {
+  if (model.api !== "anthropic-messages" || level === "off") return undefined;
+  const piLevel: PiThinkingBudgetLevel = level === "xhigh" || level === "max" ? "high" : level;
+  return { [piLevel]: anthropicReasoningBudgetTokens(level) };
+}
 
 /**
  * Adapt Appstrate's complete LiteLLM vocabulary to Pi's six-level selector.
  * Pi has no first-class `max` selector, but its `xhigh` slot can map to the
- * provider-native `max` value. The mapping is request-scoped so models that
- * support both values preserve the distinction.
+ * provider-native `max` value. Classic Anthropic requests also receive a
+ * request-scoped token budget because Pi otherwise clamps both levels to its
+ * `high` budget. Models that support both values therefore stay distinct.
  */
 export function prepareRequestedThinkingLevel(
   model: PiModelConfig,
   level: ModelReasoningLevel,
-): { model: PiModelConfig; thinkingLevel: PiThinkingLevel } {
+): {
+  model: PiModelConfig;
+  thinkingLevel: PiThinkingLevel;
+  thinkingBudgets?: PiThinkingBudgets;
+} {
+  const thinkingBudgets = prepareAnthropicThinkingBudgets(model, level);
   if (level !== "max") {
     return {
       model: preserveRequestedThinkingLevel(model, level),
       thinkingLevel: level,
+      ...(thinkingBudgets ? { thinkingBudgets } : {}),
     };
   }
 
@@ -123,6 +142,7 @@ export function prepareRequestedThinkingLevel(
       } as PiModelConfig["thinkingLevelMap"],
     },
     thinkingLevel: "xhigh",
+    ...(thinkingBudgets ? { thinkingBudgets } : {}),
   };
 }
 
@@ -466,10 +486,11 @@ export class PiRunner implements Runner {
     const cwd = this.opts.cwd ?? process.cwd();
     const agentDir = this.opts.agentDir ?? "/tmp/pi-agent";
     const requestedThinkingLevel = this.opts.thinkingLevel ?? "medium";
-    const { model: sessionModel, thinkingLevel } = prepareRequestedThinkingLevel(
-      model,
-      requestedThinkingLevel,
-    );
+    const {
+      model: sessionModel,
+      thinkingLevel,
+      thinkingBudgets,
+    } = prepareRequestedThinkingLevel(model, requestedThinkingLevel);
 
     // Load the heavy Pi SDK value surface here (not at module top) so the
     // ~200ms `@mariozechner/pi-coding-agent` eval stays off the runtime's
@@ -548,6 +569,7 @@ export class PiRunner implements Runner {
       sessionManager: SessionManager.inMemory(),
       settingsManager: SettingsManager.inMemory({
         compaction: budget.compaction,
+        thinkingBudgets,
         transport: this.opts.transport ?? "auto",
         // Pi SDK's built-in retry (Retry-After honoring + jitter) covers
         // transient 429/5xx upstream — including OpenAI's mid-stream 5xx

--- a/packages/runner-pi/src/pi-runner.ts
+++ b/packages/runner-pi/src/pi-runner.ts
@@ -38,6 +38,10 @@ import {
 } from "./pi-sdk.ts";
 import { scheduleDeadlineNudges } from "./deadline-nudges.ts";
 import type { ModelApiShape } from "@appstrate/core/sidecar-types";
+import type {
+  ModelNativeReasoningLevel,
+  ModelReasoningLevel,
+} from "@appstrate/core/model-generation";
 import { deriveResponseReserveTokens } from "@appstrate/core/token-budget";
 import type { RunEvent, ExecutionContext } from "@appstrate/afps-runtime/types";
 import {
@@ -88,6 +92,40 @@ export function preserveRequestedThinkingLevel(
   };
 }
 
+type PiThinkingLevel = Exclude<ModelReasoningLevel, "max">;
+
+/**
+ * Adapt Appstrate's complete LiteLLM vocabulary to Pi's six-level selector.
+ * Pi has no first-class `max` selector, but its `xhigh` slot can map to the
+ * provider-native `max` value. The mapping is request-scoped so models that
+ * support both values preserve the distinction.
+ */
+export function prepareRequestedThinkingLevel(
+  model: PiModelConfig,
+  level: ModelReasoningLevel,
+): { model: PiModelConfig; thinkingLevel: PiThinkingLevel } {
+  if (level !== "max") {
+    return {
+      model: preserveRequestedThinkingLevel(model, level),
+      thinkingLevel: level,
+    };
+  }
+
+  const levelMap = model.thinkingLevelMap as
+    Partial<Record<ModelReasoningLevel, ModelNativeReasoningLevel | null>> | undefined;
+  const nativeLevel = levelMap?.max ?? "max";
+  return {
+    model: {
+      ...model,
+      thinkingLevelMap: {
+        ...model.thinkingLevelMap,
+        xhigh: nativeLevel,
+      } as PiModelConfig["thinkingLevelMap"],
+    },
+    thinkingLevel: "xhigh",
+  };
+}
+
 export interface PiRunnerOptions {
   /** LLM model configuration passed to the Pi SDK. Required. */
   model: PiModelConfig;
@@ -132,7 +170,7 @@ export interface PiRunnerOptions {
   /** Path where the default auth store persists. Ignored if `authStorage` is set. */
   authStoragePath?: string;
   /** Pi SDK thinking level. Defaults to `"medium"`. */
-  thinkingLevel?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+  thinkingLevel?: ModelReasoningLevel;
   /** Provider sampling temperature. Omitted to preserve provider/Pi defaults. */
   temperature?: number;
   /**
@@ -427,8 +465,11 @@ export class PiRunner implements Runner {
     const { model, apiKey, systemPrompt, startMessage } = this.opts;
     const cwd = this.opts.cwd ?? process.cwd();
     const agentDir = this.opts.agentDir ?? "/tmp/pi-agent";
-    const thinkingLevel = this.opts.thinkingLevel ?? "medium";
-    const sessionModel = preserveRequestedThinkingLevel(model, thinkingLevel);
+    const requestedThinkingLevel = this.opts.thinkingLevel ?? "medium";
+    const { model: sessionModel, thinkingLevel } = prepareRequestedThinkingLevel(
+      model,
+      requestedThinkingLevel,
+    );
 
     // Load the heavy Pi SDK value surface here (not at module top) so the
     // ~200ms `@mariozechner/pi-coding-agent` eval stays off the runtime's

--- a/packages/runner-pi/src/pi-sdk.ts
+++ b/packages/runner-pi/src/pi-sdk.ts
@@ -19,7 +19,7 @@
 // --- cheap value (pi-ai, ~40ms) ---
 // Used synchronously at tool-registration time to build parameter schemas,
 // so it stays a static export.
-export { Type } from "@mariozechner/pi-ai";
+export { streamSimple, Type } from "@mariozechner/pi-ai";
 
 // --- types (erased at runtime) ---
 export type { AuthStorage, ExtensionAPI, ExtensionFactory } from "@mariozechner/pi-coding-agent";

--- a/packages/runner-pi/test/pi-runner-generation.test.ts
+++ b/packages/runner-pi/test/pi-runner-generation.test.ts
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "bun:test";
-import { preserveRequestedThinkingLevel, type PiModelConfig } from "../src/pi-runner.ts";
+import {
+  prepareRequestedThinkingLevel,
+  preserveRequestedThinkingLevel,
+  type PiModelConfig,
+} from "../src/pi-runner.ts";
 
 const model = (over: Partial<PiModelConfig> = {}): PiModelConfig =>
   ({
@@ -33,5 +37,22 @@ describe("preserveRequestedThinkingLevel", () => {
   it("does not mutate other reasoning levels", () => {
     const original = model();
     expect(preserveRequestedThinkingLevel(original, "high")).toBe(original);
+  });
+});
+
+describe("prepareRequestedThinkingLevel", () => {
+  it("routes portable max through Pi's xhigh slot without collapsing its native value", () => {
+    const prepared = prepareRequestedThinkingLevel(model(), "max");
+    expect(prepared.thinkingLevel).toBe("xhigh");
+    expect(prepared.model.thinkingLevelMap?.xhigh).toBe("max");
+  });
+
+  it("keeps xhigh distinct when the same model also supports max", () => {
+    const prepared = prepareRequestedThinkingLevel(
+      model({ thinkingLevelMap: { xhigh: "xhigh", max: "max" } } as Partial<PiModelConfig>),
+      "xhigh",
+    );
+    expect(prepared.thinkingLevel).toBe("xhigh");
+    expect(prepared.model.thinkingLevelMap?.xhigh).toBe("xhigh");
   });
 });

--- a/packages/runner-pi/test/pi-runner-generation.test.ts
+++ b/packages/runner-pi/test/pi-runner-generation.test.ts
@@ -6,6 +6,7 @@ import {
   preserveRequestedThinkingLevel,
   type PiModelConfig,
 } from "../src/pi-runner.ts";
+import { streamSimple } from "../src/pi-sdk.ts";
 
 const model = (over: Partial<PiModelConfig> = {}): PiModelConfig =>
   ({
@@ -54,5 +55,32 @@ describe("prepareRequestedThinkingLevel", () => {
     );
     expect(prepared.thinkingLevel).toBe("xhigh");
     expect(prepared.model.thinkingLevelMap?.xhigh).toBe("xhigh");
+  });
+
+  it("emits a distinct classic Anthropic payload for max", async () => {
+    const prepared = prepareRequestedThinkingLevel(
+      model({ api: "anthropic-messages", provider: "anthropic", maxTokens: 65_536 }),
+      "max",
+    );
+    let payload: unknown;
+    const result = await streamSimple(
+      prepared.model,
+      { messages: [] },
+      {
+        apiKey: "test-key",
+        reasoning: prepared.thinkingLevel === "off" ? undefined : prepared.thinkingLevel,
+        thinkingBudgets: prepared.thinkingBudgets,
+        onPayload: (nextPayload) => {
+          payload = nextPayload;
+          throw new Error("payload captured");
+        },
+      },
+    ).result();
+
+    expect(result.errorMessage).toBe("payload captured");
+    expect(payload).toMatchObject({
+      max_tokens: 64_768,
+      thinking: { type: "enabled", budget_tokens: 32_768 },
+    });
   });
 });

--- a/packages/ui/src/components/model-generation-controls.tsx
+++ b/packages/ui/src/components/model-generation-controls.tsx
@@ -176,7 +176,7 @@ export function ModelGenerationControls({
             variant="outline"
             aria-labelledby={`${id}-reasoning-label`}
             aria-describedby={compact ? undefined : `${id}-reasoning-description`}
-            className="grid w-full grid-cols-7 gap-0"
+            className="grid w-full grid-cols-8 gap-0"
             onValueChange={(next) => {
               if (!next) return;
               onChange(

--- a/runtime-pi/sidecar/test/model-swap-proxy.test.ts
+++ b/runtime-pi/sidecar/test/model-swap-proxy.test.ts
@@ -60,6 +60,41 @@ describe("/llm/* model-alias swap (api_key)", () => {
     expect(JSON.parse(forwarded).model).toBe("deepseek-chat");
   });
 
+  it("forwards an adaptive Anthropic payload for an aliased adaptive model", async () => {
+    let forwarded = "";
+    const fetchFn = mock(async (_url: string, init?: RequestInit) => {
+      forwarded = await readBody(init);
+      return new Response('{"model":"claude-sonnet-4-6","content":[]}', {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    const deps = makeDeps(fetchFn);
+    if (deps.config.llm?.authMode !== "api_key") throw new Error("expected api_key llm");
+    deps.config.llm.modelSwap = {
+      alias: "appstrate-adaptive",
+      real: "claude-sonnet-4-6",
+      anthropicAdaptiveReasoning: { effort: "max" },
+    };
+
+    const app = createApp(deps);
+    await app.request("/llm/v1/messages", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "appstrate-adaptive",
+        thinking: { type: "enabled", budget_tokens: 32_768, display: "summarized" },
+      }),
+    });
+
+    expect(JSON.parse(forwarded)).toMatchObject({
+      model: "claude-sonnet-4-6",
+      thinking: { type: "adaptive", display: "summarized" },
+      output_config: { effort: "max" },
+    });
+    expect(forwarded).not.toContain("budget_tokens");
+  });
+
   it("rewrites the non-stream response model real→alias", async () => {
     const fetchFn = mock(
       async () =>

--- a/runtime-pi/sidecar/test/model-swap.test.ts
+++ b/runtime-pi/sidecar/test/model-swap.test.ts
@@ -96,6 +96,25 @@ describe("swapRequestModel (alias→real)", () => {
     });
     expect(out).not.toContain("budget_tokens");
   });
+
+  it("forwards portable minimal as Anthropic's native low effort for an alias", () => {
+    const out = swapRequestModel(
+      JSON.stringify({
+        model: "appstrate-medium",
+        thinking: { type: "enabled", budget_tokens: 1024 },
+      }),
+      {
+        ...swap,
+        anthropicAdaptiveReasoning: { effort: "low" },
+      },
+    );
+
+    expect(JSON.parse(out)).toMatchObject({
+      model: "deepseek-chat",
+      thinking: { type: "adaptive" },
+      output_config: { effort: "low" },
+    });
+  });
 });
 
 describe("swapResponseModelJson (real→alias)", () => {

--- a/runtime-pi/sidecar/test/model-swap.test.ts
+++ b/runtime-pi/sidecar/test/model-swap.test.ts
@@ -75,6 +75,27 @@ describe("swapRequestModel (alias→real)", () => {
   it("passes non-JSON through unchanged", () => {
     expect(swapRequestModel("not json", swap)).toBe("not json");
   });
+
+  it("restores adaptive Anthropic reasoning for a hidden backing model", () => {
+    const adaptiveSwap = {
+      ...swap,
+      anthropicAdaptiveReasoning: { effort: "max" as const },
+    };
+    const out = swapRequestModel(
+      JSON.stringify({
+        model: "appstrate-medium",
+        thinking: { type: "enabled", budget_tokens: 32_768, display: "summarized" },
+      }),
+      adaptiveSwap,
+    );
+
+    expect(JSON.parse(out)).toMatchObject({
+      model: "deepseek-chat",
+      thinking: { type: "adaptive", display: "summarized" },
+      output_config: { effort: "max" },
+    });
+    expect(out).not.toContain("budget_tokens");
+  });
 });
 
 describe("swapResponseModelJson (real→alias)", () => {

--- a/scripts/export-litellm-catalog.py
+++ b/scripts/export-litellm-catalog.py
@@ -12,6 +12,8 @@ import sys
 from contextlib import redirect_stdout
 
 import litellm
+from litellm.exceptions import UnsupportedParamsError
+from litellm.utils import get_optional_params
 
 
 # Only these providers feed Appstrate's pricing catalog. Calling the public
@@ -33,6 +35,18 @@ PARAM_PROVIDER_ALLOWLIST = {
     "zai",
 }
 
+REASONING_EFFORTS = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+ACTIVE_REASONING_EFFORTS = tuple(
+    effort for effort in REASONING_EFFORTS if effort != "none"
+)
+SUPPORT_FLAGS = (
+    "supports_none_reasoning_effort",
+    "supports_minimal_reasoning_effort",
+    "supports_low_reasoning_effort",
+    "supports_xhigh_reasoning_effort",
+    "supports_max_reasoning_effort",
+)
+
 
 def supported_params(model: str, provider: str | None) -> list[str] | None:
     if provider not in PARAM_PROVIDER_ALLOWLIST:
@@ -49,6 +63,117 @@ def supported_params(model: str, provider: str | None) -> list[str] | None:
     except Exception as error:  # one malformed upstream entry must not abort the catalog
         print(f"warning: {model}: {error}", file=sys.stderr)
         return None
+
+
+def optional_params_support(
+    model: str,
+    provider: str,
+    **values: object,
+) -> str:
+    """Ask LiteLLM's provider adapter whether one parameter set is valid.
+
+    `get_supported_openai_params` only describes parameter names. The adapter
+    invoked here owns the value-level rules (for example GPT-5's asymmetric
+    reasoning-effort support and its temperature/reasoning constraint).
+    """
+    try:
+        with redirect_stdout(sys.stderr):
+            get_optional_params(
+                model=model,
+                custom_llm_provider=provider,
+                drop_params=False,
+                **values,
+            )
+        return "supported"
+    except UnsupportedParamsError:
+        return "unsupported"
+    except ValueError as error:
+        # Several LiteLLM adapters use a plain ValueError for their enum guard
+        # instead of UnsupportedParamsError. Keep the classification narrow so
+        # configuration/parser failures still surface as unknown below.
+        if "invalid reasoning effort" in str(error).lower():
+            return "unsupported"
+        rendered_values = ", ".join(f"{key}={value}" for key, value in values.items())
+        print(f"warning: {model} ({rendered_values}): {error}", file=sys.stderr)
+        return "unknown"
+    except Exception as error:
+        rendered_values = ", ".join(f"{key}={value}" for key, value in values.items())
+        print(f"warning: {model} ({rendered_values}): {error}", file=sys.stderr)
+        return "unknown"
+
+
+def generation_capabilities(
+    model: str,
+    provider: str | None,
+    entry: dict[str, object],
+    params: list[str] | None,
+) -> dict[str, object] | None:
+    """Normalize LiteLLM's effective generation contract for Appstrate.
+
+    Sparse `supports_*_reasoning_effort` catalog flags are deliberately not
+    interpreted as a complete enum: LiteLLM's adapters contain additional
+    defaults and validation rules. Persist their answer so downstream code is
+    a projection only and never has to reproduce provider semantics.
+    """
+    if provider not in PARAM_PROVIDER_ALLOWLIST or params is None:
+        return None
+
+    if entry.get("supports_sampling_params") is False or "temperature" not in params:
+        temperature = "unsupported"
+    else:
+        temperature = optional_params_support(model, provider, temperature=0.5)
+
+    has_reasoning_evidence = (
+        entry.get("supports_reasoning") is True
+        or "reasoning_effort" in params
+        or "thinking" in params
+        or any(entry.get(flag) is True for flag in SUPPORT_FLAGS)
+    )
+    if entry.get("supports_reasoning") is False:
+        reasoning = "unsupported"
+        levels = {effort: "unsupported" for effort in REASONING_EFFORTS}
+    elif has_reasoning_evidence:
+        levels = {
+            effort: optional_params_support(model, provider, reasoning_effort=effort)
+            for effort in REASONING_EFFORTS
+        }
+        reasoning = "supported"
+    else:
+        reasoning = "unknown"
+        levels = {effort: "unknown" for effort in REASONING_EFFORTS}
+
+    temperature_with_reasoning = "unknown"
+    supported_active_efforts = [
+        effort for effort in ACTIVE_REASONING_EFFORTS if levels[effort] == "supported"
+    ]
+    if temperature == "unsupported" or reasoning == "unsupported":
+        temperature_with_reasoning = "unsupported"
+    elif temperature == "supported" and supported_active_efforts:
+        pair_support = [
+            optional_params_support(
+                model,
+                provider,
+                temperature=0.5,
+                reasoning_effort=effort,
+            )
+            for effort in supported_active_efforts
+        ]
+        if all(value == "supported" for value in pair_support):
+            temperature_with_reasoning = "supported"
+        elif all(value == "unsupported" for value in pair_support):
+            temperature_with_reasoning = "unsupported"
+
+    return {
+        "temperature": temperature,
+        "temperatureWithReasoning": temperature_with_reasoning,
+        "reasoning": {
+            "supported": reasoning,
+            "adaptive": entry.get("supports_adaptive_thinking")
+            if isinstance(entry.get("supports_adaptive_thinking"), bool)
+            else None,
+            "levels": levels,
+        },
+    }
 
 
 if len(sys.argv) > 2:
@@ -71,6 +196,14 @@ for model, raw_entry in sorted(source_catalog.items()):
     )
     if params is not None:
         entry["_appstrate_supported_openai_params"] = params
+    generation = generation_capabilities(
+        model,
+        entry.get("litellm_provider"),
+        entry,
+        params,
+    )
+    if generation is not None:
+        entry["_appstrate_generation"] = generation
     catalog[model] = entry
 
 json.dump(catalog, sys.stdout, sort_keys=True, separators=(",", ":"))

--- a/scripts/export-litellm-catalog.py
+++ b/scripts/export-litellm-catalog.py
@@ -137,7 +137,17 @@ def generation_capabilities(
             effort: optional_params_support(model, provider, reasoning_effort=effort)
             for effort in REASONING_EFFORTS
         }
-        reasoning = "supported"
+        active_support = [levels[effort] for effort in ACTIVE_REASONING_EFFORTS]
+        if any(value == "supported" for value in active_support):
+            reasoning = "supported"
+        elif all(value == "unsupported" for value in active_support):
+            # `supports_reasoning` can describe an internally reasoning model
+            # even when its adapter exposes no configurable effort. Appstrate's
+            # field describes the control, so fail closed when every active
+            # value is explicitly rejected.
+            reasoning = "unsupported"
+        else:
+            reasoning = "unknown"
     else:
         reasoning = "unknown"
         levels = {effort: "unknown" for effort in REASONING_EFFORTS}

--- a/scripts/export-litellm-catalog.py
+++ b/scripts/export-litellm-catalog.py
@@ -152,13 +152,11 @@ def generation_capabilities(
         reasoning = "unknown"
         levels = {effort: "unknown" for effort in REASONING_EFFORTS}
 
-    temperature_with_reasoning = "unknown"
+    temperature_compatible = None
     supported_active_efforts = [
         effort for effort in ACTIVE_REASONING_EFFORTS if levels[effort] == "supported"
     ]
-    if temperature == "unsupported" or reasoning == "unsupported":
-        temperature_with_reasoning = "unsupported"
-    elif temperature == "supported" and supported_active_efforts:
+    if temperature == "supported" and reasoning == "supported" and supported_active_efforts:
         pair_support = [
             optional_params_support(
                 model,
@@ -169,20 +167,23 @@ def generation_capabilities(
             for effort in supported_active_efforts
         ]
         if all(value == "supported" for value in pair_support):
-            temperature_with_reasoning = "supported"
+            temperature_compatible = "supported"
         elif all(value == "unsupported" for value in pair_support):
-            temperature_with_reasoning = "unsupported"
+            temperature_compatible = "unsupported"
+
+    reasoning_capabilities = {
+        "supported": reasoning,
+        "adaptive": entry.get("supports_adaptive_thinking")
+        if isinstance(entry.get("supports_adaptive_thinking"), bool)
+        else None,
+        "levels": levels,
+    }
+    if temperature_compatible is not None:
+        reasoning_capabilities["temperatureCompatible"] = temperature_compatible
 
     return {
         "temperature": temperature,
-        "temperatureWithReasoning": temperature_with_reasoning,
-        "reasoning": {
-            "supported": reasoning,
-            "adaptive": entry.get("supports_adaptive_thinking")
-            if isinstance(entry.get("supports_adaptive_thinking"), bool)
-            else None,
-            "levels": levels,
-        },
+        "reasoning": reasoning_capabilities,
     }
 
 

--- a/scripts/litellm-catalog.lock.json
+++ b/scripts/litellm-catalog.lock.json
@@ -3,7 +3,7 @@
   "version": "v1.95.0",
   "image": "ghcr.io/berriai/litellm",
   "digest": "sha256:af806882b7a6ced41658db5b6a7e98ed7b9b51d03b935e0417bf1c8552d688af",
-  "normalizedDigest": "sha256:3b71f98fa09fa9edd2c4ed5b5a68c0e1556b247b2ef3221a0ec975e3710b5e05",
+  "normalizedDigest": "sha256:d12c7acc8dc99b1ea5b03a5a5f1fe578fe6ebbc03c4fd34d3e2626a854ebb878",
   "catalog": {
     "repository": "BerriAI/litellm",
     "commit": "a79f598f692e66ce49790bfda699b7f4dccb3ca0",

--- a/scripts/litellm-catalog.lock.json
+++ b/scripts/litellm-catalog.lock.json
@@ -1,8 +1,9 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "version": "v1.95.0",
   "image": "ghcr.io/berriai/litellm",
   "digest": "sha256:af806882b7a6ced41658db5b6a7e98ed7b9b51d03b935e0417bf1c8552d688af",
+  "normalizedDigest": "sha256:3b71f98fa09fa9edd2c4ed5b5a68c0e1556b247b2ef3221a0ec975e3710b5e05",
   "catalog": {
     "repository": "BerriAI/litellm",
     "commit": "a79f598f692e66ce49790bfda699b7f4dccb3ca0",

--- a/scripts/refresh-pricing-catalog.ts
+++ b/scripts/refresh-pricing-catalog.ts
@@ -38,7 +38,6 @@
 
 import { resolve } from "node:path";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { createHash } from "node:crypto";
 import type {
   ModelCapabilitySupport,
   ModelGenerationCapabilities,
@@ -250,7 +249,9 @@ function assertNormalizedCatalogDigest(serialized: string, expectedDigest: unkno
   if (typeof expectedDigest !== "string" || !/^sha256:[0-9a-f]{64}$/.test(expectedDigest)) {
     throw new Error("LiteLLM lock is missing a valid normalizedDigest");
   }
-  const actualDigest = `sha256:${createHash("sha256").update(serialized).digest("hex")}`;
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(serialized);
+  const actualDigest = `sha256:${hasher.digest("hex")}`;
   if (actualDigest !== expectedDigest) {
     throw new Error(
       `LiteLLM normalized artifact digest mismatch: expected ${expectedDigest}, got ${actualDigest}`,

--- a/scripts/refresh-pricing-catalog.ts
+++ b/scripts/refresh-pricing-catalog.ts
@@ -26,12 +26,13 @@
  *     branch on upstream schema drift — that risk is contained here.
  *
  * Two modes:
- *   - **dry run** (default): downloads, diffs against the local files,
- *     prints a summary, exits 1 on drift. CI weekly workflow consumes this.
+ *   - **dry run** (default): diffs a normalized exporter artifact against the
+ *     local files, prints a summary, exits 1 on drift.
  *   - **apply** (`--apply`): writes the new content from a normalized exporter artifact.
  *
  * Usage:
- *   bun scripts/refresh-pricing-catalog.ts          # dry run
+ *   LITELLM_CATALOG_PATH=/path/to/export.json \
+ *     bun scripts/refresh-pricing-catalog.ts         # dry run
  *   LITELLM_CATALOG_PATH=/path/to/export.json \
  *     bun scripts/refresh-pricing-catalog.ts --apply
  */
@@ -45,8 +46,6 @@ import type {
   ModelReasoningLevel,
 } from "@appstrate/core/model-generation";
 
-const UPSTREAM_URL =
-  "https://raw.githubusercontent.com/BerriAI/litellm/main/litellm/model_prices_and_context_window_backup.json";
 const REPO_ROOT = new URL("..", import.meta.url).pathname;
 const DATA_DIR = resolve(REPO_ROOT, "apps/api/src/data/pricing");
 const LITELLM_LOCK_PATH = resolve(REPO_ROOT, "scripts/litellm-catalog.lock.json");
@@ -169,16 +168,6 @@ interface LiteLLMEntry {
   cache_read_input_token_cost?: number;
   cache_creation_input_token_cost?: number;
   supports_vision?: boolean;
-  supports_reasoning?: boolean;
-  supports_sampling_params?: boolean;
-  supports_none_reasoning_effort?: boolean;
-  supports_minimal_reasoning_effort?: boolean;
-  supports_low_reasoning_effort?: boolean;
-  supports_xhigh_reasoning_effort?: boolean;
-  supports_max_reasoning_effort?: boolean;
-  supports_adaptive_thinking?: boolean;
-  /** Added by the isolated pinned-LiteLLM exporter, never by the raw fallback. */
-  _appstrate_supported_openai_params?: string[];
   /** Effective value-level contract computed by the pinned LiteLLM adapters. */
   _appstrate_generation?: {
     temperature: ModelCapabilitySupport;
@@ -412,80 +401,31 @@ function deriveLabel(id: string): string {
     .join(" ");
 }
 
-function support(value: boolean | undefined): ModelCapabilitySupport {
-  return value === true ? "supported" : value === false ? "unsupported" : "unknown";
-}
-
-function deriveGenerationCapabilities(entry: LiteLLMEntry): ModelGenerationCapabilities {
+function projectGenerationCapabilities(entry: LiteLLMEntry): ModelGenerationCapabilities {
   const exported = entry._appstrate_generation;
-  if (exported) {
-    return {
-      temperature: exported.temperature,
-      reasoning: {
-        supported: exported.reasoning.supported,
-        ...(exported.reasoning.temperatureCompatible !== undefined
-          ? { temperatureCompatible: exported.reasoning.temperatureCompatible }
-          : {}),
-        adaptive: exported.reasoning.adaptive,
-        levels: {
-          off: exported.reasoning.levels.none ?? "unknown",
-          minimal: exported.reasoning.levels.minimal ?? "unknown",
-          low: exported.reasoning.levels.low ?? "unknown",
-          medium: exported.reasoning.levels.medium ?? "unknown",
-          high: exported.reasoning.levels.high ?? "unknown",
-          xhigh: exported.reasoning.levels.xhigh ?? "unknown",
-          max: exported.reasoning.levels.max ?? "unknown",
-        },
-      },
-    };
+  if (!exported) {
+    throw new Error("LiteLLM entry is missing its normalized generation contract");
   }
 
-  const supportedParams = entry._appstrate_supported_openai_params;
-  const hasSupportedReasoningLevel = [
-    entry.supports_none_reasoning_effort,
-    entry.supports_minimal_reasoning_effort,
-    entry.supports_low_reasoning_effort,
-    entry.supports_xhigh_reasoning_effort,
-    entry.supports_max_reasoning_effort,
-  ].some((value) => value === true);
-  const temperature =
-    entry.supports_sampling_params === false
-      ? "unsupported"
-      : supportedParams
-        ? supportedParams.includes("temperature")
-          ? "supported"
-          : "unsupported"
-        : "unknown";
-  const reasoning: ModelCapabilitySupport =
-    entry.supports_reasoning === false
-      ? "unsupported"
-      : entry.supports_reasoning === true ||
-          hasSupportedReasoningLevel ||
-          supportedParams?.includes("reasoning_effort") === true ||
-          supportedParams?.includes("thinking") === true
-        ? "supported"
-        : "unknown";
-  const levels: Partial<Record<ModelReasoningLevel, ModelCapabilitySupport>> = {
-    off: support(entry.supports_none_reasoning_effort),
-    minimal: support(entry.supports_minimal_reasoning_effort),
-    // A general `supports_reasoning` fact confirms the control, not each
-    // individual effort value. Keep unreported levels unknown rather than
-    // inventing provider support that can turn into a 400 at inference time.
-    low: support(entry.supports_low_reasoning_effort),
-    medium: "unknown",
-    high: "unknown",
-    xhigh: support(entry.supports_xhigh_reasoning_effort),
-    max: support(entry.supports_max_reasoning_effort),
-  };
+  // The normalized artifact remains exhaustive for validation and review. The
+  // runtime projection is sparse: omission already means "not confirmed", so
+  // persisting thousands of explicit `unknown` values only creates catalog
+  // churn without changing resolution or UI behaviour.
+  const levels: Partial<Record<ModelReasoningLevel, ModelCapabilitySupport>> = {};
+  for (const nativeLevel of NATIVE_REASONING_LEVELS) {
+    const capability = exported.reasoning.levels[nativeLevel];
+    if (capability === "unknown" || capability === undefined) continue;
+    levels[nativeLevel === "none" ? "off" : nativeLevel] = capability;
+  }
 
   return {
-    temperature,
+    temperature: exported.temperature,
     reasoning: {
-      supported: reasoning,
-      adaptive:
-        typeof entry.supports_adaptive_thinking === "boolean"
-          ? entry.supports_adaptive_thinking
-          : null,
+      supported: exported.reasoning.supported,
+      ...(exported.reasoning.temperatureCompatible !== undefined
+        ? { temperatureCompatible: exported.reasoning.temperatureCompatible }
+        : {}),
+      adaptive: exported.reasoning.adaptive,
       levels,
     },
   };
@@ -504,7 +444,7 @@ function projectEntry(id: string, entry: LiteLLMEntry): CompactEntry | null {
   ) {
     return null;
   }
-  const generation = deriveGenerationCapabilities(entry);
+  const generation = projectGenerationCapabilities(entry);
   const caps: string[] = ["text"];
   if (entry.supports_vision) caps.push("image");
   if (generation.reasoning.supported === "supported") caps.push("reasoning");
@@ -667,26 +607,18 @@ function buildFeatured(
   return ranked.filter((id) => !excluded.has(id)).slice(0, FEATURED_COUNT);
 }
 
-async function fetchUpstream(): Promise<Record<string, LiteLLMEntry>> {
+function readNormalizedCatalog(): Record<string, LiteLLMEntry> {
   const artifactPath = process.env.LITELLM_CATALOG_PATH;
-  const artifactContents = artifactPath ? readFileSync(artifactPath, "utf8") : null;
-  const data = artifactContents
-    ? (JSON.parse(artifactContents) as Record<string, LiteLLMEntry>)
-    : await (async () => {
-        const res = await fetch(UPSTREAM_URL);
-        if (!res.ok) throw new Error(`fetch ${UPSTREAM_URL} → HTTP ${res.status}`);
-        process.stderr.write(
-          "WARNING: using the unpinned raw LiteLLM fallback; CI uses the pinned exporter artifact\n",
-        );
-        return (await res.json()) as Record<string, LiteLLMEntry>;
-      })();
-  if (artifactContents) {
-    const lock = JSON.parse(readFileSync(LITELLM_LOCK_PATH, "utf8")) as {
-      normalizedDigest?: unknown;
-    };
-    assertNormalizedCatalogDigest(artifactContents, lock.normalizedDigest);
-    assertNormalizedGenerationCatalog(data);
+  if (!artifactPath) {
+    throw new Error("LITELLM_CATALOG_PATH is required; use the pinned LiteLLM exporter artifact");
   }
+  const artifactContents = readFileSync(artifactPath, "utf8");
+  const data = JSON.parse(artifactContents) as Record<string, LiteLLMEntry>;
+  const lock = JSON.parse(readFileSync(LITELLM_LOCK_PATH, "utf8")) as {
+    normalizedDigest?: unknown;
+  };
+  assertNormalizedCatalogDigest(artifactContents, lock.normalizedDigest);
+  assertNormalizedGenerationCatalog(data);
   // Remove LiteLLM's `sample_spec` synthetic top-level entry — it documents
   // the schema, not a real model.
   delete data.sample_spec;
@@ -753,18 +685,12 @@ async function main(): Promise<void> {
     (globalThis as { process?: { argv?: string[] } }).process?.argv?.includes("--apply") ?? false;
   console.log(`Refreshing pricing catalog from LiteLLM (apply=${apply})\n`);
 
-  if (apply && !process.env.LITELLM_CATALOG_PATH) {
-    throw new Error(
-      "--apply requires LITELLM_CATALOG_PATH from the pinned LiteLLM exporter; " +
-        "the raw fallback does not contain value-level generation capabilities",
-    );
-  }
-
   if (apply && !existsSync(DATA_DIR)) {
     mkdirSync(DATA_DIR, { recursive: true });
   }
 
-  const [upstream, modelsDev] = await Promise.all([fetchUpstream(), fetchModelsDev()]);
+  const upstream = readNormalizedCatalog();
+  const modelsDev = await fetchModelsDev();
   const summaries: Summary[] = [];
   const snapshots: Record<string, Record<string, CompactEntry>> = {};
   const coverageRows: CoverageRow[] = [];
@@ -926,7 +852,7 @@ export {
   buildFeatured,
   countCacheRates,
   coverageRow,
-  deriveGenerationCapabilities,
+  projectGenerationCapabilities,
   formatCoverageSummary,
   projectEntry,
 };

--- a/scripts/refresh-pricing-catalog.ts
+++ b/scripts/refresh-pricing-catalog.ts
@@ -182,9 +182,9 @@ interface LiteLLMEntry {
   /** Effective value-level contract computed by the pinned LiteLLM adapters. */
   _appstrate_generation?: {
     temperature: ModelCapabilitySupport;
-    temperatureWithReasoning: ModelCapabilitySupport;
     reasoning: {
       supported: ModelCapabilitySupport;
+      temperatureCompatible?: ModelCapabilitySupport;
       adaptive: boolean | null;
       levels: Partial<Record<ModelNativeReasoningLevel, ModelCapabilitySupport>>;
     };
@@ -226,8 +226,9 @@ function assertNormalizedGenerationCatalog(data: Record<string, LiteLLMEntry>): 
     const valid =
       generation != null &&
       isSupport(generation.temperature) &&
-      isSupport(generation.temperatureWithReasoning) &&
       isSupport(generation.reasoning?.supported) &&
+      (generation.reasoning?.temperatureCompatible === undefined ||
+        isSupport(generation.reasoning.temperatureCompatible)) &&
       (generation.reasoning?.adaptive === null ||
         typeof generation.reasoning?.adaptive === "boolean") &&
       validLevels;
@@ -420,9 +421,11 @@ function deriveGenerationCapabilities(entry: LiteLLMEntry): ModelGenerationCapab
   if (exported) {
     return {
       temperature: exported.temperature,
-      temperatureWithReasoning: exported.temperatureWithReasoning,
       reasoning: {
         supported: exported.reasoning.supported,
+        ...(exported.reasoning.temperatureCompatible !== undefined
+          ? { temperatureCompatible: exported.reasoning.temperatureCompatible }
+          : {}),
         adaptive: exported.reasoning.adaptive,
         levels: {
           off: exported.reasoning.levels.none ?? "unknown",

--- a/scripts/refresh-pricing-catalog.ts
+++ b/scripts/refresh-pricing-catalog.ts
@@ -190,6 +190,59 @@ interface LiteLLMEntry {
   };
 }
 
+const NATIVE_REASONING_LEVELS: readonly ModelNativeReasoningLevel[] = [
+  "none",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+];
+const CAPABILITY_SUPPORT_VALUES: readonly ModelCapabilitySupport[] = [
+  "supported",
+  "unsupported",
+  "unknown",
+];
+
+/** Fail closed when a pinned exporter artifact lacks its normalized contract. */
+function assertNormalizedGenerationCatalog(data: Record<string, LiteLLMEntry>): void {
+  const vendoredProviders = new Set(Object.keys(LITELLM_TO_OURS));
+  const isSupport = (value: unknown): value is ModelCapabilitySupport =>
+    CAPABILITY_SUPPORT_VALUES.includes(value as ModelCapabilitySupport);
+  let vendoredChatEntries = 0;
+
+  for (const [modelId, entry] of Object.entries(data)) {
+    if (entry.mode !== "chat" || !vendoredProviders.has(entry.litellm_provider ?? "")) continue;
+    vendoredChatEntries += 1;
+
+    const generation = entry._appstrate_generation;
+    const levels = generation?.reasoning?.levels;
+    const validLevels =
+      levels != null &&
+      Object.keys(levels).length === NATIVE_REASONING_LEVELS.length &&
+      NATIVE_REASONING_LEVELS.every((level) => isSupport(levels[level]));
+    const valid =
+      generation != null &&
+      isSupport(generation.temperature) &&
+      isSupport(generation.temperatureWithReasoning) &&
+      isSupport(generation.reasoning?.supported) &&
+      (generation.reasoning?.adaptive === null ||
+        typeof generation.reasoning?.adaptive === "boolean") &&
+      validLevels;
+
+    if (!valid) {
+      throw new Error(
+        `LiteLLM model ${modelId} has an invalid or missing _appstrate_generation contract`,
+      );
+    }
+  }
+
+  if (vendoredChatEntries === 0) {
+    throw new Error("LiteLLM artifact contains no vendored chat entries");
+  }
+}
+
 interface Summary {
   provider: string;
   localSize: number;
@@ -607,6 +660,7 @@ async function fetchUpstream(): Promise<Record<string, LiteLLMEntry>> {
         );
         return (await res.json()) as Record<string, LiteLLMEntry>;
       })();
+  if (artifactPath) assertNormalizedGenerationCatalog(data);
   // Remove LiteLLM's `sample_spec` synthetic top-level entry — it documents
   // the schema, not a real model.
   delete data.sample_spec;
@@ -841,6 +895,7 @@ if (import.meta.main) {
 
 export {
   aliasedBackings,
+  assertNormalizedGenerationCatalog,
   buildFeatured,
   countCacheRates,
   coverageRow,

--- a/scripts/refresh-pricing-catalog.ts
+++ b/scripts/refresh-pricing-catalog.ts
@@ -15,6 +15,7 @@
  *     "contextWindow": 200000,
  *     "maxTokens": 64000,
  *     "capabilities": ["text","image","reasoning"],
+ *     "generation": { "temperature": "supported", "reasoning": { … } },
  *     "cost": { "input": 1.0, "output": 5.0, "cacheRead": 0.1, "cacheWrite": 1.25 }
  *   }
  *
@@ -27,11 +28,12 @@
  * Two modes:
  *   - **dry run** (default): downloads, diffs against the local files,
  *     prints a summary, exits 1 on drift. CI weekly workflow consumes this.
- *   - **apply** (`--apply`): writes the new content.
+ *   - **apply** (`--apply`): writes the new content from a normalized exporter artifact.
  *
  * Usage:
  *   bun scripts/refresh-pricing-catalog.ts          # dry run
- *   bun scripts/refresh-pricing-catalog.ts --apply  # write to disk
+ *   LITELLM_CATALOG_PATH=/path/to/export.json \
+ *     bun scripts/refresh-pricing-catalog.ts --apply
  */
 
 import { resolve } from "node:path";
@@ -39,6 +41,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import type {
   ModelCapabilitySupport,
   ModelGenerationCapabilities,
+  ModelNativeReasoningLevel,
   ModelReasoningLevel,
 } from "@appstrate/core/model-generation";
 
@@ -175,6 +178,16 @@ interface LiteLLMEntry {
   supports_adaptive_thinking?: boolean;
   /** Added by the isolated pinned-LiteLLM exporter, never by the raw fallback. */
   _appstrate_supported_openai_params?: string[];
+  /** Effective value-level contract computed by the pinned LiteLLM adapters. */
+  _appstrate_generation?: {
+    temperature: ModelCapabilitySupport;
+    temperatureWithReasoning: ModelCapabilitySupport;
+    reasoning: {
+      supported: ModelCapabilitySupport;
+      adaptive: boolean | null;
+      levels: Partial<Record<ModelNativeReasoningLevel, ModelCapabilitySupport>>;
+    };
+  };
 }
 
 interface Summary {
@@ -333,13 +346,28 @@ function support(value: boolean | undefined): ModelCapabilitySupport {
   return value === true ? "supported" : value === false ? "unsupported" : "unknown";
 }
 
-function supportEither(a: boolean | undefined, b: boolean | undefined): ModelCapabilitySupport {
-  if (a === true || b === true) return "supported";
-  if (a === false || b === false) return "unsupported";
-  return "unknown";
-}
-
 function deriveGenerationCapabilities(entry: LiteLLMEntry): ModelGenerationCapabilities {
+  const exported = entry._appstrate_generation;
+  if (exported) {
+    return {
+      temperature: exported.temperature,
+      temperatureWithReasoning: exported.temperatureWithReasoning,
+      reasoning: {
+        supported: exported.reasoning.supported,
+        adaptive: exported.reasoning.adaptive,
+        levels: {
+          off: exported.reasoning.levels.none ?? "unknown",
+          minimal: exported.reasoning.levels.minimal ?? "unknown",
+          low: exported.reasoning.levels.low ?? "unknown",
+          medium: exported.reasoning.levels.medium ?? "unknown",
+          high: exported.reasoning.levels.high ?? "unknown",
+          xhigh: exported.reasoning.levels.xhigh ?? "unknown",
+          max: exported.reasoning.levels.max ?? "unknown",
+        },
+      },
+    };
+  }
+
   const supportedParams = entry._appstrate_supported_openai_params;
   const hasSupportedReasoningLevel = [
     entry.supports_none_reasoning_effort,
@@ -374,24 +402,9 @@ function deriveGenerationCapabilities(entry: LiteLLMEntry): ModelGenerationCapab
     low: support(entry.supports_low_reasoning_effort),
     medium: "unknown",
     high: "unknown",
-    // Pi exposes one portable top level (`xhigh`). LiteLLM calls that level
-    // either xhigh or max depending on the provider adapter.
-    xhigh: supportEither(
-      entry.supports_xhigh_reasoning_effort,
-      entry.supports_max_reasoning_effort,
-    ),
+    xhigh: support(entry.supports_xhigh_reasoning_effort),
+    max: support(entry.supports_max_reasoning_effort),
   };
-  const nativeLevels =
-    levels.xhigh === "supported"
-      ? {
-          xhigh:
-            entry.litellm_provider === "anthropic" && entry.supports_max_reasoning_effort === true
-              ? ("max" as const)
-              : entry.supports_xhigh_reasoning_effort === true
-                ? ("xhigh" as const)
-                : ("max" as const),
-        }
-      : undefined;
 
   return {
     temperature,
@@ -402,7 +415,6 @@ function deriveGenerationCapabilities(entry: LiteLLMEntry): ModelGenerationCapab
           ? entry.supports_adaptive_thinking
           : null,
       levels,
-      ...(nativeLevels ? { nativeLevels } : {}),
     },
   };
 }
@@ -660,6 +672,13 @@ async function main(): Promise<void> {
   const apply =
     (globalThis as { process?: { argv?: string[] } }).process?.argv?.includes("--apply") ?? false;
   console.log(`Refreshing pricing catalog from LiteLLM (apply=${apply})\n`);
+
+  if (apply && !process.env.LITELLM_CATALOG_PATH) {
+    throw new Error(
+      "--apply requires LITELLM_CATALOG_PATH from the pinned LiteLLM exporter; " +
+        "the raw fallback does not contain value-level generation capabilities",
+    );
+  }
 
   if (apply && !existsSync(DATA_DIR)) {
     mkdirSync(DATA_DIR, { recursive: true });

--- a/scripts/refresh-pricing-catalog.ts
+++ b/scripts/refresh-pricing-catalog.ts
@@ -38,6 +38,7 @@
 
 import { resolve } from "node:path";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
 import type {
   ModelCapabilitySupport,
   ModelGenerationCapabilities,
@@ -49,6 +50,7 @@ const UPSTREAM_URL =
   "https://raw.githubusercontent.com/BerriAI/litellm/main/litellm/model_prices_and_context_window_backup.json";
 const REPO_ROOT = new URL("..", import.meta.url).pathname;
 const DATA_DIR = resolve(REPO_ROOT, "apps/api/src/data/pricing");
+const LITELLM_LOCK_PATH = resolve(REPO_ROOT, "scripts/litellm-catalog.lock.json");
 
 /**
  * LiteLLM `litellm_provider` slug → our vendored-file basename.
@@ -240,6 +242,19 @@ function assertNormalizedGenerationCatalog(data: Record<string, LiteLLMEntry>): 
 
   if (vendoredChatEntries === 0) {
     throw new Error("LiteLLM artifact contains no vendored chat entries");
+  }
+}
+
+/** Verify that the artifact is the exact normalized output recorded by the lock. */
+function assertNormalizedCatalogDigest(serialized: string, expectedDigest: unknown): void {
+  if (typeof expectedDigest !== "string" || !/^sha256:[0-9a-f]{64}$/.test(expectedDigest)) {
+    throw new Error("LiteLLM lock is missing a valid normalizedDigest");
+  }
+  const actualDigest = `sha256:${createHash("sha256").update(serialized).digest("hex")}`;
+  if (actualDigest !== expectedDigest) {
+    throw new Error(
+      `LiteLLM normalized artifact digest mismatch: expected ${expectedDigest}, got ${actualDigest}`,
+    );
   }
 }
 
@@ -650,8 +665,9 @@ function buildFeatured(
 
 async function fetchUpstream(): Promise<Record<string, LiteLLMEntry>> {
   const artifactPath = process.env.LITELLM_CATALOG_PATH;
-  const data = artifactPath
-    ? (JSON.parse(readFileSync(artifactPath, "utf8")) as Record<string, LiteLLMEntry>)
+  const artifactContents = artifactPath ? readFileSync(artifactPath, "utf8") : null;
+  const data = artifactContents
+    ? (JSON.parse(artifactContents) as Record<string, LiteLLMEntry>)
     : await (async () => {
         const res = await fetch(UPSTREAM_URL);
         if (!res.ok) throw new Error(`fetch ${UPSTREAM_URL} → HTTP ${res.status}`);
@@ -660,7 +676,13 @@ async function fetchUpstream(): Promise<Record<string, LiteLLMEntry>> {
         );
         return (await res.json()) as Record<string, LiteLLMEntry>;
       })();
-  if (artifactPath) assertNormalizedGenerationCatalog(data);
+  if (artifactContents) {
+    const lock = JSON.parse(readFileSync(LITELLM_LOCK_PATH, "utf8")) as {
+      normalizedDigest?: unknown;
+    };
+    assertNormalizedCatalogDigest(artifactContents, lock.normalizedDigest);
+    assertNormalizedGenerationCatalog(data);
+  }
   // Remove LiteLLM's `sample_spec` synthetic top-level entry — it documents
   // the schema, not a real model.
   delete data.sample_spec;
@@ -895,6 +917,7 @@ if (import.meta.main) {
 
 export {
   aliasedBackings,
+  assertNormalizedCatalogDigest,
   assertNormalizedGenerationCatalog,
   buildFeatured,
   countCacheRates,

--- a/scripts/test/refresh-pricing-catalog.test.ts
+++ b/scripts/test/refresh-pricing-catalog.test.ts
@@ -16,8 +16,8 @@ import {
   buildFeatured,
   countCacheRates,
   coverageRow,
-  deriveGenerationCapabilities,
   formatCoverageSummary,
+  projectGenerationCapabilities,
   projectEntry,
   type CoverageRow,
 } from "../refresh-pricing-catalog.ts";
@@ -332,38 +332,9 @@ describe("generation capabilities", () => {
     ).toThrow(/model.*_appstrate_generation/);
   });
 
-  it("normalizes LiteLLM reasoning efforts and supported request parameters", () => {
-    expect(
-      deriveGenerationCapabilities({
-        supports_reasoning: true,
-        supports_none_reasoning_effort: true,
-        supports_minimal_reasoning_effort: false,
-        supports_low_reasoning_effort: true,
-        supports_xhigh_reasoning_effort: false,
-        supports_adaptive_thinking: true,
-        _appstrate_supported_openai_params: ["temperature", "tools"],
-      }),
-    ).toEqual({
-      temperature: "supported",
-      reasoning: {
-        supported: "supported",
-        adaptive: true,
-        levels: {
-          off: "supported",
-          minimal: "unsupported",
-          low: "supported",
-          medium: "unknown",
-          high: "unknown",
-          xhigh: "unsupported",
-          max: "unknown",
-        },
-      },
-    });
-  });
-
   it("projects LiteLLM's effective value-level contract without re-deriving it", () => {
     expect(
-      deriveGenerationCapabilities({
+      projectGenerationCapabilities({
         _appstrate_generation: {
           temperature: "supported",
           reasoning: {
@@ -401,52 +372,42 @@ describe("generation capabilities", () => {
     });
   });
 
-  it("keeps absent upstream facts unknown instead of guessing", () => {
-    expect(deriveGenerationCapabilities({})).toEqual({
+  it("omits unknown levels from the runtime projection", () => {
+    expect(
+      projectGenerationCapabilities({
+        _appstrate_generation: {
+          temperature: "unknown",
+          reasoning: {
+            supported: "unknown",
+            adaptive: null,
+            levels: {
+              none: "unsupported",
+              minimal: "unknown",
+              low: "supported",
+              medium: "unknown",
+              high: "unknown",
+              xhigh: "unknown",
+              max: "unsupported",
+            },
+          },
+        },
+      }),
+    ).toEqual({
       temperature: "unknown",
       reasoning: {
         supported: "unknown",
         adaptive: null,
         levels: {
-          off: "unknown",
-          minimal: "unknown",
-          low: "unknown",
-          medium: "unknown",
-          high: "unknown",
-          xhigh: "unknown",
-          max: "unknown",
+          off: "unsupported",
+          low: "supported",
+          max: "unsupported",
         },
       },
     });
   });
 
-  it("uses LiteLLM's supported parameter list as a reasoning capability fact", () => {
-    const capabilities = deriveGenerationCapabilities({
-      _appstrate_supported_openai_params: ["reasoning_effort"],
-    });
-    expect(capabilities.reasoning.supported).toBe("supported");
-    expect(capabilities.reasoning.levels.low).toBe("unknown");
-    expect(capabilities.reasoning.levels.medium).toBe("unknown");
-    expect(capabilities.reasoning.levels.high).toBe("unknown");
-  });
-
-  it("derives reasoning support from an explicitly supported level", () => {
-    const capabilities = deriveGenerationCapabilities({
-      supports_minimal_reasoning_effort: true,
-    });
-    expect(capabilities.reasoning.supported).toBe("supported");
-    expect(capabilities.reasoning.levels.minimal).toBe("supported");
-    expect(capabilities.reasoning.levels.high).toBe("unknown");
-  });
-
-  it("keeps LiteLLM's max effort distinct from xhigh", () => {
-    const capabilities = deriveGenerationCapabilities({
-      litellm_provider: "anthropic",
-      supports_reasoning: true,
-      supports_max_reasoning_effort: true,
-    });
-    expect(capabilities.reasoning.levels.xhigh).toBe("unknown");
-    expect(capabilities.reasoning.levels.max).toBe("supported");
+  it("rejects an entry without the normalized source contract", () => {
+    expect(() => projectGenerationCapabilities({})).toThrow(/normalized generation contract/);
   });
 
   it("vendors the normalized generation block with pricing", () => {
@@ -454,10 +415,9 @@ describe("generation capabilities", () => {
       input_cost_per_token: 0.000001,
       output_cost_per_token: 0.000002,
       max_input_tokens: 10_000,
-      supports_reasoning: true,
-      supports_sampling_params: false,
+      _appstrate_generation: normalizedGeneration,
     });
-    expect(projected?.generation.temperature).toBe("unsupported");
+    expect(projected?.generation.temperature).toBe("supported");
     expect(projected?.generation.reasoning.supported).toBe("supported");
   });
 
@@ -466,7 +426,7 @@ describe("generation capabilities", () => {
       input_cost_per_token: 0.000001,
       output_cost_per_token: 0.000002,
       max_input_tokens: 10_000,
-      _appstrate_supported_openai_params: ["reasoning_effort"],
+      _appstrate_generation: normalizedGeneration,
     });
     expect(projected?.generation.reasoning.supported).toBe("supported");
     expect(projected?.capabilities).toContain("reasoning");

--- a/scripts/test/refresh-pricing-catalog.test.ts
+++ b/scripts/test/refresh-pricing-catalog.test.ts
@@ -239,9 +239,9 @@ describe("formatCoverageSummary", () => {
 describe("generation capabilities", () => {
   const normalizedGeneration = {
     temperature: "supported",
-    temperatureWithReasoning: "unsupported",
     reasoning: {
       supported: "supported",
+      temperatureCompatible: "unsupported",
       adaptive: null,
       levels: {
         none: "supported",
@@ -262,6 +262,22 @@ describe("generation capabilities", () => {
           litellm_provider: "openai",
           mode: "chat",
           _appstrate_generation: normalizedGeneration,
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts an omitted pair fact when LiteLLM is inconclusive", () => {
+    const { temperatureCompatible: _temperatureCompatible, ...reasoning } =
+      normalizedGeneration.reasoning;
+    void _temperatureCompatible;
+
+    expect(() =>
+      assertNormalizedGenerationCatalog({
+        model: {
+          litellm_provider: "openai",
+          mode: "chat",
+          _appstrate_generation: { ...normalizedGeneration, reasoning },
         },
       }),
     ).not.toThrow();
@@ -292,6 +308,24 @@ describe("generation capabilities", () => {
           _appstrate_generation: {
             ...normalizedGeneration,
             temperature: "maybe",
+          },
+        } as never,
+      }),
+    ).toThrow(/model.*_appstrate_generation/);
+  });
+
+  it("rejects a malformed optional pair fact", () => {
+    expect(() =>
+      assertNormalizedGenerationCatalog({
+        model: {
+          litellm_provider: "openai",
+          mode: "chat",
+          _appstrate_generation: {
+            ...normalizedGeneration,
+            reasoning: {
+              ...normalizedGeneration.reasoning,
+              temperatureCompatible: "maybe",
+            },
           },
         } as never,
       }),
@@ -332,9 +366,9 @@ describe("generation capabilities", () => {
       deriveGenerationCapabilities({
         _appstrate_generation: {
           temperature: "supported",
-          temperatureWithReasoning: "unsupported",
           reasoning: {
             supported: "supported",
+            temperatureCompatible: "unsupported",
             adaptive: null,
             levels: {
               none: "supported",
@@ -350,9 +384,9 @@ describe("generation capabilities", () => {
       }),
     ).toEqual({
       temperature: "supported",
-      temperatureWithReasoning: "unsupported",
       reasoning: {
         supported: "supported",
+        temperatureCompatible: "unsupported",
         adaptive: null,
         levels: {
           off: "supported",

--- a/scripts/test/refresh-pricing-catalog.test.ts
+++ b/scripts/test/refresh-pricing-catalog.test.ts
@@ -9,9 +9,11 @@
  */
 
 import { describe, it, expect, afterEach } from "bun:test";
+import { createHash } from "node:crypto";
 import {
   aliasedBackings,
   assertNormalizedGenerationCatalog,
+  assertNormalizedCatalogDigest,
   buildFeatured,
   countCacheRates,
   coverageRow,
@@ -435,5 +437,24 @@ describe("generation capabilities", () => {
     });
     expect(projected?.generation.reasoning.supported).toBe("supported");
     expect(projected?.capabilities).toContain("reasoning");
+  });
+});
+
+describe("normalized artifact provenance", () => {
+  const artifact = '{"model":{"mode":"chat"}}\n';
+  const digest = `sha256:${createHash("sha256").update(artifact).digest("hex")}`;
+
+  it("accepts the exact normalized output recorded in the lock", () => {
+    expect(() => assertNormalizedCatalogDigest(artifact, digest)).not.toThrow();
+  });
+
+  it("rejects a stale or handcrafted normalized output", () => {
+    expect(() => assertNormalizedCatalogDigest(`${artifact} `, digest)).toThrow(
+      /normalized artifact digest mismatch/,
+    );
+  });
+
+  it("rejects a lock without a normalized output digest", () => {
+    expect(() => assertNormalizedCatalogDigest(artifact, undefined)).toThrow(/normalizedDigest/);
   });
 });

--- a/scripts/test/refresh-pricing-catalog.test.ts
+++ b/scripts/test/refresh-pricing-catalog.test.ts
@@ -9,7 +9,6 @@
  */
 
 import { describe, it, expect, afterEach } from "bun:test";
-import { createHash } from "node:crypto";
 import {
   aliasedBackings,
   assertNormalizedGenerationCatalog,
@@ -442,7 +441,7 @@ describe("generation capabilities", () => {
 
 describe("normalized artifact provenance", () => {
   const artifact = '{"model":{"mode":"chat"}}\n';
-  const digest = `sha256:${createHash("sha256").update(artifact).digest("hex")}`;
+  const digest = "sha256:780b6be6695be8ea016ce4e2b957c03570cddef06e87a64b7695e2b248e09e08";
 
   it("accepts the exact normalized output recorded in the lock", () => {
     expect(() => assertNormalizedCatalogDigest(artifact, digest)).not.toThrow();

--- a/scripts/test/refresh-pricing-catalog.test.ts
+++ b/scripts/test/refresh-pricing-catalog.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect, afterEach } from "bun:test";
 import {
   aliasedBackings,
+  assertNormalizedGenerationCatalog,
   buildFeatured,
   countCacheRates,
   coverageRow,
@@ -235,6 +236,67 @@ describe("formatCoverageSummary", () => {
 });
 
 describe("generation capabilities", () => {
+  const normalizedGeneration = {
+    temperature: "supported",
+    temperatureWithReasoning: "unsupported",
+    reasoning: {
+      supported: "supported",
+      adaptive: null,
+      levels: {
+        none: "supported",
+        minimal: "unsupported",
+        low: "supported",
+        medium: "supported",
+        high: "supported",
+        xhigh: "supported",
+        max: "supported",
+      },
+    },
+  } as const;
+
+  it("accepts a complete normalized generation contract for vendored chat entries", () => {
+    expect(() =>
+      assertNormalizedGenerationCatalog({
+        model: {
+          litellm_provider: "openai",
+          mode: "chat",
+          _appstrate_generation: normalizedGeneration,
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects a vendored chat entry without the normalized generation contract", () => {
+    expect(() =>
+      assertNormalizedGenerationCatalog({
+        model: { litellm_provider: "openai", mode: "chat" },
+      }),
+    ).toThrow(/model.*_appstrate_generation/);
+  });
+
+  it("rejects an artifact with no vendored chat entries", () => {
+    expect(() =>
+      assertNormalizedGenerationCatalog({
+        embedding: { litellm_provider: "openai", mode: "embedding" },
+      }),
+    ).toThrow(/no vendored chat entries/);
+  });
+
+  it("rejects malformed normalized generation values", () => {
+    expect(() =>
+      assertNormalizedGenerationCatalog({
+        model: {
+          litellm_provider: "anthropic",
+          mode: "chat",
+          _appstrate_generation: {
+            ...normalizedGeneration,
+            temperature: "maybe",
+          },
+        } as never,
+      }),
+    ).toThrow(/model.*_appstrate_generation/);
+  });
+
   it("normalizes LiteLLM reasoning efforts and supported request parameters", () => {
     expect(
       deriveGenerationCapabilities({

--- a/scripts/test/refresh-pricing-catalog.test.ts
+++ b/scripts/test/refresh-pricing-catalog.test.ts
@@ -258,6 +258,47 @@ describe("generation capabilities", () => {
           medium: "unknown",
           high: "unknown",
           xhigh: "unsupported",
+          max: "unknown",
+        },
+      },
+    });
+  });
+
+  it("projects LiteLLM's effective value-level contract without re-deriving it", () => {
+    expect(
+      deriveGenerationCapabilities({
+        _appstrate_generation: {
+          temperature: "supported",
+          temperatureWithReasoning: "unsupported",
+          reasoning: {
+            supported: "supported",
+            adaptive: null,
+            levels: {
+              none: "supported",
+              minimal: "unsupported",
+              low: "supported",
+              medium: "supported",
+              high: "supported",
+              xhigh: "supported",
+              max: "supported",
+            },
+          },
+        },
+      }),
+    ).toEqual({
+      temperature: "supported",
+      temperatureWithReasoning: "unsupported",
+      reasoning: {
+        supported: "supported",
+        adaptive: null,
+        levels: {
+          off: "supported",
+          minimal: "unsupported",
+          low: "supported",
+          medium: "supported",
+          high: "supported",
+          xhigh: "supported",
+          max: "supported",
         },
       },
     });
@@ -276,6 +317,7 @@ describe("generation capabilities", () => {
           medium: "unknown",
           high: "unknown",
           xhigh: "unknown",
+          max: "unknown",
         },
       },
     });
@@ -300,14 +342,14 @@ describe("generation capabilities", () => {
     expect(capabilities.reasoning.levels.high).toBe("unknown");
   });
 
-  it("maps LiteLLM's max effort to Appstrate's portable xhigh level", () => {
+  it("keeps LiteLLM's max effort distinct from xhigh", () => {
     const capabilities = deriveGenerationCapabilities({
       litellm_provider: "anthropic",
       supports_reasoning: true,
       supports_max_reasoning_effort: true,
     });
-    expect(capabilities.reasoning.levels.xhigh).toBe("supported");
-    expect(capabilities.reasoning.nativeLevels?.xhigh).toBe("max");
+    expect(capabilities.reasoning.levels.xhigh).toBe("unknown");
+    expect(capabilities.reasoning.levels.max).toBe("supported");
   });
 
   it("vendors the normalized generation block with pricing", () => {


### PR DESCRIPTION
## Summary

- derive temperature and reasoning-effort capabilities by probing the pinned LiteLLM adapter
- keep the temperature/reasoning pair fact sparse as optional `reasoning.temperatureCompatible`; omission means unknown
- serialize only 136 conclusive pair facts (120 supported, 16 unsupported) and retain the preflight guard for the 16 OpenAI incompatibilities
- keep Anthropic's stricter wire constraint and `minimal` → `low` mapping in one shared override used by API-key and Claude Code transports
- preserve `xhigh` and `max` as distinct portable levels across the API, chat UI, runs, and Pi runtime
- expose only verified portable generation capabilities for aliased models, including fail-closed pair compatibility, while keeping their backing private
- require the normalized pinned catalog for applied refreshes

This branch is rebased on current `main` after #1100. The retired top-level `temperatureWithReasoning` field is not restored. This PR absorbs #1101.

## Validation

- `bun run check` — 33/33 tasks passed on exact head
- 124 targeted generation, catalog, alias, provider, chat, run-launcher, and Pi tests passed
- OpenAPI structural validation and generated API type verification passed
- breaking-change detector passed with 0 breaking changes
- pinned LiteLLM export digest verified
- catalog refresh rerun from the pinned normalized artifact: 0/14 snapshots changed

## Notes

- ordinary models remain forward-compatible when pair compatibility is unknown
- public aliases remain fail-closed
- provider-native mappings remain server-side
- the catalog workflow will preserve this representation on its next run because the exporter, normalized digest, refresh projection, and vendored snapshots were updated together
