### PR TITLE
feat(web): expose the account menu during onboarding

### DIFF
--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -30,7 +30,19 @@ function getInitials(name: string): string {
     .toUpperCase();
 }
 
-export function NavUser() {
+interface NavUserProps {
+  /**
+   * Drop every entry that needs an organization to be resolvable.
+   *
+   * `/preferences` lives under `MainLayout`, behind `OrgGate`: a user with no
+   * org who follows it is bounced straight back to `/onboarding/create`. The
+   * onboarding flow therefore mounts this menu with only the identity header,
+   * the theme switcher and logout — all org-independent.
+   */
+  minimal?: boolean;
+}
+
+export function NavUser({ minimal = false }: NavUserProps) {
   const { t } = useTranslation();
   const { user, profile, logout } = useAuth();
   const { theme, setTheme } = useTheme();
@@ -77,12 +89,14 @@ export function NavUser() {
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem asChild>
-          <Link to="/preferences" className="flex items-center gap-2">
-            <Settings size={14} />
-            {t("userMenu.preferences")}
-          </Link>
-        </DropdownMenuItem>
+        {!minimal && (
+          <DropdownMenuItem asChild>
+            <Link to="/preferences" className="flex items-center gap-2">
+              <Settings size={14} />
+              {t("userMenu.preferences")}
+            </Link>
+          </DropdownMenuItem>
+        )}
         <DropdownMenuSub>
           <DropdownMenuSubTrigger>
             <Palette size={14} />
@@ -104,17 +118,19 @@ export function NavUser() {
             ))}
           </DropdownMenuSubContent>
         </DropdownMenuSub>
-        <DropdownMenuItem asChild>
-          <a
-            href="/api/docs"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2"
-          >
-            <FileText size={14} />
-            {t("userMenu.apiDocs")}
-          </a>
-        </DropdownMenuItem>
+        {!minimal && (
+          <DropdownMenuItem asChild>
+            <a
+              href="/api/docs"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2"
+            >
+              <FileText size={14} />
+              {t("userMenu.apiDocs")}
+            </a>
+          </DropdownMenuItem>
+        )}
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={() => void handleLogout()} className="flex items-center gap-2">
           <LogOut size={14} />

--- a/apps/web/src/components/onboarding-layout.tsx
+++ b/apps/web/src/components/onboarding-layout.tsx
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { cn } from "@appstrate/ui/cn";
 import { Button } from "@appstrate/ui/components/button";
 import { useOrg } from "../hooks/use-org";
 import { useTheme } from "../stores/theme-store";
 import { useAppConfig } from "../hooks/use-app-config";
+import { NavUser } from "./nav-user";
 import { ArrowLeft, ArrowRight } from "lucide-react";
 
 export type StepKey = "create" | "plan" | "model" | "members" | "complete";
@@ -109,18 +110,33 @@ export function OnboardingLayout({
 }: OnboardingLayoutProps) {
   const { t } = useTranslation(["settings", "common"]);
   const { resolvedTheme } = useTheme();
+  const { orgs } = useOrg();
   const { steps, index: currentIndex, total: totalSteps } = useOnboardingNav(step);
 
   return (
     <div className="bg-background flex min-h-svh flex-col items-center justify-center gap-6 p-6 md:p-10">
       <div className="w-full max-w-lg">
-        {/* Logo */}
-        <div className="mb-6 flex justify-center">
+        {/*
+         * Header: logo optically centred, account cluster pinned right. The
+         * cluster is what lets a user escape a half-finished onboarding —
+         * sign out (wrong account, account switch) or, once an org exists,
+         * go straight to the app. It sits outside the scrollable content
+         * area below so the dropdown is never clipped.
+         */}
+        <div className="relative mb-6 flex items-center justify-center">
           <img
             src={resolvedTheme === "dark" ? "/logo-dark.svg" : "/logo-light.svg"}
             alt="Appstrate"
             className="h-[34px] w-auto"
           />
+          <div className="absolute right-0 flex items-center gap-1">
+            {orgs.length > 0 && (
+              <Button variant="ghost" size="sm" asChild>
+                <Link to="/">{t("onboarding.backToApp")}</Link>
+              </Button>
+            )}
+            <NavUser minimal />
+          </div>
         </div>
 
         {/* Progress bar */}

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -511,6 +511,7 @@
   "onboarding.waitingSubtitle": "This Appstrate instance runs in invitation-only mode. Ask an administrator to invite you to an existing organization to access the platform.",
   "onboarding.waitingSignedInAs": "Signed in as {{email}}",
   "onboarding.waitingLogout": "Sign out",
+  "onboarding.backToApp": "Back to app",
   "onboarding.createTitle": "Create your organization",
   "onboarding.createSubtitle": "An organization groups your agents, integrations, and members.",
   "onboarding.createAction": "Create",

--- a/apps/web/src/locales/fr/settings.json
+++ b/apps/web/src/locales/fr/settings.json
@@ -511,6 +511,7 @@
   "onboarding.waitingSubtitle": "Cette instance Appstrate fonctionne en mode invitation. Demandez à un administrateur de vous inviter dans une organisation existante pour accéder à la plateforme.",
   "onboarding.waitingSignedInAs": "Connecté en tant que {{email}}",
   "onboarding.waitingLogout": "Se déconnecter",
+  "onboarding.backToApp": "Retour à l'application",
   "onboarding.createTitle": "Créer votre organisation",
   "onboarding.createSubtitle": "L'organisation regroupe vos agents, intégrations et membres.",
   "onboarding.createAction": "Créer",

--- a/e2e/tests/auth/onboarding-logout.ui.spec.ts
+++ b/e2e/tests/auth/onboarding-logout.ui.spec.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Browser E2E for the onboarding escape hatches.
+ *
+ * A signed-in user with no organization is pinned to `/onboarding/*` by
+ * `OrgGate`. Before the account menu was mounted in `OnboardingLayout` there
+ * was no way out of that state — a user who signed in with the wrong account
+ * had to clear cookies by hand. These tests assert the two exits:
+ *
+ *   - sign out from any onboarding step → back to `/login`;
+ *   - once an org exists, "Retour à l'application" → back to the dashboard.
+ *
+ * They also pin the reason the onboarding menu is `minimal`: `/preferences`
+ * lives behind `OrgGate`, so offering it here would bounce an org-less user
+ * straight back into onboarding.
+ *
+ * @tags @critical
+ */
+
+import { test, expect } from "../../fixtures/browser.fixture.ts";
+import { registerUser } from "../../helpers/seed.ts";
+import type { Browser, Page } from "@playwright/test";
+
+const USER_MENU = "Menu utilisateur";
+
+/**
+ * Browser context for a freshly registered user with NO organization: session
+ * cookie only, no org/app localStorage. `OrgGate` sends it to onboarding.
+ */
+async function orglessPage(browser: Browser, cookie: string): Promise<Page> {
+  const context = await browser.newContext();
+  const value = cookie.match(/better-auth\.session_token=([^;]+)/)![1];
+  await context.addCookies([
+    { name: "better-auth.session_token", value, domain: "localhost", path: "/" },
+  ]);
+  return context.newPage();
+}
+
+test.describe("Onboarding — account menu", () => {
+  test("an org-less user can sign out from the onboarding flow @critical", async ({
+    browser,
+    request,
+  }) => {
+    const auth = await registerUser(request);
+    const page = await orglessPage(browser, auth.cookie);
+
+    await page.goto("/");
+    await expect(page).toHaveURL(/\/onboarding\/create/);
+
+    await page.getByRole("button", { name: USER_MENU }).click();
+
+    // Identity is visible, so a wrong-account user can tell before acting.
+    await expect(page.getByText(auth.email)).toBeVisible();
+    // Org-scoped entries are hidden: `/preferences` would bounce off OrgGate.
+    await expect(page.getByRole("menuitem", { name: "Préférences" })).toHaveCount(0);
+
+    await page.getByRole("menuitem", { name: "Déconnexion" }).click();
+
+    // OSS: the session is cleared and the catch-all route lands on `/login`.
+    // OIDC: `startOidcLogout` leaves the SPA for the server-side logout, which
+    // returns to `/login` — where `HostedAuthGate` immediately forwards to the
+    // hosted page under `/api/`. Both outcomes mean "signed out"; assert the
+    // union so the spec passes in whichever mode the server booted in.
+    await page.waitForURL((url) => url.pathname === "/login" || url.pathname.startsWith("/api/"), {
+      timeout: 15_000,
+    });
+
+    await page.context().close();
+  });
+
+  test("a user who already has an org can leave onboarding for the app", async ({ authedPage }) => {
+    await authedPage.goto("/onboarding/model");
+
+    const backToApp = authedPage.getByRole("link", { name: "Retour à l'application" });
+    await expect(backToApp).toBeVisible({ timeout: 15_000 });
+    await backToApp.click();
+
+    await expect(authedPage).toHaveURL(/\/$/);
+  });
+});


### PR DESCRIPTION
## Problem

A signed-in user with no organization is pinned to `/onboarding/*` by `OrgGate`. The onboarding shell showed neither who was signed in nor any way out: a user who signed in with the wrong account had to clear cookies by hand. `/onboarding/waiting` (closed mode) was the only onboarding screen with a sign-out button.

## Change

`OnboardingLayout` renders an account cluster to the right of the logo, on all five steps (`create`, `plan`, `model`, `members`, `complete`):

- the standard `NavUser` dropdown — identity (name + email), theme switcher, sign out;
- a **Retour à l'application** link, shown only once the user has at least one org. That also fixes `/onboarding/create` reached from the org switcher (`fromSwitcher`), which had no cancel path other than the browser back button.

`NavUser` gains a `minimal` prop for this mount: it hides `/preferences` and the API-docs entry. `/preferences` lives behind `OrgGate` — offering it to an org-less user would bounce them straight back into onboarding.

Sign-out itself is untouched: the existing `useAuth().logout()` seam already covers both OSS (`signOut` + `clearSession`) and OIDC (`startOidcLogout`), and `NavUser` already clears the query cache afterwards. Onboarding now gets exactly the dashboard behaviour, via the same component.

`/onboarding/waiting` is deliberately left as-is — signing out is the primary action on that dead end, so it keeps its explicit button rather than hiding it behind a dropdown.

## Scope

- `apps/web/src/components/nav-user.tsx` — `minimal` prop
- `apps/web/src/components/onboarding-layout.tsx` — header cluster
- `apps/web/src/locales/{fr,en}/settings.json` — one key, `onboarding.backToApp`
- `e2e/tests/auth/onboarding-logout.ui.spec.ts` — new UI spec

No API, DB or OpenAPI change.

## Verification

- `bun run check` passes (only the pre-existing `module-chat` react-refresh warning).
- Manual pass against a Tier-0 instance on :3100 (fresh PGlite, OSS mode): signup → lands `/onboarding/create` with the avatar and no back-link (no org yet) → menu shows name/email, theme and sign out, and no Préférences/API docs → sign out lands on `/login`; log back in, create the org → `/onboarding/model` shows **Retour à l'application** → click lands on the dashboard.
- The new e2e spec was **not** executed locally: port 3000 was occupied by another checkout's dev server and `reuseExistingServer` would have tested that build instead. It runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)