### PR TITLE
perf: audit remediation — HTTP caching, chunking, request fan-out, read paths

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -35,6 +35,7 @@ import { createUploadsRouter, createUploadContentRouter } from "./routes/uploads
 import { createDocumentsRouter, createDocumentPreviewRouter } from "./routes/documents.ts";
 import { createAdminStorageDeletionRouter } from "./routes/admin-storage-deletion.ts";
 import { createSpaFallbackHandler } from "./routes/spa.ts";
+import { staticCacheControl } from "./lib/static-cache.ts";
 import healthRouter, { bootGate, markServerReady } from "./routes/health.ts";
 import { createIntegrationsRouter } from "./routes/integrations.ts";
 import { createCredentialProxyRouter } from "./routes/credential-proxy.ts";
@@ -398,12 +399,19 @@ app.all("/api/*", (c) => {
   throw notFound(`API endpoint not found: ${c.req.method} ${pathname}`);
 });
 
-// Static files for UI (JS, CSS, images, fonts — skip index.html, served with config below)
+// Static files for UI (JS, CSS, images, fonts — skip index.html, served with config below).
+// `onFound` attaches the caching policy: Hono's static middleware emits no
+// `Cache-Control` and no validator of its own, so without it every asset is
+// re-downloaded in full on every visit (there is nothing to revalidate against,
+// so no `304` either). Policy + rationale: `lib/static-cache.ts`.
 app.use(
   "/*",
   serveStatic({
     root: "./apps/web/dist",
     rewriteRequestPath: (path) => (path === "/" || path === "/index.html" ? "/.noop" : path),
+    onFound: (path, c) => {
+      c.header("Cache-Control", staticCacheControl(path));
+    },
   }),
 );
 

--- a/apps/api/src/lib/static-cache.ts
+++ b/apps/api/src/lib/static-cache.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `Cache-Control` policy for the statically served SPA build.
+ *
+ * The static middleware (`serveStatic` in `index.ts`) emits `Content-Type` and
+ * nothing else — no `Cache-Control`, no `ETag`, no `Last-Modified`. Every asset
+ * of every page view is therefore re-downloaded in full on every visit: there
+ * is no validator for the browser to revalidate with, so there is no `304`
+ * either. This module is the single source of truth for the header that closes
+ * that, applied through the middleware's `onFound` callback.
+ *
+ * Two classes of file, distinguished by whether the FILENAME carries a content
+ * hash:
+ *
+ *  - `assets/*` — emitted by Vite with a content hash in the name
+ *    (`index-DRqZyykT.js`). The bytes behind a given name can never change, so
+ *    the response is `immutable` for a year: a repeat visit issues no request
+ *    at all. A rebuild changes the hash, hence the URL, hence the cache entry.
+ *  - everything else — `favicon.ico`, `logo.svg`, `site.webmanifest`,
+ *    `.well-known/*`: STABLE names whose bytes CAN change under them. These get
+ *    a short TTL instead. `immutable` here would pin a stale favicon for a year
+ *    with no way to bust it short of renaming the file.
+ *
+ * The SPA document itself is not served by this middleware (it is rewritten to
+ * `/.noop` and handled by `routes/spa.ts`), and must never be cached: it embeds
+ * a per-request `window.__APP_CONFIG__` and points at the current build's asset
+ * hashes. Its header lives next to the handler that injects the config.
+ */
+
+/** Content-hashed build output: safe to pin for a year, never revalidated. */
+export const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+
+/**
+ * Stable-name static files (favicons, logos, manifest, `.well-known`). Short
+ * enough that replacing one propagates in minutes, long enough to cut the
+ * per-navigation refetch.
+ */
+export const SHORT_LIVED_CACHE_CONTROL = "public, max-age=300";
+
+/**
+ * The SPA shell. `no-cache` does NOT mean "do not store" — it means "always
+ * revalidate before reuse", which is exactly right for a document that carries
+ * per-request config and must never pin an old build's asset hashes.
+ */
+export const SPA_HTML_CACHE_CONTROL = "no-cache";
+
+/**
+ * Pick the `Cache-Control` value for a file the static middleware resolved.
+ *
+ * @param path Filesystem path the middleware served, as handed to `onFound`
+ *   (e.g. `./apps/web/dist/assets/index-DRqZyykT.js`). Only the location of the
+ *   `assets/` segment matters; the root prefix is irrelevant.
+ * @returns The header value — `immutable` for content-hashed `assets/*`, a
+ *   short TTL for everything else.
+ */
+export function staticCacheControl(path: string): string {
+  // Normalize Windows separators so the segment test is platform-agnostic, then
+  // match `assets/` as a whole PATH SEGMENT: a file named `my-assets/x.js` (or
+  // `assets.js`) is not Vite build output and must not be pinned for a year.
+  const normalized = path.replace(/\\/g, "/");
+  return /(?:^|\/)assets\/[^/]+$/.test(normalized)
+    ? IMMUTABLE_CACHE_CONTROL
+    : SHORT_LIVED_CACHE_CONTROL;
+}

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -1016,6 +1016,9 @@ export const schemas = {
       "updatedAt",
       "actor_name",
       "actor_type",
+      "running_runs",
+      "unread_count",
+      "last_run_number",
     ],
     properties: {
       id: { type: "string" },
@@ -1057,6 +1060,22 @@ export const schemas = {
       updatedAt: { type: "string", format: "date-time" },
       actor_name: { type: ["string", "null"], description: "Display name of the schedule actor" },
       actor_type: { type: ["string", "null"], enum: ["user", "end_user", null] },
+      running_runs: {
+        type: "integer",
+        minimum: 0,
+        description: "Runs of this schedule currently pending or running.",
+      },
+      unread_count: {
+        type: "integer",
+        minimum: 0,
+        description:
+          "Runs of this schedule whose notification is unread by the CALLER. Scoped to the requesting actor, like `EnrichedRun.unread`.",
+      },
+      last_run_number: {
+        type: "integer",
+        minimum: 0,
+        description: "Highest run number this schedule ever produced; 0 when it never fired.",
+      },
     },
   },
   ApiKeyInfo: {

--- a/apps/api/src/routes/schedules.ts
+++ b/apps/api/src/routes/schedules.ts
@@ -161,7 +161,9 @@ export function createSchedulesRouter() {
   // GET /api/schedules — list all schedules (app-scoped)
   router.get("/schedules", async (c) => {
     const scope = getAppScope(c);
-    const schedules = await listSchedules(scope);
+    // The caller is the VIEWER of the run counters (`unread_count` is
+    // recipient-scoped), never the schedules' own execution actor.
+    const schedules = await listSchedules(scope, getActor(c));
     return c.json(listResponse(schedules));
   });
 
@@ -169,7 +171,7 @@ export function createSchedulesRouter() {
   router.get(`/agents/${SCOPED_PACKAGE_ROUTE}/schedules`, requireAgent(), async (c) => {
     const scope = getAppScope(c);
     const agent = c.get("package");
-    const schedules = await listPackageSchedules(scope, agent.id);
+    const schedules = await listPackageSchedules(scope, agent.id, getActor(c));
     return c.json(listResponse(schedules));
   });
 
@@ -268,7 +270,7 @@ export function createSchedulesRouter() {
   // GET /api/schedules/:id — get a single schedule
   router.get("/schedules/:id", async (c) => {
     const id = c.req.param("id");
-    const schedule = await getSchedule(id, getAppScope(c));
+    const schedule = await getSchedule(id, getAppScope(c), getActor(c));
     if (!schedule) {
       throw notFound(`Schedule '${id}' not found`);
     }
@@ -348,21 +350,29 @@ export function createSchedulesRouter() {
       actorChanged && data.connection_overrides === undefined ? null : data.connection_overrides;
 
     // Translate snake_case wire fields to internal camelCase for the service.
-    const schedule = await updateSchedule(scope, id, {
-      name: data.name,
-      cronExpression: data.cron_expression,
-      timezone: data.timezone,
-      input: data.input,
-      enabled: data.enabled,
-      configOverride: data.config_override,
-      modelIdOverride: data.model_id_override,
-      generationConfigOverride,
-      proxyIdOverride: data.proxy_id_override,
-      versionOverride: data.version_override,
-      connectionOverrides,
-      dependencyOverrides: data.dependency_overrides,
-      actor,
-    });
+    const schedule = await updateSchedule(
+      scope,
+      id,
+      {
+        name: data.name,
+        cronExpression: data.cron_expression,
+        timezone: data.timezone,
+        input: data.input,
+        enabled: data.enabled,
+        configOverride: data.config_override,
+        modelIdOverride: data.model_id_override,
+        generationConfigOverride,
+        proxyIdOverride: data.proxy_id_override,
+        versionOverride: data.version_override,
+        connectionOverrides,
+        dependencyOverrides: data.dependency_overrides,
+        actor,
+      },
+      // `actor` above is the schedule's (possibly re-pointed) execution
+      // identity; the run counters in the response belong to whoever is
+      // looking at it.
+      getActor(c),
+    );
     // Mirror schedule.created: explicit camelCase keys (dominant audit
     // convention — see api-keys.ts, modules/webhooks/routes.ts). Only
     // include keys the caller actually sent so the audit reflects the

--- a/apps/api/src/routes/spa.ts
+++ b/apps/api/src/routes/spa.ts
@@ -14,6 +14,7 @@
 import type { Handler } from "hono";
 import { getEnv } from "@appstrate/env";
 import type { AppEnv } from "../types/index.ts";
+import { SPA_HTML_CACHE_CONTROL } from "../lib/static-cache.ts";
 
 const INDEX_HTML = "./apps/web/dist/index.html";
 
@@ -94,6 +95,13 @@ export function createSpaFallbackHandler(
     const raw = await readIndexHtml();
     return c.html(raw.replace("</head>", `${buildAppConfigScript()}\n</head>`), 200, {
       "Content-Security-Policy": csp,
+      // `no-cache` = "revalidate before reuse", NOT "do not store". The shell
+      // must never be reused blind: it embeds a per-request
+      // `window.__APP_CONFIG__` (`bootstrapTokenPending` flips the moment an
+      // unattended install is claimed) and names the current build's hashed
+      // asset URLs, which a deploy replaces. The hashed assets it points at are
+      // the ones that get pinned for a year (`lib/static-cache.ts`).
+      "Cache-Control": SPA_HTML_CACHE_CONTROL,
     });
   };
 }

--- a/apps/api/src/services/input-parser.ts
+++ b/apps/api/src/services/input-parser.ts
@@ -881,21 +881,30 @@ export async function parseRequestInput(
         // documents bucket into the run workspace (same path as uploads — the
         // runtime is unchanged). No re-materialization: the document already
         // exists and its bytes were validated when it was created.
-        const documentFiles: FileReference[] = [];
-        for (let j = 0; j < resolvedDocs.length; j++) {
-          const { ref, doc } = resolvedDocs[j]!;
-          const docName = documentWorkspaceNames[j]!;
-          const src = await streamDocumentContent(doc.storageKey);
-          if (!src) throw notFound(`Document '${doc.id}' content is missing`);
-          await streamRunDocument(runId, docName, src);
-          documentFiles.push({
-            fieldName: ref.fieldName,
-            name: doc.name,
-            workspaceName: docName,
-            type: doc.mime,
-            size: doc.size,
-          });
-        }
+        //
+        // Same bounded concurrency as the upload pass above, and for the same
+        // reason: each copy is store-bound, so a sequential loop paid the full
+        // round-trip once per referenced document while the memory floor stayed
+        // flat either way. `mapWithConcurrency` preserves input order in its
+        // result and aborts the remaining items on the first failure, so the
+        // rollback path below is unchanged.
+        const documentFiles: FileReference[] = await mapWithConcurrency(
+          resolvedDocs,
+          DOC_STREAM_CONCURRENCY,
+          async ({ ref, doc }, j) => {
+            const docName = documentWorkspaceNames[j]!;
+            const src = await streamDocumentContent(doc.storageKey);
+            if (!src) throw notFound(`Document '${doc.id}' content is missing`);
+            await streamRunDocument(runId, docName, src);
+            return {
+              fieldName: ref.fieldName,
+              name: doc.name,
+              workspaceName: docName,
+              type: doc.mime,
+              size: doc.size,
+            };
+          },
+        );
 
         // Strip the inline payloads from the input now that the bytes live in
         // the run workspace — the persisted run input (run record, prompt

--- a/apps/api/src/services/scheduler.ts
+++ b/apps/api/src/services/scheduler.ts
@@ -5,7 +5,14 @@ import type { JobQueue, QueueJob } from "../infra/queue/index.ts";
 import { getCache } from "../infra/index.ts";
 import { and, eq, asc, inArray, sql } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
-import { schedules, endUsers, organizationMembers } from "@appstrate/db/schema";
+import {
+  schedules,
+  endUsers,
+  organizationMembers,
+  runs,
+  notifications,
+} from "@appstrate/db/schema";
+import { activeRunStatusValues } from "@appstrate/db/run-status";
 import { batchLoadUserNames } from "../lib/user-helpers.ts";
 import { logger } from "../lib/logger.ts";
 import type { ScheduleWireDto, EnrichedSchedule } from "@appstrate/shared-types";
@@ -27,7 +34,7 @@ import { validateInput } from "./schema.ts";
 import { mergeAndValidateConfigOverride } from "./agent-readiness.ts";
 import { asJSONSchemaObject } from "@appstrate/core/form";
 import { computeNextRun } from "../lib/cron.ts";
-import type { Actor } from "../lib/actor.ts";
+import { actorMatch, type Actor } from "../lib/actor.ts";
 import type { AppScope } from "../lib/scope.ts";
 import { setQueueDepthSource } from "@appstrate/core/telemetry";
 import type { ModelGenerationSettings } from "@appstrate/core/model-generation";
@@ -684,18 +691,22 @@ export async function triggerScheduledRun(
 // CRUD helpers
 // ---------------------------------------------------------------------------
 
-export async function listSchedules(scope: AppScope): Promise<EnrichedSchedule[]> {
+export async function listSchedules(
+  scope: AppScope,
+  viewer: Actor | null,
+): Promise<EnrichedSchedule[]> {
   const rows = await db
     .select()
     .from(schedules)
     .where(scopedWhere(schedules, { orgId: scope.orgId, applicationId: scope.applicationId }))
     .orderBy(asc(schedules.createdAt));
-  return enrichSchedules(rows.map(toSchedule), scope.orgId);
+  return enrichSchedules(rows.map(toSchedule), scope.orgId, viewer);
 }
 
 export async function listPackageSchedules(
   scope: AppScope,
   packageId: string,
+  viewer: Actor | null,
 ): Promise<EnrichedSchedule[]> {
   const rows = await db
     .select()
@@ -708,10 +719,14 @@ export async function listPackageSchedules(
       }),
     )
     .orderBy(asc(schedules.createdAt));
-  return enrichSchedules(rows.map(toSchedule), scope.orgId);
+  return enrichSchedules(rows.map(toSchedule), scope.orgId, viewer);
 }
 
-export async function getSchedule(id: string, scope?: AppScope): Promise<EnrichedSchedule | null> {
+export async function getSchedule(
+  id: string,
+  scope?: AppScope,
+  viewer: Actor | null = null,
+): Promise<EnrichedSchedule | null> {
   const rows = await db
     .select()
     .from(schedules)
@@ -725,17 +740,117 @@ export async function getSchedule(id: string, scope?: AppScope): Promise<Enriche
     .limit(1);
   if (!rows[0]) return null;
   const schedule = toSchedule(rows[0]);
-  const [enriched] = await enrichSchedules([schedule], schedule.orgId);
+  const [enriched] = await enrichSchedules([schedule], schedule.orgId, viewer);
   return enriched ?? null;
+}
+
+/** Per-schedule run counters served with the schedule itself (see {@link loadScheduleRunStats}). */
+interface ScheduleRunStats {
+  runningRuns: number;
+  unreadCount: number;
+  lastRunNumber: number;
+}
+
+const EMPTY_RUN_STATS: ScheduleRunStats = { runningRuns: 0, unreadCount: 0, lastRunNumber: 0 };
+
+/**
+ * Enrichment fields for the (unreachable in practice) branch where the
+ * enrichment query returns no row for a schedule we just wrote. Spread rather
+ * than re-listed at each call site so a new `EnrichedSchedule` field cannot be
+ * added to the happy path alone.
+ */
+const UNENRICHED_SCHEDULE_FIELDS = {
+  actor_name: null,
+  actor_type: null,
+  running_runs: 0,
+  unread_count: 0,
+  last_run_number: 0,
+} satisfies Omit<EnrichedSchedule, keyof ScheduleWireDto>;
+
+/**
+ * The three run counters every schedule card shows — active runs, unread runs
+ * for the VIEWER, and the highest run number — as ONE grouped query over the
+ * whole list.
+ *
+ * These used to be derived client-side: each card fetched
+ * `GET /api/schedules/:id/runs` (up to 20 enriched rows, each with its own
+ * unread EXISTS and document subqueries) purely to count three things, so a
+ * dashboard listing N schedules issued N extra HTTP requests and ~2N SQL
+ * queries. Serving them from the list the cards already have removes the fan-out
+ * entirely.
+ *
+ * Two deliberate semantics:
+ *  - the counts span ALL of a schedule's runs, not the most recent page. The
+ *    per-card version counted within the 20 rows it happened to fetch, so a
+ *    schedule with 25 unread runs reported 20.
+ *  - `unreadCount` is scoped to the VIEWER (`actorMatch` on the polymorphic
+ *    recipient tuple), never to the schedule's own actor — the same rule
+ *    `unreadForActor` applies to run lists, so a member and an end-user never
+ *    observe each other's read state. A null viewer (no actor context) reports
+ *    0: unread is a recipient-side concept.
+ */
+async function loadScheduleRunStats(
+  scheduleIds: string[],
+  orgId: string,
+  viewer: Actor | null,
+): Promise<Map<string, ScheduleRunStats>> {
+  if (scheduleIds.length === 0) return new Map();
+
+  const unreadPredicate = viewer
+    ? sql`exists (
+        select 1 from ${notifications}
+        where ${notifications.runId} = ${runs.id}
+          and ${actorMatch(viewer, {
+            typeCol: notifications.recipientType,
+            idCol: notifications.recipientId,
+          })}
+          and ${notifications.readAt} is null
+      )`
+    : sql`false`;
+
+  const rows = await db
+    .select({
+      scheduleId: runs.scheduleId,
+      runningRuns: sql<string>`count(*) filter (where ${inArray(runs.status, [
+        ...activeRunStatusValues,
+      ])})`,
+      unreadCount: sql<string>`count(*) filter (where ${unreadPredicate})`,
+      lastRunNumber: sql<string>`coalesce(max(${runs.runNumber}), 0)`,
+    })
+    .from(runs)
+    // `scheduleId` is already unique per org, but the org filter keeps the read
+    // tenant-scoped by construction rather than by trusting the id list.
+    .where(and(eq(runs.orgId, orgId), inArray(runs.scheduleId, scheduleIds)))
+    .groupBy(runs.scheduleId);
+
+  // postgres.js returns count()/max() as numeric STRINGS — coerce here so the
+  // wire DTO carries real numbers.
+  return new Map(
+    rows
+      .filter((r): r is typeof r & { scheduleId: string } => r.scheduleId !== null)
+      .map((r) => [
+        r.scheduleId,
+        {
+          runningRuns: Number(r.runningRuns),
+          unreadCount: Number(r.unreadCount),
+          lastRunNumber: Number(r.lastRunNumber),
+        },
+      ]),
+  );
 }
 
 /**
  * Enrich schedules with the display name of the actor (member or end-user)
- * each schedule runs as. Batches name lookups per actor kind.
+ * each schedule runs as, plus the viewer-scoped run counters the list UI would
+ * otherwise fetch per row. Batches every lookup across the whole list.
+ *
+ * @param viewer Actor the response is being rendered for — scopes
+ *   `unread_count` only. Null when there is no actor context.
  */
 async function enrichSchedules(
   schedules: ScheduleWireDto[],
-  _orgId: string,
+  orgId: string,
+  viewer: Actor | null,
 ): Promise<EnrichedSchedule[]> {
   if (schedules.length === 0) return [];
 
@@ -744,7 +859,7 @@ async function enrichSchedules(
     ...new Set(schedules.map((s) => s.endUserId).filter((id): id is string => !!id)),
   ];
 
-  const [userNameMap, endUserRows] = await Promise.all([
+  const [userNameMap, endUserRows, runStats] = await Promise.all([
     batchLoadUserNames(userIds),
     endUserIds.length > 0
       ? db
@@ -755,6 +870,11 @@ async function enrichSchedules(
           .from(endUsers)
           .where(inArray(endUsers.id, endUserIds))
       : Promise.resolve([] as { id: string; name: string | null }[]),
+    loadScheduleRunStats(
+      schedules.map((s) => s.id),
+      orgId,
+      viewer,
+    ),
   ]);
   const endUserNameMap = new Map(endUserRows.map((r) => [r.id, r.name]));
 
@@ -768,7 +888,16 @@ async function enrichSchedules(
       actorType = "end_user";
       actorName = endUserNameMap.get(schedule.endUserId) ?? null;
     }
-    return { ...schedule, actor_name: actorName, actor_type: actorType };
+    // A schedule that never fired has no `runs` rows, hence no group — zeroes.
+    const stats = runStats.get(schedule.id) ?? EMPTY_RUN_STATS;
+    return {
+      ...schedule,
+      actor_name: actorName,
+      actor_type: actorType,
+      running_runs: stats.runningRuns,
+      unread_count: stats.unreadCount,
+      last_run_number: stats.lastRunNumber,
+    };
   });
 }
 
@@ -830,8 +959,10 @@ export async function createSchedule(
 
   // Same EnrichedSchedule serializer as getSchedule/listSchedules, so the
   // create response matches the GET detail shape (actor_name/actor_type).
-  const [enriched] = await enrichSchedules([schedule], scope.orgId);
-  return enriched ?? { ...schedule, actor_name: null, actor_type: null };
+  // A viewer is not needed here: the schedule was just created, so it has no
+  // runs and every run counter is zero for ANY viewer.
+  const [enriched] = await enrichSchedules([schedule], scope.orgId, null);
+  return enriched ?? { ...schedule, ...UNENRICHED_SCHEDULE_FIELDS };
 }
 
 export async function updateSchedule(
@@ -856,6 +987,8 @@ export async function updateSchedule(
     // schedule always has an execution identity.
     actor?: Actor;
   },
+  /** Actor the response is rendered for — scopes `unread_count` only. */
+  viewer: Actor | null = null,
 ): Promise<EnrichedSchedule | null> {
   const existing = await getSchedule(id, scope);
   if (!existing) return null;
@@ -916,9 +1049,9 @@ export async function updateSchedule(
   }
 
   // Same EnrichedSchedule serializer as getSchedule/listSchedules, so the
-  // update response matches the GET detail shape (actor_name/actor_type).
-  const [enriched] = await enrichSchedules([schedule], scope.orgId);
-  return enriched ?? { ...schedule, actor_name: null, actor_type: null };
+  // update response matches the GET detail shape (actor/run counters).
+  const [enriched] = await enrichSchedules([schedule], scope.orgId, viewer);
+  return enriched ?? { ...schedule, ...UNENRICHED_SCHEDULE_FIELDS };
 }
 
 export async function deleteSchedule(scope: AppScope, id: string): Promise<boolean> {

--- a/apps/api/src/services/state/runs.ts
+++ b/apps/api/src/services/state/runs.ts
@@ -130,9 +130,74 @@ import { toISO } from "../../lib/date-helpers.ts";
  * `schedules`/`packages` — extracted here to keep the JOIN list inline
  * (Drizzle's query-builder types don't compose well through a helper).
  */
+/**
+ * The `runs` columns an enriched read actually needs — every column the wire
+ * DTO projects, plus `resolvedConnections` (projected into `connections_used`)
+ * and `input` (scanned for `document://` ids).
+ *
+ * Named explicitly rather than passing the whole `runs` table because the row
+ * is WIDER than the DTO: `modelCost`, `resolvedIntegrationVersions`,
+ * `chatSessionId`, `sinkSecretEncrypted`, `sinkExpiresAt`, `sinkClosedAt`,
+ * `lastEventSequence` and `lastHeartbeatAt` are never read by `mapEnrichedRun`,
+ * so selecting them made every list read carry (and every list page transfer
+ * from Postgres) bytes nobody looks at — `sinkSecretEncrypted` being an
+ * AES-256-GCM credential ciphertext, which is now not even loaded into the API
+ * process on a list read.
+ *
+ * The DTO mapper derives its parameter type from THIS object (`RunProjection`),
+ * so a column dropped here without dropping it from the DTO fails typecheck
+ * rather than turning into `undefined` on the wire.
+ */
+const enrichedRunColumns = {
+  id: runs.id,
+  packageId: runs.packageId,
+  userId: runs.userId,
+  endUserId: runs.endUserId,
+  apiKeyId: runs.apiKeyId,
+  orgId: runs.orgId,
+  applicationId: runs.applicationId,
+  scheduleId: runs.scheduleId,
+  status: runs.status,
+  input: runs.input,
+  result: runs.result,
+  artifacts: runs.artifacts,
+  checkpoint: runs.checkpoint,
+  error: runs.error,
+  metadata: runs.metadata,
+  config: runs.config,
+  configOverride: runs.configOverride,
+  startedAt: runs.startedAt,
+  completedAt: runs.completedAt,
+  duration: runs.duration,
+  cost: runs.cost,
+  costPricingStatus: runs.costPricingStatus,
+  runNumber: runs.runNumber,
+  tokenUsage: runs.tokenUsage,
+  versionLabel: runs.versionLabel,
+  versionRef: runs.versionRef,
+  proxyLabel: runs.proxyLabel,
+  modelLabel: runs.modelLabel,
+  modelSource: runs.modelSource,
+  generationConfig: runs.generationConfig,
+  generationConfigOverride: runs.generationConfigOverride,
+  runnerName: runs.runnerName,
+  runnerKind: runs.runnerKind,
+  agentScope: runs.agentScope,
+  agentName: runs.agentName,
+  runOrigin: runs.runOrigin,
+  contextSnapshot: runs.contextSnapshot,
+  modelCredentialId: runs.modelCredentialId,
+  connectionOverrides: runs.connectionOverrides,
+  dependencyOverrides: runs.dependencyOverrides,
+  resolvedConnections: runs.resolvedConnections,
+} as const;
+
+/** Row shape produced by `enrichedRunColumns` — a strict subset of a `runs` row. */
+type RunProjection = Pick<typeof runs.$inferSelect, keyof typeof enrichedRunColumns>;
+
 function enrichedRunSelect(actor: Actor | null) {
   return {
-    run: runs,
+    run: enrichedRunColumns,
     userName: profiles.displayName,
     endUserName: sql<string | null>`coalesce(${endUsers.name}, ${endUsers.externalId})`,
     apiKeyName: apiKeys.name,
@@ -195,7 +260,7 @@ function unreadForActor(actor: Actor | null): SQL<boolean> {
  * call this instead of inlining the same mapping six lines six times.
  */
 type EnrichedRunRow = {
-  run: typeof runs.$inferSelect;
+  run: RunProjection;
   userName: string | null;
   endUserName: string | null;
   apiKeyName: string | null;
@@ -215,7 +280,9 @@ type EnrichedRunRow = {
  *  1. Date → ISO string conversion happens HERE (`d?.toISOString() ?? null`)
  *     so the returned value's TS type matches the wire shape end-to-end
  *     instead of being erased at Hono's untyped `c.json()` boundary.
- *  2. DB-only columns are intentionally NOT projected. In particular
+ *  2. DB-only columns are intentionally NOT projected — and, since the read
+ *     itself selects `enrichedRunColumns` rather than the whole table, are no
+ *     longer even fetched from Postgres. In particular
  *     `sinkSecretEncrypted` (an AES-256-GCM credential ciphertext),
  *     `sinkExpiresAt`, `sinkClosedAt`, `lastHeartbeatAt`, `lastEventSequence`
  *     (an internal ordering counter for the signed-event ingestion path —
@@ -230,7 +297,7 @@ type EnrichedRunRow = {
 // if the mapper produces a field not on the wire DTO (the original bug leaked
 // `sinkSecretEncrypted` via a spread) or the wrong type for one. A new runs
 // column is only exposed if it is added here AND to `RunWireDto` deliberately.
-function runRowToWireDto(row: typeof runs.$inferSelect): RunWireDto {
+function runRowToWireDto(row: RunProjection): RunWireDto {
   return {
     id: row.id,
     packageId: row.packageId,

--- a/apps/api/test/integration/routes/runs-projection.test.ts
+++ b/apps/api/test/integration/routes/runs-projection.test.ts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * What the enriched-run reads project out of the `runs` table.
+ *
+ * The three enriched read paths (`listRunsWithFilter`, `listGlobalRuns`,
+ * `getRunFull`) select a NAMED column list, not the whole table: the row is
+ * wider than the wire DTO, and eight of its columns — `modelCost`,
+ * `resolvedIntegrationVersions`, `chatSessionId`, `sinkSecretEncrypted`,
+ * `sinkExpiresAt`, `sinkClosedAt`, `lastEventSequence`, `lastHeartbeatAt` — are
+ * never read by the mapper. `sinkSecretEncrypted` is an AES-256-GCM credential
+ * ciphertext, so not fetching it is defence in depth on top of not emitting it.
+ *
+ * Narrowing a projection is exactly the change that silently drops a field from
+ * an API response, so this pins both directions:
+ *  - every DTO field a populated run carries still round-trips, on the LIST and
+ *    on the DETAIL read (they use different query builders);
+ *  - none of the excluded columns appears in the response under any casing.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { getTestApp } from "../../helpers/app.ts";
+import { truncateAll } from "../../helpers/db.ts";
+import { createTestContext, authHeaders, type TestContext } from "../../helpers/auth.ts";
+import { seedAgent, seedRun } from "../../helpers/seed.ts";
+
+const app = getTestApp();
+
+/** Columns the projection deliberately does not fetch, in every casing they could surface as. */
+const EXCLUDED_KEYS = [
+  "modelCost",
+  "model_cost",
+  "resolvedIntegrationVersions",
+  "resolved_integration_versions",
+  "chatSessionId",
+  "chat_session_id",
+  "sinkSecretEncrypted",
+  "sink_secret_encrypted",
+  "sinkExpiresAt",
+  "sink_expires_at",
+  "sinkClosedAt",
+  "sink_closed_at",
+  "lastEventSequence",
+  "last_event_sequence",
+  "lastHeartbeatAt",
+  "last_heartbeat_at",
+  // `resolved_connections` IS read — but only through the display-safe
+  // `connections_used` projection, which drops the internal connection id.
+  "resolvedConnections",
+  "resolved_connections",
+];
+
+describe("Enriched run projection", () => {
+  let ctx: TestContext;
+  let runId: string;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext();
+    const agent = await seedAgent({ id: `@${ctx.org.slug}/proj-agent`, orgId: ctx.orgId });
+    const run = await seedRun({
+      packageId: agent.id,
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      userId: ctx.user.id,
+      status: "success",
+      runNumber: 7,
+      input: { q: "hello" },
+      result: { output: { ok: true } },
+      checkpoint: { step: 2 },
+      metadata: { source: "test" },
+      config: { a: 1 },
+      configOverride: { a: 2 },
+      contextSnapshot: { tokens: 10 },
+      error: null,
+      duration: 1234,
+      cost: 0.25,
+      costPricingStatus: "priced",
+      tokenUsage: { input_tokens: 10, output_tokens: 5 },
+      versionLabel: "1.0.0",
+      versionRef: "1.0.0",
+      proxyLabel: "proxy-a",
+      modelLabel: "model-a",
+      modelSource: "org",
+      runnerName: "runner-a",
+      runnerKind: "pi",
+      agentScope: "@acme",
+      agentName: "proj-agent",
+      runOrigin: "platform",
+      connectionOverrides: { "@acme/gmail": "conn_1" },
+      dependencyOverrides: { "@acme/skill": "draft" },
+      // Excluded-by-design columns, all populated so an accidental spread shows.
+      modelCost: { input: 1, output: 2 },
+      resolvedIntegrationVersions: {
+        "@acme/gmail": { version: "9.9.9-internal-only", source: "version" },
+      },
+      sinkSecretEncrypted: "v1:super-secret-ciphertext",
+      sinkExpiresAt: new Date(Date.now() + 3_600_000),
+      lastEventSequence: 12,
+      resolvedConnections: {
+        "@acme/gmail": { connectionId: "conn_1", label: "Work", accountId: "a@b.c", source: "pin" },
+      },
+    });
+    runId = run.id;
+  });
+
+  /** Fields whose presence AND value the DTO promises for the run seeded above. */
+  function expectDtoRoundTrip(body: Record<string, unknown>) {
+    expect(body.id).toBe(runId);
+    expect(body.status).toBe("success");
+    expect(body.runNumber).toBe(7);
+    expect(body.input).toEqual({ q: "hello" });
+    expect(body.result).toEqual({ output: { ok: true } });
+    expect(body.checkpoint).toEqual({ step: 2 });
+    expect(body.metadata).toEqual({ source: "test" });
+    expect(body.config).toEqual({ a: 1 });
+    expect(body.config_override).toEqual({ a: 2 });
+    expect(body.contextSnapshot).toEqual({ tokens: 10 });
+    expect(body.duration).toBe(1234);
+    expect(body.cost).toBe(0.25);
+    expect(body.cost_pricing_status).toBe("priced");
+    expect(body.token_usage).toEqual({ input_tokens: 10, output_tokens: 5 });
+    expect(body.version_label).toBe("1.0.0");
+    expect(body.version_ref).toBe("1.0.0");
+    expect(body.proxy_label).toBe("proxy-a");
+    expect(body.model_label).toBe("model-a");
+    expect(body.model_source).toBe("org");
+    expect(body.runner_name).toBe("runner-a");
+    expect(body.runner_kind).toBe("pi");
+    expect(body.agent_scope).toBe("@acme");
+    expect(body.agent_name).toBe("proj-agent");
+    expect(body.runOrigin).toBe("platform");
+    expect(body.connection_overrides).toEqual({ "@acme/gmail": "conn_1" });
+    expect(body.dependency_overrides).toEqual({ "@acme/skill": "draft" });
+    expect(body.started_at).toBeString();
+    expect(body.orgId).toBe(ctx.orgId);
+    expect(body.applicationId).toBe(ctx.defaultAppId);
+    expect(body.userId).toBe(ctx.user.id);
+    // Enrichment computed alongside the projection.
+    expect(body.document_counts).toEqual({ input: 0, output: 0 });
+    expect(body.unread).toBeBoolean();
+    // `resolvedConnections` reaches the client only in its display-safe form.
+    expect(body.connections_used).toEqual([
+      { integration_id: "@acme/gmail", label: "Work", account_id: "a@b.c", source: "pin" },
+    ]);
+  }
+
+  function expectNoInternalColumns(body: Record<string, unknown>) {
+    for (const key of EXCLUDED_KEYS) {
+      expect(body).not.toHaveProperty(key);
+    }
+    // Belt and braces: the ciphertext must not appear anywhere in the payload,
+    // whatever key it might have been nested under.
+    expect(JSON.stringify(body)).not.toContain("super-secret-ciphertext");
+    expect(JSON.stringify(body)).not.toContain("9.9.9-internal-only");
+  }
+
+  it("round-trips every DTO field on the detail read", async () => {
+    const res = await app.request(`/api/runs/${runId}`, { headers: authHeaders(ctx) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expectDtoRoundTrip(body);
+    expectNoInternalColumns(body);
+  });
+
+  it("round-trips every DTO field on the list read", async () => {
+    const res = await app.request("/api/runs", { headers: authHeaders(ctx) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: Record<string, unknown>[] };
+    const row = body.data.find((r) => r.id === runId);
+    expect(row).toBeDefined();
+    expectDtoRoundTrip(row!);
+    expectNoInternalColumns(row!);
+  });
+});

--- a/apps/api/test/integration/routes/schedules-run-stats.test.ts
+++ b/apps/api/test/integration/routes/schedules-run-stats.test.ts
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The run counters served WITH each schedule: `running_runs`, `unread_count`
+ * and `last_run_number`.
+ *
+ * They exist to kill an N+1: the schedule card used to fetch
+ * `GET /api/schedules/:id/runs` per row just to count these three things, so a
+ * dashboard listing N schedules issued N extra requests. What has to hold for
+ * that replacement to be honest:
+ *
+ *  - the counts are RIGHT, including across more runs than the per-card fetch
+ *    used to page through (its page size was 20, so a schedule with more unread
+ *    runs than that under-reported);
+ *  - `unread_count` follows the VIEWER, not the schedule's execution actor —
+ *    two members looking at the same schedule must see their own read state,
+ *    exactly like `EnrichedRun.unread`;
+ *  - the counts stay inside the tenant: another org's runs, or another
+ *    schedule's runs, never leak into a schedule's totals.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { db } from "@appstrate/db/client";
+import { notifications } from "@appstrate/db/schema";
+import { getTestApp } from "../../helpers/app.ts";
+import { truncateAll } from "../../helpers/db.ts";
+import {
+  createTestContext,
+  createTestUser,
+  addOrgMember,
+  authHeaders,
+  type TestContext,
+} from "../../helpers/auth.ts";
+import { seedAgent, seedSchedule, seedRun } from "../../helpers/seed.ts";
+import type { RunStatus } from "@appstrate/shared-types";
+
+const app = getTestApp();
+
+interface ScheduleWithStats {
+  id: string;
+  running_runs: number;
+  unread_count: number;
+  last_run_number: number;
+}
+
+describe("Schedule run counters", () => {
+  let ctx: TestContext;
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext();
+  });
+
+  /** Seed a schedule owned by `ctx.user` on a fresh agent. */
+  async function seedAgentSchedule(name: string) {
+    const agent = await seedAgent({ id: `@${ctx.org.slug}/${name}`, orgId: ctx.orgId });
+    return seedSchedule({
+      packageId: agent.id,
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      userId: ctx.user.id,
+      name,
+    });
+  }
+
+  async function seedScheduleRun(
+    scheduleId: string,
+    packageId: string,
+    status: RunStatus,
+    runNumber: number,
+  ) {
+    return seedRun({
+      packageId,
+      scheduleId,
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      userId: ctx.user.id,
+      status,
+      runNumber,
+    });
+  }
+
+  /** An UNREAD notification for `recipient` about `runId`. */
+  async function seedUnread(runId: string, recipientId: string) {
+    await db.insert(notifications).values({
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      recipientType: "user",
+      recipientId,
+      runId,
+      type: "run_completed",
+    });
+  }
+
+  async function listSchedules(context: TestContext): Promise<ScheduleWithStats[]> {
+    const res = await app.request("/api/schedules", { headers: authHeaders(context) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: ScheduleWithStats[] };
+    return body.data;
+  }
+
+  it("reports zeroes for a schedule that never fired", async () => {
+    await seedAgentSchedule("never-fired");
+
+    const [schedule] = await listSchedules(ctx);
+    expect(schedule).toBeDefined();
+    expect(schedule!.running_runs).toBe(0);
+    expect(schedule!.unread_count).toBe(0);
+    expect(schedule!.last_run_number).toBe(0);
+  });
+
+  it("counts active runs, unread runs and the highest run number", async () => {
+    const schedule = await seedAgentSchedule("busy");
+
+    // 2 active (pending + running), 2 terminal.
+    const r1 = await seedScheduleRun(schedule.id, schedule.packageId, "pending", 1);
+    const r2 = await seedScheduleRun(schedule.id, schedule.packageId, "running", 2);
+    const r3 = await seedScheduleRun(schedule.id, schedule.packageId, "success", 3);
+    await seedScheduleRun(schedule.id, schedule.packageId, "failed", 4);
+
+    // 3 notifications, one of them already read.
+    await seedUnread(r1.id, ctx.user.id);
+    await seedUnread(r2.id, ctx.user.id);
+    await db.insert(notifications).values({
+      orgId: ctx.orgId,
+      applicationId: ctx.defaultAppId,
+      recipientType: "user",
+      recipientId: ctx.user.id,
+      runId: r3.id,
+      type: "run_completed",
+      readAt: new Date(),
+    });
+
+    const [enriched] = await listSchedules(ctx);
+    expect(enriched!.running_runs).toBe(2);
+    expect(enriched!.unread_count).toBe(2);
+    expect(enriched!.last_run_number).toBe(4);
+  });
+
+  // The per-card fetch this replaces asked for 20 runs and counted within them.
+  it("counts across the WHOLE history, not one page of runs", async () => {
+    const schedule = await seedAgentSchedule("long-history");
+
+    for (let i = 1; i <= 25; i++) {
+      const run = await seedScheduleRun(schedule.id, schedule.packageId, "success", i);
+      await seedUnread(run.id, ctx.user.id);
+    }
+
+    const [enriched] = await listSchedules(ctx);
+    expect(enriched!.unread_count).toBe(25);
+    expect(enriched!.last_run_number).toBe(25);
+  });
+
+  it("scopes unread_count to the VIEWER, not to the schedule's actor", async () => {
+    const schedule = await seedAgentSchedule("shared");
+    const run = await seedScheduleRun(schedule.id, schedule.packageId, "success", 1);
+
+    // The schedule's own actor has an unread notification; a second member of
+    // the same org does not.
+    await seedUnread(run.id, ctx.user.id);
+
+    const other = await createTestUser();
+    await addOrgMember(ctx.orgId, other.id, "admin");
+    const otherCtx: TestContext = { ...ctx, user: other, cookie: other.cookie };
+
+    const [asOwner] = await listSchedules(ctx);
+    const [asOther] = await listSchedules(otherCtx);
+
+    expect(asOwner!.unread_count).toBe(1);
+    expect(asOther!.unread_count).toBe(0);
+    // Everything that is NOT recipient-scoped stays identical between viewers.
+    expect(asOther!.running_runs).toBe(asOwner!.running_runs);
+    expect(asOther!.last_run_number).toBe(asOwner!.last_run_number);
+  });
+
+  it("never counts another schedule's runs", async () => {
+    const a = await seedAgentSchedule("sched-a");
+    const b = await seedAgentSchedule("sched-b");
+
+    await seedScheduleRun(a.id, a.packageId, "running", 1);
+    await seedScheduleRun(b.id, b.packageId, "running", 7);
+    await seedScheduleRun(b.id, b.packageId, "running", 8);
+
+    const schedules = await listSchedules(ctx);
+    const byId = new Map(schedules.map((s) => [s.id, s]));
+    expect(byId.get(a.id)!.running_runs).toBe(1);
+    expect(byId.get(a.id)!.last_run_number).toBe(1);
+    expect(byId.get(b.id)!.running_runs).toBe(2);
+    expect(byId.get(b.id)!.last_run_number).toBe(8);
+  });
+
+  it("serves the same counters on the schedule detail endpoint", async () => {
+    const schedule = await seedAgentSchedule("detail");
+    const run = await seedScheduleRun(schedule.id, schedule.packageId, "running", 3);
+    await seedUnread(run.id, ctx.user.id);
+
+    const res = await app.request(`/api/schedules/${schedule.id}`, { headers: authHeaders(ctx) });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ScheduleWithStats;
+    expect(body.running_runs).toBe(1);
+    expect(body.unread_count).toBe(1);
+    expect(body.last_run_number).toBe(3);
+  });
+});

--- a/apps/api/test/integration/routes/spa-csp.test.ts
+++ b/apps/api/test/integration/routes/spa-csp.test.ts
@@ -135,6 +135,26 @@ describe("SPA document CSP", () => {
     }
   });
 
+  // The shell is the ONE response that must never be reused without asking the
+  // server: it embeds a per-request `window.__APP_CONFIG__` (`bootstrapTokenPending`
+  // flips the moment an unattended install is claimed) and names the current
+  // build's hashed asset URLs, which the hashed assets' own year-long
+  // `immutable` policy then depends on being fresh.
+  it("declares the document non-reusable without revalidation", async () => {
+    await withUsercontentUrl(undefined, async () => {
+      const res = await fetchSpa();
+      expect(res.headers.get("Cache-Control")).toBe("no-cache");
+    });
+  });
+
+  it("never pins the shell — no max-age, no immutable", async () => {
+    await withUsercontentUrl(undefined, async () => {
+      const cacheControl = (await fetchSpa("/agents")).headers.get("Cache-Control") ?? "";
+      expect(cacheControl).not.toContain("immutable");
+      expect(cacheControl).not.toMatch(/max-age=[1-9]/);
+    });
+  });
+
   it("still injects window.__APP_CONFIG__ into the shell", async () => {
     await withUsercontentUrl(undefined, async () => {
       const body = await (await fetchSpa()).text();

--- a/apps/api/test/integration/services/input-parser-context-documents.test.ts
+++ b/apps/api/test/integration/services/input-parser-context-documents.test.ts
@@ -137,6 +137,64 @@ describe("parseRequestInput — reserved context-documents field", () => {
     ]);
   });
 
+  /**
+   * The copies run through `mapWithConcurrency` (same bounded pool as the
+   * upload path), so more documents than the pool width is the case that would
+   * expose a concurrency bug: results landing out of order would pair a
+   * document with ANOTHER document's workspace name, and the run would read the
+   * wrong bytes under the name the prompt announces.
+   *
+   * Deliberately more documents than `DOC_STREAM_CONCURRENCY` (4), and every
+   * document holds its own index in its bytes so a swap is detectable.
+   */
+  it("materializes more documents than the concurrency limit, each under its own name", async () => {
+    const ctx = await createTestContext({ orgSlug: "ctxdocs-many" });
+    const scope: Scope = { orgId: ctx.orgId, applicationId: ctx.defaultAppId };
+
+    const COUNT = 9;
+    const ids: string[] = [];
+    for (let i = 0; i < COUNT; i++) {
+      ids.push(
+        await seedRunDocument(scope, {
+          name: `doc-${i}.txt`,
+          mime: "text/plain",
+          content: `content-${i}`,
+        }),
+      );
+    }
+
+    const { manifest, inputPatch } = injectContextDocuments(
+      inlineManifest(),
+      ids.map((id) => documentUri(id)),
+    );
+    const runId = `run_${crypto.randomUUID()}`;
+    const parsed = await parseRequestInput(
+      fakeCtx({}, scope, ctx.user.id),
+      runId,
+      asJSONSchemaObject(manifest.input!.schema),
+      { injectedInput: inputPatch },
+    );
+
+    expect(parsed.uploadedFiles).toHaveLength(COUNT);
+    // Order is the INPUT order, not completion order — the announced file list
+    // and the persisted URI list have to line up index for index.
+    expect(parsed.uploadedFiles!.map((f) => f.name)).toEqual(
+      Array.from({ length: COUNT }, (_, i) => `doc-${i}.txt`),
+    );
+    expect(parsed.input![CONTEXT_DOCUMENTS_FIELD]).toEqual(ids.map((id) => documentUri(id)));
+
+    // Every file's BYTES sit under its own workspace name — the assertion a
+    // mis-paired index would fail even though all the counts still matched.
+    for (const file of parsed.uploadedFiles!) {
+      const stream = await downloadRunDocumentStream(runId, file.workspaceName);
+      expect(stream).not.toBeNull();
+      const expected = `content-${file.name.slice("doc-".length, -".txt".length)}`;
+      expect(await new Response(stream!).text()).toBe(expected);
+    }
+
+    expect(parsed.consumedDocumentIds!.sort()).toEqual([...ids].sort());
+  });
+
   it("refuses a document from another application (container ACL preserved)", async () => {
     const owner = await createTestContext({ orgSlug: "ctxdocs-owner" });
     const other = await createTestContext({ orgSlug: "ctxdocs-other" });

--- a/apps/api/test/integration/services/scheduler.test.ts
+++ b/apps/api/test/integration/services/scheduler.test.ts
@@ -199,7 +199,7 @@ describeRequiresRedis("scheduler service", () => {
         cronExpression: "*/30 * * * *",
       });
 
-      const schedules = await listSchedules({ orgId: orgId, applicationId: defaultAppId });
+      const schedules = await listSchedules({ orgId: orgId, applicationId: defaultAppId }, actor);
 
       expect(schedules).toHaveLength(2);
       const names = schedules.map((s) => s.name);
@@ -237,20 +237,20 @@ describeRequiresRedis("scheduler service", () => {
         },
       );
 
-      const schedules = await listSchedules({ orgId: orgId, applicationId: defaultAppId });
+      const schedules = await listSchedules({ orgId: orgId, applicationId: defaultAppId }, actor);
       expect(schedules).toHaveLength(1);
       expect(schedules[0]!.name).toBe("My Schedule");
 
-      const otherSchedules = await listSchedules({
-        orgId: otherOrg.id,
-        applicationId: otherDefaultAppId,
-      });
+      const otherSchedules = await listSchedules(
+        { orgId: otherOrg.id, applicationId: otherDefaultAppId },
+        actor,
+      );
       expect(otherSchedules).toHaveLength(1);
       expect(otherSchedules[0]!.name).toBe("Other Schedule");
     });
 
     it("returns an empty array when no schedules exist", async () => {
-      const schedules = await listSchedules({ orgId: orgId, applicationId: defaultAppId });
+      const schedules = await listSchedules({ orgId: orgId, applicationId: defaultAppId }, actor);
       expect(schedules).toBeArray();
       expect(schedules).toHaveLength(0);
     });
@@ -283,6 +283,7 @@ describeRequiresRedis("scheduler service", () => {
       const schedules = await listPackageSchedules(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
+        actor,
       );
       expect(schedules).toHaveLength(1);
       expect(schedules[0]!.name).toBe("Agent 1 Schedule");
@@ -290,6 +291,7 @@ describeRequiresRedis("scheduler service", () => {
       const schedules2 = await listPackageSchedules(
         { orgId: orgId, applicationId: defaultAppId },
         pkg2.id,
+        actor,
       );
       expect(schedules2).toHaveLength(1);
       expect(schedules2[0]!.name).toBe("Agent 2 Schedule");
@@ -299,6 +301,7 @@ describeRequiresRedis("scheduler service", () => {
       const schedules = await listPackageSchedules(
         { orgId: orgId, applicationId: defaultAppId },
         packageId,
+        actor,
       );
       expect(schedules).toBeArray();
       expect(schedules).toHaveLength(0);
@@ -572,7 +575,7 @@ describeRequiresRedis("scheduler service", () => {
 
       await deleteSchedule({ orgId: orgId, applicationId: defaultAppId }, schedule2.id);
 
-      const remaining = await listSchedules({ orgId: orgId, applicationId: defaultAppId });
+      const remaining = await listSchedules({ orgId: orgId, applicationId: defaultAppId }, actor);
       expect(remaining).toHaveLength(1);
       expect(remaining[0]!.id).toBe(schedule1.id);
       expect(remaining[0]!.name).toBe("Keep This");

--- a/apps/api/test/unit/static-cache.test.ts
+++ b/apps/api/test/unit/static-cache.test.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The SPA build's HTTP caching policy.
+ *
+ * Two halves, and both matter:
+ *  - the POLICY (`staticCacheControl`) — `immutable` is only ever correct for a
+ *    filename that carries a content hash. Handing it to a stable-named file
+ *    (`favicon.ico`, `site.webmanifest`) pins a stale byte stream in every
+ *    browser cache for a year with no way to bust it short of a rename, so the
+ *    segment test that separates the two classes is a correctness boundary, not
+ *    a formatting detail.
+ *  - the WIRING — the policy only exists as a header if `index.ts` actually
+ *    passes it to the static middleware's `onFound`. Hono's `serveStatic` emits
+ *    no `Cache-Control` of its own, so dropping the callback silently restores
+ *    "re-download everything, every visit" while every assertion on the pure
+ *    function stays green.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import {
+  staticCacheControl,
+  IMMUTABLE_CACHE_CONTROL,
+  SHORT_LIVED_CACHE_CONTROL,
+  SPA_HTML_CACHE_CONTROL,
+} from "../../src/lib/static-cache.ts";
+
+describe("staticCacheControl", () => {
+  it("pins content-hashed build output for a year", () => {
+    expect(staticCacheControl("./apps/web/dist/assets/index-DRqZyykT.js")).toBe(
+      IMMUTABLE_CACHE_CONTROL,
+    );
+    expect(staticCacheControl("./apps/web/dist/assets/styles-Bh1lwVYD.css")).toBe(
+      IMMUTABLE_CACHE_CONTROL,
+    );
+  });
+
+  it("does NOT pin stable-named files — their bytes change under the same URL", () => {
+    for (const path of [
+      "./apps/web/dist/favicon.ico",
+      "./apps/web/dist/site.webmanifest",
+      "./apps/web/dist/logo-dark.svg",
+      "./apps/web/dist/.well-known/apple-app-site-association",
+    ]) {
+      expect(staticCacheControl(path)).toBe(SHORT_LIVED_CACHE_CONTROL);
+    }
+  });
+
+  it("matches `assets` as a whole path segment, not as a substring", () => {
+    // Neither of these is Vite build output; a substring test would pin both.
+    expect(staticCacheControl("./apps/web/dist/my-assets/logo.svg")).toBe(
+      SHORT_LIVED_CACHE_CONTROL,
+    );
+    expect(staticCacheControl("./apps/web/dist/assets.js")).toBe(SHORT_LIVED_CACHE_CONTROL);
+  });
+
+  it("is root-prefix agnostic and separator agnostic", () => {
+    expect(staticCacheControl("assets/index-abc.js")).toBe(IMMUTABLE_CACHE_CONTROL);
+    expect(staticCacheControl("/srv/app/apps/web/dist/assets/index-abc.js")).toBe(
+      IMMUTABLE_CACHE_CONTROL,
+    );
+    expect(staticCacheControl(String.raw`apps\web\dist\assets\index-abc.js`)).toBe(
+      IMMUTABLE_CACHE_CONTROL,
+    );
+  });
+
+  it("declares a year for immutable output and a revalidating SPA document", () => {
+    // The two values that would be actively harmful if they drifted into each
+    // other: a year on the shell, or `immutable` on anything revalidatable.
+    expect(IMMUTABLE_CACHE_CONTROL).toBe("public, max-age=31536000, immutable");
+    expect(SPA_HTML_CACHE_CONTROL).toBe("no-cache");
+    expect(SHORT_LIVED_CACHE_CONTROL).not.toContain("immutable");
+  });
+});
+
+/**
+ * Production wiring, read out of the source for the same reason
+ * `spa-csp.test.ts` does it: importing `index.ts` boots a real server.
+ */
+const INDEX_TS = readFileSync(
+  fileURLToPath(new URL("../../src/index.ts", import.meta.url)),
+  "utf-8",
+);
+
+describe("static-asset cache wiring in index.ts", () => {
+  it("hands every served file to the cache policy via onFound", () => {
+    expect(INDEX_TS).toContain(`import { staticCacheControl } from "./lib/static-cache.ts"`);
+    expect(INDEX_TS).toMatch(
+      /onFound:\s*\(path, c\) => \{\s*c\.header\("Cache-Control", staticCacheControl\(path\)\);/,
+    );
+  });
+});

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -5669,6 +5669,12 @@ export interface components {
             actor_name: string | null;
             /** @enum {string|null} */
             actor_type: "user" | "end_user" | null;
+            /** @description Runs of this schedule currently pending or running. */
+            running_runs: number;
+            /** @description Runs of this schedule whose notification is unread by the CALLER. Scoped to the requesting actor, like `EnrichedRun.unread`. */
+            unread_count: number;
+            /** @description Highest run number this schedule ever produced; 0 when it never fired. */
+            last_run_number: number;
         };
         SmtpConfigView: {
             applicationId: string;

--- a/apps/web/src/components/run-list.tsx
+++ b/apps/web/src/components/run-list.tsx
@@ -32,6 +32,89 @@ interface RunListProps {
   kind?: RunKindFilter;
 }
 
+interface RunRowsProps {
+  /** Runs to render, already fetched by the caller. */
+  runs: EnrichedRun[];
+  /** Still loading — renders the loading placeholder instead of the rows. */
+  isLoading?: boolean;
+  fixedAgentName?: string;
+  hideAgentName?: boolean;
+  emptyState?: React.ReactNode;
+  /** Row pinned above the list (e.g. scheduled next-run preview). */
+  banner?: React.ReactNode;
+}
+
+/**
+ * The presentation half of {@link RunList}: rows, agent-name resolution, empty
+ * and loading states — no fetching of its own.
+ *
+ * Split out so a page that ALREADY has runs in hand can render them without a
+ * second request. The dashboard is exactly that case: it loads 15 runs for its
+ * own header, and mounting `<RunList pageSize={7}>` underneath issued a second
+ * `GET /api/runs` (a different `limit` = a different React Query key = a
+ * different network call, each one a `COUNT` plus an enriched page read).
+ *
+ * `useAgents()` here is not an extra request: it is the same query key every
+ * caller of this component already holds, served from cache.
+ */
+export function RunRows({
+  runs,
+  isLoading = false,
+  fixedAgentName,
+  hideAgentName = false,
+  emptyState,
+  banner,
+}: RunRowsProps) {
+  const { t } = useTranslation(["agents"]);
+  const { data: agents } = useAgents();
+
+  const agentNameMap = new Map<string, string>();
+  if (!hideAgentName && !fixedAgentName && agents) {
+    for (const f of agents) {
+      agentNameMap.set(f.id, f.display_name ?? f.id);
+    }
+  }
+
+  const resolveAgentName = (run: EnrichedRun) => {
+    if (hideAgentName) return undefined;
+    if (fixedAgentName) return fixedAgentName;
+    // Inline runs: use the manifest displayName snapshot (run.agent_name) — the
+    // raw shadow packageId (`@inline/r-…`) is never meaningful to users, and
+    // the ephemeral row isn't in `agents` so the map lookup would miss anyway.
+    if (run.package_ephemeral === true) {
+      return inlineRunDisplayName(run.agent_name, t("runs.inlineBadge"));
+    }
+    // Source agent deleted (FK SET NULL): fall back to the denormalized
+    // `agent_name` snapshot stamped at INSERT time, then to a generic label.
+    if (run.packageId == null) {
+      return run.agent_name ?? t("runs.deletedAgent", { ns: "agents" });
+    }
+    return agentNameMap.get(run.packageId) ?? run.agent_name ?? run.packageId;
+  };
+
+  if (isLoading) {
+    return (
+      <div className="border-border text-muted-foreground rounded-md border p-8 text-center text-sm">
+        {t("loading", { ns: "common" })}
+      </div>
+    );
+  }
+
+  if (runs.length === 0) {
+    if (emptyState) return <>{emptyState}</>;
+    return <EmptyState message={t("detail.emptyRuns")} icon={PlayCircle} compact />;
+  }
+
+  return (
+    <div className="border-border rounded-md border">
+      {banner}
+      {runs.map((run) => (
+        <RunRow key={run.id} run={run} agentName={resolveAgentName(run)} />
+      ))}
+    </div>
+  );
+}
+
 export function RunList({
   packageId,
   scheduleId,
@@ -60,53 +143,30 @@ export function RunList({
   const total = data?.total ?? 0;
   const totalPages = Math.ceil(total / pageSize);
 
-  // Resolve agent names (skip if fixed or hidden)
-  const { data: agents } = useAgents();
-  const agentNameMap = new Map<string, string>();
-  if (!hideAgentName && !fixedAgentName && agents) {
-    for (const f of agents) {
-      agentNameMap.set(f.id, f.display_name ?? f.id);
-    }
-  }
+  // Only the first page shows a placeholder; paging keeps the previous rows.
+  const showLoading = isLoading && page === 0;
 
-  if (isLoading && page === 0) {
+  if (showLoading || runs.length === 0) {
     return (
-      <div className="border-border text-muted-foreground rounded-md border p-8 text-center text-sm">
-        {t("loading", { ns: "common" })}
-      </div>
+      <RunRows
+        runs={runs}
+        isLoading={showLoading}
+        fixedAgentName={fixedAgentName}
+        hideAgentName={hideAgentName}
+        emptyState={emptyState}
+      />
     );
   }
 
-  if (runs.length === 0) {
-    if (emptyState) return <>{emptyState}</>;
-    return <EmptyState message={t("detail.emptyRuns")} icon={PlayCircle} compact />;
-  }
-
-  const resolveAgentName = (run: EnrichedRun) => {
-    if (hideAgentName) return undefined;
-    if (fixedAgentName) return fixedAgentName;
-    // Inline runs: use the manifest displayName snapshot (run.agent_name) — the
-    // raw shadow packageId (`@inline/r-…`) is never meaningful to users, and
-    // the ephemeral row isn't in `agents` so the map lookup would miss anyway.
-    if (run.package_ephemeral === true) {
-      return inlineRunDisplayName(run.agent_name, t("runs.inlineBadge"));
-    }
-    // Source agent deleted (FK SET NULL): fall back to the denormalized
-    // `agent_name` snapshot stamped at INSERT time, then to a generic label.
-    if (run.packageId == null) {
-      return run.agent_name ?? t("runs.deletedAgent", { ns: "agents" });
-    }
-    return agentNameMap.get(run.packageId) ?? run.agent_name ?? run.packageId;
-  };
-
   return (
     <div className="space-y-2">
-      <div className="border-border rounded-md border">
-        {page === 0 && firstPageBanner}
-        {runs.map((run) => (
-          <RunRow key={run.id} run={run} agentName={resolveAgentName(run)} />
-        ))}
-      </div>
+      <RunRows
+        runs={runs}
+        fixedAgentName={fixedAgentName}
+        hideAgentName={hideAgentName}
+        emptyState={emptyState}
+        banner={page === 0 ? firstPageBanner : undefined}
+      />
 
       {paginated && totalPages > 1 && (
         <div className="flex items-center justify-end gap-4 pt-1">

--- a/apps/web/src/components/run-row.tsx
+++ b/apps/web/src/components/run-row.tsx
@@ -73,6 +73,38 @@ export function RunRowDetails({ run }: { run: EnrichedRun }) {
   );
 }
 
+/** Seconds-with-one-decimal, the format both the live and the final figure use. */
+function formatDuration(ms: number): string {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+/**
+ * Live elapsed time of a running run, ticking at 10 Hz.
+ *
+ * A LEAF on purpose: the interval used to live in `RunRow`, so every tick
+ * re-rendered the whole row — badges, trigger, popover, links — ten times a
+ * second, per running run on screen. Here the state that changes is owned by
+ * the only node that displays it, so a tick re-renders one `<span>`.
+ *
+ * Exported for the unit test, which asserts exactly that isolation.
+ */
+export function ElapsedDuration({ startedAt }: { startedAt: string }) {
+  const [elapsed, setElapsed] = useState(() => Date.now() - new Date(startedAt).getTime());
+
+  useEffect(() => {
+    const start = new Date(startedAt).getTime();
+    const tick = () => setElapsed(Date.now() - start);
+    tick();
+    const id = setInterval(tick, 100);
+    return () => clearInterval(id);
+  }, [startedAt]);
+
+  // Mirrors the pre-split behaviour: a run that has not measurably started yet
+  // renders nothing rather than a flickering `0.0s`.
+  if (!elapsed) return null;
+  return <span className="text-muted-foreground font-mono text-xs">{formatDuration(elapsed)}</span>;
+}
+
 export function RunRow({
   run,
   agentName,
@@ -95,19 +127,11 @@ export function RunRow({
   // badge so users understand why "Re-run" / agent-config links are gone.
   const isOrphaned = run.packageId == null && !isInline;
 
-  // Live elapsed timer while running
-  const [elapsed, setElapsed] = useState(0);
-  useEffect(() => {
-    if (!isRunning || !run.started_at) return;
-    const start = new Date(run.started_at).getTime();
-    const tick = () => setElapsed(Date.now() - start);
-    tick();
-    const id = setInterval(tick, 100);
-    return () => clearInterval(id);
-  }, [isRunning, run.started_at]);
-
-  const time = isRunning ? elapsed : run.duration;
-  const duration = time ? `${(time / 1000).toFixed(1)}s` : "";
+  // While the run is live the elapsed time ticks inside `<ElapsedDuration>`;
+  // once it is over the row renders the frozen `duration` itself. Neither path
+  // re-renders this component on a timer.
+  const isLive = isRunning && run.started_at != null;
+  const finalDuration = run.duration ? formatDuration(run.duration) : "";
 
   // `document_counts` is a non-optional field of the run DTO — every list and
   // detail endpoint computes it — so read it straight.
@@ -178,7 +202,13 @@ export function RunRow({
         )}
         {/* How long the run took is a primary figure, not a wide-viewport
             bonus — it stays visible at every breakpoint (#1046). */}
-        {duration && <span className="text-muted-foreground font-mono text-xs">{duration}</span>}
+        {isLive ? (
+          <ElapsedDuration startedAt={run.started_at!} />
+        ) : (
+          finalDuration && (
+            <span className="text-muted-foreground font-mono text-xs">{finalDuration}</span>
+          )
+        )}
         {!isDetail && <span className="text-muted-foreground text-xs">{date}</span>}
         {isDetail && (
           <Popover>

--- a/apps/web/src/components/schedule-card.tsx
+++ b/apps/web/src/components/schedule-card.tsx
@@ -5,8 +5,7 @@ import { Badge } from "./status-badge";
 import { ScheduleStatusBadge } from "./schedule-status-badge";
 import { NextRunPreview } from "./next-run-preview";
 import { ActorLabel } from "./actor-label";
-import { useScheduleRuns } from "../hooks/use-schedules";
-import { ACTIVE_RUN_STATUSES, type EnrichedSchedule } from "@appstrate/shared-types";
+import type { EnrichedSchedule } from "@appstrate/shared-types";
 
 interface ScheduleCardProps {
   schedule: EnrichedSchedule;
@@ -14,19 +13,17 @@ interface ScheduleCardProps {
 }
 
 export function ScheduleCard({ schedule, agentName }: ScheduleCardProps) {
-  // PERF: N+1 — each card issues its own `GET .../schedules/:id/runs`, so a
-  // list of N schedules fans out to N requests. Acceptable at current list
-  // sizes; if this list grows, hoist the running/unread/last-run counts into
-  // the parent's schedule list payload (server-side aggregate) or a single
-  // batch endpoint and pass them down as props instead of querying per row.
-  const { data: runs } = useScheduleRuns(schedule.id);
-
-  // Running + unread counts scoped to this schedule's runs
-  const runningRuns = runs?.filter((e) => ACTIVE_RUN_STATUSES.has(e.status)).length ?? 0;
-  const unreadCount = runs?.filter((e) => e.unread).length ?? 0;
+  // The three counters this card shows are served WITH the schedule list
+  // (`enrichSchedules` in services/scheduler.ts). They used to come from a
+  // per-card `GET .../schedules/:id/runs`, which made a list of N schedules
+  // fan out to N HTTP requests and ~2N SQL queries just to count three things.
+  // They are also whole-history counts now, not counts within the last page of
+  // runs the card happened to fetch.
+  const runningRuns = schedule.running_runs;
+  const unreadCount = schedule.unread_count;
+  const lastRunNumber = schedule.last_run_number;
 
   const isActive = schedule.enabled ?? true;
-  const lastRunNumber = runs?.[0]?.runNumber ?? 0;
 
   const statusBadge = <ScheduleStatusBadge enabled={schedule.enabled ?? true} />;
 

--- a/apps/web/src/components/test/request-fanout.test.ts
+++ b/apps/web/src/components/test/request-fanout.test.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Guards on the three request patterns this codebase removed, each of which is
+ * a one-line edit away from coming back:
+ *
+ *  1. the dashboard mounting `<RunList>` under a run query it already made
+ *     (two `GET /api/runs` per page view, two `COUNT`s, for the same rows);
+ *  2. the schedule CARD fetching a schedule's runs to count three numbers
+ *     (N cards → N requests);
+ *  3. the notification queries polling every 30s, which is only safe to slow
+ *     down while the realtime stream reconciles them on (re)connect — the SSE
+ *     protocol has no replay, so dropping the reconnect-side invalidation would
+ *     leave a badge stale for a full poll interval.
+ *
+ * Source-scanned rather than rendered: these modules import the SPA's typed API
+ * client, which uses `import.meta.glob` and cannot be evaluated by the bun test
+ * runner (the same reason `document-preview.test.ts` scans its component).
+ */
+
+import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const read = (rel: string) => readFileSync(fileURLToPath(new URL(rel, import.meta.url)), "utf-8");
+
+/**
+ * Source with comments removed. The removed patterns are NAMED in the comments
+ * that explain why they were removed, so an absence assertion against the raw
+ * file would fail on its own documentation.
+ */
+const code = (source: string) =>
+  source
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, "") // JSX comment expressions
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+
+const DASHBOARD = read("../../pages/dashboard.tsx");
+const SCHEDULE_CARD = read("../schedule-card.tsx");
+const RUN_LIST = read("../run-list.tsx");
+const NOTIFICATIONS = read("../../hooks/use-notifications.ts");
+const GLOBAL_SYNC = read("../../hooks/use-global-run-sync.ts");
+
+describe("dashboard reuses its own runs", () => {
+  it("renders the presentational rows, not a second fetching list", () => {
+    expect(DASHBOARD).toContain("<RunRows runs={runs.slice(0, RECENT_RUNS_COUNT)} />");
+    // `<RunList …>` here is what issues the duplicate query.
+    expect(code(DASHBOARD)).not.toMatch(/<RunList[\s/>]/);
+  });
+
+  it("keeps exactly one run query on the page", () => {
+    expect([...DASHBOARD.matchAll(/usePaginatedRuns\(/g)]).toHaveLength(1);
+  });
+
+  it("still exposes a fetching RunList for the pages that page through runs", () => {
+    // The split must not have turned the paginated list into a dead export:
+    // /runs, the agent tab and the schedule detail all rely on it.
+    expect(RUN_LIST).toContain("export function RunList(");
+    expect(RUN_LIST).toContain("export function RunRows(");
+  });
+});
+
+describe("schedule cards read their counters from the schedule", () => {
+  it("does not fetch a schedule's runs per card", () => {
+    expect(code(SCHEDULE_CARD)).not.toContain("useScheduleRuns");
+    expect(code(SCHEDULE_CARD)).not.toContain("/runs");
+  });
+
+  it("reads the three counters served with the list payload", () => {
+    expect(SCHEDULE_CARD).toContain("schedule.running_runs");
+    expect(SCHEDULE_CARD).toContain("schedule.unread_count");
+    expect(SCHEDULE_CARD).toContain("schedule.last_run_number");
+  });
+});
+
+describe("notification freshness", () => {
+  it("polls as a backstop (5 min), on every notification query", () => {
+    expect(NOTIFICATIONS).toContain("const NOTIFICATION_POLL_INTERVAL_MS = 300_000;");
+    const intervals = [...NOTIFICATIONS.matchAll(/refetchInterval:\s*([^,\n]+)/g)].map(
+      (m) => m[1]!,
+    );
+    expect(intervals).toHaveLength(3);
+    expect(intervals.every((v) => v === "NOTIFICATION_POLL_INTERVAL_MS")).toBe(true);
+  });
+
+  // The load-bearing half: without this, slowing the poll down means a missed
+  // terminal event leaves the badge wrong for five minutes.
+  it("reconciles the badges on every SSE (re)connect, before reading frames", () => {
+    const connectStart = GLOBAL_SYNC.indexOf("const connectOnce = async () => {");
+    const readerStart = GLOBAL_SYNC.indexOf("const reader = res.body.getReader();");
+    expect(connectStart).toBeGreaterThan(-1);
+    expect(readerStart).toBeGreaterThan(connectStart);
+
+    const onConnect = GLOBAL_SYNC.slice(connectStart, readerStart);
+    expect(onConnect).toContain("invalidateNotificationQueries(qcRef.current)");
+  });
+
+  it("still invalidates them on a terminal run seen live", () => {
+    expect(GLOBAL_SYNC).toContain("TERMINAL_RUN_STATUSES.has(status)");
+    expect([...GLOBAL_SYNC.matchAll(/invalidateNotificationQueries\(/g)].length).toBeGreaterThan(1);
+  });
+});

--- a/apps/web/src/components/test/run-row.test.tsx
+++ b/apps/web/src/components/test/run-row.test.tsx
@@ -13,6 +13,8 @@
 
 import type { ReactElement } from "react";
 import { describe, it, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { renderToStaticMarkup } from "react-dom/server";
 import { MemoryRouter } from "react-router-dom";
 import { I18nextProvider } from "react-i18next";
@@ -20,7 +22,7 @@ import type { EnrichedRun } from "@appstrate/shared-types";
 import agentsFr from "../../locales/fr/agents.json";
 import { formatDateField } from "../../lib/markdown.ts";
 import i18n, { i18nReady } from "../../i18n.ts";
-import { RunRow, RunRowDetails } from "../run-row.tsx";
+import { RunRow, RunRowDetails, ElapsedDuration } from "../run-row.tsx";
 
 // The SPA's own i18n instance, not a hand-rolled one: `formatDateField` reads
 // `i18n.language` off this singleton, so a private instance would render dates
@@ -131,6 +133,56 @@ describe("RunRow duration", () => {
       expect(html).not.toMatch(/class="[^"]*hidden[^"]*"[^>]*>4\.2s/);
     });
   }
+});
+
+/**
+ * The live timer is a LEAF (`ElapsedDuration`). It used to be a `setInterval`
+ * inside `RunRow` itself, which re-rendered the whole row — badges, trigger,
+ * links, popover — ten times a second for every running run on screen.
+ */
+describe("RunRow live elapsed timer", () => {
+  const RUN_ROW_SOURCE = readFileSync(
+    fileURLToPath(new URL("../run-row.tsx", import.meta.url)),
+    "utf-8",
+  );
+
+  it("renders the time elapsed since the run started", () => {
+    const startedAt = new Date(Date.now() - 2_500).toISOString();
+    const html = render(<ElapsedDuration startedAt={startedAt} />);
+    // ~2.5s, allowing for the render taking a few milliseconds.
+    expect(html).toMatch(/>2\.[45]s</);
+  });
+
+  it("is what a RUNNING row renders instead of the frozen duration", () => {
+    const startedAt = new Date(Date.now() - 3_000).toISOString();
+    const html = render(<RunRow run={makeRun({ status: "running", started_at: startedAt })} />);
+    // The stale `duration` column (4200ms) must not win over live time.
+    expect(html).not.toContain("4.2s");
+    expect(html).toMatch(/>[23]\.\ds</);
+  });
+
+  it("leaves a terminal row on its frozen duration", () => {
+    const html = render(<RunRow run={makeRun({ status: "success" })} />);
+    expect(html).toContain("4.2s");
+  });
+
+  it("keeps the ticking state OUT of RunRow — only the leaf owns a timer", () => {
+    const leafStart = RUN_ROW_SOURCE.indexOf("export function ElapsedDuration");
+    const rowStart = RUN_ROW_SOURCE.indexOf("export function RunRow(");
+    expect(leafStart).toBeGreaterThan(-1);
+    expect(rowStart).toBeGreaterThan(leafStart);
+
+    // Exactly one timer in the file, and it sits before `RunRow` begins.
+    const intervals = [...RUN_ROW_SOURCE.matchAll(/setInterval\(/g)].map((m) => m.index);
+    expect(intervals).toHaveLength(1);
+    expect(intervals[0]).toBeGreaterThan(leafStart);
+    expect(intervals[0]).toBeLessThan(rowStart);
+
+    // And `RunRow` holds no ticking state of its own.
+    const rowBody = RUN_ROW_SOURCE.slice(rowStart);
+    expect(rowBody).not.toContain("useState");
+    expect(rowBody).not.toContain("useEffect");
+  });
 });
 
 describe("RunRowDetails (the panel body)", () => {

--- a/apps/web/src/hooks/use-global-run-sync.ts
+++ b/apps/web/src/hooks/use-global-run-sync.ts
@@ -253,9 +253,15 @@ export function useGlobalRunSync() {
       }
 
       // The protocol is signal-only: frames emitted while the stream was down
-      // are lost forever. Reconcile the chat list on every (re)connect instead
-      // of leaving a missed `chat_session_update` to the 60s safety net.
+      // are lost forever. Reconcile on every (re)connect instead of leaving a
+      // missed frame to a polling safety net.
       handleChatSessionUpdate(qcRef.current);
+      // Same reconciliation for the notification badges. This is what lets
+      // their `refetchInterval` be a 5-minute backstop instead of a 30-second
+      // poll: a terminal run seen live invalidates them (below), and a terminal
+      // run MISSED while the stream was down is caught here, on reconnect —
+      // seconds after connectivity returns, not at the next poll tick.
+      invalidateNotificationQueries(qcRef.current);
 
       const reader = res.body.getReader();
       const decoder = new TextDecoder();

--- a/apps/web/src/hooks/use-notifications.ts
+++ b/apps/web/src/hooks/use-notifications.ts
@@ -6,6 +6,24 @@ import { useCurrentApplicationId } from "./use-current-application";
 import { useOrgScope } from "./use-org-scope";
 import { paginatedRunsKeys, runsKeys, runKeys } from "../lib/query-keys";
 
+/**
+ * Safety-net poll for the notification queries — a BACKSTOP, not the freshness
+ * mechanism.
+ *
+ * Freshness comes from the realtime stream: `use-global-run-sync` invalidates
+ * these caches on every terminal run it sees, and re-invalidates them on every
+ * (re)connect, which is what covers the frames lost while the stream was down
+ * (the SSE protocol has no replay). With both of those in place the poll only
+ * has to cover a client that is somehow neither streaming nor reconnecting, so
+ * it runs at 5 minutes instead of 30 seconds — 10× fewer requests per open tab,
+ * across three queries.
+ *
+ * Do NOT raise this without keeping the reconnect-side invalidation: on its own
+ * the interval is the ONLY thing that would eventually correct a badge, and
+ * "eventually" would become five minutes.
+ */
+const NOTIFICATION_POLL_INTERVAL_MS = 300_000;
+
 export function useUnreadCount() {
   const scope = useOrgScope();
   // Badge counters only need an application context (legacy behavior).
@@ -15,7 +33,7 @@ export function useUnreadCount() {
     "/api/notifications/unread-count",
     { params: { header: scope.header } },
     {
-      refetchInterval: 30_000,
+      refetchInterval: NOTIFICATION_POLL_INTERVAL_MS,
       enabled: !!applicationId,
       select: (d) => d.count,
     },
@@ -32,7 +50,7 @@ export function useNotifications(opts: { unread?: boolean; limit?: number } = {}
     "/api/notifications",
     { params: { header: scope.header, query: { unread, limit } } },
     {
-      refetchInterval: 30_000,
+      refetchInterval: NOTIFICATION_POLL_INTERVAL_MS,
       enabled: !!applicationId,
       select: (d) => d.data,
     },
@@ -48,7 +66,7 @@ export function useUnreadCountsByAgent() {
     "/api/notifications/unread-counts-by-agent",
     { params: { header: scope.header } },
     {
-      refetchInterval: 30_000,
+      refetchInterval: NOTIFICATION_POLL_INTERVAL_MS,
       enabled: !!applicationId,
       select: (d) => d.counts,
     },

--- a/apps/web/src/hooks/use-schedules.ts
+++ b/apps/web/src/hooks/use-schedules.ts
@@ -16,24 +16,15 @@ import type { ModelGenerationSettings } from "@appstrate/core/model-generation";
 import { useAgentProxy } from "./use-proxies";
 import { onMutationError } from "./use-mutations";
 import { scheduleKeys } from "../lib/query-keys";
-import type { ScheduleWireDto, EnrichedSchedule, EnrichedRun } from "@appstrate/shared-types";
+import type { ScheduleWireDto, EnrichedSchedule } from "@appstrate/shared-types";
 
-export function useScheduleRuns(scheduleId: string | undefined) {
-  const orgId = useCurrentOrgId();
-  const applicationId = useCurrentApplicationId();
-  return useQuery({
-    // Key pinned to the legacy shape: use-global-run-sync invalidates
-    // ["schedule-runs", orgId, applicationId, scheduleId] on SSE events.
-    queryKey: scheduleKeys.runs(orgId, applicationId, scheduleId),
-    queryFn: async (): Promise<EnrichedRun[]> => {
-      const { data } = await client.GET("/api/schedules/{id}/runs", {
-        params: { path: { id: scheduleId! } },
-      });
-      return data?.data ?? [];
-    },
-    enabled: !!scheduleId && !!applicationId,
-  });
-}
+// `useScheduleRuns` used to live here: the schedule CARD fetched a schedule's
+// runs purely to count active/unread/last-number, once per card. Those three
+// counters now ride on the schedule itself (`EnrichedSchedule.running_runs` /
+// `unread_count` / `last_run_number`), and the only remaining consumer of the
+// endpoint is `<RunList scheduleId>` on the schedule-detail page, which fetches
+// it through `usePaginatedRuns`. The `scheduleKeys.runs` cache key is still
+// invalidated by `use-global-run-sync` for that list.
 
 export function useAllSchedules() {
   const orgId = useCurrentOrgId();

--- a/apps/web/src/pages/dashboard.tsx
+++ b/apps/web/src/pages/dashboard.tsx
@@ -10,7 +10,10 @@ import { usePaginatedRuns } from "../hooks/use-paginated-runs";
 import { LoadingState, ErrorState } from "../components/page-states";
 import { PackageCard } from "../components/package-card";
 import { ScheduleCard } from "../components/schedule-card";
-import { RunList } from "../components/run-list";
+import { RunRows } from "../components/run-list";
+
+/** Rows shown under "recent runs" — a prefix of the page's own run query. */
+const RECENT_RUNS_COUNT = 7;
 
 export function DashboardPage() {
   const { t } = useTranslation(["agents", "common"]);
@@ -157,7 +160,12 @@ export function DashboardPage() {
             {t("dashboard.seeAll")}
           </Link>
         </div>
-        <RunList pageSize={7} paginated={false} />
+        {/* Rendered from the runs THIS page already loaded. Mounting
+            `<RunList pageSize={7}>` here instead issued a second
+            `GET /api/runs` (a different `limit` is a different query key), and
+            with it a second `COUNT` + enriched page read, for rows the 15 above
+            already contain. */}
+        <RunRows runs={runs.slice(0, RECENT_RUNS_COUNT)} />
       </section>
     </div>
   );

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -108,14 +108,32 @@ export default defineConfig({
         //   ajv dependency — which IS needed eagerly by @appstrate/core via
         //   @afps-spec/schema — and would drag the whole RJSF chunk into the
         //   entry graph.
-        advancedChunks: {
+        // `codeSplitting`, NOT `advancedChunks`: rolldown (bundled by Vite 8)
+        // deprecated the latter in 1.1 — "if `advancedChunks` and
+        // `codeSplitting` are both specified, `advancedChunks` will be ignored".
+        // Same option shape, so this is a rename plus the tightening below.
+        codeSplitting: {
+          // Without a floor, a group's `test` promotes even a two-line shared
+          // module into a chunk of its own, and the entry graph pays a request
+          // for each. Anything under 20 kB is cheaper inlined into its importer.
+          minSize: 20_000,
           groups: [
             {
               name: "react-vendor",
               test: /node_modules\/(react|react-dom|react-router|react-router-dom|scheduler)\//,
             },
-            { name: "query", test: /node_modules\/@tanstack\// },
-            { name: "radix", test: /node_modules\/@radix-ui\// },
+            // Query, narrowed from all of `@tanstack/*`: the entry graph needs
+            // the query client, while the other `@tanstack` packages (table,
+            // virtual, …) are reached from lazy routes only and were being
+            // dragged forward by the wider test.
+            { name: "query", test: /node_modules\/@tanstack\/(query-core|react-query)\// },
+            // Icons are imported by nearly every route; one shared chunk beats
+            // the same icon module being duplicated across route chunks.
+            { name: "icons", test: /node_modules\/lucide-react\// },
+            // Deliberately NO `@radix-ui` group: the primitives are imported
+            // per-component, so natural chunking already places each one with
+            // the route that uses it. Forcing them together built one large
+            // chunk that every route had to fetch to render any dialog.
           ],
         },
       },

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -354,6 +354,19 @@ export type EnrichedSchedule = ScheduleWireDto & {
   actor_name: string | null;
   /** Which actor kind owns the schedule run. Null for org/system-owned schedules. */
   actor_type: "user" | "end_user" | null;
+  /**
+   * Runs of this schedule currently in a non-terminal status (`pending` or
+   * `running`), across every run it ever produced.
+   */
+  running_runs: number;
+  /**
+   * Runs of this schedule whose notification is unread **by the caller**. Scoped
+   * to the requesting actor, like `EnrichedRun.unread` — a member and an
+   * end-user never observe each other's read state.
+   */
+  unread_count: number;
+  /** Highest `runNumber` this schedule ever produced; 0 when it never fired. */
+  last_run_number: number;
 };
 
 // --- Organization Types ---


### PR DESCRIPTION
Implements the eight actionable items of the 2026-08-05 performance audit (P1 + P2). The three P3 items (Better Auth `cookieCache`, a slimmer run-list DTO, dropping prefix indexes) are deliberately **not** here — each needs production measurement first, and two of them are contract or security trade-offs rather than free wins.

No new infrastructure, no new cache layer, no new endpoint. One commit per change, each independently revertable.

## P1

**HTTP caching for the SPA build** (`9086d4e`)
Hono's static middleware emits `Content-Type` and nothing else — no `Cache-Control`, no `ETag`, no `Last-Modified` — so every asset was re-downloaded on every visit with no validator to revalidate against (there was never a `304` to be had). Policy now lives in `lib/static-cache.ts`, applied via the middleware's existing `onFound`: content-hashed `assets/*` are `immutable` for a year, stable-named files (favicons, manifest, `.well-known`) get 5 minutes, and the SPA shell is `no-cache` — it embeds a per-request `window.__APP_CONFIG__` and names the current build's asset hashes.

**Vendor chunking** (`6e1b717`)
`advancedChunks` is deprecated in rolldown 1.1 and ignored outright when `codeSplitting` is also set. Migrated, plus a `minSize` floor, a query group narrowed to `query-core` + `react-query`, a `lucide-react` group, and the blanket `@radix-ui` group dropped.

Measured on the eagerly-loaded graph (entry + transitive static imports):

| | chunks | raw | gzip |
|---|---:|---:|---:|
| before | 85 | 990,321 | 315,609 |
| after | 77 | 917,635 | 298,933 |
| | **−8** | **−7.3%** | **−5.3%** |

**Dashboard double-fetch + schedule N+1** (`4ac4215`)
- The dashboard loaded 15 runs and then mounted `<RunList pageSize={7}>` under them — a different query key, so a second `GET /api/runs`, another `COUNT`, another enriched page read, for rows it already had. `RunList` is split into a presentational `RunRows`; the fetching/paginating `RunList` is unchanged for the pages that need it.
- Each schedule card fetched `GET /api/schedules/:id/runs` (up to 20 enriched rows) to count three numbers. `EnrichedSchedule` now carries `running_runs`, `unread_count` and `last_run_number` from one grouped query in `enrichSchedules`. The counts span the whole history instead of one page of runs, and `unread_count` is scoped to the **viewer**, matching `EnrichedRun.unread`.

## P2

**Run projection** (`5680705`) — the enriched reads selected the whole `runs` table while the mapper reads a subset; eight columns were fetched and discarded on every list page, `sinkSecretEncrypted` (an AES-256-GCM ciphertext) among them. `enrichedRunColumns` names the projection once and the DTO mapper derives its parameter type from it, so narrowing it without narrowing the DTO fails typecheck.

**`document://` concurrency** (`429d668`) — the durable-document pass was a sequential loop next to an upload pass already using `mapWithConcurrency`. Same primitive, same limit; order and failure behaviour unchanged.

**Live run timer** (`6efa40a`) — the 100ms interval lived in `RunRow`, re-rendering the whole row 10×/s per running run. It moves into an `ElapsedDuration` leaf.

**Notification polling** (`4ac4215`) — 30s → 5min on three queries, but **only** because the realtime stream now reconciles the badges on every (re)connect. The SSE protocol has no replay, so without that step a frame missed while the stream was down would have left a badge wrong for a full interval. The reconnect-side invalidation is the precondition, not a bonus.

## Tests

- `apps/api/test/unit/static-cache.test.ts` — policy per file class, `assets` matched as a path segment, plus the `onFound` wiring (the policy is inert without it)
- `spa-csp.test.ts` — the shell revalidates and is never pinned
- `schedules-run-stats.test.ts` — counter correctness, counts beyond the old 20-row page, viewer-scoped unread across two members, no cross-schedule bleed, same values on the detail read
- `runs-projection.test.ts` — every DTO field round-trips on list **and** detail (a narrowed projection is exactly the change that silently drops a field), and no internal column appears under any casing
- `input-parser-context-documents.test.ts` — more documents than the concurrency limit, each byte payload under its own workspace name (a mis-paired index would survive a count-only assertion)
- `run-row.test.tsx` — live vs frozen duration, and exactly one timer in the file, before `RunRow` begins
- `request-fanout.test.ts` — guards on all three removed request patterns

`bun run check` green. Full API suite: 3768 pass / 0 fail. Web suite: 347 pass / 0 fail.

## Notes for review

- `GET /api/schedules` and `/api/schedules/:id` gain three response fields (additive; `required` in the OpenAPI schema, which is what `verify-openapi` step 7 compares against `EnrichedSchedule`).
- `unread_count` semantics: whole history, viewer-scoped. The old per-card number was "unread within the last 20 runs of this schedule" — the change is a fix, but it is a visible one.
- `useScheduleRuns` is removed (no consumers left); the `scheduleKeys.runs` cache key still exists and is still invalidated for `<RunList scheduleId>` on the schedule-detail page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)