### PR TITLE
fix(integrations): list org-shared connections, not only the caller's

### DIFF
--- a/apps/api/src/lib/actor.ts
+++ b/apps/api/src/lib/actor.ts
@@ -75,3 +75,27 @@ export function actorScopeFilter(actor: Actor, cols: { userId: Column; endUserId
   if (actor.type === "end_user") return ownership;
   return or(ownership, isNull(cols.userId))!;
 }
+
+/**
+ * WHERE clause for "connections this actor may use": their own rows UNION
+ * every row opted into org-wide sharing, whoever owns it. Applies to any
+ * table carrying the `{userId, endUserId, sharedWithOrg}` triple —
+ * `integration_connections` today.
+ *
+ * This is the set the runtime resolver picks from, so it is also the set
+ * every *read* surface must show: a reader that narrows to ownership alone
+ * reports "not connected" for an actor whose run would in fact resolve a
+ * shared connection, and hides from admin pickers the very connections the
+ * pin endpoints accept. Unlike {@link actorScopeFilter} the sharing branch
+ * is NOT gated on the actor kind — sharing is an explicit opt-in on the row
+ * (`shared_with_org`), so an end-user actor inherits it on the same terms.
+ *
+ * The single canonical helper for that semantic; do not re-derive the
+ * `or(ownership, eq(sharedWithOrg, true))` pattern inline.
+ */
+export function actorOrSharedFilter(
+  actor: Actor,
+  cols: { userId: Column; endUserId: Column; sharedWithOrg: Column },
+): SQL {
+  return or(actorFilter(actor, cols), eq(cols.sharedWithOrg, true))!;
+}

--- a/apps/api/src/openapi/paths/integrations.ts
+++ b/apps/api/src/openapi/paths/integrations.ts
@@ -130,6 +130,11 @@ const integrationConnectionSchema = {
     expiresAt: { type: ["string", "null"], format: "date-time" },
     owner_type: { type: "string", enum: ["user", "end_user"] },
     owner_id: { type: "string" },
+    owner_name: {
+      type: ["string", "null"],
+      description:
+        "Display name of the connection's owner (member name, or end-user name falling back to its external id); null when the owner row was deleted. Returned by the list surfaces, which include org-shared connections owned by other members; absent from the single-connection write responses, where the row is the caller's own.",
+    },
     label: { type: ["string", "null"] },
     shared_with_org: { type: "boolean" },
     client_ref: {
@@ -995,7 +1000,9 @@ export const integrationsPaths = {
     get: {
       operationId: "listIntegrationConnections",
       tags: ["Integrations"],
-      summary: "List the caller's connections for an integration",
+      summary: "List the connections the caller can use for an integration",
+      description:
+        "Returns the caller's own connections **plus** every connection in the application opted into org-wide sharing (`shared_with_org: true`), whoever owns it — the same set the runtime resolver picks from. Rows the caller does not own carry `owner_name` and have `identity_claims` redacted to `null`.",
       parameters: [
         { $ref: "#/components/parameters/XOrgId" },
         { $ref: "#/components/parameters/XAppId" },

--- a/apps/api/src/routes/integrations.ts
+++ b/apps/api/src/routes/integrations.ts
@@ -1131,7 +1131,14 @@ export function createIntegrationsRouter() {
       });
       // 200 + the bare connection resource — same serializer as the
       // connections list / connect flows (#657), not a hand-built stub.
-      return c.json(serializeIntegrationConnection(updated));
+      //
+      // An org admin may rename a connection they do not own, so this echo
+      // must honour the same rule the list does: sharing a connection consents
+      // to using it, not to publishing the owner's OIDC claim bag. Without the
+      // redaction a `PATCH {label}` reads back what
+      // `GET .../connections` deliberately withheld.
+      const serialized = serializeIntegrationConnection(updated);
+      return c.json(isOwner ? serialized : { ...serialized, identity_claims: null });
     },
   );
 

--- a/apps/api/src/services/integration-connection-owner-names.ts
+++ b/apps/api/src/services/integration-connection-owner-names.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Owner display-name resolution for `integration_connections` rows.
+ *
+ * A connection is owned either by a dashboard user (`user_id`) or by an
+ * end-user (`end_user_id`) — never both (DB check constraint). Any surface
+ * that lists connections the caller does not own has to say *whose* they
+ * are, which means one batched lookup per owner kind.
+ *
+ * Extracted here because two independent readers need the exact same
+ * resolution and must not drift on the end-user fallback rule
+ * (`name` first, then `externalId`): the picker
+ * (`listAccessibleConnections`) and the integration settings list
+ * (`listIntegrationConnections`).
+ */
+
+import { inArray } from "drizzle-orm";
+import { db } from "@appstrate/db/client";
+import { endUsers, user } from "@appstrate/db/schema";
+
+/** The owner columns any caller must project for a name lookup. */
+export interface ConnectionOwnerRef {
+  userId: string | null;
+  endUserId: string | null;
+}
+
+/**
+ * Resolves an owner display name for a connection row, or `null` when the
+ * owner row is gone (deleted member/end-user) — never throws on a dangling
+ * owner, the connection itself is still a legitimate row.
+ */
+export type OwnerNameLookup = (row: ConnectionOwnerRef) => string | null;
+
+/**
+ * Two batched lookups (users + end-users) over the distinct owner ids in
+ * `rows`, returned as a synchronous lookup. Issues no query for an owner
+ * kind that does not appear in `rows`, so the single-kind case (the common
+ * one — a dashboard-only application) costs one query, not two.
+ */
+export async function resolveConnectionOwnerNames(
+  rows: ReadonlyArray<ConnectionOwnerRef>,
+): Promise<OwnerNameLookup> {
+  const userIds = [...new Set(rows.map((r) => r.userId).filter((v): v is string => v !== null))];
+  const endUserIds = [
+    ...new Set(rows.map((r) => r.endUserId).filter((v): v is string => v !== null)),
+  ];
+
+  const [userRows, endUserRows] = await Promise.all([
+    userIds.length
+      ? db.select({ id: user.id, name: user.name }).from(user).where(inArray(user.id, userIds))
+      : Promise.resolve([] as { id: string; name: string }[]),
+    endUserIds.length
+      ? db
+          .select({ id: endUsers.id, name: endUsers.name, externalId: endUsers.externalId })
+          .from(endUsers)
+          .where(inArray(endUsers.id, endUserIds))
+      : Promise.resolve([] as { id: string; name: string | null; externalId: string | null }[]),
+  ]);
+
+  const userNames = new Map(userRows.map((u) => [u.id, u.name]));
+  // End-users may have no `name` (created via API with an `externalId` only);
+  // the external id is the only stable human-facing handle in that case.
+  const endUserNames = new Map(endUserRows.map((e) => [e.id, e.name ?? e.externalId]));
+
+  return (row) => {
+    if (row.userId) return userNames.get(row.userId) ?? null;
+    if (row.endUserId) return endUserNames.get(row.endUserId) ?? null;
+    return null;
+  };
+}

--- a/apps/api/src/services/integration-connection-resolver.ts
+++ b/apps/api/src/services/integration-connection-resolver.ts
@@ -48,7 +48,7 @@ import {
 } from "@appstrate/core/integration";
 import type { ResolutionFieldError } from "../lib/errors.ts";
 import type { Actor } from "../lib/actor.ts";
-import { actorFilter } from "../lib/actor.ts";
+import { actorOrSharedFilter } from "../lib/actor.ts";
 import type { AppScope } from "../lib/scope.ts";
 import { fetchIntegrationManifest, type IntegrationManifestCache } from "./integration-service.ts";
 import { listOrgDefaultsForResolver } from "./integration-org-defaults-service.ts";
@@ -734,13 +734,7 @@ async function loadAccessibleConnections(
       and(
         inArray(integrationConnections.integrationId, integrationIds),
         eq(integrationConnections.applicationId, applicationId),
-        or(
-          actorFilter(actor, {
-            userId: integrationConnections.userId,
-            endUserId: integrationConnections.endUserId,
-          }),
-          eq(integrationConnections.sharedWithOrg, true),
-        )!,
+        actorOrSharedFilter(actor, integrationConnections),
       ),
     );
   return rows;

--- a/apps/api/src/services/integration-connections.ts
+++ b/apps/api/src/services/integration-connections.ts
@@ -20,7 +20,7 @@
  * module is the write side that populates it.
  */
 
-import { and, asc, eq, inArray, or, sql, type SQL } from "drizzle-orm";
+import { and, asc, eq, inArray, sql, type SQL } from "drizzle-orm";
 import { db } from "@appstrate/db/client";
 import {
   applicationPackages,
@@ -51,7 +51,7 @@ import { mergeSystemAndDb, setExactlyOneDefault, isUuid } from "../lib/db-helper
 import { logger } from "../lib/logger.ts";
 import { notFound, conflict, invalidRequest, forbidden } from "../lib/errors.ts";
 import type { ActorScope, AppScope } from "../lib/scope.ts";
-import { actorInsert, actorFilter } from "../lib/actor.ts";
+import { actorInsert, actorFilter, actorOrSharedFilter } from "../lib/actor.ts";
 import { getPackageDisplayName } from "../lib/package-helpers.ts";
 import type { Actor } from "@appstrate/connect";
 import {
@@ -200,7 +200,7 @@ async function loadActorConnection(
   authKey: string,
   context: { applicationId: string; actor: Actor; connectionId?: string },
 ): Promise<ActorConnectionRow | null> {
-  const ownerPredicate = actorFilter(context.actor, integrationConnections);
+  const accessible = actorOrSharedFilter(context.actor, integrationConnections);
   const rows = await db
     .select({
       id: integrationConnections.id,
@@ -217,7 +217,7 @@ async function loadActorConnection(
         eq(integrationConnections.integrationId, packageId),
         eq(integrationConnections.authKey, authKey),
         eq(integrationConnections.applicationId, context.applicationId),
-        or(ownerPredicate, eq(integrationConnections.sharedWithOrg, true)),
+        accessible,
         ...(context.connectionId ? [eq(integrationConnections.id, context.connectionId)] : []),
       ),
     )
@@ -279,7 +279,7 @@ async function loadAccessibleConnectionById(
   expectedAuthKey: string | null,
   context: { applicationId: string; actor: Actor },
 ): Promise<ResolvedConnectionRow | null> {
-  const ownerPredicate = actorFilter(context.actor, integrationConnections);
+  const accessible = actorOrSharedFilter(context.actor, integrationConnections);
   const [row] = await db
     .select({
       id: integrationConnections.id,
@@ -297,7 +297,7 @@ async function loadAccessibleConnectionById(
         eq(integrationConnections.integrationId, integrationId),
         ...(expectedAuthKey !== null ? [eq(integrationConnections.authKey, expectedAuthKey)] : []),
         eq(integrationConnections.applicationId, context.applicationId),
-        or(ownerPredicate, eq(integrationConnections.sharedWithOrg, true)),
+        accessible,
       ),
     )
     .limit(1);
@@ -2050,7 +2050,6 @@ export async function listIntegrationConnections(
   actor: Actor,
 ): Promise<IntegrationConnectionSummary[]> {
   await assertApplicationInScope(scope);
-  const ownerPredicate = actorFilter(actor, integrationConnections);
   const rows = await db
     .select()
     .from(integrationConnections)
@@ -2058,7 +2057,7 @@ export async function listIntegrationConnections(
       and(
         eq(integrationConnections.integrationId, packageId),
         eq(integrationConnections.applicationId, scope.applicationId),
-        or(ownerPredicate, eq(integrationConnections.sharedWithOrg, true)),
+        actorOrSharedFilter(actor, integrationConnections),
       ),
     );
   const ownerName = await resolveConnectionOwnerNames(rows);
@@ -2111,7 +2110,6 @@ export async function listUsableIntegrationsForActor(
   actor: Actor,
 ): Promise<UsableIntegration[]> {
   await assertApplicationInScope(scope);
-  const ownerPredicate = actorFilter(actor, integrationConnections);
   const rows = await db
     .select({
       integrationId: integrationConnections.integrationId,
@@ -2123,7 +2121,7 @@ export async function listUsableIntegrationsForActor(
     .where(
       and(
         eq(integrationConnections.applicationId, scope.applicationId),
-        or(ownerPredicate, eq(integrationConnections.sharedWithOrg, true)),
+        actorOrSharedFilter(actor, integrationConnections),
       ),
     );
   if (rows.length === 0) return [];

--- a/apps/api/src/services/integration-connections.ts
+++ b/apps/api/src/services/integration-connections.ts
@@ -66,6 +66,7 @@ import {
   toSupportedTokenEndpointAuthMethod,
 } from "./integration-manifest-helpers.ts";
 import { fetchMcpServerManifest } from "./integration-service.ts";
+import { resolveConnectionOwnerNames } from "./integration-connection-owner-names.ts";
 import type { AfpsManifestAuth } from "./integration-manifest-helpers.ts";
 import type { IntegrationAuthStatus } from "@appstrate/shared-types";
 import { getIntegration } from "./integration-service.ts";
@@ -2022,9 +2023,26 @@ export async function saveIntegrationConnection(
 }
 
 /**
- * List the actor's connections for an integration. End-users see only
- * their own rows; dashboard users see only their own rows. Filtering by
- * actor matches the runtime-side resolver in Phase 1.2a.
+ * List the connections the actor can *use* for an integration in this
+ * application: their own rows, plus every row opted into org-wide sharing
+ * (`sharedWithOrg`) whoever owns it.
+ *
+ * The union — not the actor's own rows — is the correct set here because
+ * it is what the runtime resolver will actually pick from
+ * (`loadActorConnection`, `loadAccessibleConnections`,
+ * `listAccessibleConnections`). An own-only list made three surfaces built
+ * on top of it silently wrong: the admin org-default and pin pickers
+ * (which filter this list for `shared_with_org` and could therefore only
+ * ever offer the admin's *own* shared rows, while the backend happily
+ * accepts anyone's — `integration-pins-service.ts` `upsertIntegrationPin`),
+ * and `auths[].ready`, which claimed "not connected" for an actor whose
+ * run would in fact resolve a shared connection.
+ *
+ * Rows the actor does not own come back with `identity_claims: null`:
+ * sharing a connection consents to *using* it, not to publishing the
+ * owner's OIDC claim bag (email, sub, …) to every member. `account_id`
+ * and `owner_name` stay — the picker DTO already exposes both, and a
+ * connection you can pick has to be identifiable.
  */
 export async function listIntegrationConnections(
   scope: AppScope,
@@ -2040,10 +2058,19 @@ export async function listIntegrationConnections(
       and(
         eq(integrationConnections.integrationId, packageId),
         eq(integrationConnections.applicationId, scope.applicationId),
-        ownerPredicate,
+        or(ownerPredicate, eq(integrationConnections.sharedWithOrg, true)),
       ),
     );
-  return rows.map(serializeIntegrationConnection);
+  const ownerName = await resolveConnectionOwnerNames(rows);
+  return rows.map((row) => {
+    const isOwn = actor.type === "end_user" ? row.endUserId === actor.id : row.userId === actor.id;
+    const summary = serializeIntegrationConnection(row);
+    return {
+      ...summary,
+      ...(isOwn ? {} : { identity_claims: null }),
+      owner_name: ownerName(row),
+    };
+  });
 }
 
 /** One integration the actor could attach to an agent (own and/or org-shared). */
@@ -2351,6 +2378,13 @@ export async function getIntegrationAuthStatuses(
       // consumers (chat connect card, …) never re-derive connection state and
       // stay correct as that logic evolves. Agent-agnostic (no scope/pin gate);
       // a run's authoritative readiness still comes from `validateInlineRun`.
+      //
+      // Reads the own ∪ org-shared union (see `listIntegrationConnections`),
+      // so an actor who owns nothing but inherits a shared connection is
+      // `ready: true` — deliberately, because their run resolves that
+      // connection. This is what makes the state correct under
+      // `block_user_connections`, where a member cannot create a connection at
+      // all and a shared one is the only path to a successful run.
       ready: keyConnections.some((c) => !c.needs_reconnection),
       has_oauth_client: oauthClientKeys.has(key),
       // Shared platform client (SYSTEM_INTEGRATIONS): when one serves this

--- a/apps/api/src/services/integration-pins-service.ts
+++ b/apps/api/src/services/integration-pins-service.ts
@@ -48,7 +48,7 @@ import { parseManifestIntegrations } from "@appstrate/core/dependencies";
 import { isSystemIntegration } from "./integration-client-registry.ts";
 import { conflict, notFound, invalidRequest } from "../lib/errors.ts";
 import type { AppScope } from "../lib/scope.ts";
-import type { Actor } from "../lib/actor.ts";
+import { actorOrSharedFilter, type Actor } from "../lib/actor.ts";
 import type { ValidationFieldError } from "../lib/errors.ts";
 import { getPackage } from "./package-catalog.ts";
 import { resolveAgentRunVersion } from "./agent-version-resolver.ts";
@@ -65,7 +65,6 @@ import {
 // hook and OpenAPI spec can't drift from the service. Local aliases keep
 // the existing call sites readable.
 export type PinSummary = IntegrationPin;
-export type SharedConnectionSummary = AccessibleIntegrationConnection;
 export type { ConsumingAgentSummary };
 
 // ─────────────────────────── block_user_connections toggle ────────────────────
@@ -541,44 +540,29 @@ export async function loadConnectionOwnership(connectionId: string): Promise<{
  * List the connections an actor can pick from for a given
  * (application, integration). Used by the UI picker:
  * own + shared, with caller-facing labels.
+ *
+ * Same set — and now the same predicate — as `listIntegrationConnections`
+ * on the settings surface; only the projected DTO differs (this one carries
+ * `owner_name` and the split owner ids the picker keys on, the other the
+ * full connection summary). Both go through `actorOrSharedFilter`, so the
+ * two surfaces cannot drift on what "accessible" means.
  */
 export async function listAccessibleConnections(
   scope: AppScope,
   integrationId: string,
-  actorFilter: { userId?: string; endUserId?: string },
-): Promise<SharedConnectionSummary[]> {
-  const baseConditions = [
-    eq(integrationConnections.applicationId, scope.applicationId),
-    eq(integrationConnections.integrationId, integrationId),
-  ];
-
-  const [own, shared] = await Promise.all([
-    actorFilter.userId || actorFilter.endUserId
-      ? db
-          .select()
-          .from(integrationConnections)
-          .where(
-            and(
-              ...baseConditions,
-              actorFilter.userId
-                ? eq(integrationConnections.userId, actorFilter.userId)
-                : eq(integrationConnections.endUserId, actorFilter.endUserId!),
-            ),
-          )
-      : Promise.resolve([] as ConnectionRow[]),
-    db
-      .select()
-      .from(integrationConnections)
-      .where(and(...baseConditions, eq(integrationConnections.sharedWithOrg, true))),
-  ]);
-  const seen = new Set<string>();
-  const merged: ConnectionRow[] = [];
-  for (const r of [...own, ...shared]) {
-    if (seen.has(r.id)) continue;
-    seen.add(r.id);
-    merged.push(r);
-  }
-  return attachOwnerNames(merged);
+  actor: Actor,
+): Promise<AccessibleIntegrationConnection[]> {
+  const rows = await db
+    .select()
+    .from(integrationConnections)
+    .where(
+      and(
+        eq(integrationConnections.applicationId, scope.applicationId),
+        eq(integrationConnections.integrationId, integrationId),
+        actorOrSharedFilter(actor, integrationConnections),
+      ),
+    );
+  return attachOwnerNames(rows);
 }
 
 /**
@@ -587,7 +571,7 @@ export async function listAccessibleConnections(
  * query path untouched — names are a post-pass over whatever rows
  * survived the merge.
  */
-async function attachOwnerNames(rows: ConnectionRow[]): Promise<SharedConnectionSummary[]> {
+async function attachOwnerNames(rows: ConnectionRow[]): Promise<AccessibleIntegrationConnection[]> {
   const ownerName = await resolveConnectionOwnerNames(rows);
 
   return rows.map((row) => ({
@@ -653,12 +637,11 @@ export async function resolveAgentIntegrationPick(args: {
   const manifestRes = await fetchIntegrationManifest(integrationId);
   const manifest = manifestRes.ok ? manifestRes.manifest : null;
 
-  const actorFilter = actor.type === "user" ? { userId: actor.id } : { endUserId: actor.id };
   const userId = actor.type === "user" ? actor.id : null;
 
   const [candidatesRaw, adminPins, memberPins, blocked, orgDefault, resolution] = await Promise.all(
     [
-      listAccessibleConnections(scope, integrationId, actorFilter),
+      listAccessibleConnections(scope, integrationId, actor),
       listIntegrationPins(scope, integrationId),
       userId
         ? listMemberPinsForAgent(scope, agentPackageId, userId)

--- a/apps/api/src/services/integration-pins-service.ts
+++ b/apps/api/src/services/integration-pins-service.ts
@@ -18,16 +18,14 @@
  * already has the role.
  */
 
-import { and, eq, inArray, isNull, sql } from "drizzle-orm";
+import { and, eq, isNull, sql } from "drizzle-orm";
 import { db, toRows } from "@appstrate/db/client";
 import {
   applicationPackages,
-  endUsers,
   integrationConnections,
   integrationPins,
   integrationOrgDefaults,
   packages,
-  user,
 } from "@appstrate/db/schema";
 import type {
   IntegrationConnectionRow as ConnectionRow,
@@ -56,6 +54,7 @@ import { getPackage } from "./package-catalog.ts";
 import { resolveAgentRunVersion } from "./agent-version-resolver.ts";
 import { fetchIntegrationManifest } from "./integration-service.ts";
 import { getOrgDefault } from "./integration-org-defaults-service.ts";
+import { resolveConnectionOwnerNames } from "./integration-connection-owner-names.ts";
 import {
   resolveConnectionsForRun,
   translateResolutionError,
@@ -583,31 +582,13 @@ export async function listAccessibleConnections(
 }
 
 /**
- * Resolve owner display names in two batched lookups (user + end_users)
- * and project the connection rows into picker summaries. Keeps the dual
- * own/shared query path untouched — names are a post-pass over whatever
- * rows survived the merge.
+ * Project the connection rows into picker summaries, resolving owner
+ * display names via the shared batched lookup. Keeps the dual own/shared
+ * query path untouched — names are a post-pass over whatever rows
+ * survived the merge.
  */
 async function attachOwnerNames(rows: ConnectionRow[]): Promise<SharedConnectionSummary[]> {
-  const userIds = [...new Set(rows.map((r) => r.userId).filter((v): v is string => v !== null))];
-  const endUserIds = [
-    ...new Set(rows.map((r) => r.endUserId).filter((v): v is string => v !== null)),
-  ];
-
-  const [userRows, endUserRows] = await Promise.all([
-    userIds.length
-      ? db.select({ id: user.id, name: user.name }).from(user).where(inArray(user.id, userIds))
-      : Promise.resolve([] as { id: string; name: string }[]),
-    endUserIds.length
-      ? db
-          .select({ id: endUsers.id, name: endUsers.name, externalId: endUsers.externalId })
-          .from(endUsers)
-          .where(inArray(endUsers.id, endUserIds))
-      : Promise.resolve([] as { id: string; name: string | null; externalId: string | null }[]),
-  ]);
-
-  const userNames = new Map(userRows.map((u) => [u.id, u.name]));
-  const endUserNames = new Map(endUserRows.map((e) => [e.id, e.name ?? e.externalId]));
+  const ownerName = await resolveConnectionOwnerNames(rows);
 
   return rows.map((row) => ({
     id: row.id,
@@ -616,11 +597,7 @@ async function attachOwnerNames(rows: ConnectionRow[]): Promise<SharedConnection
     label: row.label,
     owner_user_id: row.userId,
     owner_end_user_id: row.endUserId,
-    owner_name: row.userId
-      ? (userNames.get(row.userId) ?? null)
-      : row.endUserId
-        ? (endUserNames.get(row.endUserId) ?? null)
-        : null,
+    owner_name: ownerName(row),
     scopes_granted: row.scopesGranted ?? [],
     shared_with_org: row.sharedWithOrg,
     needs_reconnection: row.needsReconnection,

--- a/apps/api/test/integration/routes/integrations-connections-visibility.test.ts
+++ b/apps/api/test/integration/routes/integrations-connections-visibility.test.ts
@@ -217,6 +217,44 @@ describe("GET /api/integrations/:packageId/connections — own ∪ org-shared", 
     expect(ids).not.toContain(adminPrivate);
   });
 
+  it("keeps identity_claims redacted on the admin's rename echo of a shared connection", async () => {
+    const sharedId = await seedConnection({
+      userId: other.id,
+      accountId: "mike-shared",
+      shared: true,
+    });
+
+    // An org admin may rename a connection they do not own (owner OR admin on
+    // the label branch). The 200 echo must not hand back what the list
+    // withheld — otherwise the redaction is one PATCH away from bypassed.
+    const res = await app.request(`/api/integrations/${INTEGRATION}/connections/${sharedId}`, {
+      method: "PATCH",
+      headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+      body: JSON.stringify({ label: "Renamed by admin" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ConnectionDTO & { label?: string | null };
+    expect(body.label).toBe("Renamed by admin");
+    expect(body.identity_claims).toBeNull();
+  });
+
+  it("still returns identity_claims when the caller renames their OWN connection", async () => {
+    const ownId = await seedConnection({
+      userId: ctx.user.id,
+      accountId: "mine",
+      shared: false,
+    });
+
+    const res = await app.request(`/api/integrations/${INTEGRATION}/connections/${ownId}`, {
+      method: "PATCH",
+      headers: { ...authHeaders(ctx), "Content-Type": "application/json" },
+      body: JSON.stringify({ label: "My renamed connection" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ConnectionDTO;
+    expect(body.identity_claims).toEqual({ email: "mine@example.com", sub: "sub-mine" });
+  });
+
   it("reports auths[].ready for an actor who owns nothing but inherits a share", async () => {
     await seedConnection({ userId: other.id, accountId: "mike-shared", shared: true });
 

--- a/apps/api/test/integration/routes/integrations-connections-visibility.test.ts
+++ b/apps/api/test/integration/routes/integrations-connections-visibility.test.ts
@@ -1,0 +1,252 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Connection *visibility* at the HTTP boundary — who sees which
+ * `integration_connections` rows on the integration settings surface.
+ *
+ *   GET /api/integrations/:packageId/connections
+ *   GET /api/integrations/:packageId            (`auths[].connections`, `ready`)
+ *
+ * Both read `listIntegrationConnections`, whose predicate is the actor's own
+ * rows UNION every row opted into org-wide sharing — the same set the runtime
+ * resolver picks from. Before that union the list was own-only, which made the
+ * admin org-default and pin pickers unable to offer another member's shared
+ * connection (they filter this list for `shared_with_org`) even though the pin
+ * endpoint accepts one, and made `auths[].ready` report "not connected" for an
+ * actor whose run would in fact resolve a shared connection.
+ *
+ * Ownership-scoped *writes* keep their own tests: metadata PATCH authz lives in
+ * `integrations-authz.test.ts`, delete in `me.test.ts`.
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { getTestApp } from "../../helpers/app.ts";
+import { db, truncateAll } from "../../helpers/db.ts";
+import {
+  createTestContext,
+  createTestUser,
+  authHeaders,
+  type TestContext,
+} from "../../helpers/auth.ts";
+import { seedPackage } from "../../helpers/seed.ts";
+import { installPackage } from "../../../src/services/application-packages.ts";
+import { integrationConnections, organizationMembers } from "@appstrate/db/schema";
+import { encryptCredentialEnvelope } from "@appstrate/connect";
+import {
+  localIntegrationManifest,
+  httpHeaderDelivery,
+} from "../../helpers/integration-manifests.ts";
+
+const app = getTestApp();
+
+const INTEGRATION = "@visorg/svc";
+const MCP_SERVER = "@visorg/svc-server";
+
+interface ConnectionDTO {
+  id: string;
+  account_id: string;
+  owner_id: string;
+  owner_name?: string | null;
+  identity_claims: Record<string, unknown> | null;
+  shared_with_org?: boolean;
+}
+
+describe("GET /api/integrations/:packageId/connections — own ∪ org-shared", () => {
+  let ctx: TestContext;
+  /** A second dashboard user, plain `member` of the same org. */
+  let other: Awaited<ReturnType<typeof createTestUser>>;
+
+  function otherHeaders(): Record<string, string> {
+    return {
+      Cookie: other.cookie,
+      "X-Org-Id": ctx.orgId,
+      "X-Application-Id": ctx.defaultAppId,
+    };
+  }
+
+  async function seedConnection(opts: {
+    userId: string;
+    accountId: string;
+    shared: boolean;
+    needsReconnection?: boolean;
+  }): Promise<string> {
+    const [row] = await db
+      .insert(integrationConnections)
+      .values({
+        integrationId: INTEGRATION,
+        authKey: "primary",
+        accountId: opts.accountId,
+        applicationId: ctx.defaultAppId,
+        userId: opts.userId,
+        endUserId: null,
+        credentialsEncrypted: encryptCredentialEnvelope({ outputs: { api_key: "secret" } }),
+        scopesGranted: [],
+        identityClaims: { email: `${opts.accountId}@example.com`, sub: `sub-${opts.accountId}` },
+        sharedWithOrg: opts.shared,
+        needsReconnection: opts.needsReconnection ?? false,
+      })
+      .returning({ id: integrationConnections.id });
+    return row!.id;
+  }
+
+  async function listAs(headers: Record<string, string>): Promise<ConnectionDTO[]> {
+    const res = await app.request(`/api/integrations/${INTEGRATION}/connections`, { headers });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: ConnectionDTO[] };
+    return body.data;
+  }
+
+  beforeEach(async () => {
+    await truncateAll();
+    ctx = await createTestContext({ orgSlug: "visorg" });
+
+    other = await createTestUser({ name: "Mike Shared" });
+    await db.insert(organizationMembers).values({
+      orgId: ctx.orgId,
+      userId: other.id,
+      role: "member",
+    });
+
+    await seedPackage({
+      id: INTEGRATION,
+      orgId: ctx.orgId,
+      type: "integration",
+      source: "local",
+      draftManifest: localIntegrationManifest({
+        name: INTEGRATION,
+        serverName: MCP_SERVER,
+        version: "1.0.0",
+        auths: {
+          primary: {
+            type: "api_key",
+            authorizedUris: ["https://api.example.com/**"],
+            credentialFields: ["api_key"],
+            delivery: httpHeaderDelivery({
+              name: "Authorization",
+              prefix: "Bearer ",
+              field: "api_key",
+            }),
+          },
+        },
+        tools_policy: { search: {} },
+      }),
+    });
+    await installPackage({ orgId: ctx.orgId, applicationId: ctx.defaultAppId }, INTEGRATION);
+  });
+
+  it("returns another member's SHARED connection", async () => {
+    const sharedId = await seedConnection({
+      userId: other.id,
+      accountId: "mike-shared",
+      shared: true,
+    });
+
+    const ids = (await listAs(authHeaders(ctx))).map((c) => c.id);
+    expect(ids).toContain(sharedId);
+  });
+
+  it("never returns another member's PRIVATE connection", async () => {
+    const privateId = await seedConnection({
+      userId: other.id,
+      accountId: "mike-private",
+      shared: false,
+    });
+    const ownId = await seedConnection({
+      userId: ctx.user.id,
+      accountId: "mine",
+      shared: false,
+    });
+
+    const ids = (await listAs(authHeaders(ctx))).map((c) => c.id);
+    expect(ids).toContain(ownId);
+    expect(ids).not.toContain(privateId);
+  });
+
+  it("labels a shared row with its owner's display name", async () => {
+    const sharedId = await seedConnection({
+      userId: other.id,
+      accountId: "mike-shared",
+      shared: true,
+    });
+
+    const row = (await listAs(authHeaders(ctx))).find((c) => c.id === sharedId)!;
+    expect(row.owner_id).toBe(other.id);
+    expect(row.owner_name).toBe("Mike Shared");
+  });
+
+  it("redacts identity_claims on rows the caller does not own, keeps them on their own", async () => {
+    const sharedId = await seedConnection({
+      userId: other.id,
+      accountId: "mike-shared",
+      shared: true,
+    });
+    const ownId = await seedConnection({
+      userId: ctx.user.id,
+      accountId: "mine",
+      shared: false,
+    });
+
+    const rows = await listAs(authHeaders(ctx));
+    // Sharing consents to *using* the credential, not to publishing the
+    // owner's OIDC claim bag (email, sub) to every member of the org.
+    expect(rows.find((c) => c.id === sharedId)!.identity_claims).toBeNull();
+    expect(rows.find((c) => c.id === ownId)!.identity_claims).toEqual({
+      email: "mine@example.com",
+      sub: "sub-mine",
+    });
+    // `account_id` stays: the picker DTO already exposes it, and a connection
+    // you are allowed to pick has to be identifiable.
+    expect(rows.find((c) => c.id === sharedId)!.account_id).toBe("mike-shared");
+  });
+
+  it("is symmetric — the sharing member still sees only their own rows plus shares", async () => {
+    const adminPrivate = await seedConnection({
+      userId: ctx.user.id,
+      accountId: "admin-private",
+      shared: false,
+    });
+    const mikeOwn = await seedConnection({
+      userId: other.id,
+      accountId: "mike-shared",
+      shared: true,
+    });
+
+    const ids = (await listAs(otherHeaders())).map((c) => c.id);
+    expect(ids).toContain(mikeOwn);
+    // Being an org admin does not widen the *read* — only sharing does.
+    expect(ids).not.toContain(adminPrivate);
+  });
+
+  it("reports auths[].ready for an actor who owns nothing but inherits a share", async () => {
+    await seedConnection({ userId: other.id, accountId: "mike-shared", shared: true });
+
+    const res = await app.request(`/api/integrations/${INTEGRATION}`, {
+      headers: authHeaders(ctx),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      auths: Array<{ auth_key: string; ready: boolean; connections: ConnectionDTO[] }>;
+    };
+    const primary = body.auths.find((a) => a.auth_key === "primary")!;
+    // The caller owns no connection at all, yet a run resolves the shared one —
+    // `ready` tracks that, so the chat connect card stops asking them to
+    // connect something the platform already has.
+    expect(primary.ready).toBe(true);
+    expect(primary.connections).toHaveLength(1);
+  });
+
+  it("does not report ready when the only shared connection needs reconnection", async () => {
+    await seedConnection({
+      userId: other.id,
+      accountId: "mike-stale",
+      shared: true,
+      needsReconnection: true,
+    });
+
+    const res = await app.request(`/api/integrations/${INTEGRATION}`, {
+      headers: authHeaders(ctx),
+    });
+    const body = (await res.json()) as { auths: Array<{ auth_key: string; ready: boolean }> };
+    expect(body.auths.find((a) => a.auth_key === "primary")!.ready).toBe(false);
+  });
+});

--- a/apps/api/test/integration/services/integration-pins-service.test.ts
+++ b/apps/api/test/integration/services/integration-pins-service.test.ts
@@ -167,7 +167,10 @@ describe("integration-pins-service — DB access/ownership", () => {
       // Another member's private connection — must NOT be visible.
       await seedConnection({ applicationId: scope.applicationId, userId: memberId });
 
-      const list = await listAccessibleConnections(scope, INTEGRATION, { userId: ctx.user.id });
+      const list = await listAccessibleConnections(scope, INTEGRATION, {
+        type: "user",
+        id: ctx.user.id,
+      });
       const ids = list.map((c) => c.id);
       expect(ids).toContain(own);
       expect(ids).toContain(sharedByMember);
@@ -193,7 +196,10 @@ describe("integration-pins-service — DB access/ownership", () => {
         sharedWithOrg: true,
       });
 
-      const list = await listAccessibleConnections(scope, INTEGRATION, { userId: ctx.user.id });
+      const list = await listAccessibleConnections(scope, INTEGRATION, {
+        type: "user",
+        id: ctx.user.id,
+      });
       expect(list.map((c) => c.id)).toEqual([visible]);
     });
   });

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -1676,7 +1676,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** List the caller's connections for an integration */
+        /**
+         * List the connections the caller can use for an integration
+         * @description Returns the caller's own connections **plus** every connection in the application opted into org-wide sharing (`shared_with_org: true`), whoever owns it — the same set the runtime resolver picks from. Rows the caller does not own carry `owner_name` and have `identity_claims` redacted to `null`.
+         */
         get: operations["listIntegrationConnections"];
         put?: never;
         post?: never;
@@ -10810,6 +10813,8 @@ export interface operations {
                             /** @enum {string} */
                             owner_type: "user" | "end_user";
                             owner_id: string;
+                            /** @description Display name of the connection's owner (member name, or end-user name falling back to its external id); null when the owner row was deleted. Returned by the list surfaces, which include org-shared connections owned by other members; absent from the single-connection write responses, where the row is the caller's own. */
+                            owner_name?: string | null;
                             label?: string | null;
                             shared_with_org?: boolean;
                             /** @description The registered OAuth client that minted this connection (system env id or custom `integration_oauth_clients.id`). Null for non-oauth2 auths. The connection is bound to it — changing it requires reconnecting. */
@@ -10882,6 +10887,8 @@ export interface operations {
                                 /** @enum {string} */
                                 owner_type: "user" | "end_user";
                                 owner_id: string;
+                                /** @description Display name of the connection's owner (member name, or end-user name falling back to its external id); null when the owner row was deleted. Returned by the list surfaces, which include org-shared connections owned by other members; absent from the single-connection write responses, where the row is the caller's own. */
+                                owner_name?: string | null;
                                 label?: string | null;
                                 shared_with_org?: boolean;
                                 /** @description The registered OAuth client that minted this connection (system env id or custom `integration_oauth_clients.id`). Null for non-oauth2 auths. The connection is bound to it — changing it requires reconnecting. */
@@ -10988,6 +10995,8 @@ export interface operations {
                                 /** @enum {string} */
                                 owner_type: "user" | "end_user";
                                 owner_id: string;
+                                /** @description Display name of the connection's owner (member name, or end-user name falling back to its external id); null when the owner row was deleted. Returned by the list surfaces, which include org-shared connections owned by other members; absent from the single-connection write responses, where the row is the caller's own. */
+                                owner_name?: string | null;
                                 label?: string | null;
                                 shared_with_org?: boolean;
                                 /** @description The registered OAuth client that minted this connection (system env id or custom `integration_oauth_clients.id`). Null for non-oauth2 auths. The connection is bound to it — changing it requires reconnecting. */
@@ -11139,6 +11148,8 @@ export interface operations {
                         /** @enum {string} */
                         owner_type: "user" | "end_user";
                         owner_id: string;
+                        /** @description Display name of the connection's owner (member name, or end-user name falling back to its external id); null when the owner row was deleted. Returned by the list surfaces, which include org-shared connections owned by other members; absent from the single-connection write responses, where the row is the caller's own. */
+                        owner_name?: string | null;
                         label?: string | null;
                         shared_with_org?: boolean;
                         /** @description The registered OAuth client that minted this connection (system env id or custom `integration_oauth_clients.id`). Null for non-oauth2 auths. The connection is bound to it — changing it requires reconnecting. */
@@ -11417,6 +11428,8 @@ export interface operations {
                             /** @enum {string} */
                             owner_type: "user" | "end_user";
                             owner_id: string;
+                            /** @description Display name of the connection's owner (member name, or end-user name falling back to its external id); null when the owner row was deleted. Returned by the list surfaces, which include org-shared connections owned by other members; absent from the single-connection write responses, where the row is the caller's own. */
+                            owner_name?: string | null;
                             label?: string | null;
                             shared_with_org?: boolean;
                             /** @description The registered OAuth client that minted this connection (system env id or custom `integration_oauth_clients.id`). Null for non-oauth2 auths. The connection is bound to it — changing it requires reconnecting. */
@@ -11483,6 +11496,8 @@ export interface operations {
                         /** @enum {string} */
                         owner_type: "user" | "end_user";
                         owner_id: string;
+                        /** @description Display name of the connection's owner (member name, or end-user name falling back to its external id); null when the owner row was deleted. Returned by the list surfaces, which include org-shared connections owned by other members; absent from the single-connection write responses, where the row is the caller's own. */
+                        owner_name?: string | null;
                         label?: string | null;
                         shared_with_org?: boolean;
                         /** @description The registered OAuth client that minted this connection (system env id or custom `integration_oauth_clients.id`). Null for non-oauth2 auths. The connection is bound to it — changing it requires reconnecting. */
@@ -11985,6 +12000,8 @@ export interface operations {
                                 /** @enum {string} */
                                 owner_type: "user" | "end_user";
                                 owner_id: string;
+                                /** @description Display name of the connection's owner (member name, or end-user name falling back to its external id); null when the owner row was deleted. Returned by the list surfaces, which include org-shared connections owned by other members; absent from the single-connection write responses, where the row is the caller's own. */
+                                owner_name?: string | null;
                                 label?: string | null;
                                 shared_with_org?: boolean;
                                 /** @description The registered OAuth client that minted this connection (system env id or custom `integration_oauth_clients.id`). Null for non-oauth2 auths. The connection is bound to it — changing it requires reconnecting. */

--- a/apps/web/src/components/integration-connect/connection-label.ts
+++ b/apps/web/src/components/integration-connect/connection-label.ts
@@ -19,3 +19,23 @@ interface ConnectionLabelFields {
 export function connectionDisplayLabel(c: ConnectionLabelFields): string {
   return c.label ?? c.account_id;
 }
+
+interface ConnectionOwnerFields {
+  owner_type: "user" | "end_user";
+  owner_id: string;
+}
+
+/**
+ * Whether a connection belongs to the signed-in dashboard user.
+ *
+ * The connection lists return org-shared rows owned by other members (and,
+ * in a headless application, by end-users), so several controls key off
+ * ownership: the delete button, the share toggle and the OAuth renew CTA are
+ * owner-only server-side, and "do I already have an account connected?" must
+ * not count someone else's row. Both halves of the check matter — an
+ * `end_user` id could in principle collide with a user id, and only the pair
+ * identifies the owner.
+ */
+export function isConnectionOwnedBy(c: ConnectionOwnerFields, userId: string | undefined): boolean {
+  return c.owner_type === "user" && !!userId && c.owner_id === userId;
+}

--- a/apps/web/src/components/integration-connect/test/connection-label.test.ts
+++ b/apps/web/src/components/integration-connect/test/connection-label.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Unit tests for the connection display/ownership helpers.
+ *
+ * `isConnectionOwnedBy` gates every owner-only control on the integration
+ * detail page — delete, the share toggle, the OAuth renew CTA — against lists
+ * that now contain org-shared connections owned by OTHER members. A false
+ * positive renders a button whose request comes back 403/404; a false negative
+ * hides a control from the person who owns the row. Both halves of the check
+ * are load-bearing, so they are pinned here rather than left to the component.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { connectionDisplayLabel, isConnectionOwnedBy } from "../connection-label";
+
+describe("connectionDisplayLabel", () => {
+  it("renders the label verbatim when set", () => {
+    expect(connectionDisplayLabel({ account_id: "acct-1", label: "work@acme.com" })).toBe(
+      "work@acme.com",
+    );
+  });
+
+  it("falls back to the account id when the label is absent or null", () => {
+    expect(connectionDisplayLabel({ account_id: "acct-1" })).toBe("acct-1");
+    expect(connectionDisplayLabel({ account_id: "acct-1", label: null })).toBe("acct-1");
+  });
+});
+
+describe("isConnectionOwnedBy", () => {
+  const mine = { owner_type: "user", owner_id: "user_1" } as const;
+
+  it("matches the signed-in user's own connection", () => {
+    expect(isConnectionOwnedBy(mine, "user_1")).toBe(true);
+  });
+
+  it("rejects another member's connection", () => {
+    expect(isConnectionOwnedBy({ owner_type: "user", owner_id: "user_2" }, "user_1")).toBe(false);
+  });
+
+  it("rejects an end-user-owned row even when the ids collide", () => {
+    // Nothing guarantees an `eu_…` id can never equal a user id, and only the
+    // (type, id) pair identifies the owner — matching on the id alone would
+    // hand a dashboard user the controls for an end-user's credential.
+    expect(isConnectionOwnedBy({ owner_type: "end_user", owner_id: "user_1" }, "user_1")).toBe(
+      false,
+    );
+  });
+
+  it("rejects everything while the session is still loading", () => {
+    // `useAuth().user` is undefined on first paint; owning nothing is the safe
+    // default — controls appear once the session resolves, rather than
+    // flashing enabled for rows that may not be the caller's.
+    expect(isConnectionOwnedBy(mine, undefined)).toBe(false);
+  });
+});

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -778,6 +778,8 @@
   "integration.admin.pin.deleted": "Pin removed.",
   "integration.connection.shareWithOrg.label": "Share with organization",
   "integration.connection.shareWithOrg.help": "Other members will be able to use this connection for their runs.",
+  "integration.connection.sharedByOwner": "Shared by {{owner}}",
+  "integration.connection.sharedByUnknown": "Shared with the organization",
   "integration.connection.updated": "Connection updated.",
   "integration.connection.labelEdit": "Rename",
   "integration.connection.labelSave": "Save",

--- a/apps/web/src/locales/fr/settings.json
+++ b/apps/web/src/locales/fr/settings.json
@@ -778,6 +778,8 @@
   "integration.admin.pin.deleted": "Épinglage supprimé.",
   "integration.connection.shareWithOrg.label": "Partager avec l'organisation",
   "integration.connection.shareWithOrg.help": "Les autres membres pourront utiliser cette connexion pour leurs runs.",
+  "integration.connection.sharedByOwner": "Partagée par {{owner}}",
+  "integration.connection.sharedByUnknown": "Partagée avec l'organisation",
   "integration.connection.updated": "Connexion mise à jour.",
   "integration.connection.labelEdit": "Renommer",
   "integration.connection.labelSave": "Enregistrer",

--- a/apps/web/src/pages/integration-detail.tsx
+++ b/apps/web/src/pages/integration-detail.tsx
@@ -102,7 +102,10 @@ import { useCurrentOrgId } from "../hooks/use-org";
 import { useAuth } from "../hooks/use-auth";
 import { useCurrentApplicationId } from "../hooks/use-current-application";
 import { InlineConnectButton } from "../components/integration-connect/inline-connect-button";
-import { connectionDisplayLabel } from "../components/integration-connect/connection-label";
+import {
+  connectionDisplayLabel,
+  isConnectionOwnedBy,
+} from "../components/integration-connect/connection-label";
 import { isOauthAuthConnectable } from "../components/integration-connect/connectable-auth-keys";
 import { ConnectionStatusBadge } from "../components/integration-connect/connection-status-badge";
 
@@ -502,8 +505,8 @@ function ConnectAuthBlock({
   // account chooser" is about the CALLER's own accounts — it exists so a second
   // connect can't silently re-pick the account already signed in on this
   // browser. Someone else's shared connection says nothing about that.
-  const ownConnectionCount = status.connections.filter(
-    (c) => c.owner_type === "user" && c.owner_id === user?.id,
+  const ownConnectionCount = status.connections.filter((c) =>
+    isConnectionOwnedBy(c, user?.id),
   ).length;
 
   return (
@@ -1101,7 +1104,7 @@ function ConnectionTableRow({
   //   - share   → owner-only, because sharing is the owner's consent
   //               (`routes/integrations.ts`, `shared_with_org` branch);
   //   - rename  → owner OR org admin (same route, label branch).
-  const isOwn = connection.owner_type === "user" && connection.owner_id === user?.id;
+  const isOwn = isConnectionOwnedBy(connection, user?.id);
   const canRename = isOwn || isAdmin;
   const startEdit = () => {
     setDraftLabel(connection.label ?? "");

--- a/apps/web/src/pages/integration-detail.tsx
+++ b/apps/web/src/pages/integration-detail.tsx
@@ -99,6 +99,7 @@ import {
 import { useIntegrations } from "../hooks/use-integrations";
 import { useDisconnectIntegrationConnection } from "../hooks/use-me-connections";
 import { useCurrentOrgId } from "../hooks/use-org";
+import { useAuth } from "../hooks/use-auth";
 import { useCurrentApplicationId } from "../hooks/use-current-application";
 import { InlineConnectButton } from "../components/integration-connect/inline-connect-button";
 import { connectionDisplayLabel } from "../components/integration-connect/connection-label";
@@ -492,10 +493,18 @@ function ConnectAuthBlock({
   isAdmin: boolean;
 }) {
   const { t } = useTranslation("settings");
+  const { user } = useAuth();
   const isOAuth = status.type === "oauth2";
   // Connectable when a client is usable: org-registered, shared system client,
   // or auto-provisioned at connect time (remote MCP CIMD/DCR). Shared gate.
   const clientMissing = isOAuth && !isOauthAuthConnectable(status);
+  // `status.connections` is the own ∪ org-shared union, but "force the IdP's
+  // account chooser" is about the CALLER's own accounts — it exists so a second
+  // connect can't silently re-pick the account already signed in on this
+  // browser. Someone else's shared connection says nothing about that.
+  const ownConnectionCount = status.connections.filter(
+    (c) => c.owner_type === "user" && c.owner_id === user?.id,
+  ).length;
 
   return (
     <div className="bg-card rounded-lg border p-4" data-testid={`auth-section-${status.auth_key}`}>
@@ -518,7 +527,7 @@ function ConnectAuthBlock({
             authKey={status.auth_key}
             intent="connect"
             label={t("integration.auth.addAccount")}
-            forceAccountSelect={status.connections.length > 0}
+            forceAccountSelect={ownConnectionCount > 0}
             lockToAuthKey
           />
         ) : null}
@@ -703,6 +712,19 @@ function BlockUserConnectionsToggle({
  * overrides it. `enforce` locks members; otherwise it's a soft default a
  * member can still override with their own pick.
  */
+/**
+ * Option label for the two admin pickers (org default, pins). Those lists
+ * are org-wide — since the connections endpoint returns shared connections
+ * owned by other members, an admin choosing a cross-agent default is picking
+ * between rows whose labels can collide ("Connexion 1" for two members), so
+ * the owner is part of the identity here. The per-row table carries the same
+ * information as a badge instead, where a suffix would fight the rename UI.
+ */
+function connectionOptionLabel(c: IntegrationConnection): string {
+  const base = connectionDisplayLabel(c);
+  return c.owner_name ? `${base} — ${c.owner_name}` : base;
+}
+
 function OrgDefaultSection({ packageId }: { packageId: string }) {
   const { t } = useTranslation("settings");
   const { data: orgDefault } = useIntegrationOrgDefault(packageId);
@@ -714,7 +736,7 @@ function OrgDefaultSection({ packageId }: { packageId: string }) {
   const connectionDisplay = (id: string): string => {
     const c = (connections ?? []).find((x) => x.id === id);
     if (!c) return id;
-    return connectionDisplayLabel(c);
+    return connectionOptionLabel(c);
   };
 
   const [connectionId, setConnectionId] = useState("");
@@ -829,7 +851,7 @@ function PinManagementSection({ packageId }: { packageId: string }) {
   const connectionDisplay = (id: string): string => {
     const c = (connections ?? []).find((x) => x.id === id);
     if (!c) return id;
-    return connectionDisplayLabel(c);
+    return connectionOptionLabel(c);
   };
 
   const onSubmitNewPin = () => {
@@ -1062,6 +1084,8 @@ function ConnectionTableRow({
   const disconnect = useDisconnectIntegrationConnection();
   const orgId = useCurrentOrgId();
   const applicationId = useCurrentApplicationId();
+  const { user } = useAuth();
+  const { isAdmin } = usePermissions();
   const [editing, setEditing] = useState(false);
   const [draftLabel, setDraftLabel] = useState(connection.label ?? "");
   const [confirmDelete, setConfirmDelete] = useState(false);
@@ -1069,6 +1093,16 @@ function ConnectionTableRow({
   // "Connexion N"); render it verbatim.
   const name = connectionDisplayLabel(connection);
   const isShared = connection.shared_with_org === true;
+  // The list now returns org-shared connections owned by OTHER members, so
+  // every per-row control has to be gated on the same rule the API enforces —
+  // otherwise the button renders and the request comes back 403:
+  //   - delete  → `DELETE /api/me/connections/:id`, strictly owner-scoped
+  //               (`routes/me.ts`), no admin escape hatch by design;
+  //   - share   → owner-only, because sharing is the owner's consent
+  //               (`routes/integrations.ts`, `shared_with_org` branch);
+  //   - rename  → owner OR org admin (same route, label branch).
+  const isOwn = connection.owner_type === "user" && connection.owner_id === user?.id;
+  const canRename = isOwn || isAdmin;
   const startEdit = () => {
     setDraftLabel(connection.label ?? "");
     setEditing(true);
@@ -1139,16 +1173,29 @@ function ConnectionTableRow({
           ) : (
             <div className="flex items-center gap-1">
               <span className="truncate font-medium">{name}</span>
-              <Button
-                size="icon"
-                variant="ghost"
-                className="size-6"
-                onClick={startEdit}
-                title={t("integration.connection.labelEdit")}
-                data-testid={`label-edit-${connection.id}`}
-              >
-                <Pencil className="size-3" />
-              </Button>
+              {!isOwn && (
+                <Badge
+                  variant="secondary"
+                  className="text-[0.6rem]"
+                  data-testid={`connection-owner-${connection.id}`}
+                >
+                  {connection.owner_name
+                    ? t("integration.connection.sharedByOwner", { owner: connection.owner_name })
+                    : t("integration.connection.sharedByUnknown")}
+                </Badge>
+              )}
+              {canRename && (
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="size-6"
+                  onClick={startEdit}
+                  title={t("integration.connection.labelEdit")}
+                  data-testid={`label-edit-${connection.id}`}
+                >
+                  <Pencil className="size-3" />
+                </Button>
+              )}
             </div>
           )}
         </TableCell>
@@ -1162,7 +1209,12 @@ function ConnectionTableRow({
                   <ConnectionStatusBadge tone="needsReconnection">
                     {t("integration.auth.needsReconnection")}
                   </ConnectionStatusBadge>
-                  {canRenew && authType === "oauth2" && (
+                  {/* Owner-only: the reconnect writes through
+                      `persistCredentialBundle` kind `update-owned`, whose WHERE
+                      carries the actor identity — a non-owner reconnect 404s.
+                      Only the owner can re-authenticate their own credential,
+                      so others see the state without a dead CTA. */}
+                  {isOwn && canRenew && authType === "oauth2" && (
                     <InlineConnectButton
                       packageId={packageId}
                       authKey={authKey}
@@ -1207,41 +1259,51 @@ function ConnectionTableRow({
           )}
         </TableCell>
 
-        {/* Org-share toggle */}
+        {/* Org-share toggle — owner-only (sharing is the owner's consent) */}
         <TableCell>
-          <label
-            className="flex items-center gap-1.5 text-xs"
-            title={t("integration.connection.shareWithOrg.help")}
-          >
-            <input
-              type="checkbox"
-              checked={isShared}
-              disabled={updateConnection.isPending}
-              onChange={(e) =>
-                updateConnection.mutate({
-                  params: { path: { packageId, connectionId: connection.id } },
-                  body: { shared_with_org: e.target.checked },
-                })
-              }
-              data-testid={`share-toggle-${connection.id}`}
-            />
-            {t("integration.connection.shareWithOrg.label")}
-          </label>
+          {isOwn ? (
+            <label
+              className="flex items-center gap-1.5 text-xs"
+              title={t("integration.connection.shareWithOrg.help")}
+            >
+              <input
+                type="checkbox"
+                checked={isShared}
+                disabled={updateConnection.isPending}
+                onChange={(e) =>
+                  updateConnection.mutate({
+                    params: { path: { packageId, connectionId: connection.id } },
+                    body: { shared_with_org: e.target.checked },
+                  })
+                }
+                data-testid={`share-toggle-${connection.id}`}
+              />
+              {t("integration.connection.shareWithOrg.label")}
+            </label>
+          ) : (
+            <span className="text-muted-foreground text-xs">
+              {t("integration.connection.shareWithOrg.label")}
+            </span>
+          )}
         </TableCell>
 
-        {/* Disconnect */}
+        {/* Disconnect — owner-only: the endpoint is `/api/me/connections` */}
         <TableCell className="text-right">
-          <Button
-            size="icon"
-            variant="ghost"
-            className="size-7"
-            onClick={onDelete}
-            disabled={disconnect.isPending}
-            title={t("integration.connection.delete")}
-            data-testid={`connection-delete-${connection.id}`}
-          >
-            <Trash2 className="text-destructive size-3.5" />
-          </Button>
+          {isOwn ? (
+            <Button
+              size="icon"
+              variant="ghost"
+              className="size-7"
+              onClick={onDelete}
+              disabled={disconnect.isPending}
+              title={t("integration.connection.delete")}
+              data-testid={`connection-delete-${connection.id}`}
+            >
+              <Trash2 className="text-destructive size-3.5" />
+            </Button>
+          ) : (
+            <span className="text-muted-foreground text-xs">—</span>
+          )}
         </TableCell>
       </TableRow>
       <ConfirmModal

--- a/packages/shared-types/src/integrations.ts
+++ b/packages/shared-types/src/integrations.ts
@@ -49,6 +49,14 @@ export interface IntegrationConnection {
   owner_type: "user" | "end_user";
   owner_id: string;
   /**
+   * Display name of the owner (member name, or end-user name falling back to
+   * `externalId`); `null` when the owner row was deleted. Present on the
+   * *list* surfaces — which return org-shared rows the caller does not own,
+   * and so must say whose they are — and absent on the single-connection
+   * write responses, where the row is the caller's own by construction.
+   */
+  owner_name?: string | null;
+  /**
    * Display name, set at creation: the extracted identity (email/login) when
    * available, else "Connexion N". Stable for the connection's lifetime and
    * user-editable. The UI renders it verbatim.


### PR DESCRIPTION
## Problem

`listIntegrationConnections` (`apps/api/src/services/integration-connections.ts`) filtered on the actor alone. Every other reader of `integration_connections` reads the own ∪ `shared_with_org` union that the runtime resolver actually picks from:

| Reader | Predicate |
| --- | --- |
| `loadActorConnection` (`integration-connections.ts:219`) | own ∪ shared |
| `loadAccessibleConnectionById` (`:299`) | own ∪ shared |
| `listUsableIntegrationsForActor` (`:2099`) | own ∪ shared |
| `loadAccessibleConnections` (`integration-connection-resolver.ts:732`) | own ∪ shared |
| `listAccessibleConnections` (`integration-pins-service.ts:546`) | own ∪ shared |
| **`listIntegrationConnections`** | **own only** |

The own-only read was documented as intentional, but two surfaces built on top of it were silently wrong as a result:

1. **The admin pickers could not offer a teammate's connection.** `OrgDefaultSection` and `PinManagementSection` filter this list for `shared_with_org === true` — over own-only data, that filter can only ever match connections the admin shared themselves. The backend disagrees: `upsertIntegrationPin` (`integration-pins-service.ts:358`) only requires `sharedWithOrg = true`, whoever owns it. So the API accepted a pin the UI could never construct.

2. **`auths[].ready` reported "not connected" for an actor whose run would succeed.** `ready` is derived from this same list, so an actor who owns no connection but inherits a shared one read as not-ready — which is the *normal* state under `block_user_connections`, where a member cannot create a connection at all and a shared one is the only path to a successful run.

Two distinct read paths made this invisible in testing: the agent's Connections tab goes through `connection-readiness` → `listAccessibleConnections` (union, correct), while the integration page goes through `listIntegrationConnections` (own-only).

## Change

**Backend**
- `listIntegrationConnections` now reads `or(ownerPredicate, sharedWithOrg)`, matching the resolver.
- Rows carry `owner_name` (batched lookup) so the UI can attribute them.
- Rows the caller does **not** own come back with `identity_claims: null`. Sharing a connection consents to *using* the credential, not to publishing the owner's OIDC claim bag (email, sub) to every member of the org. `account_id` and `scopes_granted` stay — the picker DTO already exposed both, and a connection you may pick has to be identifiable.
- Owner-name resolution extracted to `services/integration-connection-owner-names.ts`, shared with the picker's `attachOwnerNames`, so the two cannot drift on the end-user fallback rule (`name`, then `externalId`).

**Frontend** — every per-row control is gated on the authz the API already enforces, so no control renders that is guaranteed to fail:

| Control | Gate | Enforced by |
| --- | --- | --- |
| Delete | owner only | `DELETE /api/me/connections/:id` (`routes/me.ts:282`) |
| Share toggle | owner only | `routes/integrations.ts` — `shared_with_org` is consent |
| OAuth renew CTA | owner only | `persistCredentialBundle` kind `update-owned` carries the actor in its WHERE → a non-owner reconnect 404s |
| Rename | owner **or** org admin | `routes/integrations.ts:1095-1117` |

Plus: a "Shared by X" badge on rows owned by others; the admin picker options are suffixed with the owner (two members' "Connexion 1" would otherwise be indistinguishable); `forceAccountSelect` now counts the caller's *own* connections rather than the union — someone else's connection says nothing about which account this browser is signed into.

**Contract** — `listIntegrationConnections` summary/description widened, `owner_name` documented on the shared connection schema (additive, present on list surfaces, absent on single-connection write responses).

## Behaviour changes worth a reviewer's attention

1. **`auths[].ready` can now be true without the member having connected anything.** The chat connect card (`packages/module-chat/src/ui/oauth-connect-card.tsx:145`) reads `auths.some(a => a.ready)` and will show "connected". This is the runtime truth — the run resolves the shared connection — but it is the most user-visible consequence.
2. **A member now sees `account_id` / `scopes_granted` of other members' shared connections.** Consistent with the agent picker, which already exposed both. `identity_claims` is redacted, which nothing exposed before.

## Testing

New `apps/api/test/integration/routes/integrations-connections-visibility.test.ts` — 7 cases: shared row visible to another member; another member's *private* row never visible; `owner_name` populated; `identity_claims` redacted for non-owned and intact for own (`account_id` preserved); symmetry from the sharing member's side; `ready` true by inheritance; `ready` false when the only shared connection is `needs_reconnection`.

- `bun run check` — 33/33 tasks, `verify:openapi` ALL CHECKS PASSED
- `bun run detect:breaking` — **0 breaking, 49 non-breaking**
- 410 tests across the touched suites (integrations routes/services, `me`, pins, web unit), 0 failures

The OpenAPI baseline is deliberately **not** regenerated: it already trails 47 unrelated additive diffs from earlier merges (`generation`, `effective_timeout_seconds`, …), and regenerating here would pull all of them into this diff. `detect:breaking` passes without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
