### PR TITLE
fix(chat): name listAgents/listSkills in the truncated-list escape hatch

### DIFF
--- a/apps/api/src/openapi/paths/me.ts
+++ b/apps/api/src/openapi/paths/me.ts
@@ -473,8 +473,8 @@ export const mePaths = {
                     description:
                       "Agents the caller can run in the current application (capped). Only " +
                       "present when the caller holds the `agents:run` permission; empty otherwise. " +
-                      "When `agents_truncated` is true, the long tail is reachable via the MCP " +
-                      "`search_operations` tool.",
+                      "When `agents_truncated` is true, the full list is reachable via the " +
+                      "`listAgents` operation.",
                     items: {
                       type: "object",
                       required: [
@@ -512,7 +512,7 @@ export const mePaths = {
                   agents_truncated: {
                     type: "boolean",
                     description:
-                      "True when the agent list was capped (more via search_operations).",
+                      "True when the agent list was capped (full list via `listAgents`).",
                   },
                   agents_total: {
                     type: "integer",
@@ -524,8 +524,8 @@ export const mePaths = {
                       "Skills the caller could attach to an agent in the current application " +
                       "(capped). Only present when the caller holds the `agents:run` permission; " +
                       "empty otherwise. Skills are not run directly — declare them under an agent " +
-                      "manifest's `dependencies.skills`. When `skills_truncated` is true, the long " +
-                      "tail is reachable via the MCP `search_operations` tool.",
+                      "manifest's `dependencies.skills`. When `skills_truncated` is true, the " +
+                      "full list is reachable via the `listSkills` operation.",
                     items: {
                       type: "object",
                       required: [
@@ -563,7 +563,7 @@ export const mePaths = {
                   skills_truncated: {
                     type: "boolean",
                     description:
-                      "True when the skill list was capped (more via search_operations).",
+                      "True when the skill list was capped (full list via `listSkills`).",
                   },
                   skills_total: {
                     type: "integer",

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -12605,7 +12605,7 @@ export interface operations {
                             /** @description AFPS §4.4 — tool(s) an agent inherits when it declares this integration without an `integrations_configuration.<id>.tools` selection. Absent or `[]` means an agent that declares this integration without its own selection ends up with nothing callable, which publish/import reject and the run aborts on — such an agent must select a tool explicitly. To use any other tool, inspect the full `tool_catalog` via GET /api/integrations/{packageId}. */
                             default_tools?: string[] | "*";
                         }[];
-                        /** @description Agents the caller can run in the current application (capped). Only present when the caller holds the `agents:run` permission; empty otherwise. When `agents_truncated` is true, the long tail is reachable via the MCP `search_operations` tool. */
+                        /** @description Agents the caller can run in the current application (capped). Only present when the caller holds the `agents:run` permission; empty otherwise. When `agents_truncated` is true, the full list is reachable via the `listAgents` operation. */
                         agents: {
                             /** @description Invokable identifier, e.g. "@appstrate/triage". */
                             package_id: string;
@@ -12618,11 +12618,11 @@ export interface operations {
                             /** @enum {string} */
                             source: "system" | "local";
                         }[];
-                        /** @description True when the agent list was capped (more via search_operations). */
+                        /** @description True when the agent list was capped (full list via `listAgents`). */
                         agents_truncated: boolean;
                         /** @description Total runnable agents before the cap. */
                         agents_total: number;
-                        /** @description Skills the caller could attach to an agent in the current application (capped). Only present when the caller holds the `agents:run` permission; empty otherwise. Skills are not run directly — declare them under an agent manifest's `dependencies.skills`. When `skills_truncated` is true, the long tail is reachable via the MCP `search_operations` tool. */
+                        /** @description Skills the caller could attach to an agent in the current application (capped). Only present when the caller holds the `agents:run` permission; empty otherwise. Skills are not run directly — declare them under an agent manifest's `dependencies.skills`. When `skills_truncated` is true, the full list is reachable via the `listSkills` operation. */
                         skills: {
                             /** @description Attachable identifier, e.g. "@appstrate/web-research". Declare under dependencies.skills. */
                             package_id: string;
@@ -12635,7 +12635,7 @@ export interface operations {
                             /** @enum {string} */
                             source: "system" | "local";
                         }[];
-                        /** @description True when the skill list was capped (more via search_operations). */
+                        /** @description True when the skill list was capped (full list via `listSkills`). */
                         skills_truncated: boolean;
                         /** @description Total installed skills before the cap. */
                         skills_total: number;

--- a/packages/module-chat/src/prompt.ts
+++ b/packages/module-chat/src/prompt.ts
@@ -251,7 +251,10 @@ export function formatCallerContext(raw: unknown, opts?: { locale?: string }): s
       );
     }
     if (ctx.agents_truncated) {
-      lines.push("More agents are available — use the search_operations tool to find them.");
+      lines.push(
+        "More agents are available — call `invoke_operation` with " +
+          '`operation_id: "listAgents"` for the full list.',
+      );
     }
     lines.push(
       "Prefer running an existing agent over doing the work inline when one fits the task. " +
@@ -269,7 +272,10 @@ export function formatCallerContext(raw: unknown, opts?: { locale?: string }): s
       );
     }
     if (ctx.skills_truncated) {
-      lines.push("More skills are available — use the search_operations tool to find them.");
+      lines.push(
+        "More skills are available — call `invoke_operation` with " +
+          '`operation_id: "listSkills"` for the full list.',
+      );
     }
     lines.push(
       "Skills are not run on their own. When you build or configure an agent and one of these " +

--- a/packages/module-chat/test/caller-context.test.ts
+++ b/packages/module-chat/test/caller-context.test.ts
@@ -131,10 +131,10 @@ describe("formatCallerContext", () => {
     expect(out).toContain("`@acme/report`");
     expect(out).toContain("(takes input: yes)");
     expect(out).toContain("Prefer running an existing agent");
-    expect(out).not.toContain("use the search_operations tool");
+    expect(out).not.toContain("More agents are available");
   });
 
-  it("adds the search_operations note only when the agent list is truncated", () => {
+  it("adds the listAgents note only when the agent list is truncated", () => {
     const out = formatCallerContext({
       user: { name: "Ada" },
       org: { role: "member" },
@@ -142,7 +142,7 @@ describe("formatCallerContext", () => {
       agents: [{ package_id: "@appstrate/triage", takes_input: false }],
       agents_truncated: true,
     });
-    expect(out).toContain("use the search_operations tool");
+    expect(out).toContain('`operation_id: "listAgents"`');
   });
 
   it("renders a context block from agents alone (no identity/connections)", () => {
@@ -199,6 +199,10 @@ describe("formatCallerContext", () => {
       skills_truncated: true,
     });
     expect(out).toContain("More skills are available");
+    // The escape hatch must name the operation. `search_operations` ranks
+    // `listSkills` below every create/delete variant, so a keyword search is
+    // not a reliable path back to the truncated list.
+    expect(out).toContain('`operation_id: "listSkills"`');
   });
 
   it("renders a context block from skills alone (no identity/connections/agents)", () => {


### PR DESCRIPTION
Fixes the misdirection described in #1119.

When the caller-context agent or skill list is capped (`DEFAULT_PACKAGE_HINT_LIMIT` = 15), the prompt told the model to recover the rest with `search_operations`. That tool searches API *operations* by keyword, not packages, so at best it is a two-step detour. In practice it does not get there:

| query | `listSkills` in results? | `best_match` returned |
|---|---|---|
| `"skills"` (limit 6) | no | **`createSkill`** (POST, creates a skill) |
| `"list skills available to attach to an agent"` (limit 25) | no | `getLibrary` |

`listSkills` is outranked by `createSkill`, `createSkillVersion`, `deleteSkill`, `deleteSkillById`, `deleteSkillVersion`. The first row is the concerning one: the tool description invites the model to invoke `best_match` directly, and that `best_match` is a **write**.

Two further reasons the old wording was the wrong default:

1. It contradicts the MCP server instructions carried in the same system prompt: *"Reach for `search_operations` only when the index is genuinely ambiguous or a capability you expect isn't listed — not as a routine first step."*
2. On the Codex engine `applyOperationIndexPolicy` trims the operation index out of the prompt, so the model cannot pick `listSkills` from the index either. Naming the operation works on both engines, since `invoke_operation` takes an `operation_id` and needs no index.

Neither `listAgents` nor `listSkills` is paginated, so one call returns everything.

## Changes

- `packages/module-chat/src/prompt.ts` — both truncation notices name their operation.
- `apps/api/src/openapi/paths/me.ts` — the four `getMyContext` descriptions carried the same misdirection (`agents` / `skills` arrays and both `*_truncated` booleans), plus the regenerated `schema.d.ts`.
- One existing assertion pinned the literal `"use the search_operations tool"`; it now asserts the operation id, with a comment on why a keyword search is not a reliable path back.

## Verification

Local instance seeded to 16 skills so `skills_truncated` is true and `@appstrate/data-analysis` falls outside the cap, then asked the chat whether that capability existed in the org.

- Before: no reliable path back to it.
- After: a single `listSkills` tool call, then the correct answer with the exact id.

`bun run check` 33/33. `bun test packages/module-chat/test` 343/343 on this branch, rebased on current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
