### PR TITLE
fix(runtime-pi): preserve OOXML api_call downloads

### DIFF
--- a/apps/api/src/modules/mcp/tools.ts
+++ b/apps/api/src/modules/mcp/tools.ts
@@ -53,6 +53,7 @@ import {
   type DocumentCapabilities,
 } from "../../services/documents.ts";
 import { isTextShapedMime, normalizeMime } from "../../services/mime-policy.ts";
+import { isTextShapedContentType } from "@appstrate/core/mime";
 import { asString, textResult } from "./tool-results.ts";
 import { buildPackageDocumentTools } from "./package-document-tools.ts";
 
@@ -509,8 +510,13 @@ export async function readResponse(response: Response): Promise<CallToolResult> 
     );
   }
 
-  const isTextual =
-    contentType.includes("json") || contentType.startsWith("text/") || contentType === "";
+  // Same predicate as every other text/binary decision in the platform
+  // (`@appstrate/core/mime`) — a package download served as OOXML must be
+  // summarised, never decoded. An ABSENT Content-Type stays textual here, which
+  // the shared predicate deliberately refuses: this path only ever reads our own
+  // API, whose bodiless 204s carry no type and must not be reported as an
+  // omitted binary.
+  const isTextual = contentType === "" || isTextShapedContentType(contentType);
   if (!isTextual) {
     const len = response.headers.get("content-length");
     return textResult(

--- a/apps/api/src/services/mime-policy.ts
+++ b/apps/api/src/services/mime-policy.ts
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * MIME policy — the ONE module that normalizes a MIME string, decides whether it
- * is text-shaped, and compares a declaration against sniffed magic bytes. Shared
- * by every path that handles a MIME so the rules cannot drift between them:
+ * MIME policy — the ONE module that compares a MIME declaration against sniffed
+ * magic bytes and decides what a path should do about a mismatch. Normalization
+ * and text-shape classification come from `@appstrate/core/mime` (re-exported
+ * below) because the runtime layers ask the same question. Shared by every path
+ * that handles a MIME so the rules cannot drift between them:
  *
  *  - Staged-upload consume (`services/uploads.ts` → run workspace / durable doc)
  *  - Proxy-upload sink (`routes/uploads.ts` — signed-vs-declared Content-Type)
@@ -26,54 +28,17 @@
  *    so the label stays honest and the preview/kind logic downstream stays safe.
  */
 
-/** Strip charset / boundary / other parameters from a MIME string and lowercase it. */
-export function normalizeMime(mime: string): string {
-  return mime.split(";")[0]?.trim().toLowerCase() ?? "";
-}
-
 /**
- * Is this MIME text-shaped — i.e. does the format carry its payload as text
- * rather than as a binary container (plain text, JSON, CSV, XML source, YAML,
- * JS, …)?
- *
- * ONE predicate, two consumers, because they ask the same question:
- *
- *  - **Sniff enforcement** ({@link shouldEnforceSniffedMime}): text-shaped
- *    formats have no magic bytes, so `file-type` can never confirm them — the
- *    strict declared-vs-sniffed check is skipped and the declared mime trusted.
- *    Callers that need strict binary validation should declare a concrete binary
- *    MIME (application/pdf, image/*, …) which `file-type` can identify.
- *  - **MCP `resources/read`** (`modules/mcp/tools.ts`): text-shaped bytes are
- *    inlined as a `text` block; anything else goes out as a base64 `blob`.
- *
- * The two used to carry separate lists and drifted: the MCP copy did not know
- * about the YAML family (`application/x-yaml`, `+yaml`), so a YAML document was
- * base64-blobbed instead of being handed to the model as readable text.
+ * {@link normalizeMime} and {@link isTextShapedMime} are re-exported from
+ * `@appstrate/core/mime`, NOT defined here. The "is this text or an opaque
+ * binary?" question is also asked by the AFPS runtime (`http-call-core.ts`) and
+ * by the sidecar (`runtime-pi/sidecar/mcp.ts`), neither of which can import
+ * from `apps/api` — core sits below all three. Every copy that lived at a call
+ * site drifted from the others and shipped a bug; add a format in core, not
+ * here.
  */
-export function isTextShapedMime(mime: string): boolean {
-  if (mime.startsWith("text/")) return true;
-  // Structured text payloads with no reliable magic signature.
-  const textShaped = new Set([
-    "application/json",
-    "application/x-ndjson",
-    "application/ld+json",
-    "application/xml",
-    "application/x-yaml",
-    "application/yaml",
-    "application/csv",
-    "application/javascript",
-    "application/ecmascript",
-    "application/x-sh",
-    "application/x-httpd-php",
-    "application/x-www-form-urlencoded",
-    "image/svg+xml", // XML-based, file-type never matches it
-  ]);
-  if (textShaped.has(mime)) return true;
-  // Structured-suffix convention (RFC 6839) — `+json`, `+xml`, `+yaml`.
-  // Anything in these families is text-shaped and cannot be magic-sniffed.
-  if (mime.endsWith("+json") || mime.endsWith("+xml") || mime.endsWith("+yaml")) return true;
-  return false;
-}
+export { normalizeMime, isTextShapedMime } from "@appstrate/core/mime";
+import { isTextShapedMime, normalizeMime } from "@appstrate/core/mime";
 
 /**
  * MIMEs whose on-disk format is a ZIP container. `file-type` samples only the

--- a/bun.lock
+++ b/bun.lock
@@ -263,6 +263,10 @@
         "semver": "^7.8.4",
         "zod": "^4.4.3",
       },
+      "devDependencies": {
+        "@types/mime-db": "^1.43.6",
+        "mime-db": "^1.54.0",
+      },
       "peerDependencies": {
         "@aws-sdk/client-s3": "^3",
         "@aws-sdk/lib-storage": "^3",
@@ -1400,6 +1404,8 @@
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/mime-db": ["@types/mime-db@1.43.6", "", {}, "sha512-r2cqxAt/Eo5yWBOQie1lyM1JZFCiORa5xtLlhSZI0w8RJggBPKw8c4g/fgQCzWydaDR5bL4imnmix2d1n52iBw=="],
 
     "@types/mime-types": ["@types/mime-types@2.1.4", "", {}, "sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w=="],
 

--- a/packages/afps-runtime/src/resolvers/http-call-core.ts
+++ b/packages/afps-runtime/src/resolvers/http-call-core.ts
@@ -1236,25 +1236,67 @@ function toArrayBufferUint8(source: Uint8Array): Uint8Array<ArrayBuffer> {
  * the bug fix at the heart of issues #149 / #151. `application/octet-stream`
  * with a body that happens to be ASCII MUST come back as inline bytes,
  * not text.
+ *
+ * CANONICAL LIST: `@appstrate/core/mime` (`isTextShapedMime`), which the
+ * platform MIME policy and the sidecar's `api_call` classifier both delegate
+ * to. This copy is NOT free-form — it is the same policy, kept local only
+ * because `afps-runtime` deliberately carries no dependency on core (it is a
+ * portable bundle runner and a standalone `afps` CLI; core sits beside it, not
+ * below it, so importing it would pull the whole platform surface into the
+ * runtime's install). `test/resolvers/http-call-core-mime-parity.test.ts`
+ * asserts the two agree, so a format added to core cannot silently skip this
+ * path. Add formats in core FIRST, then mirror them here.
+ *
+ * Every rule below matches an exact media type or an RFC 6839 structured
+ * suffix — never a substring. `contentType.includes("xml")` classifies
+ * `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` (an XLSX,
+ * i.e. a ZIP binary) as text and corrupts it on decode; that is the bug this
+ * predicate exists to prevent.
  */
-function isTextLikeMimeType(contentType: string | null | undefined): boolean {
+export function isTextLikeMimeType(contentType: string | null | undefined): boolean {
   if (!contentType) return false;
   const ct = contentType.toLowerCase();
   if (ct.startsWith("text/")) return true;
-  // Charset suffix is a strong signal regardless of base type.
+  // Charset parameter is a strong signal regardless of base type — the one
+  // rule specific to this path (an upstream that bothers to declare a charset
+  // is telling us the body is text).
   if (/;\s*charset=/.test(ct)) return true;
-  // Structured-syntax suffixes for JSON/XML (RFC 6839) — `+json`, `+xml`.
-  // These must come before the general substring tests so e.g.
-  // `application/vnd.api+json` is treated as text.
-  if (/\+json(\s*;|$)/.test(ct)) return true;
-  if (/\+xml(\s*;|$)/.test(ct)) return true;
-  // Common base types.
-  if (ct.startsWith("application/json")) return true;
-  if (ct.startsWith("application/xml")) return true;
-  if (ct.startsWith("application/javascript")) return true;
-  if (ct.startsWith("application/ecmascript")) return true;
-  return false;
+  const mediaType = ct.split(";", 1)[0]!.trim();
+  // Structured-syntax suffixes (RFC 6839) — `+json`, `+xml`, `+yaml`.
+  if (mediaType.endsWith("+json") || mediaType.endsWith("+xml") || mediaType.endsWith("+yaml")) {
+    return true;
+  }
+  return TEXT_LIKE_MEDIA_TYPES.has(mediaType);
 }
+
+/**
+ * Mirror of the media-type set in `@appstrate/core/mime`. Kept in sync by
+ * `http-call-core-mime-parity.test.ts` — do not edit one without the other.
+ */
+export const TEXT_LIKE_MEDIA_TYPES: ReadonlySet<string> = new Set([
+  // JSON family
+  "application/json",
+  "application/ld+json",
+  "application/x-ndjson",
+  "application/jsonl",
+  "application/json-seq",
+  // XML family
+  "application/xml",
+  "application/xml-dtd",
+  "application/xml-external-parsed-entity", // RFC 7303
+  "image/svg+xml",
+  // YAML family
+  "application/yaml",
+  "application/x-yaml",
+  // Scripting / tabular / form encodings with no magic signature
+  "application/javascript",
+  "application/x-javascript",
+  "application/ecmascript",
+  "application/csv",
+  "application/x-sh",
+  "application/x-httpd-php",
+  "application/x-www-form-urlencoded",
+]);
 
 function parseMimeType(contentType: string | null | undefined): string {
   if (!contentType) return "application/octet-stream";

--- a/packages/afps-runtime/test/resolvers/http-call-core-mime-parity.test.ts
+++ b/packages/afps-runtime/test/resolvers/http-call-core-mime-parity.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Appstrate
+
+/**
+ * Drift guard between `http-call-core.ts`'s local text/binary predicate and the
+ * canonical one in `@appstrate/core/mime`.
+ *
+ * These two lists must answer identically, but `afps-runtime` deliberately
+ * carries no runtime dependency on core (it ships as a portable bundle runner
+ * and a standalone `afps` CLI; core sits beside it in the dependency graph, not
+ * below it), so the list is mirrored rather than imported. Core IS a
+ * devDependency here — enough to assert the mirror at build time without
+ * putting core in a consumer's install.
+ *
+ * Three separate hand-rolled copies of this policy already drifted once: the
+ * MCP copy did not know about the YAML family, and the sidecar's substring
+ * match classified an XLSX as XML and corrupted every OOXML download. This test
+ * is what makes the fourth divergence a red build instead of a support ticket.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { isTextShapedMime, normalizeMime, TEXT_SHAPED_MEDIA_TYPES } from "@appstrate/core/mime";
+import { isTextLikeMimeType, TEXT_LIKE_MEDIA_TYPES } from "../../src/resolvers/http-call-core.ts";
+
+describe("http-call-core text predicate ↔ @appstrate/core/mime parity", () => {
+  it("mirrors core's media-type set exactly", () => {
+    expect([...TEXT_LIKE_MEDIA_TYPES].sort()).toEqual([...TEXT_SHAPED_MEDIA_TYPES].sort());
+  });
+
+  it("agrees with core on every registered text media type", () => {
+    for (const mime of TEXT_SHAPED_MEDIA_TYPES) {
+      expect(isTextLikeMimeType(mime)).toBe(true);
+      expect(isTextShapedMime(mime)).toBe(true);
+    }
+  });
+
+  // Content types that must classify identically on both sides. The charset
+  // rule is the ONE documented asymmetry (see below), so nothing here carries a
+  // charset parameter.
+  const CORPUS = [
+    "text/plain",
+    "text/csv",
+    "application/json",
+    "application/vnd.api+json",
+    "application/xml",
+    "application/atom+xml",
+    "application/vnd.oai.openapi+yaml",
+    "image/svg+xml",
+    "application/octet-stream",
+    "application/pdf",
+    "image/png",
+    "application/zip",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.ms-excel.sheet.macroenabled.12",
+    "application/vnd.oasis.opendocument.spreadsheet",
+    "application/epub+zip",
+  ];
+
+  it.each(CORPUS)("classifies %s the same way as core", (contentType) => {
+    expect(isTextLikeMimeType(contentType)).toBe(isTextShapedMime(normalizeMime(contentType)));
+  });
+
+  it("keeps the documented charset asymmetry, and only that", () => {
+    // `http_call` trusts an explicit charset parameter as a declaration of
+    // textness whatever the base type; core's predicate is media-type-only
+    // because its other consumers (upload sniff enforcement) must not let a
+    // caller talk a binary past the magic-byte check by appending a charset.
+    expect(isTextLikeMimeType("application/octet-stream; charset=utf-8")).toBe(true);
+    expect(isTextShapedMime(normalizeMime("application/octet-stream; charset=utf-8"))).toBe(false);
+  });
+
+  it("never lets a charset parameter rescue an OOXML download", () => {
+    // The asymmetry above is scoped to the charset signal. An OOXML container
+    // has no charset, so both sides refuse it and the bytes survive.
+    const xlsx = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    expect(isTextLikeMimeType(xlsx)).toBe(false);
+    expect(isTextShapedMime(normalizeMime(xlsx))).toBe(false);
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -105,6 +105,10 @@
     "semver": "^7.8.4",
     "zod": "^4.4.3"
   },
+  "devDependencies": {
+    "@types/mime-db": "^1.43.6",
+    "mime-db": "^1.54.0"
+  },
   "peerDependencies": {
     "@aws-sdk/client-s3": "^3",
     "@aws-sdk/lib-storage": "^3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,7 @@
     "./zip": "./src/zip.ts",
     "./package-files": "./src/package-files.ts",
     "./naming": "./src/naming.ts",
+    "./mime": "./src/mime.ts",
     "./dependencies": "./src/dependencies.ts",
     "./integrity": "./src/integrity.ts",
     "./semver": "./src/semver.ts",

--- a/packages/core/src/mime.ts
+++ b/packages/core/src/mime.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Appstrate
+
+/**
+ * MIME classification primitives — the ONE place that answers "is this media
+ * type a text payload or an opaque binary container?".
+ *
+ * Lives in core because the question is asked at three layers that cannot
+ * import each other:
+ *
+ *  - **Platform API** (`apps/api/src/services/mime-policy.ts`) — sniff
+ *    enforcement on uploads, MCP `resources/read` inlining.
+ *  - **AFPS runtime** (`packages/afps-runtime` → `http-call-core.ts`) — decides
+ *    whether an `http_call` response body is decoded as text or base64'd.
+ *  - **Sidecar** (`runtime-pi/sidecar/mcp.ts`) — decides whether an `api_call`
+ *    response is inlined as text or spilled to the blob store as bytes.
+ *
+ * Every one of those had its own hand-rolled list, and the lists drifted:
+ *
+ *  - The MCP copy did not know about the YAML family, so a YAML document was
+ *    base64-blobbed instead of being handed to the model as readable text.
+ *  - The sidecar matched `contentType.includes("xml")`, which classifies
+ *    `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` (an
+ *    XLSX — a ZIP binary) as text. The UTF-8 decode replaced invalid bytes with
+ *    U+FFFD and the re-encode wrote that corruption to disk, destroying every
+ *    OOXML file downloaded through `responseMode.toFile`.
+ *
+ * Both bugs are the same bug: an ad-hoc list, matched by substring instead of
+ * by media type. Add a format HERE, not at a call site.
+ */
+
+/**
+ * Strip charset / boundary / other parameters from a MIME string and lowercase
+ * it, so `text/csv; charset=utf-8` compares equal to `text/csv`.
+ *
+ * Every predicate in this module expects an already-normalized value —
+ * classification and normalization stay separate so a caller that already holds
+ * a bare media type does not pay for the split twice.
+ */
+export function normalizeMime(mime: string | null | undefined): string {
+  if (!mime) return "";
+  return mime.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+}
+
+/**
+ * Media types whose payload is text, matched EXACTLY. A substring test would
+ * classify `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`
+ * as XML — see the module doc.
+ *
+ * Exported so a layer that cannot import core (`packages/afps-runtime`, which
+ * ships as a standalone runner) can assert its own mirror of this list still
+ * agrees, instead of discovering the drift in production.
+ */
+export const TEXT_SHAPED_MEDIA_TYPES: ReadonlySet<string> = new Set([
+  // JSON family
+  "application/json",
+  "application/ld+json",
+  "application/x-ndjson",
+  "application/jsonl",
+  "application/json-seq",
+  // XML family
+  "application/xml",
+  "application/xml-dtd",
+  "application/xml-external-parsed-entity", // RFC 7303
+  "image/svg+xml", // XML-based, file-type never matches it
+  // YAML family
+  "application/yaml",
+  "application/x-yaml",
+  // Scripting / tabular / form encodings with no magic signature
+  "application/javascript",
+  "application/x-javascript",
+  "application/ecmascript",
+  "application/csv",
+  "application/x-sh",
+  "application/x-httpd-php",
+  "application/x-www-form-urlencoded",
+]);
+
+/**
+ * Is this MIME text-shaped — i.e. does the format carry its payload as text
+ * (plain text, JSON, CSV, XML source, YAML, JS, …) rather than as a binary
+ * container?
+ *
+ * Expects a NORMALIZED media type ({@link normalizeMime}); a value carrying
+ * `; charset=…` never matches the exact sets below.
+ *
+ * Three consumers ask this same question and must answer it identically:
+ *
+ *  - **Sniff enforcement** (`shouldEnforceSniffedMime`): text-shaped formats
+ *    have no magic bytes, so `file-type` can never confirm them — the strict
+ *    declared-vs-sniffed check is skipped and the declared mime trusted.
+ *    Callers needing strict binary validation should declare a concrete binary
+ *    MIME (application/pdf, image/*, …) which `file-type` can identify.
+ *  - **MCP `resources/read`**: text-shaped bytes are inlined as a `text` block;
+ *    anything else goes out as a base64 `blob`.
+ *  - **HTTP response classification** (`api_call` / `http_call`): text-shaped
+ *    bodies are UTF-8 decoded; anything else stays raw bytes. A false positive
+ *    here is data loss, not a cosmetic mislabel — the decode is lossy
+ *    (`fatal: false` → U+FFFD) and irreversible once re-encoded.
+ *
+ * `application/octet-stream` is deliberately absent: it is the explicit "opaque
+ * blob" marker and MUST stay on the binary path even when its bytes happen to
+ * be ASCII.
+ */
+export function isTextShapedMime(mime: string): boolean {
+  if (mime.startsWith("text/")) return true;
+  if (TEXT_SHAPED_MEDIA_TYPES.has(mime)) return true;
+  // Structured-syntax suffixes (RFC 6839) — `+json`, `+xml`, `+yaml`.
+  // Anything in these families is text-shaped and cannot be magic-sniffed.
+  return mime.endsWith("+json") || mime.endsWith("+xml") || mime.endsWith("+yaml");
+}
+
+/**
+ * Convenience wrapper for the common HTTP shape: classify a raw `Content-Type`
+ * header value (parameters included) in one call.
+ *
+ * An absent or empty header is NOT text — a caller that wants to treat a
+ * missing Content-Type as text must say so explicitly at its own call site,
+ * because the safe default for unknown bytes is the binary path.
+ */
+export function isTextShapedContentType(contentType: string | null | undefined): boolean {
+  const mime = normalizeMime(contentType);
+  return mime !== "" && isTextShapedMime(mime);
+}

--- a/packages/core/test/mime-registry-crosscheck.test.ts
+++ b/packages/core/test/mime-registry-crosscheck.test.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Cross-check of {@link TEXT_SHAPED_MEDIA_TYPES} against `mime-db`, the IANA /
+ * Apache / nginx media-type registry that powers `mime-types` and Express.
+ *
+ * `mime-db` is a **devDependency and a test-only oracle**, never a runtime
+ * source of truth. It cannot answer our question:
+ *
+ *  - Its `charset` field is set on 11 of 132 `text/*` entries and on 2 of the
+ *    18 media types we classify as text. `mime-types.charset()` returns `false`
+ *    for `application/xml`, `application/atom+xml` and every vendor `+json`.
+ *  - Its `compressible` field answers "does gzip help?", not "is this text".
+ *    It is `true` for `application/octet-stream` — the ONE type this codebase
+ *    documents as must-stay-binary (issues #149 / #151) — and for `font/ttf`,
+ *    `image/bmp`, `image/vnd.adobe.photoshop`, `application/x-tar`.
+ *  - Streaming-JSON and YAML spellings we must support (`application/x-ndjson`,
+ *    `application/jsonl`, `application/x-yaml`, `application/csv`) are absent
+ *    from it entirely.
+ *
+ * What `compressible: false` IS reliable for is the negative direction: the
+ * registry sets it on binary containers (OOXML, OpenDocument, PDF, PNG, ZIP,
+ * EPUB, JAR). That makes it a cheap guard against the exact bug this predicate
+ * exists to prevent — a ZIP-container media type sneaking into the text list —
+ * INCLUDING for formats nobody thought to enumerate in `mime.test.ts`.
+ *
+ * Both directions are asserted. The positive control matters: without it, a
+ * `mime-db` restructure that made every lookup return `undefined` would leave
+ * the guard silently passing while checking nothing.
+ */
+
+import { describe, expect, it } from "bun:test";
+import db from "mime-db";
+import { TEXT_SHAPED_MEDIA_TYPES, isTextShapedMime } from "../src/mime.ts";
+
+/**
+ * Media types the registry marks as incompressible — i.e. already-compressed
+ * binary containers. Used as the positive control: these MUST be found in
+ * `mime-db` with `compressible: false`, proving the lookup below is live.
+ */
+const KNOWN_INCOMPRESSIBLE = [
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.oasis.opendocument.spreadsheet",
+  "application/pdf",
+  "image/png",
+  "application/zip",
+  "application/epub+zip",
+  "application/java-archive",
+];
+
+describe("TEXT_SHAPED_MEDIA_TYPES × mime-db", () => {
+  it("reads live registry data (positive control)", () => {
+    // If this fails, `mime-db` changed shape and the guard below is vacuous.
+    expect(Object.keys(db).length).toBeGreaterThan(1000);
+    for (const mime of KNOWN_INCOMPRESSIBLE) {
+      expect(db[mime]?.compressible).toBe(false);
+    }
+  });
+
+  it("lists no media type the registry marks as an incompressible binary", () => {
+    // The guard. `compressible: false` in mime-db means "already-compressed
+    // container" — a format that can never be decoded as text. An entry that is
+    // absent or has no `compressible` field is NOT a failure: the registry does
+    // not know every spelling we support (see the module doc).
+    const offenders = [...TEXT_SHAPED_MEDIA_TYPES].filter(
+      (mime) => db[mime]?.compressible === false,
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  it("classifies every incompressible registry entry as binary", () => {
+    // Broader sweep than the hand-written list in `mime.test.ts`: walk the whole
+    // registry and assert the predicate never calls an incompressible type text.
+    // `image/svg+xml` is the documented exception — mime-db marks it
+    // compressible, so it does not appear here, but state the intent anyway.
+    const misclassified = Object.entries(db)
+      .filter(([, entry]) => entry.compressible === false)
+      .map(([mime]) => mime)
+      .filter((mime) => isTextShapedMime(mime));
+    expect(misclassified).toEqual([]);
+  });
+
+  it("would have caught the OOXML regression this predicate exists to prevent", () => {
+    // Regression anchor: `contentType.includes("xml")` classified an XLSX as
+    // text, the lossy UTF-8 decode replaced its invalid bytes with U+FFFD, and
+    // the re-encode wrote that corruption to the workspace.
+    const xlsx = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    expect(db[xlsx]?.compressible).toBe(false);
+    expect(isTextShapedMime(xlsx)).toBe(false);
+    expect(TEXT_SHAPED_MEDIA_TYPES.has(xlsx)).toBe(false);
+  });
+});

--- a/packages/core/test/mime.test.ts
+++ b/packages/core/test/mime.test.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "bun:test";
+import {
+  normalizeMime,
+  isTextShapedMime,
+  isTextShapedContentType,
+  TEXT_SHAPED_MEDIA_TYPES,
+} from "../src/mime.ts";
+
+describe("normalizeMime", () => {
+  it("strips parameters, trims and lowercases", () => {
+    expect(normalizeMime("Text/CSV; charset=UTF-8")).toBe("text/csv");
+    expect(normalizeMime("  application/json  ")).toBe("application/json");
+    expect(normalizeMime("multipart/form-data; boundary=--x")).toBe("multipart/form-data");
+  });
+
+  it("maps absent / empty input to the empty string", () => {
+    expect(normalizeMime(undefined)).toBe("");
+    expect(normalizeMime(null)).toBe("");
+    expect(normalizeMime("")).toBe("");
+  });
+});
+
+describe("isTextShapedMime", () => {
+  it("accepts the text/* family", () => {
+    for (const m of ["text/plain", "text/csv", "text/html", "text/markdown"]) {
+      expect(isTextShapedMime(m)).toBe(true);
+    }
+  });
+
+  it("accepts every registered text media type", () => {
+    for (const m of TEXT_SHAPED_MEDIA_TYPES) {
+      expect(isTextShapedMime(m)).toBe(true);
+    }
+  });
+
+  it("accepts RFC 6839 structured suffixes", () => {
+    for (const m of [
+      "application/vnd.api+json",
+      "application/problem+json",
+      "application/atom+xml",
+      "application/rss+xml",
+      "application/xhtml+xml",
+      "application/vnd.oai.openapi+yaml",
+    ]) {
+      expect(isTextShapedMime(m)).toBe(true);
+    }
+  });
+
+  // The regression this module exists for: the sidecar used to match
+  // `contentType.includes("xml")`, which classifies an XLSX (a ZIP binary whose
+  // subtype merely contains "xml") as text. The lossy UTF-8 decode that follows
+  // replaces invalid bytes with U+FFFD and destroys the file.
+  it("rejects OOXML and OpenDocument containers despite 'xml' in the subtype", () => {
+    for (const m of [
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      "application/vnd.ms-excel.sheet.macroenabled.12",
+      "application/vnd.oasis.opendocument.spreadsheet",
+    ]) {
+      expect(isTextShapedMime(m)).toBe(false);
+    }
+  });
+
+  it("rejects binary types whose subtype merely contains 'json' or 'xml'", () => {
+    for (const m of ["application/x-jsonnet-binary", "video/x-xml-container"]) {
+      expect(isTextShapedMime(m)).toBe(false);
+    }
+  });
+
+  it("keeps application/octet-stream on the binary path", () => {
+    // The explicit "opaque blob" marker. Its bytes may happen to be ASCII; the
+    // caller asked for bytes and must get bytes.
+    expect(isTextShapedMime("application/octet-stream")).toBe(false);
+  });
+
+  it("rejects common binary formats", () => {
+    for (const m of ["application/pdf", "image/png", "application/zip", "audio/mpeg"]) {
+      expect(isTextShapedMime(m)).toBe(false);
+    }
+  });
+
+  it("expects a normalized value — a parameterized string never matches", () => {
+    expect(isTextShapedMime("application/json; charset=utf-8")).toBe(false);
+    expect(isTextShapedMime(normalizeMime("application/json; charset=utf-8"))).toBe(true);
+  });
+});
+
+describe("isTextShapedContentType", () => {
+  it("normalizes before classifying", () => {
+    expect(isTextShapedContentType("application/json; charset=utf-8")).toBe(true);
+    expect(isTextShapedContentType("Text/Plain; charset=ISO-8859-1")).toBe(true);
+  });
+
+  it("treats an absent or empty header as binary", () => {
+    expect(isTextShapedContentType(undefined)).toBe(false);
+    expect(isTextShapedContentType(null)).toBe(false);
+    expect(isTextShapedContentType("")).toBe(false);
+    expect(isTextShapedContentType("   ")).toBe(false);
+  });
+
+  it("rejects the OOXML content type Google Drive serves for .xlsx downloads", () => {
+    expect(
+      isTextShapedContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+    ).toBe(false);
+  });
+});

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -61,6 +61,7 @@ import {
   type Resource,
 } from "@appstrate/mcp-transport";
 import { getErrorMessage } from "@appstrate/core/errors";
+import { isTextShapedContentType } from "@appstrate/core/mime";
 import {
   RUN_HISTORY_INJECTED_TOOL,
   RECALL_MEMORY_INJECTED_TOOL,
@@ -1279,7 +1280,11 @@ function buildBlobResourceProvider(blobStore: BlobStore) {
         // is the closest match for "URI doesn't resolve" per spec.
         throw new McpError(ErrorCode.InvalidParams, `Resource not found: ${uri}`);
       }
-      const isText = record.mimeType.startsWith("text/") || record.mimeType.includes("json");
+      // Same predicate as the spill decision in `responseToToolResult` — a body
+      // stored as text must read back as text. These were two separate lists
+      // and disagreed on the XML family: an `application/xml` body spilled from
+      // the text path came back base64-encoded.
+      const isText = isTextShapedContentType(record.mimeType);
       if (isText) {
         return {
           contents: [
@@ -1466,18 +1471,15 @@ async function responseToToolResult(
   };
 
   const ct = res.headers.get("content-type") ?? "";
-  // Match media types, never arbitrary substrings. OOXML formats such as
-  // `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` are
-  // ZIP binaries despite containing "xml" in the subtype; treating them as
-  // text replaces invalid UTF-8 bytes with U+FFFD before responseMode.toFile
-  // can write them to the workspace.
-  const mediaType = ct.split(";", 1)[0]?.trim().toLowerCase() ?? "";
-  const isText =
-    mediaType.startsWith("text/") ||
-    mediaType === "application/json" ||
-    mediaType.endsWith("+json") ||
-    mediaType === "application/xml" ||
-    mediaType.endsWith("+xml");
+  // Media-type match, never a substring test, and never a list local to this
+  // file. `contentType.includes("xml")` classified
+  // `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` (an
+  // XLSX — a ZIP binary) as text: the lossy UTF-8 decode below replaced invalid
+  // bytes with U+FFFD and the re-encode on the spill path wrote that corruption
+  // to the workspace, destroying every OOXML file downloaded through
+  // `responseMode.toFile`. The shared predicate is the fix AND the guard
+  // against the next such format.
+  const isText = isTextShapedContentType(ct);
 
   if (!isText) {
     if (!options.blobStore) {

--- a/runtime-pi/sidecar/mcp.ts
+++ b/runtime-pi/sidecar/mcp.ts
@@ -1466,7 +1466,18 @@ async function responseToToolResult(
   };
 
   const ct = res.headers.get("content-type") ?? "";
-  const isText = ct.startsWith("text/") || ct.includes("json") || ct.includes("xml");
+  // Match media types, never arbitrary substrings. OOXML formats such as
+  // `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` are
+  // ZIP binaries despite containing "xml" in the subtype; treating them as
+  // text replaces invalid UTF-8 bytes with U+FFFD before responseMode.toFile
+  // can write them to the workspace.
+  const mediaType = ct.split(";", 1)[0]?.trim().toLowerCase() ?? "";
+  const isText =
+    mediaType.startsWith("text/") ||
+    mediaType === "application/json" ||
+    mediaType.endsWith("+json") ||
+    mediaType === "application/xml" ||
+    mediaType.endsWith("+xml");
 
   if (!isText) {
     if (!options.blobStore) {

--- a/runtime-pi/sidecar/test/mcp-resources.test.ts
+++ b/runtime-pi/sidecar/test/mcp-resources.test.ts
@@ -131,6 +131,45 @@ describe("POST /mcp — api_call resource spillover", () => {
     expect(result.content[0]!.uri).toMatch(/^appstrate:\/\/api-response\/run-test\/[A-Z0-9]{26}$/);
   });
 
+  it("treats OOXML media types as binary even though their subtype contains xml", async () => {
+    // Drive serves .xlsx as this MIME type. It is a ZIP container, not XML
+    // text: decoding its invalid UTF-8 bytes turns them into U+FFFD and makes
+    // a responseMode.toFile download irreversibly corrupt.
+    const xlsxBytes = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0xff, 0x80, 0xc3, 0x28, 0x00]);
+    const fetchFn = mock(
+      async () =>
+        new Response(xlsxBytes, {
+          status: 200,
+          headers: {
+            "Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+          },
+        }),
+    );
+    const app = await makeResourcesApp({ fetchFn: fetchFn as unknown as typeof fetch });
+    const callRes = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "test__api_call",
+        arguments: { target: "https://api.example.com/book.xlsx" },
+      },
+    });
+    const callResult = callRes.json.result as {
+      content: Array<{ type: string; uri?: string; mimeType?: string }>;
+    };
+    expect(callResult.content[0]!.type).toBe("resource_link");
+    expect(callResult.content[0]!.mimeType).toBe(
+      "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    );
+
+    const readRes = await rpc(app, {
+      method: "resources/read",
+      params: { uri: callResult.content[0]!.uri! },
+    });
+    const readResult = readRes.json.result as { contents: Array<{ blob?: string }> };
+    const actual = Uint8Array.from(atob(readResult.contents[0]!.blob!), (c) => c.charCodeAt(0));
+    expect(actual).toEqual(xlsxBytes);
+  });
+
   it("spills oversized text responses to a resource_link", async () => {
     // Generate a JSON body well above the 32 KB inline threshold.
     const big = JSON.stringify({ data: "x".repeat(40 * 1024) });

--- a/runtime-pi/sidecar/test/mcp-resources.test.ts
+++ b/runtime-pi/sidecar/test/mcp-resources.test.ts
@@ -170,6 +170,74 @@ describe("POST /mcp — api_call resource spillover", () => {
     expect(actual).toEqual(xlsxBytes);
   });
 
+  it("keeps application/x-ndjson on the text path", async () => {
+    // Regression guard for the FIX, not the bug: tightening the old
+    // `contentType.includes("json")` substring match into an exact media-type
+    // test is what stops OOXML corruption, but a hand-written list of exact
+    // types silently drops the streaming-JSON family (ndjson, jsonl,
+    // json-seq) that the substring used to cover. Those are text, and an
+    // agent must get them as readable text rather than an opaque blob link.
+    const body = '{"a":1}\n{"a":2}\n';
+    const fetchFn = mock(
+      async () =>
+        new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "application/x-ndjson" },
+        }),
+    );
+    const app = await makeResourcesApp({ fetchFn: fetchFn as unknown as typeof fetch });
+    const res = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "test__api_call",
+        arguments: { target: "https://api.example.com/stream.ndjson" },
+      },
+    });
+    const result = res.json.result as {
+      content: Array<{ type: string; text?: string }>;
+    };
+    expect(result.content[0]!.type).toBe("text");
+    expect(result.content[0]!.text).toBe(body);
+  });
+
+  it("reads a spilled XML body back as text, not base64", async () => {
+    // `responseToToolResult` and the resource provider used to carry separate
+    // predicates that disagreed on the XML family: a body spilled through the
+    // TEXT path (stored as UTF-8 bytes) came back base64-encoded because the
+    // reader only recognised `text/*` and `json`. Both now share one predicate,
+    // so what goes in as text comes out as text.
+    const xml = `<?xml version="1.0"?><root>${"<item>x</item>".repeat(4000)}</root>`;
+    const fetchFn = mock(
+      async () =>
+        new Response(xml, {
+          status: 200,
+          headers: { "Content-Type": "application/xml; charset=utf-8" },
+        }),
+    );
+    const app = await makeResourcesApp({ fetchFn: fetchFn as unknown as typeof fetch });
+    const callRes = await rpc(app, {
+      method: "tools/call",
+      params: {
+        name: "test__api_call",
+        arguments: { target: "https://api.example.com/feed.xml" },
+      },
+    });
+    const callResult = callRes.json.result as {
+      content: Array<{ type: string; uri?: string }>;
+    };
+    expect(callResult.content[0]!.type).toBe("resource_link");
+
+    const readRes = await rpc(app, {
+      method: "resources/read",
+      params: { uri: callResult.content[0]!.uri! },
+    });
+    const readResult = readRes.json.result as {
+      contents: Array<{ text?: string; blob?: string }>;
+    };
+    expect(readResult.contents[0]!.blob).toBeUndefined();
+    expect(readResult.contents[0]!.text).toBe(xml);
+  });
+
   it("spills oversized text responses to a resource_link", async () => {
     // Generate a JSON body well above the 32 KB inline threshold.
     const big = JSON.stringify({ data: "x".repeat(40 * 1024) });


### PR DESCRIPTION
## Problem

`api_call` classified every response Content-Type containing `xml` as text. Google Drive serves XLSX downloads as `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`: this is a ZIP binary, not XML text.

The UTF-8 text decode replaced invalid bytes with U+FFFD, then re-encoding corrupted files written through `responseMode.toFile`.

## Fix

Use exact media-type matching for text responses: `text/*`, `application/json`, `+json`, `application/xml`, and `+xml`. OOXML now follows the binary blob path.

## Validation

- Added an MCP regression test with OOXML MIME and invalid UTF-8 bytes.
- Targeted sidecar MCP suite: 15 passing tests.
- Built the sidecar Docker image successfully.
- Real local Google Drive run with GPT-5.5 and `responseMode.toFile`:
  - Drive size: 313304 bytes
  - Downloaded size: 313304 bytes
  - Range `bytes=0-99`: 100 bytes, HTTP 206
  - U+FFFD UTF-8 sequence count: 0

The repository pre-push hook was attempted but is blocked in this checkout by a missing unrelated workspace dependency: `@appstrate/afps-shared/signed-token` from `apps/api/src/services/document-preview.ts`.