### PR TITLE
fix(conformance): make the refresh-strategy check mean what it says

### DIFF
--- a/apps/api/src/services/connect/oauth2-strategy.ts
+++ b/apps/api/src/services/connect/oauth2-strategy.ts
@@ -54,6 +54,23 @@ import type {
  */
 const USERINFO_TIMEOUT_MS = 10_000;
 
+/**
+ * The manifest's `_meta["dev.appstrate/oauth"].refresh_token_issuance`, when it
+ * declares one.
+ *
+ * `"not_supported"` = the authorization server issues access-only tokens by
+ * design (the connection re-authorises at expiry). `"default"` = it issues a
+ * refresh token unconditionally, which needs no special handling here.
+ */
+function refreshTokenIssuance(auth: Record<string, unknown>): string | undefined {
+  const meta = auth._meta;
+  if (!meta || typeof meta !== "object") return undefined;
+  const oauthMeta = (meta as Record<string, unknown>)["dev.appstrate/oauth"];
+  if (!oauthMeta || typeof oauthMeta !== "object") return undefined;
+  const value = (oauthMeta as Record<string, unknown>).refresh_token_issuance;
+  return typeof value === "string" ? value : undefined;
+}
+
 export class OAuth2Strategy implements IntegrationConnectStrategy {
   async begin(ctx: ConnectContext, opts: BeginOptions): Promise<BeginResult> {
     const { manifest, auth: rawAuth } = await readIntegrationAuth(
@@ -294,7 +311,15 @@ export class OAuth2Strategy implements IntegrationConnectStrategy {
     // without `access_type=offline` + `prompt=consent`).
     if (result.expiresAt && !refreshToken) {
       let refreshGrantSupported = true; // strict default when capability is unknown
-      if (auth.issuer) {
+      // A manifest that states the provider issues no refresh token at all is
+      // authoritative — it is the same fact discovery would report, written
+      // down for a provider that publishes no metadata. Without this the
+      // declaration was inert: the conformance gate accepted
+      // `refresh_token_issuance: "not_supported"` while this path still refused
+      // the connection, so a manifest could pass CI and fail at consent.
+      if (refreshTokenIssuance(auth) === "not_supported") {
+        refreshGrantSupported = false;
+      } else if (auth.issuer) {
         try {
           const disc = await resolveOAuthEndpoints({
             issuer: auth.issuer,

--- a/apps/api/test/helpers/integration-manifests.ts
+++ b/apps/api/test/helpers/integration-manifests.ts
@@ -100,6 +100,8 @@ interface AuthSpec {
   tokenEndpointAuthMethod?: "client_secret_post" | "client_secret_basic" | "none";
   /** AFPS `authorization_params` — extra static query params on the authorize URL. */
   authorizationParams?: Record<string, string>;
+  /** `_meta["dev.appstrate/oauth"].refresh_token_issuance` — provider refresh behaviour. */
+  refreshTokenIssuance?: "default" | "not_supported";
   resource?: string;
   codeChallengeMethodsSupported?: string[];
   scopeSeparator?: string;
@@ -131,8 +133,12 @@ function buildAuth(spec: AuthSpec): Record<string, unknown> {
     if (spec.codeChallengeMethodsSupported)
       auth.code_challenge_methods_supported = spec.codeChallengeMethodsSupported;
     if (spec.identityClaims) auth.identity_claims = spec.identityClaims;
-    if (spec.scopeSeparator) {
-      auth._meta = { "dev.appstrate/oauth": { scope_separator: spec.scopeSeparator } };
+    const oauthMeta: Record<string, unknown> = {
+      ...(spec.scopeSeparator ? { scope_separator: spec.scopeSeparator } : {}),
+      ...(spec.refreshTokenIssuance ? { refresh_token_issuance: spec.refreshTokenIssuance } : {}),
+    };
+    if (Object.keys(oauthMeta).length > 0) {
+      auth._meta = { "dev.appstrate/oauth": oauthMeta };
     }
   } else {
     auth.credentials = {

--- a/apps/api/test/integration/routes/integration-oauth-flow.test.ts
+++ b/apps/api/test/integration/routes/integration-oauth-flow.test.ts
@@ -66,6 +66,7 @@ async function setup(
   manifest: {
     tokenEndpointAuthMethod: "client_secret_post" | "client_secret_basic" | "none";
     authorizationParams?: Record<string, string>;
+    refreshTokenIssuance?: "default" | "not_supported";
   },
   client: { clientId: string; clientSecret: string },
 ): Promise<void> {
@@ -86,6 +87,9 @@ async function setup(
           codeChallengeMethodsSupported: ["S256"],
           ...(manifest.authorizationParams
             ? { authorizationParams: manifest.authorizationParams }
+            : {}),
+          ...(manifest.refreshTokenIssuance
+            ? { refreshTokenIssuance: manifest.refreshTokenIssuance }
             : {}),
           delivery: httpHeaderDelivery({
             name: "Authorization",
@@ -381,6 +385,56 @@ describe("integration OAuth2 flow (conformant provider)", () => {
     expect(decryptCredentialsToStringMap(connection!.credentialsEncrypted).refresh_token).toBe(
       provider.issuedRefreshTokens[0],
     );
+  });
+
+  // A provider that issues access-only tokens BY DESIGN (many remote MCP
+  // servers) is not a misconfiguration. Before this, the manifest could say so
+  // and be ignored: the conformance gate accepted the declaration while this
+  // path still refused the connection, so a manifest passed CI and failed at a
+  // user's consent screen.
+  it("persists an access-only connection when the manifest declares refresh_token_issuance=not_supported", async () => {
+    startProvider({
+      clientId: "cid",
+      clientSecret: "shh",
+      acceptedAuthMethods: ["client_secret_post"],
+      // Gated on a flag the manifest deliberately does not send → no refresh token.
+      offlineParam: { name: "token_access_type", value: "offline" },
+    });
+    await setup(
+      ctx,
+      provider,
+      { tokenEndpointAuthMethod: "client_secret_post", refreshTokenIssuance: "not_supported" },
+      { clientId: "cid", clientSecret: "shh" },
+    );
+    await consentAndCallback(await beginConnect(ctx));
+
+    expect(provider.issuedRefreshTokens).toHaveLength(0);
+    const connection = await storedConnection();
+    // Persisted, not refused — it re-authorises at expiry, by design.
+    expect(connection).not.toBeNull();
+    expect(decryptCredentialsToStringMap(connection!.credentialsEncrypted).refresh_token).toBe(
+      undefined,
+    );
+  });
+
+  // The declaration is authoritative only for "not_supported". A manifest that
+  // says nothing still gets the strict refusal, which is what caught
+  // @appstrate/dropbox.
+  it("still refuses when the manifest declares nothing", async () => {
+    startProvider({
+      clientId: "cid",
+      clientSecret: "shh",
+      acceptedAuthMethods: ["client_secret_post"],
+      offlineParam: { name: "token_access_type", value: "offline" },
+    });
+    await setup(
+      ctx,
+      provider,
+      { tokenEndpointAuthMethod: "client_secret_post" },
+      { clientId: "cid", clientSecret: "shh" },
+    );
+    await consentAndCallback(await beginConnect(ctx));
+    expect(await storedConnection()).toBeNull();
   });
 
   // ─── Protocol discipline the provider enforces for us ──────────────────

--- a/scripts/conformance/conformance.test.ts
+++ b/scripts/conformance/conformance.test.ts
@@ -8,7 +8,13 @@ import { resolveToken, resolveAccessToken, credentialedCount, _resetCredsCache }
 import { remoteUrl, toolsPolicyKeys, allowsUndeclared } from "./remote-parity.ts";
 import { applyAuth, checkAuthLiveness } from "./auth-live.ts";
 import { metadataCandidates, compareAuth } from "./oauth-metadata.ts";
-import { checkRefreshStrategy, checkUnverifiedBacklog, UNVERIFIED } from "./refresh-strategy.ts";
+import {
+  checkRefreshStrategy,
+  checkUnverifiedBacklog,
+  checkBacklogCeiling,
+  UNVERIFIED,
+  UNVERIFIED_CEILING,
+} from "./refresh-strategy.ts";
 import { declaredIdentityEndpoints, classifyIdentityProbe } from "./identity-endpoint.ts";
 import { buildDiscoveryProbes, discoveryIssuerMatches } from "@appstrate/connect";
 import { listAllTools } from "./mcp-list.ts";
@@ -766,6 +772,22 @@ describe("refresh-strategy", () => {
     }
   });
 
+  // The first version accepted ANY non-empty authorization_params as evidence,
+  // so a manifest carrying only `prompt` passed while requesting no offline
+  // access at all — the same "looks like it declares something" failure the
+  // check exists to catch.
+  it("rejects an authorize param that does not request offline access", () => {
+    for (const params of [
+      { prompt: "select_account" },
+      { access_type: "online" },
+      { duration: "temporary" },
+      { token_access_type: "legacy" },
+    ]) {
+      const [finding] = checkRefreshStrategy(oauth({ authorization_params: params }));
+      expect(finding!.severity).toBe("fail");
+    }
+  });
+
   it("accepts an offline scope in every spelling providers use", () => {
     for (const scope of ["offline_access", "offline", "offline.access"]) {
       const [finding] = checkRefreshStrategy(oauth({ default_scopes: ["read", scope] }));
@@ -774,12 +796,18 @@ describe("refresh-strategy", () => {
   });
 
   it("accepts an explicit _meta declaration", () => {
-    for (const refresh of ["default", "not_supported"]) {
+    for (const refresh_token_issuance of ["default", "not_supported"]) {
       const [finding] = checkRefreshStrategy(
-        oauth({ _meta: { "dev.appstrate/oauth": { refresh } } }),
+        oauth({ _meta: { "dev.appstrate/oauth": { refresh_token_issuance } } }),
       );
       expect(finding!.severity).toBe("info");
     }
+  });
+
+  it("keeps the backlog shrink-only", () => {
+    // A ceiling below the current size is what a NEW waiver would look like.
+    expect(UNVERIFIED.size).toBeLessThanOrEqual(UNVERIFIED_CEILING);
+    expect(checkBacklogCeiling()).toEqual([]);
   });
 
   // The whole point: a manifest that says nothing about offline access is the
@@ -792,7 +820,7 @@ describe("refresh-strategy", () => {
 
   it("treats an unrecognised _meta refresh value as absent, not as a waiver", () => {
     const [finding] = checkRefreshStrategy(
-      oauth({ _meta: { "dev.appstrate/oauth": { refresh: "n/a" } } }),
+      oauth({ _meta: { "dev.appstrate/oauth": { refresh_token_issuance: "n/a" } } }),
     );
     expect(finding!.severity).toBe("fail");
   });

--- a/scripts/conformance/refresh-strategy.ts
+++ b/scripts/conformance/refresh-strategy.ts
@@ -33,7 +33,7 @@
  *      access explicitly (Google / Dropbox / Reddit shape).
  *   2. `default_scopes` carries an offline-ish scope (`offline_access`,
  *      `offline`) — the Microsoft / Salesforce / Xero shape.
- *   3. `_meta["dev.appstrate/oauth"].refresh` states the provider needs
+ *   3. `_meta["dev.appstrate/oauth"].refresh_token_issuance` states the provider needs
  *      neither: `"default"` (issues a refresh token unconditionally) or
  *      `"not_supported"` (issues no refresh token at all — the connection
  *      re-authorises at expiry, by design).
@@ -59,7 +59,7 @@ const CHECK = "refresh-strategy";
  */
 const OFFLINE_SCOPE_PATTERN = /(^|[/.:])offline([_.]access)?$/i;
 
-/** Accepted values of `_meta["dev.appstrate/oauth"].refresh`. */
+/** Accepted values of `_meta["dev.appstrate/oauth"].refresh_token_issuance`. */
 const REFRESH_DECLARATIONS = new Set(["default", "not_supported"]);
 
 /**
@@ -69,7 +69,7 @@ const REFRESH_DECLARATIONS = new Set(["default", "not_supported"]);
  *
  * This list only ever shrinks. To remove an entry: read the provider's OAuth
  * docs, then either add the authorize param / scope it requires, or record
- * `_meta["dev.appstrate/oauth"].refresh` in the manifest. Do NOT add a new
+ * `_meta["dev.appstrate/oauth"].refresh_token_issuance` in the manifest. Do NOT add a new
  * integration here — a new manifest's author is the one person who has the
  * provider's docs open.
  */
@@ -122,10 +122,38 @@ function oauthAuths(manifest: Record<string, unknown>): Array<[string, OAuthAuth
   );
 }
 
-/** Whether the auth asks for offline access via an authorize-time parameter. */
-export function hasAuthorizeParam(auth: OAuthAuth): boolean {
+/**
+ * Authorize-time parameters that actually ask a provider for offline access,
+ * as `name` → accepted values. Every entry is transcribed from that provider's
+ * documentation; a parameter absent from this table proves nothing about
+ * refresh tokens.
+ *
+ * Named explicitly BECAUSE the first version of this check accepted any
+ * non-empty `authorization_params` as evidence — so a manifest carrying only
+ * `prompt: "select_account"` passed while requesting no offline access at all.
+ * That is the same "looks like it declares something" failure the check exists
+ * to catch.
+ */
+const OFFLINE_AUTHORIZE_PARAMS: Record<string, ReadonlySet<string>> = {
+  // Google (gmail, drive, calendar, sheets, forms, contacts, youtube).
+  access_type: new Set(["offline"]),
+  // Dropbox.
+  token_access_type: new Set(["offline"]),
+  // Reddit.
+  duration: new Set(["permanent"]),
+};
+
+/**
+ * Whether the auth asks for offline access via a RECOGNISED authorize-time
+ * parameter set to a value that actually requests it.
+ */
+export function requestsOfflineViaAuthorizeParam(auth: OAuthAuth): boolean {
   const params = auth.authorization_params;
-  return !!params && typeof params === "object" && Object.keys(params as object).length > 0;
+  if (!params || typeof params !== "object") return false;
+  return Object.entries(params as Record<string, unknown>).some(([name, value]) => {
+    const accepted = OFFLINE_AUTHORIZE_PARAMS[name];
+    return accepted !== undefined && typeof value === "string" && accepted.has(value);
+  });
 }
 
 /** Whether the auth asks for offline access via a scope. */
@@ -145,18 +173,18 @@ export function refreshDeclaration(auth: OAuthAuth): string | undefined {
   if (!meta || typeof meta !== "object") return undefined;
   const oauthMeta = (meta as Record<string, unknown>)["dev.appstrate/oauth"];
   if (!oauthMeta || typeof oauthMeta !== "object") return undefined;
-  const value = (oauthMeta as Record<string, unknown>).refresh;
+  const value = (oauthMeta as Record<string, unknown>).refresh_token_issuance;
   return typeof value === "string" && REFRESH_DECLARATIONS.has(value) ? value : undefined;
 }
 
 /** Evaluate one auth. Exported for the harness's own unit tests. */
 export function evaluateAuth(packageId: string, authKey: string, auth: OAuthAuth): Finding {
-  if (hasAuthorizeParam(auth)) {
+  if (requestsOfflineViaAuthorizeParam(auth)) {
     return {
       packageId,
       check: CHECK,
       severity: "info",
-      message: `${authKey}: refresh requested via authorization_params`,
+      message: `${authKey}: refresh requested via a recognised authorization parameter`,
     };
   }
   if (hasOfflineScope(auth)) {
@@ -179,7 +207,7 @@ export function evaluateAuth(packageId: string, authKey: string, auth: OAuthAuth
   const message =
     `${authKey}: no refresh strategy — the auth requests no offline access ` +
     `(authorization_params / offline scope) and declares no ` +
-    `_meta["dev.appstrate/oauth"].refresh ("default" | "not_supported"). ` +
+    `_meta["dev.appstrate/oauth"].refresh_token_issuance ("default" | "not_supported"). ` +
     `A provider that mints short-lived tokens will return none, and the ` +
     `connection is refused at connect time.`;
   return UNVERIFIED.has(`${packageId}:${authKey}`)
@@ -194,6 +222,34 @@ export function declaredAuthKeys(entries: SystemPackageEntry[]): Set<string> {
     for (const [key] of oauthAuths(entry.manifest)) keys.add(`${entry.packageId}:${key}`);
   }
   return keys;
+}
+
+/**
+ * Ceiling on the backlog. Lower it — never raise it — as entries are verified
+ * and removed.
+ *
+ * Without a ceiling the waiver list is a TODO in a nicer shell: it can grow
+ * silently, and 29 permanent warnings train everyone to stop reading the
+ * report. The repo already ratchets `verify:type-coverage --at-least 98` for
+ * the same reason; this is that pattern applied to provider knowledge.
+ */
+export const UNVERIFIED_CEILING = 29;
+
+/** Fail when the backlog grows past its ceiling. */
+export function checkBacklogCeiling(): Finding[] {
+  if (UNVERIFIED.size <= UNVERIFIED_CEILING) return [];
+  return [
+    {
+      packageId: "(conformance)",
+      check: CHECK,
+      severity: "fail",
+      message:
+        `UNVERIFIED holds ${UNVERIFIED.size} entries, above the ceiling of ` +
+        `${UNVERIFIED_CEILING}. A new integration must declare its refresh strategy, ` +
+        `not join the backlog — the list only ever shrinks. If an entry was genuinely ` +
+        `verified away, lower UNVERIFIED_CEILING to match.`,
+    },
+  ];
 }
 
 /**

--- a/scripts/conformance/run.ts
+++ b/scripts/conformance/run.ts
@@ -23,7 +23,11 @@ import { checkMcpLocalParity } from "./mcp-local-parity.ts";
 import { checkMcpRemoteParity } from "./remote-parity.ts";
 import { checkAuthLiveness } from "./auth-live.ts";
 import { checkOAuthMetadata } from "./oauth-metadata.ts";
-import { checkRefreshStrategy, checkUnverifiedBacklog } from "./refresh-strategy.ts";
+import {
+  checkRefreshStrategy,
+  checkUnverifiedBacklog,
+  checkBacklogCeiling,
+} from "./refresh-strategy.ts";
 import { checkIdentityEndpoints } from "./identity-endpoint.ts";
 import { AUTH_PROBES } from "./probes.ts";
 import { credentialedCount } from "./creds.ts";
@@ -109,6 +113,7 @@ async function main(): Promise<void> {
   // filter would read as stale.
   if (!args.pkg) {
     findings.push(...checkUnverifiedBacklog(selected.map((p) => p.entry)));
+    findings.push(...checkBacklogCeiling());
   }
 
   console.log(formatReport(findings));


### PR DESCRIPTION
Follow-up to #1152 and #1153, closing the review findings on the check itself
rather than on the code it guards.

## It accepted any authorize parameter as evidence

`hasAuthorizeParam` returned true for any non-empty `authorization_params`, so a
manifest carrying only `prompt: "select_account"` passed while requesting no
offline access at all — the same "looks like it declares something" failure the
check exists to catch.

Offline parameters are now named, each transcribed from its provider's docs:

| Parameter | Value | Providers |
| --- | --- | --- |
| `access_type` | `offline` | Google (gmail, drive, calendar, sheets, forms, contacts, youtube) |
| `token_access_type` | `offline` | Dropbox |
| `duration` | `permanent` | Reddit |

Anything outside the table proves nothing.

## The declaration was inert at runtime

The gate accepted `refresh_token_issuance: "not_supported"`, but
`oauth2-strategy` still defaulted unknown refresh capability to a hard refusal.
A manifest could pass CI and fail at a user's consent screen — a gate that
disagrees with the runtime it guards is worse than no gate.

The declaration is now authoritative there: it is the fact RFC 8414 discovery
would report, written down for a provider that publishes no metadata.

## The backlog could grow

A waiver list with no ceiling is a TODO in a nicer shell, and 29 permanent
warnings train everyone to stop reading the report. `UNVERIFIED_CEILING` fails
the gate when the list grows, so a new integration must declare its refresh
strategy rather than join the backlog.

Same pattern the repo already uses for `verify:type-coverage --at-least 98`.

## Rename, while the window is open

`_meta["dev.appstrate/oauth"].refresh` → `.refresh_token_issuance`. `refresh`
alone did not say whether it described a flag, an interval or a strategy. Free
today because **no manifest declares it yet**, and impossible the moment one
does.

## Verification

- `bun run check` → exit 0, conformance gate `0 fail · 29 warn · 20 info`
- `scripts/conformance` → 84 pass, incl. new cases for rejected parameters and
  the ratchet
- affected integration suites → 23 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)