### PR TITLE
fix(db): canonicalise before constraining in migration 0038

### DIFF
--- a/packages/db/drizzle/0038_young_cassandra_nova.sql
+++ b/packages/db/drizzle/0038_young_cassandra_nova.sql
@@ -1,1 +1,12 @@
+-- Canonicalise before constraining. A row holding an EMPTY ciphertext with no
+-- declared method is a public client that predates the column — structurally
+-- it satisfies neither branch of the constraint below, so adding the
+-- constraint without this UPDATE would fail at boot and take the platform
+-- down with it. No current code path writes an empty ciphertext, but that is
+-- an assumption about production data this migration must not depend on.
+UPDATE "integration_oauth_clients"
+   SET "token_endpoint_auth_method" = 'none'
+ WHERE "token_endpoint_auth_method" IS NULL
+   AND "client_secret_encrypted" = '';
+--> statement-breakpoint
 ALTER TABLE "integration_oauth_clients" ADD CONSTRAINT "ioc_public_iff_no_secret" CHECK (("integration_oauth_clients"."token_endpoint_auth_method" = 'none' AND "integration_oauth_clients"."client_secret_encrypted" = '') OR ("integration_oauth_clients"."token_endpoint_auth_method" IS DISTINCT FROM 'none' AND "integration_oauth_clients"."client_secret_encrypted" <> ''));


### PR DESCRIPTION
`ioc_public_iff_no_secret` (from #1153) was added on the reasoning that no
existing row can violate it: a legacy public client is structurally `NULL` + a
ciphertext (of an empty secret), which satisfies the second branch.

That reasoning holds for every row the current code can produce. But it is an
assumption about **production data**, and a CHECK constraint that fails
validation aborts the migration — which aborts boot.

A row holding an empty ciphertext with no declared method satisfies neither
branch:

| `token_endpoint_auth_method` | `client_secret_encrypted` | constraint |
| --- | --- | --- |
| `'none'` | `''` | ✅ first branch |
| `NULL` | ciphertext | ✅ second branch |
| `NULL` | `''` | ❌ **neither — boot fails** |

Nothing writes that third shape today. But "nothing writes it today" is not a
statement anyone can verify against a database they cannot read, and the cost of
being wrong is a platform that will not start.

So the migration canonicalises first — an empty ciphertext with no declaration
IS a public client, and saying so in SQL costs one `UPDATE` over a table with a
handful of rows. The constraint then holds **by construction rather than by
argument**.

This lands before the release that first applies 0037/0038 to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)