### PR TITLE
chore(chat): drop the legacy turn errorText fallback

### DIFF
--- a/packages/core/src/chat-turn-metadata.ts
+++ b/packages/core/src/chat-turn-metadata.ts
@@ -121,9 +121,13 @@ export function formatTurnBudgetNote(input: { remainingMs: number; stepsUsed: nu
 export interface AppstrateTurnMetadata {
   engine: ChatTurnEngine;
   finishReason?: ChatTurnFinishReason;
-  /** Legacy client-safe failure copy; new turns persist a category for localization. */
-  errorText?: string;
-  /** Stable, provider-neutral class for retry UI + telemetry. */
+  /**
+   * Stable, provider-neutral class for retry UI + telemetry.
+   *
+   * Absent on a turn persisted before this field existed, when the failure copy
+   * was the provider's own unclassified string (`errorText`, removed): such a
+   * turn reads as `unknown` rather than rendering raw upstream text.
+   */
   errorCategory?: ChatTurnErrorCategory;
   /** Whether retrying later may succeed without changing the request. */
   errorRetryable?: boolean;

--- a/packages/module-chat/src/ui/thread.tsx
+++ b/packages/module-chat/src/ui/thread.tsx
@@ -394,7 +394,7 @@ function TurnLimitNotice() {
  * THE failure display for a turn — one component, one visual, live or
  * reloaded. The persisted provider-neutral category is localized here and
  * survives reload; the transient assistant-ui marker covers failures that have
- * not reached a finish chunk yet. `errorText` is legacy-message fallback only.
+ * not reached a finish chunk yet.
  */
 function MessageError() {
   const { t } = useChatHost();

--- a/packages/module-chat/src/ui/turn-error-state.ts
+++ b/packages/module-chat/src/ui/turn-error-state.ts
@@ -64,6 +64,11 @@ export interface TurnErrorState {
  * `null` when the turn did not fail. Two sources, in order of durability: the
  * persisted provider-neutral category, which survives reload, then the
  * transient assistant-ui error for a failure that never reached a finish chunk.
+ *
+ * Every path localizes a category — the client never renders provider text. A
+ * turn persisted before the category existed carries none, so it degrades to
+ * the generic failure instead of surfacing the raw upstream string its
+ * `errorText` used to hold.
  */
 export function turnErrorState(
   message: AssistantState["message"],
@@ -71,11 +76,8 @@ export function turnErrorState(
 ): TurnErrorState | null {
   const turn = turnMetadataFromMessage(sourceMessage(message));
   if (turn?.finishReason === "error") {
-    const category = turn.errorCategory ?? "unknown";
     return {
-      text: turn.errorCategory
-        ? t(TURN_ERROR_KEY[category])
-        : (turn.errorText ?? t("turn.error.unknown")),
+      text: t(TURN_ERROR_KEY[turn.errorCategory ?? "unknown"]),
       retryable: turn.errorRetryable !== false,
       requestId: turn.requestId,
     };

--- a/packages/module-chat/test/ai-sdk-turn-deadline.test.ts
+++ b/packages/module-chat/test/ai-sdk-turn-deadline.test.ts
@@ -262,7 +262,6 @@ describe("ai-sdk turn deadline", () => {
       errorCategory: "unknown",
       errorRetryable: true,
     });
-    expect(turnMetadataFromMessage(message)?.errorText).toBeUndefined();
   });
 
   it("does not mistake an explicit user stop for a deadline", async () => {

--- a/packages/module-chat/test/turn-error-state.test.ts
+++ b/packages/module-chat/test/turn-error-state.test.ts
@@ -50,10 +50,12 @@ describe("turnErrorState", () => {
     ).toEqual({ text: "turn.error.rateLimited", retryable: true, requestId: "req_abc123" });
   });
 
-  it("falls back to a legacy turn's own text when it predates the category", () => {
+  it("degrades a legacy category-less turn to the generic failure", () => {
+    // Turns persisted before the category existed carried the provider's own
+    // string. It is no longer read, so nothing unclassified reaches the UI.
     expect(
       turnErrorState(message(turn({ finishReason: "error", errorText: "boom" })), t),
-    ).toMatchObject({ text: "boom" });
+    ).toMatchObject({ text: "turn.error.unknown" });
   });
 
   it("localizes an in-stream failure from its marker", () => {


### PR DESCRIPTION
## Summary

`AppstrateTurnMetadata.errorText` is dead on the write side and its one surviving read is a leak.

- **No writer.** Its only writer was the subscription (Pi) engine, which persisted `m.errorMessage` verbatim into the finish metadata. #1097 replaced that on every exit path with the classified `errorCategory` / `errorRetryable` / `requestId` triple (`buildSubscriptionTurnMetadata`, `buildTurnMetadata`). The ai-sdk engine never wrote the field — `chat-stream.ts` has no reference to it before #1097 either. The other `errorText` occurrences in the chat module are unrelated homonyms: the `UIMessageChunk` error/tool-output-error chunk field, `PiChatResultMeta`, `OAuthConnectCard`, `ChatRunProgressCard`.
- **One reader, unreachable except for legacy rows.** `turnErrorState` preferred it whenever a turn carried no `errorCategory` — i.e. only turns persisted before #1097. `chat_messages` has no retention, so those rows are still around.
- **That branch is the leak #1097 closed.** The persisted string is the provider's own unclassified text, rendered straight into the UI. Removing the fallback makes those turns read as the generic failure, exactly like any other turn whose category we cannot name.

No consumer outside this repo touches the field (`cloud`, `connect-helper`, `github-action`, `website` are clean), and it is an optional field, so no `@appstrate/core` version bump is forced by this change — deliberately left out of this PR.

## Changes

- `packages/core/src/chat-turn-metadata.ts` — drop `errorText`; document on `errorCategory` what its absence means on a legacy turn.
- `packages/module-chat/src/ui/turn-error-state.ts` — always localize a category; drop the fallback.
- `packages/module-chat/src/ui/thread.tsx` — doc comment no longer advertises the fallback.
- Tests — the legacy-text case now asserts the degrade-to-generic behavior; drop the now-untypeable `errorText` assertion in the deadline suite.

## Validation

- `bunx tsc --noEmit` in `packages/core` and `packages/module-chat` — clean
- `TEST_TIER=0 bun test` on `turn-error-state.test.ts`, `ai-sdk-turn-deadline.test.ts`, `chat-turn-metadata.test.ts` — 25 pass, 0 fail
- `prettier --check` and `eslint` on every changed file — clean
- Full `bun run check` / whole suite not run locally (local Bun is 1.3.11, repo pins 1.3.14); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)