### PR TITLE
fix(sidecar): forward /llm request bodies byte-identically

### DIFF
--- a/runtime-pi/sidecar/app.ts
+++ b/runtime-pi/sidecar/app.ts
@@ -369,17 +369,20 @@ function llmBodyOversizeError(actual: number | null) {
 }
 
 /**
- * Buffer an inbound `/llm` request body as text under a hard byte cap.
+ * Buffer an inbound `/llm` request body as bytes under a hard byte cap.
  * Enforces a `Content-Length` precheck when declared AND the actual
  * buffered byte length (a missing/spoofed Content-Length is still
- * bounded by the streaming read). Returns the decoded text, or a 413
+ * bounded by the streaming read). Returns the original bytes, or a 413
  * `Response` the caller returns verbatim.
  *
  * Replaces a bare `await c.req.raw.text()` — that path was uncapped after
  * `oauth-identity.ts` (which carried the `MAX_REQUEST_BODY_SIZE` →
  * `TransformBodyTooLargeError` → 413 guard) was deleted.
  */
-async function bufferLlmBodyBounded(c: Context, maxBytes: number): Promise<string | Response> {
+async function bufferLlmBodyBytesBounded(
+  c: Context,
+  maxBytes: number,
+): Promise<Uint8Array | Response> {
   const declared = c.req.header("content-length");
   if (declared !== undefined) {
     const declaredLength = Number(declared);
@@ -391,6 +394,13 @@ async function bufferLlmBodyBounded(c: Context, maxBytes: number): Promise<strin
   if (bytes === "exceeded") {
     return c.json(llmBodyOversizeError(null), 413);
   }
+  return bytes;
+}
+
+/** Decode a bounded JSON body for the API-key model-alias rewrite path. */
+async function bufferLlmBodyBounded(c: Context, maxBytes: number): Promise<string | Response> {
+  const bytes = await bufferLlmBodyBytesBounded(c, maxBytes);
+  if (bytes instanceof Response) return bytes;
   return new TextDecoder().decode(bytes);
 }
 
@@ -702,11 +712,11 @@ export function createApp(deps: AppDeps): Hono {
     // refresh — a consumed stream can't be. The body is forwarded VERBATIM:
     // the oauth mode carries no modelSwap (aliases are rejected platform-side)
     // and never rewrites what Pi signed.
-    let body: string | undefined;
+    let body: Uint8Array | undefined;
     if (method !== "GET" && method !== "HEAD") {
-      const buffered = await bufferLlmBodyBounded(c, MAX_REQUEST_BODY_SIZE);
+      const buffered = await bufferLlmBodyBytesBounded(c, MAX_REQUEST_BODY_SIZE);
       if (buffered instanceof Response) return buffered;
-      body = buffered || undefined;
+      body = buffered.byteLength > 0 ? buffered : undefined;
     }
 
     const doFetch = (headers: Headers): Promise<Response> =>

--- a/runtime-pi/sidecar/test/oauth-llm.test.ts
+++ b/runtime-pi/sidecar/test/oauth-llm.test.ts
@@ -28,6 +28,7 @@ interface FetchCall {
   method: string;
   headers: Record<string, string>;
   body?: string;
+  bodyBytes?: Uint8Array;
 }
 
 function buildOAuthTokenResponse(overrides: Partial<OAuthTokenResponse> = {}): OAuthTokenResponse {
@@ -54,8 +55,19 @@ function setupFetchMock(handler: (url: string, init: RequestInit) => Promise<Res
           : Object.entries(h as Record<string, string>);
       for (const [k, v] of entries) headers[k.toLowerCase()] = v;
     }
-    const body = typeof init?.body === "string" ? init.body : undefined;
-    calls.push({ url: u, method: init?.method ?? "GET", headers, body });
+    const body =
+      typeof init?.body === "string"
+        ? init.body
+        : init?.body instanceof Uint8Array
+          ? new TextDecoder().decode(init.body)
+          : undefined;
+    const bodyBytes =
+      init?.body instanceof Uint8Array
+        ? new Uint8Array(init.body)
+        : body !== undefined
+          ? new TextEncoder().encode(body)
+          : undefined;
+    calls.push({ url: u, method: init?.method ?? "GET", headers, body, bodyBytes });
     return handler(u, init ?? {});
   });
   return { fetchFn, calls };
@@ -184,6 +196,26 @@ describe("/llm/* oauth — no forging", () => {
       body,
     });
     expect(calls[1]!.body).toBe(body);
+  });
+
+  it("preserves a compressed Codex body byte-identical", async () => {
+    const { fetchFn, calls } = setupFetchMock(upstreamOk);
+    const deps = makeDeps(fetchFn);
+    deps.config.llm = { ...OAUTH_CFG, baseUrl: "https://chatgpt.com/backend-api" };
+    const app = createApp(deps);
+    const compressed = new Uint8Array([0x28, 0xb5, 0x2f, 0xfd, 0xff, 0x00, 0x81, 0x7f]);
+
+    await app.request("/llm/codex/responses", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-encoding": "zstd",
+      },
+      body: compressed,
+    });
+
+    expect(calls[1]!.headers["content-encoding"]).toBe("zstd");
+    expect(calls[1]!.bodyBytes).toEqual(compressed);
   });
 
   it("logs the forwarded method and status on a redacted upstream 405", async () => {


### PR DESCRIPTION
Extrait de #1164 — indépendant du reste, mergeable seul.

## Pourquoi

La branche oauth de `/llm/*` bufferisait le corps entrant en texte via `TextDecoder`, puis passait la chaîne décodée au fetch amont. Pour un corps JSON ça fait un aller-retour propre ; pour un corps compressé, non.

Codex envoie `content-encoding: zstd`. Décoder ces octets en UTF-8 remplace chaque séquence invalide par U+FFFD : l'amont recevait une charge corrompue tout en étant informé qu'elle était en zstd.

## Modification

Bufferisation en `Uint8Array`, octets transmis verbatim. Le précontrôle `Content-Length` et le plafond d'octets en streaming sont inchangés. Le chemin API-key conserve son helper texte — il doit parser et réécrire le JSON, il a réellement besoin de la chaîne.

## Validation

- `bun test runtime-pi/sidecar/test/oauth-llm.test.ts` — 7 pass
- `tsc --noEmit` sur `runtime-pi`
- Nouveau test : corps zstd transmis octet pour octet, `content-encoding` préservé

🤖 Generated with [Claude Code](https://claude.com/claude-code)