### PR TITLE
fix(chat): make the stop button stop the server, not just the fetch

### DIFF
--- a/packages/module-chat/src/ui/index.tsx
+++ b/packages/module-chat/src/ui/index.tsx
@@ -58,6 +58,7 @@ import {
   markSessionRead,
   mintSessionId,
   SESSIONS_QUERY_KEY,
+  stopSession,
   type SessionSummary,
 } from "./sessions.ts";
 import { useSessions } from "./use-sessions.ts";
@@ -474,7 +475,18 @@ function ConversationInner({
     onConversationChange?.(id);
   }, [chat.messages.length, id, onConversationChange]);
 
-  const runtime = useAISDKRuntime(chat, { adapters: { attachments } });
+  // assistant-ui's cancel action only aborts the browser fetch. Chat producers
+  // intentionally survive disconnects so reload can resume them, therefore a
+  // real user stop must also hit the dedicated server endpoint. Start that
+  // independent request before aborting the local stream so it cannot be
+  // mistaken for an ordinary disconnect.
+  const stop = useCallback(() => {
+    void stopSession(getHeaders, id).catch(() => {});
+    return chat.stop();
+  }, [chat, getHeaders, id]);
+  const chatWithServerStop = useMemo(() => ({ ...chat, stop }), [chat, stop]);
+
+  const runtime = useAISDKRuntime(chatWithServerStop, { adapters: { attachments } });
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>

--- a/packages/module-chat/src/ui/sessions.ts
+++ b/packages/module-chat/src/ui/sessions.ts
@@ -80,6 +80,19 @@ export async function markSessionRead(
   if (!res.ok) throw new Error(`Failed to mark session read (HTTP ${res.status})`);
 }
 
+/** Explicitly stop the server-side producer for an active conversation. */
+export async function stopSession(
+  getHeaders: GetHeaders | null | undefined,
+  id: string,
+): Promise<void> {
+  const res = await fetch(`/api/chat/sessions/${id}/stop`, {
+    method: "POST",
+    credentials: "include",
+    headers: headers(getHeaders),
+  });
+  if (!res.ok) throw new Error(`Failed to stop session (HTTP ${res.status})`);
+}
+
 /** A stored message node as returned by `GET /sessions/:id`. */
 interface StoredMessage {
   id: string;

--- a/packages/module-chat/test/history-decode.test.ts
+++ b/packages/module-chat/test/history-decode.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, afterEach } from "bun:test";
-import { loadHistory } from "../src/ui/sessions.ts";
+import { loadHistory, stopSession } from "../src/ui/sessions.ts";
 
 const realFetch = globalThis.fetch;
 afterEach(() => {
@@ -37,5 +37,27 @@ describe("loadHistory decode", () => {
   it("throws on other errors", async () => {
     globalThis.fetch = (async () => new Response(null, { status: 500 })) as typeof fetch;
     await expect(loadHistory(() => ({}), "chs_x")).rejects.toThrow();
+  });
+});
+
+describe("stopSession", () => {
+  it("posts an authenticated explicit stop to the active conversation", async () => {
+    let request: { input: RequestInfo | URL; init?: RequestInit } | undefined;
+    globalThis.fetch = (async (input, init) => {
+      request = { input, init };
+      return new Response(null, { status: 204 });
+    }) as typeof fetch;
+
+    await stopSession(() => ({ "X-Org-Id": "org_1" }), "chs_1");
+
+    expect(String(request?.input)).toBe("/api/chat/sessions/chs_1/stop");
+    expect(request?.init?.method).toBe("POST");
+    expect(request?.init?.credentials).toBe("include");
+    expect(request?.init?.headers).toEqual({ "X-Org-Id": "org_1" });
+  });
+
+  it("throws when the server refuses the stop", async () => {
+    globalThis.fetch = (async () => new Response(null, { status: 500 })) as typeof fetch;
+    await expect(stopSession(() => ({}), "chs_1")).rejects.toThrow("HTTP 500");
   });
 });


### PR DESCRIPTION
Extrait de #1164 — indépendant de la pile Pi, mergeable seul.

## Pourquoi

`POST /api/chat/sessions/:id/stop` existe depuis que les producteurs de chat sont résumables, mais **rien ne l'appelait jamais**.

L'action cancel d'assistant-ui abandonne le fetch navigateur et rien de plus — et les producteurs de chat survivent délibérément à une déconnexion pour qu'un reload puisse les reprendre. Appuyer sur stop ressemblait donc à un stop et était en fait une déconnexion : la génération continuait côté serveur, gardait son slot de concurrence, consommait des tokens, et réapparaissait au chargement de page suivant.

## Modification

Le `stop` du runtime est enveloppé pour déclencher la requête de stop explicite avant d'abandonner le stream local. L'ordre compte : le serveur doit voir arriver un stop délibéré pendant que le stream est encore ouvert, sinon il ne peut pas le distinguer d'une déconnexion ordinaire.

La requête est fire-and-forget : un stop en échec ne doit pas empêcher l'abandon local, sinon le bouton paraîtrait mort exactement quand le backend est déjà en difficulté.

## Validation

- `bun test packages/module-chat/test/history-decode.test.ts` — 5 pass
- `tsc --noEmit` sur `module-chat`
- Nouveaux tests : requête authentifiée sur la bonne URL, propagation de l'échec serveur

🤖 Generated with [Claude Code](https://claude.com/claude-code)