### PR TITLE
docs(chat): archive the measurements that moved chat onto Pi

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -19,6 +19,7 @@ duplicating the detail.
 
 - [**MODEL_ALIASES.md**](./MODEL_ALIASES.md) — LLM-gateway model-alias pattern (masking real model ids across the two inference paths).
 - [**SUBSCRIPTION_COMPLIANCE.md**](./SUBSCRIPTION_COMPLIANCE.md) — Subscription credential compliance posture for the opt-in codex / claude-code provider modules.
+- [**unified-pi-chat/**](./unified-pi-chat/README.md) — _Archive._ The August 2026 measurements behind moving every chat turn onto the in-process Pi engine, and the versioned evidence for them.
 
 ## Platform posture
 

--- a/docs/architecture/unified-pi-chat/README.md
+++ b/docs/architecture/unified-pi-chat/README.md
@@ -1,0 +1,197 @@
+# Unified Pi Chat — measurement archive (August 2026)
+
+**Status: archive.** This directory records the measurements that justified
+moving chat onto the in-process Pi engine. It is evidence, not a live design
+reference — for how chat runs today, read the code and
+[`../SUPPLY_CHAIN.md`](../SUPPLY_CHAIN.md).
+
+The campaign ran on a branch that compared **two** chat inference loops: the AI
+SDK loop (API-key models) against the in-process Pi engine (OAuth subscriptions).
+That comparison no longer has a second arm: #1173 retired the AI SDK loop and
+every chat turn now runs on Pi. The numbers below are therefore historical —
+they are why the split was closed, not a claim about the engine that ships.
+
+Everything the campaign produced as code shipped separately, in the split PRs
+listed under [Where the work landed](#where-the-work-landed). Nothing here is
+pending.
+
+## What was measured
+
+Local, on an Apple M2, against isolated synthetic databases (PGlite, and one
+throwaway PostgreSQL database per cell). No production account or content was
+touched. A wave of N chats starts every conversation inside a 250 ms window —
+a deliberately severe burst, chosen to expose contention, not to model normal
+traffic.
+
+### Controlled replay on isolated PostgreSQL
+
+Medians of the p95 across three warm repetitions per cell, at commit `56706ae7`.
+1 590 of 1 590 conversations completed: no 429, no server error, no incomplete
+stream, no wrong marker. Model calls, tokens, messages, structured parts and
+usage rows all matched expectations; continuity and isolation passed; every
+synthetic database was dropped afterwards.
+
+| Concurrency | Engine | p95 first token | p95 total |    Throughput |
+| ----------: | ------ | --------------: | --------: | ------------: |
+|          60 | AI SDK |          355 ms |    593 ms | 89.74 chats/s |
+|          60 | Pi     |          656 ms |    880 ms | 64.37 chats/s |
+|          64 | AI SDK |          754 ms |  1 148 ms | 52.39 chats/s |
+|          64 | Pi     |          874 ms |  1 313 ms | 45.91 chats/s |
+|         100 | AI SDK |        1 052 ms |  1 548 ms | 61.08 chats/s |
+|         100 | Pi     |        1 530 ms |  1 882 ms | 46.51 chats/s |
+
+The gap is **not** a slow Pi cycle. At 100 chats, Pi's own work between entering
+the engine and issuing the prompt costs 8.4 ms at p95. The delay forms earlier,
+in event-loop contention: the first Pi turns do synchronous work while later
+turns wait on their PostgreSQL writes. Loop delay p95 was 96 ms for Pi against
+25 ms for AI SDK, and wave CPU 3.10 s against 2.54 s.
+
+Memory recovered in both engines. Pi went 239.6 MiB RSS at start → 324.9 MiB
+peak → 95.8 / 85.7 / 85.8 MiB after 30 / 60 / 120 s; AI SDK 147.2 → 279.3 →
+65.0 / 158.4 / 52.9 MiB. Pi carries roughly 92 MiB more fixed load, but grew
+less between start and peak in that cell (~85 MiB against ~132 MiB).
+
+### Real provider comparison — Mistral
+
+Warm, 60 concurrent chats, one repetition, `mistral-small-2603`, through the
+real endpoint: auth, model selection, proxy and ledger included.
+
+| Engine | p95 first token | p95 total |    Throughput |
+| ------ | --------------: | --------: | ------------: |
+| AI SDK |        2 771 ms |  2 910 ms | 13.39 chats/s |
+| Pi     |        2 803 ms |  3 157 ms |  9.24 chats/s |
+
+All 120 conversations completed cleanly. The 32 ms first-token difference is
+provider-dominated and imperceptible; the throughput difference under saturation
+is real and is a sizing input, not a latency one.
+
+### Subscriptions
+
+Measured at commit `c5a35b2d`, **before** the Pi 0.84.2 upgrade — kept as
+history, not as a measurement of what shipped. Each subscription completed 41 of
+41 conversations, with persistence, usage, continuity and isolation passing.
+
+| Subscription           | Concurrency | p95 first token | p95 total |   Throughput |
+| ---------------------- | ----------: | --------------: | --------: | -----------: |
+| Codex, GPT 5.6 Luna    |           1 |        1 962 ms |  2 184 ms |  0.46 chat/s |
+| Codex, GPT 5.6 Luna    |          10 |        2 888 ms |  3 124 ms | 3.19 chats/s |
+| Codex, GPT 5.6 Luna    |          30 |        3 589 ms |  3 784 ms | 7.65 chats/s |
+| Claude Code, Haiku 4.5 |           1 |        2 316 ms |  2 344 ms |  0.43 chat/s |
+| Claude Code, Haiku 4.5 |          10 |        2 506 ms |  2 540 ms | 3.93 chats/s |
+| Claude Code, Haiku 4.5 |          30 |        3 359 ms |  3 377 ms | 8.83 chats/s |
+
+Level 60 was not run: no subscription policy explicitly permits that burst.
+
+The Pi 0.84.2 subscription paths were validated functionally instead, under
+`RUN_ADAPTER=docker`, with runtime and sidecar built from the same worktree —
+Claude Code and Codex inline runs both `success`, usage and a single terminal
+event persisted, no `adapter_error`, no container left running.
+
+## What the campaign found and fixed
+
+Five costs specific to the Pi path were isolated. All five fixes shipped:
+
+1. **`ModelRuntime.create()` refreshed the whole model catalog every turn.** The
+   model is resolved upstream now; runtime creation stays under 1 ms median up
+   to 100 conversations.
+2. **The inert `proxy` auth placeholder triggered a full credential sync.** Its
+   synchronous path now costs ~0.1–0.2 ms. Codex and Claude Code OAuth
+   credentials keep their full sync.
+3. **`DefaultResourceLoader.reload()` rescanned local resources per
+   conversation** — skills, extensions and context files that chat's policy does
+   not expose at all. Chat uses a loader scoped to the turn's prompt and inline
+   extensions; reload p95 fell from 53.2 ms to 2.3 ms at 30 conversations. This
+   was the single biggest win: a CPU profile attributed **47.7 %** of the Pi wave
+   to that synchronous discovery, and removing it took Pi's first-token p95 from
+   1 243 ms to 267 ms at 30 chats. The Pi *runtime* keeps full discovery.
+4. **A deliberate cancellation after the terminal `output` tool could be
+   classified as an error.** Pi 0.84.2 can normalise it to `stopReason: "error"`
+   with the standard message `The operation was aborted.`. The bridge now
+   recognises that exact shape as a normal end — only after a terminal tool
+   succeeded, so ordinary provider errors stay errors.
+5. **Pi 0.84.2 moved its OpenAI-compatible cache-token normalisation.** The
+   anchor test follows the shipped file, and the adapter keeps the same
+   input / cache-read / cache-write split.
+
+The Pi→client stream mapper was measured at 0.05–0.15 ms and was **not** a cause.
+
+One operational constraint came out of the Docker validation: an older sidecar
+image failed Codex with `400 Bad Request` and zero model calls while Claude Code
+passed. Runtime and sidecar must be built and deployed as one coherent set.
+
+## Limits — read before quoting any number
+
+- **These are local numbers.** Apple M2, synthetic databases, synthetic bursts.
+  They do not establish Appstrate Cloud capacity, and must never be presented as
+  such. Per-replica CPU and memory, replica count, autoscaling, restarts, real
+  p95/p99 active chats, and real token and tool distributions were all unknown.
+- **Some cells are exploratory.** The targeted bench and the Mistral pair carry
+  one repetition each; only the PostgreSQL replay has three.
+- **The default Pi concurrency ceiling stays 6** until cloud capacity is
+  measured. A policy test with the ceiling pinned to 64 and 100 requested admits
+  exactly 64 and returns 36 clean 429s with `Retry-After` and no orphan message.
+  Measuring `CHAT_PI_MAX_CONCURRENCY` on a real instance is the open follow-up —
+  see [`../../plans/post-pi-unification-cleanup.md`](../../plans/post-pi-unification-cleanup.md), item 1.
+
+## Versioned evidence
+
+- [Observation schema](./performance-observation.schema.json) — the shape the
+  harness emitted, and what the result files below conform to.
+- [Compact summary](./performance-results/2026-08-19-unified-pi-pr-summary.v1.json)
+  — every table above, machine-readable.
+- [Advanced chat functional proof](./performance-results/2026-08-19-pi-advanced-chat-functional.v1.json)
+  — a Pi chat launching an inline run, creating a document, reading it back by
+  URI from two other sessions, and keeping session continuity.
+- [Docker subscription smoke](./performance-results/2026-08-19-pi-docker-subscription-smoke.v1.json)
+  — the two `RUN_ADAPTER=docker` subscription runs.
+
+Raw per-cell observations, PGlite databases and CPU profiles were never in git.
+
+## Where the work landed
+
+The campaign branch was split into these PRs, all merged:
+
+| PR    | What                                                             |
+| ----- | ---------------------------------------------------------------- |
+| #1166 | Sidecar forwards `/llm` request bodies byte-identically (zstd).   |
+| #1167 | Pi SDK 0.84.2, and the `@earendil-works` npm scope move.          |
+| #1168 | Chat history replayed as structured Pi messages, not a transcript.|
+| #1170 | The stop button stops the server, not just the fetch.             |
+| #1173 | Every chat turn runs on Pi; the AI SDK loop is gone.               |
+| #1175 | The follow-ups the unification audit left open.                   |
+
+#1164 — the campaign branch itself — was closed against these. #1169 was closed
+in favour of #1173.
+
+## Reproducing this
+
+The A/B harness is **not** in the tree. It drives two engines through
+`handleChatStream`, and one of them no longer exists — it cannot typecheck
+against `main`, and its comparative arm has nothing to compare. It is preserved,
+with its tests and its reproduction commands, on the archived campaign branch:
+
+```sh
+git fetch origin refs/tags/archive/chat-pi-unified-engine-phase4
+git show archive/chat-pi-unified-engine-phase4:scripts/chat-engine-performance.ts
+git show archive/chat-pi-unified-engine-phase4:docs/architecture/unified-pi-chat/README.md
+```
+
+That tag also holds the original French report this file condenses.
+
+A Pi-only load harness — the thing actually needed to size the cloud — would be
+new work, not a port. The invariants it must check are what made these numbers
+trustworthy, and are worth keeping: a cell counts only if it completes the
+requested conversations, with zero server errors, zero incomplete streams, the
+expected model and tool call counts, tokens and usage rows persisted, messages
+and structured parts persisted, session continuity intact, and no cross-tenant
+row. That last one is one query:
+
+```sql
+SELECT count(*) AS cross_tenant_usage_rows
+FROM llm_usage u
+JOIN chat_sessions s ON s.id = u.chat_session_id
+WHERE u.org_id IS DISTINCT FROM s.org_id
+   OR u.user_id IS DISTINCT FROM s.user_id;
+```
+
+The expected answer is zero.

--- a/docs/architecture/unified-pi-chat/performance-observation.schema.json
+++ b/docs/architecture/unified-pi-chat/performance-observation.schema.json
@@ -1,0 +1,282 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://appstrate.com/schemas/chat-pi-performance-observation-v1.json",
+  "title": "Chat engine performance observation",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schemaVersion",
+    "kind",
+    "benchmark",
+    "id",
+    "environment",
+    "cell",
+    "timing",
+    "memory",
+    "eventLoopDelayMs",
+    "cpu",
+    "latency",
+    "outcomes",
+    "usage",
+    "persistence",
+    "continuity",
+    "isolation",
+    "turns",
+    "samples"
+  ],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "kind": { "const": "chat-engine-performance-observation" },
+    "benchmark": { "enum": ["controlled", "mistral-real", "pi-subscription"] },
+    "id": { "type": "string", "minLength": 1 },
+    "environment": {
+      "type": "object",
+      "required": ["commit", "branch", "bunVersion", "platform", "port", "database"],
+      "properties": {
+        "commit": { "type": "string" },
+        "branch": { "type": "string" },
+        "bunVersion": { "type": "string" },
+        "platform": { "type": "string" },
+        "port": { "const": 3400 },
+        "database": { "type": "string" },
+        "controlledProviderPersistence": { "type": "boolean" }
+      }
+    },
+    "cell": {
+      "type": "object",
+      "required": ["engine", "form", "profile", "concurrency", "repetition", "distribution"],
+      "properties": {
+        "engine": { "enum": ["ai-sdk", "pi"] },
+        "form": { "enum": ["S", "H", "T", "L", "M"] },
+        "profile": { "enum": ["cold", "warm", "burst", "ramp", "endurance"] },
+        "concurrency": { "type": "integer", "minimum": 1 },
+        "repetition": { "type": "integer", "minimum": 1 },
+        "distribution": { "type": "string" }
+      }
+    },
+    "timing": {
+      "type": "object",
+      "required": ["waveStartedAtMs", "waveEndedAtMs", "recoveryMs"],
+      "properties": {
+        "waveStartedAtMs": { "type": "number", "minimum": 0 },
+        "waveEndedAtMs": { "type": "number", "minimum": 0 },
+        "waveStartedAtEpochMs": { "type": "number", "minimum": 0 },
+        "waveEndedAtEpochMs": { "type": "number", "minimum": 0 },
+        "recoveryMs": { "type": "number", "minimum": 0 }
+      }
+    },
+    "memory": {
+      "type": "object",
+      "required": ["initial", "peak", "end", "after30s", "after60s", "after120s"],
+      "properties": {
+        "initial": { "$ref": "#/$defs/memorySample" },
+        "peak": { "$ref": "#/$defs/memorySample" },
+        "end": { "$ref": "#/$defs/memorySample" },
+        "after30s": { "oneOf": [{ "$ref": "#/$defs/memorySample" }, { "type": "null" }] },
+        "after60s": { "oneOf": [{ "$ref": "#/$defs/memorySample" }, { "type": "null" }] },
+        "after120s": { "oneOf": [{ "$ref": "#/$defs/memorySample" }, { "type": "null" }] }
+      }
+    },
+    "eventLoopDelayMs": { "$ref": "#/$defs/percentiles" },
+    "cpu": {
+      "type": "object",
+      "required": ["userMicros", "systemMicros"],
+      "properties": {
+        "userMicros": { "type": "number", "minimum": 0 },
+        "systemMicros": { "type": "number", "minimum": 0 }
+      }
+    },
+    "latency": {
+      "type": "object",
+      "required": ["firstTokenMs", "totalMs", "throughputChatsPerSecond"],
+      "properties": {
+        "firstTokenMs": { "$ref": "#/$defs/percentiles" },
+        "totalMs": { "$ref": "#/$defs/percentiles" },
+        "throughputChatsPerSecond": { "type": "number", "minimum": 0 }
+      }
+    },
+    "diagnostics": {
+      "type": "object",
+      "required": ["providerDispatchMs"],
+      "properties": {
+        "providerDispatchMs": { "$ref": "#/$defs/percentiles" },
+        "chatTurn": {
+          "type": "object",
+          "required": ["sampleCount", "milestonesMs"],
+          "properties": {
+            "sampleCount": { "type": "integer", "minimum": 0 },
+            "milestonesMs": {
+              "type": "object",
+              "additionalProperties": { "$ref": "#/$defs/percentiles" }
+            }
+          }
+        },
+        "piEngineEntryMs": { "$ref": "#/$defs/percentiles" },
+        "piClientDeliveryAfterFirstTextMs": { "$ref": "#/$defs/percentiles" },
+        "piTurnTimelines": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "turnId",
+              "routeToEngineMs",
+              "engineToPromptMs",
+              "measuredLifecycleMs",
+              "unmeasuredEngineSetupMs",
+              "promptToFirstTextMs",
+              "firstTextToClientMs",
+              "requestToClientFirstTokenMs"
+            ],
+            "properties": {
+              "turnId": { "type": "string" },
+              "routeToEngineMs": { "type": "number" },
+              "engineToPromptMs": { "type": "number" },
+              "measuredLifecycleMs": { "type": "number" },
+              "unmeasuredEngineSetupMs": { "type": "number" },
+              "promptToFirstTextMs": { "type": "number" },
+              "firstTextToClientMs": { "type": "number" },
+              "requestToClientFirstTokenMs": { "type": "number" }
+            }
+          }
+        },
+        "piLifecycleSamples": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["turnId", "stage", "durationMs"],
+            "properties": {
+              "turnId": { "type": "string" },
+              "stage": { "type": "string" },
+              "durationMs": { "type": "number" }
+            }
+          }
+        },
+        "piPromptMilestoneSamples": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["turnId", "milestone", "elapsedMs"],
+            "properties": {
+              "turnId": { "type": "string" },
+              "milestone": { "type": "string" },
+              "elapsedMs": { "type": "number" }
+            }
+          }
+        },
+        "piLifecycle": {
+          "type": "object",
+          "required": ["sampleCount", "stagesMs", "prePromptTotalMs"],
+          "properties": {
+            "sampleCount": { "type": "integer", "minimum": 0 },
+            "stagesMs": {
+              "type": "object",
+              "additionalProperties": { "$ref": "#/$defs/percentiles" }
+            },
+            "prePromptTotalMs": { "$ref": "#/$defs/percentiles" }
+          }
+        },
+        "piPrompt": {
+          "type": "object",
+          "required": ["sampleCount", "milestonesMs"],
+          "properties": {
+            "sampleCount": { "type": "integer", "minimum": 0 },
+            "milestonesMs": {
+              "type": "object",
+              "additionalProperties": { "$ref": "#/$defs/percentiles" }
+            }
+          }
+        }
+      }
+    },
+    "outcomes": {
+      "type": "object",
+      "required": [
+        "requested",
+        "completed",
+        "rateLimited",
+        "serverErrors",
+        "incompleteStreams",
+        "markerFailures"
+      ],
+      "properties": {
+        "requested": { "type": "integer", "minimum": 0 },
+        "completed": { "type": "integer", "minimum": 0 },
+        "rateLimited": { "type": "integer", "minimum": 0 },
+        "serverErrors": { "type": "integer", "minimum": 0 },
+        "incompleteStreams": { "type": "integer", "minimum": 0 },
+        "markerFailures": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "usage": {
+      "type": "object",
+      "required": ["modelCalls", "toolCalls", "inputTokens", "outputTokens"],
+      "properties": {
+        "modelCalls": { "type": "integer", "minimum": 0 },
+        "toolCalls": { "type": "integer", "minimum": 0 },
+        "inputTokens": { "type": "integer", "minimum": 0 },
+        "outputTokens": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "persistence": {
+      "type": "object",
+      "required": ["messageCount", "structuredPartCount", "usageRows", "usageOwnershipValid"],
+      "properties": {
+        "messageCount": { "type": "integer", "minimum": 0 },
+        "structuredPartCount": { "type": "integer", "minimum": 0 },
+        "usageRows": { "type": "integer", "minimum": 0 },
+        "usageOwnershipValid": { "type": "boolean" }
+      }
+    },
+    "continuity": {
+      "type": "object",
+      "required": ["status", "complete", "markerValid", "persistedMessageCount"],
+      "properties": {
+        "status": { "type": "integer" },
+        "complete": { "type": "boolean" },
+        "markerValid": { "type": "boolean" },
+        "persistedMessageCount": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "isolation": {
+      "type": "object",
+      "required": ["foreignSessionRejected"],
+      "properties": { "foreignSessionRejected": { "type": "boolean" } }
+    },
+    "turns": { "type": "array", "items": { "type": "object" } },
+    "samples": { "type": "array", "items": { "$ref": "#/$defs/memorySample" } }
+  },
+  "$defs": {
+    "percentiles": {
+      "type": "object",
+      "required": ["p50", "p95", "p99"],
+      "properties": {
+        "p50": { "type": ["number", "null"] },
+        "p95": { "type": ["number", "null"] },
+        "p99": { "type": ["number", "null"] }
+      }
+    },
+    "memorySample": {
+      "type": "object",
+      "required": [
+        "elapsedMs",
+        "rss",
+        "heapUsed",
+        "external",
+        "arrayBuffers",
+        "cpuUserMicros",
+        "cpuSystemMicros",
+        "eventLoopDelayMs"
+      ],
+      "properties": {
+        "elapsedMs": { "type": "number", "minimum": 0 },
+        "rss": { "type": "integer", "minimum": 0 },
+        "heapUsed": { "type": "integer", "minimum": 0 },
+        "external": { "type": "integer", "minimum": 0 },
+        "arrayBuffers": { "type": "integer", "minimum": 0 },
+        "cpuUserMicros": { "type": "number", "minimum": 0 },
+        "cpuSystemMicros": { "type": "number", "minimum": 0 },
+        "eventLoopDelayMs": { "type": "number", "minimum": 0 }
+      }
+    }
+  }
+}

--- a/docs/architecture/unified-pi-chat/performance-results/2026-08-19-pi-advanced-chat-functional.v1.json
+++ b/docs/architecture/unified-pi-chat/performance-results/2026-08-19-pi-advanced-chat-functional.v1.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": 1,
+  "kind": "unified_pi_chat_advanced_functional_validation",
+  "date": "2026-08-19",
+  "environment": {
+    "origin": "http://localhost:3400",
+    "database": "isolated_pglite",
+    "data_class": "local_synthetic",
+    "run_adapter": "process",
+    "pi_version": "0.84.2"
+  },
+  "mistral_document_flow": {
+    "chat_session_id": "chs_1cd56a560f5d446abfdd46f254bb168c",
+    "provider": "mistral",
+    "model": "mistral-small-2603",
+    "engine": "pi",
+    "http_status": 200,
+    "tools": ["run_and_wait", "read_document"],
+    "run_id": "run_3603b047-6aab-4a0d-af9d-c3c2a649e4d4",
+    "run_status": "success",
+    "run_error": null,
+    "run_duration_ms": 3118,
+    "document_id": "doc_f374d194-adbd-4108-aba6-269b99c6d982",
+    "document_name": "validation-pi-unifie-PI-CLEAN-MISTRAL-1787171632016.md",
+    "document_mime": "text/markdown",
+    "document_size_bytes": 55,
+    "marker": "PI-CLEAN-MISTRAL-1787171632016",
+    "marker_verified_after_read": true,
+    "turn_step_count": 3,
+    "token_usage": {
+      "input_tokens": 13733,
+      "output_tokens": 115,
+      "cache_read_input_tokens": 13584,
+      "cache_creation_input_tokens": 0
+    },
+    "continuation": {
+      "http_status": 200,
+      "messages_before": 2,
+      "messages_after": 4,
+      "tools": [],
+      "marker_verified": true,
+      "turn_step_count": 1
+    }
+  },
+  "codex_cross_session_read": {
+    "chat_session_id": "chs_3e7790f5b7fe4d5ca4c11b0d8ff3cf24",
+    "provider": "codex",
+    "model": "gpt-5.6-luna",
+    "access": "subscription",
+    "engine": "pi",
+    "http_status": 200,
+    "tools": ["read_document"],
+    "persisted_messages": 2,
+    "marker_verified": true,
+    "turn_step_count": 2
+  },
+  "claude_orchestration": {
+    "chat_session_id": "chs_3a7c9ca2ad9a4d03807eec704c16494d",
+    "chat_provider": "claude-code",
+    "chat_model": "claude-haiku-4-5",
+    "chat_access": "subscription",
+    "chat_engine": "pi",
+    "http_status": 200,
+    "tools": ["run_and_wait"],
+    "persisted_messages": 2,
+    "marker": "PI-CLEAN-CLAUDE-MISTRAL-RUN-1787171740267",
+    "marker_verified": true,
+    "turn_step_count": 2,
+    "run_id": "run_cfe3ec7a-c33d-43bb-b933-a5ff71862178",
+    "run_model": "mistral-small-2603",
+    "run_status": "success",
+    "run_error": null,
+    "structured_result_persisted": true
+  },
+  "configured_limit": {
+    "scenario": "claude_subscription_model_inside_inline_run",
+    "run_id": "run_3ff5a4e7-49be-4e92-8000-6a05dd2e720d",
+    "status": "failed",
+    "model_calls": 0,
+    "reason": "oauth_subscription_runs_require_docker_sidecar",
+    "classification": "appstrate_configuration_limit",
+    "counted_as_pi_engine_failure": false
+  },
+  "checks": {
+    "structured_parts_persisted": true,
+    "document_persisted": true,
+    "cross_session_document_read": true,
+    "session_continuity": true,
+    "all_admitted_model_calls_completed": true
+  }
+}

--- a/docs/architecture/unified-pi-chat/performance-results/2026-08-19-pi-docker-subscription-smoke.v1.json
+++ b/docs/architecture/unified-pi-chat/performance-results/2026-08-19-pi-docker-subscription-smoke.v1.json
@@ -1,0 +1,91 @@
+{
+  "schema_version": 1,
+  "kind": "unified_pi_docker_subscription_smoke",
+  "date": "2026-08-19",
+  "environment": {
+    "origin": "http://chat-pi-unified-engine-phase4.localhost:3400",
+    "database": "isolated_pglite",
+    "data_class": "local_synthetic",
+    "run_adapter": "docker",
+    "pi_version": "0.84.2",
+    "pi_image": {
+      "reference": "appstrate-pi:phase4-pi-0.84.2",
+      "digest": "sha256:256811e7f67b48eba1f6ac546226f14a9b53ce983ca74cfd8af6013358a072b6"
+    },
+    "sidecar_image": {
+      "reference": "appstrate-sidecar:phase4-pi-0.84.2",
+      "digest": "sha256:011457fc3218cd128f9a7ef26e1bfdbd6dc75787b6479b94e9b9851baaabcecb"
+    }
+  },
+  "diagnostic": {
+    "stale_sidecar_reference": "appstrate-sidecar:latest",
+    "stale_sidecar_created_at": "2026-08-08T12:34:14.814753652-04:00",
+    "codex_run_id": "run_3fc218be-ef01-4924-99e4-abadfd7f2c55",
+    "status": "failed",
+    "duration_ms": 2117,
+    "error": "{\"detail\":\"Bad Request\"}",
+    "model_calls": 0,
+    "token_usage": {
+      "input_tokens": 0,
+      "output_tokens": 0,
+      "cache_read_input_tokens": 0,
+      "cache_creation_input_tokens": 0
+    },
+    "cause": "The sidecar image predated commit 8554de4e, which restores the native Codex transport in both runner-pi and the sidecar.",
+    "corrective_action": "Rebuild the sidecar from the current worktree and use a versioned tag aligned with the Pi 0.84.2 runtime image."
+  },
+  "claude_code": {
+    "run_id": "run_d8e2518b-0953-475e-af2a-8bc33b8a219b",
+    "provider": "claude-code",
+    "model": "claude-haiku-4-5",
+    "access": "subscription",
+    "status": "success",
+    "duration_ms": 3320,
+    "runtime_ready_ms": 938,
+    "model_turn_latency_ms": 520,
+    "mcp_connect_ms": 24,
+    "marker": "CLAUDE_DOCKER_OK",
+    "marker_observed": true,
+    "adapter_errors": 0,
+    "terminal_events": 1,
+    "token_usage": {
+      "input_tokens": 10,
+      "output_tokens": 91,
+      "cache_read_input_tokens": 4099,
+      "cache_creation_input_tokens": 0
+    }
+  },
+  "codex": {
+    "run_id": "run_8f74b628-ace4-45dd-b34a-5d56ab86d60d",
+    "provider": "codex",
+    "model": "gpt-5.6-luna",
+    "access": "subscription",
+    "status": "success",
+    "duration_ms": 75374,
+    "runtime_ready_ms": 1006,
+    "model_turn_latency_ms": 72932,
+    "mcp_connect_ms": 19,
+    "marker": "CODEX_DOCKER_OK",
+    "marker_observed": true,
+    "adapter_errors": 0,
+    "terminal_events": 1,
+    "token_usage": {
+      "input_tokens": 2680,
+      "output_tokens": 25,
+      "cache_read_input_tokens": 0,
+      "cache_creation_input_tokens": 0
+    }
+  },
+  "cleanup": {
+    "active_run_containers": 0,
+    "database_reused": true,
+    "storage_reused": true
+  },
+  "conclusion": {
+    "docker_subscription_path_validated": true,
+    "claude_code_validated": true,
+    "codex_validated": true,
+    "full_performance_matrix_replayed": false,
+    "cloud_capacity_known": false
+  }
+}

--- a/docs/architecture/unified-pi-chat/performance-results/2026-08-19-unified-pi-pr-summary.v1.json
+++ b/docs/architecture/unified-pi-chat/performance-results/2026-08-19-unified-pi-pr-summary.v1.json
@@ -1,0 +1,370 @@
+{
+  "schema_version": 1,
+  "kind": "unified_pi_pr_performance_summary",
+  "date": "2026-08-19",
+  "environment": {
+    "machine": "Apple M2 local",
+    "database": "isolated_pglite",
+    "additional_database": "isolated_postgresql_per_cell",
+    "data_class": "local_synthetic",
+    "cloud_capacity_validated": false
+  },
+  "real_mistral_c60": {
+    "campaign_commit": "fd1c56d4",
+    "model": "mistral-small-2603",
+    "profile": "warm",
+    "repetitions": 1,
+    "ai_sdk": {
+      "first_token_p95_ms": 2771.483,
+      "total_p95_ms": 2910.007,
+      "throughput_chats_per_second": 13.391,
+      "completed": 60
+    },
+    "pi": {
+      "first_token_p95_ms": 2803.227,
+      "total_p95_ms": 3156.686,
+      "throughput_chats_per_second": 9.242,
+      "completed": 60
+    },
+    "difference": {
+      "first_token_ms": 31.744,
+      "first_token_percent": 1.145,
+      "total_ms": 246.679,
+      "total_percent": 8.477,
+      "throughput_percent_of_ai_sdk": 69.013
+    },
+    "invariants": {
+      "rate_limited": 0,
+      "server_errors": 0,
+      "incomplete_streams": 0,
+      "marker_failures": 0,
+      "model_calls_expected": true,
+      "usage_persisted": true,
+      "messages_and_structured_parts_persisted": true,
+      "continuity_valid": true,
+      "isolation_valid": true
+    }
+  },
+  "controlled_warm_campaign": {
+    "campaign_commit": "fd1c56d4",
+    "repetitions_per_cell": 1,
+    "status": "exploratory",
+    "missing_optimized_concurrency_levels": [64]
+  },
+  "controlled_warm": [
+    {
+      "concurrency": 30,
+      "ai_sdk": {
+        "first_token_p95_ms": 174.316,
+        "total_p95_ms": 372.571,
+        "throughput_chats_per_second": 73.808
+      },
+      "pi": {
+        "first_token_p95_ms": 266.649,
+        "total_p95_ms": 462.146,
+        "throughput_chats_per_second": 61.352
+      },
+      "difference": {
+        "first_token_ms": 92.334,
+        "throughput_percent_of_ai_sdk": 83.13
+      }
+    },
+    {
+      "concurrency": 60,
+      "ai_sdk": {
+        "first_token_p95_ms": 312.049,
+        "total_p95_ms": 672.546,
+        "throughput_chats_per_second": 82.377
+      },
+      "pi": {
+        "first_token_p95_ms": 575.98,
+        "total_p95_ms": 865.681,
+        "throughput_chats_per_second": 66.17
+      },
+      "difference": {
+        "first_token_ms": 263.931,
+        "throughput_percent_of_ai_sdk": 80.326
+      }
+    },
+    {
+      "concurrency": 100,
+      "ai_sdk": {
+        "first_token_p95_ms": 436.786,
+        "total_p95_ms": 967.762,
+        "throughput_chats_per_second": 97.258
+      },
+      "pi": {
+        "first_token_p95_ms": 936.598,
+        "total_p95_ms": 1307.006,
+        "throughput_chats_per_second": 73.394
+      },
+      "difference": {
+        "first_token_ms": 499.811,
+        "throughput_percent_of_ai_sdk": 75.463
+      }
+    }
+  ],
+  "controlled_invariants": {
+    "requested": 380,
+    "completed": 380,
+    "rate_limited": 0,
+    "server_errors": 0,
+    "incomplete_streams": 0,
+    "marker_failures": 0,
+    "continuity_valid": true,
+    "isolation_valid": true
+  },
+  "controlled_postgresql_campaign": {
+    "campaign_commit": "56706ae7",
+    "database": "isolated_postgresql_per_cell",
+    "profile": "warm",
+    "repetitions_per_cell": 3,
+    "aggregation": "median_of_cell_p95",
+    "status": "complete"
+  },
+  "controlled_postgresql": [
+    {
+      "concurrency": 1,
+      "ai_sdk": {
+        "first_token_p95_ms": 53.144,
+        "total_p95_ms": 197.345,
+        "throughput_chats_per_second": 4.958
+      },
+      "pi": {
+        "first_token_p95_ms": 63.134,
+        "total_p95_ms": 217.879,
+        "throughput_chats_per_second": 4.546
+      },
+      "difference": {
+        "first_token_ms": 9.99,
+        "total_ms": 20.534
+      }
+    },
+    {
+      "concurrency": 10,
+      "ai_sdk": {
+        "first_token_p95_ms": 119.48,
+        "total_p95_ms": 263.777,
+        "throughput_chats_per_second": 33.451
+      },
+      "pi": {
+        "first_token_p95_ms": 208.456,
+        "total_p95_ms": 353.152,
+        "throughput_chats_per_second": 25.656
+      },
+      "difference": {
+        "first_token_ms": 88.976,
+        "total_ms": 89.374
+      }
+    },
+    {
+      "concurrency": 30,
+      "ai_sdk": {
+        "first_token_p95_ms": 282.837,
+        "total_p95_ms": 455.795,
+        "throughput_chats_per_second": 57.592
+      },
+      "pi": {
+        "first_token_p95_ms": 384.546,
+        "total_p95_ms": 541.048,
+        "throughput_chats_per_second": 52.54
+      },
+      "difference": {
+        "first_token_ms": 101.708,
+        "total_ms": 85.252
+      }
+    },
+    {
+      "concurrency": 60,
+      "ai_sdk": {
+        "first_token_p95_ms": 355.339,
+        "total_p95_ms": 592.712,
+        "throughput_chats_per_second": 89.736
+      },
+      "pi": {
+        "first_token_p95_ms": 656.188,
+        "total_p95_ms": 880.09,
+        "throughput_chats_per_second": 64.369
+      },
+      "difference": {
+        "first_token_ms": 300.849,
+        "total_ms": 287.378
+      }
+    },
+    {
+      "concurrency": 64,
+      "ai_sdk": {
+        "first_token_p95_ms": 753.669,
+        "total_p95_ms": 1147.767,
+        "throughput_chats_per_second": 52.386
+      },
+      "pi": {
+        "first_token_p95_ms": 873.666,
+        "total_p95_ms": 1312.566,
+        "throughput_chats_per_second": 45.905
+      },
+      "difference": {
+        "first_token_ms": 119.997,
+        "total_ms": 164.8
+      }
+    },
+    {
+      "concurrency": 100,
+      "ai_sdk": {
+        "first_token_p95_ms": 1052.069,
+        "total_p95_ms": 1547.727,
+        "throughput_chats_per_second": 61.08
+      },
+      "pi": {
+        "first_token_p95_ms": 1530.147,
+        "total_p95_ms": 1882.17,
+        "throughput_chats_per_second": 46.508
+      },
+      "difference": {
+        "first_token_ms": 478.078,
+        "total_ms": 334.444
+      }
+    }
+  ],
+  "controlled_postgresql_invariants": {
+    "requested": 1590,
+    "completed": 1590,
+    "rate_limited": 0,
+    "server_errors": 0,
+    "incomplete_streams": 0,
+    "marker_failures": 0,
+    "model_calls": 1590,
+    "usage_persisted": true,
+    "messages_and_structured_parts_persisted": true,
+    "continuity_valid": true,
+    "isolation_valid": true,
+    "isolated_databases_removed": true
+  },
+  "controlled_postgresql_internal_diagnostics_c100": {
+    "ai_sdk_engine_dispatch_p95_ms": 595.051,
+    "pi_engine_dispatch_p95_ms": 1085.534,
+    "pi_pre_prompt_p95_ms": 8.4,
+    "ai_sdk_event_loop_p95_ms": 25.248,
+    "pi_event_loop_p95_ms": 96.211,
+    "ai_sdk_wave_cpu_ms": 2537.329,
+    "pi_wave_cpu_ms": 3100.877,
+    "interpretation": "Earlier Pi turns execute while later turns persist their user state. Their cumulative synchronous work delays the shared event loop before those later turns enter the engine."
+  },
+  "controlled_postgresql_recovery_c100": {
+    "repetitions": 1,
+    "ai_sdk_rss_mib": {
+      "initial": 147.203,
+      "peak": 279.328,
+      "end": 279.625,
+      "after_30_seconds": 65.047,
+      "after_60_seconds": 158.422,
+      "after_120_seconds": 52.938
+    },
+    "pi_rss_mib": {
+      "initial": 239.625,
+      "peak": 324.859,
+      "end": 325.422,
+      "after_30_seconds": 95.828,
+      "after_60_seconds": 85.656,
+      "after_120_seconds": 85.797
+    },
+    "recovery_threshold_passed": true
+  },
+  "subscription_pi_only_campaign": {
+    "campaign_commit": "c5a35b2d",
+    "status": "historical_pre_pi_0_84_2_performance",
+    "current_pi_0_84_2_paths_validated_separately": true
+  },
+  "subscription_pi_only": [
+    {
+      "provider": "codex",
+      "model": "gpt-5.6-luna",
+      "concurrency": 1,
+      "first_token_p95_ms": 1962.409,
+      "total_p95_ms": 2184.164,
+      "throughput_chats_per_second": 0.457
+    },
+    {
+      "provider": "codex",
+      "model": "gpt-5.6-luna",
+      "concurrency": 10,
+      "first_token_p95_ms": 2888.401,
+      "total_p95_ms": 3124.489,
+      "throughput_chats_per_second": 3.193
+    },
+    {
+      "provider": "codex",
+      "model": "gpt-5.6-luna",
+      "concurrency": 30,
+      "first_token_p95_ms": 3588.826,
+      "total_p95_ms": 3783.903,
+      "throughput_chats_per_second": 7.645
+    },
+    {
+      "provider": "claude-code",
+      "model": "claude-haiku-4-5",
+      "concurrency": 1,
+      "first_token_p95_ms": 2316.339,
+      "total_p95_ms": 2344.174,
+      "throughput_chats_per_second": 0.426
+    },
+    {
+      "provider": "claude-code",
+      "model": "claude-haiku-4-5",
+      "concurrency": 10,
+      "first_token_p95_ms": 2506.123,
+      "total_p95_ms": 2539.959,
+      "throughput_chats_per_second": 3.928
+    },
+    {
+      "provider": "claude-code",
+      "model": "claude-haiku-4-5",
+      "concurrency": 30,
+      "first_token_p95_ms": 3358.975,
+      "total_p95_ms": 3376.858,
+      "throughput_chats_per_second": 8.829
+    }
+  ],
+  "subscription_invariants": {
+    "requested": 82,
+    "completed": 82,
+    "rate_limited": 0,
+    "server_errors": 0,
+    "incomplete_streams": 0,
+    "marker_failures": 0,
+    "continuity_valid": true,
+    "isolation_valid": true,
+    "direct_ai_sdk_comparison": false
+  },
+  "configured_benchmark_policy": {
+    "product_default_concurrency": 6,
+    "explicit_benchmark_concurrency": 64,
+    "requested": 100,
+    "admitted": 64,
+    "rate_limited": 36,
+    "server_errors": 0,
+    "incomplete_streams": 0,
+    "retry_after_present": true
+  },
+  "fixed_pi_load": {
+    "campaign_commit": "9d921a73",
+    "status": "historical_pre_pi_0_84_2_order_of_magnitude",
+    "repetitions": 10,
+    "import_duration_ms": {
+      "median": 265.028,
+      "min": 185.897,
+      "max": 1228.855
+    },
+    "rss_delta_bytes": {
+      "median": 278798336,
+      "min": 74940416,
+      "max": 378175488
+    },
+    "note": "Bun memory categories overlap and must not be summed."
+  },
+  "interpretation": {
+    "user_facing": "The single real Mistral c60 pair differs by 31.744 ms at p95 first token and 246.679 ms at p95 total, unlikely to be perceptible in ordinary interaction. This is exploratory, not a statistical non-inferiority result.",
+    "capacity": "The three-repetition PostgreSQL campaign completed all 1,590 chats. Pi added 120 to 478 ms at p95 first token for synchronized bursts of 60 to 100 chats. Its measured pre-prompt lifecycle stayed below 10 ms at p95, while cumulative synchronous work increased event-loop contention and reduced local saturation headroom.",
+    "cloud": "Replica resources, autoscaling and production traffic distributions were unavailable. Local results do not establish cloud capacity."
+  }
+}


### PR DESCRIPTION
Dernier reliquat de #1164, que je ferme juste après : le code de cette campagne est déjà sur `main` en six PR mergées, mais **les preuves étaient restées sur la branche**.

## Ce qui entre

`docs/architecture/unified-pi-chat/` — un enregistrement d'archive (197 lignes) plus les quatre observations JSON versionnées auxquelles il renvoie :

- le rejeu contrôlé sur PostgreSQL isolé, médianes des p95 sur trois répétitions, 1 590/1 590 conversations terminées ;
- le comparatif Mistral réel à 60 chats — 32 ms d'écart au premier token, 69 % du débit ;
- les abonnements Codex / Claude Code (historiques, antérieurs à 0.84.2) et leur validation fonctionnelle Docker à la place ;
- les cinq coûts isolés et corrigés, dont le profil CPU attribuant **47,7 %** de la vague Pi à un scan synchrone de ressources que le chat n'expose pas ;
- les limites, écrites pour qu'on ne cite jamais ces chiffres locaux comme une capacité cloud.

Le document est réécrit autour du résultat, pas de l'hypothèse : la conclusion d'origine était « on garde AI SDK disponible », or #1173 a supprimé la boucle AI SDK. Le cadre A/B n'a donc plus de second bras, et l'archive le dit en tête plutôt que de laisser une décision périmée dans `docs/architecture/`.

## Ce qui n'entre pas, et pourquoi

Le harness (`scripts/chat-engine-performance*.ts`, ~2 700 lignes). Il pilote deux moteurs à travers `handleChatStream` et l'un des deux n'existe plus : il ne typecheck pas contre `main` (`typecheck:scripts` casserait), et son bras comparatif n'a rien à comparer. Il référence aussi `CHAT_PI_ENGINE_ORG_IDS`, l'allowlist de #1169 que #1173 a supprimée.

Il est préservé sur le tag **`archive/chat-pi-unified-engine-phase4`** (`2afa5b81`), avec ses tests, ses commandes de reproduction et le rapport français d'origine que ce fichier condense. Le README d'archive donne les commandes `git show` pour le ressortir.

Un harness de charge Pi-only — ce qu'il faut réellement pour dimensionner le cloud — est du travail neuf, pas un portage. Les invariants qui rendaient ces mesures dignes de confiance sont donc recopiés dans l'archive pour qu'il les réutilise, y compris la requête de fuite cross-tenant.

## Vérification

- `prettier --check` sur les cinq fichiers : conforme
- tous les liens relatifs du document résolvent (`../SUPPLY_CHAIN.md`, `../../plans/post-pi-unification-cleanup.md`, les quatre JSON)
- entrée d'index ajoutée dans `docs/architecture/README.md`, marquée _Archive_
- aucun code touché : docs et JSON uniquement

Le suivi ouvert (mesurer `CHAT_PI_MAX_CONCURRENCY` sur une instance réelle) reste où il est déjà tracé, dans le plan de #1175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)